### PR TITLE
fix(reports): persist fallback error artifact when report execute() throws (swamp-club#365)

### DIFF
--- a/.claude/skills/swamp-report/references/report-types.md
+++ b/.claude/skills/swamp-report/references/report-types.md
@@ -121,6 +121,25 @@ reportRegistry.getByScope("method"); // Array<{ name, report }>
 
 Names must be unique — `register()` throws on duplicates.
 
+## Error Handling (Throw Semantics)
+
+If `execute()` throws, the error is **advisory** — it does not fail the workflow
+or change the exit code. Swamp persists a fallback error artifact under the same
+data name so `swamp data get report-{name}-json` returns structured error info:
+
+```json
+{
+  "error": true,
+  "reportName": "@example/failing-report",
+  "scope": "workflow",
+  "message": "the error message from the throw"
+}
+```
+
+Consumers should check the `error` field to distinguish success from failure. If
+your report needs to signal a gate/policy failure to downstream automation,
+return normally with the gate decision in the JSON output rather than throwing.
+
 ## Report Selection Schema (YAML)
 
 ```typescript

--- a/design/reports.md
+++ b/design/reports.md
@@ -327,6 +327,36 @@ Both artifacts are written with:
 Data handles are returned in the `ReportExecutionResult` and included in the
 final view.
 
+## Error Handling
+
+Report `execute()` throws are **advisory** — they do not fail the workflow or
+change the exit code. A broken report must not mask a successful workflow run.
+
+When `execute()` throws, swamp generates a fallback error artifact using the
+built-in `buildReportErrorResult` function
+(`src/domain/reports/builtin/report_error_report.ts`). The fallback artifact is
+persisted under the **same data name** as the original report would have used,
+so `swamp data get report-{reportName}-json` still returns useful diagnostic
+data.
+
+The fallback JSON artifact contains:
+
+```json
+{
+  "error": true,
+  "reportName": "@example/failing-report",
+  "scope": "workflow",
+  "message": "the error message from the throw"
+}
+```
+
+Consumers can check the `error` field to distinguish a successful report result
+from a fallback error artifact.
+
+If persisting the fallback artifact itself fails, the error is silently absorbed
+to avoid masking the original report error. In this case, only the `WRN` log
+line carries the error information.
+
 ## Sensitive Argument Redaction
 
 Report contexts include an optional `redactSensitiveArgs` helper that replaces

--- a/src/domain/reports/builtin/report_error_report.ts
+++ b/src/domain/reports/builtin/report_error_report.ts
@@ -1,0 +1,46 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ReportResult } from "../report.ts";
+import type { ReportScope } from "../report.ts";
+
+export function buildReportErrorResult(
+  reportName: string,
+  scope: ReportScope,
+  errorMessage: string,
+): ReportResult {
+  const markdown = [
+    `# Report Error: ${reportName}`,
+    "",
+    `The report \`${reportName}\` (scope: ${scope}) threw an error during execution.`,
+    "",
+    "## Error",
+    "",
+    errorMessage,
+  ].join("\n");
+
+  const json: Record<string, unknown> = {
+    error: true,
+    reportName,
+    scope,
+    message: errorMessage,
+  };
+
+  return { markdown, json };
+}

--- a/src/domain/reports/builtin/report_error_report_test.ts
+++ b/src/domain/reports/builtin/report_error_report_test.ts
@@ -1,0 +1,59 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { buildReportErrorResult } from "./report_error_report.ts";
+
+Deno.test("buildReportErrorResult: markdown includes report name and error message", () => {
+  const result = buildReportErrorResult(
+    "@example/my-audit",
+    "workflow",
+    "gate tripped: 3 finding(s)",
+  );
+
+  assertStringIncludes(result.markdown, "# Report Error: @example/my-audit");
+  assertStringIncludes(result.markdown, "scope: workflow");
+  assertStringIncludes(result.markdown, "## Error");
+  assertStringIncludes(result.markdown, "gate tripped: 3 finding(s)");
+});
+
+Deno.test("buildReportErrorResult: json contains error flag and details", () => {
+  const result = buildReportErrorResult(
+    "@example/my-audit",
+    "workflow",
+    "gate tripped: 3 finding(s)",
+  );
+
+  assertEquals(result.json.error, true);
+  assertEquals(result.json.reportName, "@example/my-audit");
+  assertEquals(result.json.scope, "workflow");
+  assertEquals(result.json.message, "gate tripped: 3 finding(s)");
+});
+
+Deno.test("buildReportErrorResult: works for method scope", () => {
+  const result = buildReportErrorResult(
+    "@org/cost-check",
+    "method",
+    "connection timeout",
+  );
+
+  assertStringIncludes(result.markdown, "scope: method");
+  assertEquals(result.json.scope, "method");
+  assertEquals(result.json.reportName, "@org/cost-check");
+});

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -31,6 +31,7 @@ import {
   getNestedValue,
   setNestedValue,
 } from "../models/sensitive_field_extractor.ts";
