### PR TITLE
feat(doctor): add `swamp doctor workflows` subcommand (swamp-club#330)

### DIFF
--- a/.claude/skills/swamp-troubleshooting/references/health-checks.md
+++ b/.claude/skills/swamp-troubleshooting/references/health-checks.md
@@ -10,6 +10,7 @@ piece in the output.
 - [When to use Tier 1](#when-to-use-tier-1)
 - [`swamp doctor audit`](#swamp-doctor-audit)
 - [`swamp doctor extensions`](#swamp-doctor-extensions)
+- [`swamp doctor workflows`](#swamp-doctor-workflows)
 - [Using doctor in CI](#using-doctor-in-ci)
 - [Escalating to other tiers](#escalating-to-other-tiers)
 
@@ -23,7 +24,9 @@ Reach for a doctor command when the symptom maps to a known integration:
 | Hooks aren't firing for the configured AI tool                 | `swamp doctor audit`      |
 | Extension model/vault/driver/datastore/report missing from CLI | `swamp doctor extensions` |
 | `swamp-warning:` line on stderr mentioning a load failure      | `swamp doctor extensions` |
-| CI preflight needs to gate on integration health               | either, with `--json`     |
+| Workflow YAML fails to parse or construct                      | `swamp doctor workflows`  |
+| `swamp workflow get` errors on a file that search finds        | `swamp doctor workflows`  |
+| CI preflight needs to gate on integration health               | any, with `--json`        |
 
 If the symptom is generic ("command errored", "method failed"), skip Tier 1 and
 go to Tier 2 (error inspection).
@@ -209,10 +212,96 @@ For the deeper "extension not in type search" walkthrough (stderr inspection,
 source registration, `deno.json` discovery), see
 [error-inspection.md](error-inspection.md).
 
+## `swamp doctor workflows`
+
+Checks that every workflow YAML file in the repo can be parsed and constructed
+into a valid Workflow domain object. This catches YAML syntax errors and schema
+construction failures that `findAll()` silently skips — meaning
+`swamp workflow
+validate` never sees these broken files. Exits 1 on any load
+failure.
+
+```bash
+swamp doctor workflows
+swamp doctor workflows --json
+```
+
+### What it checks
+
+Walks all workflow directories (primary `workflows/`, extension workflows,
+source-mounted workflows, pulled extension workflows) and for each `*.yaml`
+file:
+
+1. Reads the file content
+2. Parses YAML via `@std/yaml`
+3. Constructs the domain object via `Workflow.fromData()`
+
+Scope is **load-ability only** — whether the file can be parsed and constructed.
+Schema validity (DAG integrity, model references, expression validation) is the
+job of `swamp workflow validate`.
+
+### Output — log mode
+
+```
+Checking workflows...
+
+  ✓ deploy-pipeline
+  ✓ nightly-sync
+  ✗ emergency-kernel-update
+    → YAML parse error at line 42, column 15: bad indentation of a mapping entry
+
+Summary: 2/3 workflows loaded successfully
+Result: FAILED
+```
+
+### Output — JSON mode
+
+```json
+{
+  "overallStatus": "fail",
+  "workflows": [
+    {
+      "file": "workflows/workflow-abc.yaml",
+      "name": "deploy-pipeline",
+      "status": "pass"
+    },
+    {
+      "file": "workflows/workflow-broken.yaml",
+      "name": "emergency-kernel-update",
+      "status": "fail",
+      "error": "YAML parse error at line 42, column 15: bad indentation"
+    }
+  ],
+  "totalPassed": 2,
+  "totalFailed": 1
+}
+```
+
+### Common failures
+
+| Error fragment                        | Fix                                                                   |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| YAML parse error at line N            | Fix the YAML syntax at the indicated line/column                      |
+| `type "shell" is no longer supported` | Replace `type: shell` with `type: model_method` using `command/shell` |
+| Invalid uuid / missing name           | Add required `id` (UUID) and `name` fields to the workflow YAML       |
+| Invalid cron expression               | Fix the `trigger.schedule` cron expression                            |
+
+### Relationship with `swamp workflow validate`
+
+These two commands are complementary:
+
+- `doctor workflows` catches files that **fail to load** (YAML syntax, missing
+  fields, invalid types). These files are silently dropped by the workflow
+  loader, so `workflow validate` never sees them.
+- `workflow validate` checks **loaded** workflows for semantic validity (DAG
+  cycles, undefined model references, expression errors).
+
+Run both in CI for complete coverage.
+
 ## Using doctor in CI
 
-Both commands exit 1 on failure, so they compose directly into CI. Use `--json`
-to capture structured output for review.
+All doctor commands exit 1 on failure, so they compose directly into CI. Use
+`--json` to capture structured output for review.
 
 ```bash
 # Gate on audit health
@@ -220,11 +309,15 @@ swamp doctor audit --json > audit-health.json
 
 # Gate on extension health
 swamp doctor extensions --json > extension-health.json
+
+# Gate on workflow health
+swamp doctor workflows --json > workflow-health.json
 ```
 
 Run `doctor extensions` after every PR that touches `extensions/` or
-`.swamp-sources.yaml`. Run `doctor audit` after every `init` or `upgrade` step
-in CI bootstrap.
+`.swamp-sources.yaml`. Run `doctor workflows` after every PR that touches
+workflow YAML files. Run `doctor audit` after every `init` or `upgrade` step in
+CI bootstrap.
 
 ## Escalating to other tiers
 

--- a/.claude/skills/swamp-troubleshooting/references/health-checks.md
+++ b/.claude/skills/swamp-troubleshooting/references/health-checks.md
@@ -250,8 +250,7 @@ Checking workflows...
   ✗ emergency-kernel-update
     → YAML parse error at line 42, column 15: bad indentation of a mapping entry
 
-Summary: 2/3 workflows loaded successfully
-Result: FAILED
+2 passed, 1 failed — OVERALL: FAIL
 ```
 
 ### Output — JSON mode
@@ -261,12 +260,12 @@ Result: FAILED
   "overallStatus": "fail",
   "workflows": [
     {
-      "file": "workflows/workflow-abc.yaml",
+      "file": "/path/to/repo/workflows/workflow-abc.yaml",
       "name": "deploy-pipeline",
       "status": "pass"
     },
     {
-      "file": "workflows/workflow-broken.yaml",
+      "file": "/path/to/repo/workflows/workflow-broken.yaml",
       "name": "emergency-kernel-update",
       "status": "fail",
       "error": "YAML parse error at line 42, column 15: bad indentation"

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import { doctorAuditCommand } from "./doctor_audit.ts";
 import { doctorExtensionsCommand } from "./doctor_extensions.ts";
+import { doctorWorkflowsCommand } from "./doctor_workflows.ts";
 
 export const doctorCommand = new Command()
   .description(
@@ -37,6 +38,10 @@ export const doctorCommand = new Command()
     "Check that user-defined extensions in this repo load cleanly",
     "swamp doctor extensions",
   )
+  .example(
+    "Check that workflow YAML files load cleanly",
+    "swamp doctor workflows",
+  )
   // `--repo-dir` is accepted on the top-level command for consistency
   // with subcommands and other repo-scoped commands. The top-level
   // action only shows help; subcommands consume the option.
@@ -48,4 +53,5 @@ export const doctorCommand = new Command()
     this.showHelp();
   })
   .command("audit", doctorAuditCommand)
-  .command("extensions", doctorExtensionsCommand);
+  .command("extensions", doctorExtensionsCommand)
+  .command("workflows", doctorWorkflowsCommand);

--- a/src/cli/commands/doctor_workflows.ts
+++ b/src/cli/commands/doctor_workflows.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { isAbsolute, join, resolve } from "@std/path";
+import {
+  consumeStream,
+  doctorWorkflows,
+  enumeratePulledExtensionDirs,
+} from "../../libswamp/mod.ts";
+import { createWorkflowDoctorRenderer } from "../../presentation/renderers/workflow_doctor.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
+import { resolveModelsDir } from "../resolve_models_dir.ts";
+import {
+  collectDirsForKind,
+  expandSourcePaths,
+  readSwampSources,
+  resolveSourceExtensionDirs,
+} from "../../infrastructure/persistence/swamp_sources_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+async function getSourceWorkflowDirs(repoDir: string): Promise<string[]> {
+  const sourcesConfig = await readSwampSources(repoDir);
+  if (!sourcesConfig) return [];
+  const expanded = await expandSourcePaths(sourcesConfig, repoDir);
+  const resolved = await resolveSourceExtensionDirs(expanded);
+  return collectDirsForKind(resolved, "workflows");
+}
+
+export const doctorWorkflowsCommand = new Command()
+  .description(
+    "Check that workflow YAML files in this repo load cleanly.",
+  )
+  .example("Check all workflows", "swamp doctor workflows")
+  .example("Machine-readable output for CI", "swamp doctor workflows --json")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "doctor",
+      "workflows",
+    ]);
+    cliCtx.logger.debug("Executing doctor workflows command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    const { marker } = await resolveDatastoreForRepo(repoDir);
+
+    const yamlWorkflowsDir = join(repoDir, "workflows");
+
+    const workflowsDirRel = resolveWorkflowsDir(marker);
+    const workflowsDir = isAbsolute(workflowsDirRel)
+      ? workflowsDirRel
+      : resolve(repoDir, workflowsDirRel);
+
+    const sourceWorkflowDirs = await getSourceWorkflowDirs(repoDir);
+
+    const modelsDirRel = resolveModelsDir(marker);
+    const modelsDir = isAbsolute(modelsDirRel)
+      ? modelsDirRel
+      : resolve(repoDir, modelsDirRel);
+    const pulledWorkflowDirs = await enumeratePulledExtensionDirs(
+      join(modelsDir, "upstream_extensions.json"),
+      repoDir,
+      "workflows",
+    );
+
+    const workflowDirs = [
+      yamlWorkflowsDir,
+      workflowsDir,
+      ...sourceWorkflowDirs,
+      ...pulledWorkflowDirs,
+    ];
+
+    const controller = new AbortController();
+    const renderer = createWorkflowDoctorRenderer(cliCtx.outputMode);
+
+    await consumeStream(
+      doctorWorkflows({
+        workflowDirs,
+        abortSignal: controller.signal,
+      }),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("doctor workflows command completed");
+
+    if (renderer.overallStatus === "fail") {
+      Deno.exit(1);
+    }
+  });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -450,6 +450,15 @@ export {
   type WorkflowValidateInput,
 } from "./workflows/validate.ts";
 
+// Workflow doctor operations
+export {
+  type DoctorWorkflowResult,
+  doctorWorkflows,
+  type DoctorWorkflowsDeps,
+  type DoctorWorkflowsEvent,
+  type DoctorWorkflowsReport,
+} from "./workflows/doctor.ts";
+
 // Workflow evaluate operations
 export {
   createWorkflowEvaluateDeps,

--- a/src/libswamp/workflows/doctor.ts
+++ b/src/libswamp/workflows/doctor.ts
@@ -17,13 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { basename } from "@std/path";
+import { basename, join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
 import {
   Workflow,
   type WorkflowData,
 } from "../../domain/workflows/workflow.ts";
 import type { SwampError } from "../errors.ts";
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["doctor-workflows"]);
 
 /** Per-file result: pass means the file loaded cleanly. */
 export interface DoctorWorkflowResult {
@@ -50,20 +53,6 @@ export type DoctorWorkflowsEvent =
 export interface DoctorWorkflowsDeps {
   workflowDirs: string[];
   abortSignal: AbortSignal;
-}
-
-/**
- * Attempts to extract the workflow name from raw YAML content.
- * Falls back to the filename if the content cannot be parsed far enough
- * to read a `name` field.
- */
-function tryExtractName(content: string, filePath: string): string | null {
-  try {
-    const data = parseYaml(content) as { name?: string };
-    return data?.name ?? null;
-  } catch {
-    return fallbackName(filePath);
-  }
 }
 
 function fallbackName(filePath: string): string | null {
@@ -94,6 +83,12 @@ export async function* doctorWorkflows(
       }
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) continue;
+      if (error instanceof Deno.errors.PermissionDenied) {
+        logger.warn`Skipping inaccessible workflow directory ${dir}: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        continue;
+      }
       throw error;
     }
 
@@ -104,7 +99,7 @@ export async function* doctorWorkflows(
     for (const entry of yamlFiles) {
       if (deps.abortSignal.aborted) break;
 
-      const filePath = `${dir}/${entry.name}`;
+      const filePath = join(dir, entry.name);
       let content: string;
       try {
         content = await Deno.readTextFile(filePath);
@@ -123,19 +118,24 @@ export async function* doctorWorkflows(
         continue;
       }
 
-      const name = tryExtractName(content, filePath);
-
       try {
         const data = parseYaml(content) as WorkflowData;
         Workflow.fromData(data);
         const result: DoctorWorkflowResult = {
           file: filePath,
-          name: name ?? data.name ?? null,
+          name: data.name ?? fallbackName(filePath),
           status: "pass",
         };
         results.push(result);
         yield { kind: "workflow-checked", result };
       } catch (parseError) {
+        const name = (() => {
+          try {
+            return (parseYaml(content) as { name?: string })?.name ?? null;
+          } catch {
+            return fallbackName(filePath);
+          }
+        })();
         const error = parseError instanceof Error
           ? parseError.message
           : String(parseError);

--- a/src/libswamp/workflows/doctor.ts
+++ b/src/libswamp/workflows/doctor.ts
@@ -1,0 +1,166 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { basename } from "@std/path";
+import { parse as parseYaml } from "@std/yaml";
+import {
+  Workflow,
+  type WorkflowData,
+} from "../../domain/workflows/workflow.ts";
+import type { SwampError } from "../errors.ts";
+
+/** Per-file result: pass means the file loaded cleanly. */
+export interface DoctorWorkflowResult {
+  file: string;
+  name: string | null;
+  status: "pass" | "fail";
+  error?: string;
+}
+
+/** Final report shape. */
+export interface DoctorWorkflowsReport {
+  overallStatus: "pass" | "fail";
+  workflows: DoctorWorkflowResult[];
+  totalPassed: number;
+  totalFailed: number;
+}
+
+export type DoctorWorkflowsEvent =
+  | { kind: "workflow-checked"; result: DoctorWorkflowResult }
+  | { kind: "completed"; report: DoctorWorkflowsReport }
+  | { kind: "error"; error: SwampError };
+
+/** Dependencies injected by the CLI command. */
+export interface DoctorWorkflowsDeps {
+  workflowDirs: string[];
+  abortSignal: AbortSignal;
+}
+
+/**
+ * Attempts to extract the workflow name from raw YAML content.
+ * Falls back to the filename if the content cannot be parsed far enough
+ * to read a `name` field.
+ */
+function tryExtractName(content: string, filePath: string): string | null {
+  try {
+    const data = parseYaml(content) as { name?: string };
+    return data?.name ?? null;
+  } catch {
+    return fallbackName(filePath);
+  }
+}
+
+function fallbackName(filePath: string): string | null {
+  const filename = basename(filePath);
+  const stripped = filename.replace(/\.yaml$/, "");
+  return stripped || null;
+}
+
+/**
+ * Walks every supplied workflow directory and attempts to load each
+ * `*.yaml` file through the same YAML + Workflow.fromData() path
+ * the workflow loader uses. Reports parse and construction errors
+ * instead of silently skipping them.
+ */
+export async function* doctorWorkflows(
+  deps: DoctorWorkflowsDeps,
+): AsyncIterable<DoctorWorkflowsEvent> {
+  const results: DoctorWorkflowResult[] = [];
+
+  for (const dir of deps.workflowDirs) {
+    if (deps.abortSignal.aborted) break;
+
+    let entries: Deno.DirEntry[];
+    try {
+      entries = [];
+      for await (const entry of Deno.readDir(dir)) {
+        entries.push(entry);
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) continue;
+      throw error;
+    }
+
+    const yamlFiles = entries
+      .filter((e) => e.isFile && e.name.endsWith(".yaml"))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of yamlFiles) {
+      if (deps.abortSignal.aborted) break;
+
+      const filePath = `${dir}/${entry.name}`;
+      let content: string;
+      try {
+        content = await Deno.readTextFile(filePath);
+      } catch (readError) {
+        const error = readError instanceof Error
+          ? readError.message
+          : String(readError);
+        const result: DoctorWorkflowResult = {
+          file: filePath,
+          name: fallbackName(filePath),
+          status: "fail",
+          error,
+        };
+        results.push(result);
+        yield { kind: "workflow-checked", result };
+        continue;
+      }
+
+      const name = tryExtractName(content, filePath);
+
+      try {
+        const data = parseYaml(content) as WorkflowData;
+        Workflow.fromData(data);
+        const result: DoctorWorkflowResult = {
+          file: filePath,
+          name: name ?? data.name ?? null,
+          status: "pass",
+        };
+        results.push(result);
+        yield { kind: "workflow-checked", result };
+      } catch (parseError) {
+        const error = parseError instanceof Error
+          ? parseError.message
+          : String(parseError);
+        const result: DoctorWorkflowResult = {
+          file: filePath,
+          name,
+          status: "fail",
+          error,
+        };
+        results.push(result);
+        yield { kind: "workflow-checked", result };
+      }
+    }
+  }
+
+  const totalPassed = results.filter((r) => r.status === "pass").length;
+  const totalFailed = results.length - totalPassed;
+
+  yield {
+    kind: "completed",
+    report: {
+      overallStatus: totalFailed > 0 ? "fail" : "pass",
+      workflows: results,
+      totalPassed,
+      totalFailed,
+    },
+  };
+}

--- a/src/libswamp/workflows/doctor_test.ts
+++ b/src/libswamp/workflows/doctor_test.ts
@@ -1,0 +1,279 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { collect } from "../testing.ts";
+import { doctorWorkflows, type DoctorWorkflowsEvent } from "./doctor.ts";
+
+const VALID_WORKFLOW_YAML = `id: "550e8400-e29b-41d4-a716-446655440000"
+name: test-workflow
+jobs:
+  - name: test-job
+    steps:
+      - name: test-step
+        task:
+          type: model_method
+          modelIdOrName: my-model
+          methodName: validate
+`;
+
+const BROKEN_YAML = `id: "550e8400-e29b-41d4-a716-446655440001"
+name: broken-workflow
+jobs:
+  - name: bad-job
+    steps:
+      - name: bad-step
+        task:
+          type: model_method
+          modelIdOrName: my-model
+          methodName: validate
+  invalid: yaml: here
+`;
+
+const INVALID_SCHEMA_YAML = `id: "not-a-uuid"
+name: ""
+`;
+
+Deno.test("doctorWorkflows: reports pass for valid workflow", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-test.yaml"),
+      VALID_WORKFLOW_YAML,
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    assertEquals(events.length, 2);
+    assertEquals(events[0].kind, "workflow-checked");
+    const checked = events[0] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "workflow-checked" }
+    >;
+    assertEquals(checked.result.status, "pass");
+    assertEquals(checked.result.name, "test-workflow");
+
+    const completed = events[1] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "completed" }
+    >;
+    assertEquals(completed.report.overallStatus, "pass");
+    assertEquals(completed.report.totalPassed, 1);
+    assertEquals(completed.report.totalFailed, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: reports fail for broken YAML", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-broken.yaml"),
+      BROKEN_YAML,
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    assertEquals(events.length, 2);
+    const checked = events[0] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "workflow-checked" }
+    >;
+    assertEquals(checked.result.status, "fail");
+    assertEquals(typeof checked.result.error, "string");
+
+    const completed = events[1] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "completed" }
+    >;
+    assertEquals(completed.report.overallStatus, "fail");
+    assertEquals(completed.report.totalFailed, 1);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: reports fail for invalid schema", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-invalid.yaml"),
+      INVALID_SCHEMA_YAML,
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    const checked = events[0] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "workflow-checked" }
+    >;
+    assertEquals(checked.result.status, "fail");
+    assertEquals(typeof checked.result.error, "string");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: handles missing directory gracefully", async () => {
+  const events = await collect<DoctorWorkflowsEvent>(
+    doctorWorkflows({
+      workflowDirs: ["/tmp/nonexistent-swamp-dir-" + crypto.randomUUID()],
+      abortSignal: new AbortController().signal,
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const completed = events[0] as Extract<
+    DoctorWorkflowsEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.report.overallStatus, "pass");
+  assertEquals(completed.report.workflows.length, 0);
+});
+
+Deno.test("doctorWorkflows: skips non-yaml files", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(join(tmpDir, "notes.txt"), "not a workflow");
+    await Deno.writeTextFile(join(tmpDir, "data.json"), "{}");
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    assertEquals(events.length, 1);
+    assertEquals(events[0].kind, "completed");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: scans multiple directories", async () => {
+  const tmpDir1 = await Deno.makeTempDir({ prefix: "swamp_doctor_wf1_" });
+  const tmpDir2 = await Deno.makeTempDir({ prefix: "swamp_doctor_wf2_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir1, "workflow-a.yaml"),
+      VALID_WORKFLOW_YAML,
+    );
+    await Deno.writeTextFile(
+      join(tmpDir2, "workflow-b.yaml"),
+      VALID_WORKFLOW_YAML.replace(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "660e8400-e29b-41d4-a716-446655440000",
+      ).replace("test-workflow", "second-workflow"),
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir1, tmpDir2],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    assertEquals(events.length, 3);
+    const completed = events[2] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "completed" }
+    >;
+    assertEquals(completed.report.totalPassed, 2);
+    assertEquals(completed.report.overallStatus, "pass");
+  } finally {
+    await Deno.remove(tmpDir1, { recursive: true });
+    await Deno.remove(tmpDir2, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: mixed pass and fail results", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-good.yaml"),
+      VALID_WORKFLOW_YAML,
+    );
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-bad.yaml"),
+      BROKEN_YAML,
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    const completed = events[events.length - 1] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "completed" }
+    >;
+    assertEquals(completed.report.overallStatus, "fail");
+    assertEquals(completed.report.totalPassed, 1);
+    assertEquals(completed.report.totalFailed, 1);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("doctorWorkflows: extracts name from parseable YAML even when construction fails", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_wf_" });
+  try {
+    await Deno.writeTextFile(
+      join(tmpDir, "workflow-invalid-schema.yaml"),
+      INVALID_SCHEMA_YAML,
+    );
+
+    const events = await collect<DoctorWorkflowsEvent>(
+      doctorWorkflows({
+        workflowDirs: [tmpDir],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    const checked = events[0] as Extract<
+      DoctorWorkflowsEvent,
+      { kind: "workflow-checked" }
+    >;
+    assertEquals(checked.result.status, "fail");
+    // Name extraction should still work even though schema validation fails
+    // (empty string name won't parse from YAML since it's falsy)
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});

--- a/src/libswamp/workflows/doctor_test.ts
+++ b/src/libswamp/workflows/doctor_test.ts
@@ -83,7 +83,7 @@ Deno.test("doctorWorkflows: reports pass for valid workflow", async () => {
     assertEquals(completed.report.totalPassed, 1);
     assertEquals(completed.report.totalFailed, 0);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -117,7 +117,7 @@ Deno.test("doctorWorkflows: reports fail for broken YAML", async () => {
     assertEquals(completed.report.overallStatus, "fail");
     assertEquals(completed.report.totalFailed, 1);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -143,7 +143,7 @@ Deno.test("doctorWorkflows: reports fail for invalid schema", async () => {
     assertEquals(checked.result.status, "fail");
     assertEquals(typeof checked.result.error, "string");
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -180,7 +180,7 @@ Deno.test("doctorWorkflows: skips non-yaml files", async () => {
     assertEquals(events.length, 1);
     assertEquals(events[0].kind, "completed");
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -215,8 +215,8 @@ Deno.test("doctorWorkflows: scans multiple directories", async () => {
     assertEquals(completed.report.totalPassed, 2);
     assertEquals(completed.report.overallStatus, "pass");
   } finally {
-    await Deno.remove(tmpDir1, { recursive: true });
-    await Deno.remove(tmpDir2, { recursive: true });
+    await Deno.remove(tmpDir1, { recursive: true }).catch(() => {});
+    await Deno.remove(tmpDir2, { recursive: true }).catch(() => {});
   }
 });
 
@@ -247,7 +247,7 @@ Deno.test("doctorWorkflows: mixed pass and fail results", async () => {
     assertEquals(completed.report.totalPassed, 1);
     assertEquals(completed.report.totalFailed, 1);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -274,6 +274,6 @@ Deno.test("doctorWorkflows: extracts name from parseable YAML even when construc
     // Name extraction should still work even though schema validation fails
     // (empty string name won't parse from YAML since it's falsy)
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });

--- a/src/presentation/renderers/workflow_doctor.ts
+++ b/src/presentation/renderers/workflow_doctor.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, cyan, dim, green, red } from "@std/fmt/colors";
+import type {
+  DoctorWorkflowsEvent,
+  DoctorWorkflowsReport,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+export interface WorkflowDoctorRenderer extends Renderer<DoctorWorkflowsEvent> {
+  readonly overallStatus: "pass" | "fail";
+}
+
+class LogWorkflowDoctorRenderer implements WorkflowDoctorRenderer {
+  overallStatus: "pass" | "fail" = "pass";
+  private headerPrinted = false;
+
+  handlers(): EventHandlers<DoctorWorkflowsEvent> {
+    return {
+      "workflow-checked": (e) => {
+        if (!this.headerPrinted) {
+          writeOutput(bold(cyan("Checking workflows...")));
+          this.headerPrinted = true;
+        }
+        const r = e.result;
+        const label = r.name ?? dim(r.file);
+        if (r.status === "pass") {
+          writeOutput(`  ${green("✓")} ${label}`);
+        } else {
+          writeOutput(`  ${red("✗")} ${label}`);
+          if (r.error) {
+            writeOutput(`    ${red("→")} ${r.error}`);
+          }
+        }
+      },
+      completed: (e) => {
+        this.overallStatus = e.report.overallStatus;
+        if (e.report.workflows.length === 0) {
+          if (!this.headerPrinted) {
+            writeOutput(bold(cyan("Checking workflows...")));
+          }
+          writeOutput(`\n  No workflow files found`);
+          writeOutput(`\n${bold(cyan("Result:"))} ${green("PASSED")}`);
+          return;
+        }
+        writeOutput(
+          `\n${
+            bold(cyan("Summary:"))
+          } ${e.report.totalPassed}/${e.report.workflows.length} workflows loaded successfully`,
+        );
+        writeOutput(
+          `${bold(cyan("Result:"))} ${
+            e.report.overallStatus === "pass" ? green("PASSED") : red("FAILED")
+          }`,
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonWorkflowDoctorRenderer implements WorkflowDoctorRenderer {
+  overallStatus: "pass" | "fail" = "pass";
+
+  handlers(): EventHandlers<DoctorWorkflowsEvent> {
+    return {
+      "workflow-checked": () => {},
+      completed: (e) => {
+        this.overallStatus = e.report.overallStatus;
+        const report: DoctorWorkflowsReport = e.report;
+        console.log(JSON.stringify(report, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createWorkflowDoctorRenderer(
+  mode: OutputMode,
+): WorkflowDoctorRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonWorkflowDoctorRenderer();
+    case "log":
+      return new LogWorkflowDoctorRenderer();
+  }
+}

--- a/src/presentation/renderers/workflow_doctor.ts
+++ b/src/presentation/renderers/workflow_doctor.ts
@@ -20,7 +20,6 @@
 import { bold, cyan, dim, green, red } from "@std/fmt/colors";
 import type {
   DoctorWorkflowsEvent,
-  DoctorWorkflowsReport,
   EventHandlers,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
@@ -60,19 +59,18 @@ class LogWorkflowDoctorRenderer implements WorkflowDoctorRenderer {
           if (!this.headerPrinted) {
             writeOutput(bold(cyan("Checking workflows...")));
           }
-          writeOutput(`\n  No workflow files found`);
-          writeOutput(`\n${bold(cyan("Result:"))} ${green("PASSED")}`);
+          writeOutput(`  No workflow files found`);
+          writeOutput("");
+          writeOutput(
+            `0 passed, 0 failed — ${green(bold("OVERALL: PASS"))}`,
+          );
           return;
         }
+        const status = e.report.overallStatus === "pass"
+          ? green(bold("OVERALL: PASS"))
+          : red(bold("OVERALL: FAIL"));
         writeOutput(
-          `\n${
-            bold(cyan("Summary:"))
-          } ${e.report.totalPassed}/${e.report.workflows.length} workflows loaded successfully`,
-        );
-        writeOutput(
-          `${bold(cyan("Result:"))} ${
-            e.report.overallStatus === "pass" ? green("PASSED") : red("FAILED")
-          }`,
+          `\n${e.report.totalPassed} passed, ${e.report.totalFailed} failed — ${status}`,
         );
       },
       error: (e) => {
@@ -90,8 +88,7 @@ class JsonWorkflowDoctorRenderer implements WorkflowDoctorRenderer {
       "workflow-checked": () => {},
       completed: (e) => {
         this.overallStatus = e.report.overallStatus;
-        const report: DoctorWorkflowsReport = e.report;
-        console.log(JSON.stringify(report, null, 2));
+        console.log(JSON.stringify(e.report, null, 2));
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/workflow_doctor_test.ts
+++ b/src/presentation/renderers/workflow_doctor_test.ts
@@ -1,0 +1,175 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { DoctorWorkflowsReport } from "../../libswamp/mod.ts";
+import { createWorkflowDoctorRenderer } from "./workflow_doctor.ts";
+
+await initializeLogging({});
+
+function captureStdout(fn: () => void | Promise<void>): Promise<string> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  return Promise.resolve(fn())
+    .finally(() => {
+      console.log = originalLog;
+    })
+    .then(() => lines.join("\n"));
+}
+
+function buildPassReport(): DoctorWorkflowsReport {
+  return {
+    overallStatus: "pass",
+    workflows: [
+      {
+        file: "/repo/workflows/workflow-abc.yaml",
+        name: "deploy",
+        status: "pass",
+      },
+      {
+        file: "/repo/workflows/workflow-def.yaml",
+        name: "sync",
+        status: "pass",
+      },
+    ],
+    totalPassed: 2,
+    totalFailed: 0,
+  };
+}
+
+function buildFailReport(): DoctorWorkflowsReport {
+  return {
+    overallStatus: "fail",
+    workflows: [
+      {
+        file: "/repo/workflows/workflow-abc.yaml",
+        name: "deploy",
+        status: "pass",
+      },
+      {
+        file: "/repo/workflows/workflow-broken.yaml",
+        name: "broken",
+        status: "fail",
+        error: "YAML parse error at line 42, column 15",
+      },
+    ],
+    totalPassed: 1,
+    totalFailed: 1,
+  };
+}
+
+function buildEmptyReport(): DoctorWorkflowsReport {
+  return {
+    overallStatus: "pass",
+    workflows: [],
+    totalPassed: 0,
+    totalFailed: 0,
+  };
+}
+
+Deno.test("workflow_doctor json renderer: emits structured report on pass", async () => {
+  const out = await captureStdout(async () => {
+    const r = createWorkflowDoctorRenderer("json");
+    const handlers = r.handlers();
+    await handlers.completed({ kind: "completed", report: buildPassReport() });
+  });
+
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "pass");
+  assertEquals(parsed.workflows.length, 2);
+  assertEquals(parsed.totalPassed, 2);
+  assertEquals(parsed.totalFailed, 0);
+});
+
+Deno.test("workflow_doctor json renderer: emits structured report on fail", async () => {
+  const out = await captureStdout(async () => {
+    const r = createWorkflowDoctorRenderer("json");
+    const handlers = r.handlers();
+    await handlers.completed({ kind: "completed", report: buildFailReport() });
+  });
+
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "fail");
+  assertEquals(parsed.totalFailed, 1);
+  assertEquals(
+    parsed.workflows[1].error,
+    "YAML parse error at line 42, column 15",
+  );
+});
+
+Deno.test("workflow_doctor json renderer: tracks overallStatus", async () => {
+  const r = createWorkflowDoctorRenderer("json");
+  assertEquals(r.overallStatus, "pass");
+  const handlers = r.handlers();
+  await handlers.completed({ kind: "completed", report: buildFailReport() });
+  assertEquals(r.overallStatus, "fail");
+});
+
+Deno.test("workflow_doctor log renderer: tracks overallStatus on fail", async () => {
+  const r = createWorkflowDoctorRenderer("log");
+  assertEquals(r.overallStatus, "pass");
+  const handlers = r.handlers();
+  await handlers.completed({ kind: "completed", report: buildFailReport() });
+  assertEquals(r.overallStatus, "fail");
+});
+
+Deno.test("workflow_doctor log renderer: handles workflow-checked without throwing", async () => {
+  const r = createWorkflowDoctorRenderer("log");
+  const handlers = r.handlers();
+  await handlers["workflow-checked"]({
+    kind: "workflow-checked",
+    result: { file: "/repo/wf.yaml", name: "deploy", status: "pass" },
+  });
+  await handlers["workflow-checked"]({
+    kind: "workflow-checked",
+    result: {
+      file: "/repo/bad.yaml",
+      name: "broken",
+      status: "fail",
+      error: "parse error",
+    },
+  });
+  await handlers.completed({ kind: "completed", report: buildFailReport() });
+  assertEquals(r.overallStatus, "fail");
+});
+
+Deno.test("workflow_doctor log renderer: handles empty report", async () => {
+  const r = createWorkflowDoctorRenderer("log");
+  const handlers = r.handlers();
+  await handlers.completed({ kind: "completed", report: buildEmptyReport() });
+  assertEquals(r.overallStatus, "pass");
+});
+
+Deno.test("workflow_doctor json renderer: handles empty report", async () => {
+  const out = await captureStdout(async () => {
+    const r = createWorkflowDoctorRenderer("json");
+    const handlers = r.handlers();
+    await handlers.completed({ kind: "completed", report: buildEmptyReport() });
+  });
+
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "pass");
+  assertEquals(parsed.workflows.length, 0);
+});


### PR DESCRIPTION
## Summary

- Add `swamp doctor workflows` subcommand that walks all workflow directories (primary, extension, source-mounted, pulled) and checks whether each YAML file can be parsed and constructed into a valid Workflow domain object
- Catches YAML syntax errors and schema construction failures that `YamlWorkflowRepository.findAll()` silently skips — meaning `swamp workflow validate` never sees these broken files
- Supports both `--json` (structured output for CI) and log (colored pass/fail per file) output modes; exits non-zero on any failure
- Updates the swamp-troubleshooting skill health-checks reference with full documentation

## Test Plan

- 8 unit tests for the libswamp generator covering: valid workflows, YAML parse errors, schema validation failures, missing directories, non-YAML files, multiple directories, and mixed pass/fail
- 7 unit tests for the renderer covering: JSON and log mode output, overallStatus tracking, empty reports, and workflow-checked event handling
- Verified end-to-end with compiled binary against a scratch repo containing valid, broken-YAML, and schema-invalid workflow files
- `deno check`, `deno lint`, `deno fmt` all pass
- Full test suite: 5888 passed, 1 pre-existing failure (unrelated `integration/workflow_test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)