### PR TITLE
feat(datastore): scoped sync and capability-gated concurrency (swamp-club#350)

### DIFF
--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -164,6 +164,23 @@ export function assertDatastoreExportConformance(
     "resolveDatastorePath must return a non-empty string",
   );
 
+  // capabilities() is optional — providers without it must still pass
+  if (typeof provider.capabilities === "function") {
+    const caps = provider.capabilities();
+    assertEquals(
+      typeof caps,
+      "object",
+      "capabilities() must return an object",
+    );
+    if (caps.scopedSync !== undefined) {
+      assertEquals(
+        typeof caps.scopedSync,
+        "boolean",
+        "capabilities().scopedSync must be a boolean when present",
+      );
+    }
+  }
+
   // createLock must return an object with the right methods
   const lock = provider.createLock("/tmp/test-ds");
   assertExists(lock, "createLock must return a lock");

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -78,6 +78,20 @@ export interface DatastoreSyncOptions {
    * `DatastoreSyncService.markDirty` JSDoc for the full contract.
    */
   relPath?: string;
+  /**
+   * Prefix scope for pull/push. When set, the implementation MUST sync
+   * at least all files whose cache-relative path starts with this prefix.
+   * It MAY sync additional files (a superset is always safe). When absent,
+   * the implementation syncs the entire datastore (current behavior).
+   *
+   * Forward-slash-normalized, no trailing slash.
+   * Example: "data/aws-ec2/my-instance"
+   *
+   * swamp core only sets this on `pullChanged` and `pushChanged` calls
+   * when the provider declares `capabilities().scopedSync === true`.
+   * Orthogonal to `relPath` (which is markDirty-only).
+   */
+  scope?: string;
 }
 
 /** Interface for datastore synchronization services. */
@@ -85,6 +99,24 @@ export interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   markDirty(options?: DatastoreSyncOptions): Promise<void>;
+}
+
+/**
+ * Declares which optional features a datastore provider supports.
+ * Absent or returning an empty object means no optional features —
+ * core uses the conservative default behavior for everything.
+ */
+export interface DatastoreCapabilities {
+  /**
+   * When true, the provider's sync service handles scoped push/pull
+   * correctly and its lock implementation supports concurrent per-scope
+   * writes without a global coordination point.
+   *
+   * SAFETY INVARIANT: declaring scopedSync: true is a promise that
+   * concurrent scoped pushes to non-overlapping scopes cannot corrupt
+   * shared state. This is a hard contract, not a performance hint.
+   */
+  scopedSync?: boolean;
 }
 
 /**
@@ -112,4 +144,10 @@ export interface DatastoreProvider {
    * inferred from a missing property.
    */
   resolveCachePath?(repoDir: string): string | undefined;
+  /**
+   * Declares which optional features this provider supports.
+   * Absent or returning an empty object means no optional features —
+   * core uses the conservative default behavior for everything.
+   */
+  capabilities?(): DatastoreCapabilities;
 }

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -68,7 +68,9 @@ import {
   isCustomDatastoreConfig,
   resolveSyncTimeoutMs,
 } from "../domain/datastore/datastore_config.ts";
-import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
+import type {
+  DatastoreProvider,
+} from "../domain/datastore/datastore_provider.ts";
 import type {
   DatastoreSyncService,
   MarkDirtyHook,
@@ -936,7 +938,12 @@ export async function acquireModelLocks(
           type: modelType,
           id: modelId,
         });
