### PR TITLE
feat(cli): add --extensions-dir for git worktree support

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -495,6 +495,59 @@ Only files within the respective directory boundary are included. Non-local
 imports (`npm:`, `jsr:`, `https:`) are skipped here — they are resolved and
 inlined at bundle time by `deno bundle`, not by the local-import resolver.
 
+## Split Extensions Directory (`--extensions-dir`)
+
+By default, swamp discovers local extension sources from `extensions/<kind>/`
+relative to the repository root (`--repo-dir` / `SWAMP_REPO_DIR`). The
+`--extensions-dir` flag (or `SWAMP_EXTENSIONS_DIR` env var) overrides only
+the local source scanning root while keeping all data at the repository root.
+
+This enables **git worktree** workflows where the working tree (code plane) is
+separate from the `.swamp/` data directory (data plane):
+
+```
+# Main repo has .swamp/ data + original extensions
+~/repo/
+  .swamp/          ← data, bundles, catalog (data plane)
+  .swamp.yaml      ← repo marker
+  extensions/models/my-model.ts
+
+# Worktree has its own working copy of extensions
+~/repo/trees/feature-branch/
+  .swamp.yaml      ← same marker (committed to git)
+  extensions/models/my-model.ts      ← modified copy
+  extensions/models/new-model.ts     ← worktree-only
+```
+
+Usage:
+
+```
+SWAMP_REPO_DIR=~/repo \
+SWAMP_EXTENSIONS_DIR=~/repo/trees/feature-branch \
+  swamp model type search my-model
+```
+
+### What `--extensions-dir` controls
+
+- Local extension source scanning for all 5 kinds (models, vaults, drivers,
+  datastores, reports)
+- Manifest path resolution in `extension fmt` and `extension push`
+
+### What stays at `--repo-dir`
+
+- `.swamp/` data directory (outputs, data artifacts, workflow runs)
+- Extension catalog (`_extension_catalog.db`)
+- Bundle cache (`.swamp/bundles/`)
+- Pulled extensions (`.swamp/pulled-extensions/`)
+- Model definitions (`models/<type>/<id>.yaml`)
+- Lockfiles and secrets
+
+### Validation
+
+The CLI rejects `--extensions-dir` values that point inside `.swamp/` to
+prevent accidental reads of data-plane files as extension sources. The
+directory must exist and must be a real directory (not a file).
+
 ## Dependencies
 
 Extensions can declare dependencies on other extensions. During a pull,

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -28,6 +28,7 @@ import { createExtensionFmtRenderer } from "../../presentation/renderers/extensi
 import {
   createContext,
   type GlobalOptions,
+  resolveExtensionsDir,
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
@@ -39,6 +40,7 @@ import { UserError } from "../../domain/errors.ts";
 
 interface ExtensionFmtOptions extends GlobalOptions {
   repoDir?: string;
+  extensionsDir?: string;
   check?: boolean;
 }
 
@@ -58,12 +60,17 @@ export const extensionFmtCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--extensions-dir <dir:string>",
+    "Extensions source directory (env: SWAMP_EXTENSIONS_DIR)",
+  )
   .option("--check", "Check only, do not auto-fix")
   .action(async function (options: ExtensionFmtOptions, manifestPath: string) {
     const cliCtx = createContext(options, ["extension", "fmt"]);
     cliCtx.logger.debug`Starting extension fmt`;
 
     const repoDir = resolveRepoDir(options.repoDir);
+    const extensionsDir = resolveExtensionsDir(options.extensionsDir);
     if (isPulledExtensionManifest(repoDir, manifestPath)) {
       throw new UserError(
         "Cannot run fmt on a pulled extension. Pulled extensions are read-only " +
@@ -88,6 +95,7 @@ export const extensionFmtCommand = new Command()
       manifestPath,
       repoContext,
       logger: cliCtx.logger,
+      extensionsDir,
     });
 
     // 3. Combine all files and filter to .ts

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -22,6 +22,7 @@ import { dirname, join, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
+  resolveExtensionsDir,
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
@@ -54,6 +55,7 @@ import type { CompilationError, SwampError } from "../../libswamp/mod.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir?: string;
+  extensionsDir?: string;
   yes?: boolean;
   dryRun?: boolean;
   releaseNotes?: string;
@@ -180,6 +182,10 @@ export const extensionPushCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--extensions-dir <dir:string>",
+    "Extensions source directory (env: SWAMP_EXTENSIONS_DIR)",
+  )
   .option("-y, --yes", "Skip confirmation prompts")
   .option("--dry-run", "Build archive locally without pushing to registry")
   .option(
@@ -192,6 +198,7 @@ export const extensionPushCommand = new Command()
 
     // 1. Validate repo
     const repoDir = resolveRepoDir(options.repoDir);
+    const extensionsDir = resolveExtensionsDir(options.extensionsDir);
     const { repoContext } = await requireInitializedRepoReadOnly({
       repoDir,
       outputMode: cliCtx.outputMode,
@@ -203,6 +210,7 @@ export const extensionPushCommand = new Command()
       manifestPath,
       repoContext,
       logger: cliCtx.logger,
+      extensionsDir,
     });
     const {
       manifest,

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -151,3 +151,52 @@ export function resolveRepoDir(cliValue: string | undefined): string {
   }
   return Deno.cwd();
 }
+
+/**
+ * Pre-parses --extensions-dir from raw CLI arguments before Cliffy option
+ * parsing.
+ *
+ * Supports both `--extensions-dir <value>` and `--extensions-dir=<value>` forms.
+ * Returns the resolved absolute path, or undefined if not set.
+ *
+ * Priority: --extensions-dir flag > SWAMP_EXTENSIONS_DIR env var > undefined.
+ */
+export function getExtensionsDirFromArgs(
+  args: string[],
+): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--extensions-dir" && i + 1 < args.length) {
+      return resolve(args[i + 1]);
+    }
+    if (arg.startsWith("--extensions-dir=")) {
+      return resolve(arg.slice("--extensions-dir=".length));
+    }
+  }
+  const envDir = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  if (envDir && envDir.length > 0) {
+    return resolve(envDir);
+  }
+  return undefined;
+}
+
+/**
+ * Resolves the extensions directory for a command action, given the Cliffy
+ * parsed `--extensions-dir` option value.
+ *
+ * Priority: --extensions-dir flag > SWAMP_EXTENSIONS_DIR env var > undefined.
+ *
+ * When undefined, callers should fall back to repoDir for extension scanning.
+ */
+export function resolveExtensionsDir(
+  cliValue: string | undefined,
+): string | undefined {
+  if (cliValue !== undefined) {
+    return resolve(cliValue);
+  }
+  const envDir = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  if (envDir && envDir.length > 0) {
+    return resolve(envDir);
+  }
+  return undefined;
+}

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -21,9 +21,11 @@ import { assertEquals } from "@std/assert";
 import { isAbsolute, resolve } from "@std/path";
 import {
   createContext,
+  getExtensionsDirFromArgs,
   getOutputModeFromArgs,
   getRepoDirFromArgs,
   type GlobalOptions,
+  resolveExtensionsDir,
   resolveRepoDir,
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -255,6 +257,119 @@ Deno.test("resolveRepoDir treats empty SWAMP_REPO_DIR as unset", () => {
   } finally {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
+  }
+});
+
+// ============================================================================
+// getExtensionsDirFromArgs Tests
+// ============================================================================
+
+Deno.test("getExtensionsDirFromArgs: returns undefined when no flag or env var", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+    assertEquals(getExtensionsDirFromArgs([]), undefined);
+    assertEquals(getExtensionsDirFromArgs(["model", "create"]), undefined);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    }
+  }
+});
+
+Deno.test("getExtensionsDirFromArgs: parses --extensions-dir with space separator", () => {
+  const result = getExtensionsDirFromArgs([
+    "--extensions-dir",
+    "/tmp/my-extensions",
+  ]);
+  assertPathEquals(result!, resolve("/tmp/my-extensions"));
+});
+
+Deno.test("getExtensionsDirFromArgs: parses --extensions-dir with equals separator", () => {
+  const result = getExtensionsDirFromArgs([
+    "--extensions-dir=/tmp/my-extensions",
+  ]);
+  assertPathEquals(result!, resolve("/tmp/my-extensions"));
+});
+
+Deno.test("getExtensionsDirFromArgs: resolves relative paths to absolute", () => {
+  const result = getExtensionsDirFromArgs(["--extensions-dir", "./relative"]);
+  assertEquals(isAbsolute(result!), true);
+  assertPathEquals(result!, resolve("./relative"));
+});
+
+Deno.test("getExtensionsDirFromArgs: uses SWAMP_EXTENSIONS_DIR when flag absent", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSIONS_DIR", "/tmp/env-ext");
+    assertPathEquals(getExtensionsDirFromArgs([])!, resolve("/tmp/env-ext"));
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    } else Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+  }
+});
+
+Deno.test("getExtensionsDirFromArgs: prefers flag over env var", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSIONS_DIR", "/tmp/env-ext");
+    const result = getExtensionsDirFromArgs([
+      "--extensions-dir",
+      "/tmp/flag-ext",
+    ]);
+    assertPathEquals(result!, resolve("/tmp/flag-ext"));
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    } else Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+  }
+});
+
+Deno.test("getExtensionsDirFromArgs: ignores empty env var", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSIONS_DIR", "");
+    assertEquals(getExtensionsDirFromArgs([]), undefined);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    } else Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+  }
+});
+
+// ============================================================================
+// resolveExtensionsDir Tests
+// ============================================================================
+
+Deno.test("resolveExtensionsDir: returns resolved cli value when provided", () => {
+  assertPathEquals(
+    resolveExtensionsDir("/tmp/flag-ext")!,
+    resolve("/tmp/flag-ext"),
+  );
+});
+
+Deno.test("resolveExtensionsDir: returns env var when cli value undefined", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSIONS_DIR", "/tmp/env-ext");
+    assertPathEquals(resolveExtensionsDir(undefined)!, resolve("/tmp/env-ext"));
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    } else Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+  }
+});
+
+Deno.test("resolveExtensionsDir: returns undefined when neither set", () => {
+  const original = Deno.env.get("SWAMP_EXTENSIONS_DIR");
+  try {
+    Deno.env.delete("SWAMP_EXTENSIONS_DIR");
+    assertEquals(resolveExtensionsDir(undefined), undefined);
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_EXTENSIONS_DIR", original);
+    }
   }
 });
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -21,6 +21,7 @@ import { Command } from "@cliffy/command";
 import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, join, resolve } from "@std/path";
 import { swampPath } from "../infrastructure/persistence/paths.ts";
