### PR TITLE
fix(models): use coerceMethodArgs for global arg coercion across all code paths (swamp-club#316)

### DIFF
--- a/design/inputs.md
+++ b/design/inputs.md
@@ -246,7 +246,8 @@ Method arguments take precedence when a key appears in both schemas (more
 specific scope wins).
 
 String values are coerced to match schema types (e.g., `"428"` → `428` for a
-number field) using the same `coerceInputTypes` function used elsewhere.
+number field) using `coerceMethodArgs`, which introspects the Zod schema directly
+and handles both Zod v3 and v4.
 
 This routing happens at definition creation time. The routed global arguments
 are stored in the auto-created definition; the routed method arguments are

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -30,7 +30,7 @@ import {
   stripExpressionFields,
 } from "../expressions/expression_parser.ts";
 import { detectEnvVarUsageInDefinition } from "./env_var_detector.ts";
-import { getObjectShape } from "./zod_type_coercion.ts";
+import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
 import {
   extractEnvReferences,
   extractPathReferences,
@@ -502,10 +502,11 @@ export class DefaultModelValidationService implements ModelValidationService {
         ));
       }
     }
+    const coerced = coerceMethodArgs(staticArgs, globalArgsSchema);
     return this.validateWithSchema(
       "Global arguments",
       globalArgsSchema,
-      staticArgs,
+      coerced,
     );
   }
 
@@ -545,7 +546,8 @@ export class DefaultModelValidationService implements ModelValidationService {
           continue;
         }
       }