-        await customSyncService.pullChanged();
+        const useScopedSync = customProvider?.capabilities?.()
+          ?.scopedSync === true;
+        const pullOptions = useScopedSync
+          ? { scope: `data/${modelType}/${modelId}` }
+          : undefined;
+        await customSyncService.pullChanged(pullOptions);
         synced = true;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -952,42 +959,79 @@ export async function acquireModelLocks(
 
   Deno.env.set(SWAMP_LOCK_HOLDER_PID, String(Deno.pid));
 
+  const scopedSync = customProvider?.capabilities?.()?.scopedSync === true;
+  const lockedModels = [...unique];
+
   const flush = async () => {
     try {
-      // For custom sync-capable datastores: push under global lock
+      // For custom sync-capable datastores: push changes
       if (
         customSyncService && customProvider && isCustomDatastoreConfig(config)
       ) {
-        const pushLock = customProvider.createLock(config.datastorePath);
-        try {
-          await pushLock.acquire();
-          logger.info`Pushing changes to datastore...`;
-          const pushed = await customSyncService.pushChanged();
-          if (pushed && pushed > 0) {
-            logger.info("Pushed {count} file(s) to datastore", {
-              count: pushed,
-            });
-          } else {
-            logger.info`Push complete, no changes`;
+        if (scopedSync) {
+          // Scoped push: one pushChanged call per model, no global lock
+          for (const { modelType, modelId } of lockedModels) {
+            try {
+              const scope = `data/${modelType}/${modelId}`;
+              logger.info("Pushing changes for {type}/{id} to datastore...", {
+                type: modelType,
+                id: modelId,
+              });
+              const pushed = await customSyncService.pushChanged({ scope });
+              if (pushed && pushed > 0) {
+                logger.info(
+                  "Pushed {count} file(s) for {type}/{id} to datastore",
+                  { count: pushed, type: modelType, id: modelId },
+                );
+              } else {
+                logger.info(
+                  "Push complete for {type}/{id}, no changes",
+                  { type: modelType, id: modelId },
+                );
+              }
+            } catch (error) {
+              const { summary, fields } = summarizeSyncError(
+                "push",
+                config.type,
+                error,
+              );
+              logger.error("{summary}", { summary, ...fields });
+              throw new Error(summary, { cause: error });
+            }
           }
-        } catch (error) {
-          const { summary, fields } = summarizeSyncError(
-            "push",
-            config.type,
-            error,
-          );
-          logger.error("{summary}", { summary, ...fields });
-          throw new Error(summary, { cause: error });
-        } finally {
+        } else {
+          // Global push: single pushChanged under global lock (current behavior)
+          const pushLock = customProvider.createLock(config.datastorePath);
           try {
-            await pushLock.release();
-          } catch {
-            // Best-effort release
+            await pushLock.acquire();
+            logger.info`Pushing changes to datastore...`;
+            const pushed = await customSyncService.pushChanged();
+            if (pushed && pushed > 0) {
+              logger.info("Pushed {count} file(s) to datastore", {
+                count: pushed,
+              });
+            } else {
+              logger.info`Push complete, no changes`;
+            }
+          } catch (error) {
+            const { summary, fields } = summarizeSyncError(
+              "push",
+              config.type,
+              error,
+            );
+            logger.error("{summary}", { summary, ...fields });
+            throw new Error(summary, { cause: error });
+          } finally {
+            try {
+              await pushLock.release();
+            } catch {
+              // Best-effort release
+            }
           }
         }
       }
     } finally {
-      // Always release per-model locks, even if S3 push fails
+      // Always release per-model locks, even if push fails
       for (const key of lockKeys) {
         await flushDatastoreSyncNamed(key);
       }

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -1077,3 +1077,271 @@ Deno.test(
     });
   },
 );
+
+// ============================================================================
+// Scoped Sync / Capability-Gated Concurrency Tests (swamp-club#350)
+// ============================================================================
+
+import type { DatastoreSyncOptions } from "../domain/datastore/datastore_sync_service.ts";
+
+Deno.test(
+  "acquireModelLocks - scopedSync: true passes scope to pullChanged and pushChanged per model",
+  async () => {
+    const { datastoreTypeRegistry } = await import(
+      "../domain/datastore/datastore_type_registry.ts"
+    );
+
+    const pullCalls: Array<DatastoreSyncOptions | undefined> = [];
+    const pushCalls: Array<DatastoreSyncOptions | undefined> = [];
+    let globalLockAcquired = false;
+    const typeName = "test-scoped-sync";
+
+    if (!datastoreTypeRegistry.has(typeName)) {
+      datastoreTypeRegistry.register({
+        type: typeName,
+        name: "Test scoped sync",
+        description: "Test extension for scoped sync capability",
+        isBuiltIn: false,
+        createProvider: () => ({
+          createLock: (_path: string, options?: { lockKey?: string }) => ({
+            acquire: () => {
+              if (!options?.lockKey) globalLockAcquired = true;
+              return Promise.resolve();
+            },
+            release: () => Promise.resolve(),
+            withLock: <T>(fn: () => Promise<T>) => fn(),
+            inspect: () => Promise.resolve(null),
+            forceRelease: () => Promise.resolve(true),
+          }),
+          createVerifier: () => ({
+            verify: () =>
+              Promise.resolve({
+                healthy: true,
+                message: "ok",
+                latencyMs: 1,
+                datastoreType: typeName,
+              }),
+          }),
+          resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+          resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+          createSyncService: () => ({
+            pullChanged: (options?: DatastoreSyncOptions) => {
+              pullCalls.push(options);
+              return Promise.resolve(0);
+            },
+            pushChanged: (options?: DatastoreSyncOptions) => {
+              pushCalls.push(options);
+              return Promise.resolve(0);
+            },
+            markDirty: () => Promise.resolve(),
+          }),
+          capabilities: () => ({ scopedSync: true }),
+        }),
+      });
+    }
+
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+      await configureExtensionDatastore(dir, typeName);
+
+      pullCalls.length = 0;
+      pushCalls.length = 0;
+      globalLockAcquired = false;
+
+      const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          { modelType: "aws-ec2", modelId: "server-1" },
+          { modelType: "aws-rds", modelId: "db-1" },
+        ],
+        dir,
+      );
+
+      // Pull should have been called with scope for each model
+      assertEquals(pullCalls.length, 2);
+      assertEquals(pullCalls[0]?.scope, "data/aws-ec2/server-1");
+      assertEquals(pullCalls[1]?.scope, "data/aws-rds/db-1");
+
+      await lockResult.flush();
+
+      // Push should have been called with scope for each model
+      assertEquals(pushCalls.length, 2);
+      assertEquals(pushCalls[0]?.scope, "data/aws-ec2/server-1");
+      assertEquals(pushCalls[1]?.scope, "data/aws-rds/db-1");
+
+      // Global lock should NOT have been acquired
+      assertEquals(
+        globalLockAcquired,
+        false,
+        "scopedSync: true must not acquire the global lock",
+      );
+    });
+  },
+);
+
+Deno.test(
+  "acquireModelLocks - no capabilities: global lock acquired, no scope passed",
+  async () => {
+    const { datastoreTypeRegistry } = await import(
+      "../domain/datastore/datastore_type_registry.ts"
+    );
+
+    const pullCalls: Array<DatastoreSyncOptions | undefined> = [];
+    const pushCalls: Array<DatastoreSyncOptions | undefined> = [];
+    let globalLockAcquired = false;
+    const typeName = "test-no-capabilities";
+
+    if (!datastoreTypeRegistry.has(typeName)) {
+      datastoreTypeRegistry.register({
+        type: typeName,
+        name: "Test no capabilities",
+        description: "Test extension without capabilities method",
+        isBuiltIn: false,
+        createProvider: () => ({
+          createLock: (_path: string, options?: { lockKey?: string }) => ({
+            acquire: () => {
+              if (!options?.lockKey) globalLockAcquired = true;
+              return Promise.resolve();
+            },
+            release: () => Promise.resolve(),
+            withLock: <T>(fn: () => Promise<T>) => fn(),
+            inspect: () => Promise.resolve(null),
+            forceRelease: () => Promise.resolve(true),
+          }),
+          createVerifier: () => ({
+            verify: () =>
+              Promise.resolve({
+                healthy: true,
+                message: "ok",
+                latencyMs: 1,
+                datastoreType: typeName,
+              }),
+          }),
+          resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+          resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+          createSyncService: () => ({
+            pullChanged: (options?: DatastoreSyncOptions) => {
+              pullCalls.push(options);
+              return Promise.resolve(0);
+            },
+            pushChanged: (options?: DatastoreSyncOptions) => {
+              pushCalls.push(options);
+              return Promise.resolve(0);
+            },
+            markDirty: () => Promise.resolve(),
+          }),
+        }),
+      });
+    }
+
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+      await configureExtensionDatastore(dir, typeName);
+
+      pullCalls.length = 0;
+      pushCalls.length = 0;
+      globalLockAcquired = false;
+
+      const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [{ modelType: "aws-ec2", modelId: "server-1" }],
+        dir,
+      );
+
+      // Pull should have been called without scope
+      assertEquals(pullCalls.length, 1);
+      assertEquals(pullCalls[0]?.scope, undefined);
+
+      await lockResult.flush();
+
+      // Push should have been called without scope
+      assertEquals(pushCalls.length, 1);
+      assertEquals(pushCalls[0]?.scope, undefined);
+
+      // Global lock should have been acquired
+      assertEquals(
+        globalLockAcquired,
+        true,
+        "provider without capabilities must use the global lock",
+      );
+    });
+  },
+);
+
+Deno.test(
+  "acquireModelLocks - scopedSync: true with duplicate models pushes each model exactly once",
+  async () => {
+    const { datastoreTypeRegistry } = await import(
+      "../domain/datastore/datastore_type_registry.ts"
+    );
+
+    const pushCalls: Array<DatastoreSyncOptions | undefined> = [];
+    const typeName = "test-scoped-dedup";
+
+    if (!datastoreTypeRegistry.has(typeName)) {
+      datastoreTypeRegistry.register({
+        type: typeName,
+        name: "Test scoped dedup",
+        description: "Test scoped sync deduplicates models on push",
+        isBuiltIn: false,
+        createProvider: () => ({
+          createLock: () => ({
+            acquire: () => Promise.resolve(),
+            release: () => Promise.resolve(),
+            withLock: <T>(fn: () => Promise<T>) => fn(),
+            inspect: () => Promise.resolve(null),
+            forceRelease: () => Promise.resolve(true),
+          }),
+          createVerifier: () => ({
+            verify: () =>
+              Promise.resolve({
+                healthy: true,
+                message: "ok",
+                latencyMs: 1,
+                datastoreType: typeName,
+              }),
+          }),
+          resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+          resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+          createSyncService: () => ({
+            pullChanged: () => Promise.resolve(0),
+            pushChanged: (options?: DatastoreSyncOptions) => {
+              pushCalls.push(options);
+              return Promise.resolve(0);
+            },
+            markDirty: () => Promise.resolve(),
+          }),
+          capabilities: () => ({ scopedSync: true }),
+        }),
+      });
+    }
+
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+      await configureExtensionDatastore(dir, typeName);
+
+      pushCalls.length = 0;
+
+      const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          { modelType: "aws-ec2", modelId: "server-1" },
+          { modelType: "aws-ec2", modelId: "server-1" },
+        ],
+        dir,
+      );
+
+      await lockResult.flush();
+
+      assertEquals(
+        pushCalls.length,
+        1,
+        "duplicate model must result in exactly one scoped push",
+      );
+      assertEquals(pushCalls[0]?.scope, "data/aws-ec2/server-1");
+    });
+  },
+);

