### PR TITLE
fix(models): lenient GlobalArgsSchema validation for direct execution

### DIFF
--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -31,8 +31,8 @@ Work with swamp models through the CLI.
 
 ## Prefer Direct Execution
 
-For most use cases, **direct type execution** is the right approach — pass inputs
-at runtime without managing definition YAML files:
+For most use cases, **direct type execution** is the right approach — pass
+inputs at runtime without managing definition YAML files:
 
 ```bash
 swamp model @<type> method run <method> <name> --input key=value

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -29,7 +29,24 @@ Work with swamp models through the CLI.
 - **Mutation** (`model create`, `model delete`): Use `--json` to capture the
   structured result.
 
-## CRITICAL: Model Creation Rules
+## Prefer Direct Execution
+
+For most use cases, **direct type execution** is the right approach — pass inputs
+at runtime without managing definition YAML files:
+
+```bash
+swamp model @<type> method run <method> <name> --input key=value
+```
+
+Inputs are automatically routed between global arguments and method arguments
+using the type's schemas. See
+[references/direct-execution.md](references/direct-execution.md) for details.
+
+Use `model create` only when you need **persistent, managed definitions** — CEL
+expressions in global arguments, version-controlled definition files, or shared
+definitions referenced across multiple workflows.
+
+## Model Creation Rules (when using `model create`)
 
 - **Never generate model IDs** — no `uuidgen`, `crypto.randomUUID()`, or manual
   UUIDs. Swamp assigns IDs automatically via `swamp model create`.
@@ -39,9 +56,6 @@ Work with swamp models through the CLI.
 - **Never modify the `id` field** in an existing model file.
 - **Verify CLI syntax**: If unsure about exact flags or subcommands, run
   `swamp help model` for the complete, up-to-date CLI schema.
-
-Correct flow: `swamp model create <type> <name> --json` → set global args with
-`--global-arg` or edit the YAML → validate → run.
 
 ## Quick Reference
 
@@ -395,16 +409,6 @@ swamp model evaluate --all --json
     }
   ]
 }
-```
-
-## Direct Type Execution
-
-Collapse `model create` + `model method run` into one command — recommended when
-all values come from `--input` at runtime. See
-[references/direct-execution.md](references/direct-execution.md) for details.
-
-```bash
-swamp model @command/shell method run execute my-shell --input 'run=echo hello'
 ```
 
 ## Run Methods

--- a/.claude/skills/swamp-model/references/direct-execution.md
+++ b/.claude/skills/swamp-model/references/direct-execution.md
@@ -1,7 +1,8 @@
 # Direct Type Execution
 
-Collapse `model create` + `model method run` into one command. Use when all
-values come from `--input` at runtime — scripts, CI, one-shot invocations.
+The default way to run model methods. Pass inputs at runtime without managing
+definition YAML files — the right choice for dynamic inputs, scripts, CI,
+workflows, and any case where you don't need a persistent definition.
 
 ## CLI Syntax
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -487,20 +487,13 @@ steps:
 
 Steps support two task types:
 
-**`model_method`** has two mutually exclusive variants — `modelIdOrName`
-(existing definition) or `modelType` + `modelName` (direct type execution). See
+**`model_method`** — prefer `modelType` + `modelName` (direct type execution)
+for dynamic inputs. Use `modelIdOrName` only for persistent definitions with CEL
+expressions or shared config. See
 [references/direct-execution.md](references/direct-execution.md) for details.
 
 ```yaml
-# Existing definition
-task:
-  type: model_method
-  modelIdOrName: my-model
-  methodName: run
-  inputs:
-    key: ${{ inputs.value }}
-
-# Direct type execution (auto-creates definition)
+# Direct type execution (default — dynamic inputs, no YAML to manage)
 task:
   type: model_method
   modelType: "@test/greeter"
@@ -509,6 +502,14 @@ task:
   inputs:
     greeting: ${{ inputs.greeting }}
     name: ${{ inputs.who }}
+
+# Existing definition (only for persistent config with CEL expressions)
+task:
+  type: model_method
+  modelIdOrName: my-model
+  methodName: run
+  inputs:
+    key: ${{ inputs.value }}
 ```
 
 **`workflow`** - Invoke another workflow (waits for completion):

--- a/.claude/skills/swamp-workflow/references/direct-execution.md
+++ b/.claude/skills/swamp-workflow/references/direct-execution.md
@@ -1,7 +1,7 @@
 # Direct Type Execution in Workflows
 
