### PR TITLE
fix(workflows): surface workflow-scope artifacts via data get --workflow (swamp-club#337)

### DIFF
--- a/src/domain/data/workflow_data_service.ts
+++ b/src/domain/data/workflow_data_service.ts
@@ -26,14 +26,18 @@ import { createDefinitionId } from "../definitions/definition.ts";
 
 /**
  * Represents a data item resolved from a workflow run.
+ *
+ * `jobName` and `stepName` are absent for workflow-scope artifacts (e.g.
+ * data produced by workflow-scope reports), which belong to the run as a
+ * whole rather than to any single step.
  */
 export interface WorkflowDataItem {
   data: Data;
   modelType: ModelType;
   modelId: string;
   modelName: string;
-  jobName: string;
-  stepName: string;
+  jobName?: string;
+  stepName?: string;
   contentPath: string;
 }
 
@@ -86,49 +90,82 @@ export class WorkflowDataService {
         if (step.dataArtifacts.length === 0) continue;
 
         for (const artifact of step.dataArtifacts) {
-          // Look up the data by its ID first, then fall back to name matching.
-          // Data IDs change with each version, so older run artifacts may not
-          // match the current data's ID. Name matching resolves this by finding
-          // the data item across all models that shares the same name.
-          let found = dataById.get(artifact.dataId);
-          if (!found) {
-            // Try matching by name across all models
-            for (const [, item] of dataByName) {
-              if (item.data.name === artifact.name) {
-                found = item;
-                break;
-              }
-            }
-          }
-          if (!found) continue; // GC'd or missing data
-
-          // Resolve model name
-          const modelName = await this.resolveModelName(
-            found.modelType,
-            found.modelId,
+          const resolved = await this.resolveArtifact(
+            artifact,
+            dataById,
+            dataByName,
           );
-
-          const contentPath = this.dataRepo.getContentPath(
-            found.modelType,
-            found.modelId,
-            found.data.name,
-            found.data.version,
-          );
-
+          if (!resolved) continue;
           results.push({
-            data: found.data,
-            modelType: found.modelType,
-            modelId: found.modelId,
-            modelName,
+            ...resolved,
             jobName: job.jobName,
             stepName: step.stepName,
-            contentPath,
           });
         }
       }
     }
 
+    // Workflow-scope artifacts (e.g. workflow-scope report output) are
+    // tracked on the run aggregate rather than under any single step.
+    for (const artifact of run.workflowDataArtifacts) {
+      const resolved = await this.resolveArtifact(
+        artifact,
+        dataById,
+        dataByName,
+      );
+      if (resolved) {
+        results.push(resolved);
+      }
+    }
+
     return results;
+  }
+
+  private async resolveArtifact(
+    artifact: { dataId: string; name: string },
+    dataById: Map<
+      string,
+      { data: Data; modelType: ModelType; modelId: string }
+    >,
+    dataByName: Map<
+      string,
+      { data: Data; modelType: ModelType; modelId: string }
+    >,
+  ): Promise<Omit<WorkflowDataItem, "jobName" | "stepName"> | null> {
+    // Look up the data by its ID first, then fall back to name matching.
+    // Data IDs change with each version, so older run artifacts may not
+    // match the current data's ID. Name matching resolves this by finding
+    // the data item across all models that shares the same name.
+    let found = dataById.get(artifact.dataId);
+    if (!found) {
+      for (const [, item] of dataByName) {
+        if (item.data.name === artifact.name) {
+          found = item;
+          break;
+        }
+      }
+    }
+    if (!found) return null;
+
+    const modelName = await this.resolveModelName(
+      found.modelType,
+      found.modelId,
+    );
+
+    const contentPath = this.dataRepo.getContentPath(
+      found.modelType,
+      found.modelId,
+      found.data.name,
+      found.data.version,
+    );
+
+    return {
+      data: found.data,
+      modelType: found.modelType,
+      modelId: found.modelId,
+      modelName,
+      contentPath,
+    };
   }
 
   /**

--- a/src/domain/data/workflow_data_service_test.ts
+++ b/src/domain/data/workflow_data_service_test.ts
@@ -338,3 +338,125 @@ Deno.test("WorkflowDataService.findByNameInWorkflowRun returns null for non-exis
   const result = await service.findByNameInWorkflowRun(run, "nonexistent");
   assertEquals(result, null);
 });
+
+Deno.test("WorkflowDataService.findAllForWorkflowRun resolves workflow-scope artifacts", async () => {
+  const workflowModelType = ModelType.create("workflow");
+  const wfReportData = await createTestData("report-swamp-workflow-summary", {
+    type: "report",
+    reportName: "@swamp/workflow-summary",
+    reportScope: "workflow",
+  });
+
+  const globalData = [
+    {
+      data: wfReportData,
+      modelType: workflowModelType,
+      modelId: TEST_WORKFLOW_ID,
+    },
+  ];
+
+  const run = WorkflowRun.fromData({
+    id: TEST_RUN_ID,
+    workflowId: TEST_WORKFLOW_ID,
+    workflowName: "test-workflow",
+    status: "succeeded",
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    jobs: [{
+      jobName: "main",
+      status: "succeeded",
+      steps: [{ stepName: "noop", status: "succeeded" }],
+    }],
+    workflowDataArtifacts: [{
+      dataId: wfReportData.id,
+      name: "report-swamp-workflow-summary",
+      version: 1,
+      tags: {
+        type: "report",
+        reportName: "@swamp/workflow-summary",
+        reportScope: "workflow",
+      },
+    }],
+  });
+
+  const service = new WorkflowDataService(
+    createMockDefinitionRepo(),
+    createMockDataRepo(globalData),
+  );
+
+  const result = await service.findAllForWorkflowRun(run);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].data.name, "report-swamp-workflow-summary");
+  assertEquals(result[0].modelType.normalized, "workflow");
+  // Workflow-scope items have no owning job or step.
+  assertEquals(result[0].jobName, undefined);
+  assertEquals(result[0].stepName, undefined);
+});
+
+Deno.test("WorkflowDataService.findAllForWorkflowRun returns both step and workflow-scope artifacts", async () => {
+  const stepModelType = ModelType.create("aws/ec2/vpc");
+  const stepData = await createTestData("vpc-state");
+  const wfModelType = ModelType.create("workflow");
+  const wfReportData = await createTestData("report-swamp-workflow-summary", {
+    type: "report",
+    reportScope: "workflow",
+  });
+
+  const globalData = [
+    { data: stepData, modelType: stepModelType, modelId: TEST_MODEL_ID },
+    {
+      data: wfReportData,
+      modelType: wfModelType,
+      modelId: TEST_WORKFLOW_ID,
+    },
+  ];
+
+  const run = WorkflowRun.fromData({
+    id: TEST_RUN_ID,
+    workflowId: TEST_WORKFLOW_ID,
+    workflowName: "test-workflow",
+    status: "succeeded",
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    jobs: [{
+      jobName: "main",
+      status: "succeeded",
+      steps: [{
+        stepName: "create",
+        status: "succeeded",
+        dataArtifacts: [{
+          dataId: stepData.id,
+          name: "vpc-state",
+          version: 1,
+          tags: { type: "resource" },
+        }],
+      }],
+    }],
+    workflowDataArtifacts: [{
+      dataId: wfReportData.id,
+      name: "report-swamp-workflow-summary",
+      version: 1,
+      tags: { type: "report", reportScope: "workflow" },
+    }],
+  });
+
+  const service = new WorkflowDataService(
+    createMockDefinitionRepo(),
+    createMockDataRepo(globalData),
+  );
+
+  const result = await service.findAllForWorkflowRun(run);
+  assertEquals(result.length, 2);
+
+  const stepItem = result.find((r) => r.data.name === "vpc-state");
+  if (!stepItem) throw new Error("expected step artifact");
+  assertEquals(stepItem.jobName, "main");
+  assertEquals(stepItem.stepName, "create");
+
+  const wfItem = result.find((r) =>
+    r.data.name === "report-swamp-workflow-summary"
+  );
+  if (!wfItem) throw new Error("expected workflow-scope artifact");
+  assertEquals(wfItem.jobName, undefined);
+  assertEquals(wfItem.stepName, undefined);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -57,6 +57,10 @@ import {
 } from "../data/data_record_mapper.ts";
 import { resolveModelType } from "../extensions/extension_auto_resolver.ts";
 import { MethodReportRunner } from "./method_report_runner.ts";
+import {
+  WorkflowReportRunner,
+  type WorkflowStepExecutionDetail,
+} from "./workflow_report_runner.ts";
 import { getAutoResolver } from "../extensions/auto_resolver_context.ts";
 import { DefaultMethodExecutionService } from "../models/method_execution_service.ts";
 import { DefaultModelValidationService } from "../models/validation_service.ts";
@@ -87,6 +91,7 @@ import {
 import { UserError } from "../errors.ts";
 import {
   getRunLogger,
+  getWorkflowRunLogger,
   runFileSink,
 } from "../../infrastructure/logging/logger.ts";
 import { join } from "@std/path";
@@ -1193,11 +1198,13 @@ export class WorkflowExecutionService {
   private readonly sortService = new TopologicalSortService();
   private readonly executor: StepExecutor;
   private readonly definitionRepo: YamlDefinitionRepository;
+  private readonly evaluatedDefRepo: YamlEvaluatedDefinitionRepository;
   private readonly modelResolver: ModelResolver;
   private readonly dataRepo: FileSystemUnifiedDataRepository;
   private readonly dataBaseDir?: string;
   private readonly catalogStore: CatalogStore;
   private readonly markerRepo = new RepoMarkerRepository();
+  private readonly workflowReportRunner = new WorkflowReportRunner();
   /**
    * Promise-memoized loader for `.swamp.yaml`. Instance-scoped so a
    * long-running serve process creates a fresh loader per request and
@@ -1221,6 +1228,7 @@ export class WorkflowExecutionService {
     this.dataBaseDir = dataBaseDir;
     this.catalogStore = catalogStore;
     this.definitionRepo = new YamlDefinitionRepository(repoDir);
+    this.evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(repoDir);
     this.dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       dataBaseDir,
@@ -1424,6 +1432,23 @@ export class WorkflowExecutionService {
         readGlobalConcurrencyLimit(),
       );
 
+      // Track per-step model info and data handles for the workflow-scope
+      // report context. Built up by intercepting the events the service
+      // emits as steps execute.
+      const modelInfoByStep = new Map<
+        string,
+        { modelName: string; modelType: string; methodName: string }
+      >();
+      const stepStatuses = new Map<
+        string,
+        "succeeded" | "failed" | "skipped"
+      >();
+      const stepJobNames = new Map<string, string>();
+      const dataHandlesByStep = new Map<
+        string,
+        import("../models/model.ts").DataHandle[]
+      >();
+
       // Execute jobs level by level
       for (const level of sortedJobs.levels) {
         // Merge parallel job generators within each level
@@ -1443,6 +1468,25 @@ export class WorkflowExecutionService {
             options?.signal,
           )
         ) {
+          if (event.kind === "model_resolved") {
+            const key = `${event.jobId}:${event.stepId}`;
+            modelInfoByStep.set(key, {
+              modelName: event.modelName,
+              modelType: event.modelType,
+              methodName: event.methodName,
+            });
+            stepJobNames.set(key, event.jobId);
+          } else if (event.kind === "step_completed") {
+            const key = `${event.jobId}:${event.stepId}`;
+            stepStatuses.set(key, "succeeded");
+            if (event.dataHandles) {
+              dataHandlesByStep.set(key, event.dataHandles);
+            }
+          } else if (event.kind === "step_failed") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
+          } else if (event.kind === "step_skipped") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
+          }
           yield event;
         }
         await this.saveRun(workflow.id, run);
@@ -1450,6 +1494,21 @@ export class WorkflowExecutionService {
 
       // Complete workflow
       run.complete();
+
+      // Execute workflow-scope reports before the completed event so the
+      // run aggregate carries the workflow-scope dataArtifacts produced by
+      // those reports — required for `swamp data get --workflow` and
+      // `swamp data list --workflow` to surface them.
+      yield* this.runWorkflowReports(
+        workflow,
+        run,
+        modelInfoByStep,
+        stepStatuses,
+        stepJobNames,
+        dataHandlesByStep,
+        options?.reportFilterOptions,
+      );
+
       yield { kind: "completed", run };
       await this.saveRun(workflow.id, run);
 
@@ -2151,6 +2210,109 @@ export class WorkflowExecutionService {
     run: WorkflowRun,
   ): Promise<void> {
     await this.runRepo.save(workflowId, run);
+  }
+
+  /**
+   * Runs workflow-scope reports after the workflow completes and appends
+   * their data artifacts to the WorkflowRun aggregate so the `--workflow`
+   * retrieval path can resolve them.
+   *
+   * Buffers report events emitted by the runner so they can be yielded
+   * back through the service's event stream in order.
+   */
+  private async *runWorkflowReports(
+    workflow: Workflow,
+    run: WorkflowRun,
+    modelInfoByStep: Map<
+      string,
+      { modelName: string; modelType: string; methodName: string }
+    >,
+    stepStatuses: Map<string, "succeeded" | "failed" | "skipped">,
+    stepJobNames: Map<string, string>,
+    dataHandlesByStep: Map<
+      string,
+      import("../models/model.ts").DataHandle[]
+    >,
+    reportFilterOptions:
+      | import("../reports/report_execution_service.ts").ReportFilterOptions
+      | undefined,
+  ): AsyncGenerator<WorkflowExecutionEvent> {
+    if (!reportFilterOptions) {
+      return;
+    }
+
+    const stepExecutions: WorkflowStepExecutionDetail[] = [];
+    for (const [key, info] of modelInfoByStep) {
+      const status = stepStatuses.get(key) ?? "failed";
+      const jobName = stepJobNames.get(key) ?? "";
+      const stepName = key.split(":")[1] ?? "";
+
+      // Prefer the evaluated definition (post-CEL) so report templates see
+      // resolved expression values. Fall back to the raw definition.
+      let lookupResult = await this.evaluatedDefRepo.findByNameGlobal(
+        info.modelName,
+      );
+      if (!lookupResult) {
+        lookupResult = await findDefinitionByIdOrName(
+          this.definitionRepo,
+          info.modelName,
+        );
+      }
+
+      if (!lookupResult || status === "skipped") {
+        stepExecutions.push({
+          jobName,
+          stepName,
+          modelName: info.modelName,
+          modelType: info.modelType,
+          methodName: info.methodName,
+          status,
+          dataHandles: [],
+          methodArgs: {},
+          modelId: "",
+          globalArgs: {},
+        });
+        continue;
+      }
+
+      const { definition } = lookupResult;
+      stepExecutions.push({
+        jobName,
+        stepName,
+        modelName: info.modelName,
+        modelType: info.modelType,
+        methodName: info.methodName,
+        status,
+        dataHandles: dataHandlesByStep.get(key) ?? [],
+        methodArgs: definition.getMethodArguments(info.methodName),
+        modelId: definition.id,
+        globalArgs: definition.globalArguments,
+      });
+    }
+
+    const bufferedEvents: WorkflowExecutionEvent[] = [];
+    const artifacts = await this.workflowReportRunner.runFor({
+      workflow,
+      workflowRunId: run.id,
+      workflowStatus: run.status === "succeeded" ? "succeeded" : "failed",
+      stepExecutions,
+      reportFilterOptions,
+      repoDir: this.repoDir,
+      runLogger: getWorkflowRunLogger(workflow.name),
+      unifiedDataRepo: this.dataRepo,
+      definitionRepository: this.definitionRepo,
+      emitEvent: (event: WorkflowExecutionEvent) => {
+        bufferedEvents.push(event);
+      },
+    });
+
+    for (const ref of artifacts) {
+      run.addWorkflowDataArtifact(ref);
+    }
+
+    for (const event of bufferedEvents) {
+      yield event;
+    }
   }
 
   /**

--- a/src/domain/workflows/workflow_report_runner.ts
+++ b/src/domain/workflows/workflow_report_runner.ts
@@ -1,0 +1,166 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Logger } from "@logtape/logtape";
+import type { DataHandle } from "../models/model.ts";
+import type { DataArtifactRef } from "../models/model_output.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
+import {
+  executeReports,
+  type ReportEventCallback,
+  type ReportFilterOptions,
+} from "../reports/report_execution_service.ts";
+import { reportRegistry } from "../reports/report_registry.ts";
+import type { WorkflowReportContext } from "../reports/report_context.ts";
+import { BUILTIN_WORKFLOW_REPORTS } from "../reports/builtin/mod.ts";
+import { ModelType } from "../models/model_type.ts";
+import type { Workflow } from "./workflow.ts";
+import type { WorkflowExecutionEvent } from "./execution_events.ts";
+
+/**
+ * Per-step execution detail collected during workflow execution.
+ *
+ * Built up as the service yields `model_resolved` and `step_completed`
+ * events so the workflow-scope report context can describe what each
+ * step did.
+ */
+export interface WorkflowStepExecutionDetail {
+  jobName: string;
+  stepName: string;
+  modelName: string;
+  modelType: string;
+  methodName: string;
+  status: "succeeded" | "failed" | "skipped";
+  dataHandles: DataHandle[];
+  methodArgs: Record<string, unknown>;
+  modelId: string;
+  globalArgs: Record<string, unknown>;
+}
+
+/**
+ * Inputs for running workflow-scope reports after a workflow completes.
+ */
+export interface WorkflowReportArgs {
+  workflow: Workflow;
+  workflowRunId: string;
+  workflowStatus: "succeeded" | "failed";
+  stepExecutions: WorkflowStepExecutionDetail[];
+  reportFilterOptions: ReportFilterOptions;
+  repoDir: string;
+  runLogger: Logger;
+  unifiedDataRepo: UnifiedDataRepository;
+  definitionRepository: DefinitionRepository;
+  emitEvent?: (event: WorkflowExecutionEvent) => void;
+}
+
+/**
+ * Runs workflow-scope reports after a workflow completes and returns the
+ * data artifacts they produced.
+ *
+ * Mirrors {@link MethodReportRunner} for method/model-scope reports.
+ * Caller appends the returned DataArtifactRef entries to the WorkflowRun
+ * aggregate via `addWorkflowDataArtifact` so they participate in the
+ * `--workflow` retrieval path.
+ *
+ * Errors raised inside report execution are swallowed and logged — a
+ * broken report must not mask the workflow result.
+ */
+export class WorkflowReportRunner {
+  async runFor(args: WorkflowReportArgs): Promise<DataArtifactRef[]> {
+    if (reportRegistry.getAll().length === 0) {
+      return [];
+    }
+
+    const collected: DataArtifactRef[] = [];
+
+    const callbacks: ReportEventCallback = {
+      onReportStarted: (name, scope) => {
+        args.emitEvent?.({
+          kind: "report_started",
+          reportName: name,
+          scope,
+        });
+      },
+      onReportCompleted: (name, scope, markdown, json, reportDataHandles) => {
+        args.emitEvent?.({
+          kind: "report_completed",
+          reportName: name,
+          scope,
+          markdown,
+          json,
+        });
+        for (const handle of reportDataHandles) {
+          collected.push({
+            dataId: handle.dataId,
+            name: handle.name,
+            version: handle.version,
+            tags: handle.tags,
+          });
+        }
+      },
+      onReportFailed: (name, scope, error) => {
+        args.emitEvent?.({
+          kind: "report_failed",
+          reportName: name,
+          scope,
+          error,
+        });
+      },
+    };
+
+    const context: WorkflowReportContext = {
+      scope: "workflow",
+      repoDir: args.repoDir,
+      logger: args.runLogger,
+      dataRepository: args.unifiedDataRepo,
+      definitionRepository: args.definitionRepository,
+      workflowId: args.workflow.id,
+      workflowRunId: args.workflowRunId,
+      workflowName: args.workflow.name,
+      workflowStatus: args.workflowStatus,
+      stepExecutions: args.stepExecutions,
+    };
+
+    try {
+      await executeReports(
+        reportRegistry,
+        context,
+        ModelType.create("workflow"),
+        args.workflow.id,
+        args.workflow.reportSelection,
+        args.reportFilterOptions,
+        callbacks,
+        undefined,
+        BUILTIN_WORKFLOW_REPORTS,
+      );
+    } catch (reportError) {
+      args.runLogger.debug(
+        "Failed to run workflow-scope reports: {error}",
+        {
+          error: reportError instanceof Error
+            ? reportError.message
+            : String(reportError),
+        },
+      );
+    }
+
+    return collected;
+  }
+}

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -73,6 +73,7 @@ export const WorkflowRunSchema = z.object({
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   jobs: z.array(JobRunSchema),
+  workflowDataArtifacts: z.array(DataArtifactRefSchema).optional(),
   logFile: z.string().optional(),
   tags: z.record(z.string(), z.string()).default({}),
 });