-      const result = methodArgsSchema.safeParse(staticArgs);
+      const coercedArgs = coerceMethodArgs(staticArgs, methodArgsSchema);
+      const result = methodArgsSchema.safeParse(coercedArgs);
       if (!result.success) {
         errors.push(
           `Method "${methodName}": ${formatZodError(result.error)}`,

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1592,3 +1592,65 @@ Deno.test("validateModel rejects unknown method argument key", async () => {
   assertEquals(methodResult?.passed, false);
   assertStringIncludes(methodResult?.error ?? "", "typo");
 });
+
+Deno.test("validateModel: coerces string global arguments to match schema types", async () => {
+  const NumericGlobalArgsSchema = z.object({
+    count: z.number(),
+  });
+  const numericModel: ModelDefinition = defineModel({
+    type: ModelType.create("test/numeric-global"),
+    version: "2026.05.11.1",
+    globalArguments: NumericGlobalArgsSchema,
+    resources: {},
+    methods: {
+      run: {
+        description: "Run",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  });
+
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { count: "42" },
+    methods: {},
+  });
+
+  const { results } = await service.validateModel(definition, numericModel);
+
+  const globalResult = results.find((r) => r.name === "Global arguments");
+  assertEquals(globalResult?.passed, true);
+});
+
+Deno.test("validateModel: coerces string method arguments to match schema types", async () => {
+  const service = new DefaultModelValidationService();
+  const NumericMethodModel: ModelDefinition = defineModel({
+    type: ModelType.create("test/numeric-method"),
+    version: "2026.05.11.1",
+    globalArguments: z.object({}),
+    resources: {},
+    methods: {
+      run: {
+        description: "Run",
+        arguments: z.object({ port: z.number(), verbose: z.boolean() }),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  });
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {},
+    methods: { run: { arguments: { port: "8080", verbose: "true" } } },
+  });
+
+  const { results } = await service.validateModel(
+    definition,
+    NumericMethodModel,
+  );
+
+  const methodResult = results.find((r) => r.name === "Method arguments");
+  assertEquals(methodResult?.passed, true);
+});

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -33,8 +33,10 @@ import {
   toMethodDescribeData,
   zodToJsonSchema,
 } from "../types/schema_helpers.ts";
-import { coerceInputTypes } from "../../domain/inputs/mod.ts";
-import { getObjectShape } from "../../domain/models/zod_type_coercion.ts";
+import {
+  coerceMethodArgs,
+  getObjectShape,
+} from "../../domain/models/zod_type_coercion.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -155,11 +157,9 @@ export async function* modelCreate(
       const modelDef = deps.getModelDef(modelType);
       let globalArguments = input.globalArguments;
       if (globalArguments && modelDef?.globalArguments) {
-        // Coerce CLI string values to match schema types (e.g. "428" → 428)
-        const jsonSchema = zodToJsonSchema(modelDef.globalArguments);
-        globalArguments = coerceInputTypes(
+        globalArguments = coerceMethodArgs(
           globalArguments,
-          jsonSchema as Record<string, unknown>,
+          modelDef.globalArguments,
         );
         const globalArgsSchema = modelDef.globalArguments;
         const shape = getObjectShape(globalArgsSchema);

--- a/src/libswamp/models/create_test.ts
+++ b/src/libswamp/models/create_test.ts
@@ -289,3 +289,165 @@ Deno.test("modelCreate: yields error when name already exists", async () => {
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "already_exists");
 });
+
+Deno.test("modelCreate: coerces string boolean global arguments", async () => {
+  const globalArgsSchema = z.object({
+    name: z.string(),
+    enabled: z.boolean(),
+  });
+
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/bool-args" },
+      version: "1.0.0",
+      globalArguments: globalArgsSchema,
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+    createAndSave: (_type, _name, _version, globalArguments) => {
+      assertEquals(
+        (globalArguments as Record<string, unknown>)?.enabled,
+        true,
+      );
+      return Promise.resolve({
+        id: "def-1",
+        name: "my-model",
+      } as unknown as Awaited<
+        ReturnType<ModelCreateDeps["createAndSave"]>
+      >);
+    },
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/bool-args",
+      name: "my-model",
+      globalArguments: { name: "test", enabled: "true" },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+});
+
+Deno.test("modelCreate: coerces string values with default-wrapped schema", async () => {
+  const globalArgsSchema = z.object({
+    cpus: z.number().default(4),
+  });
+
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/default-args" },
+      version: "1.0.0",
+      globalArguments: globalArgsSchema,
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+    createAndSave: (_type, _name, _version, globalArguments) => {
+      assertEquals(
+        (globalArguments as Record<string, unknown>)?.cpus,
+        8,
+      );
+      return Promise.resolve({
+        id: "def-1",
+        name: "my-model",
+      } as unknown as Awaited<
+        ReturnType<ModelCreateDeps["createAndSave"]>
+      >);
+    },
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/default-args",
+      name: "my-model",
+      globalArguments: { cpus: "8" },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+});
+
+Deno.test("modelCreate: coerces Zod v3-style schema global arguments", async () => {
+  // Simulate a Zod v3 schema where _def uses typeName instead of type,
+  // and shape is a function instead of a value.
+  const v3LikeSchema = {
+    _def: {
+      typeName: "ZodObject",
+      shape: () => ({
+        count: {
+          _def: {
+            typeName: "ZodNumber",
+          },
+          safeParse: (v: unknown) => {
+            if (typeof v === "number") {
+              return { success: true, data: v };
+            }
+            return {
+              success: false,
+              error: { issues: [{ path: [], message: "expected number" }] },
+            };
+          },
+        },
+      }),
+    },
+    safeParse: (v: unknown) => {
+      const obj = v as Record<string, unknown>;
+      if (typeof obj.count === "number") {
+        return { success: true, data: obj };
+      }
+      return {
+        success: false,
+        error: {
+          issues: [{
+            path: ["count"],
+            message: "expected number, received string",
+          }],
+        },
+      };
+    },
+  };
+
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/v3-schema" },
+      version: "1.0.0",
+      globalArguments: v3LikeSchema,
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+    createAndSave: (_type, _name, _version, globalArguments) => {
+      assertEquals(
+        (globalArguments as Record<string, unknown>)?.count,
+        42,
+      );
+      return Promise.resolve({
+        id: "def-1",
+        name: "my-model",
+      } as unknown as Awaited<
+        ReturnType<ModelCreateDeps["createAndSave"]>
+      >);
+    },
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/v3-schema",
+      name: "my-model",
+      globalArguments: { count: "42" },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+});

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -21,9 +21,10 @@ import type { z } from "zod";
 import { Definition } from "../../domain/definitions/definition.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import type { ModelDefinition } from "../../domain/models/model.ts";
-import { coerceInputTypes } from "../../domain/inputs/mod.ts";
-import { getObjectShape } from "../../domain/models/zod_type_coercion.ts";
-import { zodToJsonSchema } from "../types/schema_helpers.ts";
+import {
+  coerceMethodArgs,
+  getObjectShape,
+} from "../../domain/models/zod_type_coercion.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
@@ -113,12 +114,10 @@ export function routeInputsBySchema(
     };
   }
 
-  // Coerce global arguments to match schema types
   if (modelDef.globalArguments) {
-    const jsonSchema = zodToJsonSchema(modelDef.globalArguments);
-    const coerced = coerceInputTypes(
+    const coerced = coerceMethodArgs(
       globalArguments,
-      jsonSchema as Record<string, unknown>,
+      modelDef.globalArguments,
     );
     Object.assign(globalArguments, coerced);
   }


### PR DESCRIPTION
## Summary

- Replace the broken `zodToJsonSchema` + `coerceInputTypes` roundtrip with `coerceMethodArgs` in `create.ts` and `direct_execution.ts` — fixes `--global-arg` string values failing Zod validation for extensions using `z.number()` or `z.boolean()` (especially Zod v3 extensions where `manualZodToJsonSchema` silently returned `{}`)
- Add `coerceMethodArgs` before `safeParse` in `validation_service.ts` for both global arguments and method arguments — `model validate` now correctly coerces string-typed values from hand-edited YAML
- Update `design/inputs.md` to reference the correct function name

Fixes swamp-club#316

## Test plan

- [x] Unit tests: 3 new tests in `create_test.ts` (boolean coercion, default-wrapped schema, Zod v3-style schema)
- [x] Unit tests: 2 new tests in `validation_service_test.ts` (global arg coercion, method arg coercion)
- [x] Full test suite: 5773 passed, 0 failed
- [x] E2E: Created Zod v3 extension with `z.number().int().positive().default(4)` — `model create` with `--global-arg cpus=4` succeeds
- [x] E2E: Verified stored values are typed (numbers/booleans, not strings)
- [x] E2E: `model validate` passes with hand-edited YAML containing quoted string values
- [x] E2E: Negative number correctly coerced then caught by `.positive()` validation
- [x] E2E: Boolean `false` string coercion works
- [x] E2E: Schema defaults apply correctly when args omitted
- [x] Regression: built-in `command/shell` type unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)