### PR TITLE
fix(file-lock): log contention warning when lock is held by another process (swamp-club#387)

### DIFF
--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -262,6 +262,8 @@ export async function registerDatastoreSyncNamed(
 
   // Acquire distributed lock if provided
   if (lock) {
+    const logger = getSwampLogger(["datastore", "lock"]);
+    logger.info("Acquiring lock for {key}", { key });
     const lockSpan = getTracer().startSpan("swamp.lock.acquire", {
       attributes: { "lock.key": key, "lock.label": label },
     });

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -140,6 +140,8 @@ export class FileLock implements DistributedLock {
     await ensureDir(dirname(this.lockPath));
 
     const nonce = crypto.randomUUID();
+    const logger = getSwampLogger(["datastore", "lock"]);
+    let contentionLogged = false;
 
     while (true) {
       // Check timeout on every iteration — including retries after stale lock cleanup
@@ -189,6 +191,20 @@ export class FileLock implements DistributedLock {
             // Another process may have already cleaned it up
           }
           continue; // Retry atomic create (timeout checked at top of loop)
+        }
+
+        if (!contentionLogged) {
+          const ageMs = Date.now() - new Date(existing.acquiredAt).getTime();
+          logger.warn(
+            "Waiting for lock {path} held by {holder} (pid {pid}, acquired {age}ms ago)",
+            {
+              path: this.lockPath,
+              holder: existing.holder,
+              pid: existing.pid,
+              age: ageMs,
+            },
+          );
+          contentionLogged = true;
         }
       }
 

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -21,6 +21,9 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { FileLock } from "./file_lock.ts";
 import type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
+import { initializeLogging } from "../logging/logger.ts";
+
+await initializeLogging({});
 
 async function withTempDir(
   fn: (dir: string) => Promise<void>,


### PR DESCRIPTION
## Summary

- Add a one-time `warn`-level log message in `FileLock.acquire()` when a valid non-stale lock is detected on the first retry, showing the lock path, holder, pid, and lock age
- Add an `info`-level "Acquiring lock for {key}" message in the datastore sync coordinator before every `lock.acquire()` call, providing a breadcrumb for all lock backends (file, S3, extensions)
- Initialize logging in `file_lock_test.ts` so contention tests exercise the new log path

Closes swamp-club#387

## Test Plan

- [x] All 6014 tests pass (`deno run test`)
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] Reproduced the bug using a local MinIO S3 datastore — injected a lock object in S3, ran `model method run`, confirmed the CLI was silent for 15 seconds (timeout-killed) with zero user feedback
- [x] Verified the fix: re-ran with the dev build and confirmed the coordinator now emits `Acquiring lock for "data/command/shell/..."` before the silent wait
- [x] Verified `file_lock_test.ts` contention tests emit the new warning: `Waiting for lock "..." held by "stack72@..." (pid ..., acquired 0ms ago)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)