### PR TITLE
feat(expressions): expose workflow run context as run.* in CEL (swamp-club#331)

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -96,6 +96,46 @@ attributes:
 Inputs can be required or optional (specified in JsonSchema), and provide
 dynamic configuration without modifying definition files.
 
+## Workflow Run Context
+
+Inside workflow step inputs, the `run` namespace exposes metadata about the
+current workflow execution. This is only available at step execution time (not
+in workflow-level fields like `description`).
+
+| Field              | Type                    | Description                    |
+| ------------------ | ----------------------- | ------------------------------ |
+| `run.id`           | string (UUID)           | Unique ID of this workflow run |
+| `run.workflowId`   | string (UUID)           | Workflow definition ID         |
+| `run.workflowName` | string                  | Workflow name                  |
+| `run.startedAt`    | string (ISO 8601)       | Timestamp when the run started |
+| `run.tags`         | `Record<string,string>` | Merged workflow + runtime tags |
+
+The flat `workflowRunId` variable is also available (equivalent to `run.id`)
+for backward compatibility with `data.query()` predicates.
+
+**Run-scoped resource keys** — use `run.id` to prevent collisions when the
+same workflow runs concurrently:
+
+```yaml
+steps:
+  - name: filter-vms
+    task:
+      type: model_method
+      modelIdOrName: fleet-scanner
+      methodName: filter
+      inputs:
+        outputKey: "filtered-vms-${{ run.id }}"
+
+  - name: reboot-gate
+    dependsOn: [filter-vms]
+    task:
+      type: model_method
+      modelIdOrName: fleet-manager
+      methodName: check_kernel
+      inputs:
+        vmListKey: "filtered-vms-${{ run.id }}"
+```
+
 ## Data Versioning
 
 Data is immutable and versioned. The following CEL shortcuts cover the common

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -397,3 +397,84 @@ Deno.test("resolveAllExpressionsInData: env-only resolution does not register se
     }
   });
 });
+
+// ============================================================================
+// run.* namespace
+// ============================================================================
+
+Deno.test("resolveAllExpressionsInData: resolves run.id from context", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const ctx = makeContext({
+      run: {
+        id: "790f565a-c2e4-476f-88d9-39090bca11c5",
+        workflowId: "wf-001",
+        workflowName: "deploy",
+        startedAt: "2026-05-12T15:00:00.000Z",
+        tags: { env: "prod" },
+      },
+    });
+    const data = {
+      resourceKey: "filtered-vms-${{ run.id }}",
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      ctx,
+    ) as { resourceKey: string };
+    assertEquals(
+      result.resourceKey,
+      "filtered-vms-790f565a-c2e4-476f-88d9-39090bca11c5",
+    );
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: resolves run.workflowName and run.startedAt", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const ctx = makeContext({
+      run: {
+        id: "test-run-id",
+        workflowId: "wf-002",
+        workflowName: "kernel-update",
+        startedAt: "2026-05-12T16:30:00.000Z",
+        tags: {},
+      },
+    });
+    const data = {
+      name: "${{ run.workflowName }}",
+      started: "${{ run.startedAt }}",
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      ctx,
+    ) as { name: string; started: string };
+    assertEquals(result.name, "kernel-update");
+    assertEquals(result.started, "2026-05-12T16:30:00.000Z");
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: resolves run.tags nested access", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const ctx = makeContext({
+      run: {
+        id: "test-run-id",
+        workflowId: "wf-003",
+        workflowName: "deploy",
+        startedAt: "2026-05-12T15:00:00.000Z",
+        tags: { env: "staging", team: "platform" },
+      },
+    });
+    const data = {
+      environment: "${{ run.tags.env }}",
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      ctx,
+    ) as { environment: string };
+    assertEquals(result.environment, "staging");
+  });
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -189,6 +189,19 @@ export interface FileNamespace {
 }
 
 /**
+ * Workflow run metadata exposed as `run.*` in CEL expressions.
+ * Populated by the workflow engine after the run starts; only available
+ * inside workflow step inputs (not during workflow-level evaluation).
+ */
+export interface RunContext {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  startedAt: string;
+  tags: Record<string, string>;
+}
+
+/**
  * Context for evaluating CEL expressions.
  */
 export interface ExpressionContext {
@@ -233,6 +246,8 @@ export interface ExpressionContext {
    * Set by the workflow engine after creating the run.
    */
   workflowRunId?: string;
+  /** Structured workflow run context, available as `run.*` in CEL expressions. */
+  run?: RunContext;
   /** Index signature for CEL evaluator compatibility */
   [key: string]: unknown;
 }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1334,7 +1334,9 @@ export class WorkflowExecutionService {
       };
       const run = WorkflowRun.create(workflow, mergedTags);
 
-      // Make the workflow run ID available as a CEL variable (workflowRunId).
+      // workflowRunId is set here for backward compat; the structured
+      // run namespace is populated after run.start() below so that
+      // startedAt is available.
       if (expressionContext) {
         expressionContext.workflowRunId = run.id;
       }
@@ -1364,6 +1366,17 @@ export class WorkflowExecutionService {
 
       // Start execution
       run.start();
+
+      if (expressionContext) {
+        expressionContext.run = {
+          id: run.id,
+          workflowId: workflow.id,
+          workflowName: workflow.name,
+          startedAt: run.startedAt!.toISOString(),
+          tags: { ...run.tags },
+        };
+      }
+
       yield {
         kind: "started",
         runId: run.id,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3097,3 +3097,66 @@ Deno.test({
     });
   },
 });
