### PR TITLE
feat(models): expose cel-js Environment to extensions via ctx.createCelEnvironment()

### DIFF
--- a/.claude/skills/swamp-extension/references/model/api.md
+++ b/.claude/skills/swamp-extension/references/model/api.md
@@ -14,6 +14,7 @@ Detailed API documentation for extension model development.
 - [Lifetime Values](#lifetime-values)
 - [Standard Tags](#standard-tags)
 - [Error Handling](#error-handling)
+- [Custom CEL Evaluation](#custom-cel-evaluation)
 - [Logging API](#logging-api)
 
 ---
@@ -389,6 +390,88 @@ execute: (async (args, context) => {
 **Workflow integration:** When a model method throws, the workflow engine
 automatically marks the step as failed. Use `allowFailure: true` on a workflow
 step to catch exceptions and allow continued execution of subsequent steps.
+
+---
+
+## Custom CEL Evaluation
+
+Model methods can evaluate Google CEL expressions against data the model already
+holds — useful for selector predicates over a fleet, filter expressions over a
+list of records, or any user-supplied predicate. `ctx.createCelEnvironment()`
+returns a fresh, isolated `cel-js` `Environment` seeded with swamp's baseline
+arithmetic-overload registrations.
+
+### Basic usage
+
+```typescript
+execute: (async (args, ctx) => {
+  const env = ctx.createCelEnvironment();
+
+  // Compile once, evaluate many.
+  const predicate = env.parse(args.selector);
+
+  const matched = ctx.globalArgs.hosts.filter((h) =>
+    predicate({ name: h.name, region: h.region, tags: h.tags }) === true
+  );
+
+  // ... write resource with matched ...
+});
+```
+
+The example above takes a selector like
+`tags.role == "web" && region.startsWith("us-")` and applies it to each host in
+the fleet. `unlistedVariablesAreDyn: true` is enabled in the baseline, so any
+keys passed in the evaluation context resolve without pre-registration.
+
+### Custom function registration
+
+```typescript
+const env = ctx.createCelEnvironment();
+env.registerFunction(
+  "matchesRegex(string, string): bool",
+  (value: string, pattern: string) => new RegExp(pattern).test(value),
+);
+const predicate = env.parse('matchesRegex(region, "^us-.*")');
+```
+
+Registrations on one returned Environment do NOT affect any other — each
+`ctx.createCelEnvironment()` call returns a fresh instance.
+
+### Typing the Environment
+
+You almost never need to import `Environment` as a named type — inference from
+`ctx.createCelEnvironment()` carries the type through everything chained on the
+result. This matches the convention every existing extension follows for typing
+`MethodContext` (declared inline at the `execute` callsite, never imported).
+
+If a helper signature inside the extension needs the named type, use
+`ReturnType<typeof ctx.createCelEnvironment>` — no external import is required:
+
+```typescript
+execute: (async (args, ctx) => {
+  type CelEnv = ReturnType<typeof ctx.createCelEnvironment>;
+  return runPredicate(ctx.createCelEnvironment(), args.selector);
+
+  function runPredicate(env: CelEnv, selector: string) {
+    return env.parse(selector)({/* ... */});
+  }
+});
+```
+
+Do NOT import `Environment` from `@systeminit/swamp-testing` in production
+source — testing-named packages don't belong in production code. Do NOT import
+from `cel-js` directly unless your extension already pins cel-js for other
+runtime use; pinning a library just for a type is unnecessary churn.
+
+### Boundary caveat: no `instanceof Environment`
+
+The `Environment` _instance_ returned by `ctx.createCelEnvironment()` comes from
+swamp-host's bundled cel-js. If your extension also bundles its own cel-js
+(e.g., you import a value from it for another purpose), the two `Environment`
+class identifiers are different objects. Method calls dispatch correctly via
+prototypes, but `instanceof Environment` will return `false` across that
+boundary. Don't write identity checks against the class — duck-type against the
+methods you call.
 
 ---
 

--- a/deno.lock
+++ b/deno.lock
@@ -1670,6 +1670,7 @@
       "packages/testing": {
         "dependencies": [
           "jsr:@std/assert@1.0.19",
+          "npm:@marcbachmann/cel-js@7.6.1",
           "npm:zod@^4.3.6"
         ]
       }

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -7,6 +7,30 @@ should be able to reference models by name, then grab data from definitions or
 data, and manipulate it in place (such as string manipulation, concatenating
 array members, etc).
 
+## Two CEL Surfaces
+
+Swamp has two distinct CEL surfaces:
+
+1. **Internal**: `CelEvaluator` (`src/infrastructure/cel/cel_evaluator.ts`) is
+   used to evaluate expressions in workflow conditions, data queries,
+   `forEach` expansion, and definition evaluation. It registers swamp's own
+   namespace types (`file.contents`, `data.latest`, etc.) on top of the
+   baseline factory.
+2. **Extension-author-facing**: `createExtensionCelEnvironment()` is the same
+   factory without the swamp-internal namespace types. It is exposed on
+   `MethodContext` as `ctx.createCelEnvironment()` so extension model
+   methods can evaluate their own CEL expressions over data the model
+   already holds (e.g. selector predicates over a fleet of hosts).
+   Extensions register their own functions, types, and operators on the
+   returned Environment — registrations on one instance do not affect any
+   other. See `.claude/skills/swamp-extension/references/model/api.md` for
+   the extension-author guide.
+
+The two surfaces share the same arithmetic-overload registrations
+(bigint/double mixes) so a CEL expression parsed against either evaluates
+arithmetic identically. They diverge only on what receiver methods are
+visible.
+
 ## Model Data
 
 You should be able to access models by name or id, and then definition

--- a/integration/data_output_specs_test.ts
+++ b/integration/data_output_specs_test.ts
@@ -25,6 +25,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
+import { createExtensionCelEnvironment } from "../src/infrastructure/cel/cel_evaluator.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";
 import {
   type MethodContext,
@@ -148,6 +149,7 @@ Deno.test("Data output specs - shell model execution produces valid resource han
         extensionFile: () => {
           throw new Error("extensionFile not stubbed in this test");
         },
+        createCelEnvironment: createExtensionCelEnvironment,
       },
     );
 
@@ -241,6 +243,7 @@ Deno.test("Data output specs - undeclared resource spec fails at writeResource",
           extensionFile: () => {
             throw new Error("extensionFile not stubbed in this test");
           },
+          createCelEnvironment: createExtensionCelEnvironment,
         },
       );
     } catch (error) {
@@ -319,6 +322,7 @@ Deno.test("Data output specs - undeclared file spec fails at createFileWriter", 
           extensionFile: () => {
             throw new Error("extensionFile not stubbed in this test");
           },
+          createCelEnvironment: createExtensionCelEnvironment,
         },
       );
     } catch (error) {

--- a/integration/method_context_cel_env_test.ts
+++ b/integration/method_context_cel_env_test.ts
@@ -1,0 +1,200 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Integration test for ctx.createCelEnvironment(): wires the factory through
+// the production MethodContext construction site (buildMethodContext) into a
+// synthetic extension's execute, and verifies CEL evaluation works
+// end-to-end. A regression in the factory, the field declaration, or the
+// build factory would surface here. See lab issue #376.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import { z } from "zod";
+
+import { buildMethodContext } from "../src/domain/models/method_context.ts";
+import {
+  type MethodExecutor,
+  RawExecutionDriver,
+} from "../src/domain/drivers/raw_execution_driver.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import type {
+  MethodContext,
+  MethodDefinition,
+  ModelDefinition,
+} from "../src/domain/models/model.ts";
+import type { ExecutionRequest } from "../src/domain/drivers/execution_driver.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import { createExtensionCelEnvironment } from "../src/infrastructure/cel/cel_evaluator.ts";
+
+const TEST_MODEL_TYPE = ModelType.create("test/cel_env_ctx");
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-celctx-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function setupRepoDir(dir: string): Promise<void> {
+  await ensureDir(join(dir, ".swamp", "data"));
+  await ensureDir(join(dir, "models"));
+}
+
+function createMockRequest(): ExecutionRequest {
+  return {
+    protocolVersion: 1,
+    modelType: TEST_MODEL_TYPE.normalized,
+    modelId: "def-cel-env-ctx",
+    methodName: "run",
+    globalArgs: {},
+    methodArgs: {},
+    definitionMeta: {
+      id: "def-cel-env-ctx",
+      name: "cel-env-ctx-model",
+      version: 1,
+      tags: {},
+    },
+  };
+}
+
+Deno.test("createCelEnvironment chain: factory + driver expose a working Environment to extension execute", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+
+    const catalogStore = new CatalogStore(
+      join(repoDir, ".swamp", "data", "_catalog.db"),
+    );
+    try {
+      const dataRepo = new FileSystemUnifiedDataRepository(
+        repoDir,
+        undefined,
+        catalogStore,
+      );
+      const definitionRepo = new YamlDefinitionRepository(repoDir);
+
+      // Build a minimal execution target: one method that uses ctx.createCelEnvironment.
+      const definition = Definition.create({
+        name: "cel-env-ctx-model",
+        type: TEST_MODEL_TYPE.normalized,
+      });
+      const method: MethodDefinition = {
+        description: "run",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      };
+      const modelDef: ModelDefinition = {
+        type: TEST_MODEL_TYPE,
+        version: "2026.01.01.1",
+        globalArguments: z.object({}),
+        resources: {},
+        methods: { run: method },
+      };
+
+      // The synthetic extension's execute exercises the full extension-facing
+      // surface: pull the factory off ctx, parse, register a custom function,
+      // evaluate, and assert the result via captured variables.
+      let arithmeticResult: unknown;
+      let customResult: unknown;
+      let secondInstanceSawCustom = true;
+      const executor: MethodExecutor = {
+        execute: async (_def, _m, context) => {
+          const env = context.createCelEnvironment();
+
+          // Arithmetic overload baseline (double + int).
+          arithmeticResult = env.evaluate("a + 2", { a: 1.5 });
+
+          // Custom function registration.
+          env.registerFunction(
+            "matchesRegex(string, string): bool",
+            (value: string, pattern: string) => new RegExp(pattern).test(value),
+          );
+          customResult = env.evaluate('matchesRegex("us-east-1", "^us-.*")');
+
+          // Isolation: a second createCelEnvironment call must NOT see the
+          // function we just registered on `env`.
+          const env2 = context.createCelEnvironment();
+          try {
+            env2.evaluate("matchesRegex('x', 'y')");
+          } catch {
+            secondInstanceSawCustom = false;
+          }
+
+          return await Promise.resolve({});
+        },
+      };
+
+      const context: MethodContext = buildMethodContext(
+        {
+          dataRepository: dataRepo,
+          definitionRepository: definitionRepo,
+          createCelEnvironment: createExtensionCelEnvironment,
+        },
+        {
+          signal: new AbortController().signal,
+          repoDir,
+          modelType: TEST_MODEL_TYPE,
+          modelId: definition.id,
+          globalArgs: {},
+          definition: {
+            id: definition.id,
+            name: definition.name,
+            version: definition.version,
+            tags: definition.tags,
+          },
+          methodName: "run",
+          logger: getLogger(["test", "celctx"]),
+        },
+      );
+
+      assertExists(context.createCelEnvironment);
+
+      const driver = new RawExecutionDriver(
+        executor,
+        definition,
+        method,
+        modelDef,
+        context,
+        "run",
+      );
+      const result = await driver.execute(createMockRequest());
+
+      assertEquals(result.status, "success");
+      assertEquals(arithmeticResult, 3.5);
+      assertEquals(customResult, true);
+      assertEquals(
+        secondInstanceSawCustom,
+        false,
+        "fresh Environment from a second createCelEnvironment call must NOT carry registrations from the first",
+      );
+    } finally {
+      catalogStore.close();
+    }
+  });
+});

--- a/integration/workflow_query_data_context_test.ts
+++ b/integration/workflow_query_data_context_test.ts
@@ -46,6 +46,7 @@ import type { ExecutionRequest } from "../src/domain/drivers/execution_driver.ts
 import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import { createExtensionCelEnvironment } from "../src/infrastructure/cel/cel_evaluator.ts";
 import { DataQueryService } from "../src/domain/data/data_query_service.ts";
 
 const TEST_MODEL_TYPE = ModelType.create("test/query_data_ctx");
@@ -163,6 +164,7 @@ Deno.test("queryData chain: factory + driver derive working queryData from dataQ
           dataRepository: dataRepo,
           definitionRepository: definitionRepo,
           dataQueryService,
+          createCelEnvironment: createExtensionCelEnvironment,
         },
         {
           signal: new AbortController().signal,

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -52,6 +52,16 @@ Deno.test("run method writes expected resource", async () => {
 | `storedResources` | `{}`                | Pre-seed data for `readResource` calls                |
 | `onEvent`         | captures only       | Optional callback for domain events                   |
 
+## CEL Evaluation in Tests
+
+`createModelTestContext` provides `ctx.createCelEnvironment()` — a working
+cel-js Environment seeded with the same baseline registrations as production.
+Extensions that use CEL evaluation in their `execute` methods can be unit-tested
+with no extra setup. See the
+[Custom CEL Evaluation section in the model API
+reference](https://github.com/systeminit/swamp/blob/main/.claude/skills/swamp-extension/references/model/api.md#custom-cel-evaluation)
+for usage patterns.
+
 ## Inspection Helpers
 
 The return value includes helpers to inspect what happened during execution:

--- a/packages/testing/_cel_environment.ts
+++ b/packages/testing/_cel_environment.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Local mirror of swamp's `createExtensionCelEnvironment` factory.
+//
+// Why mirrored instead of imported: this package publishes standalone to JSR
+// (`.github/workflows/publish-testing.yml` runs `deno check mod.ts` from
+// inside this directory), so it cannot import from `../../src/`.
+//
+// Drift guard: `src/domain/models/testing_package_compat_test.ts` runs both
+// this factory and `src/infrastructure/cel/cel_evaluator.ts`'s
+// `createExtensionCelEnvironment` and asserts identical results across a
+// representative set of expressions plus that each call yields a fresh,
+// isolated Environment. If you change one, change the other.
+
+import { Environment } from "cel-js";
+
+export function createExtensionCelEnvironment(): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: true });
+
+  env.registerOperator(
+    "double + int",
+    (a: number, b: bigint) => a + Number(b),
+  );
+  env.registerOperator(
+    "int + double",
+    (a: bigint, b: number) => Number(a) + b,
+  );
+  env.registerOperator(
+    "double - int",
+    (a: number, b: bigint) => a - Number(b),
+  );
+  env.registerOperator(
+    "int - double",
+    (a: bigint, b: number) => Number(a) - b,
+  );
+  env.registerOperator(
+    "double * int",
+    (a: number, b: bigint) => a * Number(b),
+  );
+  env.registerOperator(
+    "int * double",
+    (a: bigint, b: number) => Number(a) * b,
+  );
+  env.registerOperator(
+    "double / int",
+    (a: number, b: bigint) => a / Number(b),
+  );
+  env.registerOperator(
+    "int / double",
+    (a: bigint, b: number) => Number(a) / b,
+  );
+  env.registerOperator(
+    "double % int",
+    (a: number, b: bigint) => a % Number(b),
+  );
+  env.registerOperator(
+    "int % double",
+    (a: bigint, b: number) => Number(a) % b,
+  );
+
+  return env;
+}

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -5,6 +5,7 @@
   "exports": "./mod.ts",
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.19",
+    "cel-js": "npm:@marcbachmann/cel-js@7.6.1",
     "zod": "npm:zod@^4.3.6"
   }
 }

