### PR TITLE
feat(cli): add -y/--yes flag to extension unyank (swamp-club#339)

### DIFF
--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -25,13 +25,30 @@ import {
   extensionUnyank,
   extensionUnyankPreview,
 } from "../../libswamp/mod.ts";
-import { createExtensionUnyankRenderer } from "../../presentation/renderers/extension_unyank.ts";
+import {
+  createExtensionUnyankRenderer,
+  renderExtensionUnyankCancelled,
+} from "../../presentation/renderers/extension_unyank.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return false;
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
 
 export const extensionUnyankCommand = new Command()
   .name("unyank")
@@ -48,6 +65,7 @@ export const extensionUnyankCommand = new Command()
   )
   .arguments("<extension:string> [version:string]")
   .option("--reason <reason:string>", "Optional reason (audit log only)")
+  .option("-y, --yes", "Skip confirmation prompt")
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -70,13 +88,25 @@ export const extensionUnyankCommand = new Command()
       reason: (options.reason as string | undefined) ?? null,
     };
 
+    let preview;
     try {
-      await extensionUnyankPreview(ctx, deps, input);
+      preview = await extensionUnyankPreview(ctx, deps, input);
     } catch (error) {
       if ("code" in (error as Record<string, unknown>)) {
         throw new UserError((error as { message: string }).message);
       }
       throw error;
+    }
+
+    if (cliCtx.outputMode === "log" && !options.yes) {
+      const prompt = preview.version
+        ? `Unyank ${preview.extensionName}@${preview.version}? This will restore availability.`
+        : `Unyank ALL versions of ${preview.extensionName}? This will restore availability and allow future pushes.`;
+      const confirmed = await promptConfirmation(prompt);
+      if (!confirmed) {
+        renderExtensionUnyankCancelled(cliCtx.outputMode);
+        return;
+      }
     }
 
     const renderer = createExtensionUnyankRenderer(cliCtx.outputMode);

--- a/src/presentation/renderers/extension_unyank.ts
+++ b/src/presentation/renderers/extension_unyank.ts
@@ -75,3 +75,12 @@ export function createExtensionUnyankRenderer(
       return new LogExtensionUnyankRenderer();
   }
 }
+
+export function renderExtensionUnyankCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ status: "cancelled" }));
+  } else {
+    const logger = getSwampLogger(["extension", "unyank"]);
+    logger.info("Unyank cancelled.");
+  }
+}


### PR DESCRIPTION
## Summary

- Add `-y/--yes` flag and confirmation prompt to `swamp extension unyank` for parity with `swamp extension yank`
- Unyank now prompts for confirmation in interactive mode (log output) and skips the prompt with `--yes` or in JSON mode
- Add `renderExtensionUnyankCancelled` to the unyank renderer for consistent cancellation output

Closes swamp-club#339

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] Existing unyank unit tests pass
- [ ] Manual: `swamp extension unyank @foo/bar 2026.1.1` prompts, declining cancels
- [ ] Manual: `swamp extension unyank @foo/bar 2026.1.1 -y` skips prompt
- [ ] Manual: `swamp extension unyank @foo/bar --json` skips prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)