### PR TITLE
fix(tracing): wire up W3C trace context propagation (swamp-club#317)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -24,13 +24,14 @@ import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_s
 import { getOutputModeFromArgs } from "./src/cli/context.ts";
 import {
   initTracing,
+  runWithParentTrace,
   shutdownTracing,
 } from "./src/infrastructure/tracing/mod.ts";
 
 if (import.meta.main) {
-  await initTracing();
+  const parentCtx = await initTracing();
   try {
-    await runCli(Deno.args);
+    await runWithParentTrace(parentCtx, () => runCli(Deno.args));
   } catch (error) {
     // Release datastore lock if still held (safety net for uncaught errors)
     await flushDatastoreSync();

--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -37,6 +37,14 @@ import {
 } from "../models/data_writer.ts";
 import { DataAccessService } from "../data/data_access_service.ts";
 
+function restoreEnv(key: string, saved: string | undefined): void {
+  if (saved !== undefined) {
+    Deno.env.set(key, saved);
+  } else {
+    Deno.env.delete(key);
+  }
+}
+
 /**
  * Interface for the execute method of MethodExecutionService.
  * Allows RawExecutionDriver to delegate argument validation and
@@ -79,7 +87,7 @@ export class RawExecutionDriver implements ExecutionDriver {
   ) {}
 
   async execute(
-    _request: ExecutionRequest,
+    request: ExecutionRequest,
     _callbacks?: ExecutionCallbacks,
   ): Promise<ExecutionResult> {
     const start = performance.now();
@@ -160,7 +168,15 @@ export class RawExecutionDriver implements ExecutionDriver {
       createFileWriter,
     };
 
+    const savedTraceparent = Deno.env.get("TRACEPARENT");
+    const savedTracestate = Deno.env.get("TRACESTATE");
     try {
+      if (request.traceHeaders) {
+        for (const [key, value] of Object.entries(request.traceHeaders)) {
+          Deno.env.set(key.toUpperCase().replace(/-/g, "_"), value);
+        }
+      }
+
       const result = await this.executor.execute(
         this.definition,
         this.method,
@@ -208,6 +224,9 @@ export class RawExecutionDriver implements ExecutionDriver {
         logs,
         durationMs,
       };
+    } finally {
+      restoreEnv("TRACEPARENT", savedTraceparent);
+      restoreEnv("TRACESTATE", savedTracestate);
     }
   }
 }

--- a/src/domain/drivers/raw_execution_driver_test.ts
+++ b/src/domain/drivers/raw_execution_driver_test.ts
@@ -444,3 +444,67 @@ Deno.test("RawExecutionDriver: explicit queryData wins over dataQueryService der
   assertEquals(usedExplicit, true);
   assertEquals(usedDerived, false);
 });
+
+Deno.test("RawExecutionDriver: sets TRACEPARENT env var from traceHeaders during execution", async () => {
+  let capturedTraceparent: string | undefined;
+  const originalTraceparent = Deno.env.get("TRACEPARENT");
+
+  const executor: MethodExecutor = {
+    execute: () => {
+      capturedTraceparent = Deno.env.get("TRACEPARENT");
+      return Promise.resolve({});
+    },
+  };
+
+  const context = createMockContext();
+
+  const driver = new RawExecutionDriver(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  const request = createMockRequest();
+  request.traceHeaders = {
+    traceparent: "00-abc123-def456-01",
+  };
+
+  await driver.execute(request);
+
+  assertEquals(capturedTraceparent, "00-abc123-def456-01");
+  assertEquals(Deno.env.get("TRACEPARENT"), originalTraceparent);
+});
+
+Deno.test("RawExecutionDriver: restores TRACEPARENT env var after execution error", async () => {
+  const originalTraceparent = Deno.env.get("TRACEPARENT");
+
+  const executor: MethodExecutor = {
+    execute: () => {
+      throw new Error("boom");
+    },
+  };
+
+  const context = createMockContext();
+
+  const driver = new RawExecutionDriver(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  const request = createMockRequest();
+  request.traceHeaders = {
+    traceparent: "00-abc123-def456-01",
+  };
+
+  const result = await driver.execute(request);
+
+  assertEquals(result.status, "error");
+  assertEquals(Deno.env.get("TRACEPARENT"), originalTraceparent);
+});

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { Context } from "@opentelemetry/api";
+
 /** Handle to the provider so we can flush on shutdown. */
 let providerRef: { shutdown(): Promise<void> } | undefined;
 
@@ -27,13 +29,13 @@ let providerRef: { shutdown(): Promise<void> } | undefined;
  * tracing is disabled. `@opentelemetry/api` is statically imported because it
  * returns no-op implementations by default.
  */
-export async function initTracing(): Promise<void> {
+export async function initTracing(): Promise<Context | undefined> {
   const endpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
   const exporterKind = Deno.env.get("OTEL_TRACES_EXPORTER") ?? "otlp";
 
   if (!endpoint && exporterKind !== "console") {
     // No endpoint configured and not console mode — tracing stays disabled.
-    return;
+    return undefined;
   }
 
   // Dynamic imports — only loaded when tracing is actually enabled.
@@ -107,7 +109,26 @@ export async function initTracing(): Promise<void> {
   // Register as global tracer provider
   provider.register();
 
+  // Register W3C propagator so inject/extract produce real traceparent headers.
+  const { W3CTraceContextPropagator } = await import("@opentelemetry/core");
+  contextApi.propagation.setGlobalPropagator(
+    new W3CTraceContextPropagator(),
+  );
+
   providerRef = provider;
+
+  // Extract inbound TRACEPARENT from the parent process, if present.
+  const traceparent = Deno.env.get("TRACEPARENT");
+  if (traceparent) {
+    const headers: Record<string, string> = { traceparent };
+    const tracestate = Deno.env.get("TRACESTATE");
+    if (tracestate) headers.tracestate = tracestate;
+    return contextApi.propagation.extract(
+      contextApi.context.active(),
+      headers,
+    );
+  }
+  return undefined;
 }
 
 /**
@@ -123,8 +144,9 @@ export async function shutdownTracing(): Promise<void> {
     }
     providerRef = undefined;
 
-    // Disable the global context manager
+    // Disable global context manager and propagator
     const contextApi = await import("@opentelemetry/api");
     contextApi.context.disable();
+    contextApi.propagation.disable();
   }
 }

--- a/src/infrastructure/tracing/otel_init_test.ts
+++ b/src/infrastructure/tracing/otel_init_test.ts
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { trace } from "@opentelemetry/api";
+import { assertEquals, assertExists } from "@std/assert";
+import { propagation, trace } from "@opentelemetry/api";
 import { initTracing, shutdownTracing } from "./otel_init.ts";
 
 Deno.test("initTracing: no-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set", async () => {
@@ -29,7 +29,8 @@ Deno.test("initTracing: no-op when OTEL_EXPORTER_OTLP_ENDPOINT is not set", asyn
     Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
     Deno.env.delete("OTEL_TRACES_EXPORTER");
 
-    await initTracing();
+    const parentCtx = await initTracing();
+    assertEquals(parentCtx, undefined);
 
     // Tracer should return a no-op tracer (no provider registered)
     const tracer = trace.getTracer("test");
@@ -73,6 +74,102 @@ Deno.test("initTracing: initializes when OTEL_TRACES_EXPORTER=console", async ()
       Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
     } else {
       Deno.env.delete("OTEL_TRACES_EXPORTER");
+    }
+  }
+});
+
+Deno.test("initTracing: W3C propagator is registered (inject/extract roundtrip)", async () => {
+  const originalEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
+  try {
+    Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.set("OTEL_TRACES_EXPORTER", "console");
+
+    await initTracing();
+
+    const carrier: Record<string, string> = {};
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("roundtrip");
+    const { context } = await import("@opentelemetry/api");
+    const activeCtx = trace.setSpan(context.active(), span);
+    propagation.inject(activeCtx, carrier);
+    span.end();
+
+    assertEquals(typeof carrier.traceparent, "string");
+    assertEquals(carrier.traceparent.startsWith("00-"), true);
+
+    await shutdownTracing();
+  } finally {
+    if (originalEndpoint) {
+      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", originalEndpoint);
+    }
+    if (originalExporter) {
+      Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    } else {
+      Deno.env.delete("OTEL_TRACES_EXPORTER");
+    }
+  }
+});
+
+Deno.test("initTracing: extracts inbound TRACEPARENT from environment", async () => {
+  const originalEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
+  const originalTraceparent = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.set("OTEL_TRACES_EXPORTER", "console");
+    Deno.env.set(
+      "TRACEPARENT",
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    );
+
+    const parentCtx = await initTracing();
+    assertExists(parentCtx);
+
+    await shutdownTracing();
+  } finally {
+    if (originalEndpoint) {
+      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", originalEndpoint);
+    }
+    if (originalExporter) {
+      Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    } else {
+      Deno.env.delete("OTEL_TRACES_EXPORTER");
+    }
+    if (originalTraceparent) {
+      Deno.env.set("TRACEPARENT", originalTraceparent);
+    } else {
+      Deno.env.delete("TRACEPARENT");
+    }
+  }
+});
+
+Deno.test("initTracing: returns undefined when no TRACEPARENT is set", async () => {
+  const originalEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const originalExporter = Deno.env.get("OTEL_TRACES_EXPORTER");
+  const originalTraceparent = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+    Deno.env.set("OTEL_TRACES_EXPORTER", "console");
+    Deno.env.delete("TRACEPARENT");
+
+    const parentCtx = await initTracing();
+    assertEquals(parentCtx, undefined);
+
+    await shutdownTracing();
+  } finally {
+    if (originalEndpoint) {
+      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", originalEndpoint);
+    }
+    if (originalExporter) {
+      Deno.env.set("OTEL_TRACES_EXPORTER", originalExporter);
+    } else {
+      Deno.env.delete("OTEL_TRACES_EXPORTER");
+    }
+    if (originalTraceparent) {
+      Deno.env.set("TRACEPARENT", originalTraceparent);
+    } else {
+      Deno.env.delete("TRACEPARENT");
     }
   }
 });

--- a/src/infrastructure/tracing/parent_trace.ts
+++ b/src/infrastructure/tracing/parent_trace.ts
@@ -17,13 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-export { initTracing, shutdownTracing } from "./otel_init.ts";
-export {
-  getTracer,
-  SpanStatusCode,
-  withGeneratorSpan,
-  withSpan,
-} from "./tracer.ts";
-export { extractTraceContext, injectTraceContext } from "./propagation.ts";
+import { type Context, context } from "@opentelemetry/api";
 
-export { runWithParentTrace } from "./parent_trace.ts";
+/**
+ * Runs `fn` within the given parent trace context, or directly if no
+ * parent context is provided. Keeps @opentelemetry/api imports
+ * encapsulated in the tracing module.
+ */
+export function runWithParentTrace<T>(
+  parentCtx: Context | undefined,
+  fn: () => T,
+): T {
+  if (parentCtx) {
+    return context.with(parentCtx, fn);
+  }
+  return fn();
+}

--- a/src/infrastructure/tracing/parent_trace_test.ts
+++ b/src/infrastructure/tracing/parent_trace_test.ts
@@ -17,13 +17,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-export { initTracing, shutdownTracing } from "./otel_init.ts";
-export {
-  getTracer,
-  SpanStatusCode,
-  withGeneratorSpan,
-  withSpan,
-} from "./tracer.ts";
-export { extractTraceContext, injectTraceContext } from "./propagation.ts";
+import { assertEquals } from "@std/assert";
+import { ROOT_CONTEXT } from "@opentelemetry/api";
+import { runWithParentTrace } from "./parent_trace.ts";
 
-export { runWithParentTrace } from "./parent_trace.ts";
+Deno.test("runWithParentTrace: passes through when parentCtx is undefined", () => {
+  const result = runWithParentTrace(undefined, () => 42);
+  assertEquals(result, 42);
+});
+
+Deno.test("runWithParentTrace: runs fn within the given context", () => {
+  const result = runWithParentTrace(ROOT_CONTEXT, () => "hello");
+  assertEquals(result, "hello");
+});
+
+Deno.test("runWithParentTrace: propagates async return values", async () => {
+  const result = await runWithParentTrace(
+    ROOT_CONTEXT,
+    () => Promise.resolve("async-value"),
+  );
+  assertEquals(result, "async-value");
+});


### PR DESCRIPTION
## Summary

- Register `W3CTraceContextPropagator` in `initTracing()` so `injectTraceContext()`/`extractTraceContext()` produce real W3C traceparent headers instead of no-ops
- Extract inbound `TRACEPARENT` (and `TRACESTATE`) from the environment so the CLI inherits its parent process's trace context
- Propagate `request.traceHeaders` as env vars in `RawExecutionDriver` so in-process extension methods that read `Deno.env.get("TRACEPARENT")` see the active span context
- Add `propagation.disable()` to `shutdownTracing()` for clean test isolation

Fixes swamp-club#317

## Test Plan

- 3 new tests in `otel_init_test.ts`: W3C propagator roundtrip, TRACEPARENT extraction from env, undefined return when no TRACEPARENT
- 3 new tests in `parent_trace_test.ts`: passthrough when undefined, sync context, async propagation
- 2 new tests in `raw_execution_driver_test.ts`: TRACEPARENT env var set during execution, restored after error
- All 5776 existing tests pass