### PR TITLE
fix(data): accept string type in getContent, findByName, findAllForModel (swamp-club#364)

### DIFF
--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -19,7 +19,7 @@
 
 import type { Data } from "./data.ts";
 import type { DataId } from "./data_id.ts";
-import type { ModelType } from "../models/model_type.ts";
+import type { ModelType, ModelTypeInput } from "../models/model_type.ts";
 
 /**
  * Error thrown when ownership validation fails.
@@ -70,7 +70,7 @@ export interface UnifiedDataRepository {
    * @returns The data if found, or null
    */
   findByName(
-    type: ModelType,
+    type: ModelTypeInput,
     modelId: string,
     dataName: string,
     version?: number,
@@ -113,7 +113,7 @@ export interface UnifiedDataRepository {
    * @param modelId - The model input ID
    * @returns Array of data (latest version of each)
    */
-  findAllForModel(type: ModelType, modelId: string): Promise<Data[]>;
+  findAllForModel(type: ModelTypeInput, modelId: string): Promise<Data[]>;
 
   /**
    * Saves data with its content, creating a new version.
@@ -174,7 +174,7 @@ export interface UnifiedDataRepository {
    * @returns The content or null if not found
    */
   getContent(
-    type: ModelType,
+    type: ModelTypeInput,
     modelId: string,
     dataName: string,
     version?: number,

--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -172,3 +172,10 @@ export class ModelType {
     return ModelType.RESERVED_COLLECTIVES.includes(firstSegment);
   }
 }
+
+export type ModelTypeInput = string | ModelType;
+
+export function coerceModelType(input: ModelTypeInput): ModelType {
+  if (input instanceof ModelType) return input;
+  return ModelType.create(input);
+}

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -32,7 +32,11 @@ import {
   type OwnerDefinition,
   parseDataDuration,
 } from "../../domain/data/mod.ts";
-import { ModelType } from "../../domain/models/model_type.ts";
+import {
+  coerceModelType,
+  ModelType,
+  type ModelTypeInput,
+} from "../../domain/models/model_type.ts";
 import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import type { CatalogStore } from "./catalog_store.ts";
 import {
@@ -330,12 +334,18 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   findByName(
-    type: ModelType,
+    type: ModelTypeInput,
     modelId: string,
     dataName: string,
     version?: number,
   ): Promise<Data | null> {
-    return this.findByNameWithDepth(type, modelId, dataName, version, 0);
+    return this.findByNameWithDepth(
+      coerceModelType(type),
+      modelId,
+      dataName,
+      version,
+      0,
+    );
   }
 
   private async findByNameWithDepth(
@@ -443,7 +453,11 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return versions.sort((a, b) => a - b);
   }
 
-  async findAllForModel(type: ModelType, modelId: string): Promise<Data[]> {
+  async findAllForModel(
+    type: ModelTypeInput,
+    modelId: string,
+  ): Promise<Data[]> {
+    type = coerceModelType(type);
     const dataDir = this.getModelDataDir(type, modelId);
     const results: Data[] = [];
     const seen = new Set<string>();
@@ -640,11 +654,12 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   async getContent(
-    type: ModelType,
+    type: ModelTypeInput,
     modelId: string,
     dataName: string,
     version?: number,
   ): Promise<Uint8Array | null> {
+    type = coerceModelType(type);
     const versionToRead = version ??
       await this.getLatestVersion(type, modelId, dataName);
     if (versionToRead === null) return null;

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -835,3 +835,86 @@ Deno.test(
     });
   },
 );
+
+Deno.test("getContent: accepts string type parameter", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    const data = makeData("string-type-content");
+    const content = new TextEncoder().encode("hello");
+    await repo.save(testType, "model-1", data, content);
+
+    const result = await repo.getContent(
+      "test/model",
+      "model-1",
+      "string-type-content",
+    );
+    assertExists(result);
+    assertEquals(new TextDecoder().decode(result), "hello");
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("findByName: accepts string type parameter", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    const data = makeData("string-type-find");
+    const content = new TextEncoder().encode("data");
+    await repo.save(testType, "model-1", data, content);
+
+    const result = await repo.findByName(
+      "test/model",
+      "model-1",
+      "string-type-find",
+    );
+    assertExists(result);
+    assertEquals(result.name, "string-type-find");
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("findAllForModel: accepts string type parameter", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    const data = makeData("string-type-all");
+    const content = new TextEncoder().encode("data");
+    await repo.save(testType, "model-1", data, content);
+
+    const results = await repo.findAllForModel("test/model", "model-1");
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "string-type-all");
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Production `UnifiedDataRepository.getContent()` required a `ModelType` object, but workflow-scope reports only have `step.modelType` as a string — calling `getContent(string, ...)` threw `TypeError: type.toDirectoryPath is not a function`
- The testing helper (`TestDataRepository`) accepted strings, so extension tests passed but production failed at runtime
- Added `ModelTypeInput` type alias (`string | ModelType`) and `coerceModelType()` helper, then widened `findByName`, `getContent`, and `findAllForModel` to accept strings at the domain port and coerce in the production implementation

## Test Plan

- Added 3 unit tests verifying string-typed calls to `getContent`, `findByName`, and `findAllForModel` return correct results
- Full test suite passes (5956 passed, 0 failed)
- Reproduced the bug in a scratch repo with a workflow-scope report calling `getContent(step.modelType, ...)` — confirmed `type.toDirectoryPath is not a function` error before fix, and successful data reads after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)