--- a/src/domain/datastore/datastore_provider.ts
+++ b/src/domain/datastore/datastore_provider.ts
@@ -22,6 +22,31 @@ import type { DatastoreVerifier } from "./datastore_health.ts";
 import type { DatastoreSyncService } from "./datastore_sync_service.ts";
 
 /**
+ * Declares which optional features a datastore provider supports.
+ * Absent or returning an empty object means no optional features —
+ * core uses the conservative default behavior for everything.
+ */
+export interface DatastoreCapabilities {
+  /**
+   * When true, the provider's sync service handles scoped push/pull
+   * correctly and its lock implementation supports concurrent per-scope
+   * writes without a global coordination point.
+   *
+   * Core uses this to decide whether per-model push needs the global
+   * lock. When true: per-model push passes `scope` and uses only the
+   * per-model lock. When false/absent: per-model push acquires the
+   * global lock and syncs without scope (current behavior).
+   *
+   * SAFETY INVARIANT: declaring scopedSync: true is a promise that
+   * concurrent scoped pushes to non-overlapping scopes cannot corrupt
+   * shared state. If an extension declares scopedSync: true but cannot
+   * honor it, concurrent pushes will corrupt the remote datastore.
+   * This is a hard contract, not a performance hint.
+   */
+  scopedSync?: boolean;
+}
+
+/**
  * Factory interface for user-defined datastores.
  *
  * Implementations provide the components needed to operate a datastore:
@@ -51,4 +76,10 @@ export interface DatastoreProvider {
    * inferred from a missing property.
    */
   resolveCachePath?(repoDir: string): string | undefined;
