### PR TITLE
fix(extensions): W5 review follow-ups — buffered stdin reader + comment cleanup

### DIFF
--- a/src/domain/extensions/extension_loader_test.ts
+++ b/src/domain/extensions/extension_loader_test.ts
@@ -21,11 +21,6 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { toFileUrl } from "@std/path";
 
-// W5: Per-fingerprint import URL construction tests.
-// Verifies the empty-fingerprint guard and fingerprint-present behavior
-// at the URL construction level. Cross-process verification is covered
-// by extension_loader_subprocess_test.ts.
-
 Deno.test("importBundleByPath: non-empty fingerprint appends ?fp= to import URL", async () => {
   const dir = await Deno.makeTempDir({ prefix: "swamp_fp_url_" });
   try {

--- a/src/infrastructure/testing/subprocess_entry.ts
+++ b/src/infrastructure/testing/subprocess_entry.ts
@@ -36,19 +36,26 @@ function respond(data: Record<string, unknown>): void {
   console.log(JSON.stringify(data));
 }
 
-const decoder = new TextDecoder();
+const decoder = new TextDecoder("utf-8");
 const buf = new Uint8Array(65536);
+let remainder = "";
 
 async function readLine(): Promise<string> {
-  let line = "";
   while (true) {
-    const n = await Deno.stdin.read(buf);
-    if (n === null) return line;
-    const chunk = decoder.decode(buf.subarray(0, n));
-    line += chunk;
-    if (line.includes("\n")) {
-      return line.trim();
+    const idx = remainder.indexOf("\n");
+    if (idx !== -1) {
+      const line = remainder.slice(0, idx).trim();
+      remainder = remainder.slice(idx + 1);
+      if (line) return line;
+      continue;
     }
+    const n = await Deno.stdin.read(buf);
+    if (n === null) {
+      const last = remainder.trim();
+      remainder = "";
+      return last;
+    }
+    remainder += decoder.decode(buf.subarray(0, n), { stream: true });
   }
 }
 

--- a/src/libswamp/extensions/module_reload_bench.ts
+++ b/src/libswamp/extensions/module_reload_bench.ts
@@ -17,10 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-// W5 RAM growth benchmark — measures heap delta after N module reloads
-// in a subprocess. Each reload uses a distinct fingerprint, forcing V8
-// to retain the old module and import a new one.
-//
 // Threshold: ≤ 50 MB heap growth after 100 reloads.
 
 import { join } from "@std/path";


### PR DESCRIPTION
## Summary

- Fix `readLine()` in subprocess_entry.ts to use a persistent remainder buffer, correctly handling multiple newline-delimited messages in a single stdin read (adversarial review medium finding from #1361)
- Use streaming `TextDecoder` to handle multi-byte UTF-8 at chunk boundaries (adversarial review low finding)
- Remove W5 task-referencing comment blocks from extension_loader_test.ts and module_reload_bench.ts per CLAUDE.md conventions (code review suggestion)

## Test plan

- [x] All 17 subprocess harness + module-reload tests pass
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)