### PR TITLE
fix(extensions): purge catalog rows on extension source rm (swamp-club#310)

### DIFF
--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -22,16 +22,22 @@ import { notFound, validationFailed } from "../errors.ts";
 import type { SourceModifyEvent } from "./source_events.ts";
 import type { SwampSourcesConfig } from "../../domain/repo/swamp_sources.ts";
 import {
+  expandSourcePaths,
   readSwampSources,
   removeSwampSources,
   writeSwampSources,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { existsSync } from "@std/fs/exists";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 
 /** Dependencies for the source remove operation. */
 export interface SourceRemoveDeps {
   readSources: () => Promise<SwampSourcesConfig | null>;
   writeSources: (config: SwampSourcesConfig) => Promise<void>;
   removeSources: () => Promise<void>;
+  purgeCatalogByPrefix: (prefix: string) => number;
+  expandPath: (path: string) => Promise<string[]>;
 }
 
 /** Wires real infrastructure into SourceRemoveDeps. */
@@ -40,6 +46,23 @@ export function createSourceRemoveDeps(repoDir: string): SourceRemoveDeps {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
     removeSources: () => removeSwampSources(repoDir),
+    purgeCatalogByPrefix: (prefix: string) => {
+      const dbPath = swampPath(repoDir, "_extension_catalog.db");
+      if (!existsSync(dbPath)) return 0;
+      const catalog = new ExtensionCatalogStore(dbPath);
+      try {
+        return catalog.removeBySourcePrefix(prefix);
+      } finally {
+        catalog.close();
+      }
+    },
+    expandPath: async (path: string) => {
+      const expanded = await expandSourcePaths(
+        { sources: [{ path }] },
+        repoDir,
+      );
+      return expanded.map((s) => s.path);
+    },
   };
 }
 
@@ -75,10 +98,15 @@ export async function* sourceRemove(
   const updated = existing.sources.filter((_, i) => i !== idx);
 
   if (updated.length === 0) {
-    // Last source removed — delete the file entirely
     await deps.removeSources();
   } else {
     await deps.writeSources({ sources: updated });
+  }
+
+  // Purge stale catalog rows contributed by the removed source.
+  const expandedPaths = await deps.expandPath(removed.path);
+  for (const expandedPath of expandedPaths) {
+    deps.purgeCatalogByPrefix(expandedPath);
   }
 
   yield {

--- a/src/libswamp/sources/remove_test.ts
+++ b/src/libswamp/sources/remove_test.ts
@@ -25,10 +25,15 @@ import type { SourceModifyEvent } from "./source_events.ts";
 
 function createTestDeps(
   existing: SwampSourcesConfig | null = null,
-): SourceRemoveDeps & { written: SwampSourcesConfig | null; removed: boolean } {
+): SourceRemoveDeps & {
+  written: SwampSourcesConfig | null;
+  removed: boolean;
+  purgedPrefixes: string[];
+} {
   const state = {
     written: null as SwampSourcesConfig | null,
     removed: false,
+    purgedPrefixes: [] as string[],
   };
   return {
     readSources: () => Promise.resolve(existing),
@@ -40,11 +45,19 @@ function createTestDeps(
       state.removed = true;
       return Promise.resolve();
     },
+    purgeCatalogByPrefix: (prefix: string) => {
+      state.purgedPrefixes.push(prefix);
+      return 1;
+    },
+    expandPath: (path: string) => Promise.resolve([path]),
     get written() {
       return state.written;
     },
     get removed() {
       return state.removed;
+    },
+    get purgedPrefixes() {
+      return state.purgedPrefixes;
     },
   };
 }
@@ -119,4 +132,76 @@ Deno.test("sourceRemove: errors when no sources configured", async () => {
 
   const error = events.find((e) => e.kind === "error");
   assertEquals(error?.kind, "error");
+});
+
+Deno.test("sourceRemove: purges catalog rows for removed source", async () => {
+  const deps = createTestDeps({
+    sources: [
+      { path: "~/code/ext-a" },
+      { path: "~/code/ext-b" },
+    ],
+  });
+  await collectEvents(sourceRemove(ctx, deps, "~/code/ext-a"));
+
+  assertEquals(deps.purgedPrefixes, ["~/code/ext-a"]);
+});
+
+Deno.test("sourceRemove: purges catalog for last source removed", async () => {
+  const deps = createTestDeps({
+    sources: [{ path: "/abs/path/extensions" }],
+  });
+  await collectEvents(sourceRemove(ctx, deps, "/abs/path/extensions"));
+
+  assertEquals(deps.purgedPrefixes, ["/abs/path/extensions"]);
+});
+
+Deno.test("sourceRemove: does not purge catalog on error path", async () => {
+  const deps = createTestDeps({
+    sources: [{ path: "~/code/existing" }],
+  });
+  await collectEvents(sourceRemove(ctx, deps, "~/code/nonexistent"));
+
+  assertEquals(deps.purgedPrefixes, []);
+});
+
+Deno.test("sourceRemove: purges multiple expanded paths from glob source", async () => {
+  const state = {
+    written: null as SwampSourcesConfig | null,
+    removed: false,
+    purgedPrefixes: [] as string[],
+  };
+  const deps: SourceRemoveDeps & {
+    written: SwampSourcesConfig | null;
+    removed: boolean;
+    purgedPrefixes: string[];
+  } = {
+    readSources: () => Promise.resolve({ sources: [{ path: "~/code/ext-*" }] }),
+    writeSources: (_config) => {
+      state.written = _config;
+      return Promise.resolve();
+    },
+    removeSources: () => {
+      state.removed = true;
+      return Promise.resolve();
+    },
+    purgeCatalogByPrefix: (prefix: string) => {
+      state.purgedPrefixes.push(prefix);
+      return 1;
+    },
+    expandPath: () =>
+      Promise.resolve(["/expanded/ext-one", "/expanded/ext-two"]),
+    get written() {
+      return state.written;
+    },
+    get removed() {
+      return state.removed;
+    },
+    get purgedPrefixes() {
+      return state.purgedPrefixes;
+    },
+  };
+
+  await collectEvents(sourceRemove(ctx, deps, "~/code/ext-*"));
+
+  assertEquals(deps.purgedPrefixes, ["/expanded/ext-one", "/expanded/ext-two"]);
 });


### PR DESCRIPTION
## Summary

- `swamp extension source rm` now purges stale `bundle_types` rows from `_extension_catalog.db` after removing the source from `.swamp-sources.yaml`
- Expands the source path to absolute form before purging, handling globs and relative paths correctly
- Guards against missing catalog DB (fresh repos that never reconciled) with a file-exists check

Fixes swamp-club#310 — previously, orphaned `@local/.<repo>` rows caused `DuplicateTypeError` on subsequent `swamp extension pull`, blocking the user with no clean recovery path.

## Test Plan

- [x] Unit tests: 4 new tests covering purge on remove, purge on last-source remove, no purge on error path, and glob expansion
- [x] Manual verification: reproduced the bug in a scratch repo, confirmed stale rows are purged after the fix
- [x] Full test suite passes (5764 tests, 0 failures)
- [x] Type checking, linting, and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)