+  /**
+   * Declares which optional features this provider supports.
+   * Absent or returning an empty object means no optional features —
+   * core uses the conservative default behavior for everything.
+   */
+  capabilities?(): DatastoreCapabilities;
 }

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -49,6 +49,24 @@ export interface DatastoreSyncOptions {
    * or push consume it.)
    */
   relPath?: string;
+  /**
+   * Prefix scope for pull/push. When set, the implementation MUST sync
+   * at least all files whose cache-relative path starts with this prefix.
+   * It MAY sync additional files (a superset is always safe). When absent,
+   * the implementation syncs the entire datastore (current behavior).
+   *
+   * Scoped pull: only download files matching the prefix.
+   * Scoped push: only upload dirty files matching the prefix.
+   *
+   * Forward-slash-normalized, no trailing slash.
+   * Example: "data/aws-ec2/my-instance"
+   *
+   * Field scope: swamp core only sets this on `pullChanged` and
+   * `pushChanged` calls when the provider declares
+   * `capabilities().scopedSync === true`. Orthogonal to `relPath`
+   * (which is markDirty-only).
+   */
+  scope?: string;
 }
 
 /**

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -54,7 +54,10 @@ export {
   SyncTimeoutError,
 } from "./datastore_sync_service.ts";
 
-export { type DatastoreProvider } from "./datastore_provider.ts";
+export {
+  type DatastoreCapabilities,
+  type DatastoreProvider,
+} from "./datastore_provider.ts";
 
 export {
   type DatastoreTypeInfo,


### PR DESCRIPTION
## Summary

- Add opt-in `DatastoreCapabilities` interface with `scopedSync` flag and optional `capabilities()` method on `DatastoreProvider`
- Add `scope` field to `DatastoreSyncOptions` for prefix-scoped pull/push (orthogonal to `relPath` which is markDirty-only)
- Gate `acquireModelLocks` flush on `scopedSync`: when true, iterate per-model with scoped `pushChanged`/`pullChanged` calls and no global lock; when false/absent, preserve current global-lock behavior unchanged
- Update testing package (`datastore_types.ts`, `datastore_conformance.ts`) so extension authors see the new contract and providers without `capabilities()` still pass conformance

Phase 1 of the scoped sync roadmap documented in `design/datastores.md`. Delivers the framework contracts so document-store backends (e.g. `@keeb/mongodb-datastore`) can declare `scopedSync: true` and benefit immediately. S3/GCS need index partitioning (Phase 3) before they can opt in.

## Test Plan

- [x] `deno check` — all files pass
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 5933 passed, 0 failed
- [x] `deno run compile` — binary compiles successfully
- [x] Testing package compatibility test passes (`testing_package_compat_test.ts`)
- [x] 3 new unit tests: scoped sync path (scope passed to pull/push, no global lock), default-path regression (global lock, no scope), deduplication (duplicate models → one scoped push)
- [x] Manual test: filesystem datastore — model create + method run
- [x] Manual test: S3 datastore against Minio — model create, method run, sync, status (default path, no `scopedSync` declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)