### PR TITLE
fix(workflows): validate honors method args set in model definition (swamp-club#359)

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -66,9 +66,19 @@ export class WorkflowValidationResult {
 
 /**
  * Result of resolving a method's required arguments.
+ *
+ * `definitionProvidedArgs` carries the keys of arguments already populated
+ * on the resolved definition — both `methods.<methodName>.arguments` and
+ * `globalArguments`. The runtime merges these as fallbacks under step-level
+ * inputs (see DefaultMethodExecutionService.execute), so the validator must
+ * treat them as satisfied when checking required arguments.
  */
 export type MethodResolution =
-  | { status: "resolved"; requiredArgs: string[] }
+  | {
+    status: "resolved";
+    requiredArgs: string[];
+    definitionProvidedArgs?: string[];
+  }
   | { status: "model_not_found" }
   | { status: "method_not_found"; modelType: string }
   | { status: "type_unresolvable"; modelType: string };
@@ -439,9 +449,12 @@ export class DefaultWorkflowValidationService
           ),
         ];
       case "resolved": {
-        const inputKeys = new Set(Object.keys(inputs ?? {}));
+        const provided = new Set<string>([
+          ...Object.keys(inputs ?? {}),
+          ...(resolution.definitionProvidedArgs ?? []),
+        ]);
         const missing = resolution.requiredArgs.filter((arg) =>
-          !inputKeys.has(arg)
+          !provided.has(arg)
         );
         if (missing.length > 0) {
           return [

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -765,6 +765,164 @@ Deno.test("validateStepInputs: method with no required args and no inputs passes
   assertEquals(inputResult?.passed, true);
 });
 
+// --- Definition-provided arguments (issue #359) ---
+
+Deno.test("validateStepInputs: passes when definition provides all required args", async () => {
+  const resolver = mockResolver({
+    "shell.execute": {
+      status: "resolved",
+      requiredArgs: ["run"],
+      definitionProvidedArgs: ["run"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("shell", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: passes when definition and step inputs together cover required args", async () => {
+  const resolver = mockResolver({
+    "deploy.run": {
+      status: "resolved",
+      requiredArgs: ["environment", "version"],
+      definitionProvidedArgs: ["environment"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("deploy", "run", { version: "1.0" }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: fails only on truly missing args when definition supplies some", async () => {
+  const resolver = mockResolver({
+    "deploy.run": {
+      status: "resolved",
+      requiredArgs: ["environment", "version", "region"],
+      definitionProvidedArgs: ["environment"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("deploy", "run", { version: "1.0" }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error, "Missing required inputs: region");
+});
+
+Deno.test("validateStepInputs: definition and step inputs overlap on the same key (no double-count, still passes)", async () => {
+  const resolver = mockResolver({
+    "shell.execute": {
+      status: "resolved",
+      requiredArgs: ["run"],
+      definitionProvidedArgs: ["run"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("shell", "execute", {
+              run: "echo override",
+            }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+Deno.test("validateStepInputs: missing definitionProvidedArgs field preserves legacy behavior", async () => {
+  // Mocks written before issue #359 omit definitionProvidedArgs entirely.
+  // The validator must treat the field as empty (no args provided by the
+  // definition) so existing behavior is unchanged.
+  const resolver = mockResolver({
+    "my-model.deploy": {
+      status: "resolved",
+      requiredArgs: ["environment"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "deploy"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("environment"), true);
+});
+
 Deno.test("validateStepInputs: skips dynamic CEL model reference", async () => {
   const resolver = mockResolver({});
   const svc = new DefaultWorkflowValidationService(resolver);

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -120,7 +120,20 @@ function createModelMethodResolver(
       };
       const requiredArgs = jsonSchema.required ?? [];
 
-      return { status: "resolved", requiredArgs };
+      // Arguments the definition already supplies — runtime merges these as
+      // fallbacks under step-level inputs (see DefaultMethodExecutionService).
+      // The validator treats any defined key as "present" regardless of value,
+      // including unresolved ${{ ... }} expressions: invalid CEL is a runtime
+      // concern, not a validator concern.
+      const { definition } = lookupResult;
+      const definitionProvidedArgs = Array.from(
+        new Set([
+          ...Object.keys(definition.getMethodArguments(methodName)),
+          ...Object.keys(definition.globalArguments),
+        ]),
+      );
+
+      return { status: "resolved", requiredArgs, definitionProvidedArgs };
     },
   };
 }


### PR DESCRIPTION
## Summary

- `swamp workflow validate` falsely reported `Missing required inputs: <arg>` for `model_method` steps whose argument was supplied by the model definition (`methods.<method>.arguments` or `globalArguments`) instead of the step's `inputs:` block.
- Validation check #8 inspected only the step `inputs:` and ignored definition-supplied args, even though the runtime executor merges them as fallbacks — workflows ran fine; only `validate` was wrong.
- Fixes swamp-club#359.

## Approach

- Enriches the `MethodResolution` (resolved variant) with an optional `definitionProvidedArgs: string[]`.
- `createModelMethodResolver` populates it from `definition.getMethodArguments(method)` ∪ `definition.globalArguments`, mirroring the runtime merge in `DefaultMethodExecutionService.execute`.
- `validateModelMethodInputs` unions step inputs with `definitionProvidedArgs` when computing the missing-arg set.
- Optional field with `?? []` fallback preserves backward compatibility for any existing `MethodResolution` constructions.

## Test Plan

- 5 new unit tests in `validation_service_test.ts` covering: definition supplies all, partial split with step inputs, partial unsatisfied (error names only the truly-missing key), step+definition overlap, and legacy-mock backward compat.
- End-to-end repro in `/tmp/swamp-repro-issue-359` (command/shell model with `methods.execute.arguments.run` set, workflow step with no `inputs:`): `swamp workflow validate` now passes 8/8 and `swamp workflow run` still succeeds.
- Negative repro (no definition args, no step inputs): still correctly fails with `Missing required inputs: run`.
- `deno check`, `deno lint`, `deno fmt`, `deno run test` (5952 passed, 0 failed), `deno run compile` — all green.

## Follow-up

- Will file a UAT issue in `systeminit/swamp-uat` to cover this scenario in `tests/cli/workflow/validate_test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)