--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -26,6 +26,7 @@ import type {
   MethodContext,
   MethodExecutionEvent,
 } from "./types.ts";
+import { createExtensionCelEnvironment } from "./_cel_environment.ts";
 
 /** A resource captured by the test context's writeResource. */
 export interface WrittenResource {
@@ -307,6 +308,7 @@ export function createModelTestContext(
     writeResource,
     readResource,
     createFileWriter,
+    createCelEnvironment: createExtensionCelEnvironment,
     onEvent,
   };
 

--- a/packages/testing/test_context_test.ts
+++ b/packages/testing/test_context_test.ts
@@ -35,6 +35,33 @@ Deno.test("createModelTestContext: returns context with default values", () => {
   assertExists(context.writeResource);
   assertExists(context.readResource);
   assertExists(context.createFileWriter);
+  assertExists(context.createCelEnvironment);
+});
+
+Deno.test("createModelTestContext: createCelEnvironment returns a working Environment", () => {
+  const { context } = createModelTestContext();
+  const env = context.createCelEnvironment();
+
+  // Baseline arithmetic overloads work (double + int).
+  assertEquals(env.evaluate("a + 2", { a: 1.5 }), 3.5);
+
+  // Custom function registration works.
+  env.registerFunction("triple(int): int", (x: bigint) => x * 3n);
+  assertEquals(env.evaluate("triple(7)"), 21n);
+
+  // Compile-once-evaluate-many pattern.
+  const predicate = env.parse('name == "web"');
+  assertEquals(predicate({ name: "web" }), true);
+  assertEquals(predicate({ name: "db" }), false);
+});
+
+Deno.test("createModelTestContext: each createCelEnvironment call yields a fresh Environment", () => {
+  const { context } = createModelTestContext();
+  const first = context.createCelEnvironment();
+  first.registerFunction("only_on_first(): bool", () => true);
+
+  const second = context.createCelEnvironment();
+  assertThrows(() => second.evaluate("only_on_first()"), Error);
 });
 
 Deno.test("createModelTestContext: accepts custom options", () => {

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -25,6 +25,11 @@
  * compatibility with the canonical types.
  */
 
+// Type-only — used to type the `createCelEnvironment` field below.
+// Extensions get Environment instances via `ctx.createCelEnvironment()` and
+// rely on inference; no consumer-facing re-export is provided.
+import type { Environment } from "cel-js";
+
 /**
  * Lifetime determines how long data should be retained.
  * - Duration strings: "1h", "5m", "10d", "2w", "1mo", "10y"
@@ -175,6 +180,15 @@ export interface MethodContext<TGlobalArgs = Record<string, unknown>> {
   ) => Promise<Record<string, unknown> | null>;
   /** Create a file writer for binary/streaming content. */
   createFileWriter: (specName: string, name: string) => DataWriter;
+  /**
+   * Build a fresh, isolated cel-js `Environment` seeded with swamp's
+   * baseline arithmetic-overload registrations. Use this to evaluate
+   * CEL expressions over data the extension already holds (e.g. a
+   * selector predicate over a fleet of hosts). Each call returns a
+   * new Environment — registrations on one returned instance do not
+   * affect any other.
+   */
+  createCelEnvironment: () => Environment;
   /** Optional callback for emitting domain events during execution. */
   onEvent?: (event: MethodExecutionEvent) => void;
 }

--- a/src/domain/drivers/raw_execution_driver_test.ts
+++ b/src/domain/drivers/raw_execution_driver_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { RawExecutionDriver } from "./raw_execution_driver.ts";
 import type { MethodExecutor } from "./raw_execution_driver.ts";
 import type { ExecutionRequest } from "./execution_driver.ts";
@@ -138,6 +139,7 @@ function createMockContext(): MethodContext {
     extensionFile: () => {
       throw new Error("extensionFile not stubbed in this test");
     },
+    createCelEnvironment: createExtensionCelEnvironment,
   } as MethodContext;
 }
 

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { assertNotEquals } from "@std/assert/not-equals";
+import { createExtensionCelEnvironment } from "../../../../infrastructure/cel/cel_evaluator.ts";
 import { createDefinitionId } from "../../../definitions/definition.ts";
 import {
   SHELL_MODEL_TYPE,
@@ -292,6 +293,7 @@ function createTestContext(
     extensionFile: () => {
       throw new Error("extensionFile not stubbed in this test");
     },
+    createCelEnvironment: createExtensionCelEnvironment,
     ...overrides,
   };
   return { context, getResults };

--- a/src/domain/models/method_context.ts
+++ b/src/domain/models/method_context.ts
@@ -40,6 +40,14 @@ export interface CommonMethodContextDeps {
   redactor?: MethodContext["redactor"];
   dataQueryService?: MethodContext["dataQueryService"];
   cloudControlClientFactory?: MethodContext["cloudControlClientFactory"];
+  /**
+   * Factory that builds a fresh cel-js Environment with swamp's baseline
+   * arithmetic-overload registrations for extension use. Passed in by the
+   * application layer (libswamp / CLI) so the domain layer does not need
+   * to import the cel-js binding directly. See
+   * `src/infrastructure/cel/cel_evaluator.ts#createExtensionCelEnvironment`.
+   */
+  createCelEnvironment: MethodContext["createCelEnvironment"];
 }
 
 /**
@@ -127,5 +135,6 @@ export function buildMethodContext(
     vaultSecrets: invocation.vaultSecrets,
     unresolvedMethodArgs: invocation.unresolvedMethodArgs,
     extensionFile: (relPath: string) => resolveExtensionFile(root, relPath),
+    createCelEnvironment: common.createCelEnvironment,
   };
 }

--- a/src/domain/models/method_context_test.ts
+++ b/src/domain/models/method_context_test.ts
@@ -25,6 +25,7 @@ import {
   type CommonMethodContextDeps,
   type MethodInvocationContext,
 } from "./method_context.ts";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { ModelType } from "./model_type.ts";
 import type { DataQueryService } from "../data/data_query_service.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
@@ -41,6 +42,7 @@ function makeCommon(
   return {
     dataRepository,
     definitionRepository,
+    createCelEnvironment: createExtensionCelEnvironment,
     ...overrides,
   };
 }
@@ -71,7 +73,11 @@ Deno.test("buildMethodContext: passes through required common deps", () => {
   const definitionRepository = {} as DefinitionRepository;
 
   const ctx = buildMethodContext(
-    { dataRepository, definitionRepository },
+    {
+      dataRepository,
+      definitionRepository,
+      createCelEnvironment: createExtensionCelEnvironment,
+    },
     makeInvocation(),
   );
 

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { DefaultMethodExecutionService } from "./method_execution_service.ts";
 import { createDefinitionId, Definition } from "../definitions/definition.ts";
 import { ModelType } from "./model_type.ts";
@@ -271,6 +272,7 @@ function createTestContext(
     extensionFile: () => {
       throw new Error("extensionFile not stubbed in this test");
     },
+    createCelEnvironment: createExtensionCelEnvironment,
     ...overrides,
   };
   return { context, getResults };

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -20,6 +20,7 @@
 import { z } from "zod";
 import { isZodSchemaLike } from "../zod_compat.ts";
 import type { CloudControlClient } from "@aws-sdk/client-cloudcontrol";
+import type { Environment } from "cel-js";
 import type { Logger } from "@logtape/logtape";
 import { ModelType } from "./model_type.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
@@ -355,6 +356,19 @@ export interface MethodContext {
    * (pulled vs source) to give actionable guidance.
    */
   extensionFile: (relPath: string) => string;
+
+  /**
+   * Build a fresh, isolated cel-js `Environment` seeded with swamp's
+   * baseline arithmetic-overload registrations. Use this to evaluate
+   * CEL expressions over data the extension already holds (e.g. a
+   * selector predicate over a fleet of hosts). Each call returns a
+   * new Environment — registrations on one returned instance do not
+   * affect any other. The returned Environment does NOT carry swamp's
+   * internal namespace types (`file.contents`, `data.latest`, etc.);
+   * extensions may freely register their own functions, types, and
+   * operators on top.
+   */
+  createCelEnvironment: () => Environment;
 }
 
 /**

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { z } from "zod";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import {
   type DataHandle,
   type DataWriter,
@@ -234,6 +235,7 @@ function createTestContext(modelType: ModelType): {
     extensionFile: () => {
       throw new Error("extensionFile not stubbed in this test");
     },
+    createCelEnvironment: createExtensionCelEnvironment,
   };
   return { context, getResults };
 }

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -78,6 +78,8 @@ function _checkContextFields(ctx: TestingMethodContext) {
   const _repoDir: _CanonicalMethodContext["repoDir"] = ctx.repoDir;
   const _globalArgs: _CanonicalMethodContext["globalArgs"] = ctx.globalArgs;
   const _methodName: _CanonicalMethodContext["methodName"] = ctx.methodName;
+  const _createCelEnvironment: _CanonicalMethodContext["createCelEnvironment"] =
+    ctx.createCelEnvironment;
 
   // definition sub-fields (canonical uses inline object type, not DefinitionInfo)
   const _defName: string = ctx.definition.name;
@@ -85,7 +87,7 @@ function _checkContextFields(ctx: TestingMethodContext) {
   const _defVersion: number = ctx.definition.version;
   const _defTags: Record<string, string> = ctx.definition.tags;
 
-  void [_signal, _repoDir, _globalArgs, _methodName];
+  void [_signal, _repoDir, _globalArgs, _methodName, _createCelEnvironment];
   void [_defName, _defId, _defVersion, _defTags];
 }
 
@@ -221,4 +223,53 @@ Deno.test("testing package types: compile-time compatibility check", () => {
     _checkMethodDefinitionFields,
     _checkModelDefinitionFields,
   ];
+});
+
+// Runtime drift + isolation: the testing package mirrors swamp's
+// createExtensionCelEnvironment locally (it cannot import from src/ during
+// JSR publish). These tests fail loudly if the two implementations diverge.
+import { assertEquals, assertThrows } from "@std/assert";
+import { createExtensionCelEnvironment as canonicalFactory } from "../../infrastructure/cel/cel_evaluator.ts";
+import { createExtensionCelEnvironment as testingFactory } from "../../../packages/testing/_cel_environment.ts";
+
+Deno.test("cel env factory parity: both factories produce identical results", () => {
+  const exprs: Array<[string, Record<string, unknown>]> = [
+    ["a + 2", { a: 1.5 }],
+    ["a - 1", { a: 3.5 }],
+    ["a * 2", { a: 1.5 }],
+    ["a / 2", { a: 5.0 }],
+    ["a % 2", { a: 5.0 }],
+    ["2 + a", { a: 1.5 }],
+  ];
+
+  const a = canonicalFactory();
+  const b = testingFactory();
+
+  for (const [expr, ctx] of exprs) {
+    assertEquals(
+      a.evaluate(expr, ctx),
+      b.evaluate(expr, ctx),
+      `Factories diverge on expression "${expr}"`,
+    );
+  }
+
+  // Custom function registration parity: both must accept the same signature.
+  a.registerFunction("quadruple(int): int", (x: bigint) => x * 4n);
+  b.registerFunction("quadruple(int): int", (x: bigint) => x * 4n);
+  assertEquals(a.evaluate("quadruple(5)"), b.evaluate("quadruple(5)"));
+});
+
+Deno.test("cel env factory isolation: each call returns a fresh Environment", () => {
+  for (const factory of [canonicalFactory, testingFactory]) {
+    const first = factory();
+    first.registerFunction("only_on_first(): bool", () => true);
+    assertEquals(first.evaluate("only_on_first()"), true);
+
+    // Second call must not see registrations from the first.
+    const second = factory();
+    assertThrows(
+      () => second.evaluate("only_on_first()"),
+      Error,
+    );
+  }
 });

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -23,6 +23,7 @@ import {
   assertStringIncludes,
 } from "@std/assert";
 import { dirname, join } from "@std/path";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { ExtensionLoader } from "../extensions/extension_loader.ts";
 import {
   clearAttachedExtensions,
@@ -265,6 +266,7 @@ function createTestContext(
     extensionFile: () => {
       throw new Error("extensionFile not stubbed in this test");
     },
+    createCelEnvironment: createExtensionCelEnvironment,
   };
   return { context, getResults };
 }

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -235,6 +235,13 @@ export interface CheckValidationContext {
   dataRepository: MethodContext["dataRepository"];
   definitionRepository: DefinitionRepository;
   dataQueryService?: DataQueryService;
+  /**
+   * Factory that builds a fresh cel-js Environment with swamp's baseline
+   * registrations. Forwarded to `buildMethodContext` so the domain layer
+   * does not import the cel-js binding directly. The application layer
+   * (libswamp / CLI) supplies the implementation.
+   */
+  createCelEnvironment: MethodContext["createCelEnvironment"];
   labels?: string[];
   method?: string;
 }
