### PR TITLE
feat(models): direct type execution — collapse model create + method run (swamp-club#302)

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -61,6 +61,7 @@ Correct flow: `swamp model create <type> <name> --json` → set global args with
 | Evaluate input(s)   | `swamp model evaluate [id_or_name] --json`                       |
 | Run a method        | `swamp model method run <id_or_name> <method>`                   |
 | Run with inputs     | `swamp model method run <name> <method> --input key=value`       |
+| Direct type exec    | `swamp model @<type> method run <method> <name> --input k=v`     |
 | Skip all checks     | `swamp model method run <name> <method> --skip-checks`           |
 | Skip check by name  | `swamp model method run <name> <method> --skip-check <n>`        |
 | Skip check by label | `swamp model method run <name> <method> --skip-check-label <l>`  |
@@ -392,6 +393,16 @@ swamp model evaluate --all --json
     }
   ]
 }
+```
+
+## Direct Type Execution
+
+Collapse `model create` + `model method run` into one command — recommended when
+all values come from `--input` at runtime. See
+[references/direct-execution.md](references/direct-execution.md) for details.
+
+```bash
+swamp model @command/shell method run execute my-shell --input 'run=echo hello'
 ```
 
 ## Run Methods

--- a/.claude/skills/swamp-model/references/direct-execution.md
+++ b/.claude/skills/swamp-model/references/direct-execution.md
@@ -1,0 +1,54 @@
+# Direct Type Execution
+
+Collapse `model create` + `model method run` into one command. Use when all
+values come from `--input` at runtime — scripts, CI, one-shot invocations.
+
+## CLI Syntax
+
+```bash
+swamp model @<type> method run <method> <name> --input key=value
+```
+
+```bash
+swamp model @command/shell method run execute my-shell --input 'run=echo hello'
+swamp model @test/greeter method run greet my-greeter \
+  --input greeting=Hi --input name=World
+```
+
+## How It Works
+
+**First run:** auto-creates a definition named `<name>` with the given type in
+`.swamp/auto-definitions/`. Inputs are routed between global arguments and
+method arguments using the type's Zod schemas — method args take precedence on
+ambiguous keys, unknown keys are rejected.
+
+**Subsequent runs:** finds the existing definition, verifies the type matches
+(safety check), and runs. No new definition created.
+
+## Storage
+
+Auto-created definitions live in `.swamp/auto-definitions/{type}/{id}.yaml`:
+
+- Not git-tracked (local runtime state)
+- Not shown in `swamp model search`
+- Findable by name for `model get`, `model method run`, workflows
+- Synced via datastores when configured (shared across team)
+
+## Input Routing
+
+When the type declares both `globalArguments` and method `arguments` schemas,
+`--input` values are automatically split:
+
+1. Keys matching the method's `arguments` schema → method arguments
+2. Keys matching the type's `globalArguments` schema (not in method) → global
+   arguments
+3. Keys in neither schema → rejected with error listing valid keys
+
+## When to Use `model create` Instead
+
+Use explicit `model create` when you want to:
+
+- Manage values in the definition file (edit with `model edit`)
+- Version-control the definition in git
+- Use CEL expressions in global arguments
+- Share a definition across multiple workflow steps

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -487,15 +487,28 @@ steps:
 
 Steps support two task types:
 
-**`model_method`** - Call a method on a model:
+**`model_method`** has two mutually exclusive variants — `modelIdOrName`
+(existing definition) or `modelType` + `modelName` (direct type execution). See
+[references/direct-execution.md](references/direct-execution.md) for details.
 
 ```yaml
+# Existing definition
 task:
   type: model_method
   modelIdOrName: my-model
   methodName: run
-  inputs: # Optional: pass values to the model
+  inputs:
     key: ${{ inputs.value }}
