### PR TITLE
fix(extensions): preserve binaries field in push archive manifest (swamp-club#309)

### DIFF
--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -1054,6 +1054,9 @@ async function createArchive(
           ? { include: input.manifest.include }
           : {}),
         additionalFiles: input.manifest.additionalFiles,
+        ...(input.manifest.binaries.length > 0
+          ? { binaries: input.manifest.binaries }
+          : {}),
         ...(input.manifest.platforms.length > 0
           ? { platforms: input.manifest.platforms }
           : {}),

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -322,3 +322,72 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "round-trip: binaries field survives push → extract in archive manifest",
+  async () => {
+    const { parse: parseYaml } = await import("@std/yaml");
+    const src = await Deno.makeTempDir({ prefix: "rt-bin-src-" });
+    const dst = await Deno.makeTempDir({ prefix: "rt-bin-dst-" });
+    try {
+      const modelsDir = join(src, "extensions", "models");
+      await Deno.mkdir(modelsDir, { recursive: true });
+      await Deno.writeTextFile(
+        join(modelsDir, "echo.ts"),
+        'export const model = { type: "@t/e", version: "1.0.0" };',
+      );
+      await Deno.mkdir(join(src, "bin"), { recursive: true });
+      await Deno.writeTextFile(join(src, "bin", "helper"), "#!/bin/sh\nexit 0");
+
+      const manifest = makeManifest({
+        binaries: ["bin/helper"],
+        additionalFiles: [],
+      });
+      const input: ExtensionPushPrepareInput = {
+        manifest,
+        repoDir: src,
+        modelsDir,
+        allModelFiles: [join(modelsDir, "echo.ts")],
+        modelEntryPoints: [join(modelsDir, "echo.ts")],
+        vaultsDir: join(src, "vaults"),
+        allVaultFiles: [],
+        vaultEntryPoints: [],
+        driversDir: join(src, "drivers"),
+        allDriverFiles: [],
+        driverEntryPoints: [],
+        datastoresDir: join(src, "datastores"),
+        allDatastoreFiles: [],
+        datastoreEntryPoints: [],
+        reportsDir: join(src, "reports"),
+        allReportFiles: [],
+        reportEntryPoints: [],
+        workflowFiles: [],
+        skillDirs: [],
+        allSkillFiles: [],
+        includeFilePaths: [],
+        additionalFilePaths: [],
+        binaryFilePaths: [join(src, "bin", "helper")],
+        dryRun: true,
+      };
+
+      const ctx = createLibSwampContext();
+      const prepared = await extensionPushPrepare(
+        ctx,
+        makePrepareDeps(),
+        input,
+      );
+
+      await untarArchiveTo(prepared.archiveBytes, dst);
+
+      const onWire = parseYaml(
+        await Deno.readTextFile(join(dst, "extension", "manifest.yaml")),
+      ) as Record<string, unknown>;
+      assertEquals(onWire.binaries, ["bin/helper"]);
+
+      await Deno.stat(join(dst, "extension", "files", "bin", "helper"));
+    } finally {
+      await Deno.remove(src, { recursive: true });
+      await Deno.remove(dst, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- `swamp extension push` was dropping the `binaries:` field from the re-emitted archive `manifest.yaml`, causing pull-side consumers to miss the security warning and `chmod 0o755` step
- Added the missing `binaries` conditional spread to the `stringifyYaml` call in `push.ts`, matching the existing pattern for `skills`, `include`, `platforms`, and `labels`
- Added a round-trip regression test asserting `binaries` survives push → extract in both the manifest YAML and the file tree

Fixes https://swamp-club.com/lab/issues/309

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] New round-trip test verifies `binaries` field in archive manifest and binary file presence under `extension/files/`
- [x] Verified against reproduction at `/tmp/swamp-repro-issue-309` with compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)