### PR TITLE
fix(expressions): tolerate invalid CEL syntax inside prose strings (swamp-club#291)

### DIFF
--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -165,6 +165,13 @@ export class ExpressionEvaluationService {
         continue;
       }
 
+      // Skip syntactically-invalid CEL: the ${{ ... }} sequence appears
+      // inside a prose string (e.g. a plan body that documents expression
+      // syntax). Leaving the raw text in place preserves prose round-trip.
+      if (!this.celEvaluator.validate(expr.celExpression).valid) {
+        continue;
+      }
+
       const value = await this.celEvaluator.evaluateAsync(
         expr.celExpression,
         context,
@@ -477,6 +484,14 @@ export class ExpressionEvaluationService {
     const secretBag = new VaultSecretBag();
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
+      // Skip syntactically-invalid CEL: the ${{ ... }} sequence appears
+      // inside a prose string (e.g. a plan body that documents env.* /
+      // vault.get() syntax). Leaving the raw text in place preserves
+      // prose round-trip; real misconfigurations still throw at evaluate.
+      if (!this.celEvaluator.validate(expr.celExpression).valid) {
+        continue;
+      }
+
       // Resolve vault references first (if any), then evaluate the full CEL
       let resolvedCelExpr = expr.celExpression;
       if (containsVaultExpression(expr.celExpression)) {
@@ -564,6 +579,14 @@ export class ExpressionEvaluationService {
   ): Promise<Definition> {
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
+      // Skip syntactically-invalid CEL: the ${{ ... }} sequence appears
+      // inside a prose field (e.g. a method input documenting env.* /
+      // vault.get() syntax). Leaving the raw text in place preserves
+      // prose round-trip; real misconfigurations still throw at evaluate.
+      if (!this.celEvaluator.validate(expr.celExpression).valid) {
+        continue;
+      }
+
       // Resolve vault references first (if any), then evaluate the CEL expression
       let resolvedCelExpr = expr.celExpression;
       if (containsVaultExpression(expr.celExpression)) {

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -478,3 +478,94 @@ Deno.test("resolveAllExpressionsInData: resolves run.tags nested access", async 
     assertEquals(result.environment, "staging");
   });
 });
+
+// ============================================================================
+// Invalid-CEL-in-prose tolerance (swamp-club#291 follow-up)
+//
+// When the ${{ ... }} sequence appears inside prose (a plan body, an issue
+// description, a method-input string that documents expression syntax), the
+// inner CEL is often syntactically invalid (e.g. `env.*`, `vault.get(...)`).
+// These must be left as raw text rather than failing the surrounding call,
+// otherwise any model whose inputs round-trip such prose becomes unrunnable.
+// ============================================================================
+
+Deno.test("evaluateData: leaves invalid-CEL prose unchanged", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const data = {
+      doc:
+        "driverConfig.volumes does not resolve ${{ inputs.* }} expressions yet",
+    };
+    const result = await service.resolveAllExpressionsInData(
+      data,
+      makeContext(),
+    ) as { doc: string };
+    assertEquals(result.doc, data.doc);
+  });
+});
+
+Deno.test("resolveRuntimeExpressionsInData: leaves invalid env.* prose unchanged", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const data = {
+      reasoning:
+        "driverConfig.volumes does not resolve ${{ env.* }} / ${{ vault.get(...) }} expressions",
+    };
+    const result = await service.resolveRuntimeExpressionsInData(
+      data,
+    ) as { reasoning: string };
+    assertEquals(result.reasoning, data.reasoning);
+  });
+});
+
+Deno.test("resolveAllExpressionsInData: mixed prose and valid env resolves only the valid one", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    Deno.env.set("SWAMP_TEST_MIXED", "ok");
+    try {
+      const data = {
+        doc: "documentation: ${{ env.* }} is invalid syntax",
+        real: "${{ env.SWAMP_TEST_MIXED }}",
+      };
+      const result = await service.resolveAllExpressionsInData(
+        data,
+        makeContext(),
+      ) as { doc: string; real: string };
+      assertEquals(result.doc, data.doc);
+      assertEquals(result.real, "ok");
+    } finally {
+      Deno.env.delete("SWAMP_TEST_MIXED");
+    }
+  });
+});
+
+Deno.test("resolveRuntimeExpressionsInDefinition: leaves invalid env.* prose in method args unchanged", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+
+    const definition = Definition.create({
+      name: "prose-model",
+      methods: {
+        triage: {
+          arguments: {
+            reasoning:
+              "driverConfig.volumes does not resolve ${{ env.* }} / ${{ vault.get(...) }}",
+          },
+        },
+      },
+    });
+
+    const result = await service.resolveRuntimeExpressionsInDefinition(
+      definition,
+    );
+
+    assertEquals(
+      result.definition.getMethodArguments("triage").reasoning,
+      "driverConfig.volumes does not resolve ${{ env.* }} / ${{ vault.get(...) }}",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up on swamp-club#291. When `${{ ... }}` appears inside a prose string — a plan body, an issue description, a method-input field that documents expression syntax — the inner content is often not syntactically-valid CEL (e.g. `env.*`, `vault.get(...)`). The runtime resolver was unconditionally calling the CEL evaluator on every extracted `${{ ... }}` and propagating parse failures, breaking any model whose inputs round-tripped such prose.

The CEL-only pass in `evaluateDefinition` already absorbed failures (existing try/catch around `evaluateAsync`); the three sibling sites did not:

- `evaluateData` — used by workflow step inputs.
- `resolveRuntimeExpressionsInData` — used by `driverConfig` resolution at the model-method seam (added in #1368).
- `resolveRuntimeInExpressions` — used by `resolveRuntimeExpressionsInDefinition` on every model method run.

This adds a `celEvaluator.validate(...)` guard at each site. If the inner CEL fails to parse, the raw `${{ ... }}` text is left in place. Runtime evaluation failures on syntactically-valid expressions (e.g. `${{ env.NONEXISTENT }}`) still throw as before, so real misconfigurations remain visible.

## Reproduction

Pre-fix (against `20260518.174231.0-sha.7cbab349`):

```bash
swamp model method run <model> <method> \
  --input notes='resolves ${{ env.* }} / ${{ vault.get(...) }} expressions'
# → Method execution failed: Invalid expression: Expected IDENTIFIER, got MULTIPLY
#   >    1 | env.*
#                ^
```

Post-fix: the same call succeeds, and the `notes` field round-trips the prose untouched.

Reported in https://swamp.club/lab/291 as a follow-up after the original #1368 shipped.

## Test plan

- [x] 4 new unit tests in `expression_evaluation_service_test.ts`:
  - `evaluateData` leaves invalid-CEL prose unchanged
  - `resolveRuntimeExpressionsInData` leaves invalid `env.*`/`vault.get(...)` prose unchanged
  - `resolveAllExpressionsInData` resolves valid expressions while leaving invalid-CEL prose siblings untouched
  - `resolveRuntimeExpressionsInDefinition` leaves invalid-CEL prose in method args unchanged
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] `deno run test`: 5965 passed; only the pre-existing `extension_quality_test.ts: missing README` failure (same one #1368 flagged on main) remains
- [x] `deno run compile` succeeds
- [x] End-to-end against the recompiled binary: `command/shell` model with `globalArguments.notes` containing literal `${{ env.* }} / ${{ vault.get(...) }}` now runs cleanly

Closes swamp-club#291 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)