@@ -415,6 +416,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _jobs: JobRun[],
     private _logFile: string | undefined,
     private readonly _tags: Record<string, string>,
+    private _workflowDataArtifacts: DataArtifactRef[] = [],
   ) {}
 
   /**
@@ -442,6 +444,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       jobs,
       undefined,
       tags ?? {},
+      [],
     );
   }
 
@@ -462,6 +465,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       jobs,
       validated.logFile,
       validated.tags,
+      validated.workflowDataArtifacts ?? [],
     );
   }
 
@@ -479,6 +483,21 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   get jobs(): ReadonlyArray<JobRun> {
     return this._jobs;
+  }
+
+  /**
+   * Gets the data artifacts produced at workflow scope (e.g. by workflow-scope
+   * reports), independent of any single step.
+   */
+  get workflowDataArtifacts(): ReadonlyArray<DataArtifactRef> {
+    return this._workflowDataArtifacts;
+  }
+
+  /**
+   * Adds a workflow-scope data artifact reference to this run.
+   */
+  addWorkflowDataArtifact(artifact: DataArtifactRef): void {
+    this._workflowDataArtifacts.push({ ...artifact });
   }
 
   /**
@@ -549,6 +568,11 @@ export class WorkflowRun implements TriggerEvaluationContext {
     };
     if (this._logFile) {
       data.logFile = this._logFile;
+    }
+    if (this._workflowDataArtifacts.length > 0) {
+      data.workflowDataArtifacts = this._workflowDataArtifacts.map((a) => ({
+        ...a,
+      }));
     }
     return data;
   }

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -462,3 +462,101 @@ Deno.test("WorkflowRun.fromData with missing tags defaults to empty", () => {
   const run = WorkflowRun.fromData(data);
   assertEquals(run.tags, {});
 });
+
+Deno.test("WorkflowRun.create starts with no workflow data artifacts", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  assertEquals(run.workflowDataArtifacts.length, 0);
+});
+
+Deno.test("WorkflowRun.addWorkflowDataArtifact stores the ref", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.addWorkflowDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-44665544aaaa",
+    name: "report-summary",
+    version: 1,
+    tags: { type: "report", reportScope: "workflow" },
+  });
+
+  assertEquals(run.workflowDataArtifacts.length, 1);
+  assertEquals(run.workflowDataArtifacts[0].name, "report-summary");
+  assertEquals(run.workflowDataArtifacts[0].tags.reportScope, "workflow");
+});
+
+Deno.test("WorkflowRun.toData omits workflowDataArtifacts when empty", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  const data = run.toData();
+  assertEquals(data.workflowDataArtifacts, undefined);
+});
+
+Deno.test("WorkflowRun.toData includes workflowDataArtifacts when present", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.addWorkflowDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-44665544bbbb",
+    name: "report-md",
+    version: 2,
+    tags: { type: "report" },
+  });
+  run.addWorkflowDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-44665544cccc",
+    name: "report-json",
+    version: 1,
+    tags: { type: "report" },
+  });
+
+  const data = run.toData();
+  assertEquals(data.workflowDataArtifacts?.length, 2);
+  assertEquals(data.workflowDataArtifacts?.[0].name, "report-md");
+  assertEquals(data.workflowDataArtifacts?.[1].name, "report-json");
+});
+
+Deno.test("WorkflowRun.fromData with missing workflowDataArtifacts defaults to empty", () => {
+  const data = {
+    id: "550e8400-e29b-41d4-a716-446655440002",
+    workflowId: "550e8400-e29b-41d4-a716-446655440000",
+    workflowName: "test-workflow",
+    status: "succeeded" as const,
+    startedAt: new Date().toISOString(),
+    jobs: [
+      {
+        jobName: "job1",
+        status: "succeeded" as const,
+        steps: [{ stepName: "step1", status: "succeeded" as const }],
+      },
+    ],
+  };
+
+  const run = WorkflowRun.fromData(data);
+  assertEquals(run.workflowDataArtifacts.length, 0);
+});
+
+Deno.test("WorkflowRun roundtrip preserves workflowDataArtifacts", () => {
+  const workflow = createTestWorkflow();
+  const original = WorkflowRun.create(workflow);
+  original.addWorkflowDataArtifact({
+    dataId: "550e8400-e29b-41d4-a716-44665544dddd",
+    name: "report-swamp-workflow-summary",
+    version: 1,
+    tags: {
+      type: "report",
+      reportName: "@swamp/workflow-summary",
+      reportScope: "workflow",
+    },
+  });
+
+  const data = original.toData();
+  const restored = WorkflowRun.fromData(data);
+
+  assertEquals(restored.workflowDataArtifacts.length, 1);
+  assertEquals(
+    restored.workflowDataArtifacts[0].dataId,
+    "550e8400-e29b-41d4-a716-44665544dddd",
+  );
+  assertEquals(
+    restored.workflowDataArtifacts[0].tags.reportName,
+    "@swamp/workflow-summary",
+  );
+});

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -65,8 +65,10 @@ export interface WorkflowDataListItem extends DataListItem {
   modelId: string;
   modelName: string;
   modelType: string;
-  jobName: string;
-  stepName: string;
+  /** Absent for workflow-scope artifacts not produced by a single step. */
+  jobName?: string;
+  /** Absent for workflow-scope artifacts not produced by a single step. */
+  stepName?: string;
 }
 
 /** Workflow-scoped data list. */
