### PR TITLE
feat(cli): add --markdown flag to `swamp report get`

### DIFF
--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -43,6 +43,7 @@ up-to-date CLI schema.
 | Workflow with reports    | `swamp workflow run <workflow>`                                   |
 | Workflow skip reports    | `swamp workflow run <workflow> --skip-reports`                    |
 | Get stored report        | `swamp report get <report-name> --model <model> --json`           |
+| Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
 
 ## End-to-End Workflow
 
@@ -198,6 +199,11 @@ swamp data get my-model report-cost-estimate --json
 **Log mode** (default): renders report markdown with terminal formatting plus a
 pass/fail summary. The built-in `@swamp/method-summary` markdown is compact —
 narrative + retrieval hint only.
+
+**Markdown mode** (`--markdown`): raw markdown output with no ANSI escape
+sequences or box-drawing characters. Use for pasting into GitHub PRs, Linear
+tickets, wikis, or saving to `.md` files. Mutually exclusive with `--json`.
+Retrieve with `swamp report get <name> --model <model> --markdown`.
 
 **JSON mode** (`--json`): full structured detail for agents. The built-in
 `@swamp/method-summary` JSON includes narrative, output schema, and data

--- a/src/cli/commands/report_get.ts
+++ b/src/cli/commands/report_get.ts
@@ -49,6 +49,10 @@ export const reportGetCommand = new Command()
     "Scoped to a workflow",
     "swamp report get cost-summary --workflow deploy-pipeline",
   )
+  .example(
+    "Output as markdown",
+    "swamp report get cost-summary --model my-server --markdown > report.md",
+  )
   .arguments("<report_name:string>")
   .option(
     "--repo-dir <dir:string>",
@@ -61,6 +65,13 @@ export const reportGetCommand = new Command()
     "Get specific version (default: latest)",
   )
   .option("--variant <variant:string>", "Select a specific forEach variant")
+  .option(
+    "--markdown",
+    "Output as plain markdown instead of terminal-formatted",
+    {
+      conflicts: ["json"],
+    },
+  )
   .action(async function (options: AnyOptions, reportName: string) {
     const ctx = createContext(options as GlobalOptions, ["report", "get"]);
 
@@ -98,7 +109,8 @@ export const reportGetCommand = new Command()
     };
 
     const libCtx = createLibSwampContext({ logger: ctx.logger });
-    const renderer = createReportGetRenderer(ctx.outputMode);
+    const reportMode = options.markdown ? "markdown" as const : ctx.outputMode;
+    const renderer = createReportGetRenderer(reportMode);
 
     await consumeStream(
       reportGet(libCtx, deps, {

--- a/src/presentation/renderers/report_get.ts
+++ b/src/presentation/renderers/report_get.ts
@@ -22,7 +22,12 @@ import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
+import {
+  renderMarkdownPlain,
+  renderMarkdownToTerminal,
+} from "../markdown_renderer.ts";
+
+type ReportOutputMode = OutputMode | "markdown";
 
 class LogReportGetRenderer implements Renderer<ReportGetEvent> {
   handlers(): EventHandlers<ReportGetEvent> {
@@ -63,12 +68,38 @@ class JsonReportGetRenderer implements Renderer<ReportGetEvent> {
   }
 }
 
+class MarkdownReportGetRenderer implements Renderer<ReportGetEvent> {
+  handlers(): EventHandlers<ReportGetEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const r = e.data;
+        const source = r.workflowName
+          ? `Workflow: ${r.workflowName}`
+          : `Model: ${r.modelName} (${r.modelType})`;
+        const varySuffixLabel = r.varySuffix
+          ? `  |  Variant: ${r.varySuffix}`
+          : "";
+        writeOutput(
+          `## ${r.reportName}\n\n${source}  |  Scope: ${r.reportScope}${varySuffixLabel}  |  v${r.version}  |  ${r.createdAt}\n`,
+        );
+        writeOutput(renderMarkdownPlain(r.markdown));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
 export function createReportGetRenderer(
-  mode: OutputMode,
+  mode: ReportOutputMode,
 ): Renderer<ReportGetEvent> {
   switch (mode) {
     case "json":
       return new JsonReportGetRenderer();
+    case "markdown":
+      return new MarkdownReportGetRenderer();
     case "log":
       return new LogReportGetRenderer();
   }

--- a/src/presentation/renderers/report_get_test.ts
+++ b/src/presentation/renderers/report_get_test.ts
@@ -149,6 +149,139 @@ Deno.test("report get log renderer - omits Variant when varySuffix absent", () =
   }
 });
 
+Deno.test("report get markdown renderer - outputs raw markdown without ANSI escapes", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("markdown");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        markdown:
+          "# Cost Report\n\n| Item | Cost |\n| --- | --- |\n| EC2 | $42 |",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    // deno-lint-ignore no-control-regex
+    const ansiPattern = /\x1b\[/;
+    assertEquals(ansiPattern.test(combined), false);
+    assertStringIncludes(combined, "## cost-report");
+    assertStringIncludes(combined, "Model: my-ec2 (aws/ec2)");
+    assertStringIncludes(combined, "| Item | Cost |");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get markdown renderer - includes Variant when varySuffix present", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("markdown");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        varySuffix: "10.0.0.1",
+        markdown: "# Cost Report\nTotal: $42",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertStringIncludes(combined, "Variant: 10.0.0.1");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get markdown renderer - omits Variant when varySuffix absent", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("markdown");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "cost-report",
+        reportScope: "model",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 1,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-cost",
+        markdown: "# Cost Report\nTotal: $42",
+        json: { total: 42 },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertEquals(combined.includes("Variant"), false);
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("report get markdown renderer - shows workflow source", () => {
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+
+  try {
+    const renderer = createReportGetRenderer("markdown");
+    const handlers = renderer.handlers();
+    handlers.completed({
+      kind: "completed",
+      data: {
+        reportName: "audit-report",
+        reportScope: "workflow",
+        modelId: "test-id",
+        modelName: "my-ec2",
+        modelType: "aws/ec2",
+        version: 3,
+        createdAt: "2026-01-15T10:00:00.000Z",
+        dataName: "report-audit",
+        workflowName: "deploy-pipeline",
+        markdown: "# Audit\nAll good.",
+        json: { status: "pass" },
+      },
+    });
+
+    const combined = output.join("\n");
+    assertStringIncludes(combined, "Workflow: deploy-pipeline");
+    assertEquals(combined.includes("Model:"), false);
+  } finally {
+    console.log = origLog;
+  }
+});
+
 Deno.test("report get renderer - throws on error", () => {
   const renderer = createReportGetRenderer("log");
   const handlers = renderer.handlers();


### PR DESCRIPTION
## Summary

Closes swamp-club#346.

- Add `--markdown` flag to `swamp report get` that emits clean markdown (pipe tables, `##` headings, no ANSI escapes or box-drawing) instead of terminal-formatted output
- Mutually exclusive with `--json` via Cliffy's `conflicts` declaration
- Uses the existing `renderMarkdownPlain()` function which was previously unused
- Update `swamp-report` skill to document the new flag

## Test Plan

- [x] 4 new unit tests for the markdown renderer (no ANSI escapes, varySuffix handling, workflow source)
- [x] All 9 renderer tests pass
- [x] `deno check` / `deno lint` / `deno fmt` pass
- [x] Compiled binary and verified `--markdown` produces clean markdown with real report data
- [x] Verified `--markdown --json` correctly errors with conflict message

🤖 Generated with [Claude Code](https://claude.com/claude-code)