### PR TITLE
feat(doctor): surface reconcile transitions in doctor extensions output (swamp-club#341)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1142,8 +1142,18 @@ Orphans accumulate linearly per deleted source. The `bundle_path` column is
 the source of truth for which files are referenced.
 
 **Event model:** `DoctorExtensionsReport` extended with additive
-`aggregateState` and `repairReport` fields. No new event kinds. Backward
-compatible for existing `--json` consumers.
+`aggregateState`, `repairReport`, and `recentTransitions` fields. No new
+event kinds. Backward compatible for existing `--json` consumers.
+
+**`recentTransitions`**: Always-present array (empty when no transitions
+occurred) populated from `ReconcileResult.transitions[]`. Each entry
+serializes `sourcePath` (from `SourceLocation.canonicalPath`, matching
+`sourceDetails[].sourcePath`), `fromState`, `toState`, and `reason`. No
+timestamp — post-#334 every `doctor extensions` invocation triggers
+reconcile, so all transitions are current-process. In JSON mode the array
+is unconditionally present; in log mode it renders only with `--verbose`.
+Surfaced via `DoctorExtensionsDeps.getRecentTransitions` callback so the
+generator stays infrastructure-free.
 
 **Repair safety:** `--dry-run` is the default. Only `--repair --apply`
 performs destructive operations. Indexed and Bundled rows are NEVER touched.

--- a/integration/extensions/doctor_extensions_transitions_test.ts
+++ b/integration/extensions/doctor_extensions_transitions_test.ts
@@ -1,0 +1,256 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { initializeTestRepo, runCliCommand } from "../test_helpers.ts";
+
+const VALID_MODEL = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@tutorial/transitions-test",
+  version: "2026.05.12.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
+async function withTestRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp-doctor-transitions-test-",
+  });
+  try {
+    await initializeTestRepo(repoDir);
+    await fn(repoDir);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+interface TransitionEntry {
+  sourcePath: string;
+  fromState: string | null;
+  toState: string;
+  reason: string;
+}
+
+interface DoctorReport {
+  overallStatus: string;
+  recentTransitions: TransitionEntry[];
+  aggregateState?: {
+    sourceDetails: {
+      sourcePath: string;
+      stateTag: string;
+    }[];
+  };
+}
+
+async function runDoctor(repoDir: string): Promise<DoctorReport> {
+  const result = await runCliCommand(
+    ["doctor", "extensions", "--json", "--verbose"],
+    repoDir,
+  );
+  assertEquals(result.code, 0, `doctor failed: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+// AC 1: Deleted local extension source → recentTransitions contains
+// Tombstoned or OrphanedBundleOnly transition. The first doctor run
+// populates the catalog via the loader; the pre-reconcile step on a
+// fresh catalog produces no transitions because loadAll() returns an
+// empty set. The deletion transition surfaces on the subsequent run.
+Deno.test("doctor extensions transitions: deleted local source produces transition", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "tombstone_test.ts");
+
+    await Deno.writeTextFile(modelPath, VALID_MODEL);
+
+    // First run: populate the catalog (loader indexes the source)
+    const first = await runDoctor(repoDir);
+    assert(
+      first.aggregateState,
+      "Expected aggregateState in verbose output",
+    );
+    const indexedDetail = first.aggregateState.sourceDetails.find((d) =>
+      d.sourcePath.includes("tombstone_test.ts")
+    );
+    assert(indexedDetail, "Source should appear in sourceDetails");
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    // Delete the source file
+    await Deno.remove(modelPath);
+
+    // Second run: reconcile detects the missing source
+    const second = await runDoctor(repoDir);
+    assert(
+      Array.isArray(second.recentTransitions),
+      "recentTransitions must be an array",
+    );
+    const transition = second.recentTransitions.find((t) =>
+      t.sourcePath.includes("tombstone_test.ts") &&
+      (t.toState === "Tombstoned" || t.toState === "OrphanedBundleOnly")
+    );
+    assert(
+      transition,
+      `Expected transition to Tombstoned or OrphanedBundleOnly, got: ${
+        JSON.stringify(second.recentTransitions)
+      }`,
+    );
+    assertEquals(transition.fromState, "Indexed");
+  });
+});
+
+// AC 2: Deleted pulled extension source → transition
+Deno.test("doctor extensions transitions: deleted pulled source produces transition", async () => {
+  await withTestRepo(async (repoDir) => {
+    const extName = "@test/pulled-transitions";
+    const extRoot = join(repoDir, ".swamp", "pulled-extensions", extName);
+    const modelDir = join(extRoot, "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "pulled_model.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/transitions-test",
+        "@test/pulled-transition-model",
+      ),
+    );
+
+    const lockfileDir = join(repoDir, "extensions", "models");
+    await ensureDir(lockfileDir);
+    const lockfilePath = join(lockfileDir, "upstream_extensions.json");
+    const lockfile: Record<string, unknown> = {};
+    lockfile[extName] = {
+      version: "2026.05.12.0",
+      pulledAt: new Date().toISOString(),
+    };
+    await Deno.writeTextFile(lockfilePath, JSON.stringify(lockfile, null, 2));
+
+    // First run: populate the catalog
+    const first = await runDoctor(repoDir);
+    assert(first.aggregateState, "Expected aggregateState");
+    const indexedDetail = first.aggregateState.sourceDetails.find((d) =>
+      d.sourcePath.includes("pulled_model.ts")
+    );
+    assert(indexedDetail, "Pulled source should appear in sourceDetails");
+    assertEquals(indexedDetail.stateTag, "Indexed");
+
+    // Delete the pulled source file
+    await Deno.remove(modelPath);
+
+    // Second run: reconcile detects the missing source
+    const second = await runDoctor(repoDir);
+    assert(
+      Array.isArray(second.recentTransitions),
+      "recentTransitions must be an array",
+    );
+    const transition = second.recentTransitions.find((t) =>
+      t.sourcePath.includes("pulled_model.ts")
+    );
+    assert(
+      transition,
+      `Expected transition for deleted pulled source, got: ${
+        JSON.stringify(second.recentTransitions)
+      }`,
+    );
+  });
+});
+
+// AC 3: No deletion → recentTransitions is empty (steady state)
+Deno.test("doctor extensions transitions: no changes produces empty recentTransitions on second run", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "stable_model.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/transitions-test",
+        "@tutorial/stable",
+      ),
+    );
+
+    // First run: populate the catalog
+    await runDoctor(repoDir);
+
+    // Second run: no changes, steady state
+    const second = await runDoctor(repoDir);
+    assertEquals(
+      second.recentTransitions,
+      [],
+      "Steady-state run should produce no transitions",
+    );
+  });
+});
+
+// Path-format consistency: sourcePath in recentTransitions matches sourceDetails
+Deno.test("doctor extensions transitions: sourcePath format matches sourceDetails", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "path_check.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/transitions-test",
+        "@tutorial/path-check",
+      ),
+    );
+
+    // First run: populate the catalog, record the sourcePath used
+    const first = await runDoctor(repoDir);
+    assert(first.aggregateState, "Expected aggregateState");
+    const detail = first.aggregateState.sourceDetails.find((d) =>
+      d.sourcePath.includes("path_check.ts")
+    );
+    assert(detail, "Expected sourceDetail for new source");
+    const detailSourcePath = detail.sourcePath;
+
+    // Delete the source to force a transition
+    await Deno.remove(modelPath);
+
+    // Second run: capture the transition
+    const second = await runDoctor(repoDir);
+    const transition = second.recentTransitions.find((t) =>
+      t.sourcePath.includes("path_check.ts")
+    );
+    assert(transition, "Expected transition for deleted source");
+
+    assertEquals(
+      transition.sourcePath,
+      detailSourcePath,
+      "recentTransitions[].sourcePath must exactly match sourceDetails[].sourcePath",
+    );
+  });
+});

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -47,6 +47,7 @@ import {
   doctorExtensions,
   type DoctorRegistryDeps,
   ReconcileFromDiskService,
+  type ReconcileTransition,
   repairExtensions,
 } from "../../libswamp/mod.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
@@ -170,6 +171,7 @@ export const doctorExtensionsCommand = new Command()
     // visible to the loaders regardless of close ordering; the close
     // is connection hygiene, not synchronization.
     const localManifestIdentity = readLocalManifestIdentity(repoDir);
+    let reconcileTransitions: readonly ReconcileTransition[] = [];
     try {
       const reconcileLockfileRepo = await LockfileRepository.create(
         lockfilePath,
@@ -192,7 +194,8 @@ export const doctorExtensionsCommand = new Command()
           repoDir,
           localManifestIdentity,
         });
-        await reconciler.execute();
+        const result = await reconciler.execute();
+        reconcileTransitions = result.transitions;
       } finally {
         rescanRepo.close();
       }
@@ -273,6 +276,7 @@ export const doctorExtensionsCommand = new Command()
             repo.close();
           }
         },
+        getRecentTransitions: () => reconcileTransitions,
         runRepair: repair
           ? async (aggregateReport) => {
             // In interactive mode without --force, preview first and prompt.

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -25,6 +25,7 @@ import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/ups
 import type { SwampError } from "../errors.ts";
 import type { DoctorAggregateReport } from "./doctor_aggregate.ts";
 import type { RepairReport } from "./doctor_repair.ts";
+import type { ReconcileTransition } from "./reconcile_from_disk_service.ts";
 import { extractTopLevelRoot } from "./layout.ts";
 
 /**
@@ -104,6 +105,12 @@ export interface DoctorExtensionsReport {
    * Contains the list of operations (dry-run or applied).
    */
   repairReport?: RepairReport;
+  /**
+   * State transitions from the most recent reconcile pass. Always
+   * present (empty array when no transitions occurred). Each entry
+   * captures a source's fromState → toState with reason.
+   */
+  recentTransitions: readonly ReconcileTransition[];
 }
 
 /**
@@ -169,6 +176,13 @@ export interface DoctorExtensionsDeps {
   runRepair?: (
     aggregateReport: DoctorAggregateReport,
   ) => Promise<RepairReport>;
+  /**
+   * Returns transitions from the most recent reconcile pass. Injected
+   * by the CLI so the generator doesn't depend on infrastructure
+   * objects. Returns an empty array when reconcile was skipped or
+   * failed.
+   */
+  getRecentTransitions?: () => readonly ReconcileTransition[];
 }
 
 function overallStatus(
@@ -388,6 +402,8 @@ export async function* doctorExtensions(
     repairReport = await deps.runRepair(aggregateState);
   }
 
+  const recentTransitions = deps.getRecentTransitions?.() ?? [];
+
   yield {
     kind: "completed",
     report: {
@@ -396,6 +412,7 @@ export async function* doctorExtensions(
       orphanFiles,
       aggregateState,
       repairReport,
+      recentTransitions,
     },
   };
 }

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -108,6 +108,7 @@ Deno.test("doctorExtensions: clean state — all five registries pass", async ()
   assertEquals(completed?.kind, "completed");
   if (completed?.kind !== "completed") return;
   assertEquals(completed.report.overallStatus, "pass");
+  assertEquals(completed.report.recentTransitions, []);
   for (const registry of DOCTOR_REGISTRY_ORDER) {
     const result = completed.report.registries[registry];
     assertEquals(result.status, "pass");
@@ -250,6 +251,8 @@ Deno.test("doctorExtensions: completed report has all five registry keys even on
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import type { UpstreamExtensionsMap } from "../../infrastructure/persistence/upstream_extensions.ts";
+import type { ReconcileTransition } from "./reconcile_from_disk_service.ts";
+import { makeSourceLocation } from "../../domain/extensions/source_location.ts";
 
 Deno.test(
   "doctorExtensions: detects an orphan file under a per-extension subtree",
@@ -475,5 +478,58 @@ Deno.test(
     } finally {
       await Deno.remove(tmpDir, { recursive: true });
     }
+  },
+);
+
+Deno.test(
+  "doctorExtensions: recentTransitions defaults to empty array when no callback provided",
+  async () => {
+    resetExtensionLoadWarnings();
+    const { deps } = buildDeps();
+
+    const events = await collect(doctorExtensions(deps));
+    const completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.recentTransitions, []);
+  },
+);
+
+Deno.test(
+  "doctorExtensions: recentTransitions surfaces transitions from getRecentTransitions callback",
+  async () => {
+    resetExtensionLoadWarnings();
+    const transitions: ReconcileTransition[] = [
+      {
+        source: makeSourceLocation("/repo/extensions/models/a.ts", "/repo"),
+        fromState: "Indexed",
+        toState: "Tombstoned",
+        reason: "source file deleted from disk",
+      },
+      {
+        source: makeSourceLocation("/repo/extensions/models/b.ts", "/repo"),
+        fromState: null,
+        toState: "Indexed",
+        reason: "new source discovered",
+      },
+    ];
+
+    const { deps } = buildDeps();
+    deps.getRecentTransitions = () => transitions;
+
+    const events = await collect(doctorExtensions(deps));
+    const completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.recentTransitions.length, 2);
+    assertEquals(completed.report.recentTransitions[0].toState, "Tombstoned");
+    assertEquals(
+      completed.report.recentTransitions[0].source.canonicalPath,
+      "/repo/extensions/models/a.ts",
+    );
+    assertEquals(completed.report.recentTransitions[1].fromState, null);
+    assertEquals(completed.report.recentTransitions[1].toState, "Indexed");
   },
 );

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -281,6 +281,20 @@ class LogDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
           renderAggregateStateLog(e.report.aggregateState, this.verbose);
         }
 
+        if (this.verbose && e.report.recentTransitions.length > 0) {
+          writeOutput(`\n${bold(cyan("Recent Transitions"))}`);
+          for (const t of e.report.recentTransitions) {
+            const from = t.fromState
+              ? stateColor(t.fromState)(t.fromState)
+              : dim("(new)");
+            const to = stateColor(t.toState)(t.toState);
+            writeOutput(
+              `  ${t.source.canonicalPath}  ${from} ${dim("→")} ${to}`,
+            );
+            writeOutput(`    ${dim(t.reason)}`);
+          }
+        }
+
         // W6: Repair report rendering.
         if (e.report.repairReport) {
           renderRepairLog(e.report.repairReport);
@@ -337,6 +351,12 @@ class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
         if (e.report.repairReport) {
           output.repairReport = e.report.repairReport;
         }
+        output.recentTransitions = e.report.recentTransitions.map((t) => ({
+          sourcePath: t.source.canonicalPath,
+          fromState: t.fromState,
+          toState: t.toState,
+          reason: t.reason,
+        }));
         console.log(JSON.stringify(output, null, 2));
       },
       error: (e) => {

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -23,7 +23,9 @@ import type {
   DoctorExtensionsReport,
   DoctorRegistryName,
   DoctorRegistryResult,
+  ReconcileTransition,
 } from "../../libswamp/mod.ts";
+import { makeSourceLocation } from "../../domain/extensions/source_location.ts";
 import { createDoctorExtensionsRenderer } from "./doctor_extensions.ts";
 
 await initializeLogging({});
@@ -65,6 +67,7 @@ function buildPassReport(): DoctorExtensionsReport {
       report: passResult("report"),
     },
     orphanFiles: [],
+    recentTransitions: [],
   };
 }
 
@@ -81,6 +84,7 @@ function buildFailReport(): DoctorExtensionsReport {
       report: passResult("report"),
     },
     orphanFiles: [],
+    recentTransitions: [],
   };
 }
 
@@ -165,6 +169,7 @@ Deno.test("doctor_extensions json renderer: stable key ordering", async () => {
         model: passResult("model"),
       },
       orphanFiles: [],
+      recentTransitions: [],
     };
     await handlers.completed({ kind: "completed", report: reversed });
   });
@@ -230,6 +235,7 @@ Deno.test(
             path: ".swamp/pulled-extensions/@hivemq/harvester/models/orphan.ts",
           },
         ],
+        recentTransitions: [],
       };
       await handlers.completed({ kind: "completed", report });
     });
@@ -266,6 +272,7 @@ Deno.test(
             path: ".swamp/pulled-extensions/@x/y/models/orphan.ts",
           },
         ],
+        recentTransitions: [],
       };
       // Drive the kind-completed events first so the registry headers
       // get rendered, then completed.
@@ -299,5 +306,61 @@ Deno.test(
     if (!out.includes("OVERALL: PASS")) {
       throw new Error(`expected OVERALL: PASS, got: ${out}`);
     }
+  },
+);
+
+function sampleTransitions(): ReconcileTransition[] {
+  return [
+    {
+      source: makeSourceLocation("/repo/extensions/models/a.ts", "/repo"),
+      fromState: "Indexed",
+      toState: "Tombstoned",
+      reason: "source file deleted from disk",
+    },
+  ];
+}
+
+Deno.test(
+  "doctor_extensions json renderer: recentTransitions always present in JSON output",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("json");
+      const handlers = r.handlers();
+      await handlers.completed({
+        kind: "completed",
+        report: buildPassReport(),
+      });
+    });
+
+    const parsed = JSON.parse(out);
+    assertEquals(parsed.recentTransitions, []);
+  },
+);
+
+Deno.test(
+  "doctor_extensions json renderer: recentTransitions serializes sourcePath from canonicalPath",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("json");
+      const handlers = r.handlers();
+      const report: DoctorExtensionsReport = {
+        ...buildPassReport(),
+        recentTransitions: sampleTransitions(),
+      };
+      await handlers.completed({ kind: "completed", report });
+    });
+
+    const parsed = JSON.parse(out);
+    assertEquals(parsed.recentTransitions.length, 1);
+    assertEquals(
+      parsed.recentTransitions[0].sourcePath,
+      "/repo/extensions/models/a.ts",
+    );
+    assertEquals(parsed.recentTransitions[0].fromState, "Indexed");
+    assertEquals(parsed.recentTransitions[0].toState, "Tombstoned");
+    assertEquals(
+      parsed.recentTransitions[0].reason,
+      "source file deleted from disk",
+    );
   },
 );


### PR DESCRIPTION
## Summary

- Thread `ReconcileResult.transitions[]` into `doctor extensions` JSON and log output as a `recentTransitions[]` field — the reconcile service already collected transitions (including Tombstoned) but the return value was discarded at `doctor_extensions.ts:195`
- JSON mode: `recentTransitions` is always-present (empty array when no transitions), serializing `sourcePath` from `SourceLocation.canonicalPath` to match `sourceDetails[].sourcePath` format
- Log mode: renders transitions behind `--verbose` with colored `fromState → toState` display
- No timestamp field — post-#334 every `doctor extensions` invocation triggers reconcile, so all transitions are current-process

## Test Plan

- Unit tests for doctor generator: transitions from callback appear in completed event, empty array when no callback (2 new tests in `doctor_test.ts`)
- Unit tests for renderers: JSON always includes `recentTransitions`, serializes `sourcePath` from `canonicalPath` (2 new tests in `doctor_extensions_test.ts`)
- Subprocess integration tests in `doctor_extensions_transitions_test.ts` (4 scenarios):
  - AC 1: deleted local source → `Indexed → OrphanedBundleOnly` transition
  - AC 2: deleted pulled source → transition with reason
  - AC 3: steady state → empty `recentTransitions[]`
  - Path-format consistency: `recentTransitions[].sourcePath` matches `sourceDetails[].sourcePath` exactly
- Verified against compiled binary: all ACs pass
- No regression in existing `doctor_extensions_failure_states_test.ts` (7/7 pass)
- Full test suite: 5901 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)