@@ -112,8 +114,10 @@ interface WorkflowDataEntry {
   modelId: string;
   modelName: string;
   modelType: ModelType;
-  jobName: string;
-  stepName: string;
+  /** Absent for workflow-scope artifacts not produced by a single step. */
+  jobName?: string;
+  /** Absent for workflow-scope artifacts not produced by a single step. */
+  stepName?: string;
 }
 
 /** Minimal workflow info for data list operations. */
@@ -302,21 +306,24 @@ async function* workflowScopedList(
     ? workflowData.filter((d) => d.data.type === input.typeFilter)
     : workflowData;
 
-  const items: WorkflowDataListItem[] = filteredData.map((item) => ({
-    id: item.data.id,
-    name: item.data.name,
-    version: item.data.version,
-    contentType: item.data.contentType,
-    type: item.data.type,
-    streaming: item.data.streaming,
-    size: item.data.size,
-    createdAt: item.data.createdAt.toISOString(),
-    modelId: item.modelId,
-    modelName: item.modelName,
-    modelType: item.modelType.normalized,
-    jobName: item.jobName,
-    stepName: item.stepName,
-  }));
+  const items: WorkflowDataListItem[] = filteredData.map((item) => {
+    const listItem: WorkflowDataListItem = {
+      id: item.data.id,
+      name: item.data.name,
+      version: item.data.version,
+      contentType: item.data.contentType,
+      type: item.data.type,
+      streaming: item.data.streaming,
+      size: item.data.size,
+      createdAt: item.data.createdAt.toISOString(),
+      modelId: item.modelId,
+      modelName: item.modelName,
+      modelType: item.modelType.normalized,
+    };
+    if (item.jobName !== undefined) listItem.jobName = item.jobName;
+    if (item.stepName !== undefined) listItem.stepName = item.stepName;
+    return listItem;
+  });
 
   const groups = groupByType(items);
 

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -34,7 +34,6 @@ import type {
   WorkflowRunView,
 } from "./workflow_run_view.ts";
 import type { ReportResultView } from "../models/model_method_run_view.ts";
-import { toReportResultView } from "../models/run.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
@@ -48,23 +47,9 @@ import {
   type InputValidationError,
   InputValidationService,
 } from "../../domain/inputs/mod.ts";
-import {
-  executeReports,
-} from "../../domain/reports/report_execution_service.ts";
-import { reportRegistry } from "../../domain/reports/report_registry.ts";
-import { BUILTIN_WORKFLOW_REPORTS } from "../../domain/reports/builtin/mod.ts";
-import type {
-  WorkflowReportContext,
-} from "../../domain/reports/report_context.ts";
-import { ModelType } from "../../domain/models/model_type.ts";
-import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import { getWorkflowRunLogger } from "../../infrastructure/logging/logger.ts";
-import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
-import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
-import type { DataHandle } from "../../domain/models/model.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
 
@@ -356,6 +341,15 @@ export function toRunData(
     }),
     duration: startTime && endTime ? endTime - startTime : undefined,
     path,
