### PR TITLE
fix(workflows): actionable error messages for common workflow authoring mistakes

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -130,7 +130,8 @@ swamp model type describe command/shell --json
     {
       "name": "execute",
       "description": "Execute a shell command and capture output",
-      "arguments": {/* JSON Schema */}
+      "arguments": {/* JSON Schema */},
+      "inputs": {/* JSON Schema (same as arguments) */}
     }
   ]
 }
@@ -139,7 +140,8 @@ swamp model type describe command/shell --json
 **Key fields:**
 
 - `globalArguments` - JSON Schema for input YAML `globalArguments` section
-- `methods` - Available operations with their per-method `arguments` schemas
+- `methods` - Available operations with their per-method `inputs` schemas (also
+  available as `arguments` for backward compatibility)
 
 ## Create Model Inputs
 

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -42,6 +42,27 @@ export const JobDependencySchema = z.object({
  */
 export type JobDependencyData = z.infer<typeof JobDependencySchema>;
 
+const JobDependencyFieldSchema = z.preprocess((data) => {
+  if (Array.isArray(data)) {
+    const hasStrings = data.some((item) => typeof item === "string");
+    if (hasStrings) {
+      const example = typeof data[0] === "string" ? data[0] : "job-name";
+      throw new Error(
+        `dependsOn entries must be objects, not strings.\n\n` +
+          `Replace:\n` +
+          `  dependsOn:\n` +
+          `    - ${example}\n\n` +
+          `With:\n` +
+          `  dependsOn:\n` +
+          `    - job: ${example}\n` +
+          `      condition:\n` +
+          `        type: succeeded`,
+      );
+    }
+  }
+  return data;
+}, z.array(JobDependencySchema).default([]));
+
 /**
  * Zod schema for Job entity.
  */
@@ -49,7 +70,7 @@ export const JobSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
   steps: z.array(StepSchema).min(1),
-  dependsOn: z.array(JobDependencySchema).default([]),
+  dependsOn: JobDependencyFieldSchema,
   weight: z.number().default(0),
   concurrency: z.number().int().nonnegative().optional(),
   driver: DriverFieldSchema,

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -248,3 +248,26 @@ Deno.test("Job.fromData and toData roundtrip correctly", () => {
   assertEquals(restored.dependsOn.length, original.dependsOn.length);
   assertEquals(restored.weight, original.weight);
 });
+
+import { JobSchema } from "./job.ts";
+
+Deno.test("JobSchema throws clear error for string dependsOn entries", () => {
+  assertThrows(
+    () => {
+      JobSchema.parse({
+        name: "deploy",
+        steps: [{
+          name: "step1",
+          task: {
+            type: "model_method",
+            modelIdOrName: "my-model",
+            methodName: "run",
+          },
+        }],
+        dependsOn: ["build-job"],
+      });
+    },
+    Error,
+    "dependsOn entries must be objects, not strings",
+  );
+});

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { Job } from "./job.ts";
+import { Job, JobSchema } from "./job.ts";
 import { Step } from "./step.ts";
 import { StepTask } from "./step_task.ts";
 import { TriggerCondition } from "./trigger_condition.ts";
@@ -248,8 +248,6 @@ Deno.test("Job.fromData and toData roundtrip correctly", () => {
   assertEquals(restored.dependsOn.length, original.dependsOn.length);
   assertEquals(restored.weight, original.weight);
 });
-
-import { JobSchema } from "./job.ts";
 
 Deno.test("JobSchema throws clear error for string dependsOn entries", () => {
   assertThrows(

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -57,6 +57,27 @@ export type StepDependencyData = z.infer<typeof StepDependencySchema>;
  */
 export type ForEachData = z.infer<typeof ForEachSchema>;
 
+const StepDependencyFieldSchema = z.preprocess((data) => {
+  if (Array.isArray(data)) {
+    const hasStrings = data.some((item) => typeof item === "string");
+    if (hasStrings) {
+      const example = typeof data[0] === "string" ? data[0] : "step-name";
+      throw new Error(
+        `dependsOn entries must be objects, not strings.\n\n` +
+          `Replace:\n` +
+          `  dependsOn:\n` +
+          `    - ${example}\n\n` +
+          `With:\n` +
+          `  dependsOn:\n` +
+          `    - step: ${example}\n` +
+          `      condition:\n` +
+          `        type: succeeded`,
+      );
+    }
+  }
+  return data;
+}, z.array(StepDependencySchema).default([]));
+
 /**
  * Zod schema for Step entity.
  */
@@ -65,7 +86,7 @@ export const StepSchema = z.object({
   description: z.string().optional(),
   task: StepTaskSchema,
   forEach: ForEachSchema.optional(),
-  dependsOn: z.array(StepDependencySchema).default([]),
+  dependsOn: StepDependencyFieldSchema,
   weight: z.number().default(0),
   concurrency: z.number().int().nonnegative().optional(),
   dataOutputOverrides: z.array(DataOutputOverrideSchema).optional(),

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -63,6 +63,18 @@ export const StepTaskSchema = z.preprocess((data) => {
           `      command: "your-command-here"`,
       );
     }
+    if ("arguments" in d && !("inputs" in d)) {
+      throw new Error(
+        `Unknown field "arguments" in step task. Did you mean "inputs"?\n\n` +
+          `Example:\n` +
+          `  task:\n` +
+          `    type: model_method\n` +
+          `    modelIdOrName: my-model\n` +
+          `    methodName: run\n` +
+          `    inputs:\n` +
+          `      param: value`,
+      );
+    }
     if (d.type === "model_method") {
       const hasExisting = "modelIdOrName" in d && d.modelIdOrName;
       const hasDirect = "modelType" in d && d.modelType;

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -283,3 +283,18 @@ Deno.test("StepTaskSchema rejects neither modelIdOrName nor modelType", () => {
     "requires either modelIdOrName or modelType",
   );
 });
+
+Deno.test("StepTaskSchema throws clear error for arguments instead of inputs", () => {
+  assertThrows(
+    () => {
+      StepTaskSchema.parse({
+        type: "model_method",
+        modelIdOrName: "my-model",
+        methodName: "run",
+        arguments: { key: "value" },
+      });
+    },
+    Error,
+    'Did you mean "inputs"',
+  );
+});

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { Step } from "./step.ts";
+import { assertEquals, assertThrows } from "@std/assert";
+import { Step, StepSchema } from "./step.ts";
 import { StepTask } from "./step_task.ts";
 import { TriggerCondition } from "./trigger_condition.ts";
 
@@ -356,4 +356,22 @@ Deno.test("Step.fromData and toData roundtrip with forEach", () => {
   assertEquals(restored.name, original.name);
   assertEquals(restored.forEach?.item, original.forEach?.item);
   assertEquals(restored.forEach?.in, original.forEach?.in);
+});
+
+Deno.test("StepSchema throws clear error for string dependsOn entries", () => {
+  assertThrows(
+    () => {
+      StepSchema.parse({
+        name: "deploy",
+        task: {
+          type: "model_method",
+          modelIdOrName: "my-model",
+          methodName: "run",
+        },
+        dependsOn: ["build-step"],
+      });
+    },
+    Error,
+    "dependsOn entries must be objects, not strings",
+  );
 });

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -103,7 +103,7 @@ export class YamlWorkflowRepository implements WorkflowRepository {
                 .warn`Skipping workflow ${workflowName}: uses deprecated 'shell' task. Delete or update to 'type: model_method' with 'command/shell'. File: ${path}`;
             } else {
               logger
-                .warn`Skipping broken workflow ${workflowName}: ${errorMsg}. File: ${path}`;
+                .warn`Skipping broken workflow ${workflowName}: ${errorMsg}. Run 'swamp doctor workflows --json' to see all errors. File: ${path}`;
             }
           }
         }

--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -46,6 +46,7 @@ export interface MethodDescribeData {
   name: string;
   description: string;
   arguments: object;
+  inputs: object;
   dataOutputSpecs?: DataOutputSpecDescribeData[];
 }
 
@@ -220,10 +221,12 @@ export function toMethodDescribeData(
 
   const dataOutputSpecs = [...resourceSpecs, ...fileSpecs];
 
+  const schema = zodToJsonSchema(method.arguments);
   return {
     name,
     description: method.description,
-    arguments: zodToJsonSchema(method.arguments),
+    arguments: schema,
+    inputs: schema,
     dataOutputSpecs: dataOutputSpecs.length > 0 ? dataOutputSpecs : undefined,
   };
 }

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -572,7 +572,7 @@ export async function* workflowRun(
 export function workflowNotFound(idOrName: string): SwampError {
   return {
     code: "workflow_not_found",
-    message: `Workflow not found: ${idOrName}. ` +
+    message: `Workflow not found: ${idOrName}.\n` +
       `Create it with 'swamp workflow create ${idOrName}', ` +
       `or run 'swamp doctor workflows --json' to check for broken workflow files`,
   };

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -572,7 +572,9 @@ export async function* workflowRun(
 export function workflowNotFound(idOrName: string): SwampError {
   return {
     code: "workflow_not_found",
-    message: `Workflow not found: ${idOrName}`,
+    message: `Workflow not found: ${idOrName}. ` +
+      `Create it with 'swamp workflow create ${idOrName}', ` +
+      `or run 'swamp doctor workflows --json' to check for broken workflow files`,
   };
 }
 

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -386,7 +386,8 @@ Deno.test("workflowNotFound returns correct error", () => {
   assertEquals(error.code, "workflow_not_found");
   assertEquals(
     error.message,
-    "Workflow not found: my-wf. Create it with 'swamp workflow create my-wf', " +
+    "Workflow not found: my-wf.\n" +
+      "Create it with 'swamp workflow create my-wf', " +
       "or run 'swamp doctor workflows --json' to check for broken workflow files",
   );
 });

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -384,7 +384,11 @@ Deno.test("workflowRun completed event contains WorkflowRunData", async () => {
 Deno.test("workflowNotFound returns correct error", () => {
   const error = workflowNotFound("my-wf");
   assertEquals(error.code, "workflow_not_found");
-  assertEquals(error.message, "Workflow not found: my-wf");
+  assertEquals(
+    error.message,
+    "Workflow not found: my-wf. Create it with 'swamp workflow create my-wf', " +
+      "or run 'swamp doctor workflows --json' to check for broken workflow files",
+  );
 });
 
 Deno.test("workflowExecutionFailed wraps error", () => {

--- a/src/presentation/output/type_describe_output_test.ts
+++ b/src/presentation/output/type_describe_output_test.ts
@@ -50,6 +50,13 @@ const testData: TypeDescribeData = {
         },
         required: ["message"],
       },
+      inputs: {
+        type: "object",
+        properties: {
+          message: { type: "string", minLength: 1 },
+        },
+        required: ["message"],
+      },
     },
   ],
 };
@@ -73,6 +80,13 @@ const testDataWithSpecs: TypeDescribeData = {
       name: "create",
       description: "Create a new VPC",
       arguments: {
+        type: "object",
+        properties: {
+          cidrBlock: { type: "string" },
+        },
+        required: ["cidrBlock"],
+      },
+      inputs: {
         type: "object",
         properties: {
           cidrBlock: { type: "string" },

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -93,7 +93,7 @@ export function formatMethodLines(methods: MethodDescribeData[]): string[] {
       "      ",
     );
     if (methodAttrs.length > 0) {
-      lines.push(`    ${cyan("Arguments:")}`);
+      lines.push(`    ${cyan("Inputs:")}`);
       lines.push(...methodAttrs);
     }
 

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -89,7 +89,7 @@ export function formatMethodLines(methods: MethodDescribeData[]): string[] {
     );
 
     const methodAttrs = formatSchemaAttributes(
-      method.arguments,
+      method.inputs,
       "      ",
     );
     if (methodAttrs.length > 0) {

--- a/src/presentation/renderers/model_method_describe.ts
+++ b/src/presentation/renderers/model_method_describe.ts
@@ -47,10 +47,10 @@ class LogModelMethodDescribeRenderer
           } ${data.method.description}`,
         );
 
-        const argAttrs = formatSchemaAttributes(data.method.arguments, "  ");
+        const argAttrs = formatSchemaAttributes(data.method.inputs, "  ");
         if (argAttrs.length > 0) {
           lines.push("");
-          lines.push(bold(cyan("Arguments:")));
+          lines.push(bold(cyan("Inputs:")));
           lines.push(...argAttrs);
         }
 

--- a/src/presentation/renderers/model_method_describe_test.ts
+++ b/src/presentation/renderers/model_method_describe_test.ts
@@ -31,6 +31,7 @@ const testData = {
     name: "run",
     description: "Run the command",
     arguments: { type: "object", properties: {}, required: [] },
+    inputs: { type: "object", properties: {}, required: [] },
     dataOutputSpecs: [],
   },
 };

--- a/src/presentation/renderers/type_describe_test.ts
+++ b/src/presentation/renderers/type_describe_test.ts
@@ -31,6 +31,7 @@ const testData = {
       name: "run",
       description: "Run",
       arguments: { type: "object", properties: {}, required: [] },
+      inputs: { type: "object", properties: {}, required: [] },
       dataOutputSpecs: [],
     },
   ],


### PR DESCRIPTION
## Summary

Benchmark analysis (k8s-debug-v2) showed 35% of agent turns were spent on
workflow authoring errors that could have been caught or guided by better error
messages. The agent hit 6 sequential errors before succeeding — each one
discoverable only by running the workflow and parsing failure output.

This PR adds actionable error messages at the point of failure:

- **`arguments` → `inputs` detection** — step task preprocessing now catches
  `arguments:` (wrong) and suggests `inputs:` (correct) with an example. Root
  cause: `swamp model type describe` showed "Arguments:" which agents
  copy into workflow YAML.
- **String `dependsOn` detection** — job and step schemas now detect bare
  strings in `dependsOn` arrays and show the required `{ job, condition }`
  object format instead of a raw Zod validation dump.
- **"Workflow not found" guidance** — now suggests both `swamp workflow create`
  and `swamp doctor workflows --json` so agents can self-recover.
- **"Skipping broken workflow" guidance** — warns suggest
  `swamp doctor workflows --json` to see all errors at once.
- **Terminology alignment** — method parameters header renamed from
  "Arguments:" to "Inputs:" in log output; `inputs` field added alongside
  `arguments` in JSON output (backward compatible).

## Test plan

- [x] New test: `arguments` in step task throws clear error
- [x] New test: string `dependsOn` in job throws clear error
- [x] Updated test: `workflowNotFound` message includes create + doctor guidance
- [x] All 5939 tests pass, `deno check` clean, `deno lint` clean
- [x] Binary compiles successfully
- [x] Verified in benchmark re-runs: "Workflow not found" with guidance caused
  1-step recovery; `inputs` field in JSON output prevented the arguments/inputs
  confusion entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)