### PR TITLE
feat(repo): custom agent tool definitions via swamp agent setup

### DIFF
--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import {
   buildInstructionsChoices,
+  buildSkillsDirChoices,
   deriveDefaults,
   detectToolConfig,
   validateCustomToolName,
@@ -97,7 +98,22 @@ export const agentSetupCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["agent", "setup"]);
     const repoDir = resolveRepoDir(undefined);
 
-    const name = await promptLine("\nAgent name: ");
+    await Deno.stdout.write(encoder.encode(`
+To set up a custom agent you'll need to know three things about your tool:
+
+  1. Where it reads instructions/rules from (e.g. AGENTS.md, .toolname/rules/)
+  2. Whether it needs a header block to auto-load rules (like Cursor's):
+       ---
+       alwaysApply: true
+       ---
+  3. Where it expects skills/context files to live
+
+If you have an existing repo where the tool is already configured, point
+the scanner at it and swamp will detect what it can.
+
+`));
+
+    const name = await promptLine("Agent name: ");
     if (!name) {
       console.error("No name provided.");
       Deno.exit(1);
@@ -164,9 +180,36 @@ Some tools need a header like this to auto-load rules:
       name,
       instructionsPath,
       detection.configDir,
+      detection.skillsDir,
     );
     if (frontmatter) {
       def.frontmatter = frontmatter;
+    }
+
+    const skillsDirChoices = buildSkillsDirChoices(detection, def.skillsDir);
+    let chosenSkillsDir: string | undefined;
+    if (skillsDirChoices.length > 1) {
+      const chosen = await promptChoice(
+        `\nWhere should swamp write skills for ${name}?`,
+        skillsDirChoices,
+      );
+      if (chosen !== def.skillsDir) {
+        chosenSkillsDir = chosen;
+      }
+    } else {
+      const override = await promptLine(
+        `\nSkills directory: ${def.skillsDir}/  (Enter to accept, or type a path): `,
+      );
+      if (override) {
+        chosenSkillsDir = override;
+      }
+    }
+    if (chosenSkillsDir) {
+      const normalized = chosenSkillsDir.replace(/\/+$/, "");
+      def.skillsDir = normalized;
+      const gitignoreComment = name.charAt(0).toUpperCase() + name.slice(1);
+      def.gitignoreEntries =
+        `# ${gitignoreComment} skills (managed by swamp)\n${normalized}/`;
     }
 
     await addCustomTool(repoDir, def);

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -35,6 +35,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -98,6 +99,12 @@ export const agentSetupCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["agent", "setup"]);
     const repoDir = resolveRepoDir(undefined);
 
+    if (cliCtx.outputMode === "json") {
+      throw new UserError(
+        "agent setup requires interactive mode. Remove --json to run the wizard.",
+      );
+    }
+
     await Deno.stdout.write(encoder.encode(`
 To set up a custom agent you'll need to know three things about your tool:
 
@@ -115,8 +122,7 @@ the scanner at it and swamp will detect what it can.
 
     const name = await promptLine("Agent name: ");
     if (!name) {
-      console.error("No name provided.");
-      Deno.exit(1);
+      throw new UserError("No agent name provided.");
     }
     validateCustomToolName(name);
 
@@ -236,6 +242,12 @@ export const agentListCommand = new Command()
     const repoDir = resolveRepoDir(undefined);
 
     const tools = await readCustomTools(repoDir);
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({ tools }, null, 2));
+      return;
+    }
+
     if (tools.length === 0) {
       console.log(
         "No custom tools defined. Run `swamp agent setup` to create one.",
@@ -266,19 +278,27 @@ export const agentRemoveCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["agent", "rm"]);
     const repoDir = resolveRepoDir(undefined);
 
-    const confirmed = await promptConfirmation(
-      `Remove custom tool "${name}" from .swamp-custom-tools.yaml?`,
-    );
-    if (!confirmed) {
-      console.log("Cancelled.");
-      return;
+    if (cliCtx.outputMode !== "json") {
+      const confirmed = await promptConfirmation(
+        `Remove custom tool "${name}" from .swamp-custom-tools.yaml?`,
+      );
+      if (!confirmed) {
+        console.log("Cancelled.");
+        return;
+      }
     }
 
     const removed = await removeCustomTool(repoDir, name);
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({ name, removed }, null, 2));
+      return;
+    }
+
     if (removed) {
       console.log(`Removed custom tool "${name}".`);
     } else {
-      console.log(`Custom tool "${name}" not found.`);
+      throw new UserError(`Custom tool "${name}" not found.`);
     }
 
     cliCtx.logger.debug`Agent rm completed for ${name}`;

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -1,0 +1,249 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  buildInstructionsChoices,
+  deriveDefaults,
+  detectToolConfig,
+  validateCustomToolName,
+} from "../../domain/repo/custom_tool.ts";
+import {
+  addCustomTool,
+  readCustomTools,
+  removeCustomTool,
+} from "../../infrastructure/persistence/custom_tools_repository.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function promptLine(message: string): Promise<string> {
+  await Deno.stdout.write(encoder.encode(message));
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return "";
+  return decoder.decode(buf.subarray(0, n)).trim();
+}
+
+async function promptConfirmation(message: string): Promise<boolean> {
+  const response = await promptLine(`${message} [y/N] `);
+  return response === "y" || response === "yes";
+}
+
+async function promptChoice(
+  message: string,
+  choices: string[],
+): Promise<string> {
+  await Deno.stdout.write(encoder.encode(`${message}\n`));
+  for (let i = 0; i < choices.length; i++) {
+    await Deno.stdout.write(
+      encoder.encode(`  ${i + 1}. ${choices[i]}\n`),
+    );
+  }
+  await Deno.stdout.write(
+    encoder.encode(`  ${choices.length + 1}. Other path\n`),
+  );
+  const response = await promptLine("> ");
+  const index = parseInt(response, 10) - 1;
+  if (index >= 0 && index < choices.length) {
+    return choices[index];
+  }
+  if (index === choices.length) {
+    return await promptLine("Path: ");
+  }
+  return response || choices[0];
+}
+
+async function promptMultilineFrontmatter(): Promise<string> {
+  await Deno.stdout.write(
+    encoder.encode("  Paste frontmatter (end with blank line):\n"),
+  );
+  const lines: string[] = [];
+  while (true) {
+    const line = await promptLine("  ");
+    if (line === "") break;
+    lines.push(line);
+  }
+  return lines.join("\n") + "\n";
+}
+
+export const agentSetupCommand = new Command()
+  .description("Define a custom AI agent tool for this repository")
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, ["agent", "setup"]);
+    const repoDir = resolveRepoDir(undefined);
+
+    const name = await promptLine("\nAgent name: ");
+    if (!name) {
+      console.error("No name provided.");
+      Deno.exit(1);
+    }
+    validateCustomToolName(name);
+
+    const scanPath = await promptLine(
+      `\nDo you have an existing repo where ${name} is set up?\n` +
+        "Path (or Enter to skip): ",
+    );
+    const scanDir = scanPath || repoDir;
+
+    await Deno.stdout.write(
+      encoder.encode(
+        scanPath
+          ? `\nScanning ${scanPath}...\n`
+          : "\nScanning current repo...\n",
+      ),
+    );
+    const detection = await detectToolConfig(scanDir, name);
+
+    if (detection.configDir) {
+      const subdirInfo = detection.subdirs.length > 0
+        ? ` (${
+          detection.subdirs.map((s) => `${detection.configDir}/${s}/`).join(
+            ", ",
+          )
+        } found)`
+        : "";
+      await Deno.stdout.write(
+        encoder.encode(`  .${name}/  detected${subdirInfo}\n`),
+      );
+    }
+    for (const file of detection.rootFiles) {
+      await Deno.stdout.write(encoder.encode(`  ${file}  (found)\n`));
+    }
+    if (!detection.configDir && detection.rootFiles.length === 0) {
+      await Deno.stdout.write(
+        encoder.encode("  No existing config detected.\n"),
+      );
+    }
+
+    const choices = buildInstructionsChoices(detection, name);
+    const instructionsPath = await promptChoice(
+      `\nWhere does ${name} read rules/instructions from?`,
+      choices,
+    );
+
+    let frontmatter: string | undefined;
+    await Deno.stdout.write(encoder.encode(`
+Some tools need a header like this to auto-load rules:
+  ---
+  alwaysApply: true
+  ---
+`));
+    const wantsFrontmatter = await promptConfirmation(
+      `Does ${name} need this?`,
+    );
+    if (wantsFrontmatter) {
+      frontmatter = await promptMultilineFrontmatter();
+    }
+
+    const def = deriveDefaults(
+      name,
+      instructionsPath,
+      detection.configDir,
+    );
+    if (frontmatter) {
+      def.frontmatter = frontmatter;
+    }
+
+    await addCustomTool(repoDir, def);
+
+    await Deno.stdout.write(encoder.encode(`
+Custom agent "${name}" configured:
+  Skills:        ${def.skillsDir}/
+  Instructions:  ${def.instructionsFile}${
+      def.instructionsMode === "shared" ? " (shared)" : ""
+    }
+  Frontmatter:   ${def.frontmatter ? "yes" : "none"}
+
+Saved to .swamp-custom-tools.yaml
+Run \`swamp repo init --tool ${name}\` to set up this repo.
+`));
+
+    cliCtx.logger.debug`Agent setup completed for ${name}`;
+  });
+
+export const agentListCommand = new Command()
+  .description("List custom AI agent tools defined for this repository")
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, ["agent", "list"]);
+    const repoDir = resolveRepoDir(undefined);
+
+    const tools = await readCustomTools(repoDir);
+    if (tools.length === 0) {
+      console.log(
+        "No custom tools defined. Run `swamp agent setup` to create one.",
+      );
+      return;
+    }
+
+    console.log(`Custom tools (from .swamp-custom-tools.yaml):\n`);
+    for (const tool of tools) {
+      console.log(`  ${tool.name}`);
+      console.log(`    Skills dir:      ${tool.skillsDir}`);
+      console.log(`    Instructions:    ${tool.instructionsFile}`);
+      console.log(`    Mode:            ${tool.instructionsMode}`);
+      if (tool.frontmatter) {
+        console.log(`    Frontmatter:     yes`);
+      }
+      console.log();
+    }
+
+    cliCtx.logger.debug`Agent list completed`;
+  });
+
+export const agentRemoveCommand = new Command()
+  .name("rm")
+  .description("Remove a custom AI agent tool definition")
+  .arguments("<name:string>")
+  .action(async function (options: AnyOptions, name: string) {
+    const cliCtx = createContext(options as GlobalOptions, ["agent", "rm"]);
+    const repoDir = resolveRepoDir(undefined);
+
+    const confirmed = await promptConfirmation(
+      `Remove custom tool "${name}" from .swamp-custom-tools.yaml?`,
+    );
+    if (!confirmed) {
+      console.log("Cancelled.");
+      return;
+    }
+
+    const removed = await removeCustomTool(repoDir, name);
+    if (removed) {
+      console.log(`Removed custom tool "${name}".`);
+    } else {
+      console.log(`Custom tool "${name}" not found.`);
+    }
+
+    cliCtx.logger.debug`Agent rm completed for ${name}`;
+  });
+
+export const agentCommand = new Command()
+  .name("agent")
+  .description("Manage custom AI agent tool definitions")
+  .command("setup", agentSetupCommand)
+  .command("list", agentListCommand)
+  .command("rm", agentRemoveCommand);

