### PR TITLE
fix(workflows): preserve colons in step name when building workflow-scope report executions (swamp-club#338)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -192,6 +192,18 @@ export interface StepExecutor {
 const MAX_WORKFLOW_NESTING_DEPTH = 10;
 
 /**
+ * Decode the step-name segment of a `${jobId}:${stepName}` composite key.
+ *
+ * Splits on the FIRST colon only, so step names that themselves contain
+ * colons (e.g. `docker:build`) round-trip without truncation. Returns ""
+ * when the key has no colon.
+ */
+export function stepNameFromCompositeKey(key: string): string {
+  const idx = key.indexOf(":");
+  return idx >= 0 ? key.slice(idx + 1) : "";
+}
+
+/**
  * Infrastructure dependencies the {@link DefaultStepExecutor} needs to
  * run a model method. Inject this for tests so the executor can be
  * exercised without disk, real vaults, or YAML on the filesystem.
@@ -2245,7 +2257,7 @@ export class WorkflowExecutionService {
     for (const [key, info] of modelInfoByStep) {
       const status = stepStatuses.get(key) ?? "failed";
       const jobName = stepJobNames.get(key) ?? "";
-      const stepName = key.split(":")[1] ?? "";
+      const stepName = stepNameFromCompositeKey(key);
 
       // Prefer the evaluated definition (post-CEL) so report templates see
       // resolved expression values. Fall back to the raw definition.

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -23,6 +23,7 @@ import {
   DefaultStepExecutor,
   type StepExecutionContext,
   type StepExecutor,
+  stepNameFromCompositeKey,
   WorkflowExecutionService,
 } from "./execution_service.ts";
 import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
@@ -3160,3 +3161,19 @@ Deno.test("run.id expression in step inputs resolves to the workflow run UUID", 
     assertNotEquals(ctx.expressionContext?.run?.startedAt, undefined);
   });
 });
+
+Deno.test(
+  "stepNameFromCompositeKey: preserves colons in the step name segment",
+  () => {
+    const cases: Array<[string, string]> = [
+      ["job1:step1", "step1"],
+      ["job1:docker:build", "docker:build"],
+      ["job1:a:b:c", "a:b:c"],
+      ["jobOnly", ""],
+      ["", ""],
+    ];
+    for (const [key, expected] of cases) {
+      assertEquals(stepNameFromCompositeKey(key), expected, `key=${key}`);
+    }
+  },
+);


### PR DESCRIPTION
## Summary

The workflow-scope report flow built per-step lookup keys as `${jobId}:${stepId}` then extracted the step name via `key.split(":")[1] ?? ""`, silently truncating any step name that contained a colon (e.g. `docker:build`). `StepSchema.name` is `z.string().min(1)` and does not enforce a no-colon invariant, so the truncation is reachable in principle — though step names happen to be simple identifiers in practice today, so there is no observable user impact. Filed as a defensive-coding follow-up from the swamp-club#337 / #1372 adversarial review.

- Add exported pure helper `stepNameFromCompositeKey` in `src/domain/workflows/execution_service.ts` that slices on the FIRST colon via `indexOf`, so the step-name segment retains any remaining colons.
- Replace the single call site in `runWorkflowReports`.
- Direct unit test on the helper with five cases: simple (`job1:step1`), reported bug (`job1:docker:build`), multi-colon (`job1:a:b:c`), no-colon (`jobOnly`), and empty (`""`).

Closes swamp-club#338.

## Test Plan

- [x] `deno fmt --check` clean
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno run test` — 5874 passed, 0 failed (new helper test included)
- [x] `deno run compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)