### PR TITLE
refactor(extensions): replace allExtensionMethodsAttached with fingerprint-aware tracking set (swamp-club#318)

### DIFF
--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -278,18 +278,22 @@ export class ExtensionLoader {
         return result;
       }
 
-      const eagerlyRegisteredTypes = new Set<string>();
+      const typesNeedingExtensionAttach = new Set<string>();
       for (const { absolutePath, relativePath, baseDir } of staleFiles) {
         try {
-          const registeredType = await this.rebundleAndUpdateCatalog(
-            absolutePath,
-            relativePath,
-            denoPath,
-            baseDir,
-            catalog,
-          );
+          const { registeredType, extensionTarget } = await this
+            .rebundleAndUpdateCatalog(
+              absolutePath,
+              relativePath,
+              denoPath,
+              baseDir,
+              catalog,
+            );
           if (registeredType) {
-            eagerlyRegisteredTypes.add(registeredType);
+            typesNeedingExtensionAttach.add(registeredType);
+          }
+          if (extensionTarget) {
+            typesNeedingExtensionAttach.add(extensionTarget);
           }
           result.loaded.push(relativePath);
         } catch (error) {
@@ -298,7 +302,7 @@ export class ExtensionLoader {
       }
 
       if (this.adapter.attachPendingExtensionsForType) {
-        for (const type of eagerlyRegisteredTypes) {
+        for (const type of typesNeedingExtensionAttach) {
           await this.adapter.attachPendingExtensionsForType(
             type,
             catalog,
@@ -632,10 +636,10 @@ export class ExtensionLoader {
     denoPath: string,
     baseDir: string,
     catalog: ExtensionCatalogStore,
-  ): Promise<string | undefined> {
+  ): Promise<{ registeredType?: string; extensionTarget?: string }> {
     const source = await Deno.readTextFile(absolutePath);
     if (!this.adapter.exportRegex.test(source)) {
-      return undefined;
+      return {};
     }
 
     const { js, fromCache } = await this.bundleWithCache(
@@ -718,7 +722,7 @@ export class ExtensionLoader {
         );
       }
 
-      return typeNormalized;
+      return { registeredType: typeNormalized };
     }
 
     if (
@@ -755,9 +759,11 @@ export class ExtensionLoader {
         source_mtime: sourceMtime,
         source_fingerprint: effectiveFingerprint,
       });
+
+      return { extensionTarget: typeNormalized };
     }
 
-    return undefined;
+    return {};
   }
 
   resolveBundlePath(...segments: string[]): string {

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -56,6 +56,36 @@ import type {
 
 const logger = getLogger(["swamp", "models", "loader"]);
 
+const attachedExtensions: Map<string, Map<string, string>> = new Map();
+
+export function clearAttachedExtensions(): void {
+  attachedExtensions.clear();
+}
+
+function markExtensionAttached(
+  typeNormalized: string,
+  sourcePath: string,
+  fingerprint: string,
+): void {
+  let paths = attachedExtensions.get(typeNormalized);
+  if (!paths) {
+    paths = new Map();
+    attachedExtensions.set(typeNormalized, paths);
+  }
+  paths.set(sourcePath, fingerprint);
+}
+
+function isExtensionAttached(
+  typeNormalized: string,
+  sourcePath: string,
+  fingerprint: string | undefined,
+): boolean {
+  const recorded = attachedExtensions.get(typeNormalized)?.get(sourcePath);
+  if (recorded === undefined) return false;
+  if (fingerprint === undefined) return true;
+  return recorded === fingerprint;
+}
+
 interface UserMethodResult {
   dataHandles?: DataHandle[];
   [key: string]: unknown;
@@ -596,10 +626,17 @@ export const modelKindAdapter: KindAdapter = {
       result,
     );
 
+    const genuine: typeof result.failed = [];
     for (const failure of result.failed) {
-      logger
-        .warn`Failed to extend model from ${failure.file}: ${failure.error}`;
+      if (String(failure.error).includes("already exists on model type")) {
+        result.extended.push(failure.file);
+      } else {
+        genuine.push(failure);
+        logger
+          .warn`Failed to extend model from ${failure.file}: ${failure.error}`;
+      }
     }
+    result.failed = genuine;
   },
 
   async attachPendingExtensionsForType(
@@ -618,13 +655,26 @@ export const modelKindAdapter: KindAdapter = {
 
     const extensions = catalog.findExtensionsForType(typeNormalized);
     for (const entry of extensions) {
-      if (await allExtensionMethodsAttached(entry, base, importFn)) continue;
+      if (
+        isExtensionAttached(
+          typeNormalized,
+          entry.source_path,
+          entry.source_fingerprint,
+        )
+      ) continue;
       const result: ExtensionLoadResult = {
         loaded: [],
         extended: [],
         failed: [],
       };
       await modelKindAdapter.importAndExtendBundle!(entry, importFn, result);
+      if (result.extended.length > 0) {
+        markExtensionAttached(
+          typeNormalized,
+          entry.source_path,
+          entry.source_fingerprint ?? "",
+        );
+      }
     }
   },
 
@@ -665,52 +715,3 @@ export const modelKindAdapter: KindAdapter = {
 
   resolveDenoConfig: findNearestDenoConfig,
 };
-
-async function allExtensionMethodsAttached(
-  entry: ExtensionTypeRow,
-  base: ModelDefinition,
-  importFn: (
-    paths: {
-      bundlePath: string;
-      sourcePath: string;
-      sourceFingerprint?: string;
-    },
-  ) => Promise<Record<string, unknown>>,
-): Promise<boolean> {
-  let module: Record<string, unknown>;
-  try {
-    module = await importFn({
-      bundlePath: entry.bundle_path,
-      sourcePath: entry.source_path,
-      sourceFingerprint: entry.source_fingerprint || undefined,
-    });
-  } catch {
-    return false;
-  }
-  if (!module.extension) return false;
-
-  const parsed = UserExtensionSchema.safeParse(module.extension);
-  if (!parsed.success) return false;
-
-  const methodNames = new Set<string>();
-  for (const record of parsed.data.methods) {
-    for (const name of Object.keys(record)) {
-      methodNames.add(name);
-    }
-  }
-  const checkNames = new Set<string>();
-  for (const record of parsed.data.checks ?? []) {
-    for (const name of Object.keys(record)) {
-      checkNames.add(name);
-    }
-  }
-  if (methodNames.size === 0 && checkNames.size === 0) return true;
-
-  for (const name of methodNames) {
-    if (base.methods[name] === undefined) return false;
-  }
-  for (const name of checkNames) {
-    if (base.checks?.[name] === undefined) return false;
-  }
-  return true;
-}

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -24,7 +24,10 @@ import {
 } from "@std/assert";
 import { dirname, join } from "@std/path";
 import { ExtensionLoader } from "../extensions/extension_loader.ts";
-import { modelKindAdapter } from "../extensions/model_kind_adapter.ts";
+import {
+  clearAttachedExtensions,
+  modelKindAdapter,
+} from "../extensions/model_kind_adapter.ts";
 import { modelRegistry } from "./model.ts";
 import { bundleNamespace } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
@@ -3876,3 +3879,381 @@ export const model = {
     }
   },
 );
+
+// Regression tests for swamp-club#318 / #123: the fingerprint-aware
+// tracking set that replaced allExtensionMethodsAttached.
+
+Deno.test("attachPendingExtensionsForType: idempotent across two code paths (issue #123 regression)", async () => {
+  const ts = Date.now();
+  const typeId = `@user/issue123-cross-path-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  methods: {
+    seed: {
+      description: "Seed",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "${typeId}",
+  methods: [{
+    extra: {
+      description: "Extra method from extension",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_issue123_r_" });
+  const modelsDir = await Deno.makeTempDir({ prefix: "swamp_issue123_m_" });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    clearAttachedExtensions();
+    await Deno.writeTextFile(join(modelsDir, "base.ts"), modelCode);
+    await Deno.writeTextFile(join(modelsDir, "ext.ts"), extCode);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const repository = makeRepoForCatalog(catalog, repoDir);
+    const loader = new ExtensionLoader(
+      testDenoRuntime,
+      modelKindAdapter,
+      repoDir,
+      undefined,
+      repository,
+    );
+
+    // Path A: buildIndex registers the base and attaches the extension
+    // via the post-loop attachPendingExtensionsForType.
+    await loader.buildIndex(modelsDir);
+    assertEquals(
+      "extra" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must be attached after buildIndex",
+    );
+
+    // Path B: explicit attachPendingExtensionsForType (simulates
+    // hotLoadModels' post-load attachment loop). Must be a no-op —
+    // the tracking set should prevent a duplicate extend() call.
+    await loader.attachPendingExtensionsForType(typeId);
+    assertEquals(
+      "extra" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must remain attached after second attachment call",
+    );
+
+    const methods = Object.keys(modelRegistry.get(typeId)!.methods);
+    assertEquals(
+      methods.filter((m) => m === "extra").length,
+      1,
+      "Method 'extra' must appear exactly once (no duplicates)",
+    );
+
+    catalog.close();
+  } finally {
+    clearAttachedExtensions();
+    if (Deno.build.os === "windows") {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+      await Deno.remove(modelsDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(repoDir, { recursive: true });
+      await Deno.remove(modelsDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("attachPendingExtensionsForType: load-then-attach cross-path produces no failures (hotLoadModels scenario)", async () => {
+  const ts = Date.now();
+  const typeId = `@user/issue318-hotload-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  methods: {
+    seed: {
+      description: "Seed",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "${typeId}",
+  methods: [{
+    hotloaded: {
+      description: "Hot-loaded extension method",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_hotload_r_" });
+  const modelsDir = await Deno.makeTempDir({ prefix: "swamp_hotload_m_" });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    clearAttachedExtensions();
+    await Deno.writeTextFile(join(modelsDir, "base.ts"), modelCode);
+    await Deno.writeTextFile(join(modelsDir, "ext.ts"), extCode);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const repository = makeRepoForCatalog(catalog, repoDir);
+    const loader = new ExtensionLoader(
+      testDenoRuntime,
+      modelKindAdapter,
+      repoDir,
+      undefined,
+      repository,
+    );
+
+    // Simulate the hotLoadModels sequence:
+    // 1. load() discovers and attaches the extension via processSecondaryExport
+    const loadResult = await loader.load(modelsDir);
+    assertEquals(loadResult.failed.length, 0, "load must not fail");
+    assertEquals(
+      "hotloaded" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must be attached after load",
+    );
+
+    // 2. Populate the catalog so attachPendingExtensionsForType can find it
+    await loader.buildIndex(modelsDir);
+
+    // 3. attachPendingExtensionsForType tries to re-attach the same
+    //    extension. importAndExtendBundle must treat "already exists"
+    //    as idempotent — no failures, no warnings.
+    await loader.attachPendingExtensionsForType(typeId);
+
+    assertEquals(
+      "hotloaded" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must remain attached",
+    );
+
+    catalog.close();
+  } finally {
+    clearAttachedExtensions();
+    if (Deno.build.os === "windows") {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+      await Deno.remove(modelsDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(repoDir, { recursive: true });
+      await Deno.remove(modelsDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("attachPendingExtensionsForType: attaches new extension B while skipping already-attached A", async () => {
+  const ts = Date.now();
+  const typeId = `@user/issue318-ab-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  methods: {
+    seed: {
+      description: "Seed",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extACode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "${typeId}",
+  methods: [{
+    alpha: {
+      description: "Extension A",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+  const extBCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "${typeId}",
+  methods: [{
+    beta: {
+      description: "Extension B",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_issue318_ab_r_" });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_issue318_ab_m_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    clearAttachedExtensions();
+    await Deno.writeTextFile(join(modelsDir, "base.ts"), modelCode);
+    await Deno.writeTextFile(join(modelsDir, "ext_a.ts"), extACode);
+
+    const catalog1 = new ExtensionCatalogStore(dbPath);
+    const repository1 = makeRepoForCatalog(catalog1, repoDir);
+    const loader1 = new ExtensionLoader(
+      testDenoRuntime,
+      modelKindAdapter,
+      repoDir,
+      undefined,
+      repository1,
+    );
+
+    await loader1.buildIndex(modelsDir);
+    assertEquals(
+      "alpha" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension A must be attached",
+    );
+    catalog1.close();
+
+    // Add extension B — a new file targeting the same base type.
+    // The base model file is unchanged, so only ext_b.ts is stale.
+    // buildIndex must still trigger attachment for the target type
+    // because a stale secondary export was processed.
+    await Deno.writeTextFile(join(modelsDir, "ext_b.ts"), extBCode);
+
+    const catalog2 = new ExtensionCatalogStore(dbPath);
+    const repository2 = makeRepoForCatalog(catalog2, repoDir);
+    const loader2 = new ExtensionLoader(
+      testDenoRuntime,
+      modelKindAdapter,
+      repoDir,
+      undefined,
+      repository2,
+    );
+
+    await loader2.buildIndex(modelsDir);
+
+    const model = modelRegistry.get(typeId)!;
+    assertEquals(
+      "alpha" in model.methods,
+      true,
+      "Extension A must still be attached",
+    );
+    assertEquals(
+      "beta" in model.methods,
+      true,
+      "Extension B must be attached after second buildIndex",
+    );
+
+    catalog2.close();
+  } finally {
+    clearAttachedExtensions();
+    if (Deno.build.os === "windows") {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+      await Deno.remove(modelsDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(repoDir, { recursive: true });
+      await Deno.remove(modelsDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("attachPendingExtensionsForType: resetLoadedFlag does not break tracking (ADV-2)", async () => {
+  const ts = Date.now();
+  const typeId = `@user/issue318-reset-${ts}`;
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "${typeId}",
+  version: "2026.02.09.1",
+  methods: {
+    seed: {
+      description: "Seed",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "${typeId}",
+  methods: [{
+    tracked: {
+      description: "Tracked extension method",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_issue318_rst_r_" });
+  const modelsDir = await Deno.makeTempDir({
+    prefix: "swamp_issue318_rst_m_",
+  });
+  const dbPath = join(repoDir, ".swamp", "_extension_catalog.db");
+
+  try {
+    clearAttachedExtensions();
+    await Deno.writeTextFile(join(modelsDir, "base.ts"), modelCode);
+    await Deno.writeTextFile(join(modelsDir, "ext.ts"), extCode);
+
+    const catalog = new ExtensionCatalogStore(dbPath);
+    const repository = makeRepoForCatalog(catalog, repoDir);
+    const loader = new ExtensionLoader(
+      testDenoRuntime,
+      modelKindAdapter,
+      repoDir,
+      undefined,
+      repository,
+    );
+
+    await loader.buildIndex(modelsDir);
+    assertEquals(
+      "tracked" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must be attached after buildIndex",
+    );
+
+    // resetLoadedFlag doesn't clear models — extensions remain attached.
+    // The tracking set should correctly report this.
+    modelRegistry.resetLoadedFlag();
+
+    await loader.attachPendingExtensionsForType(typeId);
+    assertEquals(
+      "tracked" in modelRegistry.get(typeId)!.methods,
+      true,
+      "Extension must remain attached after resetLoadedFlag + re-attach",
+    );
+
+    catalog.close();
+  } finally {
+    clearAttachedExtensions();
+    if (Deno.build.os === "windows") {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+      await Deno.remove(modelsDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(repoDir, { recursive: true });
+      await Deno.remove(modelsDir, { recursive: true });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Replaced the expensive `allExtensionMethodsAttached` idempotency guard (which re-imported extension bundles and re-parsed schemas on every call) with a cheap fingerprint-aware `Map<type, Map<sourcePath, fingerprint>>` tracking set — O(1) lookup instead of O(import+parse)
- Fixed a pre-existing gap where `buildIndex` didn't trigger extension attachment for new extension files unless the base model file also changed — `rebundleAndUpdateCatalog` now returns `extensionTarget` for stale secondary exports
- `importAndExtendBundle` treats "already exists on model type" as an idempotent no-op, covering the `load()` → `attachPendingExtensionsForType` cross-path in `hotLoadModels`
- Added 4 regression tests: #123 cross-path idempotency, hotLoadModels load-then-attach scenario, extension A/B selective attachment, and `resetLoadedFlag` invariant (ADV-2)

### Audit findings (from triage)

Six model registration paths were audited. Full path consolidation was ruled out — extensions and base models are discovered from different sources (local, pulled, catalog), making attachment inherently a separate step. The tracking set approach delivers the same end state (no expensive guard, idempotent attachment) via a structurally honest path.

### Adversarial review dispositions

- **ADV-1** (low/scope): Step 1 analysis folded into PR description — no separate implementation step
- **ADV-2** (medium/risk): `resetLoadedFlag` stale-tracking — tested empirically, not just documented. `resetLoadedFlag` doesn't un-attach extensions, so the tracker's claim remains correct
- **ADV-3** (low/complexity): Used `Map<string, Map<string, string>>` instead of null-byte separator — more readable and greppable
- **ADV-4** (low/correctness): `eagerlyRegisteredTypes` narrowing — superseded by the `extensionTarget` approach which is strictly better
- **ADV-5** (low/documentation): No design docs or skills reference the guard — no updates needed
- **ADV-6** (low/testing): Purely internal change — no UAT or docs gaps

## Test Plan

- [x] All 5821 unit + integration tests pass (1 pre-existing vault loader timing flake)
- [x] E2E verified with compiled binary: base model + extension A loaded, extension B hot-attached without base model change, both methods execute, idempotent on repeat access
- [x] Regression test: #123 cross-path scenario (buildIndex + explicit attach)
- [x] Regression test: hotLoadModels load-then-attach cross-path (no failures/warnings)
- [x] Regression test: extension A/B selective attachment (new B attaches, existing A skipped)
- [x] Regression test: resetLoadedFlag invariant (ADV-2 verification)
- [x] Genuine method-name conflicts still fail properly (existing test passes)

Closes swamp-club#318

🤖 Generated with [Claude Code](https://claude.com/claude-code)