+    workflowDataArtifacts: run.workflowDataArtifacts &&
+        run.workflowDataArtifacts.length > 0
+      ? run.workflowDataArtifacts.map((a) => ({
+        dataId: a.dataId,
+        name: a.name,
+        version: a.version,
+        tags: a.tags,
+      }))
+      : undefined,
   };
 }
 
@@ -477,21 +471,6 @@ export async function* workflowRun(
         deps.catalogStore,
       );
 
-      // Track model info from events for post-run reports
-      const modelInfoByStep = new Map<
-        string,
-        { modelName: string; modelType: string; methodName: string }
-      >();
-      // Track step statuses from events
-      const stepStatuses = new Map<
-        string,
-        "succeeded" | "failed" | "skipped"
-      >();
-      // Track step job names
-      const stepJobNames = new Map<string, string>();
-      // Track per-step data handles from step_completed events
-      const dataHandlesByStep = new Map<string, DataHandle[]>();
-
       // Per-method-invocation telemetry bridge. Constructed once per
       // stream consumption and finalized in the outer try/finally so
       // any in-flight invocations on cancellation / throw are still
@@ -501,10 +480,12 @@ export async function* workflowRun(
         : undefined;
 
       try {
-        let completedEvent: WorkflowRunEvent | undefined;
-
-        // Collect per-step report results from execution service events
-        const perStepReportResults: ReportResultView[] = [];
+        // Aggregate report results from both method-scope (yielded during
+        // step execution) and workflow-scope (yielded by the execution
+        // service after run.complete()). All report_completed and
+        // report_failed events arrive before the completed event, so the
+        // accumulated list is attached to the run view at that point.
+        const reportResults: ReportResultView[] = [];
 
         for await (
           const event of service.run(resolvedInput.workflowIdOrName, {
@@ -526,44 +507,16 @@ export async function* workflowRun(
             skipAllChecks: resolvedInput.skipAllChecks,
           })
         ) {
-          // Track model_resolved events for report context
-          if (event.kind === "model_resolved") {
-            const key = `${event.jobId}:${event.stepId}`;
-            modelInfoByStep.set(key, {
-              modelName: event.modelName,
-              modelType: event.modelType,
-              methodName: event.methodName,
-            });
-            stepJobNames.set(key, event.jobId);
-          }
-          if (event.kind === "step_completed") {
-            stepStatuses.set(`${event.jobId}:${event.stepId}`, "succeeded");
-            if (event.dataHandles) {
-              dataHandlesByStep.set(
-                `${event.jobId}:${event.stepId}`,
-                event.dataHandles,
-              );
-            }
-          }
-          if (event.kind === "step_failed") {
-            stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
-          }
-          if (event.kind === "step_skipped") {
-            stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
-          }
-
-          // Collect per-step report results from execution service events
           if (event.kind === "report_completed") {
-            perStepReportResults.push({
+            reportResults.push({
               name: event.reportName,
               scope: event.scope,
               success: true,
               markdown: event.markdown,
               json: event.json,
             });
-          }
-          if (event.kind === "report_failed") {
-            perStepReportResults.push({
+          } else if (event.kind === "report_failed") {
+            reportResults.push({
               name: event.reportName,
               scope: event.scope,
               success: false,
@@ -571,7 +524,7 @@ export async function* workflowRun(
             });
           }
 
-          const mapped = mapEvent(event, deps, resolvedInput);
+          let mapped = mapEvent(event, deps, resolvedInput);
 
           // Per-method telemetry observer — runs alongside existing
           // event handling. Skipped when telemetry is disabled.
@@ -579,36 +532,14 @@ export async function* workflowRun(
             await telemetryBridge.observe(mapped);
           }
 
-          // Intercept the completed event to run reports first
-          if (mapped.kind === "completed") {
-            completedEvent = mapped;
-            continue;
+          if (mapped.kind === "completed" && reportResults.length > 0) {
+            mapped = {
+              ...mapped,
+              run: { ...mapped.run, reports: reportResults },
+            };
           }
 
           yield mapped;
-        }
-
-        // Execute post-run reports (workflow-scope only) before yielding the completed event
-        if (completedEvent && completedEvent.kind === "completed") {
-          const reportResults: ReportResultView[] = [...perStepReportResults];
-          yield* executePostRunReports(
-            deps,
-            resolvedInput,
-            workflow,
-            completedEvent.run,
-            modelInfoByStep,
-            stepStatuses,
-            stepJobNames,
-            reportResults,
-            dataHandlesByStep,
-          );
-          if (reportResults.length > 0) {
-            completedEvent = {
-              ...completedEvent,
-              run: { ...completedEvent.run, reports: reportResults },
-            };
-          }
-          yield completedEvent;
         }
       } catch (error) {
         if (
@@ -633,158 +564,6 @@ export async function* workflowRun(
       }
     })(),
   );
-}
-
-/**
- * Executes post-run reports (workflow-scope only) after a workflow completes.
- *
- * Method-scope and model-scope reports are now executed inline during
- * `executeModelMethod()` in the execution service, where the forEach
- * variable is in scope for computing vary suffixes.
- */
-async function* executePostRunReports(
-  deps: WorkflowRunDeps,
-  input: WorkflowRunInput,
-  workflow: Workflow,
-  runView: WorkflowRunView,
-  modelInfoByStep: Map<
-    string,
-    { modelName: string; modelType: string; methodName: string }
-  >,
-  stepStatuses: Map<string, "succeeded" | "failed" | "skipped">,
-  stepJobNames: Map<string, string>,
-  reportResults: ReportResultView[],
-  dataHandlesByStep: Map<string, DataHandle[]>,
-): AsyncGenerator<WorkflowRunEvent> {
-  // Reports require dataRepo and definitionRepo; skip if not provided
-  if (!deps.dataRepo || !deps.definitionRepo) {
-    return;
-  }
-
-  if (reportRegistry.getAll().length === 0) {
-    return;
-  }
-
-  const filterOptions = {
-    skipAllReports: input.skipAllReports,
-    skipReportNames: input.skipReportNames,
-    skipReportLabels: input.skipReportLabels,
-    reportNames: input.reportNames,
-    reportLabels: input.reportLabels,
-  };
-
-  const noopEvents = {
-    onReportStarted: () => {},
-    onReportCompleted: () => {},
-    onReportFailed: () => {},
-  };
-
-  // Build workflow-scope step executions context
-  const stepExecutions: WorkflowReportContext["stepExecutions"] = [];
-
-  // Prefer evaluated definitions (post-CEL) over raw definitions
-  const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(deps.repoDir);
-
-  for (const [key, info] of modelInfoByStep) {
-    const status = stepStatuses.get(key) ?? "failed";
-    const jobName = stepJobNames.get(key) ?? "";
-    // Extract step name from key (format: jobId:stepId)
-    const stepName = key.split(":")[1] ?? "";
-
-    // Look up the evaluated definition first, then fall back to raw
-    let lookupResult = await evaluatedDefRepo.findByNameGlobal(info.modelName);
-    if (!lookupResult) {
-      lookupResult = await findDefinitionByIdOrName(
-        deps.definitionRepo as YamlDefinitionRepository,
-        info.modelName,
-      );
-    }
-
-    if (!lookupResult || status === "skipped") {
-      stepExecutions.push({
-        jobName,
-        stepName,
-        modelName: info.modelName,
-        modelType: info.modelType,
-        methodName: info.methodName,
-        status: status as "succeeded" | "failed" | "skipped",
-        dataHandles: [],
-        methodArgs: {},
-        modelId: "",
-        globalArgs: {},
-      });
-      continue;
-    }
-
-    const { definition } = lookupResult;
-
-    // Use data handles tracked from step_completed events (current-run only)
-    const stepDataHandles = dataHandlesByStep.get(key) ?? [];
-
-    stepExecutions.push({
-      jobName,
-      stepName,
-      modelName: info.modelName,
-      modelType: info.modelType,
-      methodName: info.methodName,
-      status: status as "succeeded" | "failed" | "skipped",
-      dataHandles: stepDataHandles,
-      methodArgs: definition.getMethodArguments(info.methodName),
-      modelId: definition.id,
-      globalArgs: definition.globalArguments,
-    });
-  }
-
-  // Workflow-scope reports
-  const wfContext: WorkflowReportContext = {
-    scope: "workflow",
-    repoDir: deps.repoDir,
-    logger: getWorkflowRunLogger(workflow.name),
-    dataRepository: deps.dataRepo,
-    definitionRepository: deps.definitionRepo,
-    workflowId: workflow.id,
-    workflowRunId: runView.id,
-    workflowName: workflow.name,
-    workflowStatus: runView.status === "succeeded" ? "succeeded" : "failed",
-    stepExecutions,
-  };
-
-  const wfSummary = await executeReports(
-    reportRegistry,
-    wfContext,
-    ModelType.create("workflow"),
-    workflow.id,
-    workflow.reportSelection,
-    filterOptions,
-    noopEvents,
-    undefined, // methodName
-    BUILTIN_WORKFLOW_REPORTS,
-  );
-
-  for (const result of wfSummary.results) {
-    yield {
-      kind: "report_started",
-      reportName: result.name,
-      scope: result.scope,
-    };
-    if (result.success) {
-      yield {
-        kind: "report_completed",
-        reportName: result.name,
-        scope: result.scope,
-        markdown: result.markdown!,
-        json: result.json!,
-      };
-    } else {
-      yield {
-        kind: "report_failed",
-        reportName: result.name,
-        scope: result.scope,
-        error: result.error!,
-      };
-    }
-    reportResults.push(toReportResultView(result));
-  }
 }
 
 /**

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -76,4 +76,6 @@ export interface WorkflowRunView {
   duration?: number;
   path?: string;
   reports?: ReportResultView[];
+  /** Data artifacts produced at workflow scope (e.g. workflow-scope reports). */
+  workflowDataArtifacts?: DataArtifactRefData[];
 }

--- a/src/presentation/renderers/data_list.ts
+++ b/src/presentation/renderers/data_list.ts
@@ -92,7 +92,9 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
       );
       for (const item of group.items) {
         const size = formatSize(item.size);
-        const step = `${item.jobName}.${item.stepName}`;
+        const step = item.jobName !== undefined && item.stepName !== undefined
+          ? `${item.jobName}.${item.stepName}`
+          : "(workflow)";
         console.log(
           `  ${item.name}  v${item.version}  ${item.modelName}  ${step}  ${size}`,
         );

--- a/src/presentation/renderers/data_list_test.ts
+++ b/src/presentation/renderers/data_list_test.ts
@@ -62,6 +62,89 @@ Deno.test("JsonDataListRenderer - completed outputs JSON", async () => {
   }
 });
 
+Deno.test("LogDataListRenderer - workflow-scope row renders '(workflow)' placeholder", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg = "") => logs.push(msg);
+
+  try {
+    const renderer = createDataListRenderer("log");
+    await consumeStream(
+      toStream([
+        { kind: "resolving" },
+        {
+          kind: "completed",
+          data: {
+            workflowId: "wf-1",
+            workflowName: "deploy",
+            runId: "abcdef0123456789",
+            runStatus: "succeeded",
+            groups: [
+              {
+                type: "report",
+                items: [
+                  {
+                    id: "d-step",
+                    name: "report-step-summary",
+                    version: 1,
+                    contentType: "text/markdown",
+                    type: "report",
+                    streaming: false,
+                    size: 100,
+                    createdAt: new Date().toISOString(),
+                    modelId: "m-1",
+                    modelName: "my-model",
+                    modelType: "ns/type",
+                    jobName: "main",
+                    stepName: "build",
+                  },
+                  {
+                    id: "d-wf",
+                    name: "report-swamp-workflow-summary",
+                    version: 1,
+                    contentType: "text/markdown",
+                    type: "report",
+                    streaming: false,
+                    size: 200,
+                    createdAt: new Date().toISOString(),
+                    modelId: "wf-1",
+                    modelName: "",
+                    modelType: "workflow",
+                  },
+                ],
+              },
+            ],
+            total: 2,
+          },
+        },
+      ]),
+      renderer.handlers(),
+    );
+
+    const joined = logs.join("\n");
+    // Step-scoped artifact keeps the "job.step" rendering.
+    const stepLine = logs.find((l) => l.includes("report-step-summary"));
+    if (!stepLine) {
+      throw new Error(`expected step line in logs:\n${joined}`);
+    }
+    if (!stepLine.includes("main.build")) {
+      throw new Error(`expected 'main.build' in step line: ${stepLine}`);
+    }
+    // Workflow-scoped artifact renders "(workflow)".
+    const wfLine = logs.find((l) =>
+      l.includes("report-swamp-workflow-summary")
+    );
+    if (!wfLine) {
+      throw new Error(`expected workflow line in logs:\n${joined}`);
+    }
+    if (!wfLine.includes("(workflow)")) {
+      throw new Error(`expected '(workflow)' in workflow line: ${wfLine}`);
+    }
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("DataListRenderer - error throws UserError", () => {
   const renderer = createDataListRenderer("log");
   const handlers = renderer.handlers();

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -210,6 +210,11 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
         }
       }
     }
+    if (run.workflowDataArtifacts) {
+      for (const artifact of run.workflowDataArtifacts) {
+        artifactNames.add(artifact.name);
+      }
+    }
 
     if (artifactNames.size > 0) {
       logger.info("");


### PR DESCRIPTION
## Summary

Workflow-scope reports (e.g. `@swamp/workflow-summary`) persisted markdown + JSON artifacts to disk but were unreachable through `swamp data get --workflow` or `swamp data list --workflow`. The retrieval path only walked `run.jobs[].steps[].dataArtifacts`, and workflow-scope artifacts were never referenced from the `WorkflowRun` aggregate.

- Extend `WorkflowRun` with `workflowDataArtifacts: DataArtifactRef[]` + `addWorkflowDataArtifact()` (mirrors `StepRun.dataArtifacts`).
- Move workflow-scope report execution from libswamp into `WorkflowExecutionService` between `run.complete()` and the final `saveRun`, so the aggregate carries the references in a single transaction. Libswamp simplifies to event forwarding (~150 lines of event-reconstruction logic removed).
- New `WorkflowReportRunner` parallels `MethodReportRunner` for the per-step (method/model) case.
- `WorkflowDataService.findAllForWorkflowRun` walks both step and workflow-level artifacts; `jobName`/`stepName` made optional on `WorkflowDataItem`.
- Data list renderer shows `(workflow)` in the step column for workflow-scope rows.
- "View produced data" hint at end of a workflow run now lists workflow-scope artifacts too.

Closes swamp-club#337.

## Test Plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` applied
- [x] `deno run test` — 5873 passed, 0 failed
- [x] `deno run compile` succeeds
- [x] Manual repro at `/tmp/swamp-repro-issue-337`:
  - `swamp data get --workflow repro-workflow report-swamp-workflow-summary` returns markdown (was: `Data not found`)
  - `swamp data get --workflow repro-workflow report-swamp-workflow-summary-json` returns JSON
  - `swamp data list --workflow repro-workflow` lists both report artifacts with `(workflow)` in the step column
  - Step-scope retrieval (`swamp data get --workflow repro-workflow result`) still works
  - Workflow run output's "View produced data" hint lists workflow-scope artifacts
- [x] Independently verified on a real audit workflow with 4 custom workflow-scope reports

## Follow-ups

- File UAT issue in `systeminit/swamp-uat` for `swamp data get --workflow` coverage of workflow-scope reports — the absence of this test let the bug ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)