### PR TITLE
fix(rendering): adapt terminal output to narrow widths (swamp-club#377)

### DIFF
--- a/design/rendering.md
+++ b/design/rendering.md
@@ -624,3 +624,35 @@ Command handlers depend on both libswamp (for the event stream) and the
 presentation layer (for the renderer). The presentation layer depends on
 infrastructure (loggers, color formatting). libswamp depends on domain and
 infrastructure but never on presentation.
+
+## Terminal Width Awareness
+
+All renderers must adapt to the current terminal width to avoid broken layouts
+at non-standard sizes (large fonts, narrow windows, split panes).
+
+### Ink/TUI renderers (interactive mode)
+
+Use the `useTerminalSize()` hook from
+`presentation/output/hooks/useTerminalSize.ts`. Constrain content containers
+with `overflow="hidden"` and explicit `width` props so Ink clips content rather
+than wrapping it. The shared `ResultsList` and `PreviewPane` components handle
+this automatically — individual `renderResultLine` and `renderPreview` callbacks
+do not need to truncate manually.
+
+### Log-mode renderers (non-interactive)
+
+Use `getTerminalColumns()` from `presentation/output/terminal_size.ts` to query
+the terminal width synchronously. Apply width constraints only to `writeOutput()`
+calls (which have no prefix). `logger.info()` calls are left unconstrained —
+LogTape's formatter handles its own line formatting.
+
+Guidelines:
+
+- **Separators**: Use `"─".repeat(getTerminalColumns())` instead of hardcoded
+  widths like `"─".repeat(60)`.
+- **Column widths**: Clamp `padEnd()` values so the total line width does not
+  exceed terminal columns.
+- **Truncation**: Truncate plain text before applying ANSI colors to avoid
+  breaking escape sequences mid-string.
+- **Markdown reports**: Pass `{ maxWidth: getTerminalColumns() }` to
+  `renderMarkdownToTerminal()`.

--- a/src/presentation/output/terminal_size.ts
+++ b/src/presentation/output/terminal_size.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+const DEFAULT_COLUMNS = 80;
+
+/**
+ * Returns the current terminal width in columns for non-Ink (log-mode)
+ * renderers. Falls back to 80 columns when stdout is not a TTY (piped
+ * output, CI, non-interactive environments).
+ *
+ * For Ink/React components, use the useTerminalSize() hook instead.
+ */
+export function getTerminalColumns(): number {
+  try {
+    return Deno.consoleSize().columns;
+  } catch {
+    return DEFAULT_COLUMNS;
+  }
+}

--- a/src/presentation/output/terminal_size_test.ts
+++ b/src/presentation/output/terminal_size_test.ts
@@ -1,0 +1,30 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert } from "@std/assert";
+import { getTerminalColumns } from "./terminal_size.ts";
+
+Deno.test("getTerminalColumns: returns a positive integer", () => {
+  const columns = getTerminalColumns();
+  assert(columns > 0, `Expected positive columns, got ${columns}`);
+  assert(
+    Number.isInteger(columns),
+    `Expected integer columns, got ${columns}`,
+  );
+});

--- a/src/presentation/renderers/audit_timeline.ts
+++ b/src/presentation/renderers/audit_timeline.ts
@@ -26,6 +26,7 @@ import {
   writeOutput,
 } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 import type { AuditEntry } from "../../domain/audit/audit_entry.ts";
 import { auditEntryToData } from "../../domain/audit/audit_entry.ts";
 
@@ -65,13 +66,17 @@ function renderTimelineTable(
     return;
   }
 
+  const cols = getTerminalColumns();
+  const prefixLen = 12 + 1 + 8 + 1; // time + space + source + space
+  const maxSummaryLen = Math.max(20, cols - prefixLen);
+
   // Print header
   writeOutput(
     bold(
       `${"Time".padEnd(12)} ${"Source".padEnd(8)} ${"Summary"}`,
     ),
   );
