### PR TITLE
fix(cli): switch 5 read-only commands from global write lock to lock-free path (swamp-club#382)

### DIFF
--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -30,7 +30,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   isPulledExtensionManifest,
   resolveExtensionFiles,
@@ -72,7 +72,7 @@ export const extensionFmtCommand = new Command()
       );
     }
 
-    const { repoContext } = await requireInitializedRepo({
+    const { repoContext } = await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/extension_install.ts
+++ b/src/cli/commands/extension_install.ts
@@ -23,7 +23,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -62,7 +62,7 @@ export const extensionInstallCommand = new Command()
     cliCtx.logger.debug`Starting extension install`;
 
     const repoDir = resolveRepoDir(options.repoDir);
-    await requireInitializedRepo({
+    await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -24,7 +24,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import { resolveExtensionFiles } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
 import { sourceHasBareSpecifiers } from "../../domain/models/bundle.ts";
@@ -192,7 +192,7 @@ export const extensionPushCommand = new Command()
 
     // 1. Validate repo
     const repoDir = resolveRepoDir(options.repoDir);
-    const { repoContext } = await requireInitializedRepo({
+    const { repoContext } = await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -34,7 +34,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 import {
   isPulledExtensionManifest,
   resolveExtensionFiles,
@@ -105,7 +105,7 @@ export const extensionQualityCommand = new Command()
         );
       }
 
-      const { repoContext } = await requireInitializedRepo({
+      const { repoContext } = await requireInitializedRepoReadOnly({
         repoDir,
         outputMode: cliCtx.outputMode,
       });

--- a/src/cli/commands/vault_read_secret.ts
+++ b/src/cli/commands/vault_read_secret.ts
@@ -30,7 +30,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -79,7 +79,7 @@ unless --force is set. In --json mode, outputs the value directly.`,
     ]);
     cliCtx.logger.debug`Reading secret from vault: ${vaultName}`;
 
-    const { repoDir, repoContext } = await requireInitializedRepo({
+    const { repoDir, repoContext } = await requireInitializedRepoReadOnly({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });


### PR DESCRIPTION
## Summary

- Switch `vault read-secret`, `extension install`, `extension fmt`, `extension push`, and `extension quality` from `requireInitializedRepo()` (global write lock + sync) to `requireInitializedRepoReadOnly()` (no lock, no sync)
- None of these commands write to the datastore — they read secrets, download extensions from the registry, format local TS files, publish to the registry API, or score extensions locally
- Under concurrent writers (scheduled model pushes on S3), the 60s lock timeout caused these commands to fail with `LockTimeoutError`

## Reproduction

Setup: scratch repo with `@swamp/s3-datastore` against local MinIO. Planted a fake `.datastore.lock` object to simulate a concurrent writer.

| Command | Before (lock held) | After (patched) |
|---|---|---|
| `vault read-secret` | **23.6s** (waited for stale lock) | **3.1s** |
| `extension install` | **26.6s** (waited for stale lock) | **0.8s** |
| `vault list-keys` (control, already read-only) | 1.1s | n/a |

With a real writer heartbeating the lock, the "before" times would be the full **60s timeout → LockTimeoutError**.

## Full audit

Audited all 30+ commands using `requireInitializedRepo`. The remaining callers are genuine writers (vault put/create/edit/migrate, extension pull/rm/update, model create/delete/edit, data delete/gc/rename, datastore compact/setup, workflow create/delete/edit/run) or already have conditional lock logic (model_validate, model_evaluate, workflow_evaluate, extension_search, datastore_sync).

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test` — 6014 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Verified patched binary against MinIO reproduction (timing above)
- [ ] Filed UAT adversarial test: systeminit/swamp-uat#226

Closes swamp-club#382

🤖 Generated with [Claude Code](https://claude.com/claude-code)