### PR TITLE
fix(extensions): distinguish validation-throw from bundle-throw in reconcile catch (swamp-club#340)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1113,8 +1113,11 @@ throws `DuplicateTypeError` at the repository layer.
 to `UNREADABLE_PLACEHOLDER` (internal to `computeSourceFingerprint`).
 No external code compares against it. Broken transitive deps produce a
 stable fingerprint; the failure surfaces at `bundleAndIndexOne` as
-`BundleBuildFailed`. Existing catalog rows with the old sentinel value
-are caught by the first reconcile run — no schema migration needed.
+`BundleBuildFailed`. Zod schema validation failures (bundle built
+successfully but export rejected) surface as `ValidationFailed` via a
+`ValidationError` subclass that carries the bundle path and fingerprint
+(see `validation_error.ts`). Existing catalog rows with the old sentinel
+value are caught by the first reconcile run — no schema migration needed.
 
 **Forward-only revert posture.** Same as W1b/W2: revert means deleting
 `_extension_catalog.db` and rebuilding from disk on the next cold-start.

--- a/integration/extensions/doctor_extensions_failure_states_test.ts
+++ b/integration/extensions/doctor_extensions_failure_states_test.ts
@@ -43,6 +43,11 @@ const SCHEMA_INVALID_MODEL = `
 export const model = "not an object";
 `;
 
+const UNRESOLVABLE_IMPORT_MODEL = `
+import { nonexistent } from "./this_file_does_not_exist.ts";
+export const model = nonexistent;
+`;
+
 const VALIDATION_FAILING_MODEL = `
 import { z } from "npm:zod@4";
 export const model = {
@@ -84,12 +89,17 @@ interface DoctorReport {
   };
 }
 
-async function runDoctor(repoDir: string): Promise<DoctorReport> {
+async function runDoctor(
+  repoDir: string,
+  opts?: { allowNonZero?: boolean },
+): Promise<DoctorReport> {
   const result = await runCliCommand(
     ["doctor", "extensions", "--json", "--verbose"],
     repoDir,
   );
-  assertEquals(result.code, 0, `doctor failed: ${result.stderr}`);
+  if (!opts?.allowNonZero) {
+    assertEquals(result.code, 0, `doctor failed: ${result.stderr}`);
+  }
   return JSON.parse(result.stdout);
 }
 
@@ -112,8 +122,8 @@ function findFailure(
   );
 }
 
-// AC 1: schema-invalid content → BundleBuildFailed in sourceDetails
-Deno.test("doctor extensions: schema-invalid content produces BundleBuildFailed in sourceDetails", async () => {
+// AC 1: schema-invalid content → ValidationFailed in sourceDetails (#340)
+Deno.test("doctor extensions: schema-invalid content produces ValidationFailed in sourceDetails", async () => {
   await withTestRepo(async (repoDir) => {
     const modelDir = join(repoDir, "extensions", "models");
     await ensureDir(modelDir);
@@ -135,20 +145,20 @@ Deno.test("doctor extensions: schema-invalid content produces BundleBuildFailed 
       failedDetail,
       "Source should appear in sourceDetails after corruption",
     );
-    assertEquals(failedDetail.stateTag, "BundleBuildFailed");
+    assertEquals(failedDetail.stateTag, "ValidationFailed");
 
     // AC 5: no dual-write
     const dualWrite = findFailure(second, "model", "test_model.ts");
     assertEquals(
       dualWrite,
       undefined,
-      "BundleBuildFailed source must NOT also appear in registries.model.failures[]",
+      "ValidationFailed source must NOT also appear in registries.model.failures[]",
     );
   });
 });
 
-// AC 2: validation-failing content → BundleBuildFailed in sourceDetails
-Deno.test("doctor extensions: validation-failing content produces BundleBuildFailed in sourceDetails", async () => {
+// AC 2: validation-failing content → ValidationFailed in sourceDetails (#340)
+Deno.test("doctor extensions: validation-failing content produces ValidationFailed in sourceDetails", async () => {
   await withTestRepo(async (repoDir) => {
     const modelDir = join(repoDir, "extensions", "models");
     await ensureDir(modelDir);
@@ -170,14 +180,14 @@ Deno.test("doctor extensions: validation-failing content produces BundleBuildFai
     const second = await runDoctor(repoDir);
     const failedDetail = findSourceDetail(second, "bad_validation.ts");
     assert(failedDetail, "Source should appear after corruption");
-    assertEquals(failedDetail.stateTag, "BundleBuildFailed");
+    assertEquals(failedDetail.stateTag, "ValidationFailed");
 
     // AC 5: no dual-write
     const dualWrite = findFailure(second, "model", "bad_validation.ts");
     assertEquals(
       dualWrite,
       undefined,
-      "BundleBuildFailed source must NOT also appear in registries.model.failures[]",
+      "ValidationFailed source must NOT also appear in registries.model.failures[]",
     );
   });
 });
@@ -259,8 +269,8 @@ Deno.test("doctor extensions: deleted local source with bundle produces Orphaned
   });
 });
 
-// Addition 1: recovery path — BundleBuildFailed → valid content → Indexed
-Deno.test("doctor extensions: BundleBuildFailed recovers to Indexed when source is fixed", async () => {
+// Recovery path — ValidationFailed → valid content → Indexed (#340)
+Deno.test("doctor extensions: ValidationFailed recovers to Indexed when source is fixed", async () => {
   await withTestRepo(async (repoDir) => {
     const modelDir = join(repoDir, "extensions", "models");
     await ensureDir(modelDir);
@@ -279,12 +289,12 @@ Deno.test("doctor extensions: BundleBuildFailed recovers to Indexed when source 
     assert(indexed);
     assertEquals(indexed.stateTag, "Indexed");
 
-    // Corrupt → BundleBuildFailed
+    // Corrupt → ValidationFailed
     await Deno.writeTextFile(modelPath, SCHEMA_INVALID_MODEL);
     const second = await runDoctor(repoDir);
     const failed = findSourceDetail(second, "recovery_model.ts");
     assert(failed);
-    assertEquals(failed.stateTag, "BundleBuildFailed");
+    assertEquals(failed.stateTag, "ValidationFailed");
 
     // Fix → Indexed again
     await Deno.writeTextFile(
@@ -301,13 +311,13 @@ Deno.test("doctor extensions: BundleBuildFailed recovers to Indexed when source 
     assertNotEquals(
       recovered.fingerprint,
       failed.fingerprint,
-      "Fingerprint should change from BundleBuildFailed to Indexed",
+      "Fingerprint should change from ValidationFailed to Indexed",
     );
   });
 });
 
-// Addition 2: catalog-column-level fingerprint assertion
-Deno.test("doctor extensions: BundleBuildFailed stores current source fingerprint", async () => {
+// Fingerprint assertion — ValidationFailed stores current source fingerprint (#340)
+Deno.test("doctor extensions: ValidationFailed stores current source fingerprint", async () => {
   await withTestRepo(async (repoDir) => {
     const modelDir = join(repoDir, "extensions", "models");
     await ensureDir(modelDir);
@@ -328,17 +338,95 @@ Deno.test("doctor extensions: BundleBuildFailed stores current source fingerprin
     const second = await runDoctor(repoDir);
     const failed = findSourceDetail(second, "fp_model.ts");
     assert(failed);
-    assertEquals(failed.stateTag, "BundleBuildFailed");
+    assertEquals(failed.stateTag, "ValidationFailed");
 
     assert(
       failed.fingerprint,
-      "BundleBuildFailed source should have a fingerprint",
+      "ValidationFailed source should have a fingerprint",
     );
     assertNotEquals(
       failed.fingerprint,
       indexedFingerprint,
-      "BundleBuildFailed fingerprint must differ from the prior Indexed fingerprint",
+      "ValidationFailed fingerprint must differ from the prior Indexed fingerprint",
     );
+  });
+});
+
+// #340 regression: unresolvable import → BundleBuildFailed (not ValidationFailed)
+Deno.test("doctor extensions: unresolvable import produces BundleBuildFailed in sourceDetails", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "bad_import.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/bad-import-test",
+      ),
+    );
+    const first = await runDoctor(repoDir);
+    const indexed = findSourceDetail(first, "bad_import.ts");
+    assert(indexed, "Source should appear in sourceDetails");
+    assertEquals(indexed.stateTag, "Indexed");
+
+    // Delete cached bundles so the fallback path doesn't reuse the valid bundle
+    const bundlesDir = join(repoDir, ".swamp", "bundles");
+    await Deno.remove(bundlesDir, { recursive: true }).catch(() => {});
+
+    await Deno.writeTextFile(modelPath, UNRESOLVABLE_IMPORT_MODEL);
+    const second = await runDoctor(repoDir, { allowNonZero: true });
+    const failed = findSourceDetail(second, "bad_import.ts");
+    assert(failed, "Source should appear after corruption");
+    assertEquals(
+      failed.stateTag,
+      "BundleBuildFailed",
+      "Unresolvable import must produce BundleBuildFailed, not ValidationFailed",
+    );
+  });
+});
+
+// #340: BundleBuildFailed recovery — unresolvable import → fix → Indexed
+Deno.test("doctor extensions: BundleBuildFailed recovers to Indexed when import is fixed", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    const modelPath = join(modelDir, "import_recovery.ts");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/import-recovery",
+      ),
+    );
+    const first = await runDoctor(repoDir);
+    const indexed = findSourceDetail(first, "import_recovery.ts");
+    assert(indexed);
+    assertEquals(indexed.stateTag, "Indexed");
+
+    // Delete cached bundles so the fallback path doesn't reuse the valid bundle
+    const bundlesDir = join(repoDir, ".swamp", "bundles");
+    await Deno.remove(bundlesDir, { recursive: true }).catch(() => {});
+
+    await Deno.writeTextFile(modelPath, UNRESOLVABLE_IMPORT_MODEL);
+    const second = await runDoctor(repoDir, { allowNonZero: true });
+    const failed = findSourceDetail(second, "import_recovery.ts");
+    assert(failed);
+    assertEquals(failed.stateTag, "BundleBuildFailed");
+
+    await Deno.writeTextFile(
+      modelPath,
+      VALID_MODEL.replace(
+        "@tutorial/failure-test",
+        "@tutorial/import-recovery",
+      ),
+    );
+    const third = await runDoctor(repoDir);
+    const recovered = findSourceDetail(third, "import_recovery.ts");
+    assert(recovered);
+    assertEquals(recovered.stateTag, "Indexed");
   });
 });
 

--- a/src/domain/extensions/extension.ts
+++ b/src/domain/extensions/extension.ts
@@ -359,6 +359,10 @@ export function recordBundleBuildFailed(
  * Records that the bundle imported cleanly but Zod schema validation
  * rejected the export. Per I3, the fingerprint and bundle are retained.
  * Returns a NEW Extension.
+ *
+ * When {@link fingerprint} is provided, the Source's fingerprint is
+ * updated atomically with the state transition (same pattern as
+ * {@link recordBundleBuildFailed}).
  */
 export function recordValidationFailed(
   extension: Extension,
@@ -366,17 +370,25 @@ export function recordValidationFailed(
     location: SourceLocation;
     bundle: BundleLocation;
     lastError: string;
+    fingerprint?: SourceFingerprint;
+    sourceMtime?: string;
   },
 ): Extension {
-  return updateSourceState(
-    extension,
-    args.location,
-    {
-      tag: "ValidationFailed",
-      bundle: args.bundle,
-      lastError: args.lastError,
-    },
-  );
+  const state: RowState = {
+    tag: "ValidationFailed",
+    bundle: args.bundle,
+    lastError: args.lastError,
+  };
+  if (args.fingerprint !== undefined) {
+    return updateSourceStateAndFingerprint(
+      extension,
+      args.location,
+      state,
+      args.fingerprint,
+      args.sourceMtime,
+    );
+  }
+  return updateSourceState(extension, args.location, state);
 }
 
 /**

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -56,6 +56,7 @@ import type {
   KindAdapter,
   RegistrationContext,
 } from "./kind_adapter.ts";
+import { ValidationError } from "./validation_error.ts";
 
 export class ExtensionLoader {
   private readonly denoRuntime: DenoRuntime;
@@ -420,8 +421,10 @@ export class ExtensionLoader {
         module[this.adapter.primaryExportKey],
       );
       if (!parsed.success) {
-        throw new Error(
+        throw new ValidationError(
           this.adapter.formatValidationError(parsed.error),
+          this.getBundlePath(args.relativePath, args.baseDir),
+          fingerprint,
         );
       }
       const validated = parsed.data as Record<string, unknown>;
@@ -443,7 +446,11 @@ export class ExtensionLoader {
         module[this.adapter.secondaryExportKey],
       );
       if (!parsed.success) {
-        throw new Error(parsed.error.message);
+        throw new ValidationError(
+          parsed.error.message,
+          this.getBundlePath(args.relativePath, args.baseDir),
+          fingerprint,
+        );
       }
       const validated = parsed.data as Record<string, unknown>;
       return {

--- a/src/domain/extensions/extension_test.ts
+++ b/src/domain/extensions/extension_test.ts
@@ -297,6 +297,35 @@ Deno.test("recordValidationFailed: retains fingerprint and bundle (I3)", () => {
   }
 });
 
+Deno.test("recordValidationFailed: updates fingerprint when provided (I3 freshness)", () => {
+  const initial = indexedSource("models/a.ts", "@scope/foo/a");
+  const ext = makeExtension({
+    name: "@scope/foo",
+    version: "1.0.0",
+    origin: "pulled",
+    extensionRoot: EXT_ROOT,
+    sources: [initial],
+  });
+  const newFp = "newfingerprint456";
+  const newBundle = makeBundleLocation("/repo/.swamp/bundles/y.js", newFp);
+  const failed = recordValidationFailed(ext, {
+    location: initial.id,
+    bundle: newBundle,
+    lastError: "schema mismatch",
+    fingerprint: newFp,
+    sourceMtime: "2026-05-13T00:00:00.000Z",
+  });
+  const after = [...failed.sources.values()][0];
+  assertEquals(after.fingerprint, newFp);
+  assertEquals(after.sourceMtime, "2026-05-13T00:00:00.000Z");
+  if (after.state.tag === "ValidationFailed") {
+    assertEquals(after.state.bundle, newBundle);
+    assertEquals(after.state.lastError, "schema mismatch");
+  } else {
+    throw new Error("expected ValidationFailed");
+  }
+});
+
 Deno.test("markSourceMissing: → OrphanedBundleOnly when bundle present", () => {
   const initial = indexedSource("models/a.ts", "@scope/foo/a");
   const ext = makeExtension({

--- a/src/domain/extensions/validation_error.ts
+++ b/src/domain/extensions/validation_error.ts
@@ -1,0 +1,36 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { SourceFingerprint } from "./source_fingerprint.ts";
+
+export class ValidationError extends Error {
+  readonly bundlePath: string;
+  readonly fingerprint: SourceFingerprint;
+
+  constructor(
+    message: string,
+    bundlePath: string,
+    fingerprint: SourceFingerprint,
+  ) {
+    super(message);
+    this.name = "ValidationError";
+    this.bundlePath = bundlePath;
+    this.fingerprint = fingerprint;
+  }
+}

--- a/src/domain/extensions/validation_error_test.ts
+++ b/src/domain/extensions/validation_error_test.ts
@@ -1,0 +1,50 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertInstanceOf } from "@std/assert";
+import { ValidationError } from "./validation_error.ts";
+
+Deno.test("ValidationError: extends Error and carries bundlePath + fingerprint", () => {
+  const err = new ValidationError(
+    "Invalid input: expected object, received string",
+    "/tmp/repo/.swamp/bundles/abc/test/entry.js",
+    "sha256-abc123",
+  );
+
+  assertInstanceOf(err, Error);
+  assertInstanceOf(err, ValidationError);
+  assertEquals(err.name, "ValidationError");
+  assertEquals(
+    err.message,
+    "Invalid input: expected object, received string",
+  );
+  assertEquals(
+    err.bundlePath,
+    "/tmp/repo/.swamp/bundles/abc/test/entry.js",
+  );
+  assertEquals(err.fingerprint, "sha256-abc123");
+});
+
+Deno.test("ValidationError: instanceof distinguishes from plain Error", () => {
+  const validationErr = new ValidationError("bad schema", "/bundle.js", "fp");
+  const plainErr = new Error("bundle build failed");
+
+  assert(validationErr instanceof ValidationError);
+  assert(!(plainErr instanceof ValidationError));
+});

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -28,13 +28,17 @@ import {
   recordBundleBuildFailed,
   recordBundled,
   recordEntryPointUnreadable,
+  recordValidationFailed,
   tombstoneAll,
 } from "../../domain/extensions/extension.ts";
 import type { LocalManifestIdentity } from "../../infrastructure/persistence/local_manifest_reader.ts";
 import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { makeSource } from "../../domain/extensions/source.ts";
 import { makeSourceLocation } from "../../domain/extensions/source_location.ts";
-import { makeBundleLocation } from "../../domain/extensions/bundle_location.ts";
+import {
+  type BundleLocation,
+  makeBundleLocation,
+} from "../../domain/extensions/bundle_location.ts";
 import {
   computeSourceFingerprint,
   createFreshnessCache,
@@ -50,6 +54,7 @@ import { BUNDLE_LAYOUT_VERSION } from "../../infrastructure/persistence/extensio
 import type { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { ExtensionLoader } from "../../domain/extensions/extension_loader.ts";
+import { ValidationError } from "../../domain/extensions/validation_error.ts";
 import { modelKindAdapter } from "../../domain/extensions/model_kind_adapter.ts";
 import { vaultKindAdapter } from "../../domain/extensions/vault_kind_adapter.ts";
 import { driverKindAdapter } from "../../domain/extensions/driver_kind_adapter.ts";
@@ -502,33 +507,69 @@ export class ReconcileFromDiskService {
           failFp = "";
         }
 
-        if (existingSource) {
-          ext = recordBundleBuildFailed(ext, {
-            location: effectiveLoc,
-            lastError: errorMsg,
-            fingerprint: failFp,
-            sourceMtime,
-          });
-        } else {
-          ext = makeExtensionWithNewSource(
-            ext,
-            effectiveLoc,
-            kind,
-            {
-              tag: "BundleBuildFailed",
-              lastError: errorMsg,
-            },
-            sourceMtime,
-            failFp,
+        const isValidation = error instanceof ValidationError;
+        const toState: RowStateTag = isValidation
+          ? "ValidationFailed"
+          : "BundleBuildFailed";
+
+        if (isValidation) {
+          const bundle = makeBundleLocation(
+            error.bundlePath,
+            error.fingerprint,
           );
+          if (existingSource) {
+            ext = recordValidationFailed(ext, {
+              location: effectiveLoc,
+              bundle,
+              lastError: errorMsg,
+              fingerprint: failFp,
+              sourceMtime,
+            });
+          } else {
+            ext = makeExtensionWithNewSource(
+              ext,
+              effectiveLoc,
+              kind,
+              {
+                tag: "ValidationFailed",
+                bundle,
+                lastError: errorMsg,
+              },
+              sourceMtime,
+              failFp,
+            );
+          }
+        } else {
+          if (existingSource) {
+            ext = recordBundleBuildFailed(ext, {
+              location: effectiveLoc,
+              lastError: errorMsg,
+              fingerprint: failFp,
+              sourceMtime,
+            });
+          } else {
+            ext = makeExtensionWithNewSource(
+              ext,
+              effectiveLoc,
+              kind,
+              {
+                tag: "BundleBuildFailed",
+                lastError: errorMsg,
+              },
+              sourceMtime,
+              failFp,
+            );
+          }
         }
 
-        if (fromState !== "BundleBuildFailed") {
+        if (fromState !== toState) {
           transitions.push({
             source: effectiveLoc,
             fromState,
-            toState: "BundleBuildFailed",
-            reason: `bundle build failed: ${errorMsg}`,
+            toState,
+            reason: isValidation
+              ? `validation failed: ${errorMsg}`
+              : `bundle build failed: ${errorMsg}`,
           });
         }
       }
@@ -702,7 +743,9 @@ function makeExtensionWithNewSource(
   extension: Extension,
   location: SourceLocation,
   kindDir: KindDir,
-  state: { tag: "BundleBuildFailed"; lastError: string },
+  state:
+    | { tag: "BundleBuildFailed"; lastError: string }
+    | { tag: "ValidationFailed"; bundle: BundleLocation; lastError: string },
   sourceMtime: string,
   fingerprint = "",
 ): Extension {

--- a/src/libswamp/extensions/reconcile_from_disk_service_test.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service_test.ts
@@ -414,7 +414,7 @@ Deno.test({
           repoDir,
         });
 
-        // First reconcile: bundleAndIndexOne fails → BundleBuildFailed.
+        // First reconcile: bundleAndIndexOne fails → ValidationFailed.
         await service.execute();
         // The file might be skipped entirely (bundleAndIndexOne returns
         // null for non-model exports) or fail. Either way, subsequent


### PR DESCRIPTION
## Summary

- Introduce `ValidationError` custom error class carrying `bundlePath` and `fingerprint`, thrown at both validation sites in `bundleAndIndexOne` (primary + secondary export)
- Bifurcate the reconcile catch block: `instanceof ValidationError` routes to `recordValidationFailed` (producing `ValidationFailed` state), plain `Error` stays on `recordBundleBuildFailed` (preserving existing behavior)
- Update `recordValidationFailed` to accept optional `fingerprint`/`sourceMtime` for I3 invariant compliance (freshness termination on stable-broken content)
- Widen `makeExtensionWithNewSource` to accept `ValidationFailed` state for new-source discovery of schema-invalid files

## Test Plan

- [x] Unit tests: `ValidationError` class instantiation and `instanceof` check
- [x] Unit tests: `recordValidationFailed` with `fingerprint`/`sourceMtime` delegates to `updateSourceStateAndFingerprint`
- [x] Integration tests: 4 existing `#334` tests flipped from `BundleBuildFailed` → `ValidationFailed` (same-PR fix, CI would break without)
- [x] Integration tests: unresolvable import → `BundleBuildFailed` regression test (bifurcation doesn't re-route bundle failures)
- [x] Integration tests: `BundleBuildFailed` recovery (unresolvable import → fix → `Indexed`)
- [x] Manual verification: scratch repo at `/tmp/swamp-repro-issue-340` confirms `stateTag: "ValidationFailed"` for schema-invalid content
- [x] Manual verification: unresolvable import content still produces `BundleBuildFailed`
- [x] Full test suite: 5898 passed, 0 failed

## Follow-up

After merge, file a swamp-uat issue to update `tests/cli/extension/state/validation_failed_test.ts` — flip assertions from `registries.failures[]` to `sourceDetails[].stateTag === "ValidationFailed"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)