### PR TITLE
fix(workflows): resolve runtime expressions in driverConfig (swamp-club#291)

### DIFF
--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -503,6 +503,31 @@ export class ExpressionEvaluationService {
   }
 
   /**
+   * Resolves both CEL expressions (with the supplied context, including
+   * self.* for forEach iteration) and runtime expressions (env, vault)
+   * in arbitrary data in a single call. Two-pass composition:
+   *
+   *   1. {@link evaluateData} — CEL only, skips runtime. Resolves self.*,
+   *      inputs.*, model.*, data.*, etc. against the supplied context.
+   *   2. {@link resolveRuntimeExpressionsInData} — env and vault. Vault
+   *      values are resolved to raw strings and registered with the
+   *      optional redactor for log scrubbing.
+   *
+   * Used at execution-time seams that consume workflow-level driverConfig
+   * (post-DriverPlan.withDefinition and post-resolveDriverConfig), where
+   * CEL must materialize before runtime resolution walks the now-CEL-
+   * resolved tree.
+   */
+  async resolveAllExpressionsInData(
+    data: unknown,
+    context: ExpressionContext,
+    redactor?: SecretRedactor,
+  ): Promise<unknown> {
+    const afterCel = await this.evaluateData(data, context);
+    return await this.resolveRuntimeExpressionsInData(afterCel, redactor);
+  }
+
+  /**
    * @deprecated Use resolveRuntimeExpressionsInDefinition instead.
    */
   async resolveVaultExpressionsInDefinition(

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -27,6 +27,8 @@ import {
   containsVaultExpression,
   ExpressionEvaluationService,
 } from "./expression_evaluation_service.ts";
+import type { ExpressionContext } from "./model_resolver.ts";
+import { SecretRedactor } from "../secrets/secret_redactor.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-eval-service-" });
@@ -237,5 +239,161 @@ Deno.test("evaluateDefinition: directly-missing input in globalArguments stays u
       result.definition.globalArguments.unusedArg as string,
       "${{",
     );
