### PR TITLE
fix(cli): allow `swamp issue get` to run without authentication (swamp-club#313)

### DIFF
--- a/src/cli/commands/issue_get.ts
+++ b/src/cli/commands/issue_get.ts
@@ -29,6 +29,7 @@ import { createIssueGetRenderer } from "../../presentation/renderers/issue_get.t
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
 import { UserError } from "../../domain/errors.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -47,17 +48,14 @@ export const issueGetCommand = new Command()
     }
 
     const credentials = await new AuthRepository().load();
-    if (!credentials) {
-      throw new UserError(
-        'Not logged in. Run "swamp auth login" first.',
-      );
-    }
+    const serverUrl = credentials?.serverUrl ??
+      Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
 
-    const client = new SwampClubClient(credentials.serverUrl);
+    const client = new SwampClubClient(serverUrl);
     const deps: IssueGetDeps = {
       fetchIssue: async (num) => {
-        const issue = await client.fetchIssue(credentials.apiKey, num);
-        return { ...issue, serverUrl: credentials.serverUrl };
+        const issue = await client.fetchIssue(credentials?.apiKey, num);
+        return { ...issue, serverUrl };
       },
     };
 

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -266,15 +266,19 @@ export class SwampClubClient {
 
   /**
    * Fetch an existing Lab issue by number.
-   * Authenticates using the x-api-key header.
+   * When an API key is provided, authenticates using the x-api-key header.
    */
   async fetchIssue(
-    apiKey: string,
+    apiKey: string | undefined,
     issueNumber: number,
   ): Promise<FetchIssueResponse> {
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["x-api-key"] = apiKey;
+    }
     const res = await this.fetch(`/api/v1/lab/issues/${issueNumber}`, {
       method: "GET",
-      headers: { "x-api-key": apiKey },
+      headers,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary

- Make `swamp issue get` work without authentication by making the auth
  check optional — when credentials exist the API key is sent for
  authenticated access; when absent the request is unauthenticated
- `SwampClubClient.fetchIssue` now accepts `apiKey: string | undefined`
  and omits the `x-api-key` header when undefined
- Falls back to `SWAMP_CLUB_URL` env var or `DEFAULT_SWAMP_CLUB_URL`
  when no stored credentials exist, matching the pattern used by
  `extension search`, `extension list`, and other unauthenticated commands

Closes swamp-club#313

## Test Plan

- [x] Reproduced: `swamp issue get 1` with no credentials fails with
  "Not logged in" error
- [x] Verified: compiled binary succeeds unauthenticated (confirmed API
  returns 200 without `x-api-key`)
- [x] Verified: authenticated path still works when credentials exist
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Full test suite passes (5781 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)