### PR TITLE
fix(expressions): wire DataQueryService into model evaluate and detect nested unresolved expressions (swamp-club#358)

### DIFF
--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -569,3 +569,53 @@ Deno.test("resolveRuntimeExpressionsInDefinition: leaves invalid env.* prose in 
     );
   });
 });
+
+// ============================================================================
+// evaluateDefinition — nested globalArguments (swamp-club#358)
+// ============================================================================
+
+Deno.test("evaluateDefinition: resolves expressions in nested globalArguments objects and arrays", async () => {
+  await withTempDir(async (repoDir) => {
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const service = new ExpressionEvaluationService(definitionRepo, repoDir);
+    const type = ModelType.create("command/shell");
+
+    const definition = Definition.create({
+      name: "nested-ga-test",
+      inputs: {
+        properties: {
+          region: { type: "string" },
+          key_name: { type: "string" },
+        },
+        required: ["region", "key_name"],
+      },
+      globalArguments: {
+        name: "my-pool",
+        config: {
+          region: "${{ inputs.region }}",
+          keys: ["${{ inputs.key_name }}"],
+          nested: {
+            deep_value: '${{ "resolved-" + inputs.region }}',
+          },
+        },
+      },
+      methods: { exec: { arguments: { run: "echo hello" } } },
+    });
+
+    const result = await service.evaluateDefinition(
+      definition,
+      type,
+      { region: "us-east-1", key_name: "my-key" },
+    );
+
+    const ga = result.definition.globalArguments;
+    assertEquals(ga.name, "my-pool");
+
+    const config = ga.config as Record<string, unknown>;
+    assertEquals(config.region, "us-east-1");
+    assertEquals((config.keys as string[])[0], "my-key");
+
+    const nested = config.nested as Record<string, unknown>;
+    assertEquals(nested.deep_value, "resolved-us-east-1");
+  });
+});

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -41,10 +41,7 @@ import {
   createResourceWriter,
 } from "./data_writer.ts";
 import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
-import {
-  containsExpression,
-  valueContainsExpression,
-} from "../expressions/expression_parser.ts";
+import { valueContainsExpression } from "../expressions/expression_parser.ts";
 import type { Data } from "../data/data.ts";
 import type { DriverOutput } from "../drivers/execution_driver.ts";
 import { RawExecutionDriver } from "../drivers/raw_execution_driver.ts";