+import { UserError } from "../domain/errors.ts";
 import { enumeratePulledExtensionDirs } from "../libswamp/mod.ts";
 import { getLogger, parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -49,6 +50,7 @@ import { openCommand } from "./commands/open.ts";
 import { createHelpCommand } from "./commands/help.ts";
 import { unknownCommandErrorHandler } from "./unknown_command_handler.ts";
 import {
+  getExtensionsDirFromArgs,
   getRepoDirFromArgs,
   type GlobalOptions,
   isStdinTty,
@@ -244,7 +246,9 @@ export async function configureExtensionLoaders(
   resolvedSources: ResolvedSourceDirs[],
   deferredWarnings: DeferredWarning[],
   quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
+  const effectiveExtDir = extensionsDir ?? repoDir;
   const denoRuntime = new EmbeddedDenoRuntime();
   const sourceModelsDirs = collectDirsForKind(resolvedSources, "models");
   const sourceVaultsDirs = collectDirsForKind(resolvedSources, "vaults");
@@ -314,6 +318,7 @@ export async function configureExtensionLoaders(
       lazyResolver,
       repository,
       quiet,
+      effectiveExtDir,
     )
   );
   vaultTypeRegistry.setLoader(() =>
@@ -325,6 +330,7 @@ export async function configureExtensionLoaders(
       lazyResolver,
       repository,
       quiet,
+      effectiveExtDir,
     )
   );
   driverTypeRegistry.setLoader(() =>
@@ -336,6 +342,7 @@ export async function configureExtensionLoaders(
       lazyResolver,
       repository,
       quiet,
+      effectiveExtDir,
     )
   );
   datastoreTypeRegistry.setLoader(() =>
@@ -346,6 +353,7 @@ export async function configureExtensionLoaders(
       sourceDatastoresDirs,
       repository,
       quiet,
+      effectiveExtDir,
     )
   );
   reportRegistry.setLoader(() =>
@@ -357,6 +365,7 @@ export async function configureExtensionLoaders(
       lazyResolver,
       repository,
       quiet,
+      effectiveExtDir,
     )
   );
 
@@ -452,13 +461,15 @@ async function loadUserModels(
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   repository?: ExtensionRepository,
   _quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
   try {
+    const extBase = extensionsDir ?? repoDir;
     const modelsDir = resolveModelsDir(marker);
     // Handle both absolute and relative paths (cross-platform)
     const absoluteModelsDir = isAbsolute(modelsDir)
       ? modelsDir
-      : resolve(repoDir, modelsDir);
+      : resolve(extBase, modelsDir);
 
     // W1b/(a-2): if no repository was passed, bootstrap one with an
     // empty lockfile lookup. The catalog stays open for the process
@@ -536,12 +547,14 @@ async function loadUserVaults(
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   repository?: ExtensionRepository,
   _quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
   try {
+    const extBase = extensionsDir ?? repoDir;
     const vaultsDir = resolveVaultsDir(marker);
     const absoluteVaultsDir = isAbsolute(vaultsDir)
       ? vaultsDir
-      : resolve(repoDir, vaultsDir);
+      : resolve(extBase, vaultsDir);
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new ExtensionLoader(
@@ -599,12 +612,14 @@ async function loadUserDrivers(
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   repository?: ExtensionRepository,
   _quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
   try {
+    const extBase = extensionsDir ?? repoDir;
     const driversDir = resolveDriversDir(marker);
     const absoluteDriversDir = isAbsolute(driversDir)
       ? driversDir
-      : resolve(repoDir, driversDir);
+      : resolve(extBase, driversDir);
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new ExtensionLoader(
@@ -661,12 +676,14 @@ async function loadUserDatastores(
   sourceDirs: string[] = [],
   repository?: ExtensionRepository,
   _quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
   try {
+    const extBase = extensionsDir ?? repoDir;
     const datastoresDir = resolveDatastoresDir(marker);
     const absoluteDatastoresDir = isAbsolute(datastoresDir)
       ? datastoresDir
-      : resolve(repoDir, datastoresDir);
+      : resolve(extBase, datastoresDir);
 
     const loader = new ExtensionLoader(
       denoRuntime,
@@ -726,12 +743,14 @@ async function loadUserReports(
   resolverFactory?: () => Promise<DatastorePathResolver | undefined>,
   repository?: ExtensionRepository,
   _quiet = false,
+  extensionsDir?: string,
 ): Promise<void> {
   try {
+    const extBase = extensionsDir ?? repoDir;
     const reportsDir = resolveReportsDir(marker);
     const absoluteReportsDir = isAbsolute(reportsDir)
       ? reportsDir
-      : resolve(repoDir, reportsDir);
+      : resolve(extBase, reportsDir);
 
     const resolver = resolverFactory ? await resolverFactory() : undefined;
     const loader = new ExtensionLoader(
@@ -1012,6 +1031,37 @@ export async function runCli(args: string[]): Promise<void> {
   // Pre-parse --repo-dir so startup functions use the correct repository
   const repoDir = getRepoDirFromArgs(args);
 
+  // Pre-parse --extensions-dir for split code-plane/data-plane scenarios
+  const extensionsDir = getExtensionsDirFromArgs(args);
+
+  if (extensionsDir !== undefined) {
+    const swampDataDir = join(repoDir, ".swamp");
+    if (
+      extensionsDir === swampDataDir ||
+      extensionsDir.startsWith(swampDataDir + "/") ||
+      extensionsDir.startsWith(swampDataDir + "\\")
+    ) {
+      throw new UserError(
+        "--extensions-dir must not point inside the .swamp data directory",
+      );
+    }
+    try {
+      const stat = await Deno.stat(extensionsDir);
+      if (!stat.isDirectory) {
+        throw new UserError(
+          `--extensions-dir must be a directory: ${extensionsDir}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        throw new UserError(
+          `--extensions-dir directory not found: ${extensionsDir}`,
+        );
+      }
+      throw error;
+    }
+  }
+
   // Pre-parse check for telemetry disable flag
   const telemetryDisabled = isTelemetryDisabled(args) ||
     isTelemetryDisabledByEnv();
@@ -1069,6 +1119,7 @@ export async function runCli(args: string[]): Promise<void> {
       resolvedSources,
       deferredWarnings,
       isQuietFromArgs(args),
+      extensionsDir,
     );
     loaderSpan.end();
   }

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -46,6 +46,7 @@ export interface ResolveExtensionFilesContext {
   manifestPath: string;
   repoContext: RepositoryContext;
   logger: Logger;
+  extensionsDir?: string;
 }
 
 export interface ResolvedExtensionFiles {
@@ -116,11 +117,22 @@ export async function resolveExtensionFiles(
   ctx: ResolveExtensionFilesContext,
 ): Promise<ResolvedExtensionFiles> {
   const { repoDir, manifestPath, repoContext, logger } = ctx;
+  const extensionsDir = ctx.extensionsDir ?? repoDir;
+
+  const ext = manifestPath.split(".").pop()?.toLowerCase();
+  if (ext === "ts" || ext === "js") {
+    throw new UserError(
+      `Expected a manifest path but got a TypeScript/JavaScript file: ${manifestPath}\n` +
+        "Pass the manifest directory or manifest.yaml path instead.\n\n" +
+        "Example:\n" +
+        "  swamp extension fmt extensions/models/my-model/manifest.yaml",
+    );
+  }
 
   // 1. Read and parse manifest
   const absoluteManifestPath = isAbsolute(manifestPath)
     ? manifestPath
-    : resolve(repoDir, manifestPath);
+    : resolve(extensionsDir, manifestPath);
 
   let manifestContent: string;
   try {
@@ -176,19 +188,19 @@ export async function resolveExtensionFiles(
   const useManifestBase = manifest.paths.base === "manifest";
   const modelsDir = useManifestBase
     ? manifestDir
-    : resolve(repoDir, resolveModelsDir(marker));
+    : resolve(extensionsDir, resolveModelsDir(marker));
   const vaultsDir = useManifestBase
     ? manifestDir
-    : resolve(repoDir, resolveVaultsDir(marker));
+    : resolve(extensionsDir, resolveVaultsDir(marker));
   const driversDir = useManifestBase
     ? manifestDir
-    : resolve(repoDir, resolveDriversDir(marker));
+    : resolve(extensionsDir, resolveDriversDir(marker));
   const datastoresDir = useManifestBase
     ? manifestDir
-    : resolve(repoDir, resolveDatastoresDir(marker));
+    : resolve(extensionsDir, resolveDatastoresDir(marker));
   const reportsDir = useManifestBase
     ? manifestDir
-    : resolve(repoDir, resolveReportsDir(marker));
+    : resolve(extensionsDir, resolveReportsDir(marker));
 
   // 3. Collect model files from manifest
   const modelEntryPoints: string[] = [];

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -17,7 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { basename, dirname, isAbsolute, join, resolve } from "@std/path";
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  resolve,
+} from "@std/path";
 import type { Logger } from "@logtape/logtape";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import {
@@ -119,8 +126,8 @@ export async function resolveExtensionFiles(
   const { repoDir, manifestPath, repoContext, logger } = ctx;
   const extensionsDir = ctx.extensionsDir ?? repoDir;
 
-  const ext = manifestPath.split(".").pop()?.toLowerCase();
-  if (ext === "ts" || ext === "js") {
+  const ext = extname(manifestPath).toLowerCase();
+  if (ext === ".ts" || ext === ".js") {
     throw new UserError(
       `Expected a manifest path but got a TypeScript/JavaScript file: ${manifestPath}\n` +
         "Pass the manifest directory or manifest.yaml path instead.\n\n" +

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -894,3 +894,37 @@ Deno.test("isPulledExtensionManifest: returns false for path containing pulled-e
   const manifestPath = "/repo/pulled-extensions/manifest.yaml";
   assertEquals(isPulledExtensionManifest(repoDir, manifestPath), false);
 });
+
+// ── .ts/.js file rejection ──────────────────────────────────────────────
+
+Deno.test("resolveExtensionFiles: rejects .ts file with UserError", async () => {
+  await withTempRepo(async (dir) => {
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath: "extensions/models/my_model.ts",
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "Expected a manifest path but got a TypeScript/JavaScript file",
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles: rejects .js file with UserError", async () => {
+  await withTempRepo(async (dir) => {
+    await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath: "extensions/models/my_model.js",
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+      "Expected a manifest path but got a TypeScript/JavaScript file",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#381 — swamp CLI commands fail when invoked from git worktrees via `SWAMP_REPO_DIR`.

- Adds `--extensions-dir` flag and `SWAMP_EXTENSIONS_DIR` env var to separate the extension source root (code plane) from the `.swamp/` data directory (data plane)
- Fixes `extension fmt` crashing with a YAML parse error when given a `.ts` file — now rejects with a clear error message
- Wires through all 5 extension loaders (models, vaults, drivers, datastores, reports) so local source scanning uses `extensionsDir` when set
- Adds `--extensions-dir` Cliffy option to `extension fmt` and `extension push` commands
- Validates `--extensions-dir` rejects paths inside `.swamp/` (path traversal protection) and verifies the directory exists
- Documents the code-plane/data-plane split in `design/extension.md`

### What `--extensions-dir` controls
- Local extension source scanning for all 5 kinds
- Manifest path resolution in `extension fmt` and `extension push`

### What stays at `--repo-dir`
- `.swamp/` data directory, catalog, bundle cache, pulled extensions, model definitions, lockfiles

### Usage
```bash
SWAMP_REPO_DIR=~/repo SWAMP_EXTENSIONS_DIR=~/repo/trees/feature swamp model method run test invoke
```

### Related issues
- swamp-club#385 — `swamp extension prune` for stale catalog cleanup (filed during triage)
- swamp-club#387 — silent lock contention with no user feedback (filed during triage)
- swamp-club#388 — docs for `--extensions-dir` in swamp-club manual

## Test Plan

- Verified with compiled binary against real repos in `/tmp`:
  - Default behavior (no flag): type search, method run, doctor extensions all work unchanged
  - `SWAMP_EXTENSIONS_DIR` discovers worktree-only extensions
  - Model create + method run from worktree succeeds, data written to main repo
  - Path traversal into `.swamp/` rejected with clear error
  - Non-existent extensions dir gives clear error
  - Identity case (extensions-dir = repo-dir) behaves normally
- Full test suite: 6014 passed, 0 failed
- `deno check`, `deno lint`, `deno fmt` all pass