### PR TITLE
style: remove issue number references from code comments

### DIFF
--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -571,7 +571,7 @@ Deno.test("resolveRuntimeExpressionsInDefinition: leaves invalid env.* prose in 
 });
 
 // ============================================================================
-// evaluateDefinition — nested globalArguments (swamp-club#358)
+// evaluateDefinition — nested globalArguments
 // ============================================================================
 
 Deno.test("evaluateDefinition: resolves expressions in nested globalArguments objects and arrays", async () => {

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -419,7 +419,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         // Identify globalArg fields with unresolved expressions (inputs,
         // model resource/file refs, or any other ${{ ... }} that wasn't evaluated).
         // Uses valueContainsExpression for recursive detection of expressions
-        // inside nested objects and arrays (swamp-club#358).
+        // inside nested objects and arrays.
         let hasUnresolved = false;
         const resolvedGlobalArgs: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(rawGlobalArgs)) {

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -2955,7 +2955,7 @@ Deno.test("executeWorkflow - still rejects invalid types on provided globalArgs"
   );
 });
 
-// ---------- Nested Unresolved Expression Tests (swamp-club#358) ----------
+// ---------- Nested Unresolved Expression Tests ----------
 
 Deno.test("execute - Proxy throws for nested unresolved expression in globalArgs object", async () => {
   const service = new DefaultMethodExecutionService();


### PR DESCRIPTION
## Summary

- Remove `(swamp-club#358)` suffix from code comments in method_execution_service.ts, expression_evaluation_service_test.ts, and method_execution_service_test.ts
- Per CLAUDE.md: issue references belong in the PR description, not in code comments where they rot

Follow-up to #1403.

## Test Plan

- Comment-only change, no behavior change
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)