@@ -300,12 +297,11 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     const globalArgsProxy = new Proxy(resolvedGlobalArgs, {
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
-        if (
-          typeof prop === "string" && typeof value === "string" &&
-          containsExpression(value)
-        ) {
+        if (typeof prop === "string" && valueContainsExpression(value)) {
           throw new Error(
-            `Unresolved expression in globalArguments.${prop}: ${value}`,
+            `Unresolved expression in globalArguments.${prop}: ${
+              JSON.stringify(value)
+            }`,
           );
         }
         return value;
@@ -421,11 +417,13 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         const rawGlobalArgs = currentDefinition.globalArguments;
 
         // Identify globalArg fields with unresolved expressions (inputs,
-        // model resource/file refs, or any other ${{ ... }} that wasn't evaluated)
+        // model resource/file refs, or any other ${{ ... }} that wasn't evaluated).
+        // Uses valueContainsExpression for recursive detection of expressions
+        // inside nested objects and arrays (swamp-club#358).
         let hasUnresolved = false;
         const resolvedGlobalArgs: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(rawGlobalArgs)) {
-          if (typeof value === "string" && containsExpression(value)) {
+          if (valueContainsExpression(value)) {
             hasUnresolved = true;
           } else {
             resolvedGlobalArgs[key] = value;

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -2954,3 +2954,165 @@ Deno.test("executeWorkflow - still rejects invalid types on provided globalArgs"
     "Global arguments validation failed",
   );
 });
+
+// ---------- Nested Unresolved Expression Tests (swamp-club#358) ----------
+
+Deno.test("execute - Proxy throws for nested unresolved expression in globalArgs object", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/nested-unresolved"),
+    version: "1",
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          const _val = context.globalArgs.config;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      config: {
+        nested_key:
+          '${{ data.latest("other-model", "state").attributes.value }}',
+      },
+    },
+    methods: { run: { arguments: {} } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.execute(definition, model.methods.run, context),
+    Error,
+    "Unresolved expression in globalArguments.config",
+  );
+});
+
+Deno.test("execute - Proxy throws for unresolved expression in nested array", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const model: ModelDefinition = {
+    type: ModelType.create("test/nested-array-unresolved"),
+    version: "1",
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          const _val = context.globalArgs.ssh_keys;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      ssh_keys: [
+        '${{ data.latest("my-key", "state").attributes.fingerprint }}',
+      ],
+    },
+    methods: { run: { arguments: {} } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await assertRejects(
+    () => service.execute(definition, model.methods.run, context),
+    Error,
+    "Unresolved expression in globalArguments.ssh_keys",
+  );
+});
+
+Deno.test("execute - Proxy allows access to fully resolved nested object", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let receivedConfig: Record<string, unknown> = {};
+  const model: ModelDefinition = {
+    type: ModelType.create("test/nested-resolved"),
+    version: "1",
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          receivedConfig = context.globalArgs.config as Record<string, unknown>;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      config: {
+        region: "us-east-1",
+        keys: ["key-1", "key-2"],
+      },
+    },
+    methods: { run: { arguments: {} } },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await service.execute(definition, model.methods.run, context);
+  assertEquals(receivedConfig.region, "us-east-1");
+  assertEquals((receivedConfig.keys as string[])[0], "key-1");
+});
+
+Deno.test("executeWorkflow - detects nested unresolved expressions in globalArgs validation", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  const schema = z.object({
+    name: z.string(),
+    config: z.object({
+      region: z.string(),
+    }),
+  });
+
+  let receivedName = "";
+  const model: ModelDefinition = {
+    type: ModelType.create("test/nested-unresolved-validation"),
+    version: "1",
+    globalArguments: schema,
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: (_args: Record<string, unknown>, context) => {
+          receivedName = context.globalArgs.name as string;
+          return Promise.resolve({});
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      name: "my-server",
+      config: {
+        region: "${{ inputs.region }}",
+      },
+    },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "run",
+    context,
+  );
+  assertEquals(result !== undefined, true);
+  assertEquals(receivedName, "my-server");
+});

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -25,6 +25,7 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import type { EvaluatedDefinition } from "../../domain/expressions/expression_evaluation_service.ts";
 import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
@@ -92,15 +93,17 @@ export function createModelEvaluateDeps(
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
   const dataRepo = new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
-    createCatalogStore(repoDir, datastoreResolver),
+    catalogStore,
   );
+  const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const evaluationService = new ExpressionEvaluationService(
     definitionRepo,
     repoDir,
-    { dataRepo },
+    { dataRepo, dataQueryService },
   );
   const evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(
     repoDir,


### PR DESCRIPTION
## Summary

- **Primary fix**: `createModelEvaluateDeps` was the only evaluation path missing a `DataQueryService`, causing `data.latest()` and all `data.*` functions to silently return `null` during `swamp model evaluate`. The workflow evaluate, model validate, and model method run paths all had it wired up — the model evaluate path was missed. Added the same 2-line pattern.

- **Defense-in-depth**: Fixed `method_execution_service.ts` to detect unresolved `${{ }}` expressions inside nested globalArguments objects/arrays. The `hasUnresolved` check and `globalArgsProxy` both only examined top-level string values — switched to the recursive `valueContainsExpression` that was already imported and used elsewhere in the same file.

## Test Plan

- [x] Added regression test for nested `evaluateDefinition` with `inputs.*` expressions (expression_evaluation_service_test.ts)
- [x] Added 4 tests for nested unresolved expression detection in method_execution_service_test.ts:
  - Proxy throws for nested unresolved object
  - Proxy throws for unresolved array element
  - Proxy allows fully resolved nested objects
  - executeWorkflow detects nested unresolved in validation path
- [x] Existing 5992 tests pass with 0 failures
- [x] Reproduced bug in scratch repo before fix (`data.latest()` unresolved at all depths)
- [x] Verified fix in scratch repo after compile (`data.latest()` resolved at all depths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)