### PR TITLE
fix(extensions): prune empty per-extension scaffold dirs on rm (swamp-club#383)

### DIFF
--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -56,6 +56,31 @@ export const PULLED_TYPE_DIRS: ReadonlySet<string> = new Set([
   "files",
 ]);
 
+/**
+ * Per-extension scaffold dir names that `pull` unconditionally creates
+ * under `.swamp/pulled-extensions/<name>/` regardless of whether the
+ * extension ships content for that kind. Skills are excluded because
+ * they land at the tool-specific skills dir, not under the per-extension
+ * root. These scaffold dirs are NOT recorded in the lockfile's tracked
+ * files, so `extension rm` must enumerate them explicitly to prune any
+ * empty ones — `pruneEmptyDirs` in `remove_extension_service.ts` walks
+ * up from tracked-file parents and would otherwise stop at the
+ * extension root when it sees the untracked scaffolds as entries.
+ *
+ * Stays in sync with the seven `Deno.mkdir` calls in `installExtension`
+ * in `pull.ts`. If `pull` adds a new per-extension kind dir, add it
+ * here too.
+ */
+export const PER_EXTENSION_SCAFFOLD_DIRS: readonly string[] = [
+  "models",
+  "workflows",
+  "vaults",
+  "drivers",
+  "datastores",
+  "reports",
+  "files",
+];
+
 const PULLED_PREFIX = `${SWAMP_DATA_DIR}/pulled-extensions/`;
 const GEN1_PREFIX = "extensions/";
 

--- a/src/libswamp/extensions/remove_extension_service.ts
+++ b/src/libswamp/extensions/remove_extension_service.ts
@@ -21,7 +21,9 @@ import { dirname, join, resolve } from "@std/path";
 import { tombstoneAll } from "../../domain/extensions/extension.ts";
 import type { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
 import type { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { UserError } from "../../domain/errors.ts";
+import { PER_EXTENSION_SCAFFOLD_DIRS } from "./layout.ts";
 
 /** Result of `RemoveExtensionService.execute()`. */
 export interface RemoveExtensionResult {
@@ -148,7 +150,23 @@ export class RemoveExtensionService {
       }
     }
 
-    // 5. Prune empty parent directories up to (but not including)
+    // 5. Add the per-extension scaffold subdirs that `pull` creates
+    //    unconditionally — they are never recorded as tracked files,
+    //    so without this push `pruneEmptyDirs` would see them as
+    //    "non-empty entries" when walking up through the extension
+    //    root and bail. For legacy gen-1 / gen-2 installs these paths
+    //    don't exist on disk; `pruneEmptyDirs`'s `try/catch` around
+    //    `Deno.readDir` absorbs the resulting `NotFound` safely, so
+    //    the push is unconditional.
+    const extensionRoot = join(
+      swampPath(this.repoDir, "pulled-extensions"),
+      name,
+    );
+    for (const scaffoldDir of PER_EXTENSION_SCAFFOLD_DIRS) {
+      parentDirs.push(join(extensionRoot, scaffoldDir));
+    }
+
+    // 6. Prune empty parent directories up to (but not including)
     //    the repo root.
     const dirsRemoved = await pruneEmptyDirs(parentDirs, this.repoDir);
 

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -508,3 +508,262 @@ Deno.test(
     );
   },
 );
+
+// =============================================================
+// swamp-club#383: empty per-extension scaffold dirs left behind
+// =============================================================
+//
+// `pull` unconditionally `Deno.mkdir`s seven per-extension scaffold
+// dirs (`models`, `workflows`, `vaults`, `drivers`, `datastores`,
+// `reports`, `files`) regardless of whether the extension ships
+// content for that kind. These dirs are never recorded in the
+// lockfile's tracked-file list. Pre-fix, `pruneEmptyDirs`'s upward
+// walk from tracked-file parents stopped at the extension root
+// because the un-tracked scaffolds made it appear non-empty —
+// leaving the entire per-extension subtree on disk after rm.
+//
+// The fix has RemoveExtensionService push the seven scaffold paths
+// into parentDirs so pruneEmptyDirs sweeps them too. These tests
+// pin (a) the canonical case, (b) sibling-extension safety, and
+// (c) flat (non-scoped) name handling.
+//
+// Tests intentionally hardcode the seven scaffold names rather than
+// importing PER_EXTENSION_SCAFFOLD_DIRS from production — a silent
+// shrinkage of that constant must show up as a regression here.
+
+async function stageScaffoldDirs(extRoot: string): Promise<void> {
+  for (
+    const kind of [
+      "models",
+      "workflows",
+      "vaults",
+      "drivers",
+      "datastores",
+      "reports",
+      "files",
+    ]
+  ) {
+    await ensureDir(join(extRoot, kind));
+  }
+}
+
+Deno.test(
+  "swamp-club#383: rm prunes empty per-extension scaffold dirs (canonical)",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, lockfileRepository }) => {
+        const ts = Date.now();
+        const extName = `@test/scaffold-${ts}`;
+        const typeId = `@test/scaffold-model-${ts}`;
+        await stageModel(
+          repoDir,
+          extName,
+          "model.ts",
+          MINIMAL_MODEL_CODE(typeId),
+        );
+        const extRoot = join(
+          swampPath(repoDir, "pulled-extensions"),
+          extName,
+        );
+        await stageScaffoldDirs(extRoot);
+
+        const installSvc = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: async (ref, ctx) => {
+            await ctx.lockfileRepository.writeEntry(
+              ref.name,
+              "1.0.0",
+              [`.swamp/pulled-extensions/${ref.name}/models/model.ts`],
+            );
+            return makeStubInstallResult(ref.name, "1.0.0", [
+              `.swamp/pulled-extensions/${ref.name}/models/model.ts`,
+            ]);
+          },
+        });
+        await installSvc.execute(
+          { name: extName, version: "1.0.0" },
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+
+        const removeSvc = new RemoveExtensionService({
+          repository,
+          lockfileRepository,
+          repoDir,
+        });
+        await removeSvc.execute(extName);
+
+        // The per-extension subtree must be entirely gone — neither
+        // the extension root nor any of the empty scaffold dirs may
+        // remain.
+        await assertRejects(
+          () => Deno.stat(extRoot),
+          Deno.errors.NotFound,
+          undefined,
+          "Post-rm: per-extension subtree must be removed",
+        );
+        // The `@scope/` dir is also gone since this fixture has no
+        // sibling extensions under `@test/`.
+        const scopeDir = join(
+          swampPath(repoDir, "pulled-extensions"),
+          "@test",
+        );
+        await assertRejects(
+          () => Deno.stat(scopeDir),
+          Deno.errors.NotFound,
+          undefined,
+          "Post-rm: empty scope dir must be removed",
+        );
+      },
+    );
+  },
+);
+
+Deno.test(
+  "swamp-club#383: rm preserves sibling extension under the same @scope",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, lockfileRepository }) => {
+        const ts = Date.now();
+        const extA = `@test/sibling-a-${ts}`;
+        const extB = `@test/sibling-b-${ts}`;
+        const typeA = `@test/sibling-type-a-${ts}`;
+        const typeB = `@test/sibling-type-b-${ts}`;
+        await stageModel(repoDir, extA, "a.ts", MINIMAL_MODEL_CODE(typeA));
+        await stageModel(repoDir, extB, "b.ts", MINIMAL_MODEL_CODE(typeB));
+        const extRootA = join(
+          swampPath(repoDir, "pulled-extensions"),
+          extA,
+        );
+        const extRootB = join(
+          swampPath(repoDir, "pulled-extensions"),
+          extB,
+        );
+        await stageScaffoldDirs(extRootA);
+        await stageScaffoldDirs(extRootB);
+
+        const installSvc = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: async (ref, ctx) => {
+            const fileName = ref.name === extA ? "a.ts" : "b.ts";
+            await ctx.lockfileRepository.writeEntry(
+              ref.name,
+              "1.0.0",
+              [`.swamp/pulled-extensions/${ref.name}/models/${fileName}`],
+            );
+            return makeStubInstallResult(ref.name, "1.0.0", [
+              `.swamp/pulled-extensions/${ref.name}/models/${fileName}`,
+            ]);
+          },
+        });
+        await installSvc.execute(
+          { name: extA, version: "1.0.0" },
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+        await installSvc.execute(
+          { name: extB, version: "1.0.0" },
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+
+        const removeSvc = new RemoveExtensionService({
+          repository,
+          lockfileRepository,
+          repoDir,
+        });
+        await removeSvc.execute(extA);
+
+        // A is gone — both subtree and scaffolds.
+        await assertRejects(
+          () => Deno.stat(extRootA),
+          Deno.errors.NotFound,
+          undefined,
+          "Post-rm: extA subtree must be removed",
+        );
+        // B is intact — including its scaffold dirs and its tracked
+        // model file.
+        const bStat = await Deno.stat(extRootB);
+        assertEquals(
+          bStat.isDirectory,
+          true,
+          "Post-rm: extB subtree must be preserved",
+        );
+        const bModelStat = await Deno.stat(
+          join(extRootB, "models", "b.ts"),
+        );
+        assertEquals(
+          bModelStat.isFile,
+          true,
+          "Post-rm: extB tracked file must be preserved",
+        );
+        // The shared `@test/` scope dir is also preserved because B
+        // still lives inside it.
+        const scopeStat = await Deno.stat(
+          join(swampPath(repoDir, "pulled-extensions"), "@test"),
+        );
+        assertEquals(
+          scopeStat.isDirectory,
+          true,
+          "Post-rm: shared @scope dir must be preserved",
+        );
+      },
+    );
+  },
+);
+
+Deno.test(
+  "swamp-club#383: rm prunes scaffold dirs for flat (non-scoped) extension names",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, lockfileRepository }) => {
+        const ts = Date.now();
+        const extName = `flat-scaffold-${ts}`;
+        const typeId = `flat-scaffold-model-${ts}`;
+        await stageModel(
+          repoDir,
+          extName,
+          "model.ts",
+          MINIMAL_MODEL_CODE(typeId),
+        );
+        const extRoot = join(
+          swampPath(repoDir, "pulled-extensions"),
+          extName,
+        );
+        await stageScaffoldDirs(extRoot);
+
+        const installSvc = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: async (ref, ctx) => {
+            await ctx.lockfileRepository.writeEntry(
+              ref.name,
+              "1.0.0",
+              [`.swamp/pulled-extensions/${ref.name}/models/model.ts`],
+            );
+            return makeStubInstallResult(ref.name, "1.0.0", [
+              `.swamp/pulled-extensions/${ref.name}/models/model.ts`,
+            ]);
+          },
+        });
+        await installSvc.execute(
+          { name: extName, version: "1.0.0" },
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+
+        const removeSvc = new RemoveExtensionService({
+          repository,
+          lockfileRepository,
+          repoDir,
+        });
+        await removeSvc.execute(extName);
+
+        await assertRejects(
+          () => Deno.stat(extRoot),
+          Deno.errors.NotFound,
+          undefined,
+          "Post-rm: flat-name subtree must be removed",
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Closes swamp-club#383.

`pull` unconditionally `Deno.mkdir`s the seven per-extension kind dirs (`models`, `workflows`, `vaults`, `drivers`, `datastores`, `reports`, `files`) regardless of whether the extension ships content for that kind. These scaffolds are never recorded in the lockfile's tracked-file list. `RemoveExtensionService`'s `pruneEmptyDirs` walks UP from tracked-file parents and stops at the first non-empty dir — at the extension root it sees the untracked scaffolds as entries and bails, leaving the entire per-extension subtree on disk after `rm`.

Fix: push the seven scaffold paths into `parentDirs` before pruning so the existing walk sweeps them. A new `PER_EXTENSION_SCAFFOLD_DIRS` constant in `layout.ts` keeps the kind list authoritative (sibling to `PULLED_TYPE_DIRS`).

## Backwards compatibility

- Legacy gen-1 / gen-2 installs (no per-extension subtree) are unaffected — the pushed paths don't exist on disk and `pruneEmptyDirs`'s existing `ENOENT` catch absorbs the `Deno.readDir` failure.
- Pre-existing repos with already-leaked scaffold dirs: the next `rm` cleans them up. No migration required.

## Follow-ups (out of scope)

- swamp-club#392 — sibling leak for `.swamp/<kind>-bundles/<hash>/` namespace dirs (filed during verification of this fix). Same shape of bug at the repo-root level.
- Pull-side lazy-`mkdir` cleanup in `pull.ts:866-960` (deferred). Removes the redundant scaffold mkdirs so new installs don't create empty dirs in the first place.

## Test plan

- [x] Three pinning tests added to `remove_extension_service_test.ts`: canonical empty-scaffold cleanup, sibling-extension preservation under a shared `@scope/`, and flat (non-scoped) extension name handling.
- [x] All three tests FAIL on `main` (confirmed via `git stash`) and PASS with the fix.
- [x] Full suite: 6016 passed, 0 failed.
- [x] `deno check`, `deno lint`, `deno fmt` clean.
- [x] End-to-end re-verification: `pull @alvagante/docker-image-test` then `rm --force` leaves no per-extension artifacts on disk (12 dirs pruned vs 4 pre-fix).