### PR TITLE
fix(audit): resolve repo root from hook payload cwd instead of process cwd (swamp-club#390)

### DIFF
--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
+import { isAbsolute } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
@@ -128,7 +129,10 @@ export const auditRecordCommand = new Command()
         failure,
       );
 
-      const repoDir = resolveRepoDir(options.repoDir as string | undefined);
+      const hookCwd = isAbsolute(normalized.cwd) ? normalized.cwd : undefined;
+      const repoDir = resolveRepoDir(
+        (options.repoDir as string | undefined) ?? hookCwd,
+      );
       const repository = new JsonlAuditRepository(repoDir);
       await repository.append(entry);
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -432,7 +432,11 @@ export function configureExtensionAutoResolver(
 
 export function commandNeedsLoaderSetup(args: string[]): boolean {
   const commandInfo = extractCommandInfo(args);
-  return !NON_REPO_COMMANDS.has(commandInfo.command);
+  if (NON_REPO_COMMANDS.has(commandInfo.command)) return false;
+  if (commandInfo.command === "audit" && commandInfo.subcommand === "record") {
+    return false;
+  }
+  return true;
 }
 
 /** A deferred warning message to emit after logging is initialized. */

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -605,6 +605,17 @@ Deno.test("commandNeedsLoaderSetup returns false for version with global flags",
   assertEquals(commandNeedsLoaderSetup(["--json", "version"]), false);
 });
 
+Deno.test("commandNeedsLoaderSetup returns false for audit record (hook command)", () => {
+  assertEquals(
+    commandNeedsLoaderSetup(["audit", "record", "--from-hook"]),
+    false,
+  );
+});
+
+Deno.test("commandNeedsLoaderSetup returns true for audit (timeline viewer)", () => {
+  assertEquals(commandNeedsLoaderSetup(["audit"]), true);
+});
+
 Deno.test("commandNeedsLoaderSetup returns true for model type search with global flags", () => {
   assertEquals(
     commandNeedsLoaderSetup(["--json", "model", "type", "search", "aws"]),


### PR DESCRIPTION
## Summary

- **Fix repo dir resolution in `audit record`**: When `--from-hook` fires from a subdirectory, the command now uses the hook payload's `cwd` field (the agent's project root) instead of the process working directory. This prevents stray `.swamp/` datastores from being created in arbitrary subdirectories.
- **Skip extension loader setup for `audit record`**: This lightweight hook command doesn't need extensions — skipping the loader prevents a stray `_extension_catalog.db` from being created in the process cwd.

Fixes swamp-club#390.

## Test Plan

- [x] Unit tests: 2 new tests for `commandNeedsLoaderSetup` (audit record → false, audit → true)
- [x] Type check: `deno check` passes
- [x] Lint: `deno lint` passes
- [x] Format: `deno fmt` passes
- [x] Full test suite: 6030 passed (1 pre-existing failure in unrelated workflow integration test)
- [x] Manual verification: compiled binary, re-created scratch repo, ran hook from subdirectory — no stray `.swamp/` or `_extension_catalog.db`, audit record correctly written to repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)