-Workflow steps can auto-create model definitions using `modelType` + `modelName`
-instead of referencing an existing definition with `modelIdOrName`.
+The default way to call model methods from workflows. Use `modelType` +
+`modelName` to drive inputs dynamically without managing definition YAML files.
 
 ## Syntax
 
@@ -47,8 +47,9 @@ all iterations, or a template `modelName` for per-iteration definitions.
 
 ## When to Use `modelIdOrName` Instead
 
-Use `modelIdOrName` when:
+Use `modelIdOrName` only when the definition needs persistent, managed
+configuration:
 
-- The definition is pre-created with `model create` and managed in `models/`
-- You need CEL expressions in global arguments
-- The definition is shared across multiple workflows
+- CEL expressions in global arguments (vault refs, cross-model data refs)
+- Version-controlled definition files committed to the repo
+- A shared definition referenced across multiple workflows

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -463,7 +463,16 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
               );
             }
           }
-          const globalArgsResult = globalArgsSchema.safeParse(
+          // Use lenient validation: validate provided fields but don't
+          // require missing ones. Direct execution creates ephemeral instances
+          // where not all globalArgs are needed (e.g. get doesn't need
+          // creation-time fields). swamp model create validates strictly.
+          const lenientSchema =
+            "partial" in globalArgsSchema &&
+              typeof globalArgsSchema.partial === "function"
+              ? (globalArgsSchema.partial() as z.ZodTypeAny)
+              : globalArgsSchema;
+          const globalArgsResult = lenientSchema.safeParse(
             coercedGlobalArgs,
           );
           if (!globalArgsResult.success) {

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -467,11 +467,10 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           // require missing ones. Direct execution creates ephemeral instances
           // where not all globalArgs are needed (e.g. get doesn't need
           // creation-time fields). swamp model create validates strictly.
-          const lenientSchema =
-            "partial" in globalArgsSchema &&
+          const lenientSchema = "partial" in globalArgsSchema &&
               typeof globalArgsSchema.partial === "function"
-              ? (globalArgsSchema.partial() as z.ZodTypeAny)
-              : globalArgsSchema;
+            ? (globalArgsSchema.partial() as z.ZodTypeAny)
+            : globalArgsSchema;
           const globalArgsResult = lenientSchema.safeParse(
             coercedGlobalArgs,
           );

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -2897,7 +2897,10 @@ Deno.test("executeWorkflow - passes with required globalArgs schema when definit
   const model: ModelDefinition = {
     type: ModelType.create("test/required-globals-exec"),
     version: "1",
-    globalArguments: z.object({ Bucket: z.string(), PolicyDocument: z.string() }),
+    globalArguments: z.object({
+      Bucket: z.string(),
+      PolicyDocument: z.string(),
+    }),
     methods: {
       get: {
         description: "Get resource",

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -2890,3 +2890,64 @@ Deno.test(
     assertEquals(capturedRequest!.methodArgs.token, "real-token-value");
   },
 );
+
+Deno.test("executeWorkflow - passes with required globalArgs schema when definition has empty globalArgs", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/required-globals-exec"),
+    version: "1",
+    globalArguments: z.object({ Bucket: z.string(), PolicyDocument: z.string() }),
+    methods: {
+      get: {
+        description: "Get resource",
+        arguments: z.object({ identifier: z.string() }),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "policy-lookup",
+    globalArguments: {},
+    methods: { get: { arguments: { identifier: "my-bucket" } } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "get",
+    context,
+  );
+  assertEquals(result !== undefined, true);
+});
+
+Deno.test("executeWorkflow - still rejects invalid types on provided globalArgs", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/typed-globals-exec"),
+    version: "1",
+    globalArguments: z.object({ region: z.string(), count: z.number() }),
+    methods: {
+      run: {
+        description: "Run",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-typed",
+    globalArguments: { region: 12345 },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.executeWorkflow(definition, model, "run", context),
+    Error,
+    "Global arguments validation failed",
+  );
+});

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -503,9 +503,19 @@ export class DefaultModelValidationService implements ModelValidationService {
       }
     }
     const coerced = coerceMethodArgs(staticArgs, globalArgsSchema);
+    // Use lenient validation: validate provided fields but don't require
+    // missing ones. Direct execution and workflow steps create ephemeral
+    // instances where not all globalArgs are needed (e.g. get/sync/delete
+    // don't need creation-time fields). swamp model create has its own
+    // strict validation in create.ts.
+    const lenient =
+      "partial" in globalArgsSchema &&
+        typeof globalArgsSchema.partial === "function"
+        ? (globalArgsSchema.partial() as z.ZodTypeAny)
+        : globalArgsSchema;
     return this.validateWithSchema(
       "Global arguments",
-      globalArgsSchema,
+      lenient,
       coerced,
     );
   }

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -508,11 +508,10 @@ export class DefaultModelValidationService implements ModelValidationService {
     // instances where not all globalArgs are needed (e.g. get/sync/delete
     // don't need creation-time fields). swamp model create has its own
     // strict validation in create.ts.
-    const lenient =
-      "partial" in globalArgsSchema &&
+    const lenient = "partial" in globalArgsSchema &&
         typeof globalArgsSchema.partial === "function"
-        ? (globalArgsSchema.partial() as z.ZodTypeAny)
-        : globalArgsSchema;
+      ? (globalArgsSchema.partial() as z.ZodTypeAny)
+      : globalArgsSchema;
     return this.validateWithSchema(
       "Global arguments",
       lenient,

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1654,3 +1654,55 @@ Deno.test("validateModel: coerces string method arguments to match schema types"
   const methodResult = results.find((r) => r.name === "Method arguments");
   assertEquals(methodResult?.passed, true);
 });
+
+Deno.test("validateModel passes with required globalArgs schema when definition has empty globalArgs", async () => {
+  const service = new DefaultModelValidationService();
+  const RequiredArgsModel = defineModel({
+    type: ModelType.create("test/required-globals"),
+    version: "2026.05.18.1",
+    globalArguments: z.object({ Bucket: z.string(), PolicyDocument: z.string() }),
+    resources: {},
+    methods: {
+      get: {
+        description: "Get",
+        arguments: z.object({ identifier: z.string() }),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  });
+
+  const definition = Definition.create({
+    name: "policy-lookup",
+    globalArguments: {},
+  });
+
+  const { results } = await service.validateModel(definition, RequiredArgsModel);
+  const globalResult = results.find((r) => r.name === "Global arguments");
+  assertEquals(globalResult?.passed, true);
+});
+
+Deno.test("validateModel still rejects invalid types on provided globalArgs", async () => {
+  const service = new DefaultModelValidationService();
+  const TypedModel = defineModel({
+    type: ModelType.create("test/typed-globals"),
+    version: "2026.05.18.1",
+    globalArguments: z.object({ region: z.string(), count: z.number() }),
+    resources: {},
+    methods: {
+      run: {
+        description: "Run",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  });
+
+  const definition = Definition.create({
+    name: "test-typed",
+    globalArguments: { region: 12345 },
+  });
+
+  const { results } = await service.validateModel(definition, TypedModel);
+  const globalResult = results.find((r) => r.name === "Global arguments");
+  assertEquals(globalResult?.passed, false);
+});

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1660,7 +1660,10 @@ Deno.test("validateModel passes with required globalArgs schema when definition 
   const RequiredArgsModel = defineModel({
     type: ModelType.create("test/required-globals"),
     version: "2026.05.18.1",
-    globalArguments: z.object({ Bucket: z.string(), PolicyDocument: z.string() }),
+    globalArguments: z.object({
+      Bucket: z.string(),
+      PolicyDocument: z.string(),
+    }),
     resources: {},
     methods: {
       get: {
@@ -1676,7 +1679,10 @@ Deno.test("validateModel passes with required globalArgs schema when definition 
     globalArguments: {},
   });
 
-  const { results } = await service.validateModel(definition, RequiredArgsModel);
+  const { results } = await service.validateModel(
+    definition,
+    RequiredArgsModel,
+  );
   const globalResult = results.find((r) => r.name === "Global arguments");
   assertEquals(globalResult?.passed, true);
 });

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -183,9 +183,17 @@ export async function resolveOrCreateDefinition(
     };
   }
 
-  // Validate global arguments against schema
+  // Validate provided global arguments but don't require missing ones.
+  // Direct execution creates ephemeral instances — methods like get/sync/delete
+  // don't need creation-time fields, and the cloud API enforces required-ness
+  // at call time for methods that do (create/update).
   if (modelDef.globalArguments) {
-    const result = modelDef.globalArguments.safeParse(routed.globalArguments);
+    const schema = modelDef.globalArguments;
+    const lenient =
+      "partial" in schema && typeof schema.partial === "function"
+        ? (schema.partial() as z.ZodTypeAny)
+        : schema;
+    const result = lenient.safeParse(routed.globalArguments);
     if (!result.success) {
       const issues = result.error.issues.map((i: z.ZodIssue) => {
         const path = i.path.length > 0 ? `${i.path.join(".")}: ` : "";

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -189,10 +189,9 @@ export async function resolveOrCreateDefinition(
   // at call time for methods that do (create/update).
   if (modelDef.globalArguments) {
     const schema = modelDef.globalArguments;
-    const lenient =
-      "partial" in schema && typeof schema.partial === "function"
-        ? (schema.partial() as z.ZodTypeAny)
-        : schema;
+    const lenient = "partial" in schema && typeof schema.partial === "function"
+      ? (schema.partial() as z.ZodTypeAny)
+      : schema;
     const result = lenient.safeParse(routed.globalArguments);
     if (!result.success) {
       const issues = result.error.issues.map((i: z.ZodIssue) => {

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -274,3 +274,68 @@ Deno.test("resolveOrCreateDefinition: rejects type mismatch", async () => {
     assertStringIncludes(result.error.message, "test/old-type");
   }
 });
+
+Deno.test("resolveOrCreateDefinition: succeeds with required globalArgs when none provided (direct exec get)", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ Bucket: z.string(), PolicyDocument: z.string() }),
+    { get: z.object({ identifier: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/bucket-policy");
+  let savedDefinition: Definition | null = null;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: (_type, def) => {
+        savedDefinition = def;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/${id}.yaml`,
+    },
+    "test/bucket-policy",
+    "policy-lookup",
+    "get",
+    { identifier: "my-bucket" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, true);
+    assertEquals(result.routedInputs.globalArguments, {});
+    assertEquals(result.routedInputs.methodArguments, {
+      identifier: "my-bucket",
+    });
+    assertEquals(savedDefinition !== null, true);
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: still rejects invalid types on provided globalArgs", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string(), account: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/typed-model");
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: () => Promise.resolve(),
+      getDefinitionPath: (_type, id) => `/tmp/models/test/${id}.yaml`,
+    },
+    "test/typed-model",
+    "my-model",
+    "run",
+    { region: 12345, id: "abc" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertStringIncludes(result.error.message, "Invalid global arguments");
+  }
+});


### PR DESCRIPTION
## Summary

- Use `.partial()` on GlobalArgsSchema at three validation points in the direct execution / workflow execution pipeline so missing globalArgs fields are allowed while provided fields are still type-checked
- `swamp model create` retains strict validation (its own `safeParse` in `create.ts` is untouched)
- Reframe direct execution as the default approach in swamp-model and swamp-workflow skills

## Context

Closes swamp-club#366. Models like `@swamp/aws/s3/bucket-policy` have required fields (`Bucket`, `PolicyDocument`) in their `GlobalArgsSchema` because the upstream CloudFormation schema declares them required. This blocked workflow YAML direct execution of `get` — the method doesn't need those fields, but the validation rejected the empty globalArgs before the method could run.

Direct execution already had no useful GlobalArgsSchema validation — models with all-optional fields (like `@swamp/aws/s3/bucket`) passed `{}` without checking anything. The validation was binary: all-optional = pass everything, any required = block everything.

## Changes

| File | Change |
|---|---|
| `direct_execution.ts` | `.partial()` on GlobalArgsSchema when auto-creating definitions |
| `validation_service.ts` | `.partial()` in pre-execution model validation |
| `method_execution_service.ts` | `.partial()` at method execution time |
| `direct_execution_test.ts` | 2 new tests: empty required globalArgs passes, wrong types still rejected |
| `validation_service_test.ts` | 2 new tests: same pattern |
| `method_execution_service_test.ts` | 2 new tests: same pattern |
| `swamp-model/SKILL.md` | Reframe direct execution as default, `model create` as exception |
| `swamp-model/references/direct-execution.md` | Same |
| `swamp-workflow/SKILL.md` | Same |
| `swamp-workflow/references/direct-execution.md` | Same |

## Test plan

- [x] 6 new unit tests (2 per validation point) — empty required globalArgs succeeds, invalid types on provided fields still rejected
- [x] All 134 existing tests pass across the three test files
- [x] UAT CLI suite: 501 passed, 62 failed (baseline with released binary: 450 passed, 113 failed — no regressions)
- [x] Manual reproduction: workflow direct-exec of `bucket-policy get` now passes all three validation gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)