### PR TITLE
feat(cli): add --close/--reopen flags and comment alias to ripple command (swamp-club#329)

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-issue
-description: Fetch issue details and submit issues to the swamp Lab or route them to the publisher's repository — fetch issue details, file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension, and post follow-up ripples (comments) on existing Lab issues. Use when the user wants to view an issue, report a bug, request a feature, disclose a vulnerability, comment on an existing issue, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug", "ripple", "comment on issue", "reply to issue", "follow up on issue", "add comment to issue", "get issue", "view issue", "fetch issue", "issue details", "show issue".
+description: Fetch issue details and submit issues to the swamp Lab or route them to the publisher's repository — fetch issue details, file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension, and post follow-up ripples (comments) on existing Lab issues with optional close/reopen. Use when the user wants to view an issue, report a bug, request a feature, disclose a vulnerability, comment on an existing issue, close or reopen an issue, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug", "ripple", "comment on issue", "reply to issue", "follow up on issue", "add comment to issue", "close issue", "reopen issue", "get issue", "view issue", "fetch issue", "issue details", "show issue".
 ---
 
 # Swamp Issue Skill
@@ -22,6 +22,8 @@ to the publisher's declared repository (for third-party extensions).
 To follow up on an existing Lab issue (e.g. add a related finding, link a
 sibling issue, or update reproduction steps discovered later), use
 `swamp issue ripple <number>` — this posts a comment ("ripple") on the issue.
+`swamp issue comment` is an alias for `ripple`. Add `--close` to close the issue
+after posting, or `--reopen` to reopen it.
 
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
 `swamp help issue` for the complete, up-to-date CLI schema.
@@ -39,7 +41,7 @@ directly.
 | `swamp issue bug`             | Title, description, steps to reproduce, environment                                           |
 | `swamp issue feature`         | Title, problem statement, proposed solution, alternatives                                     |
 | `swamp issue security`        | Title, description, reproduction, affected components, impact                                 |
-| `swamp issue ripple <number>` | Free-form markdown body (no title)                                                            |
+| `swamp issue ripple <number>` | Free-form markdown body (no title); alias: `swamp issue comment`                              |
 
 **Basic non-interactive examples:**
 
@@ -51,6 +53,9 @@ swamp issue feature --title "Add dark mode" --body "I'd like..." --json
 swamp issue security --title "..." --body "..." --json
 swamp issue bug --email --title "Crash report" --body "Details..."
 swamp issue ripple 184 --body "See also #183 for the related finding." --json
+swamp issue ripple 327 --body "Fixed in latest build" --close --json
+swamp issue ripple 42 --body "Re-opening per discussion" --reopen
+swamp issue comment 184 --body "See also #183."
 ```
 
 ## Ripple Constraints
@@ -61,6 +66,9 @@ Ripples (described in the intro) have these submission rules:
 - `--body` skips the editor; `--json` requires `--body`.
 - The body is plain markdown; the server enforces a 65,536-character limit and
   rejects profanity.
+- `--close` and `--reopen` are mutually exclusive. The ripple is posted first;
+  the status change is a separate operation. If the status change fails, the
+  ripple is still posted (partial success).
 
 **Output shape** (with `--json`):
 
@@ -68,9 +76,15 @@ Ripples (described in the intro) have these submission rules:
 {
   "issueNumber": 184,
   "commentId": "ripple_abc123",
-  "serverUrl": "https://swamp.club"
+  "serverUrl": "https://swamp.club",
+  "statusChanged": "closed",
+  "statusError": null
 }
 ```
+
+The `statusChanged` field is present only when `--close` or `--reopen` was used
+and the status change succeeded. `statusError` appears when the ripple posted
+but the status change failed.
 
 ## Plain Submission Flow (no `--extension`)
 

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -76,15 +76,13 @@ Ripples (described in the intro) have these submission rules:
 {
   "issueNumber": 184,
   "commentId": "ripple_abc123",
-  "serverUrl": "https://swamp.club",
-  "statusChanged": "closed",
-  "statusError": null
+  "serverUrl": "https://swamp.club"
 }
 ```
 
-The `statusChanged` field is present only when `--close` or `--reopen` was used
-and the status change succeeded. `statusError` appears when the ripple posted
-but the status change failed.
+With `--close`: adds `"statusChanged": "closed"`. With `--reopen`: adds
+`"statusChanged": "open"`. If the status change fails after a successful ripple,
+`"statusError"` contains the error message instead.
 
 ## Plain Submission Flow (no `--extension`)
 

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -27,7 +27,7 @@ import { issueSecurityCommand } from "./issue_security.ts";
 export const issueCommand = new Command()
   .name("issue")
   .description(
-    "Fetch issue details, submit bug reports, feature requests, security reports, and ripples",
+    "Fetch issue details, submit bug reports, feature requests, security reports, and ripples (comments)",
   )
   .action(function () {
     this.showHelp();

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -24,6 +24,7 @@ import {
   createLibSwampContext,
   issueComment,
   type IssueCommentDeps,
+  type IssueStatusTransition,
 } from "../../libswamp/mod.ts";
 import {
   createIssueCommentRenderer,
@@ -69,8 +70,19 @@ export const issueRippleCommand = new Command()
     "Post a ripple directly",
     'swamp issue ripple 184 --body "See also #183."',
   )
+  .example(
+    "Close with a ripple",
+    'swamp issue ripple 327 --body "Fixed in latest build" --close',
+  )
+  .alias("comment")
   .arguments("<number:integer>")
   .option("-b, --body <body:string>", "Ripple body (skips editor)")
+  .option("--close", "Close the issue after posting the ripple", {
+    conflicts: ["reopen"],
+  })
+  .option("--reopen", "Reopen the issue after posting the ripple", {
+    conflicts: ["close"],
+  })
   .action(async function (options: AnyOptions, issueNumber: number) {
     const ctx = createContext(options as GlobalOptions, ["issue", "ripple"]);
 
@@ -125,6 +137,12 @@ export const issueRippleCommand = new Command()
       }
     }
 
+    const statusTransition: IssueStatusTransition | undefined = options.close
+      ? "closed"
+      : options.reopen
+      ? "open"
+      : undefined;
+
     const libCtx = createLibSwampContext({ logger: ctx.logger });
     const renderer = createIssueCommentRenderer(ctx.outputMode);
     const client = new SwampClubClient(credentials.serverUrl);
@@ -140,10 +158,17 @@ export const issueRippleCommand = new Command()
           serverUrl: credentials.serverUrl,
         };
       },
+      updateStatus: async (input) => {
+        await client.updateIssueStatus(
+          credentials.apiKey,
+          input.issueNumber,
+          input.status,
+        );
+      },
     };
 
     await consumeStream(
-      issueComment(libCtx, deps, { issueNumber, body }),
+      issueComment(libCtx, deps, { issueNumber, body, statusTransition }),
       renderer.handlers(),
     );
   });

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -266,6 +266,41 @@ export class SwampClubClient {
   }
 
   /**
+   * Update the status of an existing Lab issue (close or reopen).
+   * Authenticates using the x-api-key header.
+   */
+  async updateIssueStatus(
+    apiKey: string,
+    issueNumber: number,
+    status: "closed" | "open",
+  ): Promise<{ status: string }> {
+    const res = await this.fetch(
+      `/api/v1/lab/issues/${issueNumber}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify({ status }),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 404) {
+        throw new UserError(`Issue #${issueNumber} not found.`);
+      }
+      throw new UserError(
+        `Failed to update issue #${issueNumber} status (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    const data = await res.json();
+    return { status: data.issue.status };
+  }
+
+  /**
    * Fetch an existing Lab issue by number.
    * When an API key is provided, authenticates using the x-api-key header.
    */

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -216,6 +216,60 @@ Deno.test("SwampClubClient - submitIssue throws UserError on failure", async () 
   }
 });
 
+Deno.test("SwampClubClient - updateIssueStatus sends PATCH with status", async () => {
+  let capturedMethod = "";
+  let capturedBody: Record<string, unknown> = {};
+  let capturedApiKey = "";
+  const mock = startMockServer(async (req) => {
+    capturedMethod = req.method;
+    capturedApiKey = req.headers.get("x-api-key") ?? "";
+    capturedBody = await req.json();
+    return Response.json({ issue: { number: 42, status: "closed" } });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.updateIssueStatus("my-key", 42, "closed");
+    assertEquals(capturedMethod, "PATCH");
+    assertEquals(capturedApiKey, "my-key");
+    assertEquals(capturedBody.status, "closed");
+    assertEquals(result.status, "closed");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssueStatus throws on 404", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("Not found", { status: 404 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.updateIssueStatus("key", 999, "closed"),
+      UserError,
+      "Issue #999 not found",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssueStatus throws on failure", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("Forbidden", { status: 403 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.updateIssueStatus("key", 42, "open"),
+      UserError,
+      "Failed to update issue #42 status",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
 Deno.test("SwampClubClient - 429 surfaces Retry-After in UserError", async () => {
   const mock = startMockServer((_req) =>
     new Response("rate limited", {

--- a/src/infrastructure/process/gh_cli_test.ts
+++ b/src/infrastructure/process/gh_cli_test.ts
@@ -362,4 +362,3 @@ Deno.test("createGithubIssueViaGh: large body is passed verbatim via stdin", asy
     body: huge,
   }, runner);
 });
-

--- a/src/infrastructure/process/gh_cli_test.ts
+++ b/src/infrastructure/process/gh_cli_test.ts
@@ -362,3 +362,4 @@ Deno.test("createGithubIssueViaGh: large body is passed verbatim via stdin", asy
     body: huge,
   }, runner);
 });
+

--- a/src/libswamp/issues/comment.ts
+++ b/src/libswamp/issues/comment.ts
@@ -29,11 +29,15 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
  */
 export const MAX_RIPPLE_LENGTH = 65_536;
 
+export type IssueStatusTransition = "closed" | "open";
+
 /** Output of a successful ripple post. */
 export interface IssueCommentData {
   issueNumber: number;
   commentId: string;
   serverUrl: string;
+  statusChanged?: IssueStatusTransition;
+  statusError?: string;
 }
 
 export type IssueCommentEvent =
@@ -43,6 +47,7 @@ export type IssueCommentEvent =
 export interface IssueCommentInput {
   issueNumber: number;
   body: string;
+  statusTransition?: IssueStatusTransition;
 }
 
 export interface IssueCommentDeps {
@@ -50,6 +55,10 @@ export interface IssueCommentDeps {
     issueNumber: number;
     body: string;
   }) => Promise<{ commentId: string; serverUrl: string }>;
+  updateStatus?: (input: {
+    issueNumber: number;
+    status: IssueStatusTransition;
+  }) => Promise<void>;
 }
 
 /**
@@ -85,14 +94,25 @@ export async function* issueComment(
         body: input.body,
       });
 
-      yield {
-        kind: "completed",
-        data: {
-          issueNumber: input.issueNumber,
-          commentId: result.commentId,
-          serverUrl: result.serverUrl,
-        },
+      const data: IssueCommentData = {
+        issueNumber: input.issueNumber,
+        commentId: result.commentId,
+        serverUrl: result.serverUrl,
       };
+
+      if (input.statusTransition && deps.updateStatus) {
+        try {
+          await deps.updateStatus({
+            issueNumber: input.issueNumber,
+            status: input.statusTransition,
+          });
+          data.statusChanged = input.statusTransition;
+        } catch (err) {
+          data.statusError = err instanceof Error ? err.message : String(err);
+        }
+      }
+
+      yield { kind: "completed", data };
     })(),
   );
 }

--- a/src/libswamp/issues/comment_test.ts
+++ b/src/libswamp/issues/comment_test.ts
@@ -124,6 +124,77 @@ Deno.test("issueComment: rejects body exceeding max length", async () => {
   assertStringIncludes(error.message, String(MAX_RIPPLE_LENGTH));
 });
 
+Deno.test("issueComment: calls updateStatus and sets statusChanged on success", async () => {
+  let statusCalled = false;
+  const deps = makeDeps({
+    updateStatus: (input) => {
+      statusCalled = true;
+      assertEquals(input.issueNumber, 42);
+      assertEquals(input.status, "closed");
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<IssueCommentEvent>(
+    issueComment(createLibSwampContext(), deps, {
+      issueNumber: 42,
+      body: "Closing this.",
+      statusTransition: "closed",
+    }),
+  );
+
+  assertEquals(statusCalled, true);
+  assertEquals(events.length, 1);
+  const completed = events[0] as Extract<
+    IssueCommentEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.statusChanged, "closed");
+  assertEquals(completed.data.statusError, undefined);
+});
+
+Deno.test("issueComment: sets statusError on update failure without losing the comment", async () => {
+  const deps = makeDeps({
+    updateStatus: () => Promise.reject(new Error("forbidden")),
+  });
+
+  const events = await collect<IssueCommentEvent>(
+    issueComment(createLibSwampContext(), deps, {
+      issueNumber: 42,
+      body: "Try to close.",
+      statusTransition: "closed",
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const completed = events[0] as Extract<
+    IssueCommentEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.commentId, "ripple-123");
+  assertEquals(completed.data.statusChanged, undefined);
+  assertStringIncludes(completed.data.statusError!, "forbidden");
+});
+
+Deno.test("issueComment: skips status update when no statusTransition", async () => {
+  let statusCalled = false;
+  const deps = makeDeps({
+    updateStatus: () => {
+      statusCalled = true;
+      return Promise.resolve();
+    },
+  });
+
+  await collect(
+    issueComment(createLibSwampContext(), deps, {
+      issueNumber: 42,
+      body: "No status change.",
+    }),
+  );
+
+  assertEquals(statusCalled, false);
+});
+
 Deno.test("issueComment: accepts body at exactly the max length", async () => {
   const exactlyMax = "x".repeat(MAX_RIPPLE_LENGTH);
   const events = await collect<IssueCommentEvent>(

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1025,6 +1025,7 @@ export {
   type IssueCommentDeps,
   type IssueCommentEvent,
   type IssueCommentInput,
+  type IssueStatusTransition,
   MAX_RIPPLE_LENGTH,
 } from "./issues/comment.ts";
 export {

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -147,6 +147,18 @@ class LogIssueCommentRenderer implements Renderer<IssueCommentEvent> {
         logger.info("View at: {url}", {
           url: `${data.serverUrl}/lab/${data.issueNumber}`,
         });
+        if (data.statusChanged) {
+          const verb = data.statusChanged === "closed" ? "Closed" : "Reopened";
+          logger.info(`${verb} issue #{number}`, {
+            number: data.issueNumber,
+          });
+        }
+        if (data.statusError) {
+          logger.warn(
+            "Ripple posted but status change failed: {error}",
+            { error: data.statusError },
+          );
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);


### PR DESCRIPTION
## Summary

- Add `--close` and `--reopen` flags to `swamp issue ripple` for transitioning issue status alongside a comment. The flags are mutually exclusive. The ripple posts first; if the status change fails, the ripple is preserved (partial success).
- Add `comment` as a Cliffy alias so `swamp issue comment <number>` works identically to `swamp issue ripple <number>`.
- Add `SwampClubClient.updateIssueStatus()` — PATCH `/api/v1/lab/issues/{N}` for close/reopen.
- Update the swamp-issue skill to document the new flags, alias, and output shape.

Closes https://swamp-club.com/lab/329

## Test Plan

- [x] `SwampClubClient.updateIssueStatus` — 3 new tests (success, 404, 403)
- [x] `issueComment` status transition — 3 new tests (success, failure with partial success, skip when absent)
- [x] `parseRippleContent` — 6 existing tests still pass
- [x] Full test suite — 5857 tests pass, 0 failures
- [x] `deno check`, `deno lint`, `deno fmt --check` all clean
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)