### PR TITLE
fix(extensions): surface type-extraction warnings in doctor JSON output (swamp-club#351)

### DIFF
--- a/integration/extensions/doctor_extensions_failure_states_test.ts
+++ b/integration/extensions/doctor_extensions_failure_states_test.ts
@@ -59,6 +59,24 @@ export const model = {
 };
 `;
 
+const NON_LITERAL_TYPE_MODEL = `
+import { z } from "npm:zod@4";
+const TYPE = "@tutorial/non-literal";
+export const model = {
+  type: TYPE,
+  version: "2026.05.12.0",
+  globalArguments: z.object({}),
+  resources: {},
+  methods: {
+    run: {
+      description: "no-op",
+      arguments: z.object({}),
+      execute: () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+
 async function withTestRepo(
   fn: (repoDir: string) => Promise<void>,
 ): Promise<void> {
@@ -89,6 +107,11 @@ interface DoctorReport {
       lastError?: string;
     }[];
   };
+  warnings: {
+    sourcePath: string;
+    category: string;
+    message: string;
+  }[];
 }
 
 async function runDoctor(
@@ -479,5 +502,39 @@ Deno.test("doctor extensions: reconcile with >=10 extensions completes in <30s",
       result.aggregateState.totalSources >= 12,
       `Expected >=12 sources, got ${result.aggregateState.totalSources}`,
     );
+  });
+});
+
+// #351: non-literal type field → warnings-only (overallStatus=pass, exit 0, warnings populated)
+Deno.test("doctor extensions: non-literal type field appears in warnings[] without failing", async () => {
+  await withTestRepo(async (repoDir) => {
+    const modelDir = join(repoDir, "extensions", "models");
+    await ensureDir(modelDir);
+    await Deno.writeTextFile(
+      join(modelDir, "non_literal.ts"),
+      NON_LITERAL_TYPE_MODEL,
+    );
+
+    const result = await runDoctor(repoDir);
+    assertEquals(
+      result.overallStatus,
+      "pass",
+      "overallStatus must be pass — type-extraction warnings are advisory",
+    );
+
+    assert(
+      Array.isArray(result.warnings),
+      "report must include a warnings array",
+    );
+    const typeWarning = result.warnings.find((w) =>
+      w.sourcePath.includes("non_literal.ts")
+    );
+    assert(
+      typeWarning !== undefined,
+      `expected warnings[] to contain non_literal.ts; got: ${
+        JSON.stringify(result.warnings)
+      }`,
+    );
+    assertEquals(typeWarning!.category, "TypeExtractionFailed");
   });
 });

--- a/integration/extensions/silent_load_failure_test.ts
+++ b/integration/extensions/silent_load_failure_test.ts
@@ -19,7 +19,7 @@
 
 // Regression guard for swamp-club#177.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { initializeTestRepo, runCliCommand } from "../test_helpers.ts";
@@ -156,6 +156,67 @@ Deno.test(
       );
     } finally {
       await Deno.remove(repoDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "silent load failure: doctor extensions --json surfaces type-extraction warning in warnings[]",
+  async () => {
+    const repoDir = await Deno.makeTempDir({
+      prefix: "swamp-issue-351-test-",
+    });
+    try {
+      await initializeTestRepo(repoDir);
+      const modelsDir = join(repoDir, "extensions", "models");
+      await ensureDir(modelsDir);
+      await Deno.writeTextFile(
+        join(modelsDir, "working.ts"),
+        VALID_MODEL,
+      );
+      await Deno.writeTextFile(
+        join(modelsDir, "non_literal_type.ts"),
+        BAD_MODEL_REGEX,
+      );
+
+      const { stdout, stderr, code } = await runCliCommand(
+        ["--json", "doctor", "extensions"],
+        repoDir,
+      );
+
+      const report = JSON.parse(stdout);
+
+      assertEquals(
+        report.overallStatus,
+        "pass",
+        "overallStatus must be pass — type-extraction warnings are advisory",
+      );
+      assertEquals(code, 0, "exit code must be 0 for warnings-only");
+
+      assert(
+        Array.isArray(report.warnings),
+        "report must include a warnings array",
+      );
+      const typeWarning = (
+        report.warnings as Array<{
+          sourcePath: string;
+          category: string;
+          message: string;
+        }>
+      ).find((w) => w.sourcePath.includes("non_literal_type.ts"));
+      assert(
+        typeWarning !== undefined,
+        `expected warnings[] to contain non_literal_type.ts; got: ${
+          JSON.stringify(report.warnings)
+        }`,
+      );
+      assertEquals(typeWarning!.category, "TypeExtractionFailed");
+      assertStringIncludes(typeWarning!.message, "string literal");
+
+      // stderr still surfaces the warning for non-JSON consumers
+      assertStringIncludes(stderr, "non_literal_type.ts");
+    } finally {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
     }
   },
 );

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -39,6 +39,10 @@
 
 import { Command } from "@cliffy/command";
 import { bold, dim } from "@std/fmt/colors";
+import {
+  getExtensionLoadWarnings,
+  resetExtensionLoadWarnings,
+} from "../../infrastructure/logging/extension_load_warnings.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { isAbsolute, join, relative, resolve } from "@std/path";
 import {
@@ -271,6 +275,13 @@ export const doctorExtensionsCommand = new Command()
           }
         },
         getRecentTransitions: () => reconcileTransitions,
