### PR TITLE
feat(http): surface HTTP 429 with Retry-After hint on swamp-club calls (swamp-club#314)

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -19,6 +19,7 @@
 
 import { UserError } from "../../domain/errors.ts";
 import type { ExtensionContentMetadata } from "../../domain/extensions/extension_content.ts";
+import { parseRetryAfter, rateLimitError } from "./rate_limit.ts";
 
 /** Metadata sent during push initiation and confirmation. */
 export interface PushMetadata {
@@ -457,6 +458,12 @@ export class ExtensionApiClient {
 
   private async checkResponse(res: Response): Promise<void> {
     if (res.ok || res.status === 201) return;
+
+    if (res.status === 429) {
+      const retryAfter = parseRetryAfter(res.headers.get("retry-after"));
+      await res.body?.cancel();
+      throw rateLimitError(retryAfter);
+    }
 
     const body = await res.text();
 

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -543,3 +543,68 @@ Deno.test("ExtensionApiClient version-scoped methods URL-encode version path seg
     await server.shutdown();
   }
 });
+
+Deno.test("ExtensionApiClient: 429 surfaces Retry-After in UserError", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response("rate limited", {
+      status: 429,
+      headers: { "retry-after": "45" },
+    });
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+    );
+    const err = await assertRejects(
+      () => client.getLatestVersion("@test/ext"),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Rate limit exceeded");
+    assertStringIncludes(err.message, "Retry in 45s");
+    assertStringIncludes(err.message, "swamp auth login");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient: 429 on search surfaces sign-in hint", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response("rate limited", { status: 429 });
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+    );
+    const err = await assertRejects(
+      () => client.searchExtensions({ q: "aws" }),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Rate limit exceeded");
+    assertEquals(err.message.includes("Retry in"), false);
+    assertStringIncludes(err.message, "swamp auth login");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient: 429 on getDownloadUrl is preferred over 404 fallthrough", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response("rate limited", {
+      status: 429,
+      headers: { "retry-after": "10" },
+    });
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+    );
+    const err = await assertRejects(
+      () => client.getDownloadUrl("@test/ext", "2026.01.01.1"),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Rate limit exceeded");
+    assertStringIncludes(err.message, "Retry in 10s");
+  } finally {
+    await server.shutdown();
+  }
+});

--- a/src/infrastructure/http/rate_limit.ts
+++ b/src/infrastructure/http/rate_limit.ts
@@ -1,0 +1,65 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../../domain/errors.ts";
+
+/**
+ * Parse an RFC 7231 Retry-After header. Returns a non-negative integer
+ * number of seconds, or undefined if the header is missing/unparseable.
+ *
+ * Accepts both forms:
+ *   - delta-seconds: `Retry-After: 120`
+ *   - HTTP-date:     `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`
+ */
+export function parseRetryAfter(header: string | null): number | undefined {
+  if (header === null) return undefined;
+  const trimmed = header.trim();
+  if (trimmed === "") return undefined;
+
+  // Numeric form (delta-seconds) — handle entirely here so we don't fall
+  // through to Date.parse, which would interpret "-1" as a past date.
+  if (/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+    const asNumber = Number(trimmed);
+    if (Number.isFinite(asNumber) && asNumber >= 0) {
+      return Math.ceil(asNumber);
+    }
+    return undefined;
+  }
+
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return undefined;
+  const seconds = Math.ceil((date - Date.now()) / 1000);
+  return seconds > 0 ? seconds : 0;
+}
+
+/**
+ * Build the UserError shown when swamp-club returns HTTP 429.
+ * Includes the wait hint when Retry-After is parseable and a sign-in
+ * hint so unauthenticated callers know how to raise their ceiling.
+ */
+export function rateLimitError(
+  retryAfterSeconds: number | undefined,
+): UserError {
+  const wait = retryAfterSeconds !== undefined
+    ? ` Retry in ${retryAfterSeconds}s.`
+    : "";
+  return new UserError(
+    `Rate limit exceeded.${wait} Sign in with 'swamp auth login' for a higher limit.`,
+  );
+}