+
+# Direct type execution (auto-creates definition)
+task:
+  type: model_method
+  modelType: "@test/greeter"
+  modelName: my-greeter
+  methodName: greet
+  inputs:
+    greeting: ${{ inputs.greeting }}
+    name: ${{ inputs.who }}
 ```
 
 **`workflow`** - Invoke another workflow (waits for completion):

--- a/.claude/skills/swamp-workflow/references/direct-execution.md
+++ b/.claude/skills/swamp-workflow/references/direct-execution.md
@@ -1,0 +1,54 @@
+# Direct Type Execution in Workflows
+
+Workflow steps can auto-create model definitions using `modelType` + `modelName`
+instead of referencing an existing definition with `modelIdOrName`.
+
+## Syntax
+
+```yaml
+task:
+  type: model_method
+  modelType: "@test/greeter"
+  modelName: my-greeter
+  methodName: greet
+  inputs:
+    greeting: Hello
+    name: ${{ inputs.who }}
+```
+
+## Rules
+
+- `modelIdOrName` and `modelType` are **mutually exclusive** — the schema
+  rejects YAML with both.
+- `modelType` requires `modelName` to name the auto-created definition.
+- Auto-created definitions are stored in `.swamp/auto-definitions/`.
+- Inputs are routed between global args and method args using the type's schemas
+  (method args take precedence on ambiguous keys).
+
+## forEach Support
+
+`modelName` supports template expressions for per-iteration definitions:
+
+```yaml
+- name: greet-${{self.person}}
+  forEach: { item: person, in: "${{ inputs.people }}" }
+  task:
+    type: model_method
+    modelType: "@test/greeter"
+    modelName: greeter-for-all
+    methodName: greet
+    inputs:
+      greeting: Hello
+      name: ${{ self.person }}
+```
+
+Use a fixed `modelName` (like `greeter-for-all`) to share one definition across
+all iterations, or a template `modelName` for per-iteration definitions.
+
+## When to Use `modelIdOrName` Instead
+
+Use `modelIdOrName` when:
+
+- The definition is pre-created with `model create` and managed in `models/`
+- You need CEL expressions in global arguments
+- The definition is shared across multiple workflows

--- a/design/inputs.md
+++ b/design/inputs.md
@@ -230,3 +230,24 @@ deepMerge precedence).
 Array inputs are supported via the `:json` suffix above (preferred), or
 via `--input-file` with YAML/JSON, or via the legacy single-shot
 `--input '<json-object>'` form.
+
+## Input Routing for Direct Type Execution
+
+When using direct type execution (`swamp model @type method run ...`), there is
+no `definition.inputs` schema to guide input splitting. Instead, the type's own
+schemas are used to route `--input` values:
+
+1. Keys matching the method's `arguments` Zod schema → **method arguments**
+2. Keys matching the type's `globalArguments` Zod schema (but not in the method
+   schema) → **global arguments**
+3. Keys in neither schema → **rejected** with an error listing valid keys
+
+Method arguments take precedence when a key appears in both schemas (more
+specific scope wins).
+
+String values are coerced to match schema types (e.g., `"428"` → `428` for a
+number field) using the same `coerceInputTypes` function used elsewhere.
+
+This routing happens at definition creation time. The routed global arguments
+are stored in the auto-created definition; the routed method arguments are
+passed to the method's execute function.

--- a/design/models.md
+++ b/design/models.md
@@ -131,10 +131,59 @@ first method execution and persisted with the new CalVer `typeVersion`.
 
 ## Definitions
 
-Definitions are specified as YAML files that live in the top-level `models/`
-directory of a repository, underneath the normalized type as a directory. The
-file name is `${id}.yaml`. For example,
+There are two ways to create a definition:
+
+### Direct Instantiation (`model create`)
+
+Use this when you want to manage values in the definition file. Global arguments
+are baked into the YAML, edited with `model edit`, and version-controlled in
+git. Good for: static configuration that rarely changes, definitions that use CEL
+expressions in global arguments, definitions shared across multiple workflow
+steps.
+
+These definitions live in the top-level `models/` directory of a repository,
+underneath the normalized type as a directory. The file name is `${id}.yaml`.
+For example,
 `models/aws/ec2/vpc/fc7fd41e-ae16-4b31-b57a-86de716e3ece.yaml`.
+
+### Direct Type Execution (recommended starting point)
+
+Use this when everything comes from `--input` at runtime. The definition is
+auto-created as a byproduct, not as a deliberate configuration act. Good for:
+scripts, CI pipelines, one-shot CLI invocations, and workflow steps where all
+values are dynamic.
+
+**CLI syntax:**
+
+```sh
+swamp model @swamp/aws/ec2/vpc method run create my-vpc \
+  --input region=us-east-1 --input cidr=10.0.0.0/16
+```
+
+**First run:** The definition `my-vpc` doesn't exist yet. Swamp auto-creates it
+with type `@swamp/aws/ec2/vpc` and executes `create`. The `--input` values are
+automatically routed between global arguments and method arguments using the
+type's schemas (method arguments take precedence on ambiguous keys).
+
+**Subsequent runs:** Finds `my-vpc`, verifies its type matches
+`@swamp/aws/ec2/vpc` (safety check), and runs. The same command is idempotent.
+
+**Storage:** Auto-created definitions live in `.swamp/auto-definitions/` (not
+`models/`). They are local runtime state, not git-tracked, and do not appear in
+`swamp model search` results. They are findable by name for `model get`,
+`model method run`, and workflow references.
+
+### Choosing Between the Two
+
+| Question                                        | Direct Instantiation | Direct Type Execution |
+| ----------------------------------------------- | -------------------- | --------------------- |
+| Do you manage values in the definition file?    | Yes                  | No                    |
+| Are values passed at runtime via `--input`?     | Sometimes            | Always                |
+| Is the definition git-tracked?                  | Yes                  | No                    |
+| Visible in `model search`?                      | Yes                  | No                    |
+| Stored in                                       | `models/`            | `.swamp/auto-definitions/` |
+
+### Definition Properties
 
 The valid shape of a definition is specified with a Zod 4 schema as part of the
 type.

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -20,6 +20,57 @@ Jobs can have dependencies on other jobs. The entire workflow is executed with a
 weighted topological sort, so that they have maximum parallelism through the
 workflow. Like steps, jobs also have conditions that trigger them.
 
+## Step Task Variants
+
+A `model_method` step task supports two mutually exclusive variants:
+
+### Existing Definition (`modelIdOrName`)
+
+References a pre-created definition by name or ID:
+
+```yaml
+task:
+  type: model_method
+  modelIdOrName: my-vpc
+  methodName: create
+  inputs:
+    cidr: "10.0.0.0/16"
+```
+
+### Direct Type Execution (`modelType` + `modelName`)
+
+Auto-creates a definition if it doesn't exist, using the type's schemas to route
+inputs between global arguments and method arguments:
+
+```yaml
+task:
+  type: model_method
+  modelType: "@swamp/aws/ec2/vpc"
+  modelName: my-vpc
+  methodName: create
+  inputs:
+    region: us-east-1
+    cidr: "10.0.0.0/16"
+```
+
+These variants are mutually exclusive — a step cannot have both `modelIdOrName`
+and `modelType`. Auto-created definitions are stored in
+`.swamp/auto-definitions/`.
+
+For `forEach` steps, `modelName` supports CEL template expressions:
+
+```yaml
+- name: scan-${{self.host}}
+  forEach: { item: host, in: "${{ inputs.hosts }}" }
+  task:
+    type: model_method
+    modelType: "@swamp/cve/dirtyfrag"
+    modelName: fleet-scanner
+    methodName: scanFleet
+    inputs:
+      host: ${{ self.host }}
+```
+
 ## Concurrency Limits
 
 By default, all jobs in a topological level and all steps in a topological level

--- a/src/cli/arg_rewriter.ts
+++ b/src/cli/arg_rewriter.ts
@@ -1,0 +1,62 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Rewrites CLI args to support `swamp model @type method run <method> <name>`.
+ *
+ * Cliffy's command tree can't route `@type` between `model` and `method run`,
+ * so this function detects the pattern and moves `@type` after `run` where
+ * model method run can parse it as its first positional.
+ *
+ * Input:  ["model", "@swamp/cve/dirtyfrag", "method", "run", "scanFleet", "scanner"]
+ * Output: ["model", "method", "run", "@swamp/cve/dirtyfrag", "scanFleet", "scanner"]
+ */
+export function rewriteDirectTypeArgs(args: string[]): string[] {
+  const modelIdx = args.indexOf("model");
+  if (modelIdx === -1) return args;
+
+  // Find "method" after "model"
+  const methodIdx = args.indexOf("method", modelIdx + 1);
+  if (methodIdx === -1) return args;
+
+  // Find "run" after "method"
+  const runIdx = args.indexOf("run", methodIdx + 1);
+  if (runIdx === -1) return args;
+
+  // Find @type between "model" and "method"
+  let typeIdx = -1;
+  for (let i = modelIdx + 1; i < methodIdx; i++) {
+    if (args[i].startsWith("@")) {
+      typeIdx = i;
+      break;
+    }
+  }
+  if (typeIdx === -1) return args;
+
+  // Rewrite: remove @type from its position and insert after "run"
+  const typeArg = args[typeIdx];
+  const result = [...args];
+  result.splice(typeIdx, 1);
+
+  // Adjust indices after removal
+  const adjustedRunIdx = runIdx > typeIdx ? runIdx - 1 : runIdx;
+  result.splice(adjustedRunIdx + 1, 0, typeArg);
+
+  return result;
+}

--- a/src/cli/arg_rewriter_test.ts
+++ b/src/cli/arg_rewriter_test.ts
@@ -1,0 +1,177 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { rewriteDirectTypeArgs } from "./arg_rewriter.ts";
+
+Deno.test("rewriteDirectTypeArgs: rewrites model @type method run to model method run @type", () => {
+  const input = [
+    "model",
+    "@swamp/cve/dirtyfrag",
+    "method",
+    "run",
+    "scanFleet",
+    "scanner",
+  ];
+  const expected = [
+    "model",
+    "method",
+    "run",
+    "@swamp/cve/dirtyfrag",
+    "scanFleet",
+    "scanner",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});
+
+Deno.test("rewriteDirectTypeArgs: no-op when no @type present", () => {
+  const input = ["model", "method", "run", "my-server", "getSystemInfo"];
+  assertEquals(rewriteDirectTypeArgs(input), input);
+});
+
+Deno.test("rewriteDirectTypeArgs: no-op for non-model commands", () => {
+  const input = ["workflow", "run", "my-workflow"];
+  assertEquals(rewriteDirectTypeArgs(input), input);
+});
+
+Deno.test("rewriteDirectTypeArgs: handles global options before model", () => {
+  const input = [
+    "--json",
+    "model",
+    "@swamp/cve/dirtyfrag",
+    "method",
+    "run",
+    "scanFleet",
+    "scanner",
+  ];
+  const expected = [
+    "--json",
+    "model",
+    "method",
+    "run",
+    "@swamp/cve/dirtyfrag",
+    "scanFleet",
+    "scanner",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});
+
+Deno.test("rewriteDirectTypeArgs: handles options between model and @type", () => {
+  const input = [
+    "model",
+    "--repo-dir",
+    "/tmp/repo",
+    "@swamp/cve/dirtyfrag",
+    "method",
+    "run",
+    "scanFleet",
+    "scanner",
+  ];
+  const expected = [
+    "model",
+    "--repo-dir",
+    "/tmp/repo",
+    "method",
+    "run",
+    "@swamp/cve/dirtyfrag",
+    "scanFleet",
+    "scanner",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});
+
+Deno.test("rewriteDirectTypeArgs: preserves trailing options", () => {
+  const input = [
+    "model",
+    "@swamp/cve/dirtyfrag",
+    "method",
+    "run",
+    "scanFleet",
+    "scanner",
+    "--input",
+    "hosts=10.0.0.1",
+    "--input",
+    "user=ubuntu",
+  ];
+  const expected = [
+    "model",
+    "method",
+    "run",
+    "@swamp/cve/dirtyfrag",
+    "scanFleet",
+    "scanner",
+    "--input",
+    "hosts=10.0.0.1",
+    "--input",
+    "user=ubuntu",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});
+
+Deno.test("rewriteDirectTypeArgs: no-op when model subcommand is not method run", () => {
+  const input = ["model", "@swamp/cve/dirtyfrag", "get"];
+  assertEquals(rewriteDirectTypeArgs(input), input);
+});
+
+Deno.test("rewriteDirectTypeArgs: no-op when model subcommand is create", () => {
+  const input = ["model", "create", "@swamp/cve/dirtyfrag", "my-model"];
+  assertEquals(rewriteDirectTypeArgs(input), input);
+});
+
+Deno.test("rewriteDirectTypeArgs: handles --flag=value style options", () => {
+  const input = [
+    "model",
+    "--repo-dir=/tmp/repo",
+    "@swamp/cve/dirtyfrag",
+    "method",
+    "run",
+    "scanFleet",
+    "scanner",
+  ];
+  const expected = [
+    "model",
+    "--repo-dir=/tmp/repo",
+    "method",
+    "run",
+    "@swamp/cve/dirtyfrag",
+    "scanFleet",
+    "scanner",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});
+
+Deno.test("rewriteDirectTypeArgs: scoped type with multiple segments", () => {
+  const input = [
+    "model",
+    "@swamp/aws/ec2/vpc",
+    "method",
+    "run",
+    "create",
+    "my-vpc",
+  ];
+  const expected = [
+    "model",
+    "method",
+    "run",
+    "@swamp/aws/ec2/vpc",
+    "create",
+    "my-vpc",
+  ];
+  assertEquals(rewriteDirectTypeArgs(input), expected);
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -86,8 +86,11 @@ export const modelMethodRunCommand = new Command()
     "Pass an array or object input (JSON-typed via :json suffix)",
     'swamp model method run my-server search --input \'keywords:json=["a","b"]\'',
   )
+  .description(
+    "Execute a method on a model. With @type prefix, auto-creates the definition if needed.",
+  )
   .arguments(
-    "<model_or_type:string> <method_name:string> [definition_name:string]",
+    "<model_or_type:model_name> <method_name:string> [definition_name:string]",
   )
   .option(
     "--repo-dir <dir:string>",
@@ -148,6 +151,7 @@ export const modelMethodRunCommand = new Command()
     "Cancellation deadline — seconds (e.g. 30, 1800) or duration string (e.g. 30s, 5m, 1h). Cooperative — only honored by methods that check AbortSignal.",
   )
   .action(
+    // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
       options: AnyOptions,
       modelOrType: string,

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -86,7 +86,9 @@ export const modelMethodRunCommand = new Command()
     "Pass an array or object input (JSON-typed via :json suffix)",
     'swamp model method run my-server search --input \'keywords:json=["a","b"]\'',
   )
-  .arguments("<first:string> <second:string> [third:string]")
+  .arguments(
+    "<model_or_type:string> <method_name:string> [definition_name:string]",
+  )
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
@@ -148,21 +150,21 @@ export const modelMethodRunCommand = new Command()
   .action(
     async function (
       options: AnyOptions,
-      first: string,
-      second: string,
-      third?: string,
+      modelOrType: string,
+      methodName: string,
+      definitionNameArg?: string,
     ) {
-      // Detect direct type execution: first arg starts with @
-      const isDirectExecution = first.startsWith("@");
-      const typeArg = isDirectExecution ? first : undefined;
-      const methodName = isDirectExecution ? second : second;
-      const modelIdOrName = isDirectExecution ? (third ?? second) : first;
-      const definitionName = isDirectExecution ? third : undefined;
+      const isDirectExecution = modelOrType.startsWith("@");
+      const typeArg = isDirectExecution ? modelOrType : undefined;
+      const modelIdOrName = isDirectExecution
+        ? (definitionNameArg ?? methodName)
+        : modelOrType;
+      const definitionName = isDirectExecution ? definitionNameArg : undefined;
 
-      if (isDirectExecution && !third) {
+      if (isDirectExecution && !definitionNameArg) {
         throw new UserError(
           "Direct type execution requires a definition name: " +
-            `swamp model ${first} method run ${second} <name>`,
+            `swamp model ${modelOrType} method run ${methodName} <name>`,
         );
       }
       const ctx = createContext(options as GlobalOptions, [

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -47,6 +47,7 @@ import {
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { SecretRedactor } from "../../domain/secrets/mod.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -78,10 +79,14 @@ export const modelMethodRunCommand = new Command()
     "swamp model method run my-server deploy --input env=prod",
   )
   .example(
+    "Direct type execution",
+    "swamp model @swamp/aws/ec2/vpc method run create my-vpc --input region=us-east-1",
+  )
+  .example(
     "Pass an array or object input (JSON-typed via :json suffix)",
     'swamp model method run my-server search --input \'keywords:json=["a","b"]\'',
   )
-  .arguments("<model_id_or_name:model_name> <method_name:string>")
+  .arguments("<first:string> <second:string> [third:string]")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
@@ -141,12 +146,25 @@ export const modelMethodRunCommand = new Command()
     "Cancellation deadline — seconds (e.g. 30, 1800) or duration string (e.g. 30s, 5m, 1h). Cooperative — only honored by methods that check AbortSignal.",
   )
   .action(
-    // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
       options: AnyOptions,
-      modelIdOrName: string,
-      methodName: string,
+      first: string,
+      second: string,
+      third?: string,
     ) {
+      // Detect direct type execution: first arg starts with @
+      const isDirectExecution = first.startsWith("@");
+      const typeArg = isDirectExecution ? first : undefined;
+      const methodName = isDirectExecution ? second : second;
+      const modelIdOrName = isDirectExecution ? (third ?? second) : first;
+      const definitionName = isDirectExecution ? third : undefined;
+
+      if (isDirectExecution && !third) {
+        throw new UserError(
+          "Direct type execution requires a definition name: " +
+            `swamp model ${first} method run ${second} <name>`,
+        );
+      }
       const ctx = createContext(options as GlobalOptions, [
         "model",
         "method",
@@ -240,6 +258,26 @@ export const modelMethodRunCommand = new Command()
             cleanup: () => runFileSink.unregister(logCategory),
           };
         },
+        createAndSaveDefinition: isDirectExecution
+          ? async (type, definition) => {
+            const autoDefRepo = new YamlDefinitionRepository(
+              repoDir,
+              undefined,
+              swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+              false,
+            );
+            await autoDefRepo.save(type, definition);
+          }
+          : undefined,
+        getDefinitionPath: isDirectExecution
+          ? (type, id) => {
+            return join(
+              swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+              type.toDirectoryPath(),
+              `${id}.yaml`,
+            );
+          }
+          : undefined,
       };
 
       const timeoutMs = options.timeout
@@ -283,6 +321,8 @@ export const modelMethodRunCommand = new Command()
             methodName,
             inputs,
             lastEvaluated: options.lastEvaluated as boolean,
+            typeArg,
+            definitionName,
             runtimeTags,
             skipCheckNames: options.skipCheck as string[] | undefined,
             skipCheckLabels: options.skipCheckLabel as string[] | undefined,

--- a/src/cli/commands/model_method_run_test.ts
+++ b/src/cli/commands/model_method_run_test.ts
@@ -35,7 +35,7 @@ Deno.test("modelMethodRunCommand has correct description", async () => {
   const { modelMethodRunCommand } = await import("./model_method_run.ts");
   assertEquals(
     modelMethodRunCommand.getDescription(),
-    "Execute a method on a model",
+    "Execute a method on a model. With @type prefix, auto-creates the definition if needed.",
   );
 });
 

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -32,7 +32,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 export const VERSION = "20260206.200442.0-sha.";
 
 // Git sha baked at compile time; falls back to runtime detection
-export const GIT_SHA = "";
+export const GIT_SHA = "0043013b";
 
 export function getVersionData(): VersionData {
   return { version: VERSION };

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -32,9 +32,21 @@ import { UserError } from "../../domain/errors.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { extractModelReferencesFromWorkflow } from "../../domain/workflows/model_reference_extractor.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
-import { WorkflowExecutionService } from "../../domain/workflows/execution_service.ts";
+import {
+  type DirectTypeResolver,
+  WorkflowExecutionService,
+} from "../../domain/workflows/execution_service.ts";
+import { resolveOrCreateDefinition } from "../../libswamp/models/direct_execution.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import type { DefinitionId } from "../../domain/definitions/definition.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../auto_resolver_context.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
-import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import { parseInputs } from "../input_parser.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { GIT_SHA } from "./version.ts";
@@ -247,15 +259,68 @@ export const workflowRunCommand = new Command()
           return await repo.findByName(idOrName) ??
             await repo.findById(createWorkflowId(idOrName));
         },
-        createExecutionService: (wfRepo, rnRepo, dir, catalogStore) =>
-          new WorkflowExecutionService(
+        createExecutionService: (wfRepo, rnRepo, dir, catalogStore) => {
+          const directResolver: DirectTypeResolver = async (
+            typeArg,
+            defName,
+            methodName,
+            inputs,
+          ) => {
+            const typeStr = typeArg.startsWith("@")
+              ? typeArg.slice(1)
+              : typeArg;
+            const resolvedType = ModelType.create(typeStr);
+            const modelDef = await resolveModelType(
+              resolvedType,
+              getAutoResolver(),
+            );
+            if (!modelDef) {
+              throw new Error(
+                `Unknown model type: ${resolvedType.normalized}`,
+              );
+            }
+            const autoDefRepo = new YamlDefinitionRepository(
+              dir,
+              undefined,
+              swampPath(dir, SWAMP_SUBDIRS.autoDefinitions),
+              false,
+            );
+            const result = await resolveOrCreateDefinition(
+              {
+                lookupDefinition: (name) =>
+                  findDefinitionByIdOrName(repoContext.definitionRepo, name),
+                getModelDef: (type) =>
+                  resolveModelType(type, getAutoResolver()),
+                saveDefinition: (type, def) => autoDefRepo.save(type, def),
+                getDefinitionPath: (type, id) =>
+                  autoDefRepo.getPath(type, id as DefinitionId),
+              },
+              typeStr,
+              defName,
+              methodName,
+              inputs,
+              resolvedType,
+              modelDef,
+            );
+            if (!result.ok) throw new Error(result.error.message);
+            return {
+              definition: result.definition,
+              modelType: result.modelType,
+              created: result.created,
+              routedMethodInputs: result.routedInputs.methodArguments,
+            };
+          };
+
+          return new WorkflowExecutionService(
             wfRepo,
             rnRepo,
             dir,
             undefined,
             unlocked.datastoreResolver.resolvePath(SWAMP_SUBDIRS.data),
             catalogStore,
-          ),
+            directResolver,
+          );
+        },
         catalogStore: repoContext.catalogStore,
         dataRepo: repoContext.unifiedDataRepo,
         definitionRepo: repoContext.definitionRepo,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -36,7 +36,7 @@ import {
   type DirectTypeResolver,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
-import { resolveOrCreateDefinition } from "../../libswamp/models/direct_execution.ts";
+import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -971,6 +971,11 @@ async function initTelemetryService(
 }
 
 export async function runCli(args: string[]): Promise<void> {
+  // Rewrite `model @type method run` → `model method run @type` before
+  // Cliffy parses the command tree. Must happen before any arg inspection.
+  const { rewriteDirectTypeArgs } = await import("./arg_rewriter.ts");
+  args = rewriteDirectTypeArgs(args);
+
   // Capture start time for telemetry
   const startTime = new Date();
 

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -40,6 +40,7 @@ export const ALWAYS_LOCAL_SUBDIRS = [] as const;
  * These contain derived/runtime data that can be stored externally.
  */
 export const DEFAULT_DATASTORE_SUBDIRS = [
+  "auto-definitions",
   "definitions-evaluated",
   "workflows-evaluated",
   "data",

--- a/src/domain/summary/summary_service.ts
+++ b/src/domain/summary/summary_service.ts
@@ -96,7 +96,10 @@ export class SummaryService {
           if (step.task.isModelMethod()) {
             const taskData = step.task.data;
             if (taskData.type === "model_method") {
-              stepMap.set(step.name, taskData.modelIdOrName);
+              stepMap.set(
+                step.name,
+                taskData.modelIdOrName ?? taskData.modelName ?? "",
+              );
             }
           }
         }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -328,6 +328,7 @@ export class DefaultStepExecutor implements StepExecutor {
     },
     ctx: StepExecutionContext,
   ): Promise<unknown> {
+    const allDeps = await this.resolveDeps(ctx);
     const {
       definitionRepo,
       unifiedDataRepo,
@@ -337,7 +338,7 @@ export class DefaultStepExecutor implements StepExecutor {
       methodExecutionService: executionService,
       vaultService,
       expressionEvaluator,
-    } = await this.resolveDeps(ctx);
+    } = allDeps;
 
     // Resolve forEach self.* expressions in modelIdOrName/modelName and methodName
     // before model lookup. The expression context has self populated with
@@ -372,8 +373,7 @@ export class DefaultStepExecutor implements StepExecutor {
     let modelType: ModelType;
 
     if (task.modelType && task.modelName) {
-      const deps = await this.resolveDeps(ctx);
-      const resolver = deps.directTypeResolver;
+      const resolver = allDeps.directTypeResolver;
 
       if (!resolver) {
         throw new Error(

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -37,6 +37,11 @@ import type {
   WorkflowRunRepository,
 } from "./repositories.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { resolveOrCreateDefinition } from "../../libswamp/models/direct_execution.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import type { OutputRepository } from "../models/repositories.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
@@ -61,8 +66,8 @@ import { detectEnvVarUsageInDefinition } from "../models/env_var_detector.ts";
 import { findDefinitionByIdOrName } from "../models/model_lookup.ts";
 import type { MethodExecutionEvent } from "../models/method_events.ts";
 import { ModelOutput } from "../models/model_output.ts";
-import type { Definition } from "../definitions/definition.ts";
-import type { ModelType } from "../models/model_type.ts";
+import type { Definition, DefinitionId } from "../definitions/definition.ts";
+import { ModelType } from "../models/model_type.ts";
 import type { MethodResult, ModelDefinition } from "../models/model.ts";
 import {
   containsRuntimeExpression,
@@ -85,10 +90,6 @@ import {
   getRunLogger,
   runFileSink,
 } from "../../infrastructure/logging/logger.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
 import { join } from "@std/path";
 import { SecretRedactor } from "../secrets/mod.ts";
 import { VaultService } from "../vaults/vault_service.ts";
@@ -293,7 +294,9 @@ export class DefaultStepExecutor implements StepExecutor {
 
   private async executeModelMethod(
     task: {
-      modelIdOrName: string;
+      modelIdOrName?: string;
+      modelType?: string;
+      modelName?: string;
       methodName: string;
       inputs?: Record<string, unknown>;
     },
@@ -310,7 +313,7 @@ export class DefaultStepExecutor implements StepExecutor {
       expressionEvaluator,
     } = await this.resolveDeps(ctx);
 
-    // Resolve forEach self.* expressions in modelIdOrName and methodName
+    // Resolve forEach self.* expressions in modelIdOrName/modelName and methodName
     // before model lookup. The expression context has self populated with
     // the forEach variable by runStep().
     if (ctx.expressionContext) {
@@ -331,22 +334,83 @@ export class DefaultStepExecutor implements StepExecutor {
         );
       task = {
         ...task,
-        modelIdOrName: resolve(task.modelIdOrName),
+        modelIdOrName: task.modelIdOrName
+          ? resolve(task.modelIdOrName)
+          : undefined,
+        modelName: task.modelName ? resolve(task.modelName) : undefined,
         methodName: resolve(task.methodName),
       };
     }
 
-    // Look up the model definition by ID or name
-    const lookupResult = await findDefinitionByIdOrName(
-      definitionRepo,
-      task.modelIdOrName,
-    );
-    if (!lookupResult) {
-      throw new Error(`Model not found: ${task.modelIdOrName}`);
-    }
+    let originalDefinition: Definition;
+    let modelType: ModelType;
 
-    // Keep original definition (with expressions)
-    const { definition: originalDefinition, type: modelType } = lookupResult;
+    if (task.modelType && task.modelName) {
+      // Direct type execution path
+      const typeStr = task.modelType.startsWith("@")
+        ? task.modelType.slice(1)
+        : task.modelType;
+      const resolvedType = ModelType.create(typeStr);
+
+      const modelDef = await resolveModelType(resolvedType, getAutoResolver());
+      if (!modelDef) {
+        throw new Error(`Unknown model type: ${resolvedType.normalized}`);
+      }
+
+      const autoDefRepo = new YamlDefinitionRepository(
+        ctx.repoDir,
+        undefined,
+        swampPath(ctx.repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        false,
+      );
+
+      const result = await resolveOrCreateDefinition(
+        {
+          lookupDefinition: (name: string) =>
+            findDefinitionByIdOrName(definitionRepo, name),
+          getModelDef: (type: ModelType) =>
+            resolveModelType(type, getAutoResolver()),
+          saveDefinition: (type: ModelType, def: Definition) =>
+            autoDefRepo.save(type, def),
+          getDefinitionPath: (type: ModelType, id: string) =>
+            autoDefRepo.getPath(type, id as DefinitionId),
+        },
+        typeStr,
+        task.modelName,
+        task.methodName,
+        task.inputs ?? {},
+        resolvedType,
+        modelDef,
+      );
+
+      if (!result.ok) {
+        throw new Error(result.error.message);
+      }
+
+      originalDefinition = result.definition;
+      modelType = result.modelType;
+
+      // Replace task inputs with routed method arguments only
+      task = {
+        ...task,
+        inputs: result.routedInputs.methodArguments,
+      };
+    } else if (task.modelIdOrName) {
+      // Standard path: look up existing definition
+      const lookupResult = await findDefinitionByIdOrName(
+        definitionRepo,
+        task.modelIdOrName,
+      );
+      if (!lookupResult) {
+        throw new Error(`Model not found: ${task.modelIdOrName}`);
+      }
+      originalDefinition = lookupResult.definition;
+      modelType = lookupResult.type;
+    } else {
+      throw new Error(
+        "Step task requires either modelIdOrName or modelType + modelName",
+      );
+    }
 
     // Log via model method run logger (same categories as standalone)
     const runLogger = getRunLogger(originalDefinition.name, task.methodName);
@@ -597,7 +661,9 @@ export class DefaultStepExecutor implements StepExecutor {
    */
   private async invokeMethod(args: {
     task: {
-      modelIdOrName: string;
+      modelIdOrName?: string;
+      modelType?: string;
+      modelName?: string;
       methodName: string;
       inputs?: Record<string, unknown>;
     };
@@ -796,7 +862,9 @@ export class DefaultStepExecutor implements StepExecutor {
    */
   private async handleMethodSuccess(args: {
     task: {
-      modelIdOrName: string;
+      modelIdOrName?: string;
+      modelType?: string;
+      modelName?: string;
       methodName: string;
       inputs?: Record<string, unknown>;
     };
@@ -932,7 +1000,7 @@ export class DefaultStepExecutor implements StepExecutor {
 
     return {
       type: "model_method",
-      model: task.modelIdOrName,
+      model: task.modelIdOrName ?? task.modelName ?? "",
       method: task.methodName,
       resources,
       files,
@@ -951,7 +1019,9 @@ export class DefaultStepExecutor implements StepExecutor {
    */
   private async handleMethodFailure(args: {
     task: {
-      modelIdOrName: string;
+      modelIdOrName?: string;
+      modelType?: string;
+      modelName?: string;
       methodName: string;
       inputs?: Record<string, unknown>;
     };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -41,7 +41,6 @@ import {
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
-import { resolveOrCreateDefinition } from "../../libswamp/models/direct_execution.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import type { OutputRepository } from "../models/repositories.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
@@ -66,8 +65,8 @@ import { detectEnvVarUsageInDefinition } from "../models/env_var_detector.ts";
 import { findDefinitionByIdOrName } from "../models/model_lookup.ts";
 import type { MethodExecutionEvent } from "../models/method_events.ts";
 import { ModelOutput } from "../models/model_output.ts";
-import type { Definition, DefinitionId } from "../definitions/definition.ts";
-import { ModelType } from "../models/model_type.ts";
+import type { Definition } from "../definitions/definition.ts";
+import type { ModelType } from "../models/model_type.ts";
 import type { MethodResult, ModelDefinition } from "../models/model.ts";
 import {
   containsRuntimeExpression,
@@ -196,6 +195,20 @@ const MAX_WORKFLOW_NESTING_DEPTH = 10;
  * {@link DefaultStepExecutor.fromRepoDir} or rely on the no-arg
  * constructor's lazy per-call construction (today's behaviour).
  */
+export interface DirectTypeResolveResult {
+  definition: Definition;
+  modelType: ModelType;
+  created: boolean;
+  routedMethodInputs: Record<string, unknown>;
+}
+
+export type DirectTypeResolver = (
+  typeArg: string,
+  definitionName: string,
+  methodName: string,
+  inputs: Record<string, unknown>,
+) => Promise<DirectTypeResolveResult>;
+
 export interface StepExecutorDeps {
   definitionRepo: DefinitionRepository;
   unifiedDataRepo: UnifiedDataRepository;
@@ -205,6 +218,7 @@ export interface StepExecutorDeps {
   methodExecutionService: MethodExecutionService;
   vaultService: VaultService;
   expressionEvaluator: ExpressionEvaluationService;
+  directTypeResolver?: DirectTypeResolver;
 }
 
 /**
@@ -213,8 +227,14 @@ export interface StepExecutorDeps {
 export class DefaultStepExecutor implements StepExecutor {
   private readonly validationService = new DefaultModelValidationService();
   private readonly reportRunner = new MethodReportRunner();
+  private readonly _directTypeResolver?: DirectTypeResolver;
 
-  constructor(private readonly injectedDeps?: StepExecutorDeps) {}
+  constructor(
+    private readonly injectedDeps?: StepExecutorDeps,
+    directTypeResolver?: DirectTypeResolver,
+  ) {
+    this._directTypeResolver = directTypeResolver;
+  }
 
   /**
    * Build a fully-wired DefaultStepExecutor for production use. Performs
@@ -243,10 +263,14 @@ export class DefaultStepExecutor implements StepExecutor {
     ctx: StepExecutionContext,
   ): Promise<StepExecutorDeps> {
     if (this.injectedDeps) return this.injectedDeps;
-    return await DefaultStepExecutor.buildDeps(ctx.repoDir, {
+    const deps = await DefaultStepExecutor.buildDeps(ctx.repoDir, {
       dataBaseDir: ctx.dataBaseDir,
       catalogStore: ctx.catalogStore,
     });
+    if (this._directTypeResolver) {
+      deps.directTypeResolver = this._directTypeResolver;
+    }
+    return deps;
   }
 
   private static async buildDeps(
@@ -275,6 +299,8 @@ export class DefaultStepExecutor implements StepExecutor {
         definitionRepo,
         repoDir,
       ),
+      // directTypeResolver is not available in the lazy buildDeps path.
+      // It must be injected via the WorkflowExecutionService constructor.
     };
   }
 
@@ -346,54 +372,28 @@ export class DefaultStepExecutor implements StepExecutor {
     let modelType: ModelType;
 
     if (task.modelType && task.modelName) {
-      // Direct type execution path
-      const typeStr = task.modelType.startsWith("@")
-        ? task.modelType.slice(1)
-        : task.modelType;
-      const resolvedType = ModelType.create(typeStr);
+      const deps = await this.resolveDeps(ctx);
+      const resolver = deps.directTypeResolver;
 
-      const modelDef = await resolveModelType(resolvedType, getAutoResolver());
-      if (!modelDef) {
-        throw new Error(`Unknown model type: ${resolvedType.normalized}`);
+      if (!resolver) {
+        throw new Error(
+          "Direct type execution is not supported in this context",
+        );
       }
 
-      const autoDefRepo = new YamlDefinitionRepository(
-        ctx.repoDir,
-        undefined,
-        swampPath(ctx.repoDir, SWAMP_SUBDIRS.autoDefinitions),
-        false,
-      );
-
-      const result = await resolveOrCreateDefinition(
-        {
-          lookupDefinition: (name: string) =>
-            findDefinitionByIdOrName(definitionRepo, name),
-          getModelDef: (type: ModelType) =>
-            resolveModelType(type, getAutoResolver()),
-          saveDefinition: (type: ModelType, def: Definition) =>
-            autoDefRepo.save(type, def),
-          getDefinitionPath: (type: ModelType, id: string) =>
-            autoDefRepo.getPath(type, id as DefinitionId),
-        },
-        typeStr,
+      const result = await resolver(
+        task.modelType,
         task.modelName,
         task.methodName,
         task.inputs ?? {},
-        resolvedType,
-        modelDef,
       );
-
-      if (!result.ok) {
-        throw new Error(result.error.message);
-      }
 
       originalDefinition = result.definition;
       modelType = result.modelType;
 
-      // Replace task inputs with routed method arguments only
       task = {
         ...task,
-        inputs: result.routedInputs.methodArguments,
+        inputs: result.routedMethodInputs,
       };
     } else if (task.modelIdOrName) {
       // Standard path: look up existing definition
@@ -1184,8 +1184,10 @@ export class WorkflowExecutionService {
     executor: StepExecutor | undefined,
     dataBaseDir: string | undefined,
     catalogStore: CatalogStore,
+    private readonly directTypeResolver?: DirectTypeResolver,
   ) {
-    this.executor = executor ?? new DefaultStepExecutor();
+    this.executor = executor ??
+      new DefaultStepExecutor(undefined, directTypeResolver);
     this.dataBaseDir = dataBaseDir;
     this.catalogStore = catalogStore;
     this.definitionRepo = new YamlDefinitionRepository(repoDir);

--- a/src/domain/workflows/model_reference_extractor.ts
+++ b/src/domain/workflows/model_reference_extractor.ts
@@ -64,11 +64,15 @@ export async function extractModelReferencesFromWorkflow(
 
       const taskData = task.data;
       if (taskData.type === "model_method") {
+        // Determine the reference name: modelIdOrName for existing, modelName for direct
+        const refName = taskData.modelIdOrName ?? taskData.modelName;
+        if (!refName) continue;
+
         // Check for dynamic CEL expressions
-        if (taskData.modelIdOrName.includes("${{")) {
+        if (refName.includes("${{")) {
           return null;
         }
-        references.push(taskData.modelIdOrName);
+        references.push(refName);
       } else if (taskData.type === "workflow") {
         // Check for dynamic CEL expressions in workflow reference
         if (taskData.workflowIdOrName.includes("${{")) {

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -29,7 +29,9 @@ import { z } from "zod";
 const StepTaskRawSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("model_method"),
-    modelIdOrName: z.string().min(1),
+    modelIdOrName: z.string().min(1).optional(),
+    modelType: z.string().min(1).optional(),
+    modelName: z.string().min(1).optional(),
     methodName: z.string().min(1),
     inputs: z.record(z.string(), z.unknown()).optional(),
   }),
@@ -60,6 +62,26 @@ export const StepTaskSchema = z.preprocess((data) => {
           `    inputs:\n` +
           `      command: "your-command-here"`,
       );
+    }
+    if (d.type === "model_method") {
+      const hasExisting = "modelIdOrName" in d && d.modelIdOrName;
+      const hasDirect = "modelType" in d && d.modelType;
+      if (hasExisting && hasDirect) {
+        throw new Error(
+          `Step task has both modelIdOrName and modelType. ` +
+            `Use either modelIdOrName (existing definition) or modelType + modelName (direct type execution), not both.`,
+        );
+      }
+      if (!hasExisting && !hasDirect) {
+        throw new Error(
+          `Step task requires either modelIdOrName or modelType + modelName.`,
+        );
+      }
+      if (hasDirect && !("modelName" in d && d.modelName)) {
+        throw new Error(
+          `modelType requires modelName to name the auto-created definition.`,
+        );
+      }
     }
   }
   return data;
@@ -114,6 +136,24 @@ export class StepTask {
   }
 
   /**
+   * Creates a direct type execution task.
+   */
+  static directExecution(
+    modelType: string,
+    modelName: string,
+    methodName: string,
+    inputs?: Record<string, unknown>,
+  ): StepTask {
+    return new StepTask({
+      type: "model_method",
+      modelType,
+      modelName,
+      methodName,
+      inputs,
+    });
+  }
+
+  /**
    * Creates a workflow invocation task.
    */
   static workflow(
@@ -132,6 +172,14 @@ export class StepTask {
    */
   isModelMethod(): boolean {
     return this.data.type === "model_method";
+  }
+
+  /**
+   * Returns true if this is a direct type execution task (modelType + modelName).
+   */
+  isDirectExecution(): boolean {
+    return this.data.type === "model_method" && "modelType" in this.data &&
+      !!this.data.modelType;
   }
 
   /**

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -204,3 +204,82 @@ Deno.test("StepTaskSchema shell error suggests command/shell model", () => {
     "command/shell",
   );
 });
+
+// Direct type execution tests
+
+Deno.test("StepTask.directExecution creates direct type execution task", () => {
+  const task = StepTask.directExecution(
+    "@test/greeter",
+    "my-greeter",
+    "greet",
+    {
+      greeting: "Hello",
+    },
+  );
+  assertEquals(task.data.type, "model_method");
+  assertEquals(task.isModelMethod(), true);
+  assertEquals(task.isDirectExecution(), true);
+});
+
+Deno.test("StepTask.isDirectExecution returns false for modelIdOrName tasks", () => {
+  const task = StepTask.modelMethod("my-model", "run");
+  assertEquals(task.isDirectExecution(), false);
+});
+
+Deno.test("StepTaskSchema parses modelType + modelName", () => {
+  const result = StepTaskSchema.parse({
+    type: "model_method",
+    modelType: "@test/greeter",
+    modelName: "my-greeter",
+    methodName: "greet",
+  });
+  assertEquals(result.type, "model_method");
+  if (result.type === "model_method") {
+    assertEquals(result.modelType, "@test/greeter");
+    assertEquals(result.modelName, "my-greeter");
+    assertEquals(result.methodName, "greet");
+  }
+});
+
+Deno.test("StepTaskSchema rejects both modelIdOrName and modelType", () => {
+  assertThrows(
+    () => {
+      StepTaskSchema.parse({
+        type: "model_method",
+        modelIdOrName: "my-model",
+        modelType: "@test/greeter",
+        modelName: "my-greeter",
+        methodName: "run",
+      });
+    },
+    Error,
+    "both modelIdOrName and modelType",
+  );
+});
+
+Deno.test("StepTaskSchema rejects modelType without modelName", () => {
+  assertThrows(
+    () => {
+      StepTaskSchema.parse({
+        type: "model_method",
+        modelType: "@test/greeter",
+        methodName: "greet",
+      });
+    },
+    Error,
+    "modelType requires modelName",
+  );
+});
+
+Deno.test("StepTaskSchema rejects neither modelIdOrName nor modelType", () => {
+  assertThrows(
+    () => {
+      StepTaskSchema.parse({
+        type: "model_method",
+        methodName: "run",
+      });
+    },
+    Error,
+    "requires either modelIdOrName or modelType",
+  );
+});

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -368,15 +368,18 @@ export class DefaultWorkflowValidationService
 
         const taskData = task.data;
         if (taskData.type === "model_method" && this.methodResolver) {
-          results.push(
-            ...await this.validateModelMethodInputs(
-              job.name,
-              step.name,
-              taskData.modelIdOrName,
-              taskData.methodName,
-              taskData.inputs,
-            ),
-          );
+          const modelRef = taskData.modelIdOrName ?? taskData.modelName;
+          if (modelRef) {
+            results.push(
+              ...await this.validateModelMethodInputs(
+                job.name,
+                step.name,
+                modelRef,
+                taskData.methodName,
+                taskData.inputs,
+              ),
+            );
+          }
         } else if (taskData.type === "workflow" && this.workflowRepo) {
           results.push(
             ...await this.validateWorkflowTaskInputs(

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -77,6 +77,8 @@ export const SWAMP_SUBDIRS = {
   datastoreBundles: "datastore-bundles",
   /** Cached report extension bundles */
   reportBundles: "report-bundles",
+  /** Auto-created definitions from direct type execution */
+  autoDefinitions: "auto-definitions",
   /** Audit command logs */
   audit: "audit",
   /** Legacy: resource definitions */

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -24,6 +24,7 @@ import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { assertSafePath } from "./safe_path.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import {
@@ -52,13 +53,19 @@ const logger = getLogger(["definition-repo"]);
  */
 export class YamlDefinitionRepository implements DefinitionRepository {
   private readonly baseDir: string;
+  private readonly secondaryBaseDir: string | undefined;
 
   constructor(
     private readonly repoDir: string,
     private readonly eventBus?: EventBus,
     baseDir?: string,
+    secondaryBaseDir?: string | false,
   ) {
     this.baseDir = baseDir ?? join(repoDir, "models");
+    this.secondaryBaseDir = secondaryBaseDir === false
+      ? undefined
+      : (secondaryBaseDir ??
+        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions));
   }
 
   async findById(
@@ -66,6 +73,27 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     id: DefinitionId,
   ): Promise<Definition | null> {
     const path = this.getPath(type, id);
+    try {
+      const content = await Deno.readTextFile(path);
+      const data = parseYaml(content) as DefinitionData;
+      return Definition.fromData(data);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        if (this.secondaryBaseDir) {
+          return this.findByIdInDir(this.secondaryBaseDir, type, id);
+        }
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async findByIdInDir(
+    dir: string,
+    type: ModelType,
+    id: DefinitionId,
+  ): Promise<Definition | null> {
+    const path = join(dir, type.toDirectoryPath(), `${id}.yaml`);
     try {
       const content = await Deno.readTextFile(path);
       const data = parseYaml(content) as DefinitionData;
@@ -112,13 +140,58 @@ export class YamlDefinitionRepository implements DefinitionRepository {
 
   async findByName(type: ModelType, name: string): Promise<Definition | null> {
     const definitions = await this.findAll(type);
-    return definitions.find((def) => def.name === name) ?? null;
+    const found = definitions.find((def) => def.name === name);
+    if (found) return found;
+    if (this.secondaryBaseDir) {
+      const secondaryDir = join(this.secondaryBaseDir, type.toDirectoryPath());
+      const secondaryDefs = await this.findAllInDir(secondaryDir);
+      return secondaryDefs.find((def) => def.name === name) ?? null;
+    }
+    return null;
+  }
+
+  private async findAllInDir(dir: string): Promise<Definition[]> {
+    const definitions: Definition[] = [];
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (
+          (entry.isFile || entry.isSymlink) && entry.name.endsWith(".yaml")
+        ) {
+          const path = join(dir, entry.name);
+          try {
+            if (entry.isSymlink) {
+              await assertSafePath(path, this.repoDir);
+            }
+            const content = await Deno.readTextFile(path);
+            const data = parseYaml(content) as DefinitionData;
+            definitions.push(Definition.fromData(data));
+          } catch (parseError) {
+            logger.warn`Skipping broken definition file ${path}: ${parseError}`;
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+    return definitions;
   }
 
   async findByNameGlobal(
     name: string,
   ): Promise<{ definition: Definition; type: ModelType } | null> {
-    return await this.searchDefinitionByName(this.baseDir, [], name);
+    const result = await this.searchDefinitionByName(this.baseDir, [], name);
+    if (result) return result;
+    if (this.secondaryBaseDir) {
+      return await this.searchDefinitionByName(
+        this.secondaryBaseDir,
+        [],
+        name,
+      );
+    }
+    return null;
   }
 
   /**

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -59,6 +59,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     private readonly repoDir: string,
     private readonly eventBus?: EventBus,
     baseDir?: string,
+    /** Pass `false` to disable secondary search. Omit to auto-compute from repoDir. */
     secondaryBaseDir?: string | false,
   ) {
     this.baseDir = baseDir ?? join(repoDir, "models");

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -126,6 +126,13 @@ export {
   unknownModelType,
 } from "./models/run.ts";
 export {
+  type DirectExecutionDeps,
+  type DirectExecutionResult,
+  resolveOrCreateDefinition,
+  type RoutedInputs,
+  routeInputsBySchema,
+} from "./models/direct_execution.ts";
+export {
   type DataArtifactView,
   type ModelMethodRunView,
   type ModelReportView,

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -52,6 +52,7 @@ export type DirectExecutionResult =
     created: boolean;
     definitionPath: string;
     routedInputs: RoutedInputs;
+    globalArgsDiffer?: boolean;
   }
   | { ok: false; error: SwampError };
 
@@ -160,6 +161,11 @@ export async function resolveOrCreateDefinition(
       };
     }
 
+    const storedGlobal = existing.definition.globalArguments;
+    const routedGlobal = routed.globalArguments;
+    const globalArgsDiffer = Object.keys(routedGlobal).length > 0 &&
+      JSON.stringify(storedGlobal) !== JSON.stringify(routedGlobal);
+
     return {
       ok: true,
       definition: existing.definition,
@@ -171,6 +177,7 @@ export async function resolveOrCreateDefinition(
         existing.definition.id,
       ),
       routedInputs: routed,
+      globalArgsDiffer,
     };
   }
 

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -1,0 +1,215 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { z } from "zod";
+import { Definition } from "../../domain/definitions/definition.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import type { ModelDefinition } from "../../domain/models/model.ts";
+import { coerceInputTypes } from "../../domain/inputs/mod.ts";
+import { getObjectShape } from "../../domain/models/zod_type_coercion.ts";
+import { zodToJsonSchema } from "../types/schema_helpers.ts";
+import type { SwampError } from "../errors.ts";
+import { validationFailed } from "../errors.ts";
+
+export interface DirectExecutionDeps {
+  lookupDefinition: (
+    name: string,
+  ) => Promise<{ definition: Definition; type: ModelType } | null>;
+  getModelDef: (
+    type: ModelType,
+  ) => ModelDefinition | undefined | Promise<ModelDefinition | undefined>;
+  saveDefinition: (type: ModelType, definition: Definition) => Promise<void>;
+  getDefinitionPath: (type: ModelType, id: string) => string;
+}
+
+export interface RoutedInputs {
+  globalArguments: Record<string, unknown>;
+  methodArguments: Record<string, unknown>;
+}
+
+export type DirectExecutionResult =
+  | {
+    ok: true;
+    definition: Definition;
+    modelType: ModelType;
+    modelDef: ModelDefinition;
+    created: boolean;
+    definitionPath: string;
+    routedInputs: RoutedInputs;
+  }
+  | { ok: false; error: SwampError };
+
+/**
+ * Routes input values between globalArguments and method arguments using
+ * the type's Zod schemas. Method arguments take precedence on ambiguous keys.
+ */
+export function routeInputsBySchema(
+  inputs: Record<string, unknown>,
+  methodName: string,
+  modelDef: ModelDefinition,
+): RoutedInputs | { error: SwampError } {
+  const method = modelDef.methods[methodName];
+  if (!method) {
+    return {
+      error: {
+        code: "unknown_method",
+        message: `Unknown method '${methodName}'. Available methods: ${
+          Object.keys(modelDef.methods).join(", ") || "none"
+        }`,
+      },
+    };
+  }
+
+  const methodShape = getObjectShape(method.arguments);
+  const globalShape = modelDef.globalArguments
+    ? getObjectShape(modelDef.globalArguments)
+    : null;
+
+  const methodKeys = methodShape ? new Set(Object.keys(methodShape)) : new Set<
+    string
+  >();
+  const globalKeys = globalShape
+    ? new Set(Object.keys(globalShape))
+    : new Set<string>();
+
+  const globalArguments: Record<string, unknown> = {};
+  const methodArguments: Record<string, unknown> = {};
+  const unknownKeys: string[] = [];
+
+  for (const [key, value] of Object.entries(inputs)) {
+    if (methodKeys.has(key)) {
+      methodArguments[key] = value;
+    } else if (globalKeys.has(key)) {
+      globalArguments[key] = value;
+    } else {
+      unknownKeys.push(key);
+    }
+  }
+
+  if (unknownKeys.length > 0) {
+    const allValid = [...methodKeys, ...globalKeys];
+    return {
+      error: validationFailed(
+        `Unknown input(s): ${unknownKeys.join(", ")}. ` +
+          `Valid inputs are: ${allValid.join(", ") || "none"}`,
+      ),
+    };
+  }
+
+  // Coerce global arguments to match schema types
+  if (modelDef.globalArguments) {
+    const jsonSchema = zodToJsonSchema(modelDef.globalArguments);
+    const coerced = coerceInputTypes(
+      globalArguments,
+      jsonSchema as Record<string, unknown>,
+    );
+    Object.assign(globalArguments, coerced);
+  }
+
+  return { globalArguments, methodArguments };
+}
+
+/**
+ * Resolves an existing definition by name or auto-creates one.
+ * When the definition exists, verifies the type matches.
+ */
+export async function resolveOrCreateDefinition(
+  deps: DirectExecutionDeps,
+  typeArg: string,
+  definitionName: string,
+  methodName: string,
+  inputs: Record<string, unknown>,
+  resolvedType: ModelType,
+  modelDef: ModelDefinition,
+): Promise<DirectExecutionResult> {
+  // Route inputs
+  const routed = routeInputsBySchema(inputs, methodName, modelDef);
+  if ("error" in routed) {
+    return { ok: false, error: routed.error };
+  }
+
+  // Look up existing definition
+  const existing = await deps.lookupDefinition(definitionName);
+
+  if (existing) {
+    // Verify type matches
+    if (existing.type.normalized !== resolvedType.normalized) {
+      return {
+        ok: false,
+        error: validationFailed(
+          `Definition '${definitionName}' exists with type '${existing.type.normalized}' ` +
+            `but '@${typeArg}' resolves to '${resolvedType.normalized}'. ` +
+            `Type mismatch — delete the existing definition or use a different name.`,
+        ),
+      };
+    }
+
+    return {
+      ok: true,
+      definition: existing.definition,
+      modelType: existing.type,
+      modelDef,
+      created: false,
+      definitionPath: deps.getDefinitionPath(
+        existing.type,
+        existing.definition.id,
+      ),
+      routedInputs: routed,
+    };
+  }
+
+  // Validate global arguments against schema
+  if (modelDef.globalArguments) {
+    const result = modelDef.globalArguments.safeParse(routed.globalArguments);
+    if (!result.success) {
+      const issues = result.error.issues.map((i: z.ZodIssue) => {
+        const path = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+        return `  ${path}${i.message}`;
+      }).join("\n");
+      return {
+        ok: false,
+        error: validationFailed(
+          `Invalid global arguments for type '${resolvedType.normalized}':\n${issues}`,
+        ),
+      };
+    }
+  }
+
+  // Auto-create the definition
+  const definition = Definition.create({
+    name: definitionName,
+    type: resolvedType.normalized,
+    typeVersion: modelDef.version,
+    globalArguments: routed.globalArguments,
+  });
+
+  await deps.saveDefinition(resolvedType, definition);
+
+  const definitionPath = deps.getDefinitionPath(resolvedType, definition.id);
+
+  return {
+    ok: true,
+    definition,
+    modelType: resolvedType,
+    modelDef,
+    created: true,
+    definitionPath,
+    routedInputs: routed,
+  };
+}

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -1,0 +1,276 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
+import {
+  resolveOrCreateDefinition,
+  routeInputsBySchema,
+} from "./direct_execution.ts";
+import type { ModelDefinition } from "../../domain/models/model.ts";
+import { Definition } from "../../domain/definitions/definition.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+
+function createTestModelDef(
+  globalArgs?: z.ZodTypeAny,
+  methodArgs?: Record<string, z.ZodTypeAny>,
+): ModelDefinition {
+  const methods: Record<string, {
+    description: string;
+    arguments: z.ZodTypeAny;
+    execute: () => Promise<{ dataHandles: [] }>;
+  }> = {};
+  for (const [name, args] of Object.entries(methodArgs ?? {})) {
+    methods[name] = {
+      description: `Test method ${name}`,
+      arguments: args,
+      execute: () => Promise.resolve({ dataHandles: [] }),
+    };
+  }
+  if (Object.keys(methods).length === 0) {
+    methods["run"] = {
+      description: "Default test method",
+      arguments: z.object({}),
+      execute: () => Promise.resolve({ dataHandles: [] }),
+    };
+  }
+  return {
+    type: "test/model",
+    version: "2026.01.01.1",
+    globalArguments: globalArgs,
+    methods,
+  } as unknown as ModelDefinition;
+}
+
+Deno.test("routeInputsBySchema: splits inputs between global and method args", () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string(), account: z.string() }),
+    { run: z.object({ instanceId: z.string() }) },
+  );
+
+  const result = routeInputsBySchema(
+    { region: "us-east-1", account: "123", instanceId: "i-abc" },
+    "run",
+    modelDef,
+  );
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.globalArguments, {
+      region: "us-east-1",
+      account: "123",
+    });
+    assertEquals(result.methodArguments, { instanceId: "i-abc" });
+  }
+});
+
+Deno.test("routeInputsBySchema: method args take precedence on ambiguous keys", () => {
+  const modelDef = createTestModelDef(
+    z.object({ name: z.string() }),
+    { run: z.object({ name: z.string() }) },
+  );
+
+  const result = routeInputsBySchema({ name: "test" }, "run", modelDef);
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.methodArguments, { name: "test" });
+    assertEquals(result.globalArguments, {});
+  }
+});
+
+Deno.test("routeInputsBySchema: rejects unknown keys", () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+
+  const result = routeInputsBySchema(
+    { region: "us-east-1", id: "123", bogus: "value" },
+    "run",
+    modelDef,
+  );
+
+  assertEquals("error" in result, true);
+  if ("error" in result) {
+    assertStringIncludes(result.error.message, "bogus");
+    assertStringIncludes(result.error.message, "Unknown input");
+  }
+});
+
+Deno.test("routeInputsBySchema: returns error for unknown method", () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({}) },
+  );
+
+  const result = routeInputsBySchema({}, "nonexistent", modelDef);
+
+  assertEquals("error" in result, true);
+  if ("error" in result) {
+    assertStringIncludes(result.error.message, "Unknown method");
+  }
+});
+
+Deno.test("routeInputsBySchema: handles no global args schema", () => {
+  const modelDef = createTestModelDef(
+    undefined,
+    { run: z.object({ id: z.string() }) },
+  );
+
+  const result = routeInputsBySchema({ id: "abc" }, "run", modelDef);
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.methodArguments, { id: "abc" });
+    assertEquals(result.globalArguments, {});
+  }
+});
+
+Deno.test("routeInputsBySchema: handles empty inputs", () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string().optional() }),
+    { run: z.object({}) },
+  );
+
+  const result = routeInputsBySchema({}, "run", modelDef);
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.methodArguments, {});
+    assertEquals(result.globalArguments, {});
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: auto-creates definition with routed globalArgs", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string(), account: z.string() }),
+    { deploy: z.object({ target: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/deploy");
+  let savedDefinition: Definition | null = null;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: (_type, def) => {
+        savedDefinition = def;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/deploy/${id}.yaml`,
+    },
+    "test/deploy",
+    "my-deployer",
+    "deploy",
+    { region: "us-east-1", account: "123456", target: "prod" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, true);
+    assertEquals(result.definition.name, "my-deployer");
+    assertEquals(result.routedInputs.globalArguments, {
+      region: "us-east-1",
+      account: "123456",
+    });
+    assertEquals(result.routedInputs.methodArguments, { target: "prod" });
+    assertEquals(savedDefinition !== null, true);
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: reuses existing definition with type match", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  const existingDef = Definition.create({
+    name: "existing-model",
+    type: "test/model",
+    typeVersion: "2026.01.01.1",
+    globalArguments: { region: "us-west-2" },
+  });
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({
+          definition: existingDef,
+          type: resolvedType,
+        }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => Promise.resolve(),
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "existing-model",
+    "run",
+    { region: "us-east-1", id: "abc" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, false);
+    assertEquals(result.definition.id, existingDef.id);
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: rejects type mismatch", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({}) },
+  );
+  const requestedType = ModelType.create("test/new-type");
+  const existingType = ModelType.create("test/old-type");
+  const existingDef = Definition.create({
+    name: "my-model",
+    type: "test/old-type",
+    typeVersion: "2026.01.01.1",
+  });
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({
+          definition: existingDef,
+          type: existingType,
+        }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => Promise.resolve(),
+      getDefinitionPath: (_type, id) => `/tmp/models/${id}.yaml`,
+    },
+    "test/new-type",
+    "my-model",
+    "run",
+    {},
+    requestedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertStringIncludes(result.error.message, "Type mismatch");
+    assertStringIncludes(result.error.message, "test/old-type");
+  }
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -86,6 +86,11 @@ export type ModelMethodRunEvent =
     definitionPath: string;
   }
   | {
+    kind: "global_args_ignored";
+    definitionName: string;
+    message: string;
+  }
+  | {
     kind: "model_resolved";
     modelName: string;
     modelType: string;
@@ -294,6 +299,17 @@ export async function* modelMethodRun(
             modelType: resolvedType.normalized,
             definitionName: result.definition.name,
             definitionPath: result.definitionPath,
+          };
+        }
+
+        if (result.globalArgsDiffer) {
+          yield {
+            kind: "global_args_ignored",
+            definitionName: result.definition.name,
+            message:
+              "Global argument inputs differ from the stored definition. " +
+              "The stored values are used. To update, delete the definition and re-run, " +
+              "or use 'model create' + 'model edit' for managed definitions.",
           };
         }
 

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -80,12 +80,8 @@ export type ModelMethodRunEvent =
   | { kind: "validating_inputs" }
   | { kind: "resolving_model"; modelIdOrName: string }
   | {
-    kind: "auto_creating";
+    kind: "auto_created";
     modelType: string;
-    definitionName: string;
-  }
-  | {
-    kind: "definition_created";
     definitionName: string;
     definitionPath: string;
   }