--- a/src/cli/commands/doctor_audit.ts
+++ b/src/cli/commands/doctor_audit.ts
@@ -48,8 +48,8 @@ import { resolveDatastoreForRepo } from "../repo_context.ts";
  */
 export function resolveTargetTool(
   flagTool: string | undefined,
-  markerTool: AiTool | undefined,
-): AiTool {
+  markerTool: string | undefined,
+): string {
   const overrideTool = flagTool ? parseAiToolOrThrow(flagTool) : undefined;
   const resolved = overrideTool ?? markerTool;
   if (!resolved) {

--- a/src/cli/commands/doctor_audit.ts
+++ b/src/cli/commands/doctor_audit.ts
@@ -24,7 +24,7 @@ import {
   NoToolConfiguredError,
   type SpawnFn,
 } from "../../libswamp/mod.ts";
-import type { AiTool } from "../../infrastructure/persistence/repo_marker_repository.ts";
+
 import {
   SWAMP_SUBDIRS,
   swampPath,

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Command, EnumType } from "@cliffy/command";
+import { type ArgumentValue, Command, StringType } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import {
   consumeStream,
@@ -43,15 +43,15 @@ import { VERSION } from "./version.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-const aiToolType = new EnumType([
-  "claude",
-  "cursor",
-  "opencode",
-  "codex",
-  "copilot",
-  "kiro",
-  "none",
-]);
+class ToolNameType extends StringType {
+  override complete(): string[] {
+    return ["claude", "cursor", "opencode", "codex", "copilot", "kiro", "none"];
+  }
+
+  override parse(type: ArgumentValue): string {
+    return type.value;
+  }
+}
 
 /**
  * Resolves a Cliffy `--tool` collect array into the `tools` list passed
@@ -117,8 +117,9 @@ const TOOL_FLAG_DESCRIPTION =
   "AI coding tool to configure for. Repeat to enroll multiple tools " +
   "(e.g. `--tool claude --tool kiro`). Duplicates are collapsed. " +
   "Use `--tool none` (alone) to skip tool scaffolding. Defaults to " +
-  "`claude` when omitted. Valid values: claude, cursor, opencode, codex, " +
-  "copilot, kiro, none.";
+  "`claude` when omitted. Built-in: claude, cursor, opencode, codex, " +
+  "copilot, kiro, none. Custom tools defined via `swamp agent setup` " +
+  "are also accepted.";
 
 export const repoInitCommand = new Command()
   .description("Initialize a new swamp repository")
@@ -131,8 +132,10 @@ export const repoInitCommand = new Command()
   .example("Force reinitialize", "swamp repo init --force")
   .arguments("[path:string]")
   .option("-f, --force", "Reinitialize if already exists")
-  .type("aiTool", aiToolType)
-  .option("-t, --tool <tool:aiTool>", TOOL_FLAG_DESCRIPTION, { collect: true })
+  .type("toolName", new ToolNameType())
+  .option("-t, --tool <tool:toolName>", TOOL_FLAG_DESCRIPTION, {
+    collect: true,
+  })
   .action(repoInitAction);
 
 export const repoUpgradeCommand = new Command()
@@ -146,9 +149,9 @@ export const repoUpgradeCommand = new Command()
     "swamp repo upgrade --tool claude --tool kiro",
   )
   .arguments("[path:string]")
-  .type("aiTool", aiToolType)
+  .type("toolName", new ToolNameType())
   .option(
-    "-t, --tool <tool:aiTool>",
+    "-t, --tool <tool:toolName>",
     "Replace the enrolled tool list. Repeat to enroll multiple tools " +
       "(e.g. `--tool claude --tool kiro`). Omit to preserve the existing " +
       "list and just bump the swamp version. `--tool none` clears.",

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -47,6 +47,7 @@ import { doctorCommand } from "./commands/doctor.ts";
 import { reportCommand } from "./commands/report.ts";
 import { serveCommand } from "./commands/serve.ts";
 import { openCommand } from "./commands/open.ts";
+import { agentCommand } from "./commands/agent_setup.ts";
 import { createHelpCommand } from "./commands/help.ts";
 import { unknownCommandErrorHandler } from "./unknown_command_handler.ts";
 import { groupCommandAction } from "./group_action.ts";
@@ -1235,7 +1236,8 @@ export async function runCli(args: string[]): Promise<void> {
     .command("doctor", doctorCommand)
     .command("report", reportCommand)
     .command("serve", serveCommand)
-    .command("open", openCommand);
+    .command("open", openCommand)
+    .command("agent", agentCommand);
 
   // Register help command last — needs reference to the fully-built CLI tree
   cli.command("help", createHelpCommand(cli));

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -26,7 +26,7 @@ import {
   RELEVANT_ENV_VARS,
 } from "../domain/telemetry/mod.ts";
 import type { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
-import type { AiTool } from "../infrastructure/persistence/repo_marker_repository.ts";
+
 import type { DatastoreConfigData } from "../domain/datastore/datastore_config.ts";
 
 /**

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -294,7 +294,7 @@ export function projectEnvSnapshot(): Record<string, string> {
  */
 export function buildInvocationContext(
   envSnapshot: Record<string, string>,
-  configuredAiTools: AiTool[] | undefined,
+  configuredAiTools: string[] | undefined,
   externalDatastoreConfigured: boolean,
 ): InvocationContextData {
   const detection = detectAgentHarness(envSnapshot);

--- a/src/domain/audit/doctor/check.ts
+++ b/src/domain/audit/doctor/check.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../errors.ts";
-import type { AiTool } from "../../repo/ai_tool.ts";
 
 /**
  * Types and ports for the `swamp doctor audit` preflight diagnostic.

--- a/src/domain/audit/doctor/check.ts
+++ b/src/domain/audit/doctor/check.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../errors.ts";
-import type { AiTool } from "../../repo/repo_service.ts";
+import type { AiTool } from "../../repo/ai_tool.ts";
 
 /**
  * Types and ports for the `swamp doctor audit` preflight diagnostic.
@@ -88,7 +88,7 @@ export interface CheckContext {
   /** Absolute path to the `.swamp/audit` directory inside the repo. */
   auditDir: string;
   /** The AI tool whose integration is under test. */
-  tool: AiTool;
+  tool: string;
   /** Cancellation signal for long-running checks. */
   abortSignal: AbortSignal;
   /** Spawn the swamp binary. Production wires the real binary; tests inject a fake. */
@@ -100,7 +100,7 @@ export interface PreflightCheck {
   readonly name: PreflightCheckName;
   readonly description: string;
   /** Whether this check applies to the given AI tool. */
-  appliesTo(tool: AiTool): boolean;
+  appliesTo(tool: string): boolean;
   /** Execute the check. Must not throw — return a `fail` result instead. */
   run(ctx: CheckContext): Promise<CheckResult>;
 }
@@ -110,7 +110,7 @@ export type OverallStatus = "pass" | "warn" | "fail";
 
 /** The aggregated result of running every applicable preflight check. */
 export interface AuditDoctorReport {
-  tool: AiTool;
+  tool: string;
   overallStatus: OverallStatus;
   checks: CheckResult[];
 }

--- a/src/domain/audit/doctor/checks/agent_config_loadable.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { join } from "@std/path";
-import type { AiTool } from "../../../repo/repo_service.ts";
 import type { CheckContext, CheckResult, PreflightCheck } from "../check.ts";
 
 /**

--- a/src/domain/audit/doctor/checks/agent_config_loadable.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable.ts
@@ -235,7 +235,7 @@ async function checkOpenCode(ctx: CheckContext): Promise<CheckResult> {
   };
 }
 
-function appliesTo(tool: AiTool): boolean {
+function appliesTo(tool: string): boolean {
   return tool in CONFIG_FILES;
 }
 

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -29,7 +29,7 @@ const INSTALL_HINTS: Record<string, string> = {
   opencode: "Install OpenCode: https://opencode.ai",
 };
 
-function appliesTo(tool: AiTool): boolean {
+function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
     tool === "opencode";
 }

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { AiTool } from "../../../repo/repo_service.ts";
 import type { PreflightCheck } from "../check.ts";
 import { binaryNameFor, type ResolveBinary } from "./resolve_binary.ts";
 

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -35,7 +35,7 @@ import { syntheticPayloadFor } from "../synthetic_payloads.ts";
  * throws by design (to avoid disrupting the user's coding session).
  */
 
-function appliesTo(tool: AiTool): boolean {
+function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
     tool === "opencode";
 }

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import type { AiTool } from "../../../repo/repo_service.ts";
 import { todaysAuditFilePath } from "../../audit_path.ts";
 import type { PreflightCheck } from "../check.ts";
 import { syntheticPayloadFor } from "../synthetic_payloads.ts";

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { join } from "@std/path";
-import type { AiTool } from "../../../repo/repo_service.ts";
 import type { CheckContext, CheckResult, PreflightCheck } from "../check.ts";
 import type { ResolveBinary } from "./resolve_binary.ts";
 

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -34,7 +34,7 @@ import type { ResolveBinary } from "./resolve_binary.ts";
  * This check surfaces both conditions.
  */
 
-function appliesTo(tool: AiTool): boolean {
+function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
     tool === "opencode";
 }

--- a/src/domain/audit/doctor/doctor_service.ts
+++ b/src/domain/audit/doctor/doctor_service.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { SwampError } from "../../../libswamp/errors.ts";
-import type { AiTool } from "../../repo/repo_service.ts";
+import { isBuiltInTool } from "../../repo/custom_tool.ts";
 import type {
   AuditDoctorReport,
   CheckResult,
@@ -50,7 +50,7 @@ export type AuditDoctorEvent =
 export interface AuditDoctorDeps {
   repoPath: string;
   auditDir: string;
-  tool: AiTool;
+  tool: string;
   spawnSwamp: SpawnFn;
   abortSignal: AbortSignal;
   /**
@@ -114,7 +114,11 @@ export async function* auditDoctor(
   const { tool, abortSignal } = deps;
 
   // Tools without audit hook integration: short-circuit cleanly.
-  if (tool === "codex" || tool === "copilot" || tool === "none") {
+  // Custom tools (non-built-in) also skip — they have no audit hooks.
+  if (
+    !isBuiltInTool(tool) || tool === "codex" || tool === "copilot" ||
+    tool === "none"
+  ) {
     const skipResult: CheckResult = {
       name: "recording-smoke-test",
       status: "skip",

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -44,7 +44,6 @@
  *   https://opencode.ai/docs/plugins (plugin emits normalized JSON on stdin)
  */
 
-import type { AiTool } from "../../repo/repo_service.ts";
 import { DIAGNOSTIC_COMMAND_PREFIX } from "../audit_service.ts";
 
 /**

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -78,7 +78,7 @@ export interface SyntheticPayload {
  * nonce becomes part of the command string the smoke-test greps for.
  */
 export function syntheticPayloadFor(
-  tool: AiTool,
+  tool: string,
   nonce: string,
 ): SyntheticPayload | null {
   const expectedCommand = `${DOCTOR_SMOKE_TEST_COMMAND_PREFIX} ${nonce}`;
@@ -128,6 +128,7 @@ export function syntheticPayloadFor(
     case "codex":
     case "copilot":
     case "none":
+    default:
       return null;
   }
 }

--- a/src/domain/repo/ai_tool.ts
+++ b/src/domain/repo/ai_tool.ts
@@ -35,3 +35,5 @@ export type AiTool =
   | "copilot"
   | "kiro"
   | "none";
+
+export { isBuiltInTool } from "./custom_tool.ts";

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join, resolve } from "@std/path";
+import { join, resolve, SEPARATOR } from "@std/path";
 import type { AiTool } from "./ai_tool.ts";
 import { UserError } from "../errors.ts";
 
@@ -84,7 +84,8 @@ export function assertPathContained(
   const resolved = resolve(join(repoRoot, relativePath));
   const normalizedRoot = resolve(repoRoot);
   if (
-    !resolved.startsWith(normalizedRoot + "/") && resolved !== normalizedRoot
+    !resolved.startsWith(normalizedRoot + SEPARATOR) &&
+    resolved !== normalizedRoot
   ) {
     throw new UserError(
       `${label} "${relativePath}" escapes the repository root.`,

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { join, resolve } from "@std/path";
 import type { AiTool } from "./ai_tool.ts";
 import { UserError } from "../errors.ts";
 
@@ -41,7 +42,7 @@ export interface ToolConfig {
   gitignoreEntries?: string;
 }
 
-const BUILT_IN_TOOLS: ReadonlySet<string> = new Set<string>([
+export const BUILT_IN_TOOL_NAMES: readonly string[] = [
   "claude",
   "cursor",
   "opencode",
@@ -49,7 +50,11 @@ const BUILT_IN_TOOLS: ReadonlySet<string> = new Set<string>([
   "copilot",
   "kiro",
   "none",
-]);
+];
+
+const BUILT_IN_TOOLS: ReadonlySet<string> = new Set<string>(
+  BUILT_IN_TOOL_NAMES,
+);
 
 export function isBuiltInTool(name: string): name is AiTool {
   return BUILT_IN_TOOLS.has(name);
@@ -67,6 +72,22 @@ export function validateCustomToolName(name: string): void {
     throw new UserError(
       `Invalid custom tool name "${name}". ` +
         "Names must be alphanumeric with hyphens (e.g. windsurf, Pi, my-tool).",
+    );
+  }
+}
+
+export function assertPathContained(
+  repoRoot: string,
+  relativePath: string,
+  label: string,
+): void {
+  const resolved = resolve(join(repoRoot, relativePath));
+  const normalizedRoot = resolve(repoRoot);
+  if (
+    !resolved.startsWith(normalizedRoot + "/") && resolved !== normalizedRoot
+  ) {
+    throw new UserError(
+      `${label} "${relativePath}" escapes the repository root.`,
     );
   }
 }
@@ -222,7 +243,7 @@ export async function detectToolConfig(
   const result: DetectionResult = { subdirs: [], rootFiles: [] };
 
   const configDirName = `.${toolName}`;
-  const configDirPath = `${repoDir}/${configDirName}`;
+  const configDirPath = join(repoDir, configDirName);
   try {
     const stat = await Deno.stat(configDirPath);
     if (stat.isDirectory) {
@@ -230,7 +251,7 @@ export async function detectToolConfig(
 
       for (const subdir of KNOWN_SUBDIRS) {
         try {
-          const subStat = await Deno.stat(`${configDirPath}/${subdir}`);
+          const subStat = await Deno.stat(join(configDirPath, subdir));
           if (subStat.isDirectory) {
             result.subdirs.push(subdir);
           }
@@ -245,7 +266,7 @@ export async function detectToolConfig(
 
   for (const file of KNOWN_ROOT_FILES) {
     try {
-      const stat = await Deno.stat(`${repoDir}/${file}`);
+      const stat = await Deno.stat(join(repoDir, file));
       if (stat.isFile) {
         result.rootFiles.push(file);
       }
@@ -256,7 +277,7 @@ export async function detectToolConfig(
 
   // Check for a bare skills/ directory (e.g. deepAgents convention)
   try {
-    const stat = await Deno.stat(`${repoDir}/skills`);
+    const stat = await Deno.stat(join(repoDir, "skills"));
     if (stat.isDirectory) {
       result.skillsDir = "skills";
     }

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -94,7 +94,6 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         frontmatter:
           "---\ndescription: Swamp automation rules\nalwaysApply: true\n---\n",
         skillReferenceStyle: "path",
-        gitignoreEntries: "# Cursor skills (managed by swamp)\n.cursor/skills/",
       };
     case "opencode":
       return {
@@ -104,7 +103,6 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
         skillReferenceStyle: "path",
-        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
       };
     case "codex":
       return {
@@ -114,7 +112,6 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
         skillReferenceStyle: "path",
-        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
       };
     case "copilot":
       return {
@@ -124,7 +121,6 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
         skillReferenceStyle: "path",
-        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
       };
     case "kiro":
       return {
@@ -135,7 +131,6 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         instructionsMode: "owned",
         frontmatter: "---\ninclusion: always\n---\n",
         skillReferenceStyle: "path",
-        gitignoreEntries: "# Kiro skills (managed by swamp)\n.kiro/skills/",
       };
     case "none":
       return {

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -1,0 +1,285 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AiTool } from "./ai_tool.ts";
+import { UserError } from "../errors.ts";
+
+export interface CustomToolDefinition {
+  name: string;
+  skillsDir: string;
+  instructionsFile: string;
+  instructionsMode: "shared" | "owned";
+  frontmatter?: string;
+  skillReferenceStyle: "name" | "path";
+  gitignoreEntries?: string;
+}
+
+export interface ToolConfig {
+  name: string;
+  isBuiltIn: boolean;
+  skillsDir: string;
+  instructionsFile: string;
+  instructionsMode: "shared" | "owned";
+  frontmatter?: string;
+  skillReferenceStyle: "name" | "path";
+  gitignoreEntries?: string;
+}
+
+const BUILT_IN_TOOLS: ReadonlySet<string> = new Set<string>([
+  "claude",
+  "cursor",
+  "opencode",
+  "codex",
+  "copilot",
+  "kiro",
+  "none",
+]);
+
+export function isBuiltInTool(name: string): name is AiTool {
+  return BUILT_IN_TOOLS.has(name);
+}
+
+const CUSTOM_TOOL_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+export function validateCustomToolName(name: string): void {
+  if (isBuiltInTool(name.toLowerCase())) {
+    throw new UserError(
+      `"${name}" conflicts with a built-in tool and cannot be used as a custom tool name.`,
+    );
+  }
+  if (!CUSTOM_TOOL_NAME_PATTERN.test(name)) {
+    throw new UserError(
+      `Invalid custom tool name "${name}". ` +
+        "Names must be alphanumeric with hyphens (e.g. windsurf, Pi, my-tool).",
+    );
+  }
+}
+
+export function builtInToolConfig(tool: AiTool): ToolConfig {
+  switch (tool) {
+    case "claude":
+      return {
+        name: "claude",
+        isBuiltIn: true,
+        skillsDir: ".claude/skills",
+        instructionsFile: "CLAUDE.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "name",
+        gitignoreEntries:
+          "# Claude Code configuration (managed by swamp)\n.claude/worktrees/\n.claude/settings.local.json\n.claude/scheduled_tasks.lock\n.claude/scheduled_tasks.json",
+      };
+    case "cursor":
+      return {
+        name: "cursor",
+        isBuiltIn: true,
+        skillsDir: ".cursor/skills",
+        instructionsFile: ".cursor/rules/swamp.mdc",
+        instructionsMode: "owned",
+        frontmatter:
+          "---\ndescription: Swamp automation rules\nalwaysApply: true\n---\n",
+        skillReferenceStyle: "path",
+        gitignoreEntries: "# Cursor skills (managed by swamp)\n.cursor/skills/",
+      };
+    case "opencode":
+      return {
+        name: "opencode",
+        isBuiltIn: true,
+        skillsDir: ".agents/skills",
+        instructionsFile: "AGENTS.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "path",
+        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
+      };
+    case "codex":
+      return {
+        name: "codex",
+        isBuiltIn: true,
+        skillsDir: ".agents/skills",
+        instructionsFile: "AGENTS.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "path",
+        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
+      };
+    case "copilot":
+      return {
+        name: "copilot",
+        isBuiltIn: true,
+        skillsDir: ".agents/skills",
+        instructionsFile: "AGENTS.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "path",
+        gitignoreEntries: "# Agent skills (managed by swamp)\n.agents/skills/",
+      };
+    case "kiro":
+      return {
+        name: "kiro",
+        isBuiltIn: true,
+        skillsDir: ".kiro/skills",
+        instructionsFile: ".kiro/steering/swamp-rules.md",
+        instructionsMode: "owned",
+        frontmatter: "---\ninclusion: always\n---\n",
+        skillReferenceStyle: "path",
+        gitignoreEntries: "# Kiro skills (managed by swamp)\n.kiro/skills/",
+      };
+    case "none":
+      return {
+        name: "none",
+        isBuiltIn: true,
+        skillsDir: ".swamp/pulled-extensions/skills",
+        instructionsFile: "",
+        instructionsMode: "owned",
+        skillReferenceStyle: "path",
+      };
+  }
+}
+
+export function customToolConfig(def: CustomToolDefinition): ToolConfig {
+  return {
+    name: def.name,
+    isBuiltIn: false,
+    skillsDir: def.skillsDir,
+    instructionsFile: def.instructionsFile,
+    instructionsMode: def.instructionsMode,
+    frontmatter: def.frontmatter,
+    skillReferenceStyle: def.skillReferenceStyle,
+    gitignoreEntries: def.gitignoreEntries,
+  };
+}
+
+const ROOT_LEVEL_SHARED_FILES = new Set([
+  "AGENTS.md",
+  "AGENT.md",
+  "CLAUDE.md",
+  "CONVENTIONS.md",
+]);
+
+export function deriveDefaults(
+  name: string,
+  instructionsPath: string,
+  detectedConfigDir?: string,
+): CustomToolDefinition {
+  const isRootFile = !instructionsPath.includes("/") &&
+    !instructionsPath.includes("\\");
+  const isShared = isRootFile && ROOT_LEVEL_SHARED_FILES.has(instructionsPath);
+
+  let skillsDir: string;
+  if (!isRootFile) {
+    const topDir = instructionsPath.split("/")[0];
+    if (topDir.startsWith(".")) {
+      skillsDir = `${topDir}/skills`;
+    } else {
+      skillsDir = `.${name.toLowerCase()}/skills`;
+    }
+  } else if (detectedConfigDir) {
+    skillsDir = `${detectedConfigDir}/skills`;
+  } else {
+    skillsDir = `.${name.toLowerCase()}/skills`;
+  }
+
+  const gitignoreComment = isBuiltInTool(name)
+    ? name
+    : name.charAt(0).toUpperCase() + name.slice(1);
+
+  return {
+    name,
+    skillsDir,
+    instructionsFile: instructionsPath,
+    instructionsMode: isShared ? "shared" : "owned",
+    skillReferenceStyle: "path",
+    gitignoreEntries:
+      `# ${gitignoreComment} skills (managed by swamp)\n${skillsDir}/`,
+  };
+}
+
+export interface DetectionResult {
+  configDir?: string;
+  subdirs: string[];
+  rootFiles: string[];
+}
+
+const KNOWN_SUBDIRS = ["rules", "guidelines", "steering"];
+const KNOWN_ROOT_FILES = ["AGENTS.md", "AGENT.md", "CONVENTIONS.md"];
+
+export async function detectToolConfig(
+  repoDir: string,
+  toolName: string,
+): Promise<DetectionResult> {
+  const result: DetectionResult = { subdirs: [], rootFiles: [] };
+
+  const configDirName = `.${toolName}`;
+  const configDirPath = `${repoDir}/${configDirName}`;
+  try {
+    const stat = await Deno.stat(configDirPath);
+    if (stat.isDirectory) {
+      result.configDir = configDirName;
+
+      for (const subdir of KNOWN_SUBDIRS) {
+        try {
+          const subStat = await Deno.stat(`${configDirPath}/${subdir}`);
+          if (subStat.isDirectory) {
+            result.subdirs.push(subdir);
+          }
+        } catch {
+          // subdir doesn't exist
+        }
+      }
+    }
+  } catch {
+    // config dir doesn't exist
+  }
+
+  for (const file of KNOWN_ROOT_FILES) {
+    try {
+      const stat = await Deno.stat(`${repoDir}/${file}`);
+      if (stat.isFile) {
+        result.rootFiles.push(file);
+      }
+    } catch {
+      // file doesn't exist
+    }
+  }
+
+  return result;
+}
+
+export function buildInstructionsChoices(
+  detection: DetectionResult,
+  _toolName: string,
+): string[] {
+  const choices: string[] = [];
+
+  for (const rootFile of detection.rootFiles) {
+    choices.push(rootFile);
+  }
+
+  if (detection.configDir) {
+    for (const subdir of detection.subdirs) {
+      choices.push(`${detection.configDir}/${subdir}/swamp.md`);
+    }
+    if (detection.subdirs.length === 0) {
+      choices.push(`${detection.configDir}/rules/swamp.md`);
+    }
+  }
+
+  if (choices.length === 0) {
+    choices.push("AGENTS.md");
+  }
+
+  return choices;
+}

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -173,13 +173,16 @@ export function deriveDefaults(
   name: string,
   instructionsPath: string,
   detectedConfigDir?: string,
+  detectedSkillsDir?: string,
 ): CustomToolDefinition {
   const isRootFile = !instructionsPath.includes("/") &&
     !instructionsPath.includes("\\");
   const isShared = isRootFile && ROOT_LEVEL_SHARED_FILES.has(instructionsPath);
 
   let skillsDir: string;
-  if (!isRootFile) {
+  if (detectedSkillsDir) {
+    skillsDir = detectedSkillsDir;
+  } else if (!isRootFile) {
     const topDir = instructionsPath.split("/")[0];
     if (topDir.startsWith(".")) {
       skillsDir = `${topDir}/skills`;
@@ -211,6 +214,7 @@ export interface DetectionResult {
   configDir?: string;
   subdirs: string[];
   rootFiles: string[];
+  skillsDir?: string;
 }
 
 const KNOWN_SUBDIRS = ["rules", "guidelines", "steering"];
@@ -255,6 +259,16 @@ export async function detectToolConfig(
     }
   }
 
+  // Check for a bare skills/ directory (e.g. deepAgents convention)
+  try {
+    const stat = await Deno.stat(`${repoDir}/skills`);
+    if (stat.isDirectory) {
+      result.skillsDir = "skills";
+    }
+  } catch {
+    // skills dir doesn't exist
+  }
+
   return result;
 }
 
@@ -279,6 +293,31 @@ export function buildInstructionsChoices(
 
   if (choices.length === 0) {
     choices.push("AGENTS.md");
+  }
+
+  return choices;
+}
+
+export function buildSkillsDirChoices(
+  detection: DetectionResult,
+  derivedDefault: string,
+): string[] {
+  const seen = new Set<string>();
+  const choices: string[] = [];
+
+  choices.push(derivedDefault);
+  seen.add(derivedDefault);
+
+  if (detection.skillsDir && !seen.has(detection.skillsDir)) {
+    choices.push(detection.skillsDir);
+    seen.add(detection.skillsDir);
+  }
+
+  if (detection.configDir) {
+    const configSkills = `${detection.configDir}/skills`;
+    if (!seen.has(configSkills)) {
+      choices.push(configSkills);
+    }
   }
 
   return choices;

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -1,0 +1,254 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  buildInstructionsChoices,
+  builtInToolConfig,
+  customToolConfig,
+  deriveDefaults,
+  detectToolConfig,
+  isBuiltInTool,
+  validateCustomToolName,
+} from "./custom_tool.ts";
+import { UserError } from "../errors.ts";
+
+Deno.test("isBuiltInTool: recognizes built-in tools", () => {
+  assertEquals(isBuiltInTool("claude"), true);
+  assertEquals(isBuiltInTool("cursor"), true);
+  assertEquals(isBuiltInTool("opencode"), true);
+  assertEquals(isBuiltInTool("codex"), true);
+  assertEquals(isBuiltInTool("copilot"), true);
+  assertEquals(isBuiltInTool("kiro"), true);
+  assertEquals(isBuiltInTool("none"), true);
+});
+
+Deno.test("isBuiltInTool: rejects unknown names", () => {
+  assertEquals(isBuiltInTool("windsurf"), false);
+  assertEquals(isBuiltInTool("tabnine"), false);
+  assertEquals(isBuiltInTool(""), false);
+});
+
+Deno.test("validateCustomToolName: accepts valid names", () => {
+  validateCustomToolName("windsurf");
+  validateCustomToolName("tabnine");
+  validateCustomToolName("my-tool");
+  validateCustomToolName("tool123");
+  validateCustomToolName("Pi");
+  validateCustomToolName("MyTool");
+});
+
+Deno.test("validateCustomToolName: rejects built-in names", () => {
+  assertThrows(
+    () => validateCustomToolName("claude"),
+    UserError,
+    "built-in tool",
+  );
+  assertThrows(
+    () => validateCustomToolName("none"),
+    UserError,
+    "built-in tool",
+  );
+});
+
+Deno.test("validateCustomToolName: rejects built-in names case-insensitively", () => {
+  assertThrows(
+    () => validateCustomToolName("Claude"),
+    UserError,
+    "conflicts with a built-in",
+  );
+  assertThrows(
+    () => validateCustomToolName("KIRO"),
+    UserError,
+    "conflicts with a built-in",
+  );
+});
+
+Deno.test("validateCustomToolName: rejects invalid patterns", () => {
+  assertThrows(
+    () => validateCustomToolName("my tool"),
+    UserError,
+    "alphanumeric",
+  );
+  assertThrows(
+    () => validateCustomToolName(""),
+    UserError,
+    "alphanumeric",
+  );
+  assertThrows(
+    () => validateCustomToolName("-tool"),
+    UserError,
+    "alphanumeric",
+  );
+});
+
+Deno.test("builtInToolConfig: claude config", () => {
+  const config = builtInToolConfig("claude");
+  assertEquals(config.name, "claude");
+  assertEquals(config.isBuiltIn, true);
+  assertEquals(config.skillsDir, ".claude/skills");
+  assertEquals(config.instructionsFile, "CLAUDE.md");
+  assertEquals(config.instructionsMode, "shared");
+  assertEquals(config.skillReferenceStyle, "name");
+});
+
+Deno.test("builtInToolConfig: cursor config", () => {
+  const config = builtInToolConfig("cursor");
+  assertEquals(config.name, "cursor");
+  assertEquals(config.isBuiltIn, true);
+  assertEquals(config.skillsDir, ".cursor/skills");
+  assertEquals(config.instructionsFile, ".cursor/rules/swamp.mdc");
+  assertEquals(config.instructionsMode, "owned");
+  assertEquals(config.skillReferenceStyle, "path");
+  assertEquals(config.frontmatter !== undefined, true);
+});
+
+Deno.test("builtInToolConfig: kiro config", () => {
+  const config = builtInToolConfig("kiro");
+  assertEquals(config.name, "kiro");
+  assertEquals(config.isBuiltIn, true);
+  assertEquals(config.skillsDir, ".kiro/skills");
+  assertEquals(config.instructionsFile, ".kiro/steering/swamp-rules.md");
+  assertEquals(config.instructionsMode, "owned");
+});
+
+Deno.test("builtInToolConfig: opencode/codex/copilot share AGENTS.md", () => {
+  for (const tool of ["opencode", "codex", "copilot"] as const) {
+    const config = builtInToolConfig(tool);
+    assertEquals(config.instructionsFile, "AGENTS.md");
+    assertEquals(config.instructionsMode, "shared");
+    assertEquals(config.skillsDir, ".agents/skills");
+  }
+});
+
+Deno.test("customToolConfig: wraps definition correctly", () => {
+  const def = {
+    name: "windsurf",
+    skillsDir: ".windsurf/skills",
+    instructionsFile: "AGENTS.md",
+    instructionsMode: "shared" as const,
+    skillReferenceStyle: "path" as const,
+  };
+  const config = customToolConfig(def);
+  assertEquals(config.name, "windsurf");
+  assertEquals(config.isBuiltIn, false);
+  assertEquals(config.skillsDir, ".windsurf/skills");
+  assertEquals(config.instructionsFile, "AGENTS.md");
+  assertEquals(config.instructionsMode, "shared");
+});
+
+Deno.test("deriveDefaults: root-level shared file without config dir", () => {
+  const def = deriveDefaults("windsurf", "AGENTS.md");
+  assertEquals(def.name, "windsurf");
+  assertEquals(def.skillsDir, ".windsurf/skills");
+  assertEquals(def.instructionsFile, "AGENTS.md");
+  assertEquals(def.instructionsMode, "shared");
+  assertEquals(def.skillReferenceStyle, "path");
+});
+
+Deno.test("deriveDefaults: root-level shared file with detected config dir", () => {
+  const def = deriveDefaults("windsurf", "AGENTS.md", ".windsurf");
+  assertEquals(def.skillsDir, ".windsurf/skills");
+  assertEquals(def.instructionsMode, "shared");
+});
+
+Deno.test("deriveDefaults: file inside dot-directory", () => {
+  const def = deriveDefaults("tabnine", ".tabnine/guidelines/swamp.md");
+  assertEquals(def.skillsDir, ".tabnine/skills");
+  assertEquals(def.instructionsFile, ".tabnine/guidelines/swamp.md");
+  assertEquals(def.instructionsMode, "owned");
+});
+
+Deno.test("deriveDefaults: file inside non-dot directory", () => {
+  const def = deriveDefaults("mytool", "config/rules/swamp.md");
+  assertEquals(def.skillsDir, ".mytool/skills");
+  assertEquals(def.instructionsMode, "owned");
+});
+
+Deno.test("deriveDefaults: root-level non-shared file", () => {
+  const def = deriveDefaults("mytool", "RULES.md");
+  assertEquals(def.instructionsMode, "owned");
+  assertEquals(def.skillsDir, ".mytool/skills");
+});
+
+Deno.test("detectToolConfig: empty directory returns no detections", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const result = await detectToolConfig(dir, "windsurf");
+    assertEquals(result.configDir, undefined);
+    assertEquals(result.subdirs, []);
+    assertEquals(result.rootFiles, []);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("detectToolConfig: detects config dir and subdirs", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${dir}/.windsurf/rules`, { recursive: true });
+    await Deno.mkdir(`${dir}/.windsurf/guidelines`, { recursive: true });
+    const result = await detectToolConfig(dir, "windsurf");
+    assertEquals(result.configDir, ".windsurf");
+    assertEquals(result.subdirs.includes("rules"), true);
+    assertEquals(result.subdirs.includes("guidelines"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("detectToolConfig: detects root-level files", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${dir}/AGENTS.md`, "# Agents");
+    const result = await detectToolConfig(dir, "windsurf");
+    assertEquals(result.rootFiles, ["AGENTS.md"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("buildInstructionsChoices: with detected root files and config dir", () => {
+  const choices = buildInstructionsChoices(
+    {
+      configDir: ".windsurf",
+      subdirs: ["rules"],
+      rootFiles: ["AGENTS.md"],
+    },
+    "windsurf",
+  );
+  assertEquals(choices.includes("AGENTS.md"), true);
+  assertEquals(choices.includes(".windsurf/rules/swamp.md"), true);
+});
+
+Deno.test("buildInstructionsChoices: no detections defaults to AGENTS.md", () => {
+  const choices = buildInstructionsChoices(
+    { subdirs: [], rootFiles: [] },
+    "windsurf",
+  );
+  assertEquals(choices, ["AGENTS.md"]);
+});
+
+Deno.test("buildInstructionsChoices: config dir without known subdirs suggests rules/", () => {
+  const choices = buildInstructionsChoices(
+    { configDir: ".tabnine", subdirs: [], rootFiles: [] },
+    "tabnine",
+  );
+  assertEquals(choices.includes(".tabnine/rules/swamp.md"), true);
+});

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import {
+  assertPathContained,
   buildInstructionsChoices,
   buildSkillsDirChoices,
   builtInToolConfig,
@@ -311,4 +312,28 @@ Deno.test("buildSkillsDirChoices: deduplicates when derived matches detected", (
     "skills",
   );
   assertEquals(choices, ["skills"]);
+});
+
+Deno.test("assertPathContained: allows paths within repo", () => {
+  assertPathContained("/repo", "skills", "skillsDir");
+  assertPathContained("/repo", ".foo/skills", "skillsDir");
+  assertPathContained("/repo", "AGENTS.md", "instructionsFile");
+});
+
+Deno.test("assertPathContained: rejects path traversal", () => {
+  assertThrows(
+    () => assertPathContained("/repo", "../../etc/foo", "skillsDir"),
+    UserError,
+    "escapes the repository root",
+  );
+  assertThrows(
+    () =>
+      assertPathContained(
+        "/repo",
+        "../.ssh/authorized_keys",
+        "instructionsFile",
+      ),
+    UserError,
+    "escapes the repository root",
+  );
 });

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   buildInstructionsChoices,
+  buildSkillsDirChoices,
   builtInToolConfig,
   customToolConfig,
   deriveDefaults,
@@ -194,6 +195,7 @@ Deno.test("detectToolConfig: empty directory returns no detections", async () =>
     assertEquals(result.configDir, undefined);
     assertEquals(result.subdirs, []);
     assertEquals(result.rootFiles, []);
+    assertEquals(result.skillsDir, undefined);
   } finally {
     await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
@@ -251,4 +253,62 @@ Deno.test("buildInstructionsChoices: config dir without known subdirs suggests r
     "tabnine",
   );
   assertEquals(choices.includes(".tabnine/rules/swamp.md"), true);
+});
+
+Deno.test("detectToolConfig: detects bare skills/ directory", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${dir}/skills`, { recursive: true });
+    const result = await detectToolConfig(dir, "deepagents");
+    assertEquals(result.skillsDir, "skills");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("deriveDefaults: uses detectedSkillsDir when provided", () => {
+  const def = deriveDefaults("deepagents", "AGENTS.md", undefined, "skills");
+  assertEquals(def.skillsDir, "skills");
+  assertEquals(def.instructionsMode, "shared");
+  assertEquals(
+    def.gitignoreEntries,
+    "# Deepagents skills (managed by swamp)\nskills/",
+  );
+});
+
+Deno.test("deriveDefaults: detectedSkillsDir takes priority over configDir", () => {
+  const def = deriveDefaults("mytool", "AGENTS.md", ".mytool", "skills");
+  assertEquals(def.skillsDir, "skills");
+});
+
+Deno.test("buildSkillsDirChoices: single choice when no detection", () => {
+  const choices = buildSkillsDirChoices(
+    { subdirs: [], rootFiles: [] },
+    ".deepagents/skills",
+  );
+  assertEquals(choices, [".deepagents/skills"]);
+});
+
+Deno.test("buildSkillsDirChoices: includes detected skillsDir", () => {
+  const choices = buildSkillsDirChoices(
+    { subdirs: [], rootFiles: [], skillsDir: "skills" },
+    ".deepagents/skills",
+  );
+  assertEquals(choices, [".deepagents/skills", "skills"]);
+});
+
+Deno.test("buildSkillsDirChoices: includes configDir/skills", () => {
+  const choices = buildSkillsDirChoices(
+    { configDir: ".mytool", subdirs: [], rootFiles: [] },
+    "other/skills",
+  );
+  assertEquals(choices, ["other/skills", ".mytool/skills"]);
+});
+
+Deno.test("buildSkillsDirChoices: deduplicates when derived matches detected", () => {
+  const choices = buildSkillsDirChoices(
+    { subdirs: [], rootFiles: [], skillsDir: "skills" },
+    "skills",
+  );
+  assertEquals(choices, ["skills"]);
 });

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -314,26 +314,36 @@ Deno.test("buildSkillsDirChoices: deduplicates when derived matches detected", (
   assertEquals(choices, ["skills"]);
 });
 
-Deno.test("assertPathContained: allows paths within repo", () => {
-  assertPathContained("/repo", "skills", "skillsDir");
-  assertPathContained("/repo", ".foo/skills", "skillsDir");
-  assertPathContained("/repo", "AGENTS.md", "instructionsFile");
+Deno.test("assertPathContained: allows paths within repo", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    assertPathContained(dir, "skills", "skillsDir");
+    assertPathContained(dir, ".foo/skills", "skillsDir");
+    assertPathContained(dir, "AGENTS.md", "instructionsFile");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
 });
 
-Deno.test("assertPathContained: rejects path traversal", () => {
-  assertThrows(
-    () => assertPathContained("/repo", "../../etc/foo", "skillsDir"),
-    UserError,
-    "escapes the repository root",
-  );
-  assertThrows(
-    () =>
-      assertPathContained(
-        "/repo",
-        "../.ssh/authorized_keys",
-        "instructionsFile",
-      ),
-    UserError,
-    "escapes the repository root",
-  );
+Deno.test("assertPathContained: rejects path traversal", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    assertThrows(
+      () => assertPathContained(dir, "../../etc/foo", "skillsDir"),
+      UserError,
+      "escapes the repository root",
+    );
+    assertThrows(
+      () =>
+        assertPathContained(
+          dir,
+          "../.ssh/authorized_keys",
+          "instructionsFile",
+        ),
+      UserError,
+      "escapes the repository root",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
 });

--- a/src/domain/repo/primary_tool.ts
+++ b/src/domain/repo/primary_tool.ts
@@ -35,6 +35,6 @@ import type {
  * "no tools enrolled" (represented as `tools: []`); it never appears inside
  * `tools` and is therefore never returned.
  */
-export function resolvePrimaryTool(marker: RepoMarkerData | null): AiTool {
+export function resolvePrimaryTool(marker: RepoMarkerData | null): string {
   return marker?.tools?.[0] ?? "claude";
 }

--- a/src/domain/repo/primary_tool.ts
+++ b/src/domain/repo/primary_tool.ts
@@ -17,10 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type {
-  AiTool,
-  RepoMarkerData,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import type { RepoMarkerData } from "../../infrastructure/persistence/repo_marker_repository.ts";
 
 /**
  * Resolves the primary AI tool for a repository.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -36,12 +36,8 @@ import {
 import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import { assertNever, UserError } from "../errors.ts";
 import { resolvePrimaryTool } from "./primary_tool.ts";
-import { resolveSkillsDir, SKILL_DIRS } from "./skill_dirs.ts";
-import {
-  builtInToolConfig,
-  isBuiltInTool,
-  type ToolConfig,
-} from "./custom_tool.ts";
+import { resolveSkillsDir } from "./skill_dirs.ts";
+import type { ToolConfig } from "./custom_tool.ts";
 import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
 
@@ -67,20 +63,6 @@ const LEGACY_INSTRUCTIONS_SIGNATURE = "This repository is managed with [swamp]";
  * - "skipped": gitignore management was not opted in
  */
 export type GitignoreAction = "created" | "updated" | "unchanged" | "skipped";
-
-const INSTRUCTIONS_FILES: Partial<Record<AiTool, string>> = {
-  claude: "CLAUDE.md",
-  cursor: ".cursor/rules/swamp.mdc",
-  opencode: "AGENTS.md",
-  codex: "AGENTS.md",
-  copilot: "AGENTS.md",
-  kiro: ".kiro/steering/swamp-rules.md",
-};
-
-const GITIGNORE_TOOL_ENTRIES: Partial<Record<AiTool, string>> = {
-  claude:
-    "# Claude Code configuration (managed by swamp)\n.claude/worktrees/\n.claude/settings.local.json\n.claude/scheduled_tasks.lock\n.claude/scheduled_tasks.json",
-};
 
 /**
  * Dedupes a tools list while preserving first-seen order, so set semantics

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -37,6 +37,13 @@ import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import { assertNever, UserError } from "../errors.ts";
 import { resolvePrimaryTool } from "./primary_tool.ts";
 import { resolveSkillsDir, SKILL_DIRS } from "./skill_dirs.ts";
+import {
+  builtInToolConfig,
+  isBuiltInTool,
+  type ToolConfig,
+} from "./custom_tool.ts";
+import { ToolResolver } from "./tool_resolver.ts";
+import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
 
 const logger = getLogger(["swamp", "repo", "service"]);
 
@@ -79,9 +86,9 @@ const GITIGNORE_TOOL_ENTRIES: Partial<Record<AiTool, string>> = {
  * Dedupes a tools list while preserving first-seen order, so set semantics
  * on `marker.tools` are enforced at the domain boundary.
  */
-function normalizeToolsList(tools: AiTool[]): AiTool[] {
-  const seen = new Set<AiTool>();
-  const result: AiTool[] = [];
+function normalizeToolsList(tools: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
   for (const tool of tools) {
     if (!seen.has(tool)) {
       seen.add(tool);
@@ -95,7 +102,7 @@ function normalizeToolsList(tools: AiTool[]): AiTool[] {
  * Renders a tools list for human-readable error/diagnostic messages.
  * Empty list renders as "none" so output is never ambiguous.
  */
-function formatToolsList(tools: AiTool[]): string {
+function formatToolsList(tools: string[]): string {
   return tools.length === 0 ? "none" : tools.join(", ");
 }
 
@@ -142,7 +149,7 @@ export async function detectSupersededSkills(
  * for the new tool.
  */
 export interface ExtensionsToReinstall {
-  tool: AiTool;
+  tool: string;
   names: string[];
 }
 
@@ -157,12 +164,12 @@ export interface RepoInitResult {
   instructionsFileCreated: boolean;
   settingsCreated: boolean;
   gitignoreAction: GitignoreAction;
-  tools: AiTool[];
+  tools: string[];
   /**
    * Tools previously enrolled (when `--force` reinit drops some) whose
    * scaffolding files were left on disk. Empty for fresh inits.
    */
-  removedTools: AiTool[];
+  removedTools: string[];
 }
 
 /**
@@ -178,10 +185,10 @@ export interface RepoUpgradeResult {
   settingsUpdated: boolean;
   gitignoreAction: GitignoreAction;
   /** Enrolled tools as recorded by `marker.tools` BEFORE this upgrade. */
-  previousTools: AiTool[];
-  tools: AiTool[];
-  addedTools: AiTool[];
-  removedTools: AiTool[];
+  previousTools: string[];
+  tools: string[];
+  addedTools: string[];
+  removedTools: string[];
   extensionsToReinstall: ExtensionsToReinstall[];
 }
 
@@ -191,7 +198,7 @@ export interface RepoUpgradeResult {
  */
 export interface RepoInitOptions {
   force?: boolean;
-  tools?: AiTool[];
+  tools?: string[];
 }
 
 /**
@@ -201,7 +208,7 @@ export interface RepoInitOptions {
  *  - [list]: replace
  */
 export interface RepoUpgradeOptions {
-  tools?: AiTool[];
+  tools?: string[];
   includeGitignore?: boolean;
 }
 
@@ -240,7 +247,7 @@ export class RepoService {
     const tools = normalizeToolsList(options.tools ?? ["claude"]);
     const isAlreadyInit = await this.isInitialized(repoPath);
 
-    let removedTools: AiTool[] = [];
+    let removedTools: string[] = [];
 
     if (isAlreadyInit) {
       const existingMarker = await this.markerRepo.read(repoPath);
@@ -270,20 +277,31 @@ export class RepoService {
     // Create data directory structure
     await this.createDataDirectoryStructure(repoPath);
 
-    // Run scaffolding for each enrolled tool
+    // Resolve tools to configs and run scaffolding
+    const resolver = new ToolResolver(repoPath.value, readCustomTools);
+    const resolvedConfigs: ToolConfig[] = [];
     let skillsCopied: string[] = [];
     let instructionsFileCreated = false;
     let settingsCreated = false;
     for (const tool of tools) {
-      const r = await this.applyToolScaffolding(repoPath, tool, isAlreadyInit);
+      const config = await resolver.resolve(tool);
+      resolvedConfigs.push(config);
+      const r = await this.applyToolScaffolding(
+        repoPath,
+        config,
+        isAlreadyInit,
+      );
       if (r.skillsCopied.length > 0) skillsCopied = r.skillsCopied;
       instructionsFileCreated = instructionsFileCreated ||
         r.instructionsFileChanged;
       settingsCreated = settingsCreated || r.settingsChanged;
     }
 
-    // Always manage .gitignore on init (single call with the full tools list)
-    const gitignoreAction = await this.ensureGitignoreSection(repoPath, tools);
+    // Always manage .gitignore on init (single call with resolved configs)
+    const gitignoreAction = await this.ensureGitignoreSection(
+      repoPath,
+      resolvedConfigs,
+    );
     markerData.gitignoreManaged = true;
 
     await this.markerRepo.write(repoPath, markerData);
@@ -360,12 +378,16 @@ export class RepoService {
     );
     updatedMarker.tools = tools;
 
-    // Run scaffolding for each currently-enrolled tool
+    // Resolve tools to configs and run scaffolding
+    const resolver = new ToolResolver(repoPath.value, readCustomTools);
+    const resolvedConfigs: ToolConfig[] = [];
     let skillsUpdated: string[] = [];
     let instructionsUpdated = false;
     let settingsUpdated = false;
     for (const tool of tools) {
-      const r = await this.applyToolScaffolding(repoPath, tool, true);
+      const config = await resolver.resolve(tool);
+      resolvedConfigs.push(config);
+      const r = await this.applyToolScaffolding(repoPath, config, true);
       if (r.skillsCopied.length > 0) skillsUpdated = r.skillsCopied;
       instructionsUpdated = instructionsUpdated || r.instructionsFileChanged;
       settingsUpdated = settingsUpdated || r.settingsChanged;
@@ -382,7 +404,10 @@ export class RepoService {
 
     let gitignoreAction: GitignoreAction;
     if (shouldManageGitignore) {
-      gitignoreAction = await this.ensureGitignoreSection(repoPath, tools);
+      gitignoreAction = await this.ensureGitignoreSection(
+        repoPath,
+        resolvedConfigs,
+      );
     } else {
       gitignoreAction = "skipped";
     }
@@ -427,14 +452,14 @@ export class RepoService {
    */
   private async applyToolScaffolding(
     repoPath: RepoPath,
-    tool: AiTool,
+    config: ToolConfig,
     alreadyExists: boolean,
   ): Promise<{
     skillsCopied: string[];
     instructionsFileChanged: boolean;
     settingsChanged: boolean;
   }> {
-    if (tool === "none") {
+    if (config.name === "none") {
       return {
         skillsCopied: [],
         instructionsFileChanged: false,
@@ -443,7 +468,7 @@ export class RepoService {
     }
 
     // Copy skills to tool-appropriate directory
-    const skillsDir = join(repoPath.value, SKILL_DIRS[tool]!);
+    const skillsDir = join(repoPath.value, config.skillsDir);
     await this.skillAssets.copySkillsTo(skillsDir);
     const skillsCopied = this.skillAssets.getSkillNames();
 
@@ -452,46 +477,50 @@ export class RepoService {
 
     // Create or update instructions file
     const instructionsFileChanged = alreadyExists
-      ? await this.updateInstructionsFile(repoPath, tool)
-      : await this.createInstructionsFileIfNotExists(repoPath, tool);
+      ? await this.updateInstructionsFile(repoPath, config)
+      : await this.createInstructionsFileIfNotExists(repoPath, config);
 
-    // Create or update tool-specific settings
+    // Create or update tool-specific settings (built-in tools only)
     let settingsChanged = false;
-    switch (tool) {
-      case "claude":
-        settingsChanged = alreadyExists
-          ? await this.updateClaudeSettings(repoPath)
-          : await this.createClaudeSettingsIfNotExists(repoPath);
-        break;
-      case "cursor":
-        settingsChanged = alreadyExists
-          ? await this.updateCursorHooks(repoPath)
-          : await this.createCursorHooksIfNotExists(repoPath);
-        break;
-      case "kiro": {
-        const s = alreadyExists
-          ? await this.updateKiroSettings(repoPath)
-          : await this.createKiroSettingsIfNotExists(repoPath);
-        const h = alreadyExists
-          ? await this.updateKiroHooks(repoPath)
-          : await this.createKiroHooksIfNotExists(repoPath);
-        const a = alreadyExists
-          ? await this.updateKiroAgentConfig(repoPath)
-          : await this.createKiroAgentConfigIfNotExists(repoPath);
-        const c = await this.ensureKiroCliDefaultAgent(repoPath);
-        settingsChanged = s || h || a || c;
-        break;
+    if (config.isBuiltIn) {
+      const tool = config.name as AiTool;
+      switch (tool) {
+        case "claude":
+          settingsChanged = alreadyExists
+            ? await this.updateClaudeSettings(repoPath)
+            : await this.createClaudeSettingsIfNotExists(repoPath);
+          break;
+        case "cursor":
+          settingsChanged = alreadyExists
+            ? await this.updateCursorHooks(repoPath)
+            : await this.createCursorHooksIfNotExists(repoPath);
+          break;
+        case "kiro": {
+          const s = alreadyExists
+            ? await this.updateKiroSettings(repoPath)
+            : await this.createKiroSettingsIfNotExists(repoPath);
+          const h = alreadyExists
+            ? await this.updateKiroHooks(repoPath)
+            : await this.createKiroHooksIfNotExists(repoPath);
+          const a = alreadyExists
+            ? await this.updateKiroAgentConfig(repoPath)
+            : await this.createKiroAgentConfigIfNotExists(repoPath);
+          const c = await this.ensureKiroCliDefaultAgent(repoPath);
+          settingsChanged = s || h || a || c;
+          break;
+        }
+        case "opencode":
+          settingsChanged = alreadyExists
+            ? await this.updateOpenCodePlugin(repoPath)
+            : await this.createOpenCodePluginIfNotExists(repoPath);
+          break;
+        case "codex":
+        case "copilot":
+        case "none":
+          break;
+        default:
+          assertNever(tool);
       }
-      case "opencode":
-        settingsChanged = alreadyExists
-          ? await this.updateOpenCodePlugin(repoPath)
-          : await this.createOpenCodePluginIfNotExists(repoPath);
-        break;
-      case "codex":
-      case "copilot":
-        break;
-      default:
-        assertNever(tool);
     }
 
     return { skillsCopied, instructionsFileChanged, settingsChanged };
@@ -534,14 +563,13 @@ export class RepoService {
    */
   private async createInstructionsFileIfNotExists(
     repoPath: RepoPath,
-    tool: AiTool,
+    config: ToolConfig,
   ): Promise<boolean> {
-    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]!);
+    if (!config.instructionsFile) return false;
+    const filePath = join(repoPath.value, config.instructionsFile);
 
-    // For shared-file tools, always ensure the managed section exists
-    // (merges into existing file or creates new one)
-    if (this.usesSharedInstructionsFile(tool)) {
-      return this.ensureInstructionsSection(filePath, tool);
+    if (config.instructionsMode === "shared") {
+      return this.ensureInstructionsSection(filePath, config);
     }
 
     // For tool-specific files, only create if missing
@@ -554,7 +582,7 @@ export class RepoService {
         await ensureDir(parentDir);
         await Deno.writeTextFile(
           filePath,
-          this.generateInstructionsContent(tool),
+          this.generateInstructionsContent(config),
         );
         return true;
       }
@@ -569,16 +597,17 @@ export class RepoService {
    */
   private updateInstructionsFile(
     repoPath: RepoPath,
-    tool: AiTool,
+    config: ToolConfig,
   ): Promise<boolean> {
-    const filePath = join(repoPath.value, INSTRUCTIONS_FILES[tool]!);
-    if (!this.usesSharedInstructionsFile(tool)) {
+    if (!config.instructionsFile) return Promise.resolve(false);
+    const filePath = join(repoPath.value, config.instructionsFile);
+    if (config.instructionsMode !== "shared") {
       return this.overwriteIfChanged(
         filePath,
-        this.generateInstructionsContent(tool),
+        this.generateInstructionsContent(config),
       );
     }
-    return this.ensureInstructionsSection(filePath, tool);
+    return this.ensureInstructionsSection(filePath, config);
   }
 
   /**
@@ -591,9 +620,9 @@ export class RepoService {
    */
   private async ensureInstructionsSection(
     filePath: string,
-    tool: AiTool,
+    config: ToolConfig,
   ): Promise<boolean> {
-    const newSection = this.buildInstructionsSection(tool);
+    const newSection = this.buildInstructionsSection(config);
 
     let existingContent: string | null = null;
     try {
@@ -717,29 +746,16 @@ export class RepoService {
    * Returns true if the tool shares its instructions file with user content
    * (CLAUDE.md, AGENTS.md) and needs section markers to avoid overwriting.
    */
-  private usesSharedInstructionsFile(tool: AiTool): boolean {
-    switch (tool) {
-      case "claude":
-      case "opencode":
-      case "codex":
-      case "copilot":
-        return true;
-      case "cursor":
-      case "kiro":
-        return false;
-      case "none":
-        return false;
-      default:
-        assertNever(tool);
-    }
+  private usesSharedInstructionsFile(config: ToolConfig): boolean {
+    return config.instructionsMode === "shared";
   }
 
   /**
    * Generates the raw instructions body without any frontmatter or markers.
    */
-  private generateInstructionsBody(tool: AiTool): string {
-    const skillsDir = SKILL_DIRS[tool] ?? ".agents/skills";
-    const useSkillNames = tool === "claude";
+  private generateInstructionsBody(config: ToolConfig): string {
+    const skillsDir = config.skillsDir;
+    const useSkillNames = config.skillReferenceStyle === "name";
 
     const skillAction = (name: string, verb: string): string =>
       useSkillNames
@@ -864,8 +880,8 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
   /**
    * Wraps the instructions body in BEGIN/END markers for shared files.
    */
-  private buildInstructionsSection(tool: AiTool): string {
-    const body = this.generateInstructionsBody(tool);
+  private buildInstructionsSection(config: ToolConfig): string {
+    const body = this.generateInstructionsBody(config);
     return INSTRUCTIONS_SECTION_BEGIN + "\n" + body +
       INSTRUCTIONS_SECTION_END;
   }
@@ -874,31 +890,12 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
    * Generates the full instructions content for tool-specific files (cursor/kiro).
    * Shared-file tools should use buildInstructionsSection() instead.
    */
-  private generateInstructionsContent(tool: AiTool): string {
-    const body = this.generateInstructionsBody(tool);
-
-    switch (tool) {
-      case "cursor":
-        return `---
-description: Swamp automation rules
-alwaysApply: true
----
-${body}`;
-      case "kiro":
-        return `---
-inclusion: always
----
-${body}`;
-      case "claude":
-      case "opencode":
-      case "codex":
-      case "copilot":
-        return body;
-      case "none":
-        return body;
-      default:
-        assertNever(tool);
+  private generateInstructionsContent(config: ToolConfig): string {
+    const body = this.generateInstructionsBody(config);
+    if (config.frontmatter) {
+      return config.frontmatter + body;
     }
+    return body;
   }
 
   /**
@@ -911,10 +908,10 @@ ${body}`;
    */
   private async ensureGitignoreSection(
     repoPath: RepoPath,
-    tools: AiTool[],
+    configs: ToolConfig[],
   ): Promise<GitignoreAction> {
     const gitignorePath = join(repoPath.value, GITIGNORE_FILENAME);
-    const newSection = this.buildGitignoreSection(tools);
+    const newSection = this.buildGitignoreSection(configs);
 
     let existingContent: string | null = null;
     try {
@@ -968,8 +965,8 @@ ${body}`;
   /**
    * Builds the full managed section including BEGIN/END markers.
    */
-  private buildGitignoreSection(tools: AiTool[]): string {
-    const body = this.generateGitignoreSectionBody(tools);
+  private buildGitignoreSection(configs: ToolConfig[]): string {
+    const body = this.generateGitignoreSectionBody(configs);
     return GITIGNORE_SECTION_BEGIN + "\n" + body + GITIGNORE_SECTION_END;
   }
 
@@ -978,7 +975,7 @@ ${body}`;
    * Emits one entry per enrolled tool that has tool-specific gitignore
    * entries (currently only Claude for local config files).
    */
-  private generateGitignoreSectionBody(tools: AiTool[]): string {
+  private generateGitignoreSectionBody(configs: ToolConfig[]): string {
     const lines = [
       "",
       "# Runtime data (not needed in version control)",
@@ -989,8 +986,8 @@ ${body}`;
     ];
 
     const seenEntries = new Set<string>();
-    for (const tool of tools) {
-      const toolEntry = GITIGNORE_TOOL_ENTRIES[tool];
+    for (const config of configs) {
+      const toolEntry = config.gitignoreEntries;
       if (toolEntry && !seenEntries.has(toolEntry)) {
         seenEntries.add(toolEntry);
         lines.push("", toolEntry);

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -37,7 +37,7 @@ import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import { assertNever, UserError } from "../errors.ts";
 import { resolvePrimaryTool } from "./primary_tool.ts";
 import { resolveSkillsDir } from "./skill_dirs.ts";
-import type { ToolConfig } from "./custom_tool.ts";
+import { assertPathContained, type ToolConfig } from "./custom_tool.ts";
 import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
 
@@ -449,6 +449,17 @@ export class RepoService {
       };
     }
 
+    if (!config.isBuiltIn) {
+      assertPathContained(repoPath.value, config.skillsDir, "skillsDir");
+      if (config.instructionsFile) {
+        assertPathContained(
+          repoPath.value,
+          config.instructionsFile,
+          "instructionsFile",
+        );
+      }
+    }
+
     // Copy skills to tool-appropriate directory
     const skillsDir = join(repoPath.value, config.skillsDir);
     await this.skillAssets.copySkillsTo(skillsDir);
@@ -722,14 +733,6 @@ export class RepoService {
     const suffix = after.length > 0 ? after : "\n";
 
     return prefix + newSection + "\n" + suffix;
-  }
-
-  /**
-   * Returns true if the tool shares its instructions file with user content
-   * (CLAUDE.md, AGENTS.md) and needs section markers to avoid overwriting.
-   */
-  private usesSharedInstructionsFile(config: ToolConfig): boolean {
-    return config.instructionsMode === "shared";
   }
 
   /**

--- a/src/domain/repo/tool_resolver.ts
+++ b/src/domain/repo/tool_resolver.ts
@@ -1,0 +1,95 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  builtInToolConfig,
+  customToolConfig,
+  type CustomToolDefinition,
+  isBuiltInTool,
+  type ToolConfig,
+} from "./custom_tool.ts";
+import { UserError } from "../errors.ts";
+
+export type CustomToolLoader = (
+  repoDir: string,
+) => Promise<CustomToolDefinition[]>;
+
+const VALID_BUILT_IN_NAMES = [
+  "claude",
+  "cursor",
+  "opencode",
+  "codex",
+  "copilot",
+  "kiro",
+  "none",
+];
+
+export class ToolResolver {
+  private customTools: CustomToolDefinition[] | null = null;
+
+  constructor(
+    private repoDir: string,
+    private loadCustomToolsFn: CustomToolLoader,
+  ) {}
+
+  async resolve(name: string): Promise<ToolConfig> {
+    if (isBuiltInTool(name)) {
+      return builtInToolConfig(name);
+    }
+
+    const custom = await this.findCustomTool(name);
+    if (custom) {
+      return customToolConfig(custom);
+    }
+
+    const known = await this.allKnownNames();
+    throw new UserError(
+      `Unknown tool "${name}". Available tools: ${known.join(", ")}. ` +
+        `Run \`swamp agent setup\` to define a custom tool.`,
+    );
+  }
+
+  async isKnown(name: string): Promise<boolean> {
+    if (isBuiltInTool(name)) return true;
+    const custom = await this.findCustomTool(name);
+    return custom !== undefined;
+  }
+
+  async allKnownNames(): Promise<string[]> {
+    const customs = await this.loadCustomTools();
+    return [
+      ...VALID_BUILT_IN_NAMES.filter((n) => n !== "none"),
+      ...customs.map((c) => c.name),
+    ];
+  }
+
+  private async findCustomTool(
+    name: string,
+  ): Promise<CustomToolDefinition | undefined> {
+    const customs = await this.loadCustomTools();
+    return customs.find((c) => c.name === name);
+  }
+
+  private async loadCustomTools(): Promise<CustomToolDefinition[]> {
+    if (this.customTools === null) {
+      this.customTools = await this.loadCustomToolsFn(this.repoDir);
+    }
+    return this.customTools;
+  }
+}

--- a/src/domain/repo/tool_resolver.ts
+++ b/src/domain/repo/tool_resolver.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import {
+  BUILT_IN_TOOL_NAMES,
   builtInToolConfig,
   customToolConfig,
   type CustomToolDefinition,
@@ -29,16 +30,6 @@ import { UserError } from "../errors.ts";
 export type CustomToolLoader = (
   repoDir: string,
 ) => Promise<CustomToolDefinition[]>;
-
-const VALID_BUILT_IN_NAMES = [
-  "claude",
-  "cursor",
-  "opencode",
-  "codex",
-  "copilot",
-  "kiro",
-  "none",
-];
 
 export class ToolResolver {
   private customTools: CustomToolDefinition[] | null = null;
@@ -74,7 +65,7 @@ export class ToolResolver {
   async allKnownNames(): Promise<string[]> {
     const customs = await this.loadCustomTools();
     return [
-      ...VALID_BUILT_IN_NAMES.filter((n) => n !== "none"),
+      ...BUILT_IN_TOOL_NAMES.filter((n) => n !== "none"),
       ...customs.map((c) => c.name),
     ];
   }

--- a/src/domain/repo/tool_resolver_test.ts
+++ b/src/domain/repo/tool_resolver_test.ts
@@ -1,0 +1,158 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { ToolResolver } from "./tool_resolver.ts";
+import {
+  readCustomTools,
+  writeCustomTools,
+} from "../../infrastructure/persistence/custom_tools_repository.ts";
+import { UserError } from "../errors.ts";
+
+Deno.test("ToolResolver.resolve: returns built-in tool config", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const resolver = new ToolResolver(dir, readCustomTools);
+    const config = await resolver.resolve("claude");
+    assertEquals(config.name, "claude");
+    assertEquals(config.isBuiltIn, true);
+    assertEquals(config.skillsDir, ".claude/skills");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.resolve: returns custom tool config", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [{
+      name: "windsurf",
+      skillsDir: ".windsurf/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+    const resolver = new ToolResolver(dir, readCustomTools);
+    const config = await resolver.resolve("windsurf");
+    assertEquals(config.name, "windsurf");
+    assertEquals(config.isBuiltIn, false);
+    assertEquals(config.skillsDir, ".windsurf/skills");
+    assertEquals(config.instructionsFile, "AGENTS.md");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.resolve: throws for unknown tool", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const resolver = new ToolResolver(dir, readCustomTools);
+    await assertRejects(
+      () => resolver.resolve("nonexistent"),
+      UserError,
+      "Unknown tool",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.resolve: error message suggests swamp agent setup", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const resolver = new ToolResolver(dir, readCustomTools);
+    await assertRejects(
+      () => resolver.resolve("nonexistent"),
+      UserError,
+      "swamp agent setup",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.isKnown: built-in tools", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const resolver = new ToolResolver(dir, readCustomTools);
+    assertEquals(await resolver.isKnown("claude"), true);
+    assertEquals(await resolver.isKnown("none"), true);
+    assertEquals(await resolver.isKnown("nonexistent"), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.isKnown: custom tools", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [{
+      name: "windsurf",
+      skillsDir: ".windsurf/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+    const resolver = new ToolResolver(dir, readCustomTools);
+    assertEquals(await resolver.isKnown("windsurf"), true);
+    assertEquals(await resolver.isKnown("tabnine"), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver.allKnownNames: includes built-in and custom", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [{
+      name: "windsurf",
+      skillsDir: ".windsurf/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+    const resolver = new ToolResolver(dir, readCustomTools);
+    const names = await resolver.allKnownNames();
+    assertEquals(names.includes("claude"), true);
+    assertEquals(names.includes("cursor"), true);
+    assertEquals(names.includes("windsurf"), true);
+    assertEquals(names.includes("none"), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ToolResolver: caches custom tools across calls", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [{
+      name: "windsurf",
+      skillsDir: ".windsurf/skills",
+      instructionsFile: "AGENTS.md",
+      instructionsMode: "shared",
+      skillReferenceStyle: "path",
+    }]);
+    const resolver = new ToolResolver(dir, readCustomTools);
+    const config1 = await resolver.resolve("windsurf");
+    const config2 = await resolver.resolve("windsurf");
+    assertEquals(config1.name, config2.name);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -41,7 +41,7 @@ import type { DetectableAiTool } from "./agent_harness_detection.ts";
  *    normalised), an explicit opt-out of tool integration.
  */
 export interface InvocationContext {
-  readonly configuredAiTools?: AiTool[];
+  readonly configuredAiTools?: string[];
   readonly detectedAiTool?: DetectableAiTool;
   readonly agentSessionDetected: boolean;
   readonly isInteractive: boolean;
@@ -52,7 +52,7 @@ export interface InvocationContext {
  * Data transfer object for InvocationContext.
  */
 export interface InvocationContextData {
-  configuredAiTools?: AiTool[];
+  configuredAiTools?: string[];
   detectedAiTool?: DetectableAiTool;
   agentSessionDetected: boolean;
   isInteractive: boolean;

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { AiTool } from "../repo/ai_tool.ts";
 import type { DetectableAiTool } from "./agent_harness_detection.ts";
 
 /**

--- a/src/infrastructure/persistence/custom_tools_repository.ts
+++ b/src/infrastructure/persistence/custom_tools_repository.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import type { CustomToolDefinition } from "../../domain/repo/custom_tool.ts";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+import { swampCustomToolsPath } from "./paths.ts";
+import { UserError } from "../../domain/errors.ts";
+
+interface CustomToolsFileData {
+  tools?: CustomToolDefinitionData[];
+}
+
+interface CustomToolDefinitionData {
+  name: string;
+  skillsDir: string;
+  instructionsFile: string;
+  instructionsMode: string;
+  frontmatter?: string;
+  skillReferenceStyle: string;
+  gitignoreEntries?: string;
+}
+
+function validateMode(
+  mode: string,
+): asserts mode is "shared" | "owned" {
+  if (mode !== "shared" && mode !== "owned") {
+    throw new UserError(
+      `Invalid instructionsMode "${mode}" — must be "shared" or "owned".`,
+    );
+  }
+}
+
+function validateRefStyle(
+  style: string,
+): asserts style is "name" | "path" {
+  if (style !== "name" && style !== "path") {
+    throw new UserError(
+      `Invalid skillReferenceStyle "${style}" — must be "name" or "path".`,
+    );
+  }
+}
+
+function toDefinition(data: CustomToolDefinitionData): CustomToolDefinition {
+  validateMode(data.instructionsMode);
+  validateRefStyle(data.skillReferenceStyle);
+  return {
+    name: data.name,
+    skillsDir: data.skillsDir,
+    instructionsFile: data.instructionsFile,
+    instructionsMode: data.instructionsMode,
+    frontmatter: data.frontmatter,
+    skillReferenceStyle: data.skillReferenceStyle,
+    gitignoreEntries: data.gitignoreEntries,
+  };
+}
+
+export async function readCustomTools(
+  repoDir: string,
+): Promise<CustomToolDefinition[]> {
+  const path = swampCustomToolsPath(repoDir);
+  try {
+    const content = await Deno.readTextFile(path);
+    const data = parseYaml(content) as CustomToolsFileData | null;
+    if (!data?.tools || !Array.isArray(data.tools)) {
+      return [];
+    }
+    return data.tools.map(toDefinition);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function writeCustomTools(
+  repoDir: string,
+  tools: CustomToolDefinition[],
+): Promise<void> {
+  const path = swampCustomToolsPath(repoDir);
+  const data: CustomToolsFileData = { tools };
+  const cleanData = JSON.parse(JSON.stringify(data));
+  const content = stringifyYaml(cleanData as Record<string, unknown>);
+  await atomicWriteTextFile(path, content);
+}
+
+export async function addCustomTool(
+  repoDir: string,
+  tool: CustomToolDefinition,
+): Promise<void> {
+  const existing = await readCustomTools(repoDir);
+  if (existing.some((t) => t.name === tool.name)) {
+    throw new UserError(
+      `Custom tool "${tool.name}" already exists in .swamp-custom-tools.yaml.`,
+    );
+  }
+  existing.push(tool);
+  await writeCustomTools(repoDir, existing);
+}
+
+export async function removeCustomTool(
+  repoDir: string,
+  name: string,
+): Promise<boolean> {
+  const existing = await readCustomTools(repoDir);
+  const filtered = existing.filter((t) => t.name !== name);
+  if (filtered.length === existing.length) {
+    return false;
+  }
+  await writeCustomTools(repoDir, filtered);
+  return true;
+}
+
+export async function findCustomTool(
+  repoDir: string,
+  name: string,
+): Promise<CustomToolDefinition | undefined> {
+  const tools = await readCustomTools(repoDir);
+  return tools.find((t) => t.name === name);
+}

--- a/src/infrastructure/persistence/custom_tools_repository.ts
+++ b/src/infrastructure/persistence/custom_tools_repository.ts
@@ -57,7 +57,21 @@ function validateRefStyle(
   }
 }
 
+function validateRequiredString(
+  value: unknown,
+  field: string,
+): asserts value is string {
+  if (typeof value !== "string" || !value) {
+    throw new UserError(
+      `Missing or empty "${field}" in .swamp-custom-tools.yaml.`,
+    );
+  }
+}
+
 function toDefinition(data: CustomToolDefinitionData): CustomToolDefinition {
+  validateRequiredString(data.name, "name");
+  validateRequiredString(data.skillsDir, "skillsDir");
+  validateRequiredString(data.instructionsFile, "instructionsFile");
   validateMode(data.instructionsMode);
   validateRefStyle(data.skillReferenceStyle);
   return {

--- a/src/infrastructure/persistence/custom_tools_repository_test.ts
+++ b/src/infrastructure/persistence/custom_tools_repository_test.ts
@@ -168,3 +168,43 @@ Deno.test("findCustomTool: returns undefined for missing tool", async () => {
     await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });
+
+Deno.test("readCustomTools: rejects entry with missing name", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const yaml = `tools:
+  - skillsDir: .foo/skills
+    instructionsFile: AGENTS.md
+    instructionsMode: shared
+    skillReferenceStyle: path
+`;
+    await Deno.writeTextFile(`${dir}/.swamp-custom-tools.yaml`, yaml);
+    await assertRejects(
+      () => readCustomTools(dir),
+      UserError,
+      '"name"',
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("readCustomTools: rejects entry with missing skillsDir", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const yaml = `tools:
+  - name: mytool
+    instructionsFile: AGENTS.md
+    instructionsMode: shared
+    skillReferenceStyle: path
+`;
+    await Deno.writeTextFile(`${dir}/.swamp-custom-tools.yaml`, yaml);
+    await assertRejects(
+      () => readCustomTools(dir),
+      UserError,
+      '"skillsDir"',
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/infrastructure/persistence/custom_tools_repository_test.ts
+++ b/src/infrastructure/persistence/custom_tools_repository_test.ts
@@ -1,0 +1,170 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import type { CustomToolDefinition } from "../../domain/repo/custom_tool.ts";
+import {
+  addCustomTool,
+  findCustomTool,
+  readCustomTools,
+  removeCustomTool,
+  writeCustomTools,
+} from "./custom_tools_repository.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function makeDef(name: string): CustomToolDefinition {
+  return {
+    name,
+    skillsDir: `.${name}/skills`,
+    instructionsFile: "AGENTS.md",
+    instructionsMode: "shared",
+    skillReferenceStyle: "path",
+  };
+}
+
+Deno.test("readCustomTools: returns empty array when file missing", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const tools = await readCustomTools(dir);
+    assertEquals(tools, []);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("writeCustomTools + readCustomTools: round-trip", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const tools = [makeDef("windsurf"), makeDef("tabnine")];
+    await writeCustomTools(dir, tools);
+    const loaded = await readCustomTools(dir);
+    assertEquals(loaded.length, 2);
+    assertEquals(loaded[0].name, "windsurf");
+    assertEquals(loaded[1].name, "tabnine");
+    assertEquals(loaded[0].skillsDir, ".windsurf/skills");
+    assertEquals(loaded[0].instructionsMode, "shared");
+    assertEquals(loaded[0].skillReferenceStyle, "path");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("writeCustomTools: preserves frontmatter field", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const def: CustomToolDefinition = {
+      ...makeDef("windsurf"),
+      instructionsMode: "owned",
+      frontmatter: "---\ntrigger: always_on\n---\n",
+    };
+    await writeCustomTools(dir, [def]);
+    const loaded = await readCustomTools(dir);
+    assertEquals(loaded[0].frontmatter, "---\ntrigger: always_on\n---\n");
+    assertEquals(loaded[0].instructionsMode, "owned");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("addCustomTool: appends to existing list", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf")]);
+    await addCustomTool(dir, makeDef("tabnine"));
+    const loaded = await readCustomTools(dir);
+    assertEquals(loaded.length, 2);
+    assertEquals(loaded[1].name, "tabnine");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("addCustomTool: rejects duplicate names", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf")]);
+    await assertRejects(
+      () => addCustomTool(dir, makeDef("windsurf")),
+      UserError,
+      "already exists",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("addCustomTool: creates file when missing", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await addCustomTool(dir, makeDef("windsurf"));
+    const loaded = await readCustomTools(dir);
+    assertEquals(loaded.length, 1);
+    assertEquals(loaded[0].name, "windsurf");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("removeCustomTool: removes matching tool", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf"), makeDef("tabnine")]);
+    const removed = await removeCustomTool(dir, "windsurf");
+    assertEquals(removed, true);
+    const loaded = await readCustomTools(dir);
+    assertEquals(loaded.length, 1);
+    assertEquals(loaded[0].name, "tabnine");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("removeCustomTool: returns false for non-existent tool", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf")]);
+    const removed = await removeCustomTool(dir, "nonexistent");
+    assertEquals(removed, false);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("findCustomTool: finds matching tool", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf"), makeDef("tabnine")]);
+    const found = await findCustomTool(dir, "tabnine");
+    assertEquals(found?.name, "tabnine");
+    assertEquals(found?.skillsDir, ".tabnine/skills");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("findCustomTool: returns undefined for missing tool", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await writeCustomTools(dir, [makeDef("windsurf")]);
+    const found = await findCustomTool(dir, "nonexistent");
+    assertEquals(found, undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -35,6 +35,9 @@ export const SWAMP_MARKER_FILE = ".swamp.yaml";
 /** The sources file name for local extension sources */
 export const SWAMP_SOURCES_FILE = ".swamp-sources.yaml";
 
+/** The custom tools file name for user-defined AI tool configurations */
+export const SWAMP_CUSTOM_TOOLS_FILE = ".swamp-custom-tools.yaml";
+
 /**
  * Subdirectory names within the .swamp directory.
  */
@@ -132,6 +135,10 @@ export function swampMarkerPath(repoDir: string): string {
  */
 export function swampSourcesPath(repoDir: string): string {
   return join(repoDir, SWAMP_SOURCES_FILE);
+}
+
+export function swampCustomToolsPath(repoDir: string): string {
+  return join(repoDir, SWAMP_CUSTOM_TOOLS_FILE);
 }
 
 /**

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -49,7 +49,7 @@ export interface RepoMarkerData {
   telemetryEndpoint?: string;
   telemetryDisabled?: boolean;
   telemetryKeepFlushed?: boolean;
-  tools?: AiTool[];
+  tools?: string[];
   /** @deprecated legacy single-tool field; promoted to `tools` on read. */
   tool?: AiTool;
   logLevel?: string;

--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -19,7 +19,6 @@
 
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import {
-  type AiTool,
   type RepoInitResult,
   RepoService,
   type RepoUpgradeResult,
@@ -83,7 +82,7 @@ export interface RepoInitInput {
 export interface RepoInitDeps {
   init: (
     repoPath: RepoPath,
-    options: { force?: boolean; tools?: AiTool[] },
+    options: { force?: boolean; tools?: string[] },
   ) => Promise<RepoInitResult>;
 }
 
@@ -156,12 +155,12 @@ export async function* repoInit(
 function resolveToolsInput(
   tools: string[] | undefined,
   tool: string | undefined,
-): AiTool[] | undefined {
+): string[] | undefined {
   if (tools !== undefined) {
-    return tools as AiTool[];
+    return tools;
   }
   if (tool !== undefined) {
-    return [tool as AiTool];
+    return [tool];
   }
   return undefined;
 }
@@ -176,7 +175,7 @@ function resolveToolsInput(
  *  - `tools: [X, Y, ...]` (multi-tool) → `null` so SDK consumers cannot
  *    silently miss the second enrolled tool — they must read `tools`.
  */
-function legacyToolField(tools: AiTool[]): string | null {
+function legacyToolField(tools: string[]): string | null {
   if (tools.length === 0) return "none";
   if (tools.length === 1) return tools[0];
   return null;
@@ -257,7 +256,7 @@ export interface RepoUpgradeInput {
 export interface RepoUpgradeDeps {
   upgrade: (
     repoPath: RepoPath,
-    options: { tools?: AiTool[]; includeGitignore?: boolean },
+    options: { tools?: string[]; includeGitignore?: boolean },
   ) => Promise<RepoUpgradeResult>;
 }
 


### PR DESCRIPTION
## Summary

- Adds `swamp agent setup` interactive wizard for defining custom AI agent tools
- Custom tools get skills + instructions + gitignore scaffolding, stored in `.swamp-custom-tools.yaml` at repo root
- `swamp repo init --tool <custom-name>` works once defined
- Built-in tools (claude, cursor, kiro, etc.) retain full audit/hooks/doctor integration
- Custom tools skip audit subsystems — promoted to built-in when adoption warrants

### How it works

1. `swamp agent setup` asks the tool name, optionally scans an existing repo for config patterns (`.windsurf/rules/`, `AGENTS.md`, etc.), then asks where the tool reads instructions from
2. Defaults are derived: skills go to `.<name>/skills/`, instructions mode (shared vs owned) from the file location
3. Definition saved to `.swamp-custom-tools.yaml` — committable, copyable between repos
4. `swamp repo init --tool <name>` resolves custom tools via `ToolResolver`, copies skills, generates instructions

### Architecture

- `ToolConfig` value object unifies built-in and custom tools at the scaffolding layer
- `AiTool` union stays closed for built-in exhaustiveness checks
- Boundary types (`RepoMarkerData.tools`, init/upgrade options/results) widened to `string[]`
- `ToolResolver` checks built-in tools first (O(1)), then custom-tools.yaml (lazy-loaded)
- DDD: `ToolResolver` accepts an injected `CustomToolLoader` to avoid domain→infrastructure import

### New files

- `src/domain/repo/custom_tool.ts` — types, factories, validation, detection, defaults derivation
- `src/domain/repo/tool_resolver.ts` — resolution layer (built-in + custom)
- `src/infrastructure/persistence/custom_tools_repository.ts` — YAML persistence
- `src/cli/commands/agent_setup.ts` — `swamp agent setup/list/rm` commands
- Tests for all new modules (41 tests)

### Ecosystem research

Researched 12 AI coding tools (Windsurf, Zed, Amp, Aider, Cline, Roo Code, Kilo Code, Trae, Augment, Tabnine, PearAI, Pi). AGENTS.md is converging as the cross-tool standard. Most tools use `.<toolname>/rules/` for config. Skills at `.<toolname>/skills/` works for tools with native support (Pi, Kilo) and via instructions references for others.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` clean on new files
- [x] `deno fmt` applied
- [x] `deno run test` — 6007 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [ ] Manual: `swamp agent setup` → define custom tool → `swamp repo init --tool <name>` → verify scaffolding
- [ ] Manual: `swamp agent list` / `swamp agent rm`
- [ ] Manual: `swamp repo init --tool nonexistent` → helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)