### PR TITLE
fix(extensions): drive reconcile from doctor handler to surface failure states in sourceDetails (swamp-club#334)

### DIFF
--- a/integration/extensions/doctor_extensions_failure_states_test.ts
+++ b/integration/extensions/doctor_extensions_failure_states_test.ts
@@ -1,0 +1,374 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { initializeTestRepo, runCliCommand } from "../test_helpers.ts";
+
+const VALID_MODEL = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/failure-test",
+  version: "2026.05.12.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+const SCHEMA_INVALID_MODEL = `
+export const model = "not an object";
+`;
+
+const VALIDATION_FAILING_MODEL = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/bad-import",
+  version: "2026.05.12.0",
+  globalArguments: "not a zod schema",
+  resources: {},
+  methods: {},
+};
+`;
+
+async function withTestRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp-doctor-failure-test-",
+  });
+  try {
+    await initializeTestRepo(repoDir);
+    await fn(repoDir);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+interface DoctorReport {
+  overallStatus: string;
+  registries: Record<
+    string,
+    { status: string; failures: { file: string }[] }
+  >;
+  aggregateState: {
+    totalSources: number;
+    sourceDetails: {
+      sourcePath: string;
+      stateTag: string;
+      fingerprint?: string;
+    }[];
+  };
+}
+
+async function runDoctor(repoDir: string): Promise<DoctorReport> {
+  const result = await runCliCommand(
+    ["doctor", "extensions", "--json", "--verbose"],
+    repoDir,
+  );
+  assertEquals(result.code, 0, `doctor failed: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function findSourceDetail(
+  report: DoctorReport,
+  pathFragment: string,
+): DoctorReport["aggregateState"]["sourceDetails"][0] | undefined {
+  return report.aggregateState.sourceDetails.find((d) =>
+    d.sourcePath.includes(pathFragment)
+  );
+}
+
+function findFailure(
+  report: DoctorReport,
+  registry: string,
+  pathFragment: string,
+): { file: string } | undefined {
+  return report.registries[registry]?.failures?.find((f) =>
+    f.file.includes(pathFragment)
+  );
+}
+
+// AC 1: schema-invalid content → BundleBuildFailed in sourceDetails
+Deno.test("doctor extensions: schema-invalid content produces BundleBuildFailed in sourceDetails", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "test_model.ts");
+
+    await Deno.writeTextFile(modelPath, VALID_MODEL);
+    const first = await runDoctor(repoDir);
+    const indexedDetail = findSourceDetail(first, "test_model.ts");
+    assert(
+      indexedDetail,
+      "Source should appear in sourceDetails after first run",
+    );
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    await Deno.writeTextFile(modelPath, SCHEMA_INVALID_MODEL);
+    const second = await runDoctor(repoDir);
+    const failedDetail = findSourceDetail(second, "test_model.ts");
+    assert(
+      failedDetail,
+      "Source should appear in sourceDetails after corruption",
+    );
+    assertEquals(failedDetail.stateTag, "BundleBuildFailed");
+
+    // AC 5: no dual-write
+    const dualWrite = findFailure(second, "model", "test_model.ts");
+    assertEquals(
+      dualWrite,
+      undefined,
+      "BundleBuildFailed source must NOT also appear in registries.model.failures[]",
+    );
+  });
+});
+
+// AC 2: validation-failing content → BundleBuildFailed in sourceDetails
+Deno.test("doctor extensions: validation-failing content produces BundleBuildFailed in sourceDetails", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "bad_validation.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/bad-import",
+      ),
+    );
+    const first = await runDoctor(repoDir);
+    const indexedDetail = findSourceDetail(first, "bad_validation.ts");
+    assert(indexedDetail, "Source should appear in sourceDetails");
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    await Deno.writeTextFile(modelPath, VALIDATION_FAILING_MODEL);
+    const second = await runDoctor(repoDir);
+    const failedDetail = findSourceDetail(second, "bad_validation.ts");
+    assert(failedDetail, "Source should appear after corruption");
+    assertEquals(failedDetail.stateTag, "BundleBuildFailed");
+
+    // AC 5: no dual-write
+    const dualWrite = findFailure(second, "model", "bad_validation.ts");
+    assertEquals(
+      dualWrite,
+      undefined,
+      "BundleBuildFailed source must NOT also appear in registries.model.failures[]",
+    );
+  });
+});
+
+// AC 3: deleted source file for pulled extension → EntryPointUnreadable
+Deno.test("doctor extensions: deleted pulled source produces EntryPointUnreadable in sourceDetails", async () => {
+  await withTestRepo(async (repoDir) => {
+    const extName = "@test/pulled-ext";
+    const extRoot = join(repoDir, ".swamp", "pulled-extensions", extName);
+    const modelDir = join(extRoot, "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "pulled_model.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@test/pulled-model",
+      ),
+    );
+
+    // Create lockfile entry in the default models dir (extensions/models/)
+    const lockfileDir = join(repoDir, "extensions", "models");
+    await ensureDir(lockfileDir);
+    const lockfilePath = join(lockfileDir, "upstream_extensions.json");
+    const lockfile: Record<string, unknown> = {};
+    lockfile[extName] = {
+      version: "2026.05.12.0",
+      pulledAt: new Date().toISOString(),
+    };
+    await Deno.writeTextFile(lockfilePath, JSON.stringify(lockfile, null, 2));
+
+    const first = await runDoctor(repoDir);
+    const indexedDetail = findSourceDetail(first, "pulled_model.ts");
+    assert(indexedDetail, "Pulled source should appear in sourceDetails");
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    // Delete the source file, keep the lockfile entry
+    await Deno.remove(modelPath);
+    const second = await runDoctor(repoDir);
+    const missingDetail = findSourceDetail(second, "pulled_model.ts");
+    assert(
+      missingDetail,
+      "Source should remain in sourceDetails after deletion",
+    );
+    assertEquals(missingDetail.stateTag, "EntryPointUnreadable");
+  });
+});
+
+// AC 4: deleted local source with bundle → OrphanedBundleOnly
+Deno.test("doctor extensions: deleted local source with bundle produces OrphanedBundleOnly", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "ephemeral_model.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/ephemeral",
+      ),
+    );
+
+    const first = await runDoctor(repoDir);
+    const indexedDetail = findSourceDetail(first, "ephemeral_model.ts");
+    assert(indexedDetail, "Source should appear in sourceDetails");
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    // Delete the source file, leave the bundle on disk
+    await Deno.remove(modelPath);
+    const second = await runDoctor(repoDir);
+    const orphanDetail = findSourceDetail(second, "ephemeral_model.ts");
+    assert(
+      orphanDetail,
+      "Source should remain in sourceDetails after deletion",
+    );
+    assertEquals(orphanDetail.stateTag, "OrphanedBundleOnly");
+  });
+});
+
+// Addition 1: recovery path — BundleBuildFailed → valid content → Indexed
+Deno.test("doctor extensions: BundleBuildFailed recovers to Indexed when source is fixed", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "recovery_model.ts");
+
+    // Start valid → Indexed
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/recovery",
+      ),
+    );
+    const first = await runDoctor(repoDir);
+    const indexed = findSourceDetail(first, "recovery_model.ts");
+    assert(indexed);
+    assertEquals(indexed.stateTag, "Indexed");
+
+    // Corrupt → BundleBuildFailed
+    await Deno.writeTextFile(modelPath, SCHEMA_INVALID_MODEL);
+    const second = await runDoctor(repoDir);
+    const failed = findSourceDetail(second, "recovery_model.ts");
+    assert(failed);
+    assertEquals(failed.stateTag, "BundleBuildFailed");
+
+    // Fix → Indexed again
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/recovery",
+      ),
+    );
+    const third = await runDoctor(repoDir);
+    const recovered = findSourceDetail(third, "recovery_model.ts");
+    assert(recovered);
+    assertEquals(recovered.stateTag, "Indexed");
+    assertNotEquals(
+      recovered.fingerprint,
+      failed.fingerprint,
+      "Fingerprint should change from BundleBuildFailed to Indexed",
+    );
+  });
+});
+
+// Addition 2: catalog-column-level fingerprint assertion
+Deno.test("doctor extensions: BundleBuildFailed stores current source fingerprint", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "fp_model.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace("@tutorial/failure-test", "@tutorial/fp-check"),
+    );
+    const first = await runDoctor(repoDir);
+    const indexed = findSourceDetail(first, "fp_model.ts");
+    assert(indexed);
+    assertEquals(indexed.stateTag, "Indexed");
+    const indexedFingerprint = indexed.fingerprint;
+    assert(indexedFingerprint, "Indexed source should have a fingerprint");
+
+    await Deno.writeTextFile(modelPath, SCHEMA_INVALID_MODEL);
+    const second = await runDoctor(repoDir);
+    const failed = findSourceDetail(second, "fp_model.ts");
+    assert(failed);
+    assertEquals(failed.stateTag, "BundleBuildFailed");
+
+    assert(
+      failed.fingerprint,
+      "BundleBuildFailed source should have a fingerprint",
+    );
+    assertNotEquals(
+      failed.fingerprint,
+      indexedFingerprint,
+      "BundleBuildFailed fingerprint must differ from the prior Indexed fingerprint",
+    );
+  });
+});
+
+// Addition 3: smoke perf check — >=10 extensions must complete in <30s
+Deno.test("doctor extensions: reconcile with >=10 extensions completes in <30s", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+
+    for (let i = 0; i < 12; i++) {
+      await Deno.writeTextFile(
+        join(modelDir, `perf_model_${i}.ts`),
+        VALID_MODEL
+          .replace("@tutorial/failure-test", `@tutorial/perf-${i}`)
+          .replace("2026.05.12.0", `2026.05.12.${i}`),
+      );
+    }
+
+    const start = Date.now();
+    const result = await runDoctor(repoDir);
+    const elapsed = Date.now() - start;
+
+    assert(
+      elapsed < 30_000,
+      `doctor with 12 extensions took ${elapsed}ms, expected <30000ms`,
+    );
+    assertEquals(result.overallStatus, "pass");
+    assert(
+      result.aggregateState.totalSources >= 12,
+      `Expected >=12 sources, got ${result.aggregateState.totalSources}`,
+    );
+  });
+});

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -46,8 +46,10 @@ import {
   consumeStream,
   doctorExtensions,
   type DoctorRegistryDeps,
+  ReconcileFromDiskService,
   repairExtensions,
 } from "../../libswamp/mod.ts";
+import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import {
   getExtensionLoadWarnings,
   resetExtensionLoadWarnings,
@@ -156,22 +158,41 @@ export const doctorExtensionsCommand = new Command()
       : resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // Invalidate the catalog so the loaders run a full re-validation
-    // instead of returning the cached lazy entries. Without this, the
-    // doctor reports stale results when run after another swamp
-    // command in the same repo.
-    // W1b: forceCatalogRescan(repoDir) → repository.invalidateAll().
+    // Invalidate the catalog and run reconcile so failure states
+    // (BundleBuildFailed, EntryPointUnreadable, OrphanedBundleOnly)
+    // are written through the Extension aggregate and surface in
+    // sourceDetails[]. Without reconcile, failures only land in
+    // registries.<kind>.failures[] via the legacy buildIndex path.
+    //
+    // This repository instance and the loaders' repository (constructed
+    // at mod.ts startup) are two separate ExtensionRepository objects
+    // pointing at the same SQLite DB. Writes here are process-wide-
+    // visible to the loaders regardless of close ordering; the close
+    // is connection hygiene, not synchronization.
+    const localManifestIdentity = readLocalManifestIdentity(repoDir);
     try {
-      const lockfileRepository = await LockfileRepository.create(lockfilePath);
+      const reconcileLockfileRepo = await LockfileRepository.create(
+        lockfilePath,
+      );
       const rescanRepo = new ExtensionRepository({
         catalog: new ExtensionCatalogStore(
           swampPath(repoDir, "_extension_catalog.db"),
         ),
-        lockfileRepository,
+        lockfileRepository: reconcileLockfileRepo,
         repoRoot: repoDir,
+        localManifestIdentity,
       });
       try {
         rescanRepo.invalidateAll();
+        const denoRuntime = new EmbeddedDenoRuntime();
+        const reconciler = new ReconcileFromDiskService({
+          denoRuntime,
+          repository: rescanRepo,
+          lockfileRepository: reconcileLockfileRepo,
+          repoDir,
+          localManifestIdentity,
+        });
+        await reconciler.execute();
       } finally {
         rescanRepo.close();
       }

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { relative, resolve } from "@std/path";
+import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 
 /**
@@ -271,7 +272,7 @@ export async function findStaleFiles(
   const catalogEntries = kinds.flatMap((k) => catalog.findByKind(k));
   const catalogBySource = new Map<string, FreshnessCatalogRow>();
   for (const entry of catalogEntries) {
-    catalogBySource.set(entry.source_path, entry);
+    catalogBySource.set(canonicalizePath(entry.source_path), entry);
   }
 
   const seenSources = new Set<string>();
@@ -286,9 +287,10 @@ export async function findStaleFiles(
     const files = await discoverFiles(dir);
     for (const relativePath of files) {
       const absolutePath = resolve(dir, relativePath);
-      seenSources.add(absolutePath);
+      const canonical = canonicalizePath(absolutePath);
+      seenSources.add(canonical);
 
-      const catalogEntry = catalogBySource.get(absolutePath);
+      const catalogEntry = catalogBySource.get(canonical);
       if (!catalogEntry) {
         stale.push({ absolutePath, relativePath, baseDir: dir });
         continue;

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -318,9 +318,16 @@ export async function findStaleFiles(
     }
   }
 
-  for (const [sourcePath] of catalogBySource) {
+  const FAILURE_STATES = new Set([
+    "BundleBuildFailed",
+    "EntryPointUnreadable",
+    "OrphanedBundleOnly",
+  ]);
+  for (const [sourcePath, entry] of catalogBySource) {
     if (!seenSources.has(sourcePath)) {
-      catalog.removeBySourcePath(sourcePath);
+      if (!FAILURE_STATES.has(entry.state ?? "Indexed")) {
+        catalog.removeBySourcePath(sourcePath);
+      }
     }
   }
 

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -17,8 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { relative, resolve } from "@std/path";
-import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
+import { relative, resolve, SEPARATOR } from "@std/path";
 import { resolveLocalImports } from "../models/local_import_resolver.ts";
 
 /**
@@ -269,10 +268,14 @@ export async function findStaleFiles(
 
   const allDirs = [modelsDir, ...(additionalDirs ?? [])];
 
+  const needsNormalize = SEPARATOR === "\\";
+  const normalizePath = (p: string): string =>
+    needsNormalize ? p.toLowerCase().replaceAll("\\", "/") : p;
+
   const catalogEntries = kinds.flatMap((k) => catalog.findByKind(k));
   const catalogBySource = new Map<string, FreshnessCatalogRow>();
   for (const entry of catalogEntries) {
-    catalogBySource.set(canonicalizePath(entry.source_path), entry);
+    catalogBySource.set(normalizePath(entry.source_path), entry);
   }
 
   const seenSources = new Set<string>();
@@ -287,10 +290,9 @@ export async function findStaleFiles(
     const files = await discoverFiles(dir);
     for (const relativePath of files) {
       const absolutePath = resolve(dir, relativePath);
-      const canonical = canonicalizePath(absolutePath);
-      seenSources.add(canonical);
+      seenSources.add(normalizePath(absolutePath));
 
-      const catalogEntry = catalogBySource.get(canonical);
+      const catalogEntry = catalogBySource.get(normalizePath(absolutePath));
       if (!catalogEntry) {
         stale.push({ absolutePath, relativePath, baseDir: dir });
         continue;
@@ -325,10 +327,10 @@ export async function findStaleFiles(
     "EntryPointUnreadable",
     "OrphanedBundleOnly",
   ]);
-  for (const [sourcePath, entry] of catalogBySource) {
-    if (!seenSources.has(sourcePath)) {
+  for (const [normalizedPath, entry] of catalogBySource) {
+    if (!seenSources.has(normalizedPath)) {
       if (!FAILURE_STATES.has(entry.state ?? "Indexed")) {
-        catalog.removeBySourcePath(sourcePath);
+        catalog.removeBySourcePath(entry.source_path);
       }
     }
   }

--- a/src/domain/extensions/extension.ts
+++ b/src/domain/extensions/extension.ts
@@ -323,16 +323,36 @@ export function recordBundled(
 /**
  * Records that a bundle build failed AND no cached bundle exists on
  * disk. Returns a NEW Extension.
+ *
+ * When {@link fingerprint} is provided, the Source's fingerprint is
+ * updated atomically with the state transition. This prevents
+ * {@link findStaleFiles} from re-marking the file as stale on the
+ * next pass — the stored fingerprint matches the on-disk content,
+ * terminating the rebundle loop.
  */
 export function recordBundleBuildFailed(
   extension: Extension,
-  args: { location: SourceLocation; lastError: string },
+  args: {
+    location: SourceLocation;
+    lastError: string;
+    fingerprint?: SourceFingerprint;
+    sourceMtime?: string;
+  },
 ): Extension {
-  return updateSourceState(
-    extension,
-    args.location,
-    { tag: "BundleBuildFailed", lastError: args.lastError },
-  );
+  const state: RowState = {
+    tag: "BundleBuildFailed",
+    lastError: args.lastError,
+  };
+  if (args.fingerprint !== undefined) {
+    return updateSourceStateAndFingerprint(
+      extension,
+      args.location,
+      state,
+      args.fingerprint,
+      args.sourceMtime,
+    );
+  }
+  return updateSourceState(extension, args.location, state);
 }
 
 /**
@@ -450,6 +470,34 @@ function updateSourceState(
   }
   const next = new Map(extension.sources);
   next.set(location, withState(existing, state));
+  const resolved = enforceI2(next);
+  return { ...extension, sources: resolved };
+}
+
+function updateSourceStateAndFingerprint(
+  extension: Extension,
+  location: SourceLocation,
+  state: RowState,
+  fingerprint: SourceFingerprint,
+  sourceMtime?: string,
+): Extension {
+  const existing = extension.sources.get(location);
+  if (!existing) {
+    throw new Error(
+      `Extension ${extension.name}@${extension.version} has no Source at ` +
+        `${location.canonicalPath}; cannot update state to ${state.tag}.`,
+    );
+  }
+  const next = new Map(extension.sources);
+  next.set(
+    location,
+    withFingerprintAndState(
+      existing,
+      fingerprint,
+      state,
+      sourceMtime ?? existing.sourceMtime,
+    ),
+  );
   const resolved = enforceI2(next);
   return { ...extension, sources: resolved };
 }

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -553,6 +553,7 @@ export class ExtensionLoader {
       const entries = catalog.findByKind(kind);
       for (const entry of entries) {
         if (entry.state === "ValidationFailed") continue;
+        if (!entry.type_normalized) continue;
         this.adapter.registerLazy(entry);
       }
     }

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -484,16 +484,42 @@ export class ReconcileFromDiskService {
         const fromState = existingSource?.state.tag ?? null;
         const errorMsg = error instanceof Error ? error.message : String(error);
 
+        // Store the current fingerprint so findStaleFiles sees the file
+        // as fresh and doesn't re-trigger a redundant rebundle on the
+        // next buildIndex pass. Fallback to "" if the file became
+        // unreadable mid-flight — "" never matches a computed hash, so
+        // subsequent reconciles will re-attempt the bundle (acceptable
+        // for this rare case).
+        let failFp: string;
+        try {
+          failFp = await computeSourceFingerprint(
+            absolutePath,
+            baseDir,
+            cache,
+          );
+        } catch {
+          failFp = "";
+        }
+
         if (existingSource) {
           ext = recordBundleBuildFailed(ext, {
             location: effectiveLoc,
             lastError: errorMsg,
+            fingerprint: failFp,
+            sourceMtime,
           });
         } else {
-          ext = makeExtensionWithNewSource(ext, effectiveLoc, kind, {
-            tag: "BundleBuildFailed",
-            lastError: errorMsg,
-          }, sourceMtime);
+          ext = makeExtensionWithNewSource(
+            ext,
+            effectiveLoc,
+            kind,
+            {
+              tag: "BundleBuildFailed",
+              lastError: errorMsg,
+            },
+            sourceMtime,
+            failFp,
+          );
         }
 
         if (fromState !== "BundleBuildFailed") {
@@ -671,12 +697,13 @@ function makeExtensionWithNewSource(
   kindDir: KindDir,
   state: { tag: "BundleBuildFailed"; lastError: string },
   sourceMtime: string,
+  fingerprint = "",
 ): Extension {
   const kind = kindDirToExtensionKind(kindDir);
   const source = makeSource({
     id: location,
     kind,
-    fingerprint: "",
+    fingerprint,
     state,
     sourceMtime,
   });

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -31,6 +31,7 @@ import {
   tombstoneAll,
 } from "../../domain/extensions/extension.ts";
 import type { LocalManifestIdentity } from "../../infrastructure/persistence/local_manifest_reader.ts";
+import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { makeSource } from "../../domain/extensions/source.ts";
 import { makeSourceLocation } from "../../domain/extensions/source_location.ts";
 import { makeBundleLocation } from "../../domain/extensions/bundle_location.ts";
@@ -534,9 +535,15 @@ export class ReconcileFromDiskService {
     }
 
     // Phase 2: Sources in aggregate but NOT on disk → transition.
+    // Canonicalize on-disk keys for comparison — on Windows the raw
+    // absolutePath uses backslashes while loc.canonicalPath uses forward
+    // slashes (see canonicalizePath).
+    const onDiskCanonical = new Set(
+      [...onDiskSources.keys()].map(canonicalizePath),
+    );
     for (const [loc, source] of ext.sources) {
       if (source.state.tag === "Tombstoned") continue;
-      if (onDiskSources.has(loc.canonicalPath)) continue;
+      if (onDiskCanonical.has(loc.canonicalPath)) continue;
 
       const fromState = source.state.tag;
 


### PR DESCRIPTION
## Summary

- **Root cause**: `doctor extensions` called `invalidateAll()` after the startup reconcile gate (`mod.ts:291`) had already decided not to run, so failure states (`BundleBuildFailed`, `EntryPointUnreadable`, `OrphanedBundleOnly`) never surfaced in `sourceDetails[]` — they only appeared in `registries.<kind>.failures[]` via the legacy `buildIndex` path.
- **Fix**: Run `ReconcileFromDiskService` synchronously from the doctor handler after `invalidateAll()`, before `ensureLoaded()`. Three supporting changes prevent dual-write and crash issues:
  - Update source fingerprint when recording `BundleBuildFailed` (prevents `findStaleFiles` rebundle loop)
  - Guard `findStaleFiles` cleanup against removing failure-state catalog rows
  - Guard `registerLazyFromCatalog` against empty `type_normalized` entries

Closes swamp-club#334.

## Test Plan

- 7 new integration tests in `integration/extensions/doctor_extensions_failure_states_test.ts`:
  - AC 1: Schema-invalid content → `BundleBuildFailed` in `sourceDetails`
  - AC 2: Validation-failing content → `BundleBuildFailed` in `sourceDetails`
  - AC 3: Deleted pulled source → `EntryPointUnreadable` in `sourceDetails`
  - AC 4: Deleted local source with bundle → `OrphanedBundleOnly` in `sourceDetails`
  - AC 5: No dual-write — failures in `sourceDetails` do NOT also appear in `registries.<kind>.failures[]`
  - Recovery path: `BundleBuildFailed` → valid content → `Indexed`
  - Fingerprint propagation: `BundleBuildFailed` stores current source fingerprint, not the prior `Indexed` fingerprint
  - Perf smoke check: ≥10 extensions completes `doctor` in <30s
- All 18 extension integration tests pass (11 existing + 7 new)
- Full test suite: 5853 passed, 0 failed
- Manual reproduction from the issue verified: corrupted extension now shows `BundleBuildFailed` in `sourceDetails` instead of staying `Indexed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)