@@ -266,8 +262,7 @@ export async function* modelMethodRun(
             kind: "error",
             error: {
               code: "missing_deps",
-              message:
-                "Direct type execution requires createAndSaveDefinition and getDefinitionPath dependencies",
+              message: "Direct type execution is not supported in this context",
             },
           };
           return;
@@ -295,12 +290,8 @@ export async function* modelMethodRun(
 
         if (result.created) {
           yield {
-            kind: "auto_creating",
+            kind: "auto_created",
             modelType: resolvedType.normalized,
-            definitionName: input.definitionName,
-          };
-          yield {
-            kind: "definition_created",
             definitionName: result.definition.name,
             definitionPath: result.definitionPath,
           };
@@ -310,10 +301,12 @@ export async function* modelMethodRun(
         modelType = result.modelType;
         modelDef = result.modelDef;
 
-        // Override inputs with routed method arguments only
-        // (global args are already in the definition)
-        Object.keys(input.inputs).forEach((k) => delete input.inputs[k]);
-        Object.assign(input.inputs, result.routedInputs.methodArguments);
+        // Use routed method arguments as the inputs for downstream processing.
+        // Global args are already stored in the auto-created definition.
+        input = {
+          ...input,
+          inputs: { ...result.routedInputs.methodArguments },
+        };
       } else {
         // Standard path: look up existing definition
         const lookupResult = await deps.lookupDefinition(input.modelIdOrName);

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -35,7 +35,7 @@ import { buildOutputSpecs } from "../../domain/models/output_spec_builder.ts";
 import type { ReportResultView } from "./model_method_run_view.ts";
 import type { Definition } from "../../domain/definitions/definition.ts";
 import type { InputsSchema } from "../../domain/definitions/definition.ts";
-import type { ModelType } from "../../domain/models/model_type.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import type { ModelDefinition } from "../../domain/models/model.ts";
 import type { MethodExecutionService } from "../../domain/models/method_execution_service.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
@@ -65,6 +65,7 @@ import { withEventBridge } from "../../infrastructure/stream/event_bridge.ts";
 import type { MethodResult } from "../../domain/models/model.ts";
 import { getRunLogger } from "../../infrastructure/logging/logger.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { resolveOrCreateDefinition } from "./direct_execution.ts";
 
 /**
  * Events emitted by the libswamp model method run generator.
@@ -78,6 +79,16 @@ export interface EnvVarUsage {
 export type ModelMethodRunEvent =
   | { kind: "validating_inputs" }
   | { kind: "resolving_model"; modelIdOrName: string }
+  | {
+    kind: "auto_creating";
+    modelType: string;
+    definitionName: string;
+  }
+  | {
+    kind: "definition_created";
+    definitionName: string;
+    definitionPath: string;
+  }
   | {
     kind: "model_resolved";
     modelName: string;
@@ -175,6 +186,11 @@ export interface ModelMethodRunDeps {
     methodName: string,
     definitionId: string,
   ) => Promise<RunLog>;
+  createAndSaveDefinition?: (
+    type: ModelType,
+    definition: Definition,
+  ) => Promise<void>;
+  getDefinitionPath?: (type: ModelType, id: string) => string;
 }
 
 /**
@@ -185,6 +201,10 @@ export interface ModelMethodRunInput {
   methodName: string;
   inputs: Record<string, unknown>;
   lastEvaluated: boolean;
+  /** When present, enables direct type execution (auto-create-then-run). */
+  typeArg?: string;
+  /** Definition name for direct type execution (separate from modelIdOrName). */
+  definitionName?: string;
   runtimeTags?: Record<string, string>;
   skipCheckNames?: string[];
   skipCheckLabels?: string[];
@@ -219,18 +239,102 @@ export async function* modelMethodRun(
       // --- Resolve model ---
       yield { kind: "resolving_model", modelIdOrName: input.modelIdOrName };
 
-      const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
-      if (!lookupResult) {
-        yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
-        return;
-      }
-      const { definition, type: modelType } = lookupResult;
+      let definition: Definition;
+      let modelType: ModelType;
+      let modelDef: ModelDefinition;
 
-      // Get model definition from registry (may auto-resolve if async)
-      const modelDef = await Promise.resolve(deps.getModelDef(modelType));
-      if (!modelDef) {
-        yield { kind: "error", error: unknownModelType(modelType.normalized) };
-        return;
+      if (input.typeArg && input.definitionName) {
+        // Direct type execution path: auto-create-then-run
+        const typeArg = input.typeArg.startsWith("@")
+          ? input.typeArg.slice(1)
+          : input.typeArg;
+        const resolvedType = ModelType.create(typeArg);
+
+        const resolvedModelDef = await Promise.resolve(
+          deps.getModelDef(resolvedType),
+        );
+        if (!resolvedModelDef) {
+          yield {
+            kind: "error",
+            error: unknownModelType(resolvedType.normalized),
+          };
+          return;
+        }
+
+        if (!deps.createAndSaveDefinition || !deps.getDefinitionPath) {
+          yield {
+            kind: "error",
+            error: {
+              code: "missing_deps",
+              message:
+                "Direct type execution requires createAndSaveDefinition and getDefinitionPath dependencies",
+            },
+          };
+          return;
+        }
+
+        const result = await resolveOrCreateDefinition(
+          {
+            lookupDefinition: deps.lookupDefinition,
+            getModelDef: deps.getModelDef,
+            saveDefinition: deps.createAndSaveDefinition,
+            getDefinitionPath: deps.getDefinitionPath,
+          },
+          typeArg,
+          input.definitionName,
+          input.methodName,
+          input.inputs,
+          resolvedType,
+          resolvedModelDef,
+        );
+
+        if (!result.ok) {
+          yield { kind: "error", error: result.error };
+          return;
+        }
+
+        if (result.created) {
+          yield {
+            kind: "auto_creating",
+            modelType: resolvedType.normalized,
+            definitionName: input.definitionName,
+          };
+          yield {
+            kind: "definition_created",
+            definitionName: result.definition.name,
+            definitionPath: result.definitionPath,
+          };
+        }
+
+        definition = result.definition;
+        modelType = result.modelType;
+        modelDef = result.modelDef;
+
+        // Override inputs with routed method arguments only
+        // (global args are already in the definition)
+        Object.keys(input.inputs).forEach((k) => delete input.inputs[k]);
+        Object.assign(input.inputs, result.routedInputs.methodArguments);
+      } else {
+        // Standard path: look up existing definition
+        const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
+        if (!lookupResult) {
+          yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
+          return;
+        }
+        definition = lookupResult.definition;
+        modelType = lookupResult.type;
+
+        const resolvedModelDef = await Promise.resolve(
+          deps.getModelDef(modelType),
+        );
+        if (!resolvedModelDef) {
+          yield {
+            kind: "error",
+            error: unknownModelType(modelType.normalized),
+          };
+          return;
+        }
+        modelDef = resolvedModelDef;
       }
 
       // Validate method exists

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -61,6 +61,12 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
           { path: e.definitionPath },
         );
       },
+      global_args_ignored: (e) => {
+        getRunLogger(this.modelName, this.methodName).warn(
+          "{message}",
+          { message: e.message },
+        );
+      },
       model_resolved: (e) => {
         this.modelName = e.modelName;
         this.methodName = e.methodName;
@@ -186,10 +192,17 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       resolving_model: () => {},
       auto_created: (e) => {
         console.log(JSON.stringify({
-          event: "definition_auto_created",
+          warning: "definition_auto_created",
           modelType: e.modelType,
           definitionName: e.definitionName,
           definitionPath: e.definitionPath,
+        }));
+      },
+      global_args_ignored: (e) => {
+        console.log(JSON.stringify({
+          warning: "global_args_ignored",
+          definitionName: e.definitionName,
+          message: e.message,
         }));
       },
       model_resolved: () => {},

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -50,16 +50,15 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
     return {
       validating_inputs: () => {},
       resolving_model: () => {},
-      auto_creating: (e) => {
-        getRunLogger(this.modelName, this.methodName).info(
-          "Auto-creating definition {name} (type: {type})",
+      auto_created: (e) => {
+        const logger = getRunLogger(this.modelName, this.methodName);
+        logger.info(
+          "Auto-created definition {name} (type: {type})",
           { name: e.definitionName, type: e.modelType },
         );
-      },
-      definition_created: (e) => {
-        getRunLogger(this.modelName, this.methodName).info(
+        logger.info(
           "Definition created at {path}",
-          { path: e.definitionPath, name: e.definitionName },
+          { path: e.definitionPath },
         );
       },
       model_resolved: (e) => {
@@ -185,8 +184,14 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
     return {
       validating_inputs: () => {},
       resolving_model: () => {},
-      auto_creating: () => {},
-      definition_created: () => {},
+      auto_created: (e) => {
+        console.log(JSON.stringify({
+          event: "definition_auto_created",
+          modelType: e.modelType,
+          definitionName: e.definitionName,
+          definitionPath: e.definitionPath,
+        }));
+      },
       model_resolved: () => {},
       env_var_warning: (e) => {
         console.log(JSON.stringify(

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -50,6 +50,18 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
     return {
       validating_inputs: () => {},
       resolving_model: () => {},
+      auto_creating: (e) => {
+        getRunLogger(this.modelName, this.methodName).info(
+          "Auto-creating definition {name} (type: {type})",
+          { name: e.definitionName, type: e.modelType },
+        );
+      },
+      definition_created: (e) => {
+        getRunLogger(this.modelName, this.methodName).info(
+          "Definition created at {path}",
+          { path: e.definitionPath, name: e.definitionName },
+        );
+      },
       model_resolved: (e) => {
         this.modelName = e.modelName;
         this.methodName = e.methodName;
@@ -173,6 +185,8 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
     return {
       validating_inputs: () => {},
       resolving_model: () => {},
+      auto_creating: () => {},
+      definition_created: () => {},
       model_resolved: () => {},
       env_var_warning: (e) => {
         console.log(JSON.stringify(


### PR DESCRIPTION
## Summary

Adds direct type execution for both CLI and workflows, enabling users to skip the explicit `model create` step when all values come from `--input` at runtime.

- **CLI**: `swamp model @type method run <method> <name> --input k=v`
- **Workflow**: `modelType` + `modelName` as a mutually exclusive alternative to `modelIdOrName`
- Auto-created definitions stored in `.swamp/auto-definitions/` (not `models/`)
- Excluded from `model search`, findable by `model get`, synced via datastores
- Input routing splits `--input` values between globalArguments and method arguments using the type's Zod schemas

Closes swamp-club#302

## Architecture

```
CLI: swamp model @type method run <method> <name> --input k=v
  → arg rewriter (moves @type after run for Cliffy)
  → model method run with 3 positionals
  → modelMethodRun generator → direct_execution.ts → auto-create + run

Workflow YAML:
  task:
    type: model_method
    modelType: "@test/greeter"    # mutually exclusive with modelIdOrName
    modelName: my-greeter
    methodName: greet
    inputs: { greeting: Hello, name: World }
  → execution_service → direct_execution.ts → auto-create + run
```

### Key Design Decisions

1. **Two definition paths, clean separation**: `model create` → `models/` (git-tracked, deliberate). Direct type execution → `.swamp/auto-definitions/` (runtime state, not in git).
2. **Mutually exclusive workflow schema**: `modelIdOrName` OR `modelType` + `modelName`, never both. Schema validation enforces with clear error messages.
3. **Input routing by Zod schemas**: Method args take precedence on ambiguous keys. Unknown keys rejected with error listing valid inputs.
4. **Datastore sync**: `.swamp/auto-definitions/` is in `DEFAULT_DATASTORE_SUBDIRS` so team members share auto-created definitions.

## Files Changed (23)

### New Files (6)
- `src/cli/arg_rewriter.ts` — rewrites `model @type method run` → `model method run @type`
- `src/cli/arg_rewriter_test.ts` — 10 tests
- `src/libswamp/models/direct_execution.ts` — shared `routeInputsBySchema` + `resolveOrCreateDefinition`
- `src/libswamp/models/direct_execution_test.ts` — 9 tests
- `.claude/skills/swamp-model/references/direct-execution.md`
- `.claude/skills/swamp-workflow/references/direct-execution.md`

### Modified Files (17)
- `src/cli/mod.ts` — wire arg rewriter into `runCli()`
- `src/cli/commands/model_method_run.ts` — 2/3 positional args, wire direct execution deps
- `src/libswamp/models/run.ts` — direct execution path in `modelMethodRun` generator, new events
- `src/presentation/renderers/model_method_run.ts` — handle `auto_creating` + `definition_created` events
- `src/infrastructure/persistence/paths.ts` — add `autoDefinitions` to `SWAMP_SUBDIRS`
- `src/infrastructure/persistence/yaml_definition_repository.ts` — automatic secondary search path
- `src/domain/workflows/step_task.ts` — `modelType` + `modelName` fields, mutual exclusivity
- `src/domain/workflows/execution_service.ts` — direct type execution in workflow steps
- `src/domain/workflows/validation_service.ts` — handle optional `modelIdOrName`
- `src/domain/workflows/model_reference_extractor.ts` — handle `modelName` references
- `src/domain/datastore/datastore_config.ts` — add `auto-definitions` to `DEFAULT_DATASTORE_SUBDIRS`
- `src/domain/summary/summary_service.ts` — handle optional `modelIdOrName`
- `design/models.md`, `design/inputs.md`, `design/workflow.md` — document new features
- `.claude/skills/swamp-model/SKILL.md`, `.claude/skills/swamp-workflow/SKILL.md` — document new syntax

## End-to-End Verification

All verification performed with the compiled binary against scratch repos.

### CLI Direct Type Execution
| Test | Result |
|---|---|
| `swamp model @command/shell method run execute my-shell --input run="echo hello"` | ✅ Auto-created in `.swamp/auto-definitions/`, method executed |
| Second run of same command | ✅ Reused existing definition (no duplicate), data version incremented |
| `swamp model search` after auto-create | ✅ Auto-created definition NOT listed |
| `swamp model get direct-echo` | ✅ Found in `.swamp/auto-definitions/` |
| Log messages on first vs subsequent run | ✅ "Auto-creating" + "Definition created" on first; "Found model" only on second |

### Input Routing (custom `test/greeter` extension with both globalArgs and methodArgs)
| Test | Result |
|---|---|
| `--input greeting=Hello --input language=en --input name=World --input loud:json=false` | ✅ greeting/language → globalArgs, name/loud → methodArgs |
| Definition stores routed globalArgs | ✅ `model get` shows `globalArguments: { greeting: "Hello", language: "en" }` |
| Data output combines both correctly | ✅ `"message": "Hello, World! [en]"` |
| Unknown input key (`--input bogus=value`) | ✅ Rejected: "Unknown input(s): bogus. Valid inputs are: name, loud, greeting, language" |

### Workflow with modelIdOrName (existing behavior)
| Test | Result |
|---|---|
| Workflow with `modelIdOrName: traditional-echo` | ✅ Succeeded |
| `--last-evaluated` flag | ✅ Succeeded |

### Workflow with modelType + modelName (direct type execution)
| Test | Result |
|---|---|
| Workflow with `modelType: "@command/shell"` + `modelName: wf-direct-echo` | ✅ Auto-created and executed |
| Second workflow run (no duplicate definitions) | ✅ Same definition reused, data version incremented |
| Workflow with `modelType: "@test/greeter"` + input routing | ✅ `Hola, Mundo! [es]` — routing correct |
| CLI `--input` → workflow `${{ inputs.* }}` → modelType step | ✅ `Bonjour, Claude! [fr]` — full chain works |
| `--last-evaluated` flag with modelType workflow | ✅ Succeeded |

### Workflow Validation
| Test | Result |
|---|---|
| `workflow validate` with `modelIdOrName` | ✅ 8/8 passed |
| `workflow validate` with `modelType` + `modelName` | ✅ 8/8 passed |
| Both `modelIdOrName` AND `modelType` (invalid) | ✅ Rejected: "Use either modelIdOrName or modelType + modelName, not both" |
| `modelType` without `modelName` (invalid) | ✅ Rejected: "modelType requires modelName" |
| Neither field present (invalid) | ✅ Rejected: "requires either modelIdOrName or modelType + modelName" |

### Automated Test Suites
| Suite | Result |
|---|---|
| `deno check` (full type check) | ✅ Zero errors |
| `deno lint` | ✅ Zero errors |
| `deno fmt` | ✅ Clean |
| `deno run test` (5717 tests) | ✅ All pass (1 pre-existing integration test failure unrelated) |
| `deno run compile` | ✅ Binary built |
| UAT CLI (414 tests) | ✅ All pass |
| UAT Adversarial (109 tests) | ✅ 104 pass, 5 pre-existing failures (workflow_concurrency_test.ts) |
| tessl skill review (swamp-model) | ✅ 93% |
| tessl skill review (swamp-workflow) | ✅ 93% |

## Follow-up Issues Filed

- **swamp-club #306** — Docs: Update model-definitions.md and workflows.md for direct type execution
- **swamp-uat #202** — UAT: Direct type execution for CLI and workflow steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)