### PR TITLE
fix(models): review follow-ups for direct type execution (swamp-club#302)

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -159,11 +159,6 @@ export const modelMethodRunCommand = new Command()
       definitionNameArg?: string,
     ) {
       const isDirectExecution = modelOrType.startsWith("@");
-      const typeArg = isDirectExecution ? modelOrType : undefined;
-      const modelIdOrName = isDirectExecution
-        ? (definitionNameArg ?? methodName)
-        : modelOrType;
-      const definitionName = isDirectExecution ? definitionNameArg : undefined;
 
       if (isDirectExecution && !definitionNameArg) {
         throw new UserError(
@@ -171,6 +166,12 @@ export const modelMethodRunCommand = new Command()
             `swamp model ${modelOrType} method run ${methodName} <name>`,
         );
       }
+
+      const typeArg = isDirectExecution ? modelOrType : undefined;
+      const modelIdOrName = isDirectExecution
+        ? definitionNameArg!
+        : modelOrType;
+      const definitionName = isDirectExecution ? definitionNameArg : undefined;
       const ctx = createContext(options as GlobalOptions, [
         "model",
         "method",

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -32,7 +32,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 export const VERSION = "20260206.200442.0-sha.";
 
 // Git sha baked at compile time; falls back to runtime detection
-export const GIT_SHA = "0043013b";
+export const GIT_SHA = "";
 
 export function getVersionData(): VersionData {
   return { version: VERSION };

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -425,3 +425,138 @@ Deno.test("YamlDefinitionRepository.findAll rejects symlink pointing outside rep
     }
   });
 });
+
+// Secondary search path tests
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal finds definition in secondary dir", async () => {
+  await withTempDir(async (dir) => {
+    const primaryDir = join(dir, "models");
+    const secondaryDir = join(dir, ".swamp", "auto-definitions");
+    const repo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      secondaryDir,
+    );
+
+    // Save to secondary dir directly
+    const secondaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      secondaryDir,
+      false,
+    );
+    const def = createTestDefinition("auto-created-def");
+    await secondaryRepo.save(testType, def);
+
+    // Primary repo should find it via secondary search
+    const found = await repo.findByNameGlobal("auto-created-def");
+    assertNotEquals(found, null);
+    assertEquals(found!.definition.name, "auto-created-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findByNameGlobal prefers primary over secondary", async () => {
+  await withTempDir(async (dir) => {
+    const primaryDir = join(dir, "models");
+    const secondaryDir = join(dir, ".swamp", "auto-definitions");
+    const repo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      secondaryDir,
+    );
+
+    // Save different definitions with the same name to both dirs
+    const primaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      false,
+    );
+    const secondaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      secondaryDir,
+      false,
+    );
+
+    const primaryDef = Definition.create({
+      name: "shared-name",
+      globalArguments: { source: "primary" },
+    });
+    const secondaryDef = Definition.create({
+      name: "shared-name",
+      globalArguments: { source: "secondary" },
+    });
+
+    await primaryRepo.save(testType, primaryDef);
+    await secondaryRepo.save(testType, secondaryDef);
+
+    // Should find the primary one
+    const found = await repo.findByNameGlobal("shared-name");
+    assertNotEquals(found, null);
+    assertEquals(found!.definition.id, primaryDef.id);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findAllGlobal excludes secondary dir", async () => {
+  await withTempDir(async (dir) => {
+    const primaryDir = join(dir, "models");
+    const secondaryDir = join(dir, ".swamp", "auto-definitions");
+    const repo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      secondaryDir,
+    );
+
+    const primaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      false,
+    );
+    const secondaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      secondaryDir,
+      false,
+    );
+
+    await primaryRepo.save(testType, createTestDefinition("primary-def"));
+    await secondaryRepo.save(testType, createTestDefinition("auto-def"));
+
+    // findAllGlobal should only return primary
+    const all = await repo.findAllGlobal();
+    assertEquals(all.length, 1);
+    assertEquals(all[0].definition.name, "primary-def");
+  });
+});
+
+Deno.test("YamlDefinitionRepository.findById falls back to secondary dir", async () => {
+  await withTempDir(async (dir) => {
+    const primaryDir = join(dir, "models");
+    const secondaryDir = join(dir, ".swamp", "auto-definitions");
+    const repo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      primaryDir,
+      secondaryDir,
+    );
+
+    const secondaryRepo = new YamlDefinitionRepository(
+      dir,
+      undefined,
+      secondaryDir,
+      false,
+    );
+    const def = createTestDefinition("by-id-def");
+    await secondaryRepo.save(testType, def);
+
+    // Should find by ID in secondary
+    const found = await repo.findById(testType, def.id);
+    assertNotEquals(found, null);
+    assertEquals(found!.name, "by-id-def");
+  });
+});

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -161,10 +161,13 @@ export async function resolveOrCreateDefinition(
       };
     }
 
-    const storedGlobal = existing.definition.globalArguments;
+    const storedGlobal = existing.definition
+      .globalArguments as Record<string, unknown>;
     const routedGlobal = routed.globalArguments;
     const globalArgsDiffer = Object.keys(routedGlobal).length > 0 &&
-      JSON.stringify(storedGlobal) !== JSON.stringify(routedGlobal);
+      !Object.entries(routedGlobal).every(([k, v]) =>
+        JSON.stringify(storedGlobal?.[k]) === JSON.stringify(v)
+      );
 
     return {
       ok: true,

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -192,7 +192,7 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       resolving_model: () => {},
       auto_created: (e) => {
         console.log(JSON.stringify({
-          warning: "definition_auto_created",
+          event: "definition_auto_created",
           modelType: e.modelType,
           definitionName: e.definitionName,
           definitionPath: e.definitionPath,


### PR DESCRIPTION
## Summary

Addresses third round of review feedback on the direct type execution feature (#1352).

- Reset `GIT_SHA` to `""` (was hardcoded from compile during verification)
- Fix key-order-dependent global args comparison — use entry-by-entry instead of `JSON.stringify` to avoid false "global args differ" warnings when `--input` order changes
- Move direct execution guard before variable assignment — eliminate dead `?? methodName` fallback
- Use `"event"` key for `auto_created` JSON output instead of `"warning"` — creation is success, not a warning
- Add 4 unit tests for `YamlDefinitionRepository` secondary search path: `findByNameGlobal` fallback, primary-over-secondary priority, `findAllGlobal` exclusion, `findById` fallback

## Test plan

- [ ] 19 repository tests pass (15 existing + 4 new)
- [ ] All existing unit tests unaffected
- [ ] No functionality changes — correctness fixes and test coverage only

🤖 Generated with [Claude Code](https://claude.com/claude-code)