### PR TITLE
fix(cli): update error message to reference --stdin flag

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -204,7 +204,7 @@ export const modelMethodRunCommand = new Command()
       if (stdinContent !== null) {
         if (options.inputFile) {
           throw new UserError(
-            "Cannot combine piped stdin with --input-file.",
+            "Cannot combine --stdin with --input-file.",
           );
         }
         stdinItems = parseStdinContent(stdinContent);

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -180,7 +180,7 @@ export const workflowRunCommand = new Command()
     if (stdinContent !== null) {
       if (options.inputFile) {
         throw new UserError(
-          "Cannot combine piped stdin with --input-file.",
+          "Cannot combine --stdin with --input-file.",
         );
       }
       stdinItems = parseStdinContent(stdinContent);


### PR DESCRIPTION
## Summary

- Updates error message from `"Cannot combine piped stdin with --input-file."` to `"Cannot combine --stdin with --input-file."` in both `method run` and `workflow run` commands
- Follow-up to #1407 which replaced stdin auto-detect with an explicit `--stdin` flag

## Test plan

- [ ] `swamp model method run foo bar --stdin --input-file x.yaml` shows the updated error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)