@@ -384,6 +391,7 @@ export class DefaultModelValidationService implements ModelValidationService {
             dataRepository: checkContext.dataRepository,
             definitionRepository: checkContext.definitionRepository,
             dataQueryService: checkContext.dataQueryService,
+            createCelEnvironment: checkContext.createCelEnvironment,
           },
           {
             signal: new AbortController().signal,

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { z } from "zod";
 import {
   DefaultModelValidationService,
@@ -1133,6 +1134,7 @@ function createCheckContext(
       nextId: () => createDefinitionId(crypto.randomUUID()),
       getPath: () => "",
     },
+    createCelEnvironment: createExtensionCelEnvironment,
     ...overrides,
   };
 }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -83,7 +83,10 @@ import {
   type FileDataRecord,
   ModelResolver,
 } from "../expressions/model_resolver.ts";
-import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
+import {
+  CelEvaluator,
+  createExtensionCelEnvironment,
+} from "../../infrastructure/cel/cel_evaluator.ts";
 import {
   DefinitionExpressionEvaluator,
   WorkflowExpressionEvaluator,
@@ -847,6 +850,7 @@ export class DefaultStepExecutor implements StepExecutor {
           vaultService,
           redactor: ctx.secretRedactor,
           dataQueryService,
+          createCelEnvironment: createExtensionCelEnvironment,
         },
         {
           signal: ctx.signal,

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -178,6 +178,71 @@ export class CelDataNamespace {
 }
 
 /**
+ * Builds a fresh, isolated cel-js `Environment` with swamp's baseline
+ * registrations for extension use.
+ *
+ * Options: `{ unlistedVariablesAreDyn: true }` so callers can pass arbitrary
+ * context maps without pre-registering every variable. Extensions can
+ * `.clone({ homogeneousAggregateLiterals: false })` if they want mixed-type
+ * literals.
+ *
+ * Registrations: bigint/double arithmetic operator overloads only. The
+ * returned Environment does NOT carry swamp's internal namespace types
+ * (`CelFileNamespace`/`CelDataNamespace`) — those are private to swamp's
+ * own expression surface. Callers may freely register their own
+ * functions, types, and operators on the returned Environment.
+ */
+export function createExtensionCelEnvironment(): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: true });
+
+  // Register mixed-type arithmetic overloads. Context values from model
+  // attributes are JS numbers (double), but CEL integer literals are bigint
+  // (int). Without these, expressions like `count * 2` fail.
+  env.registerOperator(
+    "double + int",
+    (a: number, b: bigint) => a + Number(b),
+  );
+  env.registerOperator(
+    "int + double",
+    (a: bigint, b: number) => Number(a) + b,
+  );
+  env.registerOperator(
+    "double - int",
+    (a: number, b: bigint) => a - Number(b),
+  );
+  env.registerOperator(
+    "int - double",
+    (a: bigint, b: number) => Number(a) - b,
+  );
+  env.registerOperator(
+    "double * int",
+    (a: number, b: bigint) => a * Number(b),
+  );
+  env.registerOperator(
+    "int * double",
+    (a: bigint, b: number) => Number(a) * b,
+  );
+  env.registerOperator(
+    "double / int",
+    (a: number, b: bigint) => a / Number(b),
+  );
+  env.registerOperator(
+    "int / double",
+    (a: bigint, b: number) => Number(a) / b,
+  );
+  env.registerOperator(
+    "double % int",
+    (a: number, b: bigint) => a % Number(b),
+  );
+  env.registerOperator(
+    "int % double",
+    (a: bigint, b: number) => Number(a) % b,
+  );
+
+  return env;
+}
+
+/**
  * CEL evaluator that wraps the cel-js library.
  *
  * Uses the cel-js Environment class with registered types and receiver methods
@@ -189,51 +254,9 @@ export class CelEvaluator {
   private readonly warnedPatterns = new Set<string>();
 
   constructor() {
-    this.env = new Environment({ unlistedVariablesAreDyn: true });
-
-    // Register mixed-type arithmetic overloads. Context values from model
-    // attributes are JS numbers (double), but CEL integer literals are bigint
-    // (int). Without these, expressions like `count * 2` fail.
-    this.env.registerOperator(
-      "double + int",
-      (a: number, b: bigint) => a + Number(b),
-    );
-    this.env.registerOperator(
-      "int + double",
-      (a: bigint, b: number) => Number(a) + b,
-    );
-    this.env.registerOperator(
-      "double - int",
-      (a: number, b: bigint) => a - Number(b),
-    );
-    this.env.registerOperator(
-      "int - double",
-      (a: bigint, b: number) => Number(a) - b,
-    );
-    this.env.registerOperator(
-      "double * int",
-      (a: number, b: bigint) => a * Number(b),
-    );
-    this.env.registerOperator(
-      "int * double",
-      (a: bigint, b: number) => Number(a) * b,
-    );
-    this.env.registerOperator(
-      "double / int",
-      (a: number, b: bigint) => a / Number(b),
-    );
-    this.env.registerOperator(
-      "int / double",
-      (a: bigint, b: number) => Number(a) / b,
-    );
-    this.env.registerOperator(
-      "double % int",
-      (a: number, b: bigint) => a % Number(b),
-    );
-    this.env.registerOperator(
-      "int % double",
-      (a: bigint, b: number) => Number(a) % b,
-    );
+    // Start from the shared extension baseline, then layer swamp's internal
+    // namespace types on top.
+    this.env = createExtensionCelEnvironment();
 
     // Register namespace types so cel-js recognizes them via constructor
     // matching instead of trying to infer them as maps.

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -18,9 +18,64 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
-import { CelEvaluator } from "./cel_evaluator.ts";
+import {
+  CelEvaluator,
+  createExtensionCelEnvironment,
+} from "./cel_evaluator.ts";
 import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
 import { transformHyphenatedModelRefs } from "../../domain/expressions/expression_parser.ts";
+
+Deno.test("createExtensionCelEnvironment: arithmetic overloads work for double/int mixes", () => {
+  const env = createExtensionCelEnvironment();
+  assertEquals(env.evaluate("a + 2", { a: 1.5 }), 3.5);
+  assertEquals(env.evaluate("2 + a", { a: 1.5 }), 3.5);
+  assertEquals(env.evaluate("a - 1", { a: 3.5 }), 2.5);
+  assertEquals(env.evaluate("a * 2", { a: 1.5 }), 3);
+  assertEquals(env.evaluate("a / 2", { a: 5.0 }), 2.5);
+  assertEquals(env.evaluate("a % 2", { a: 5.0 }), 1);
+});
+
+Deno.test("createExtensionCelEnvironment: unlistedVariablesAreDyn allows ad-hoc context keys", () => {
+  const env = createExtensionCelEnvironment();
+  // No registerVariable call needed — the option lets unknown identifiers
+  // resolve from the evaluation context.
+  assertEquals(env.evaluate("foo + bar", { foo: 1.0, bar: 2.0 }), 3);
+});
+
+Deno.test("createExtensionCelEnvironment: callers can register custom functions", () => {
+  const env = createExtensionCelEnvironment();
+  env.registerFunction(
+    "triple(int): int",
+    (x: bigint) => x * 3n,
+  );
+  assertEquals(env.evaluate("triple(7)"), 21n);
+});
+
+Deno.test("createExtensionCelEnvironment: each call returns a fresh, isolated Environment", () => {
+  const a = createExtensionCelEnvironment();
+  a.registerFunction("only_on_a(): bool", () => true);
+  assertEquals(a.evaluate("only_on_a()"), true);
+
+  // Second factory call must NOT see the function registered on `a`.
+  const b = createExtensionCelEnvironment();
+  assertThrows(
+    () => b.evaluate("only_on_a()"),
+    Error,
+  );
+});
+
+Deno.test("createExtensionCelEnvironment: does NOT pre-register swamp's internal namespace types", () => {
+  const env = createExtensionCelEnvironment();
+  // file.contents(...) is a swamp-internal receiver method; extensions should
+  // see no such registration on a baseline Environment.
+  assertThrows(
+    () =>
+      env.evaluate("file.contents('m', 's')", {
+        file: { contents: () => null },
+      }),
+    Error,
+  );
+});
 
 Deno.test("CelEvaluator evaluates simple property access", () => {
   const evaluator = new CelEvaluator();

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -18,6 +18,17 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 export { createLibSwampContext, type LibSwampContext } from "./context.ts";
+
+// Extension CEL surface — INTERNAL re-exports for libswamp/* and CLI callers.
+// Extension authors never reach into libswamp/mod.ts directly (the top-level
+// `@swamp/cli` package only exports main.ts); they get the runtime factory
+// via `ctx.createCelEnvironment()` and type via inference. The runtime
+// constructor is deliberately kept out of any extension-author-facing
+// package — swamp-host's cel-js and an extension's bundled cel-js have
+// separate class identities, so `instanceof` checks across that boundary
+// silently fail.
+export { createExtensionCelEnvironment } from "../infrastructure/cel/cel_evaluator.ts";
+export type { Environment } from "cel-js";
 export {
   alreadyExists,
   cancelled,

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -48,6 +48,7 @@ import type { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { RepoMarkerData } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { resolveDriverConfig } from "../../domain/drivers/driver_resolution.ts";
 import { buildMethodContext } from "../../domain/models/method_context.ts";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import type {
   DataArtifactView,
   ModelMethodRunView,
@@ -644,6 +645,7 @@ export async function* modelMethodRun(
                     vaultService,
                     redactor,
                     dataQueryService: deps.dataQueryService,
+                    createCelEnvironment: createExtensionCelEnvironment,
                   },
                   {
                     signal: ctx.signal,

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -30,6 +30,7 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
@@ -137,6 +138,7 @@ export function createModelValidateDeps(
     dataRepository: dataRepo,
     definitionRepository: definitionRepo,
     dataQueryService,
+    createCelEnvironment: createExtensionCelEnvironment,
     labels: options?.labels,
     method: options?.method,
   };


### PR DESCRIPTION
## Summary

Exposes the cel-js `Environment` to extension model methods so they can evaluate their own CEL expressions over data they already hold — e.g. an SSH fleet model with a `select` method that takes a CEL selector (`tags.role == "web" && region.startsWith("us-")`) and filters hosts by it.

- New `createExtensionCelEnvironment()` in `src/infrastructure/cel/cel_evaluator.ts` — returns a fresh, isolated cel-js `Environment` seeded with swamp's baseline arithmetic-overload registrations and `{ unlistedVariablesAreDyn: true }`. It omits swamp's internal namespace types (`file.contents`, `data.latest`, …) so extensions get a clean baseline.
- `CelEvaluator`'s constructor now builds on the factory and layers the internal namespace types on top — no behavior change to swamp's internal CEL surface.
- Exposed on `MethodContext` as `ctx.createCelEnvironment()`, plumbed via dependency inversion (`CommonMethodContextDeps` / `CheckValidationContext`) so the domain layer never imports the cel-js binding directly; application-layer callers (libswamp / CLI) supply the implementation. No new domain→infrastructure violations (DDD ratchet stays at 25).
- `@systeminit/swamp-testing` mirrors the factory locally (`packages/testing/_cel_environment.ts`) — it publishes standalone to JSR and cannot import from `src/`. A parity + isolation drift test runs both implementations and fails on divergence. `createModelTestContext` wires `ctx.createCelEnvironment()` so extension unit tests work with no extra setup.
- Extensions consume the `Environment` type via inference (the common case) or `ReturnType<typeof ctx.createCelEnvironment>`; no extension-author-facing package re-exports the type, matching how `MethodContext` itself is consumed today.

Scope is intentionally limited to model methods — reports, datastores, vaults, and drivers do not get `createCelEnvironment` in this change.

Resolves swamp-club#376

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — 1329 files, no issues
- [x] `deno fmt --check` — clean
- [x] `deno run test` — 5996 passed, 0 failed, 29 ignored
- [x] `deno run compile` — binary rebuilt successfully
- New unit tests: factory arithmetic overloads, `unlistedVariablesAreDyn`, custom function registration, fresh-instance isolation, namespace-type exclusion
- New drift + isolation test comparing the `src/` and `packages/testing/` factory implementations
- New `createModelTestContext` wiring test
- New integration test (`integration/method_context_cel_env_test.ts`) driving a synthetic extension through the production `buildMethodContext` path
- Existing `CelEvaluator` regression tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)