+        getWarnings: () =>
+          getExtensionLoadWarnings().map((w) => ({
+            sourcePath: w.file,
+            category: "TypeExtractionFailed",
+            message: w.error,
+          })),
+        resetWarnings: resetExtensionLoadWarnings,
         runRepair: repair
           ? async (aggregateReport) => {
             // In interactive mode without --force, preview first and prompt.

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -30,8 +30,15 @@ export interface EmitterOptions {
   quiet?: boolean;
 }
 
+export interface ExtensionLoadWarningEvent {
+  readonly kind: ExtensionKind;
+  readonly file: string;
+  readonly error: string;
+}
+
 interface EmitterState {
   emitted: Set<string>;
+  events: ExtensionLoadWarningEvent[];
   hintsEmittedFor: Set<ExtensionKind>;
 }
 
@@ -44,6 +51,7 @@ function getState(): EmitterState {
   if (!globalAny[STATE_KEY]) {
     globalAny[STATE_KEY] = {
       emitted: new Set<string>(),
+      events: [],
       hintsEmittedFor: new Set<ExtensionKind>(),
     } satisfies EmitterState;
   }
@@ -87,6 +95,11 @@ export function emitExtensionLoadWarning(
   const key = dedupeKey(warning.kind, warning.file, warning.error);
   if (state.emitted.has(key)) return;
   state.emitted.add(key);
+  state.events.push({
+    kind: warning.kind,
+    file: warning.file,
+    error: warning.error,
+  });
 
   if (isSilenced(options)) return;
 
@@ -115,8 +128,15 @@ export function emitTypeExtractionFailure(
   );
 }
 
+export function getExtensionLoadWarnings(): ReadonlyArray<
+  ExtensionLoadWarningEvent
+> {
+  return Array.from(getState().events);
+}
+
 export function resetExtensionLoadWarnings(): void {
   const state = getState();
   state.emitted.clear();
+  state.events.length = 0;
   state.hintsEmittedFor.clear();
 }

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -71,6 +71,12 @@ export interface DoctorOrphanFile {
   path: string;
 }
 
+export interface DoctorWarning {
+  sourcePath: string;
+  category: string;
+  message: string;
+}
+
 /** Final report shape — used by the renderer's JSON mode. */
 export interface DoctorExtensionsReport {
   overallStatus: DoctorOverallStatus;
@@ -108,6 +114,13 @@ export interface DoctorExtensionsReport {
    * loader succeeds. Keyed by registry name; value is the error message.
    */
   loaderErrors?: ReadonlyMap<DoctorRegistryName, string>;
+  /**
+   * Extension load warnings — diagnostic findings about suboptimal-but-working
+   * patterns (e.g. non-literal type fields that prevent static catalog
+   * extraction). Advisory only: `overallStatus` is unchanged by warning
+   * presence. Empty array when no warnings were emitted.
+   */
+  warnings: readonly DoctorWarning[];
 }
 
 /**
@@ -176,6 +189,17 @@ export interface DoctorExtensionsDeps {
    * failed.
    */
   getRecentTransitions?: () => readonly ReconcileTransition[];
+  /**
+   * Returns extension load warnings emitted during this process run.
+   * Injected by the CLI — maps emitter events to DoctorWarning shape.
+   */
+  getWarnings?: () => readonly DoctorWarning[];
+  /**
+   * Resets the extension load warning state. Called at the start of
+   * each doctor invocation (alongside resetLoadedFlag) to prevent
+   * stale warnings from the CLI bootstrap leaking into doctor output.
+   */
+  resetWarnings?: () => void;
 }
 
 function overallStatus(
@@ -307,6 +331,7 @@ function registryHasFailures(
 export async function* doctorExtensions(
   deps: DoctorExtensionsDeps,
 ): AsyncIterable<DoctorExtensionsEvent> {
+  deps.resetWarnings?.();
   for (const reg of deps.registries) {
     reg.resetLoadedFlag();
   }
@@ -361,6 +386,7 @@ export async function* doctorExtensions(
   }
 
   const recentTransitions = deps.getRecentTransitions?.() ?? [];
+  const warnings = deps.getWarnings?.() ?? [];
 
   const results: DoctorRegistryResult[] = DOCTOR_REGISTRY_ORDER.map((name) => ({
     registry: name,
@@ -384,6 +410,7 @@ export async function* doctorExtensions(
       repairReport,
       recentTransitions,
       loaderErrors: loaderErrors.size > 0 ? loaderErrors : undefined,
+      warnings,
     },
   };
 }

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -18,14 +18,20 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { resetExtensionLoadWarnings } from "../../infrastructure/logging/extension_load_warnings.ts";
+import {
+  emitExtensionLoadWarning,
+  getExtensionLoadWarnings,
+  resetExtensionLoadWarnings,
+} from "../../infrastructure/logging/extension_load_warnings.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import {
   DOCTOR_REGISTRY_ORDER,
   doctorExtensions,
   type DoctorExtensionsDeps,
   type DoctorExtensionsEvent,
+  type DoctorRegistryDeps,
   type DoctorRegistryName,
+  type DoctorWarning,
 } from "./doctor.ts";
 import type { DoctorAggregateReport } from "./doctor_aggregate.ts";
 
@@ -526,5 +532,134 @@ Deno.test(
     );
     assertEquals(completed.report.recentTransitions[1].fromState, null);
     assertEquals(completed.report.recentTransitions[1].toState, "Indexed");
+  },
+);
+
+Deno.test(
+  "doctorExtensions: resetWarnings prevents stale bootstrap warnings from leaking into report",
+  async () => {
+    resetExtensionLoadWarnings();
+
+    emitExtensionLoadWarning(
+      {
+        kind: "model",
+        file: "/repo/extensions/models/stale.ts",
+        error: "stale bootstrap warning",
+      },
+      { quiet: true },
+    );
+    assertEquals(getExtensionLoadWarnings().length, 1);
+
+    const warnings: DoctorWarning[] = [];
+    const { deps } = buildDeps();
+    deps.resetWarnings = resetExtensionLoadWarnings;
+    deps.getWarnings = () =>
+      getExtensionLoadWarnings().map((w) => ({
+        sourcePath: w.file,
+        category: "TypeExtractionFailed",
+        message: w.error,
+      }));
+
+    const events = await collect(doctorExtensions(deps));
+    const completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.warnings.length, 0);
+    void warnings;
+  },
+);
+
+Deno.test(
+  "doctorExtensions: warnings emitted during loader pass appear in report",
+  async () => {
+    resetExtensionLoadWarnings();
+
+    const { deps } = buildDeps();
+    const originalEnsureLoaded = deps.registries[0].ensureLoaded;
+    (deps.registries as DoctorRegistryDeps[])[0] = {
+      ...deps.registries[0],
+      ensureLoaded: async () => {
+        emitExtensionLoadWarning(
+          {
+            kind: "model",
+            file: "/repo/extensions/models/non_literal.ts",
+            error: "type field could not be extracted",
+          },
+          { quiet: true },
+        );
+        await originalEnsureLoaded();
+      },
+    };
+    deps.resetWarnings = resetExtensionLoadWarnings;
+    deps.getWarnings = () =>
+      getExtensionLoadWarnings().map((w) => ({
+        sourcePath: w.file,
+        category: "TypeExtractionFailed",
+        message: w.error,
+      }));
+
+    const events = await collect(doctorExtensions(deps));
+    const completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.warnings.length, 1);
+    assertEquals(
+      completed.report.warnings[0].sourcePath,
+      "/repo/extensions/models/non_literal.ts",
+    );
+    assertEquals(
+      completed.report.warnings[0].category,
+      "TypeExtractionFailed",
+    );
+    assertEquals(completed.report.overallStatus, "pass");
+  },
+);
+
+Deno.test(
+  "doctorExtensions: second invocation does not double-count warnings",
+  async () => {
+    resetExtensionLoadWarnings();
+
+    const { deps } = buildDeps();
+    const originalEnsureLoaded = deps.registries[0].ensureLoaded;
+    (deps.registries as DoctorRegistryDeps[])[0] = {
+      ...deps.registries[0],
+      ensureLoaded: async () => {
+        emitExtensionLoadWarning(
+          {
+            kind: "model",
+            file: "/repo/extensions/models/non_literal.ts",
+            error: "type field could not be extracted",
+          },
+          { quiet: true },
+        );
+        await originalEnsureLoaded();
+      },
+    };
+    deps.resetWarnings = resetExtensionLoadWarnings;
+    deps.getWarnings = () =>
+      getExtensionLoadWarnings().map((w) => ({
+        sourcePath: w.file,
+        category: "TypeExtractionFailed",
+        message: w.error,
+      }));
+
+    // First invocation
+    let events = await collect(doctorExtensions(deps));
+    let completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.warnings.length, 1);
+
+    // Second invocation — reset should clear, loader re-emits exactly once
+    events = await collect(doctorExtensions(deps));
+    completed = events.find((e) => e.kind === "completed");
+    if (completed?.kind !== "completed") {
+      throw new Error("expected completed event");
+    }
+    assertEquals(completed.report.warnings.length, 1);
   },
 );

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -775,6 +775,7 @@ export {
   type DoctorRegistryDeps,
   type DoctorRegistryName,
   type DoctorRegistryResult,
+  type DoctorWarning,
 } from "./extensions/doctor.ts";
 
 // Extension RowState (used by doctor extensions rendering)

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -311,6 +311,24 @@ class LogDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
           );
         }
 