+  });
+});
+
+// ============================================================================
+// resolveAllExpressionsInData — driverConfig seam (swamp-club#291)
+// ============================================================================
+
+function makeContext(
+  overrides: Partial<ExpressionContext> = {},
+): ExpressionContext {
+  return {
+    model: {},
+    env: {},
+    ...overrides,
+  };
+}
+
+Deno.test("resolveAllExpressionsInData: returns literals unchanged", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const data = {
+      image: "alpine:3",
+      volumes: ["/host/path:/container/path:ro"],
+      env: { LITERAL: "value" },
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      makeContext(),
+    );
+    assertEquals(result, data);
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: resolves env runtime expressions", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    Deno.env.set("SWAMP_TEST_HOME", "/tmp/test-home-291");
+    try {
+      const data = {
+        volumes: ["${{ env.SWAMP_TEST_HOME }}:/host-home:ro"],
+      };
+      const result = await service.resolveAllExpressionsInData(
+        data,
+        makeContext(),
+      ) as { volumes: string[] };
+      assertEquals(result.volumes, ["/tmp/test-home-291:/host-home:ro"]);
+    } finally {
+      Deno.env.delete("SWAMP_TEST_HOME");
+    }
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: resolves self.* via supplied CEL context", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const ctx = makeContext({
+      self: {
+        id: "test-id",
+        name: "test",
+        version: 1,
+        tags: {},
+        globalArguments: {},
+        region: "us-west-2",
+      },
+    });
+    const data = {
+      env: { AWS_REGION: "${{ self.region }}" },
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      ctx,
+    ) as { env: Record<string, string> };
+    assertEquals(result.env.AWS_REGION, "us-west-2");
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: walks nested arrays and objects", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    Deno.env.set("SWAMP_TEST_A", "alpha");
+    Deno.env.set("SWAMP_TEST_B", "beta");
+    try {
+      const data = {
+        extraArgs: [
+          "--label",
+          "${{ env.SWAMP_TEST_A }}",
+          "--label",
+          "${{ env.SWAMP_TEST_B }}",
+        ],
+        env: {
+          FIRST: "${{ env.SWAMP_TEST_A }}",
+          NESTED: { inner: "${{ env.SWAMP_TEST_B }}" },
+        },
+      };
+      const result = await service.resolveAllExpressionsInData(
+        data,
+        makeContext(),
+      ) as {
+        extraArgs: string[];
+        env: { FIRST: string; NESTED: { inner: string } };
+      };
+      assertEquals(result.extraArgs, [
+        "--label",
+        "alpha",
+        "--label",
+        "beta",
+      ]);
+      assertEquals(result.env.FIRST, "alpha");
+      assertEquals(result.env.NESTED.inner, "beta");
+    } finally {
+      Deno.env.delete("SWAMP_TEST_A");
+      Deno.env.delete("SWAMP_TEST_B");
+    }
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: short-circuits with no expressions (no redactor calls)", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    let addedSecrets = 0;
+    const redactor = new SecretRedactor();
+    const origAdd = redactor.addSecret.bind(redactor);
+    redactor.addSecret = (v: string) => {
+      addedSecrets++;
+      origAdd(v);
+    };
+    const data = { image: "alpine:3", volumes: ["/abs/path:/dst:ro"] };
+    await service.resolveAllExpressionsInData(data, makeContext(), redactor);
+    assertEquals(addedSecrets, 0);
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: env-only resolution does not register secrets with redactor", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    Deno.env.set("SWAMP_TEST_PUB", "public-value");
+    try {
+      let addedSecrets = 0;
+      const redactor = new SecretRedactor();
+      const origAdd = redactor.addSecret.bind(redactor);
+      redactor.addSecret = (v: string) => {
+        addedSecrets++;
+        origAdd(v);
+      };
+      const data = { env: { VAR: "${{ env.SWAMP_TEST_PUB }}" } };
+      await service.resolveAllExpressionsInData(data, makeContext(), redactor);
+      assertEquals(addedSecrets, 0);
+    } finally {
+      Deno.env.delete("SWAMP_TEST_PUB");
+    }
   });
 });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -612,6 +612,7 @@ export class DefaultStepExecutor implements StepExecutor {
         evaluatedDefinition,
         runLogger,
         secretBag,
+        expressionEvaluator,
       });
 
       return await this.handleMethodSuccess({
@@ -682,6 +683,7 @@ export class DefaultStepExecutor implements StepExecutor {
       ExpressionEvaluationService["resolveRuntimeExpressionsInDefinition"]
     > extends Promise<infer R> ? R extends { secretBag: infer S } ? S : never
       : never;
+    expressionEvaluator: ExpressionEvaluationService;
   }): Promise<MethodResult> {
     const {
       task,
@@ -697,6 +699,7 @@ export class DefaultStepExecutor implements StepExecutor {
       evaluatedDefinition,
       runLogger,
       secretBag,
+      expressionEvaluator,
     } = args;
 
     runLogger.debug("Executing method {method}", { method: task.methodName });
@@ -746,10 +749,30 @@ export class DefaultStepExecutor implements StepExecutor {
     // honoured — matches the pre-DriverPlan behaviour where the
     // definition was passed to resolveDriverConfig regardless of whether
     // upper tiers were set.
-    const resolved = (ctx.driverPlan ?? new DriverPlan({})).withDefinition({
-      driver: evaluatedDefinition.driver,
-      driverConfig: evaluatedDefinition.driverConfig,
-    });
+    const resolvedDriver = (ctx.driverPlan ?? new DriverPlan({}))
+      .withDefinition({
+        driver: evaluatedDefinition.driver,
+        driverConfig: evaluatedDefinition.driverConfig,
+      });
+
+    // Resolve CEL (including self.* for forEach) and runtime expressions
+    // (env, vault) in the winning tier's driverConfig. WorkflowExpressionEvaluator
+    // deliberately skips runtime expressions and self.* during workflow
+    // evaluation, and the definition-tier driverConfig is the only tier
+    // that already went through resolveRuntimeExpressionsInDefinition; this
+    // seam covers workflow/job/step/repo tiers (and is idempotent for the
+    // definition tier). Vault values land as raw strings on driver argv;
+    // see the workflows manual reference for the visibility caveat.
+    const resolved = ctx.expressionContext && resolvedDriver.driverConfig
+      ? {
+        driver: resolvedDriver.driver,
+        driverConfig: (await expressionEvaluator.resolveAllExpressionsInData(
+          resolvedDriver.driverConfig,
+          ctx.expressionContext,
+          ctx.secretRedactor,
+        )) as Record<string, unknown>,
+      }
+      : resolvedDriver;
 
     // Yield `method_executing` AFTER driver resolution so the resolved
     // driver can ride along on the event for downstream telemetry. Note:

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -571,7 +571,7 @@ export async function* modelMethodRun(
         // (cli > definition > repo > "raw"). No workflow/job/step tiers
         // apply outside a workflow run.
         const repoMarker = await deps.loadRepoMarker();
-        const resolvedDriver = resolveDriverConfig(
+        const resolvedDriverPre = resolveDriverConfig(
           { driver: input.driver },
           undefined,
           undefined,
@@ -585,6 +585,24 @@ export async function* modelMethodRun(
             driverConfig: repoMarker?.defaultDriverConfig,
           },
         );
+
+        // Resolve runtime expressions (env, vault) in the winning tier's
+        // driverConfig. The definition-tier already went through
+        // resolveRuntimeExpressionsInDefinition above, so this pass is
+        // idempotent for that tier; it is LOAD-BEARING for the repo-tier
+        // defaultDriverConfig from .swamp.yaml, which is never resolved
+        // anywhere else. No forEach on the direct path, so the CEL/self.*
+        // pass is unnecessary here.
+        const resolvedDriver = resolvedDriverPre.driverConfig
+          ? {
+            driver: resolvedDriverPre.driver,
+            driverConfig:
+              (await evaluationService.resolveRuntimeExpressionsInData(
+                resolvedDriverPre.driverConfig,
+                redactor,
+              )) as Record<string, unknown>,
+          }
+          : resolvedDriverPre;
 
         let execResult: MethodResult;
         try {

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -128,6 +128,7 @@ function createFakeEvaluationService(): any {
         definition: def,
         secretBag: new VaultSecretBag(),
       }),
+    resolveRuntimeExpressionsInData: (data: unknown) => Promise.resolve(data),
   };
 }
 


### PR DESCRIPTION
## Summary

Workflow-level `\${{ env.* }}`, `\${{ vault.* }}`, and `\${{ self.* }}` (forEach) expressions in `driverConfig` fields were never resolved before being handed to the driver. Docker (and any out-of-process driver) received literal `\${{ ... }}` strings on argv and rejected them.

This PR adds a new `ExpressionEvaluationService.resolveAllExpressionsInData` operation that composes the existing CEL pass (`evaluateData`) and runtime pass (`resolveRuntimeExpressionsInData`), and wires it at two seams:

- **Workflow-step path:** after `DriverPlan.withDefinition` in `DefaultStepExecutor.invokeMethod`. Covers workflow/job/step driverConfig.
- **Direct model-method path:** after `resolveDriverConfig` in `libswamp/models/run.ts`. Load-bearing for repo-tier `defaultDriverConfig` from `.swamp.yaml`, which has never been runtime-resolved at any earlier point.

Vault values resolved in `driverConfig` are registered with the workflow's `SecretRedactor` for log scrubbing. They land as raw strings on the driver subprocess argv, which is documented in the manual reference (companion PR systeminit/swamp-club#527) — argv exposure to local-machine `ps` is a documented trade-off.

## Test plan

- [x] Unit tests: 6 new tests on `resolveAllExpressionsInData` covering literal no-op, env resolution, `self.*` via supplied context, nested arrays/objects walking, no-expression short-circuit, and env-only-no-secret-registration.
- [x] Existing test mock for `evaluationService` updated to satisfy the new dependency.
- [x] Full test suite: 5831 passed, 1 pre-existing failure (`extension_quality_test.ts: missing README` — exists on `main` without this PR).
- [x] `deno check`, `deno lint`, `deno fmt` all clean.
- [x] `deno run compile` succeeds.
- [x] Manual repro against `/tmp/swamp-repro-issue-291`: before fix, docker rejected with "invalid characters for a local volume name"; after fix, docker accepts the resolved `\${HOME}:/host-home:ro` volume string and only fails on an unrelated docker daemon issue on the test host.
- [ ] End-to-end UAT coverage tracked in systeminit/swamp-uat#210 (deferred — no in-repo precedent for docker-conditional integration tests).

## Companion changes

- Manual reference: systeminit/swamp-club#527 (adds `driverConfig` to supported expression sites + argv-visibility security caveat)
- UAT: systeminit/swamp-uat#210 (end-to-end coverage: env in volumes, self.* in env on forEach, vault in env with log redaction)

Closes swamp-club#291

🤖 Generated with [Claude Code](https://claude.com/claude-code)