### PR TITLE
feat(cli): add type search for driver, datastore, and report kinds

### DIFF
--- a/src/cli/commands/datastore_type_search.ts
+++ b/src/cli/commands/datastore_type_search.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  datastoreTypeSearch,
+  type DatastoreTypeSearchDeps,
+} from "../../libswamp/mod.ts";
+import { createDatastoreTypeSearchRenderer } from "../../presentation/renderers/datastore_type_search.tsx";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
+import { getDatastoreTypes } from "../../domain/datastore/datastore_types.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export async function datastoreTypeSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "datastore",
+    "type-search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching datastore types with query: ${query ?? "(none)"}`;
+
+  await datastoreTypeRegistry.ensureLoaded();
+
+  const deps: DatastoreTypeSearchDeps = {
+    getDatastoreTypes: () => getDatastoreTypes(),
+  };
+
+  const renderer = createDatastoreTypeSearchRenderer(effectiveMode);
+  await consumeStream(
+    datastoreTypeSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected datastore type: ${selected.type}`;
+    console.log(JSON.stringify(selected, null, 2));
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Datastore type search command completed");
+}
+
+export const datastoreTypeSearchCommand = new Command()
+  .name("search")
+  .description("Search for datastore types")
+  .example("Browse datastore types", "swamp datastore type search")
+  .example("Search by keyword", "swamp datastore type search s3")
+  .arguments("[query:string]")
+  .action(datastoreTypeSearchAction);

--- a/src/cli/commands/driver.ts
+++ b/src/cli/commands/driver.ts
@@ -18,42 +18,33 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { datastoreStatusCommand } from "./datastore_status.ts";
-import { datastoreSetupCommand } from "./datastore_setup.ts";
-import { datastoreSyncCommand } from "./datastore_sync.ts";
-import { datastoreLockCommand } from "./datastore_lock.ts";
-import { datastoreCompactCommand } from "./datastore_compact.ts";
 import {
-  datastoreTypeSearchAction,
-  datastoreTypeSearchCommand,
-} from "./datastore_type_search.ts";
+  driverTypeSearchAction,
+  driverTypeSearchCommand,
+} from "./driver_type_search.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
-export const datastoreTypeCommand = new Command()
+export const driverTypeCommand = new Command()
   .name("type")
-  .description("Inspect datastore types")
+  .description("Inspect driver types")
   .action(function () {
     this.showHelp();
   })
-  .command("search", datastoreTypeSearchCommand)
+  .command("search", driverTypeSearchCommand)
   .command(
     "list",
     new Command()
-      .description("Alias for datastore type search")
+      .description("Alias for driver type search")
       .hidden()
       .arguments("[query:string]")
-      .action(datastoreTypeSearchAction),
+      .action(driverTypeSearchAction),
   );
 
-export const datastoreCommand = new Command()
-  .description("Manage datastore configuration")
+export const driverCommand = new Command()
+  .name("driver")
+  .description("Manage execution drivers")
   .error(unknownCommandErrorHandler)
   .action(function () {
     this.showHelp();
   })
-  .command("type", datastoreTypeCommand)
-  .command("status", datastoreStatusCommand)
-  .command("setup", datastoreSetupCommand)
-  .command("sync", datastoreSyncCommand)
-  .command("lock", datastoreLockCommand)
-  .command("compact", datastoreCompactCommand);
+  .command("type", driverTypeCommand);

--- a/src/cli/commands/driver_type_search.ts
+++ b/src/cli/commands/driver_type_search.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  driverTypeSearch,
+  type DriverTypeSearchDeps,
+} from "../../libswamp/mod.ts";
+import { createDriverTypeSearchRenderer } from "../../presentation/renderers/driver_type_search.tsx";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
+import { getDriverTypes } from "../../domain/drivers/driver_types.ts";
+import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export async function driverTypeSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "driver",
+    "type-search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching driver types with query: ${query ?? "(none)"}`;
+
+  await driverTypeRegistry.ensureLoaded();
+
+  const deps: DriverTypeSearchDeps = {
+    getDriverTypes: () => getDriverTypes(),
+  };
+
+  const renderer = createDriverTypeSearchRenderer(effectiveMode);
+  await consumeStream(
+    driverTypeSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected driver type: ${selected.type}`;
+    console.log(JSON.stringify(selected, null, 2));
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Driver type search command completed");
+}
+
+export const driverTypeSearchCommand = new Command()
+  .name("search")
+  .description("Search for driver types")
+  .example("Browse driver types", "swamp driver type search")
+  .example("Search by keyword", "swamp driver type search docker")
+  .arguments("[query:string]")
+  .action(driverTypeSearchAction);

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -21,7 +21,27 @@ import { Command } from "@cliffy/command";
 import { reportSearchAction, reportSearchCommand } from "./report_search.ts";
 import { reportGetCommand } from "./report_get.ts";
 import { reportDescribeCommand } from "./report_describe.ts";
+import {
+  reportTypeSearchAction,
+  reportTypeSearchCommand,
+} from "./report_type_search.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+
+export const reportTypeCommand = new Command()
+  .name("type")
+  .description("Inspect report types")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("search", reportTypeSearchCommand)
+  .command(
+    "list",
+    new Command()
+      .description("Alias for report type search")
+      .hidden()
+      .arguments("[query:string]")
+      .action(reportTypeSearchAction),
+  );
 
 export const reportCommand = new Command()
   .name("report")
@@ -30,6 +50,7 @@ export const reportCommand = new Command()
   .action(function () {
     this.showHelp();
   })
+  .command("type", reportTypeCommand)
   .command("search", reportSearchCommand)
   .command("get", reportGetCommand)
   .command("describe", reportDescribeCommand)

--- a/src/cli/commands/report_type_search.ts
+++ b/src/cli/commands/report_type_search.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  reportTypeSearch,
+  type ReportTypeSearchDeps,
+} from "../../libswamp/mod.ts";
+import { createReportTypeSearchRenderer } from "../../presentation/renderers/report_type_search.tsx";
+import {
+  createContext,
+  type GlobalOptions,
+  interactiveOutputMode,
+} from "../context.ts";
+import { getReportTypes } from "../../domain/reports/report_types.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export async function reportTypeSearchAction(
+  options: AnyOptions,
+  query?: string,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, [
+    "report",
+    "type-search",
+  ]);
+  const effectiveMode = interactiveOutputMode(ctx);
+  const libCtx = createLibSwampContext();
+  ctx.logger.debug`Searching report types with query: ${query ?? "(none)"}`;
+
+  await reportRegistry.ensureLoaded();
+
+  const deps: ReportTypeSearchDeps = {
+    getReportTypes: () => getReportTypes(),
+  };
+
+  const renderer = createReportTypeSearchRenderer(effectiveMode);
+  await consumeStream(
+    reportTypeSearch(libCtx, deps, { query }),
+    renderer.handlers(),
+  );
+
+  const selected = renderer.selectedItem();
+  if (selected) {
+    ctx.logger.debug`Selected report type: ${selected.type}`;
+    console.log(JSON.stringify(selected, null, 2));
+  } else {
+    ctx.logger.debug`Search cancelled`;
+  }
+
+  ctx.logger.debug("Report type search command completed");
+}
+
+export const reportTypeSearchCommand = new Command()
+  .name("search")
+  .description("Search for report types")
+  .example("Browse report types", "swamp report type search")
+  .example("Search by keyword", "swamp report type search cost")
+  .arguments("[query:string]")
+  .action(reportTypeSearchAction);

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -41,6 +41,7 @@ import { authCommand } from "./commands/auth.ts";
 import { extensionCommand } from "./commands/extension.ts";
 import { summariseCommand } from "./commands/summarise.ts";
 import { datastoreCommand } from "./commands/datastore.ts";
+import { driverCommand } from "./commands/driver.ts";
 import { doctorCommand } from "./commands/doctor.ts";
 import { reportCommand } from "./commands/report.ts";
 import { serveCommand } from "./commands/serve.ts";
@@ -1140,6 +1141,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("extension", extensionCommand)
     .command("summarise", summariseCommand)
     .command("datastore", datastoreCommand)
+    .command("driver", driverCommand)
     .command("doctor", doctorCommand)
     .command("report", reportCommand)
     .command("serve", serveCommand)

--- a/src/domain/drivers/driver_types.ts
+++ b/src/domain/drivers/driver_types.ts
@@ -58,10 +58,23 @@ for (const driverType of BUILT_IN_DRIVER_TYPES) {
 }
 
 /**
- * Gets all available driver types.
+ * Gets all available driver types (both loaded and lazy).
+ * Lazy types are synthesized from catalog metadata.
  */
 export function getDriverTypes(): DriverTypeInfo[] {
-  return driverTypeRegistry.getAll();
+  const loaded = driverTypeRegistry.getAll();
+  const loadedKeys = new Set(loaded.map((t) => t.type.toLowerCase()));
+
+  const lazy = driverTypeRegistry.getAllLazy()
+    .filter((entry) => !loadedKeys.has(entry.type.toLowerCase()))
+    .map((entry) => ({
+      type: entry.type,
+      name: entry.type,
+      description: "",
+      isBuiltIn: false,
+    }));
+
+  return [...loaded, ...lazy];
 }
 
 /**

--- a/src/domain/reports/report_types.ts
+++ b/src/domain/reports/report_types.ts
@@ -17,42 +17,29 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import {
-  type DatastoreTypeInfo,
-  datastoreTypeRegistry,
-} from "./datastore_type_registry.ts";
+import { reportRegistry } from "./report_registry.ts";
 
-export type { DatastoreTypeInfo } from "./datastore_type_registry.ts";
-
-/**
- * Built-in datastore type definitions.
- */
-const BUILT_IN_DATASTORE_TYPES: DatastoreTypeInfo[] = [
-  {
-    type: "filesystem",
-    name: "Filesystem",
-    description:
-      "Store data directly on the local filesystem. This is the default datastore with no remote synchronization.",
-    isBuiltIn: true,
-  },
-];
-
-// Register built-in types on module load
-for (const datastoreType of BUILT_IN_DATASTORE_TYPES) {
-  if (!datastoreTypeRegistry.has(datastoreType.type)) {
-    datastoreTypeRegistry.register(datastoreType);
-  }
+export interface ReportTypeInfo {
+  type: string;
+  name: string;
+  description: string;
+  isBuiltIn: boolean;
 }
 
 /**
- * Gets all available datastore types (both loaded and lazy).
+ * Gets all available report types (both loaded and lazy).
  * Lazy types are synthesized from catalog metadata.
  */
-export function getDatastoreTypes(): DatastoreTypeInfo[] {
-  const loaded = datastoreTypeRegistry.getAll();
+export function getReportTypes(): ReportTypeInfo[] {
+  const loaded = reportRegistry.getAll().map(({ name, report }) => ({
+    type: name,
+    name,
+    description: report.description,
+    isBuiltIn: false,
+  }));
   const loadedKeys = new Set(loaded.map((t) => t.type.toLowerCase()));
 
-  const lazy = datastoreTypeRegistry.getAllLazy()
+  const lazy = reportRegistry.getAllLazy()
     .filter((entry) => !loadedKeys.has(entry.type.toLowerCase()))
     .map((entry) => ({
       type: entry.type,
@@ -62,11 +49,4 @@ export function getDatastoreTypes(): DatastoreTypeInfo[] {
     }));
 
   return [...loaded, ...lazy];
-}
-
-/**
- * Gets a datastore type by its identifier.
- */
-export function getDatastoreType(type: string): DatastoreTypeInfo | undefined {
-  return datastoreTypeRegistry.get(type);
 }

--- a/src/libswamp/datastores/type_search.ts
+++ b/src/libswamp/datastores/type_search.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface DatastoreTypeSearchItem {
+  type: string;
+  name: string;
+  description: string;
+}
+
+export interface DatastoreTypeSearchData {
+  query: string;
+  results: DatastoreTypeSearchItem[];
+}
+
+export type DatastoreTypeSearchEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: DatastoreTypeSearchData }
+  | { kind: "error"; error: SwampError };
+
+export interface DatastoreTypeSearchDeps {
+  getDatastoreTypes(): Array<{
+    type: string;
+    name: string;
+    description: string;
+  }>;
+}
+
+export interface DatastoreTypeSearchInput {
+  query?: string;
+}
+
+export async function* datastoreTypeSearch(
+  _ctx: LibSwampContext,
+  deps: DatastoreTypeSearchDeps,
+  input: DatastoreTypeSearchInput,
+): AsyncGenerator<DatastoreTypeSearchEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.type_search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const types = deps.getDatastoreTypes();
+      const results: DatastoreTypeSearchItem[] = types.map((t) => ({
+        type: t.type,
+        name: t.name,
+        description: t.description,
+      }));
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/type_search_test.ts
+++ b/src/libswamp/datastores/type_search_test.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreTypeSearch,
+  type DatastoreTypeSearchDeps,
+  type DatastoreTypeSearchEvent,
+} from "./type_search.ts";
+
+function makeDeps(
+  overrides: Partial<DatastoreTypeSearchDeps> = {},
+): DatastoreTypeSearchDeps {
+  return {
+    getDatastoreTypes: () => [
+      {
+        type: "filesystem",
+        name: "Filesystem",
+        description: "Store data on the local filesystem",
+      },
+      {
+        type: "s3",
+        name: "S3",
+        description: "Store data in Amazon S3",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreTypeSearch: returns all datastore types with no query", async () => {
+  const deps = makeDeps();
+  const events = await collect<DatastoreTypeSearchEvent>(
+    datastoreTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    DatastoreTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.query, "");
+  assertEquals(completed.data.results.length, 2);
+  assertEquals(completed.data.results[0].type, "filesystem");
+  assertEquals(completed.data.results[0].name, "Filesystem");
+});
+
+Deno.test("datastoreTypeSearch: passes query through in data", async () => {
+  const deps = makeDeps();
+  const events = await collect<DatastoreTypeSearchEvent>(
+    datastoreTypeSearch(createLibSwampContext(), deps, { query: "s3" }),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    DatastoreTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.query, "s3");
+  assertEquals(completed.data.results.length, 2);
+});
+
+Deno.test("datastoreTypeSearch: returns empty results when no datastore types", async () => {
+  const deps = makeDeps({
+    getDatastoreTypes: () => [],
+  });
+  const events = await collect<DatastoreTypeSearchEvent>(
+    datastoreTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    DatastoreTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 0);
+});

--- a/src/libswamp/drivers/type_search.ts
+++ b/src/libswamp/drivers/type_search.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface DriverTypeSearchItem {
+  type: string;
+  name: string;
+  description: string;
+}
+
+export interface DriverTypeSearchData {
+  query: string;
+  results: DriverTypeSearchItem[];
+}
+
+export type DriverTypeSearchEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: DriverTypeSearchData }
+  | { kind: "error"; error: SwampError };
+
+export interface DriverTypeSearchDeps {
+  getDriverTypes(): Array<{
+    type: string;
+    name: string;
+    description: string;
+  }>;
+}
+
+export interface DriverTypeSearchInput {
+  query?: string;
+}
+
+export async function* driverTypeSearch(
+  _ctx: LibSwampContext,
+  deps: DriverTypeSearchDeps,
+  input: DriverTypeSearchInput,
+): AsyncGenerator<DriverTypeSearchEvent> {
+  yield* withGeneratorSpan(
+    "swamp.driver.type_search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const types = deps.getDriverTypes();
+      const results: DriverTypeSearchItem[] = types.map((t) => ({
+        type: t.type,
+        name: t.name,
+        description: t.description,
+      }));
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/drivers/type_search_test.ts
+++ b/src/libswamp/drivers/type_search_test.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  driverTypeSearch,
+  type DriverTypeSearchDeps,
+  type DriverTypeSearchEvent,
+} from "./type_search.ts";
+
+function makeDeps(
+  overrides: Partial<DriverTypeSearchDeps> = {},
+): DriverTypeSearchDeps {
+  return {
+    getDriverTypes: () => [
+      {
+        type: "raw",
+        name: "Raw (In-Process)",
+        description: "Execute directly in the host Deno process",
+      },
+      {
+        type: "docker",
+        name: "Docker",
+        description: "Execute in isolated Docker containers",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+Deno.test("driverTypeSearch: returns all driver types with no query", async () => {
+  const deps = makeDeps();
+  const events = await collect<DriverTypeSearchEvent>(
+    driverTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    DriverTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.query, "");
+  assertEquals(completed.data.results.length, 2);
+  assertEquals(completed.data.results[0].type, "raw");
+  assertEquals(completed.data.results[0].name, "Raw (In-Process)");
+});
+
+Deno.test("driverTypeSearch: passes query through in data", async () => {
+  const deps = makeDeps();
+  const events = await collect<DriverTypeSearchEvent>(
+    driverTypeSearch(createLibSwampContext(), deps, { query: "docker" }),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    DriverTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.query, "docker");
+  assertEquals(completed.data.results.length, 2);
+});
+
+Deno.test("driverTypeSearch: returns empty results when no driver types", async () => {
+  const deps = makeDeps({
+    getDriverTypes: () => [],
+  });
+  const events = await collect<DriverTypeSearchEvent>(
+    driverTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    DriverTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 0);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -390,6 +390,36 @@ export {
   type VaultTypeSearchItem,
 } from "./vaults/type_search.ts";
 
+// Driver type search operations
+export {
+  driverTypeSearch,
+  type DriverTypeSearchData,
+  type DriverTypeSearchDeps,
+  type DriverTypeSearchEvent,
+  type DriverTypeSearchInput,
+  type DriverTypeSearchItem,
+} from "./drivers/type_search.ts";
+
+// Datastore type search operations
+export {
+  datastoreTypeSearch,
+  type DatastoreTypeSearchData,
+  type DatastoreTypeSearchDeps,
+  type DatastoreTypeSearchEvent,
+  type DatastoreTypeSearchInput,
+  type DatastoreTypeSearchItem,
+} from "./datastores/type_search.ts";
+
+// Report type search operations
+export {
+  reportTypeSearch,
+  type ReportTypeSearchData,
+  type ReportTypeSearchDeps,
+  type ReportTypeSearchEvent,
+  type ReportTypeSearchInput,
+  type ReportTypeSearchItem,
+} from "./reports/type_search.ts";
+
 // Vault search operations
 export {
   vaultSearch,

--- a/src/libswamp/reports/type_search.ts
+++ b/src/libswamp/reports/type_search.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface ReportTypeSearchItem {
+  type: string;
+  name: string;
+  description: string;
+}
+
+export interface ReportTypeSearchData {
+  query: string;
+  results: ReportTypeSearchItem[];
+}
+
+export type ReportTypeSearchEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: ReportTypeSearchData }
+  | { kind: "error"; error: SwampError };
+
+export interface ReportTypeSearchDeps {
+  getReportTypes(): Array<{
+    type: string;
+    name: string;
+    description: string;
+  }>;
+}
+
+export interface ReportTypeSearchInput {
+  query?: string;
+}
+
+export async function* reportTypeSearch(
+  _ctx: LibSwampContext,
+  deps: ReportTypeSearchDeps,
+  input: ReportTypeSearchInput,
+): AsyncGenerator<ReportTypeSearchEvent> {
+  yield* withGeneratorSpan(
+    "swamp.report.type_search",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const types = deps.getReportTypes();
+      const results: ReportTypeSearchItem[] = types.map((t) => ({
+        type: t.type,
+        name: t.name,
+        description: t.description,
+      }));
+
+      yield {
+        kind: "completed",
+        data: {
+          query: input.query ?? "",
+          results,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/reports/type_search_test.ts
+++ b/src/libswamp/reports/type_search_test.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  reportTypeSearch,
+  type ReportTypeSearchDeps,
+  type ReportTypeSearchEvent,
+} from "./type_search.ts";
+
+function makeDeps(
+  overrides: Partial<ReportTypeSearchDeps> = {},
+): ReportTypeSearchDeps {
+  return {
+    getReportTypes: () => [
+      {
+        type: "@swamp/method-summary",
+        name: "@swamp/method-summary",
+        description: "Summary of method execution results",
+      },
+      {
+        type: "@swamp/cost-report",
+        name: "@swamp/cost-report",
+        description: "Cost breakdown for model operations",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+Deno.test("reportTypeSearch: returns all report types with no query", async () => {
+  const deps = makeDeps();
+  const events = await collect<ReportTypeSearchEvent>(
+    reportTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    ReportTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.query, "");
+  assertEquals(completed.data.results.length, 2);
+  assertEquals(completed.data.results[0].type, "@swamp/method-summary");
+  assertEquals(completed.data.results[0].name, "@swamp/method-summary");
+});
+
+Deno.test("reportTypeSearch: passes query through in data", async () => {
+  const deps = makeDeps();
+  const events = await collect<ReportTypeSearchEvent>(
+    reportTypeSearch(createLibSwampContext(), deps, { query: "cost" }),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    ReportTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.query, "cost");
+  assertEquals(completed.data.results.length, 2);
+});
+
+Deno.test("reportTypeSearch: returns empty results when no report types", async () => {
+  const deps = makeDeps({
+    getReportTypes: () => [],
+  });
+  const events = await collect<ReportTypeSearchEvent>(
+    reportTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  const completed = events[1] as Extract<
+    ReportTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 0);
+});

--- a/src/presentation/renderers/datastore_type_search.tsx
+++ b/src/presentation/renderers/datastore_type_search.tsx
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import type {
+  DatastoreTypeSearchData,
+  DatastoreTypeSearchEvent,
+  DatastoreTypeSearchItem,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import type { SearchRenderer } from "./search_renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { renderInteractivePicker } from "./components/search_picker.tsx";
+
+function filterDatastoreTypes(
+  types: DatastoreTypeSearchItem[],
+  query: string,
+): DatastoreTypeSearchItem[] {
+  if (!query) return types;
+  const lowerQuery = query.toLowerCase();
+  return types.filter(
+    (t) =>
+      t.type.toLowerCase().includes(lowerQuery) ||
+      t.name.toLowerCase().includes(lowerQuery) ||
+      t.description.toLowerCase().includes(lowerQuery),
+  );
+}
+
+export type DatastoreTypeSearchRenderer = SearchRenderer<
+  DatastoreTypeSearchEvent,
+  DatastoreTypeSearchItem
+>;
+
+class JsonDatastoreTypeSearchRenderer implements DatastoreTypeSearchRenderer {
+  private _selected: DatastoreTypeSearchItem | undefined;
+
+  selectedItem(): DatastoreTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<DatastoreTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const filtered = filterDatastoreTypes(e.data.results, e.data.query);
+        const output: DatastoreTypeSearchData = {
+          query: e.data.query,
+          results: filtered,
+        };
+        console.log(JSON.stringify(output, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class InkDatastoreTypeSearchRenderer implements DatastoreTypeSearchRenderer {
+  private _selected: DatastoreTypeSearchItem | undefined;
+
+  selectedItem(): DatastoreTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<DatastoreTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: async (e) => {
+        const result = await renderInteractivePicker<DatastoreTypeSearchItem>(
+          e.data.results,
+          e.data.query,
+          (item) => `${item.type} ${item.name} ${item.description}`,
+          renderDatastoreTypeResultLine,
+          renderDatastoreTypePreview,
+          renderDatastoreTypeScrollback,
+          "datastore types",
+          {
+            previewKeyFn: (item) => item.type,
+          },
+        );
+        if (result) {
+          this._selected = result.item;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDatastoreTypeSearchRenderer(
+  mode: OutputMode,
+): DatastoreTypeSearchRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDatastoreTypeSearchRenderer();
+    case "log":
+      return new InkDatastoreTypeSearchRenderer();
+  }
+}
+
+function renderDatastoreTypeResultLine(
+  item: DatastoreTypeSearchItem,
+): React.ReactElement {
+  return (
+    <Text>
+      {item.type} <Text dimColor>- {item.name}</Text>
+    </Text>
+  );
+}
+
+function renderDatastoreTypePreview(
+  item: DatastoreTypeSearchItem,
+  _detail: DatastoreTypeSearchItem | undefined,
+  _width: number,
+  _height: number,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column" paddingLeft={1}>
+      <Text bold>{item.type}</Text>
+      <Text dimColor>name: {item.name}</Text>
+      <Text dimColor>{item.description}</Text>
+    </Box>
+  );
+}
+
+function renderDatastoreTypeScrollback(
+  item: DatastoreTypeSearchItem,
+  _detail: DatastoreTypeSearchItem | undefined,
+): string {
+  return `${item.type} - ${item.name}\n${item.description}`;
+}

--- a/src/presentation/renderers/driver_type_search.tsx
+++ b/src/presentation/renderers/driver_type_search.tsx
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import type {
+  DriverTypeSearchData,
+  DriverTypeSearchEvent,
+  DriverTypeSearchItem,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import type { SearchRenderer } from "./search_renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { renderInteractivePicker } from "./components/search_picker.tsx";
+
+function filterDriverTypes(
+  types: DriverTypeSearchItem[],
+  query: string,
+): DriverTypeSearchItem[] {
+  if (!query) return types;
+  const lowerQuery = query.toLowerCase();
+  return types.filter(
+    (t) =>
+      t.type.toLowerCase().includes(lowerQuery) ||
+      t.name.toLowerCase().includes(lowerQuery) ||
+      t.description.toLowerCase().includes(lowerQuery),
+  );
+}
+
+export type DriverTypeSearchRenderer = SearchRenderer<
+  DriverTypeSearchEvent,
+  DriverTypeSearchItem
+>;
+
+class JsonDriverTypeSearchRenderer implements DriverTypeSearchRenderer {
+  private _selected: DriverTypeSearchItem | undefined;
+
+  selectedItem(): DriverTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<DriverTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const filtered = filterDriverTypes(e.data.results, e.data.query);
+        const output: DriverTypeSearchData = {
+          query: e.data.query,
+          results: filtered,
+        };
+        console.log(JSON.stringify(output, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class InkDriverTypeSearchRenderer implements DriverTypeSearchRenderer {
+  private _selected: DriverTypeSearchItem | undefined;
+
+  selectedItem(): DriverTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<DriverTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: async (e) => {
+        const result = await renderInteractivePicker<DriverTypeSearchItem>(
+          e.data.results,
+          e.data.query,
+          (item) => `${item.type} ${item.name} ${item.description}`,
+          renderDriverTypeResultLine,
+          renderDriverTypePreview,
+          renderDriverTypeScrollback,
+          "driver types",
+          {
+            previewKeyFn: (item) => item.type,
+          },
+        );
+        if (result) {
+          this._selected = result.item;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDriverTypeSearchRenderer(
+  mode: OutputMode,
+): DriverTypeSearchRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDriverTypeSearchRenderer();
+    case "log":
+      return new InkDriverTypeSearchRenderer();
+  }
+}
+
+function renderDriverTypeResultLine(
+  item: DriverTypeSearchItem,
+): React.ReactElement {
+  return (
+    <Text>
+      {item.type} <Text dimColor>- {item.name}</Text>
+    </Text>
+  );
+}
+
+function renderDriverTypePreview(
+  item: DriverTypeSearchItem,
+  _detail: DriverTypeSearchItem | undefined,
+  _width: number,
+  _height: number,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column" paddingLeft={1}>
+      <Text bold>{item.type}</Text>
+      <Text dimColor>name: {item.name}</Text>
+      <Text dimColor>{item.description}</Text>
+    </Box>
+  );
+}
+
+function renderDriverTypeScrollback(
+  item: DriverTypeSearchItem,
+  _detail: DriverTypeSearchItem | undefined,
+): string {
+  return `${item.type} - ${item.name}\n${item.description}`;
+}

--- a/src/presentation/renderers/report_type_search.tsx
+++ b/src/presentation/renderers/report_type_search.tsx
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { Box, Text } from "ink";
+import type {
+  EventHandlers,
+  ReportTypeSearchData,
+  ReportTypeSearchEvent,
+  ReportTypeSearchItem,
+} from "../../libswamp/mod.ts";
+import type { SearchRenderer } from "./search_renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { renderInteractivePicker } from "./components/search_picker.tsx";
+
+function filterReportTypes(
+  types: ReportTypeSearchItem[],
+  query: string,
+): ReportTypeSearchItem[] {
+  if (!query) return types;
+  const lowerQuery = query.toLowerCase();
+  return types.filter(
+    (t) =>
+      t.type.toLowerCase().includes(lowerQuery) ||
+      t.name.toLowerCase().includes(lowerQuery) ||
+      t.description.toLowerCase().includes(lowerQuery),
+  );
+}
+
+export type ReportTypeSearchRenderer = SearchRenderer<
+  ReportTypeSearchEvent,
+  ReportTypeSearchItem
+>;
+
+class JsonReportTypeSearchRenderer implements ReportTypeSearchRenderer {
+  private _selected: ReportTypeSearchItem | undefined;
+
+  selectedItem(): ReportTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<ReportTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const filtered = filterReportTypes(e.data.results, e.data.query);
+        const output: ReportTypeSearchData = {
+          query: e.data.query,
+          results: filtered,
+        };
+        console.log(JSON.stringify(output, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class InkReportTypeSearchRenderer implements ReportTypeSearchRenderer {
+  private _selected: ReportTypeSearchItem | undefined;
+
+  selectedItem(): ReportTypeSearchItem | undefined {
+    return this._selected;
+  }
+
+  handlers(): EventHandlers<ReportTypeSearchEvent> {
+    return {
+      resolving: () => {},
+      completed: async (e) => {
+        const result = await renderInteractivePicker<ReportTypeSearchItem>(
+          e.data.results,
+          e.data.query,
+          (item) => `${item.type} ${item.name} ${item.description}`,
+          renderReportTypeResultLine,
+          renderReportTypePreview,
+          renderReportTypeScrollback,
+          "report types",
+          {
+            previewKeyFn: (item) => item.type,
+          },
+        );
+        if (result) {
+          this._selected = result.item;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createReportTypeSearchRenderer(
+  mode: OutputMode,
+): ReportTypeSearchRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonReportTypeSearchRenderer();
+    case "log":
+      return new InkReportTypeSearchRenderer();
+  }
+}
+
+function renderReportTypeResultLine(
+  item: ReportTypeSearchItem,
+): React.ReactElement {
+  return (
+    <Text>
+      {item.type} <Text dimColor>- {item.name}</Text>
+    </Text>
+  );
+}
+
+function renderReportTypePreview(
+  item: ReportTypeSearchItem,
+  _detail: ReportTypeSearchItem | undefined,
+  _width: number,
+  _height: number,
+): React.ReactElement {
+  return (
+    <Box flexDirection="column" paddingLeft={1}>
+      <Text bold>{item.type}</Text>
+      <Text dimColor>name: {item.name}</Text>
+      <Text dimColor>{item.description}</Text>
+    </Box>
+  );
+}
+
+function renderReportTypeScrollback(
+  item: ReportTypeSearchItem,
+  _detail: ReportTypeSearchItem | undefined,
+): string {
+  return `${item.type} - ${item.name}\n${item.description}`;
+}


### PR DESCRIPTION
## Summary

- Adds `swamp driver type search`, `swamp datastore type search`, and `swamp report type search` commands — matching the existing model/vault type search CLI surface
- Creates a new top-level `swamp driver` command group (driver had no CLI surface previously)
- Updates `getDriverTypes()` and `getDatastoreTypes()` to include lazy-loaded extension types, matching the existing `getVaultTypes()` pattern
- Each kind gets its own libswamp generator, presentation renderer (JSON + Ink), and CLI command

Closes swamp-club#324

## Test plan

- [x] 9 new unit tests for the 3 libswamp generators (all pass)
- [x] Full test suite: 5822 passed, 0 failed
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] Compiled binary tested against real repo:
  - `swamp driver type search --json` → returns raw + docker
  - `swamp datastore type search --json` → returns filesystem
  - `swamp report type search --json` → returns @swamp/method-summary + @swamp/workflow-summary
  - Query filtering verified (e.g. `swamp driver type search docker` returns only docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)