--- a/src/infrastructure/http/rate_limit_test.ts
+++ b/src/infrastructure/http/rate_limit_test.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertStringIncludes } from "@std/assert/string-includes";
+import { parseRetryAfter, rateLimitError } from "./rate_limit.ts";
+
+Deno.test("parseRetryAfter: returns undefined for null", () => {
+  assertEquals(parseRetryAfter(null), undefined);
+});
+
+Deno.test("parseRetryAfter: returns undefined for empty string", () => {
+  assertEquals(parseRetryAfter(""), undefined);
+  assertEquals(parseRetryAfter("   "), undefined);
+});
+
+Deno.test("parseRetryAfter: parses integer delta-seconds", () => {
+  assertEquals(parseRetryAfter("120"), 120);
+  assertEquals(parseRetryAfter("0"), 0);
+  assertEquals(parseRetryAfter("  60  "), 60);
+});
+
+Deno.test("parseRetryAfter: rounds up fractional delta-seconds", () => {
+  assertEquals(parseRetryAfter("1.2"), 2);
+  assertEquals(parseRetryAfter("0.1"), 1);
+});
+
+Deno.test("parseRetryAfter: parses HTTP-date in the future", () => {
+  const future = new Date(Date.now() + 60_000).toUTCString();
+  const seconds = parseRetryAfter(future);
+  // Allow tiny clock drift between Date.now() calls.
+  assertEquals(seconds !== undefined && seconds >= 59 && seconds <= 61, true);
+});
+
+Deno.test("parseRetryAfter: clamps HTTP-date in the past to 0", () => {
+  const past = new Date(Date.now() - 60_000).toUTCString();
+  assertEquals(parseRetryAfter(past), 0);
+});
+
+Deno.test("parseRetryAfter: returns undefined for unparseable values", () => {
+  assertEquals(parseRetryAfter("soon"), undefined);
+  assertEquals(parseRetryAfter("-1"), undefined);
+});
+
+Deno.test("rateLimitError: includes wait hint and sign-in hint when retryAfter provided", () => {
+  const err = rateLimitError(42);
+  assertStringIncludes(err.message, "Rate limit exceeded");
+  assertStringIncludes(err.message, "Retry in 42s");
+  assertStringIncludes(err.message, "swamp auth login");
+});
+
+Deno.test("rateLimitError: omits wait hint when retryAfter undefined", () => {
+  const err = rateLimitError(undefined);
+  assertStringIncludes(err.message, "Rate limit exceeded");
+  assertEquals(err.message.includes("Retry in"), false);
+  assertStringIncludes(err.message, "swamp auth login");
+});

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../domain/errors.ts";
+import { parseRetryAfter, rateLimitError } from "./rate_limit.ts";
 
 /** Response from BetterAuth sign-in endpoint. */
 export interface SignInResponse {
@@ -320,8 +321,15 @@ export class SwampClubClient {
       ? AbortSignal.any([callerSignal, timeoutSignal])
       : timeoutSignal;
     try {
-      return await fetch(url, { ...init, signal });
+      const res = await fetch(url, { ...init, signal });
+      if (res.status === 429) {
+        const retryAfter = parseRetryAfter(res.headers.get("retry-after"));
+        await res.body?.cancel();
+        throw rateLimitError(retryAfter);
+      }
+      return res;
     } catch (error) {
+      if (error instanceof UserError) throw error;
       // Re-throw AbortError from caller signal without wrapping
       if (
         callerSignal?.aborted && error instanceof DOMException &&

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { assertStringIncludes } from "@std/assert/string-includes";
 import { SwampClubClient } from "./swamp_club_client.ts";
 import { UserError } from "../../domain/errors.ts";
 
@@ -210,6 +211,45 @@ Deno.test("SwampClubClient - submitIssue throws UserError on failure", async () 
       UserError,
       "Failed to submit issue",
     );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - 429 surfaces Retry-After in UserError", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("rate limited", {
+      status: 429,
+      headers: { "retry-after": "30" },
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const err = await assertRejects(
+      () => client.fetchIssue(undefined, 1),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Rate limit exceeded");
+    assertStringIncludes(err.message, "Retry in 30s");
+    assertStringIncludes(err.message, "swamp auth login");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - 429 without Retry-After still surfaces sign-in hint", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("rate limited", { status: 429 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const err = await assertRejects(
+      () => client.fetchIssue(undefined, 1),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Rate limit exceeded");
+    assertEquals(err.message.includes("Retry in"), false);
+    assertStringIncludes(err.message, "swamp auth login");
   } finally {
     await mock.shutdown();
   }


### PR DESCRIPTION
## Summary

CLI-side companion for [swamp-club#314](https://swamp.club/lab/314). Once the Lab server begins rate-limiting unauthenticated reads (per-IP, byte-weighted on downloads, higher ceiling for auth'd users, application-level), the swamp CLI needs to translate HTTP 429 into a useful error rather than leaking through as a generic `HTTP 429` message.

- New `src/infrastructure/http/rate_limit.ts`:
  - `parseRetryAfter(header)` — RFC 7231 compliant: delta-seconds, fractional rounding, HTTP-date (past dates clamp to 0), rejects negatives/garbage.
  - `rateLimitError(seconds)` — builds the `UserError` with both the wait hint and a sign-in hint.
- `SwampClubClient` — 429 caught inside the private `fetch` wrapper so every Lab call (`fetchIssue`, `submitIssue`, ripple, whoami, sign-in) flows through the same handling. Re-throws `UserError` past the connection-error catch.
- `ExtensionApiClient` — 429 handled at the top of `checkResponse`, before the 401/403/422 branches. The body is drained to avoid leaks. This covers metadata, search, download-URL resolve, yank/unyank, etc. The 404 short-circuits in `getLatestVersion` / `getExtension` / `getDownloadUrl` correctly fall through to `checkResponse` on 429.

Message users will see (unauthenticated, `Retry-After: 30`):
```
Rate limit exceeded. Retry in 30s. Sign in with 'swamp auth login' for a higher limit.
```

Server-side rate-limiting policy itself lives in the swamp-club repo and is out of scope here.

## Test Plan

- [x] 9 unit tests for `parseRetryAfter` / `rateLimitError` covering null, empty, integer, fractional, HTTP-date future/past, garbage, and negative inputs.
- [x] 2 new integration tests on `SwampClubClient` covering 429 with `Retry-After` and 429 without `Retry-After`.
- [x] 3 new integration tests on `ExtensionApiClient` covering 429 on `getLatestVersion`, on `searchExtensions`, and the 429-vs-404 ordering on `getDownloadUrl`.
- [x] `deno check`, `deno lint`, `deno fmt --check` all clean.
- [x] Full `deno run test` — 5839 passed, 1 failed. The one failure (`extension quality: missing README fails has-readme and readme-example`) reproduces on a clean `main` checkout and is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)