+        if (e.report.warnings.length > 0) {
+          writeOutput(
+            `\n${yellow("⚠")} ${
+              bold(
+                `${e.report.warnings.length} warning(s) (advisory, not failures):`,
+              )
+            }`,
+          );
+          for (const w of e.report.warnings) {
+            writeOutput(
+              `    ${yellow("•")} ${w.sourcePath}`,
+            );
+            writeOutput(
+              `      ${dim(w.message)}`,
+            );
+          }
+        }
+
         // W6: Aggregate state rendering.
         if (e.report.aggregateState) {
           renderAggregateStateLog(e.report.aggregateState, this.verbose);
@@ -389,6 +407,7 @@ class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
         output.loaderErrors = e.report.loaderErrors
           ? Object.fromEntries(e.report.loaderErrors)
           : {};
+        output.warnings = e.report.warnings;
         output.recentTransitions = e.report.recentTransitions.map((t) => ({
           sourcePath: t.source.canonicalPath,
           fromState: t.fromState,

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -67,6 +67,7 @@ function buildPassReport(): DoctorExtensionsReport {
     },
     orphanFiles: [],
     recentTransitions: [],
+    warnings: [],
   };
 }
 
@@ -82,6 +83,7 @@ function buildFailReport(): DoctorExtensionsReport {
     },
     orphanFiles: [],
     recentTransitions: [],
+    warnings: [],
   };
 }
 
