### PR TITLE
feat(telemetry): record external-datastore-configured flag per invocation

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -105,6 +105,7 @@ import {
   buildInvocationContext,
   clearActiveTelemetryService,
   extractCommandInfo,
+  isExternalDatastoreConfigured,
   isTelemetryDisabled,
   projectEnvSnapshot,
   setActiveTelemetryService,
@@ -988,6 +989,7 @@ async function initTelemetryService(
     const invocationContext = buildInvocationContext(
       projectEnvSnapshot(),
       marker.tools,
+      isExternalDatastoreConfigured(marker.datastore),
     );
     const service = new TelemetryService(
       repository,

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -27,6 +27,19 @@ import {
 } from "../domain/telemetry/mod.ts";
 import type { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
 import type { AiTool } from "../infrastructure/persistence/repo_marker_repository.ts";
+import type { DatastoreConfigData } from "../domain/datastore/datastore_config.ts";
+
+/**
+ * True when the repo marker declares a non-`filesystem` datastore. Local
+ * `filesystem` datastores and absent configs both report false — the signal
+ * is "data lives behind a custom datastore provider," not "the user has any
+ * datastore block." Used to populate the telemetry invocation context.
+ */
+export function isExternalDatastoreConfigured(
+  datastore: DatastoreConfigData | undefined,
+): boolean {
+  return datastore !== undefined && datastore.type !== "filesystem";
+}
 
 /**
  * Module-scoped accessor for the active TelemetryService. Set once at the
@@ -282,11 +295,13 @@ export function projectEnvSnapshot(): Record<string, string> {
 export function buildInvocationContext(
   envSnapshot: Record<string, string>,
   configuredAiTools: AiTool[] | undefined,
+  externalDatastoreConfigured: boolean,
 ): InvocationContextData {
   const detection = detectAgentHarness(envSnapshot);
   const data: InvocationContextData = {
     agentSessionDetected: detection.agentSessionDetected,
     isInteractive: Deno.stdin.isTerminal(),
+    externalDatastoreConfigured,
   };
   if (configuredAiTools !== undefined) {
     data.configuredAiTools = configuredAiTools;

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -21,6 +21,7 @@ import { assert, assertEquals } from "@std/assert";
 import {
   buildInvocationContext,
   extractCommandInfo,
+  isExternalDatastoreConfigured,
   isTelemetryDisabled,
   projectEnvSnapshot,
 } from "./telemetry_integration.ts";
@@ -321,35 +322,60 @@ Deno.test("buildInvocationContext: claude detected, tools configured", () => {
   const ctx = buildInvocationContext(
     { CLAUDECODE: "1" },
     ["claude", "cursor"],
+    false,
   );
   assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
   assertEquals(ctx.detectedAiTool, "claude");
   assertEquals(ctx.agentSessionDetected, true);
+  assertEquals(ctx.externalDatastoreConfigured, false);
 });
 
 Deno.test("buildInvocationContext: configuredAiTools=undefined when no marker passed", () => {
-  const ctx = buildInvocationContext({ CLAUDECODE: "1" }, undefined);
+  const ctx = buildInvocationContext({ CLAUDECODE: "1" }, undefined, false);
   assertEquals("configuredAiTools" in ctx, false);
   assertEquals(ctx.detectedAiTool, "claude");
   assertEquals(ctx.agentSessionDetected, true);
 });
 
 Deno.test("buildInvocationContext: configuredAiTools=[] preserved (legacy opt-out)", () => {
-  const ctx = buildInvocationContext({}, []);
+  const ctx = buildInvocationContext({}, [], false);
   assertEquals(ctx.configuredAiTools, []);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, false);
 });
 
 Deno.test("buildInvocationContext: generic AGENT fallback flips agentSessionDetected", () => {
-  const ctx = buildInvocationContext({ AGENT: "1" }, ["claude"]);
+  const ctx = buildInvocationContext({ AGENT: "1" }, ["claude"], false);
   assertEquals(ctx.configuredAiTools, ["claude"]);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, true);
 });
 
 Deno.test("buildInvocationContext: empty env yields no detection", () => {
-  const ctx = buildInvocationContext({}, ["claude"]);
+  const ctx = buildInvocationContext({}, ["claude"], false);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, false);
+});
+
+Deno.test("buildInvocationContext: externalDatastoreConfigured=true is recorded", () => {
+  const ctx = buildInvocationContext({}, ["claude"], true);
+  assertEquals(ctx.externalDatastoreConfigured, true);
+});
+
+Deno.test("isExternalDatastoreConfigured: undefined marker datastore is not external", () => {
+  assertEquals(isExternalDatastoreConfigured(undefined), false);
+});
+
+Deno.test("isExternalDatastoreConfigured: filesystem type is not external", () => {
+  assertEquals(
+    isExternalDatastoreConfigured({ type: "filesystem", path: "/tmp/ds" }),
+    false,
+  );
+});
+
+Deno.test("isExternalDatastoreConfigured: custom (non-filesystem) type is external", () => {
+  assertEquals(
+    isExternalDatastoreConfigured({ type: "s3", bucket: "my-bucket" }),
+    true,
+  );
 });

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -45,6 +45,7 @@ export interface InvocationContext {
   readonly detectedAiTool?: DetectableAiTool;
   readonly agentSessionDetected: boolean;
   readonly isInteractive: boolean;
+  readonly externalDatastoreConfigured: boolean;
 }
 
 /**
@@ -55,6 +56,7 @@ export interface InvocationContextData {
   detectedAiTool?: DetectableAiTool;
   agentSessionDetected: boolean;
   isInteractive: boolean;
+  externalDatastoreConfigured: boolean;
 }
 
 /**
@@ -70,6 +72,7 @@ export function createInvocationContext(
     detectedAiTool: props.detectedAiTool,
     agentSessionDetected: props.agentSessionDetected,
     isInteractive: props.isInteractive,
+    externalDatastoreConfigured: props.externalDatastoreConfigured,
   };
 }
 
@@ -82,6 +85,7 @@ export function invocationContextToData(
   const data: InvocationContextData = {
     agentSessionDetected: context.agentSessionDetected,
     isInteractive: context.isInteractive,
+    externalDatastoreConfigured: context.externalDatastoreConfigured,
   };
   if (context.configuredAiTools !== undefined) {
     data.configuredAiTools = [...context.configuredAiTools];

--- a/src/domain/telemetry/invocation_context_test.ts
+++ b/src/domain/telemetry/invocation_context_test.ts
@@ -29,11 +29,13 @@ Deno.test("createInvocationContext: minimal context with mandatory fields only",
   const ctx = createInvocationContext({
     agentSessionDetected: false,
     isInteractive: true,
+    externalDatastoreConfigured: false,
   });
   assertEquals(ctx.configuredAiTools, undefined);
   assertEquals(ctx.detectedAiTool, undefined);
   assertEquals(ctx.agentSessionDetected, false);
   assertEquals(ctx.isInteractive, true);
+  assertEquals(ctx.externalDatastoreConfigured, false);
 });
 
 Deno.test("createInvocationContext: configuredAiTools=[] preserved (not coerced to undefined)", () => {
@@ -41,6 +43,7 @@ Deno.test("createInvocationContext: configuredAiTools=[] preserved (not coerced 
     configuredAiTools: [],
     agentSessionDetected: false,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
   assertEquals(ctx.configuredAiTools, []);
 });
@@ -51,9 +54,19 @@ Deno.test("createInvocationContext: copies configuredAiTools array (no aliasing)
     configuredAiTools: tools,
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
   tools.push("kiro");
   assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
+});
+
+Deno.test("createInvocationContext: externalDatastoreConfigured=true preserved", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: false,
+    externalDatastoreConfigured: true,
+  });
+  assertEquals(ctx.externalDatastoreConfigured, true);
 });
 
 Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", () => {
@@ -62,6 +75,7 @@ Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", (
     detectedAiTool: "claude",
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: true,
   });
   const data = invocationContextToData(ctx);
   assertEquals(data, {
@@ -69,6 +83,7 @@ Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", (
     detectedAiTool: "claude",
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: true,
   });
 });
 
@@ -76,6 +91,7 @@ Deno.test("invocationContextToData: omits absent optional fields", () => {
   const ctx = createInvocationContext({
     agentSessionDetected: false,
     isInteractive: true,
+    externalDatastoreConfigured: false,
   });
   const data = invocationContextToData(ctx);
   assertEquals("configuredAiTools" in data, false);
@@ -87,6 +103,7 @@ Deno.test("invocationContextToData: empty configuredAiTools array is preserved o
     configuredAiTools: [],
     agentSessionDetected: false,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
   const data = invocationContextToData(ctx);
   assertEquals(data.configuredAiTools, []);
@@ -98,18 +115,21 @@ Deno.test("invocationContextFromData: round-trip preserves every field", () => {
     detectedAiTool: "claude",
     agentSessionDetected: true,
     isInteractive: true,
+    externalDatastoreConfigured: true,
   });
   const restored = invocationContextFromData(invocationContextToData(original));
   assertEquals(restored.configuredAiTools, ["claude"]);
   assertEquals(restored.detectedAiTool, "claude");
   assertEquals(restored.agentSessionDetected, true);
   assertEquals(restored.isInteractive, true);
+  assertEquals(restored.externalDatastoreConfigured, true);
 });
 
 Deno.test("invocationContextFromData: agent detected without specific tool round-trips", () => {
   const original = createInvocationContext({
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
   const restored = invocationContextFromData(invocationContextToData(original));
   assertEquals(restored.detectedAiTool, undefined);

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -172,6 +172,7 @@ Deno.test("TelemetryEntry.create accepts invocationContext", () => {
       detectedAiTool: "claude",
       agentSessionDetected: true,
       isInteractive: false,
+      externalDatastoreConfigured: false,
     },
   });
 
@@ -203,6 +204,7 @@ Deno.test("TelemetryEntry round-trips invocationContext through toData/fromData"
       configuredAiTools: [],
       agentSessionDetected: true,
       isInteractive: false,
+      externalDatastoreConfigured: true,
     },
   });
 

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -382,6 +382,7 @@ Deno.test("TelemetryService.recordSuccess stamps invocationContext on entries", 
     detectedAiTool: "claude",
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
 
   await service.recordSuccess(
@@ -407,6 +408,7 @@ Deno.test("TelemetryService.recordError stamps invocationContext on entries", as
     configuredAiTools: [],
     agentSessionDetected: true,
     isInteractive: false,
+    externalDatastoreConfigured: false,
   });
 
   await service.recordError(

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -525,6 +525,7 @@ Deno.test("JsonTelemetryRepository round-trips invocationContext (with detected 
         detectedAiTool: "claude",
         agentSessionDetected: true,
         isInteractive: false,
+        externalDatastoreConfigured: false,
       },
     });
 
@@ -565,6 +566,7 @@ Deno.test("JsonTelemetryRepository round-trips invocationContext (legacy opt-out
         configuredAiTools: [],
         agentSessionDetected: false,
         isInteractive: true,
+        externalDatastoreConfigured: false,
       },
     });
 

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -235,7 +235,8 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
   // Wire-shape contract: TelemetryEntry.toData() is splatted into properties
   // verbatim, so the swamp-club consumer side queries
   // properties.invocationContext.{configuredAiTools, detectedAiTool,
-  // agentSessionDetected, isInteractive}. Lock the shape here.
+  // agentSessionDetected, isInteractive, externalDatastoreConfigured}.
+  // Lock the shape here.
   let capturedBody: string | undefined;
 
   const server = Deno.serve({ port: 0 }, async (req: Request) => {
@@ -264,6 +265,7 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
       detectedAiTool: "claude",
       agentSessionDetected: true,
       isInteractive: false,
+      externalDatastoreConfigured: true,
     },
   });
 
@@ -278,6 +280,10 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
   assertEquals(parsed.properties.invocationContext.detectedAiTool, "claude");
   assertEquals(parsed.properties.invocationContext.agentSessionDetected, true);
   assertEquals(parsed.properties.invocationContext.isInteractive, false);
+  assertEquals(
+    parsed.properties.invocationContext.externalDatastoreConfigured,
+    true,
+  );
 
   await server.shutdown();
 });


### PR DESCRIPTION
## Summary

- Adds `externalDatastoreConfigured: boolean` to `InvocationContext` / `InvocationContextData`, populated at telemetry-service init.
- True only when the repo marker declares a datastore whose `type` is not `filesystem` — custom providers like S3. Unset markers and local `filesystem` datastores both report false.
- Logic lives in a small `isExternalDatastoreConfigured(datastore)` helper next to `buildInvocationContext`, with unit coverage for the three cases.
- Wire shape lands at `properties.invocationContext.externalDatastoreConfigured` — `http_telemetry_sender_test` locks the contract so the swamp-club consumer can query it without a server-side change.

## Test Plan

- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno check`
- [x] Targeted: `deno run test src/domain/telemetry/... src/cli/telemetry_integration_test.ts src/infrastructure/persistence/json_telemetry_repository_test.ts src/infrastructure/telemetry/http_telemetry_sender_test.ts` — 102 passed