+
+// ---------------------------------------------------------------------------
+// run.* namespace in CEL expressions
+// ---------------------------------------------------------------------------
+
+Deno.test("run.id expression in step inputs resolves to the workflow run UUID", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    const capturedContexts: StepExecutionContext[] = [];
+    const capturingExecutor: StepExecutor = {
+      execute(
+        _step: Step,
+        ctx: StepExecutionContext,
+      ): Promise<unknown> {
+        capturedContexts.push(ctx);
+        return Promise.resolve({ executed: true });
+      },
+    };
+
+    const workflow = Workflow.create({
+      name: "run-id-test",
+      jobs: [
+        Job.create({
+          name: "j",
+          steps: [
+            Step.create({
+              name: "s",
+              task: StepTask.model("test-model", "run", {
+                scopedKey: "result-${{ run.id }}",
+                wfName: "${{ run.workflowName }}",
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      capturingExecutor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(capturedContexts.length, 1);
+
+    const ctx = capturedContexts[0];
+    assertNotEquals(ctx.expressionContext?.run, undefined);
+    assertEquals(ctx.expressionContext?.run?.id, run.id);
+    assertEquals(ctx.expressionContext?.run?.workflowName, "run-id-test");
+    assertNotEquals(ctx.expressionContext?.run?.startedAt, undefined);
+  });
+});

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -45,9 +45,10 @@ export interface WorkflowEvaluationResult {
 
 /**
  * Evaluates CEL expressions in a workflow definition, leaving vault
- * expressions, runtime-only expressions, self.* references, forEach.in
- * expressions, and task.inputs with step-output dependencies raw. Those
- * are resolved at runtime when their inputs become available.
+ * expressions, runtime-only expressions, self.* references, run.*
+ * references, bare workflowRunId, forEach.in expressions, and
+ * task.inputs with step-output dependencies raw. Those are resolved at
+ * runtime when their inputs become available.
  *
  * **Strict** about per-expression evaluation errors: any throw during
  * `evaluateAsync` propagates out, surfacing the error to the caller.
@@ -91,6 +92,14 @@ export class WorkflowExpressionEvaluator {
       }
       // self.* references forEach variables resolved at runtime.
       if (expr.celExpression.match(/\bself\./)) {
+        continue;
+      }
+      // run.* and workflowRunId are only available at step execution
+      // time, after the WorkflowRun is created.
+      if (
+        expr.celExpression.match(/\brun\./) ||
+        expr.celExpression.match(/\bworkflowRunId\b/)
+      ) {
         continue;
       }
       // forEach.in expressions must remain as strings for expansion.

--- a/src/domain/workflows/expression_evaluators_test.ts
+++ b/src/domain/workflows/expression_evaluators_test.ts
@@ -112,6 +112,58 @@ Deno.test("WorkflowExpressionEvaluator: skips self.* (forEach variables resolved
   assertStringIncludes(result.workflow.description ?? "", "self.env");
 });
 
+Deno.test("WorkflowExpressionEvaluator: skips run.* (resolved at step execution time)", async () => {
+  const evaluator = new WorkflowExpressionEvaluator(new CelEvaluator());
+  const workflow = Workflow.create({
+    name: "run-expr",
+    jobs: [
+      Job.create({
+        name: "j",
+        steps: [
+          Step.create({
+            name: "s",
+            task: StepTask.model("m", "run", {
+              resourceKey: "vms-${{ run.id }}",
+              wfName: "${{ run.workflowName }}",
+            }),
+          }),
+        ],
+      }),
+    ],
+  });
+  const result = await evaluator.evaluate(workflow, emptyContext());
+  assertEquals(result.expressionsEvaluated, 0);
+  const step = result.workflow.jobs[0].steps[0];
+  const inputs = step.task.data.inputs ?? {};
+  assertEquals(inputs["resourceKey"], "vms-${{ run.id }}");
+  assertEquals(inputs["wfName"], "${{ run.workflowName }}");
+});
+
+Deno.test("WorkflowExpressionEvaluator: skips bare workflowRunId (resolved at step execution time)", async () => {
+  const evaluator = new WorkflowExpressionEvaluator(new CelEvaluator());
+  const workflow = Workflow.create({
+    name: "wfrunid-expr",
+    jobs: [
+      Job.create({
+        name: "j",
+        steps: [
+          Step.create({
+            name: "s",
+            task: StepTask.model("m", "run", {
+              runId: "${{ workflowRunId }}",
+            }),
+          }),
+        ],
+      }),
+    ],
+  });
+  const result = await evaluator.evaluate(workflow, emptyContext());
+  assertEquals(result.expressionsEvaluated, 0);
+  const step = result.workflow.jobs[0].steps[0];
+  const inputs = step.task.data.inputs ?? {};
+  assertEquals(inputs["runId"], "${{ workflowRunId }}");
+});
+
 Deno.test("WorkflowExpressionEvaluator: skips forEach.in expressions (must remain string for expansion)", async () => {
   const evaluator = new WorkflowExpressionEvaluator(new CelEvaluator());
   const workflow = Workflow.create({


### PR DESCRIPTION
## Summary

- Adds a structured `run` namespace to the CEL expression context so workflow steps can reference `run.id`, `run.workflowName`, `run.workflowId`, `run.startedAt`, and `run.tags` in `${{ }}` template expressions
- Fixes the root cause where `workflowRunId` was set on the context *after* workflow expressions were eagerly evaluated — `run.*` and `workflowRunId` expressions are now deferred to step execution time, matching the existing `self.*` pattern
- Enables run-scoped resource keys (e.g. `filtered-vms-${{ run.id }}`) to prevent collisions during concurrent workflow executions

## Test plan

- [x] Unit tests: `run.id`, `run.workflowName`, `run.startedAt`, `run.tags` resolution via `resolveAllExpressionsInData`
- [x] Unit tests: `run.*` and `workflowRunId` expressions skipped during workflow evaluation
- [x] Integration test: workflow with `${{ run.id }}` in step inputs resolves to actual run UUID
- [x] E2E verification: compiled binary, scratch repo with `${{ run.id }}` and `${{ run.workflowName }}` — both resolve correctly
- [x] Full test suite: 5852 passed, 0 failed
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)