@@ -162,6 +164,7 @@ Deno.test("doctor_extensions json renderer: stable key ordering", async () => {
       },
       orphanFiles: [],
       recentTransitions: [],
+      warnings: [],
     };
     await handlers.completed({ kind: "completed", report: reversed });
   });
@@ -228,6 +231,7 @@ Deno.test(
           },
         ],
         recentTransitions: [],
+        warnings: [],
       };
       await handlers.completed({ kind: "completed", report });
     });
@@ -265,6 +269,7 @@ Deno.test(
           },
         ],
         recentTransitions: [],
+        warnings: [],
       };
       // Drive the kind-completed events first so the registry headers
       // get rendered, then completed.


### PR DESCRIPTION
## Summary

- Adds a `warnings[]` field to `swamp doctor extensions --json` output to surface extension load warnings (e.g. non-literal type fields that prevent static catalog extraction)
- Warnings are advisory — `overallStatus` and exit code are unaffected
- Wires structured warning collection through DI callbacks (`getWarnings`/`resetWarnings`) on `DoctorExtensionsDeps`, matching the `getRecentTransitions` pattern
- Resets warning state at each doctor invocation start to prevent stale bootstrap warnings from leaking

Each warning entry has the schema: `{ sourcePath, category, message }` — the `category` field future-proofs for additional warning types.

### Key design decision

Triage verified that extensions with non-literal type fields **work correctly at runtime** (type search, method execution, and describe all succeed). The original issue framing ("model doesn't register") was incorrect — the failure is only in static regex-based catalog extraction. This means a new `TypeExtractionFailed` RowState would have produced false alarms for working extensions. The `warnings[]` surface treats these as what they are: diagnostic findings about suboptimal-but-working patterns.

Closes swamp-club#351.
Follow-up: swamp-club#353 (docs update for JSON schema).

## Test Plan

- [x] 3 new unit tests in `doctor_test.ts` pin reset-at-invocation semantics (stale leak prevention, during-loader appearance, no double-counting)
- [x] Extended `silent_load_failure_test.ts` — asserts `warnings[]` in doctor JSON with `TypeExtractionFailed` category
- [x] Extended `doctor_extensions_failure_states_test.ts` — warnings-only scenario: `overallStatus=pass`, exit 0, `warnings[]` populated
- [x] Updated renderer test fixtures with `warnings: []` field
- [x] Verified against reproduction repo: `swamp doctor extensions --json` shows warning, exit code 0, `overallStatus: "pass"`
- [x] Full test suite: 5930 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)