+import { buildReportErrorResult } from "./builtin/report_error_report.ts";
 
 /**
  * Options for filtering which reports to execute.
@@ -280,7 +281,12 @@ export interface ReportEventCallback {
     json: Record<string, unknown>,
     dataHandles: DataHandle[],
   ): void;
-  onReportFailed(reportName: string, scope: ReportScope, error: string): void;
+  onReportFailed(
+    reportName: string,
+    scope: ReportScope,
+    error: string,
+    dataHandles?: DataHandle[],
+  ): void;
 }
 
 /**
@@ -422,13 +428,41 @@ export async function executeReports(
         ? error.message
         : String(error);
 
-      events?.onReportFailed(name, report.scope, errorMessage);
+      // Persist a fallback error artifact so diagnostic data is not lost.
+      let errorDataHandles: DataHandle[] | undefined;
+      try {
+        const fallback = buildReportErrorResult(
+          name,
+          report.scope,
+          errorMessage,
+        );
+        errorDataHandles = await persistReportData(
+          context.dataRepository,
+          modelType,
+          modelId,
+          name,
+          report.scope,
+          fallback.markdown,
+          fallback.json,
+          varySuffix,
+        );
+      } catch {
+        // Best-effort — don't mask the original report error.
+      }
+
+      events?.onReportFailed(
+        name,
+        report.scope,
+        errorMessage,
+        errorDataHandles,
+      );
 
       results.push({
         name,
         scope: report.scope,
         success: false,
         error: errorMessage,
+        dataHandles: errorDataHandles,
       });
       failures++;
     }

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -1393,3 +1393,122 @@ Deno.test("buildRedactSensitiveArgs: redacts array-typed sensitive method args t
   // Non-sensitive fields are preserved
   assertEquals(results!.redactedMethod.name, "test-step");
 });
+
+// --- executeReports error fallback tests ---
+
+function makeThrowingReport(
+  scope: "method" | "model" | "workflow" = "method",
+  errorMessage = "report threw",
+): ReportDefinition {
+  return {
+    description: `Throwing ${scope} report`,
+    scope,
+    execute(_context: ReportContext) {
+      return Promise.reject(new Error(errorMessage));
+    },
+  };
+}
+
+Deno.test("executeReports: persists fallback error artifact when execute() throws", async () => {
+  const registry = new ReportRegistry();
+  registry.register(
+    "@test/throwing",
+    makeThrowingReport("method", "gate tripped"),
+  );
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/throwing"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(summary.failures, 1);
+  assertEquals(summary.results.length, 1);
+  assertEquals(summary.results[0].success, false);
+  assertEquals(summary.results[0].error, "gate tripped");
+
+  // Fallback error artifact should be persisted
+  assertEquals(saved.length, 2);
+  assertEquals(saved[0].name, "report-test-throwing");
+  assertEquals(saved[1].name, "report-test-throwing-json");
+
+  // Markdown artifact contains error details
+  assertStringIncludes(saved[0].content, "Report Error: @test/throwing");
+  assertStringIncludes(saved[0].content, "gate tripped");
+
+  // JSON artifact contains structured error
+  const json = JSON.parse(saved[1].content);
+  assertEquals(json.error, true);
+  assertEquals(json.reportName, "@test/throwing");
+  assertEquals(json.message, "gate tripped");
+});
+
+Deno.test("executeReports: error result includes data handles from fallback", async () => {
+  const registry = new ReportRegistry();
+  registry.register("@test/throwing-handles", makeThrowingReport("method"));
+
+  const { repo } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/throwing-handles"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(summary.results[0].success, false);
+  assertEquals(summary.results[0].dataHandles !== undefined, true);
+  assertEquals(summary.results[0].dataHandles!.length, 2);
+});
+
+Deno.test("executeReports: onReportFailed callback receives data handles", async () => {
+  const registry = new ReportRegistry();
+  registry.register("@test/throwing-cb", makeThrowingReport("method"));
+
+  const { repo } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  let failedHandles: DataHandle[] | undefined;
+  const events = {
+    onReportStarted: () => {},
+    onReportCompleted: () => {},
+    onReportFailed: (
+      _name: string,
+      _scope: string,
+      _error: string,
+      dataHandles?: DataHandle[],
+    ) => {
+      failedHandles = dataHandles;
+    },
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/throwing-cb"] },
+    {},
+    events,
+    "run",
+  );
+
+  assertEquals(failedHandles !== undefined, true);
+  assertEquals(failedHandles!.length, 2);
+});

--- a/src/domain/workflows/method_report_runner.ts
+++ b/src/domain/workflows/method_report_runner.ts
@@ -138,7 +138,7 @@ export class MethodReportRunner {
           });
         }
       },
-      onReportFailed: (name, scope, error) => {
+      onReportFailed: (name, scope, error, dataHandles) => {
         args.emitEvent?.({
           kind: "report_failed",
           reportName: name,
@@ -147,6 +147,16 @@ export class MethodReportRunner {
           jobId: args.jobName,
           stepId: args.stepName,
         });
+        if (dataHandles) {
+          for (const handle of dataHandles) {
+            collected.push({
+              dataId: handle.dataId,
+              name: handle.name,
+              version: handle.version,
+              tags: handle.tags,
+            });
+          }
+        }
       },
     };
 
@@ -242,7 +252,7 @@ export class MethodReportRunner {
             stepId: args.stepName,
           });
         },
-        onReportFailed: (name, scope, reportError) => {
+        onReportFailed: (name, scope, reportError, _dataHandles) => {
           args.emitEvent?.({
             kind: "report_failed",
             reportName: name,

--- a/src/domain/workflows/workflow_report_runner.ts
+++ b/src/domain/workflows/workflow_report_runner.ts
@@ -115,13 +115,23 @@ export class WorkflowReportRunner {
           });
         }
       },
-      onReportFailed: (name, scope, error) => {
+      onReportFailed: (name, scope, error, dataHandles) => {
         args.emitEvent?.({
           kind: "report_failed",
           reportName: name,
           scope,
           error,
         });
+        if (dataHandles) {
+          for (const handle of dataHandles) {
+            collected.push({
+              dataId: handle.dataId,
+              name: handle.name,
+              version: handle.version,
+              tags: handle.tags,
+            });
+          }
+        }
       },
     };
 

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -155,7 +155,7 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
       },
       report_failed: (e) => {
         getRunLogger(this.modelName, this.methodName).warn(
-          "Running report: {reportName} \u2192 \u2717 {error}",
+          "Report {reportName} failed, fell back to default error report: {error}",
           { reportName: e.reportName, error: e.error },
         );
       },

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -170,7 +170,7 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
       },
       report_failed: (e) => {
         getWorkflowRunLogger(this.workflowName).warn(
-          "Running report: {reportName} \u2192 \u2717 {error}",
+          "Report {reportName} failed, fell back to default error report: {error}",
           { reportName: e.reportName, error: e.error },
         );
       },


### PR DESCRIPTION
## Summary

- When a report's `execute()` throws, swamp now persists a built-in fallback error artifact (markdown + JSON) instead of silently discarding the output
- Workflow status and exit code are unchanged — report failures remain advisory (a broken report must not fail an infra workflow with downstream success triggers)
- The WRN log now reads "Report X failed, fell back to default error report: ..." so users understand what happened
- Error artifacts are discoverable via `swamp data get report-<name>-json` with `{ error: true, reportName, scope, message }`

Closes swamp-club#365

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — 5959 passed, 0 failed
- [x] `deno run compile` succeeds
- [x] Verified against reproduction: workflow with throwing report shows "succeeded", exit 0, and error artifact persisted at `report-<name>-json`
- [x] Verified `swamp data get --workflow <wf> report-<name>-json` returns `{ error: true, ... }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)