### PR TITLE
fix(skills): correct vault read trigger to read-secret (swamp-club#370)

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -7,7 +7,7 @@ description: >
   creating custom vault TypeScript implementations (that is swamp-extension).
   Triggers on "vault", "secret", "secrets", "swamp vault", "store secret",
   "get secret", "vault expression", "aws secrets manager", "credential
-  storage", "vault create", "vault put", "vault read", "vault list-keys",
+  storage", "vault create", "vault put", "vault read-secret", "vault list-keys",
   "vault migrate".
 ---
 


### PR DESCRIPTION
## Summary

- The swamp-vault skill frontmatter listed `"vault read"` as a trigger phrase, which misled agents into constructing `swamp vault read` — a command that doesn't exist. Changed to `"vault read-secret"` to match the actual CLI subcommand.

## Test Plan

- [x] Verified the SKILL.md body already uses `read-secret` correctly (Quick Reference table, examples)
- [x] Confirmed CLI only has `read-secret` with no `read` alias (`swamp help vault`)
- [x] Confirmed swamp-club manual docs already use `read-secret` correctly
- [x] `deno fmt --check` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)