-  writeOutput(dim("-".repeat(60)));
+  writeOutput(dim("-".repeat(cols)));
 
   for (const entry of entries) {
     const time = formatTime(entry.timestamp);
@@ -79,8 +84,6 @@ function renderTimelineTable(
       ? cyan("swamp".padEnd(8))
       : yellow("direct".padEnd(8));
 
-    // Truncate long commands for display
-    const maxSummaryLen = 60;
     const summary = entry.summary.length > maxSummaryLen
       ? entry.summary.substring(0, maxSummaryLen - 3) + "..."
       : entry.summary;

--- a/src/presentation/renderers/components/results_list.tsx
+++ b/src/presentation/renderers/components/results_list.tsx
@@ -50,7 +50,7 @@ export function ResultsList<T>(
     props;
 
   return (
-    <Box flexDirection="column" width={width}>
+    <Box flexDirection="column" width={width} overflow="hidden">
       {scrollMetrics.hasMoreAbove && (
         <Text dimColor>
           {INDENT}... {scrollMetrics.moreAboveCount} more above
@@ -60,17 +60,17 @@ export function ResultsList<T>(
         const isSelected =
           index + scrollMetrics.moreAboveCount === selectedIndex;
         return (
-          <Box key={index}>
+          <Box key={index} width={width} overflow="hidden">
             {isSelected
               ? (
-                <Text inverse bold>
+                <Text inverse bold wrap="truncate-end">
                   {" "}
                   <ResultLineWrapper renderLine={renderLine} item={item} />
                   {" "}
                 </Text>
               )
               : (
-                <Text>
+                <Text wrap="truncate-end">
                   {INDENT}
                   <ResultLineWrapper renderLine={renderLine} item={item} />
                 </Text>

--- a/src/presentation/renderers/components/search_picker.tsx
+++ b/src/presentation/renderers/components/search_picker.tsx
@@ -335,7 +335,12 @@ export function SearchPicker<T, D = T>(
         </Box>
 
         {/* Results list with inline preview expansion */}
-        <Box flexDirection="column" marginTop={1}>
+        <Box
+          flexDirection="column"
+          marginTop={1}
+          width={width}
+          overflow="hidden"
+        >
           {resultsContent}
           {highlightedItem && previewContent && (
             <Box marginLeft={4} marginTop={1}>
@@ -370,7 +375,12 @@ export function SearchPicker<T, D = T>(
       </Box>
 
       {/* Results list */}
-      <Box flexDirection="column" marginTop={1}>
+      <Box
+        flexDirection="column"
+        marginTop={1}
+        width={width}
+        overflow="hidden"
+      >
         {resultsContent}
       </Box>
 

--- a/src/presentation/renderers/data_list.ts
+++ b/src/presentation/renderers/data_list.ts
@@ -26,6 +26,7 @@ import type {
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 
 /** Formats a byte size into a human-readable string. */
 function formatSize(bytes?: number): string {
@@ -60,6 +61,7 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
   }
 
   private renderModel(data: DataListData): void {
+    const cols = getTerminalColumns();
     console.log(`Data for ${data.modelName} (${data.modelType})`);
     console.log();
 
@@ -71,15 +73,19 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
       for (const item of group.items) {
         const size = formatSize(item.size);
         const date = item.createdAt.slice(0, 10);
-        console.log(
-          `  ${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`,
-        );
+        let line =
+          `  ${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`;
+        if (line.length > cols) {
+          line = line.substring(0, cols - 1) + "…";
+        }
+        console.log(line);
       }
       console.log();
     }
   }
 
   private renderWorkflow(data: WorkflowDataListData): void {
+    const cols = getTerminalColumns();
     console.log(
       `Data for workflow ${data.workflowName} (run ${data.runId.slice(0, 8)})`,
     );
@@ -95,9 +101,12 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
         const step = item.jobName !== undefined && item.stepName !== undefined
           ? `${item.jobName}.${item.stepName}`
           : "(workflow)";
-        console.log(
-          `  ${item.name}  v${item.version}  ${item.modelName}  ${step}  ${size}`,
-        );
+        let line =
+          `  ${item.name}  v${item.version}  ${item.modelName}  ${step}  ${size}`;
+        if (line.length > cols) {
+          line = line.substring(0, cols - 1) + "…";
+        }
+        console.log(line);
       }
       console.log();
     }

--- a/src/presentation/renderers/data_search.tsx
+++ b/src/presentation/renderers/data_search.tsx
@@ -236,9 +236,10 @@ function renderDataResultLine(item: DataSearchItem): React.ReactElement {
 function renderDataPreview(
   item: DataSearchItem,
   detail: DataPreviewDetail | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   // Combine metadata + content into a single string to avoid Ink layout
   // issues with multiple <Text> blocks containing ANSI-formatted content.
   const parts: string[] = [
@@ -252,8 +253,8 @@ function renderDataPreview(
   }
 
   return (
-    <Box paddingLeft={1}>
-      <Text>{parts.join("\n")}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text wrap="truncate-end">{parts.join("\n")}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/datastore_type_search.tsx
+++ b/src/presentation/renderers/datastore_type_search.tsx
@@ -133,14 +133,15 @@ function renderDatastoreTypeResultLine(
 function renderDatastoreTypePreview(
   item: DatastoreTypeSearchItem,
   _detail: DatastoreTypeSearchItem | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{item.type}</Text>
-      <Text dimColor>name: {item.name}</Text>
-      <Text dimColor>{item.description}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text bold wrap="truncate-end">{item.type}</Text>
+      <Text dimColor wrap="truncate-end">name: {item.name}</Text>
+      <Text dimColor wrap="truncate-end">{item.description}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/driver_type_search.tsx
+++ b/src/presentation/renderers/driver_type_search.tsx
@@ -133,14 +133,15 @@ function renderDriverTypeResultLine(
 function renderDriverTypePreview(
   item: DriverTypeSearchItem,
   _detail: DriverTypeSearchItem | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{item.type}</Text>
-      <Text dimColor>name: {item.name}</Text>
-      <Text dimColor>{item.description}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text bold wrap="truncate-end">{item.type}</Text>
+      <Text dimColor wrap="truncate-end">name: {item.name}</Text>
+      <Text dimColor wrap="truncate-end">{item.description}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -26,6 +26,7 @@ import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 
 const logger = getSwampLogger(["extension", "list"]);
 
@@ -65,8 +66,12 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
 
         const exts = e.data.extensions;
         const enriched = exts.some((x) => x.updateStatus !== undefined);
+        const cols = getTerminalColumns();
 
-        const maxName = Math.max(...exts.map((ext) => ext.name.length));
+        const maxName = Math.min(
+          Math.max(...exts.map((ext) => ext.name.length)),
+          Math.floor(cols * 0.4),
+        );
         const maxVersion = Math.max(
           ...exts.map((ext) => ext.version.length + 1),
         ); // +1 for "v" prefix
@@ -79,7 +84,10 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
           : 0;
 
         for (const ext of exts) {
-          const paddedName = ext.name.padEnd(maxName);
+          const name = ext.name.length > maxName
+            ? ext.name.substring(0, maxName - 1) + "…"
+            : ext.name;
+          const paddedName = name.padEnd(maxName);
           const paddedVersion = `v${ext.version}`.padEnd(maxVersion);
           let line = `${paddedName}  ${paddedVersion}`;
           if (enriched) {
@@ -94,6 +102,9 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
             }
           }
           line += `  (pulled ${ext.pulledAt})`;
+          if (line.length > cols) {
+            line = line.substring(0, cols - 1) + "…";
+          }
           logger.info("{line}", { line });
           if (this.verbose) {
             for (const file of ext.files) {

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -102,9 +102,6 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
             }
           }
           line += `  (pulled ${ext.pulledAt})`;
-          if (line.length > cols) {
-            line = line.substring(0, cols - 1) + "…";
-          }
           logger.info("{line}", { line });
           if (this.verbose) {
             for (const file of ext.files) {

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -151,55 +151,66 @@ function renderExtensionResultLine(
 function renderExtensionPreview(
   item: ExtensionSearchItem,
   _detail: ExtensionSearchItem | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
+  const lines: React.ReactElement[] = [
+    <Text key="name" wrap="truncate-end">
+      <Text color="cyan" bold>{item.name}</Text>{" "}
+      <Text dimColor>v{item.latestVersion}</Text>
+    </Text>,
+  ];
+
+  if (item.description) {
+    lines.push(<Text key="desc-gap" />);
+    lines.push(
+      <Text key="desc" wrap="truncate-end">{item.description}</Text>,
+    );
+  }
+
+  if (item.platforms.length > 0) {
+    lines.push(<Text key="plat-gap" />);
+    lines.push(
+      <Text key="platforms" wrap="truncate-end">
+        <Text bold>Platforms:</Text> {item.platforms.join(", ")}
+      </Text>,
+    );
+  }
+
+  if (item.labels.length > 0) {
+    lines.push(<Text key="label-gap" />);
+    lines.push(
+      <Text key="labels" wrap="truncate-end">
+        <Text bold>Labels:</Text> {item.labels.join(", ")}
+      </Text>,
+    );
+  }
+
+  if (item.contentTypes.length > 0) {
+    lines.push(<Text key="ct-gap" />);
+    lines.push(
+      <Text key="contentTypes" wrap="truncate-end">
+        <Text bold>Content Types:</Text> {item.contentTypes.join(", ")}
+      </Text>,
+    );
+  }
+
+  lines.push(<Text key="dates-gap" />);
+  lines.push(
+    <Text key="created" dimColor wrap="truncate-end">
+      Created: {item.createdAt}
+    </Text>,
+  );
+  lines.push(
+    <Text key="updated" dimColor wrap="truncate-end">
+      Updated: {item.updatedAt}
+    </Text>,
+  );
+
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Box>
-        <Text color="cyan" bold>{item.name}</Text>
-        <Text dimColor>v{item.latestVersion}</Text>
-      </Box>
-
-      {item.description && (
-        <Box marginTop={1}>
-          <Text>{item.description}</Text>
-        </Box>
-      )}
-
-      {item.platforms.length > 0 && (
-        <Box marginTop={1}>
-          <Text>
-            <Text bold>Platforms:</Text>
-            {item.platforms.join(", ")}
-          </Text>
-        </Box>
-      )}
-
-      {item.labels.length > 0 && (
-        <Box marginTop={1}>
-          <Text>
-            <Text bold>Labels:</Text>
-            {item.labels.join(", ")}
-          </Text>
-        </Box>
-      )}
-
-      {item.contentTypes.length > 0 && (
-        <Box marginTop={1}>
-          <Text>
-            <Text bold>Content Types:</Text>
-            {item.contentTypes.join(", ")}
-          </Text>
-        </Box>
-      )}
-
-      <Box marginTop={1}>
-        <Text dimColor>Created: {item.createdAt}</Text>
-      </Box>
-      <Box>
-        <Text dimColor>Updated: {item.updatedAt}</Text>
-      </Box>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -148,9 +148,13 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
           reportName: e.reportName,
         });
         const cols = getTerminalColumns();
+        const headerPrefix = `\u2500\u2500 Report: ${e.reportName} `;
+        const headerSep = "\u2500".repeat(
+          Math.max(0, cols - headerPrefix.length),
+        );
         const separator = "\u2500".repeat(cols);
         writeOutput(
-          `\u2500\u2500 Report: ${e.reportName} ${separator}\n${
+          `${headerPrefix}${headerSep}\n${
             renderMarkdownToTerminal(e.markdown, { maxWidth: cols })
           }\n${separator}`,
         );

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -26,6 +26,7 @@ import {
 } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 
 export interface ModelMethodRunRenderOpts {
   modelName: string;
@@ -146,10 +147,11 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
         logger.info('Running report: "{reportName}"', {
           reportName: e.reportName,
         });
-        const separator = "\u2500".repeat(60);
+        const cols = getTerminalColumns();
+        const separator = "\u2500".repeat(cols);
         writeOutput(
           `\u2500\u2500 Report: ${e.reportName} ${separator}\n${
-            renderMarkdownToTerminal(e.markdown)
+            renderMarkdownToTerminal(e.markdown, { maxWidth: cols })
           }\n${separator}`,
         );
       },

--- a/src/presentation/renderers/model_output_search.tsx
+++ b/src/presentation/renderers/model_output_search.tsx
@@ -199,87 +199,150 @@ function renderOutputResultLine(
 function renderOutputPreview(
   item: ModelOutputSearchItem,
   detail: ModelOutputGetData | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
     const displayName = item.modelName ?? item.definitionId;
+    const lines: React.ReactElement[] = [
+      <Text key="name" bold wrap="truncate-end">{displayName}</Text>,
+      <Text key="type" dimColor wrap="truncate-end">type: {item.type}</Text>,
+      <Text key="method" wrap="truncate-end">
+        method: <Text color="cyan">{item.methodName}</Text>
+      </Text>,
+      <Text key="status" wrap="truncate-end">
+        status: <Text color={getStatusColor(item.status)}>{item.status}</Text>
+      </Text>,
+      <Text key="started" dimColor wrap="truncate-end">
+        started: {item.startedAt}
+      </Text>,
+    ];
+    if (item.durationMs !== undefined) {
+      lines.push(
+        <Text key="duration" dimColor wrap="truncate-end">
+          duration: {formatDuration(item.durationMs)}
+        </Text>,
+      );
+    }
+    lines.push(
+      <Text key="defId" dimColor wrap="truncate-end">
+        definitionId: {item.definitionId}
+      </Text>,
+    );
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{displayName}</Text>
-        <Text dimColor>type: {item.type}</Text>
-        <Text>
-          method: <Text color="cyan">{item.methodName}</Text>
-        </Text>
-        <Text>
-          status: <Text color={getStatusColor(item.status)}>{item.status}</Text>
-        </Text>
-        <Text dimColor>started: {item.startedAt}</Text>
-        {item.durationMs !== undefined && (
-          <Text dimColor>duration: {formatDuration(item.durationMs)}</Text>
-        )}
-        <Text dimColor>definitionId: {item.definitionId}</Text>
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        {lines}
       </Box>
     );
   }
 
   // Full detail from fetchPreview
   const displayName = detail.modelName ?? detail.definitionId;
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">{displayName}</Text>,
+    <Text key="type" dimColor wrap="truncate-end">type: {detail.type}</Text>,
+    <Text key="method" wrap="truncate-end">
+      method: <Text color="cyan">{detail.methodName}</Text>
+    </Text>,
+    <Text key="status" wrap="truncate-end">
+      status: <Text color={getStatusColor(detail.status)}>{detail.status}</Text>
+    </Text>,
+    <Text key="started" dimColor wrap="truncate-end">
+      started: {detail.startedAt}
+    </Text>,
+  ];
+  if (detail.completedAt) {
+    lines.push(
+      <Text key="completed" dimColor wrap="truncate-end">
+        completed: {detail.completedAt}
+      </Text>,
+    );
+  }
+  if (detail.durationMs !== undefined) {
+    lines.push(
+      <Text key="duration" dimColor wrap="truncate-end">
+        duration: {formatDuration(detail.durationMs)}
+      </Text>,
+    );
+  }
+  lines.push(
+    <Text key="retries" dimColor wrap="truncate-end">
+      retries: {detail.retryCount}
+    </Text>,
+  );
+
+  // Provenance section
+  lines.push(<Text key="prov-gap" />);
+  lines.push(
+    <Text key="prov-hdr" color="cyan" bold wrap="truncate-end">
+      Provenance:
+    </Text>,
+  );
+  lines.push(
+    <Text key="prov-trigger" dimColor wrap="truncate-end">
+      {`  triggeredBy: ${detail.provenance.triggeredBy}`}
+    </Text>,
+  );
+  lines.push(
+    <Text key="prov-ver" dimColor wrap="truncate-end">
+      {`  modelVersion: ${detail.provenance.modelVersion}`}
+    </Text>,
+  );
+  lines.push(
+    <Text key="prov-hash" dimColor wrap="truncate-end">
+      {`  definitionHash: ${detail.provenance.definitionHash}`}
+    </Text>,
+  );
+  if (detail.provenance.workflowId) {
+    lines.push(
+      <Text key="prov-wf" dimColor wrap="truncate-end">
+        {`  workflow: ${detail.provenance.workflowId}`}
+      </Text>,
+    );
+  }
+  if (detail.provenance.stepName) {
+    lines.push(
+      <Text key="prov-step" dimColor wrap="truncate-end">
+        {`  step: ${detail.provenance.stepName}`}
+      </Text>,
+    );
+  }
+
+  // Artifacts section
+  if (detail.artifacts && detail.artifacts.dataArtifacts.length > 0) {
+    lines.push(<Text key="art-gap" />);
+    lines.push(
+      <Text key="art-hdr" color="cyan" bold wrap="truncate-end">
+        Artifacts:
+      </Text>,
+    );
+    for (const a of detail.artifacts.dataArtifacts) {
+      lines.push(
+        <Text key={`art-${a.dataId}`} dimColor wrap="truncate-end">
+          {`  ${a.name} v${a.version}`}
+        </Text>,
+      );
+    }
+  }
+
+  // Error section
+  if (detail.error) {
+    lines.push(<Text key="err-gap" />);
+    lines.push(
+      <Text key="err-hdr" color="red" bold wrap="truncate-end">Error:</Text>,
+    );
+    lines.push(
+      <Text key="err-msg" color="red" wrap="truncate-end">
+        {`  ${detail.error.message}`}
+      </Text>,
+    );
+  }
+
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{displayName}</Text>
-      <Text dimColor>type: {detail.type}</Text>
-      <Text>
-        method: <Text color="cyan">{detail.methodName}</Text>
-      </Text>
-      <Text>
-        status:{" "}
-        <Text color={getStatusColor(detail.status)}>{detail.status}</Text>
-      </Text>
-      <Text dimColor>started: {detail.startedAt}</Text>
-      {detail.completedAt && (
-        <Text dimColor>completed: {detail.completedAt}</Text>
-      )}
-      {detail.durationMs !== undefined && (
-        <Text dimColor>duration: {formatDuration(detail.durationMs)}</Text>
-      )}
-      <Text dimColor>retries: {detail.retryCount}</Text>
-
-      <Box flexDirection="column" marginTop={1}>
-        <Text color="cyan" bold>Provenance:</Text>
-        <Text dimColor>triggeredBy: {detail.provenance.triggeredBy}</Text>
-        <Text dimColor>modelVersion: {detail.provenance.modelVersion}</Text>
-        <Text dimColor>
-          definitionHash: {detail.provenance.definitionHash}
-        </Text>
-        {detail.provenance.workflowId && (
-          <Text dimColor>workflow: {detail.provenance.workflowId}</Text>
-        )}
-        {detail.provenance.stepName && (
-          <Text dimColor>step: {detail.provenance.stepName}</Text>
-        )}
-      </Box>
-
-      {detail.artifacts &&
-        detail.artifacts.dataArtifacts.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>Artifacts:</Text>
-          {detail.artifacts.dataArtifacts.map((a) => (
-            <Text key={a.dataId} dimColor>
-              {"  "}
-              {a.name} v{a.version}
-            </Text>
-          ))}
-        </Box>
-      )}
-
-      {detail.error && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="red" bold>Error:</Text>
-          <Text color="red">{detail.error.message}</Text>
-        </Box>
-      )}
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -185,85 +185,108 @@ function renderModelResultLine(item: ModelSearchItem): React.ReactElement {
 function renderModelPreview(
   item: ModelSearchItem,
   detail: ModelGetData | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.name}</Text>
-        <Text dimColor>type: {item.type}</Text>
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        <Text bold wrap="truncate-end">{item.name}</Text>
+        <Text dimColor wrap="truncate-end">type: {item.type}</Text>
       </Box>
     );
   }
 
   // Full detail from fetchPreview
-  return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{detail.name}</Text>
-      <Text dimColor>type: {detail.type}</Text>
-      <Text dimColor>version: {detail.version}</Text>
-      {detail.methods && detail.methods.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>Methods:</Text>
-          {detail.methods.map((method) => (
-            <Box key={method.name} flexDirection="column" marginLeft={1}>
-              <Text>
-                <Text color="cyan" bold>{method.name}</Text>
-                <Text dimColor>- {method.description}</Text>
-              </Text>
-              {renderMethodArguments(method.arguments)}
-              {method.dataOutputSpecs && method.dataOutputSpecs.length > 0 && (
-                <Box flexDirection="column" marginLeft={2}>
-                  <Text color="cyan">Data Outputs:</Text>
-                  {method.dataOutputSpecs.map((spec) => (
-                    <Text key={spec.specName} dimColor>
-                      {INDENT_2}
-                      {spec.specName} [{spec.kind}]
-                      {spec.description ? ` - ${spec.description}` : ""}
-                    </Text>
-                  ))}
-                </Box>
-              )}
-            </Box>
-          ))}
-        </Box>
-      )}
-    </Box>
-  );
-}
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">{detail.name}</Text>,
+    <Text key="type" dimColor wrap="truncate-end">type: {detail.type}</Text>,
+    <Text key="version" dimColor wrap="truncate-end">
+      version: {detail.version}
+    </Text>,
+  ];
 
-/** Renders JSON Schema arguments as Ink elements for the preview pane. */
-function renderMethodArguments(schema: object): React.ReactElement | null {
-  const s = schema as {
-    properties?: Record<
-      string,
-      { type?: string | string[]; enum?: string[]; description?: string }
-    >;
-    required?: string[];
-  };
-  if (!s.properties) return null;
+  if (detail.methods && detail.methods.length > 0) {
+    lines.push(<Text key="mhdr-gap" />);
+    lines.push(
+      <Text key="mhdr" color="cyan" bold wrap="truncate-end">Methods:</Text>,
+    );
+    for (const method of detail.methods) {
+      lines.push(
+        <Text key={`m-${method.name}`} wrap="truncate-end">
+          {INDENT_2}
+          <Text color="cyan" bold>{method.name}</Text>
+          <Text dimColor>- {method.description}</Text>
+        </Text>,
+      );
 
-  const required = new Set(s.required ?? []);
-  const entries = Object.entries(s.properties);
-  if (entries.length === 0) return null;
+      // Inline method arguments
+      const s = method.arguments as {
+        properties?: Record<
+          string,
+          { type?: string | string[]; enum?: string[]; description?: string }
+        >;
+        required?: string[];
+      };
+      if (s.properties) {
+        const required = new Set(s.required ?? []);
+        const entries = Object.entries(s.properties);
+        if (entries.length > 0) {
+          lines.push(
+            <Text key={`a-hdr-${method.name}`} color="cyan" wrap="truncate-end">
+              {INDENT_4}Arguments:
+            </Text>,
+          );
+          for (const [name, prop] of entries) {
+            const formatted = formatSchemaType(prop.type);
+            lines.push(
+              <Text key={`a-${method.name}-${name}`} wrap="truncate-end">
+                {"      "}
+                {name}
+                {formatted ? <Text dimColor>({formatted})</Text> : null}
+                {prop.enum
+                  ? <Text dimColor>[{prop.enum.join(", ")}]</Text>
+                  : null}
+                {required.has(name) ? <Text dimColor>*required</Text> : null}
+              </Text>,
+            );
+          }
+        }
+      }
 
-  return (
-    <Box flexDirection="column" marginLeft={2}>
-      <Text color="cyan">Arguments:</Text>
-      {entries.map(([name, prop]) => {
-        const formatted = formatSchemaType(prop.type);
-        return (
-          <Text key={name}>
-            {INDENT_4}
-            {name}
-            {formatted ? <Text dimColor>({formatted})</Text> : null}
-            {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
-            {required.has(name) ? <Text dimColor>*required</Text> : null}
-          </Text>
+      // Inline data output specs
+      if (method.dataOutputSpecs && method.dataOutputSpecs.length > 0) {
+        lines.push(
+          <Text
+            key={`do-hdr-${method.name}`}
+            color="cyan"
+            wrap="truncate-end"
+          >
+            {INDENT_4}Data Outputs:
+          </Text>,
         );
-      })}
+        for (const spec of method.dataOutputSpecs) {
+          lines.push(
+            <Text
+              key={`do-${method.name}-${spec.specName}`}
+              dimColor
+              wrap="truncate-end"
+            >
+              {"      "}
+              {spec.specName} [{spec.kind}]
+              {spec.description ? ` - ${spec.description}` : ""}
+            </Text>,
+          );
+        }
+      }
+    }
+  }
+
+  return (
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/report_get.ts
+++ b/src/presentation/renderers/report_get.ts
@@ -47,8 +47,7 @@ class LogReportGetRenderer implements Renderer<ReportGetEvent> {
       resolving: () => {},
       completed: (e) => {
         const r = e.data;
-        const cols = this.effectiveWidthOptions.maxWidth ??
-          getTerminalColumns();
+        const cols = this.effectiveWidthOptions.maxWidth!;
         const separator = "\u2500".repeat(cols);
         const source = r.workflowName
           ? `Workflow: ${r.workflowName}`

--- a/src/presentation/renderers/report_get.ts
+++ b/src/presentation/renderers/report_get.ts
@@ -27,18 +27,29 @@ import {
   renderMarkdownToTerminal,
   type WidthOptions,
 } from "../markdown_renderer.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 
 type ReportOutputMode = OutputMode | "markdown";
 
 class LogReportGetRenderer implements Renderer<ReportGetEvent> {
-  constructor(private widthOptions?: WidthOptions) {}
+  private readonly effectiveWidthOptions: WidthOptions;
+
+  constructor(widthOptions?: WidthOptions) {
+    const cols = getTerminalColumns();
+    this.effectiveWidthOptions = {
+      maxWidth: widthOptions?.maxWidth ?? cols,
+      maxColWidth: widthOptions?.maxColWidth,
+    };
+  }
 
   handlers(): EventHandlers<ReportGetEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
         const r = e.data;
-        const separator = "\u2500".repeat(60);
+        const cols = this.effectiveWidthOptions.maxWidth ??
+          getTerminalColumns();
+        const separator = "\u2500".repeat(cols);
         const source = r.workflowName
           ? `Workflow: ${r.workflowName}`
           : `Model: ${r.modelName} (${r.modelType})`;
@@ -48,7 +59,9 @@ class LogReportGetRenderer implements Renderer<ReportGetEvent> {
         writeOutput(
           `${separator}\n  ${r.reportName}  |  ${source}  |  Scope: ${r.reportScope}${varySuffixLabel}  |  v${r.version}  |  ${r.createdAt}\n${separator}`,
         );
-        writeOutput(renderMarkdownToTerminal(r.markdown, this.widthOptions));
+        writeOutput(
+          renderMarkdownToTerminal(r.markdown, this.effectiveWidthOptions),
+        );
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/report_search.tsx
+++ b/src/presentation/renderers/report_search.tsx
@@ -205,23 +205,51 @@ function renderReportResultLine(
 function renderReportPreview(
   item: StoredReportSummary,
   detail: StoredReportDetail | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
+    const lines: React.ReactElement[] = [
+      <Text key="name" bold wrap="truncate-end">{item.reportName}</Text>,
+      <Text key="scope" dimColor wrap="truncate-end">
+        scope: {item.reportScope}
+      </Text>,
+      <Text key="model" dimColor wrap="truncate-end">
+        model: {item.modelName}
+      </Text>,
+      <Text key="type" dimColor wrap="truncate-end">
+        type: {item.modelType}
+      </Text>,
+    ];
+    if (item.workflowName) {
+      lines.push(
+        <Text key="wf" dimColor wrap="truncate-end">
+          workflow: {item.workflowName}
+        </Text>,
+      );
+    }
+    lines.push(
+      <Text key="version" dimColor wrap="truncate-end">
+        version: {item.version}
+      </Text>,
+    );
+    lines.push(
+      <Text key="created" dimColor wrap="truncate-end">
+        created: {item.createdAt}
+      </Text>,
+    );
+    if (item.varySuffix) {
+      lines.push(
+        <Text key="variant" dimColor wrap="truncate-end">
+          variant: {item.varySuffix}
+        </Text>,
+      );
+    }
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.reportName}</Text>
-        <Text dimColor>scope: {item.reportScope}</Text>
-        <Text dimColor>model: {item.modelName}</Text>
-        <Text dimColor>type: {item.modelType}</Text>
-        {item.workflowName && (
-          <Text dimColor>workflow: {item.workflowName}</Text>
-        )}
-        <Text dimColor>version: {item.version}</Text>
-        <Text dimColor>created: {item.createdAt}</Text>
-        {item.varySuffix && <Text dimColor>variant: {item.varySuffix}</Text>}
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        {lines}
       </Box>
     );
   }
@@ -232,8 +260,8 @@ function renderReportPreview(
     `${detail.reportName}\nscope: ${detail.reportScope} | model: ${detail.modelName} | v${detail.version}\n`;
   const rendered = renderMarkdownToTerminal(detail.markdown);
   return (
-    <Box paddingLeft={1}>
-      <Text>{header + rendered}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text wrap="truncate-end">{header + rendered}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/report_type_search.tsx
+++ b/src/presentation/renderers/report_type_search.tsx
@@ -133,14 +133,15 @@ function renderReportTypeResultLine(
 function renderReportTypePreview(
   item: ReportTypeSearchItem,
   _detail: ReportTypeSearchItem | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{item.type}</Text>
-      <Text dimColor>name: {item.name}</Text>
-      <Text dimColor>{item.description}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text bold wrap="truncate-end">{item.type}</Text>
+      <Text dimColor wrap="truncate-end">name: {item.name}</Text>
+      <Text dimColor wrap="truncate-end">{item.description}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/summarise.ts
+++ b/src/presentation/renderers/summarise.ts
@@ -27,6 +27,7 @@ import {
   writeOutput,
 } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { getTerminalColumns } from "../output/terminal_size.ts";
 import type { ActivitySummary } from "../../domain/summary/summary_types.ts";
 
 function formatDateTime(iso?: string): string {
@@ -67,10 +68,15 @@ function renderMethodExecutions(
   header += ")";
   writeOutput(bold(header));
 
+  const cols = getTerminalColumns();
+
   for (const model of models) {
     writeOutput(`  Model: ${bold(model.modelName)} ${dim(`(${model.type})`)}`);
 
-    const maxMethod = Math.max(...model.methods.map((m) => m.method.length));
+    const maxMethod = Math.min(
+      Math.max(...model.methods.map((m) => m.method.length)),
+      Math.floor(cols * 0.4),
+    );
 
     for (const method of model.methods) {
       const label = method.method.padEnd(maxMethod + 3);
@@ -126,6 +132,7 @@ function renderWorkflowRuns(
     return;
   }
 
+  const cols = getTerminalColumns();
   const totalAll = groups.reduce((s, g) => s + g.total, 0);
   const succeededAll = groups.reduce((s, g) => s + g.succeeded, 0);
   const failedAll = groups.reduce((s, g) => s + g.failed, 0);
@@ -137,7 +144,10 @@ function renderWorkflowRuns(
   header += ")";
   writeOutput(bold(header));
 
-  const maxLabel = Math.max(...groups.map((g) => g.workflowName.length));
+  const maxLabel = Math.min(
+    Math.max(...groups.map((g) => g.workflowName.length)),
+    Math.floor(cols * 0.4),
+  );
 
   for (const group of groups) {
     const label = group.workflowName.padEnd(maxLabel + 2);

--- a/src/presentation/renderers/type_search.tsx
+++ b/src/presentation/renderers/type_search.tsx
@@ -33,8 +33,6 @@ import { UserError } from "../../domain/errors.ts";
 import { renderInteractivePicker } from "./components/search_picker.tsx";
 import { formatMethodLines, formatSchemaType } from "./model_get.ts";
 
-const INDENT_4 = "    ";
-
 /**
  * Filters types by a query string (case-insensitive match on raw or normalized).
  */
@@ -172,75 +170,75 @@ function renderTypeResultLine(item: TypeSearchItem): React.ReactElement {
 function renderTypePreview(
   item: TypeSearchItem,
   detail: TypeDescribeData | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
-    // Immediate content from the search item
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.normalized}</Text>
-        {item.raw !== item.normalized && <Text dimColor>raw: {item.raw}</Text>}
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        <Text bold wrap="truncate-end">{item.normalized}</Text>
+        {item.raw !== item.normalized && (
+          <Text dimColor wrap="truncate-end">raw: {item.raw}</Text>
+        )}
       </Box>
     );
   }
 
-  // Full detail from fetchPreview
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">
+      {detail.type.normalized}
+    </Text>,
+    <Text key="version" dimColor wrap="truncate-end">
+      version: {detail.version}
+    </Text>,
+  ];
+  if (detail.methods && detail.methods.length > 0) {
+    lines.push(<Text key="mhdr" />);
+    lines.push(
+      <Text key="methods" color="cyan" bold wrap="truncate-end">
+        Methods:
+      </Text>,
+    );
+    for (const method of detail.methods) {
+      lines.push(
+        <Text key={`m-${method.name}`} wrap="truncate-end">
+          {"  "}
+          <Text color="cyan" bold>{method.name}</Text>
+          <Text dimColor>- {method.description}</Text>
+        </Text>,
+      );
+      const schema = method.arguments as {
+        properties?: Record<
+          string,
+          {
+            type?: string | string[];
+            enum?: string[];
+          }
+        >;
+        required?: string[];
+      };
+      if (schema.properties) {
+        const required = new Set(schema.required ?? []);
+        for (const [name, prop] of Object.entries(schema.properties)) {
+          const formatted = formatSchemaType(prop.type);
+          const parts = [name];
+          if (formatted) parts.push(`(${formatted})`);
+          if (prop.enum) parts.push(`[${prop.enum.join(", ")}]`);
+          if (required.has(name)) parts.push("*required");
+          lines.push(
+            <Text key={`a-${method.name}-${name}`} dimColor wrap="truncate-end">
+              {"    " + parts.join(" ")}
+            </Text>,
+          );
+        }
+      }
+    }
+  }
+
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{detail.type.normalized}</Text>
-      {detail.type.raw !== detail.type.normalized && (
-        <Text dimColor>raw: {detail.type.raw}</Text>
-      )}
-      <Text dimColor>version: {detail.version}</Text>
-      {detail.methods && detail.methods.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>Methods:</Text>
-          {detail.methods.map((method) => (
-            <Box key={method.name} flexDirection="column" marginLeft={1}>
-              <Text>
-                <Text color="cyan" bold>{method.name}</Text>
-                <Text dimColor>- {method.description}</Text>
-              </Text>
-              {renderMethodArguments(method.arguments)}
-            </Box>
-          ))}
-        </Box>
-      )}
-    </Box>
-  );
-}
-
-/** Renders JSON Schema arguments as Ink elements for the preview pane. */
-function renderMethodArguments(schema: object): React.ReactElement | null {
-  const s = schema as {
-    properties?: Record<
-      string,
-      { type?: string | string[]; enum?: string[]; description?: string }
-    >;
-    required?: string[];
-  };
-  if (!s.properties) return null;
-
-  const required = new Set(s.required ?? []);
-  const entries = Object.entries(s.properties);
-  if (entries.length === 0) return null;
-
-  return (
-    <Box flexDirection="column" marginLeft={2}>
-      <Text color="cyan">Arguments:</Text>
-      {entries.map(([name, prop]) => {
-        const formatted = formatSchemaType(prop.type);
-        return (
-          <Text key={name}>
-            {INDENT_4}
-            {name}
-            {formatted ? <Text dimColor>({formatted})</Text> : null}
-            {prop.enum ? <Text dimColor>[{prop.enum.join(", ")}]</Text> : null}
-            {required.has(name) ? <Text dimColor>*required</Text> : null}
-          </Text>
-        );
-      })}
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/type_search.tsx
+++ b/src/presentation/renderers/type_search.tsx
@@ -189,10 +189,19 @@ function renderTypePreview(
     <Text key="name" bold wrap="truncate-end">
       {detail.type.normalized}
     </Text>,
+  ];
+  if (detail.type.raw !== detail.type.normalized) {
+    lines.push(
+      <Text key="raw" dimColor wrap="truncate-end">
+        raw: {detail.type.raw}
+      </Text>,
+    );
+  }
+  lines.push(
     <Text key="version" dimColor wrap="truncate-end">
       version: {detail.version}
     </Text>,
-  ];
+  );
   if (detail.methods && detail.methods.length > 0) {
     lines.push(<Text key="mhdr" />);
     lines.push(

--- a/src/presentation/renderers/vault_search.tsx
+++ b/src/presentation/renderers/vault_search.tsx
@@ -158,32 +158,38 @@ function renderVaultResultLine(item: VaultSearchItem): React.ReactElement {
 function renderVaultPreview(
   item: VaultSearchItem,
   detail: VaultDescribeData | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.name}</Text>
-        <Text dimColor>type: {item.type}</Text>
-        <Text dimColor>id: {item.id}</Text>
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        <Text bold wrap="truncate-end">{item.name}</Text>
+        <Text dimColor wrap="truncate-end">type: {item.type}</Text>
+        <Text dimColor wrap="truncate-end">id: {item.id}</Text>
       </Box>
     );
   }
 
   // Full detail from fetchPreview
   const configJson = JSON.stringify(detail.config, null, 2);
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">{detail.name}</Text>,
+    <Text key="type" dimColor wrap="truncate-end">type: {detail.type}</Text>,
+    <Text key="id" dimColor wrap="truncate-end">id: {detail.id}</Text>,
+    <Text key="created" dimColor wrap="truncate-end">
+      created: {detail.createdAt}
+    </Text>,
+    <Text key="cfg-gap" />,
+    <Text key="cfg-hdr" color="cyan" bold wrap="truncate-end">Config:</Text>,
+    <Text key="cfg" wrap="truncate-end">{configJson}</Text>,
+  ];
+
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{detail.name}</Text>
-      <Text dimColor>type: {detail.type}</Text>
-      <Text dimColor>id: {detail.id}</Text>
-      <Text dimColor>created: {detail.createdAt}</Text>
-      <Box flexDirection="column" marginTop={1}>
-        <Text color="cyan" bold>Config:</Text>
-        <Text>{configJson}</Text>
-      </Box>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/vault_type_search.tsx
+++ b/src/presentation/renderers/vault_type_search.tsx
@@ -143,14 +143,15 @@ function renderVaultTypeResultLine(
 function renderVaultTypePreview(
   item: VaultTypeSearchItem,
   _detail: VaultTypeSearchItem | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{item.type}</Text>
-      <Text dimColor>name: {item.name}</Text>
-      <Text dimColor>{item.description}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text bold wrap="truncate-end">{item.type}</Text>
+      <Text dimColor wrap="truncate-end">name: {item.name}</Text>
+      <Text dimColor wrap="truncate-end">{item.description}</Text>
     </Box>
   );
 }

--- a/src/presentation/renderers/workflow_history_search.tsx
+++ b/src/presentation/renderers/workflow_history_search.tsx
@@ -204,9 +204,10 @@ function renderHistoryResultLine(
 function renderHistoryPreview(
   item: WorkflowHistorySearchItem,
   detail: WorkflowRunView | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
     const statusColor = STATUS_COLORS[item.status] ?? "white";
@@ -223,17 +224,38 @@ function renderHistoryPreview(
       ? Object.entries(item.tags).map(([k, v]) => `${k}=${v}`).join(", ")
       : "";
 
+    const lines: React.ReactElement[] = [
+      <Text key="name" bold wrap="truncate-end">{item.workflowName}</Text>,
+      <Text key="run" dimColor wrap="truncate-end">run: {item.runId}</Text>,
+      <Text key="status" wrap="truncate-end">
+        status: <Text color={statusColor}>{item.status}</Text>
+      </Text>,
+      <Text key="started" dimColor wrap="truncate-end">
+        started: {dateStr}
+      </Text>,
+    ];
+    if (completedStr) {
+      lines.push(
+        <Text key="completed" dimColor wrap="truncate-end">
+          completed: {completedStr}
+        </Text>,
+      );
+    }
+    if (durationStr) {
+      lines.push(
+        <Text key="duration" dimColor wrap="truncate-end">
+          duration: {durationStr}
+        </Text>,
+      );
+    }
+    if (tagStr) {
+      lines.push(
+        <Text key="tags" dimColor wrap="truncate-end">tags: {tagStr}</Text>,
+      );
+    }
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.workflowName}</Text>
-        <Text dimColor>run: {item.runId}</Text>
-        <Text>
-          status: <Text color={statusColor}>{item.status}</Text>
-        </Text>
-        <Text dimColor>started: {dateStr}</Text>
-        {completedStr && <Text dimColor>completed: {completedStr}</Text>}
-        {durationStr && <Text dimColor>duration: {durationStr}</Text>}
-        {tagStr && <Text dimColor>tags: {tagStr}</Text>}
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        {lines}
       </Box>
     );
   }
@@ -244,52 +266,60 @@ function renderHistoryPreview(
     ? formatDurationSec(detail.duration)
     : "";
 
-  return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{detail.workflowName}</Text>
-      <Text dimColor>run: {detail.id}</Text>
-      <Text>
-        status: <Text color={statusColor}>{detail.status}</Text>
-      </Text>
-      {durationStr && <Text dimColor>duration: {durationStr}</Text>}
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">{detail.workflowName}</Text>,
+    <Text key="run" dimColor wrap="truncate-end">run: {detail.id}</Text>,
+    <Text key="status" wrap="truncate-end">
+      status: <Text color={statusColor}>{detail.status}</Text>
+    </Text>,
+  ];
+  if (durationStr) {
+    lines.push(
+      <Text key="duration" dimColor wrap="truncate-end">
+        duration: {durationStr}
+      </Text>,
+    );
+  }
 
-      {detail.jobs.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>Jobs:</Text>
-          {detail.jobs.map((job) => {
-            const jobIcon = STATUS_ICONS[job.status] ?? " ";
-            const jobColor = STATUS_COLORS[job.status] ?? "white";
-            const jobDur = job.duration !== undefined
-              ? ` (${formatDurationSec(job.duration)})`
-              : "";
-            return (
-              <Box key={job.name} flexDirection="column" marginLeft={1}>
-                <Text>
-                  <Text color={jobColor}>{jobIcon}</Text>{" "}
-                  <Text bold>{job.name}</Text>
-                  <Text dimColor>{jobDur}</Text>
-                </Text>
-                {job.steps.map((step) => {
-                  const stepIcon = STATUS_ICONS[step.status] ?? " ";
-                  const stepColor = STATUS_COLORS[step.status] ?? "white";
-                  const stepDur = step.duration !== undefined
-                    ? ` (${formatDurationSec(step.duration)})`
-                    : "";
-                  return (
-                    <Box key={step.name} marginLeft={2}>
-                      <Text>
-                        <Text color={stepColor}>{stepIcon}</Text> {step.name}
-                        <Text dimColor>{stepDur}</Text>
-                        {step.error && <Text color="red">- {step.error}</Text>}
-                      </Text>
-                    </Box>
-                  );
-                })}
-              </Box>
-            );
-          })}
-        </Box>
-      )}
+  if (detail.jobs.length > 0) {
+    lines.push(<Text key="jobs-gap" />);
+    lines.push(
+      <Text key="jobs-hdr" color="cyan" bold wrap="truncate-end">Jobs:</Text>,
+    );
+    for (const job of detail.jobs) {
+      const jobIcon = STATUS_ICONS[job.status] ?? " ";
+      const jobColor = STATUS_COLORS[job.status] ?? "white";
+      const jobDur = job.duration !== undefined
+        ? ` (${formatDurationSec(job.duration)})`
+        : "";
+      lines.push(
+        <Text key={`job-${job.name}`} wrap="truncate-end">
+          {"  "}
+          <Text color={jobColor}>{jobIcon}</Text> <Text bold>{job.name}</Text>
+          <Text dimColor>{jobDur}</Text>
+        </Text>,
+      );
+      for (const step of job.steps) {
+        const stepIcon = STATUS_ICONS[step.status] ?? " ";
+        const stepColor = STATUS_COLORS[step.status] ?? "white";
+        const stepDur = step.duration !== undefined
+          ? ` (${formatDurationSec(step.duration)})`
+          : "";
+        lines.push(
+          <Text key={`step-${job.name}-${step.name}`} wrap="truncate-end">
+            {"    "}
+            <Text color={stepColor}>{stepIcon}</Text> {step.name}
+            <Text dimColor>{stepDur}</Text>
+            {step.error && <Text color="red">- {step.error}</Text>}
+          </Text>,
+        );
+      }
+    }
+  }
+
+  return (
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/workflow_run_search.tsx
+++ b/src/presentation/renderers/workflow_run_search.tsx
@@ -184,9 +184,10 @@ function renderRunResultLine(
 function renderRunPreview(
   item: WorkflowRunSearchItem,
   detail: WorkflowRunView | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
     const statusColor = STATUS_COLORS[item.status] ?? "white";
@@ -203,17 +204,38 @@ function renderRunPreview(
       ? Object.entries(item.tags).map(([k, v]) => `${k}=${v}`).join(", ")
       : "";
 
+    const lines: React.ReactElement[] = [
+      <Text key="name" bold wrap="truncate-end">{item.workflowName}</Text>,
+      <Text key="run" dimColor wrap="truncate-end">run: {item.runId}</Text>,
+      <Text key="status" wrap="truncate-end">
+        status: <Text color={statusColor}>{item.status}</Text>
+      </Text>,
+      <Text key="started" dimColor wrap="truncate-end">
+        started: {dateStr}
+      </Text>,
+    ];
+    if (completedStr) {
+      lines.push(
+        <Text key="completed" dimColor wrap="truncate-end">
+          completed: {completedStr}
+        </Text>,
+      );
+    }
+    if (durationStr) {
+      lines.push(
+        <Text key="duration" dimColor wrap="truncate-end">
+          duration: {durationStr}
+        </Text>,
+      );
+    }
+    if (tagStr) {
+      lines.push(
+        <Text key="tags" dimColor wrap="truncate-end">tags: {tagStr}</Text>,
+      );
+    }
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.workflowName}</Text>
-        <Text dimColor>run: {item.runId}</Text>
-        <Text>
-          status: <Text color={statusColor}>{item.status}</Text>
-        </Text>
-        <Text dimColor>started: {dateStr}</Text>
-        {completedStr && <Text dimColor>completed: {completedStr}</Text>}
-        {durationStr && <Text dimColor>duration: {durationStr}</Text>}
-        {tagStr && <Text dimColor>tags: {tagStr}</Text>}
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        {lines}
       </Box>
     );
   }
@@ -224,52 +246,60 @@ function renderRunPreview(
     ? formatDurationSec(detail.duration)
     : "";
 
-  return (
-    <Box flexDirection="column" paddingLeft={1}>
-      <Text bold>{detail.workflowName}</Text>
-      <Text dimColor>run: {detail.id}</Text>
-      <Text>
-        status: <Text color={statusColor}>{detail.status}</Text>
-      </Text>
-      {durationStr && <Text dimColor>duration: {durationStr}</Text>}
+  const lines: React.ReactElement[] = [
+    <Text key="name" bold wrap="truncate-end">{detail.workflowName}</Text>,
+    <Text key="run" dimColor wrap="truncate-end">run: {detail.id}</Text>,
+    <Text key="status" wrap="truncate-end">
+      status: <Text color={statusColor}>{detail.status}</Text>
+    </Text>,
+  ];
+  if (durationStr) {
+    lines.push(
+      <Text key="duration" dimColor wrap="truncate-end">
+        duration: {durationStr}
+      </Text>,
+    );
+  }
 
-      {detail.jobs.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan" bold>Jobs:</Text>
-          {detail.jobs.map((job) => {
-            const jobIcon = STATUS_ICONS[job.status] ?? " ";
-            const jobColor = STATUS_COLORS[job.status] ?? "white";
-            const jobDur = job.duration !== undefined
-              ? ` (${formatDurationSec(job.duration)})`
-              : "";
-            return (
-              <Box key={job.name} flexDirection="column" marginLeft={1}>
-                <Text>
-                  <Text color={jobColor}>{jobIcon}</Text>{" "}
-                  <Text bold>{job.name}</Text>
-                  <Text dimColor>{jobDur}</Text>
-                </Text>
-                {job.steps.map((step) => {
-                  const stepIcon = STATUS_ICONS[step.status] ?? " ";
-                  const stepColor = STATUS_COLORS[step.status] ?? "white";
-                  const stepDur = step.duration !== undefined
-                    ? ` (${formatDurationSec(step.duration)})`
-                    : "";
-                  return (
-                    <Box key={step.name} marginLeft={2}>
-                      <Text>
-                        <Text color={stepColor}>{stepIcon}</Text> {step.name}
-                        <Text dimColor>{stepDur}</Text>
-                        {step.error && <Text color="red">- {step.error}</Text>}
-                      </Text>
-                    </Box>
-                  );
-                })}
-              </Box>
-            );
-          })}
-        </Box>
-      )}
+  if (detail.jobs.length > 0) {
+    lines.push(<Text key="jobs-gap" />);
+    lines.push(
+      <Text key="jobs-hdr" color="cyan" bold wrap="truncate-end">Jobs:</Text>,
+    );
+    for (const job of detail.jobs) {
+      const jobIcon = STATUS_ICONS[job.status] ?? " ";
+      const jobColor = STATUS_COLORS[job.status] ?? "white";
+      const jobDur = job.duration !== undefined
+        ? ` (${formatDurationSec(job.duration)})`
+        : "";
+      lines.push(
+        <Text key={`job-${job.name}`} wrap="truncate-end">
+          {"  "}
+          <Text color={jobColor}>{jobIcon}</Text> <Text bold>{job.name}</Text>
+          <Text dimColor>{jobDur}</Text>
+        </Text>,
+      );
+      for (const step of job.steps) {
+        const stepIcon = STATUS_ICONS[step.status] ?? " ";
+        const stepColor = STATUS_COLORS[step.status] ?? "white";
+        const stepDur = step.duration !== undefined
+          ? ` (${formatDurationSec(step.duration)})`
+          : "";
+        lines.push(
+          <Text key={`step-${job.name}-${step.name}`} wrap="truncate-end">
+            {"    "}
+            <Text color={stepColor}>{stepIcon}</Text> {step.name}
+            <Text dimColor>{stepDur}</Text>
+            {step.error && <Text color="red">- {step.error}</Text>}
+          </Text>,
+        );
+      }
+    }
+  }
+
+  return (
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      {lines}
     </Box>
   );
 }

--- a/src/presentation/renderers/workflow_search.tsx
+++ b/src/presentation/renderers/workflow_search.tsx
@@ -193,16 +193,28 @@ function renderWorkflowResultLine(
 function renderWorkflowPreview(
   item: WorkflowSearchItem,
   detail: WorkflowPreviewDetail | undefined,
-  _width: number,
+  width: number,
   _height: number,
 ): React.ReactElement {
+  const innerWidth = Math.max(10, width - 1);
   if (!detail) {
     // Immediate content from the search item
+    const lines: React.ReactElement[] = [
+      <Text key="name" bold wrap="truncate-end">{item.name}</Text>,
+    ];
+    if (item.description) {
+      lines.push(
+        <Text key="desc" wrap="truncate-end">{item.description}</Text>,
+      );
+    }
+    lines.push(
+      <Text key="jobs" dimColor wrap="truncate-end">
+        {`${item.jobCount} jobs`}
+      </Text>,
+    );
     return (
-      <Box flexDirection="column" paddingLeft={1}>
-        <Text bold>{item.name}</Text>
-        {item.description && <Text>{item.description}</Text>}
-        <Text dimColor>{`${item.jobCount} jobs`}</Text>
+      <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+        {lines}
       </Box>
     );
   }
@@ -212,8 +224,8 @@ function renderWorkflowPreview(
     `**${detail.name}**\n\n\`\`\`yaml\n${detail.yaml}\n\`\`\``,
   );
   return (
-    <Box paddingLeft={1}>
-      <Text>{rendered}</Text>
+    <Box flexDirection="column" marginLeft={1} width={innerWidth}>
+      <Text wrap="truncate-end">{rendered}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- Flatten all 14 SearchPicker preview callbacks from nested `<Box>` structures to flat `<Text>` arrays — nested Boxes cause Ink/Yoga layout garbling at narrow terminal widths
- Add `overflow="hidden"` to `ResultsList` and SearchPicker's inline/minimal tier containers
- Create `getTerminalColumns()` utility wrapping `Deno.consoleSize()` with 80-col fallback for log-mode renderers
- Update 6 log-mode renderers (audit timeline, extension list, data list, summarise, method-run reports, report get) to use terminal-width-aware separators, truncation, and markdown `maxWidth`
- Document terminal width conventions in `design/rendering.md`

## Test Plan

- Verified TUI rendering at 76, 80, and 254 columns — `model type search`, `model search`, `data search`, `extension search`, `workflow search`, `data query`
- Confirmed bordered-split layout at wide widths shows no regression
- Confirmed stacked/inline layouts at narrow widths render cleanly with truncation
- 5987 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)