### PR TITLE
fix(testing): readResource JSDoc and runtime guard for API asymmetry (swamp-club#371)

### DIFF
--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -63,8 +63,11 @@ export interface ModelTestContextOptions {
   /** Abort signal (default: never-aborted). */
   signal?: AbortSignal;
   /**
-   * Pre-seed stored resources so readResource returns them.
-   * Keys are instance names, values are the JSON data.
+   * Pre-seed stored resources so `readResource` returns them.
+   *
+   * Keys are **instance names** (the `name` parameter from `writeResource`,
+   * not the `specName`). For example, if your model writes with
+   * `writeResource("state", "main", data)`, seed with `{ "main": data }`.
    */
   storedResources?: Record<string, Record<string, unknown>>;
   /**
@@ -200,6 +203,14 @@ export function createModelTestContext(
     instanceName: string,
     _version?: number,
   ): Promise<Record<string, unknown> | null> => {
+    if (typeof _version === "string") {
+      throw new Error(
+        `readResource(instanceName, version?) received a string as version: "${_version}". ` +
+          `Unlike writeResource(specName, name, data), readResource does not take a specName — ` +
+          `the first argument is the instance name (the "name" from writeResource). ` +
+          `Use readResource("${_version}") instead of readResource("${instanceName}", "${_version}").`,
+      );
+    }
     const data = storedResources.get(instanceName) ?? null;
     return Promise.resolve(data ? structuredClone(data) : null);
   };

--- a/packages/testing/test_context_test.ts
+++ b/packages/testing/test_context_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { createModelTestContext } from "./test_context.ts";
 
 Deno.test("createModelTestContext: returns context with default values", () => {
@@ -363,4 +363,32 @@ Deno.test("createModelTestContext: writeStream handles multi-chunk streams", asy
     new TextDecoder().decode(getWrittenFiles()[0].content),
     "chunk1chunk2",
   );
+});
+
+Deno.test("createModelTestContext: readResource throws when version is a string", () => {
+  const { context } = createModelTestContext({
+    storedResources: { "foo": { val: 42 } },
+  });
+
+  assertThrows(
+    () =>
+      context.readResource(
+        "item",
+        "foo" as unknown as number,
+      ),
+    Error,
+    'readResource(instanceName, version?) received a string as version: "foo"',
+  );
+});
+
+Deno.test("createModelTestContext: readResource uses instanceName not specName", async () => {
+  const { context } = createModelTestContext();
+
+  await context.writeResource("state", "main", { status: "created" });
+  await context.writeResource("config", "settings", { debug: true });
+
+  assertEquals(await context.readResource("main"), { status: "created" });
+  assertEquals(await context.readResource("settings"), { debug: true });
+  assertEquals(await context.readResource("state"), null);
+  assertEquals(await context.readResource("config"), null);
 });

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -162,7 +162,13 @@ export interface MethodContext<TGlobalArgs = Record<string, unknown>> {
     name: string,
     data: Record<string, unknown>,
   ) => Promise<DataHandle>;
-  /** Read a previously stored resource by instance name. */
+  /**
+   * Read a previously stored resource by instance name.
+   *
+   * The `instanceName` is the `name` parameter from `writeResource`, not the
+   * `specName`. For example, after `writeResource("state", "main", data)`,
+   * read it back with `readResource("main")`.
+   */
   readResource: (
     instanceName: string,
     version?: number,


### PR DESCRIPTION
## Summary

- Improved JSDoc on `readResource` in `types.ts` and `storedResources` in `test_context.ts` to clarify that `instanceName` is the `name` parameter from `writeResource`, not `specName`
- Added a runtime guard in the test context's `readResource` that throws a helpful error when `version` is a string (catches the exact misuse pattern from the issue)
- Added tests: string-version-throws guard + instanceName-vs-specName demonstration

Closes swamp-club#371

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — 5964 passed, 0 failed
- [x] `deno run compile` succeeds
- [x] Reproduced the issue in a scratch repo, verified the fix catches the reporter's exact scenarios with a helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)