### PR TITLE
fix(models): pass unresolvedMethodArgs to pre-flight check context (swamp-club#391)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -267,8 +267,30 @@ interface CheckResult {
 ```
 
 The `execute` function receives the same `MethodContext` as a method's execute
-function, with one restriction: `writeResource` and `createFileWriter` are **not
-available**. Checks inspect state only — they do not produce data output.
+function, with two differences:
+
+- `writeResource` and `createFileWriter` are **not available**. Checks inspect
+  state only — they do not produce data output.
+- `unresolvedMethodArgs` **is populated** with the method's arguments merged over
+  filtered global arguments (global args containing unresolved `${{ }}`
+  expressions are excluded). This lets per-method checks validate that required
+  arguments are present before execution begins.
+
+```typescript
+// Example: validate a method argument in a pre-flight check
+checks: {
+  "spec-required": {
+    description: "Forward requires a spec argument",
+    appliesTo: ["forward"],
+    execute: async (context) => {
+      if (!context.unresolvedMethodArgs?.spec) {
+        return { pass: false, errors: ["forward requires a `spec`"] };
+      }
+      return { pass: true };
+    },
+  },
+},
+```
 
 ### isMutatingKind
 

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -493,6 +493,27 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       // Infer method kind for lifecycle checks
       const methodKind = inferMethodKind(methodName, method);
 
+      // Build unresolvedMethodArgs for pre-flight checks so they can
+      // validate method arguments. Mirrors the merge in execute() (line ~326):
+      // per-method args override global args, with unresolved ${{ }}
+      // expressions filtered from global args.
+      const rawMethodArgs = currentDefinition.getMethodArguments(methodName);
+      const filteredRawGlobalArgs: Record<string, unknown> = {};
+      for (
+        const [key, value] of Object.entries(
+          currentDefinition.globalArguments,
+        )
+      ) {
+        if (valueContainsExpression(value)) {
+          continue;
+        }
+        filteredRawGlobalArgs[key] = value;
+      }
+      const checkUnresolvedMethodArgs: Record<string, unknown> = {
+        ...filteredRawGlobalArgs,
+        ...rawMethodArgs,
+      };
+
       // Run pre-flight checks for mutating methods
       if (modelDef.checks && isMutatingKind(methodKind)) {
         const defChecks = currentDefinition.checkSelection;
@@ -541,6 +562,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
                   version: currentDefinition.version,
                   tags: currentDefinition.tags,
                 },
+                unresolvedMethodArgs: checkUnresolvedMethodArgs,
               });
               if (!checkResult || typeof checkResult.pass !== "boolean") {
                 failures.push({

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -3118,3 +3118,149 @@ Deno.test("executeWorkflow - detects nested unresolved expressions in globalArgs
   assertEquals(result !== undefined, true);
   assertEquals(receivedName, "my-server");
 });
+
+Deno.test("executeWorkflow: check receives unresolvedMethodArgs with method arguments", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let capturedArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/check-args"),
+    version: "1",
+    methods: {
+      forward: {
+        description: "Forward ports",
+        arguments: z.object({ spec: z.string() }),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "spec-valid": {
+        description: "Validates spec arg is present",
+        appliesTo: ["forward"],
+        execute: (context: MethodContext) => {
+          capturedArgs = context.unresolvedMethodArgs;
+          if (!context.unresolvedMethodArgs?.spec) {
+            return Promise.resolve({
+              pass: false,
+              errors: ["forward requires a `spec` argument"],
+            });
+          }
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-forward",
+    globalArguments: {},
+    methods: {
+      forward: { arguments: { spec: "19090:localhost:22" } },
+    },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  const result = await service.executeWorkflow(
+    definition,
+    model,
+    "forward",
+    context,
+  );
+
+  assertEquals(result !== undefined, true);
+  assertEquals(capturedArgs?.spec, "19090:localhost:22");
+});
+
+Deno.test("executeWorkflow: check unresolvedMethodArgs merges global and method args, method wins", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let capturedArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/check-merge"),
+    version: "1",
+    globalArguments: z.object({
+      region: z.string().optional(),
+      timeout: z.number().optional(),
+    }),
+    methods: {
+      create: {
+        description: "Create resource",
+        arguments: z.object({
+          region: z.string().optional(),
+          name: z.string().optional(),
+        }),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures unresolvedMethodArgs",
+        appliesTo: ["create"],
+        execute: (context: MethodContext) => {
+          capturedArgs = context.unresolvedMethodArgs;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-merge",
+    globalArguments: { region: "us-east-1", timeout: 30 },
+    methods: {
+      create: { arguments: { region: "eu-west-1", name: "my-resource" } },
+    },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await service.executeWorkflow(definition, model, "create", context);
+
+  assertEquals(capturedArgs?.region, "eu-west-1");
+  assertEquals(capturedArgs?.name, "my-resource");
+  assertEquals(capturedArgs?.timeout, 30);
+});
+
+Deno.test("executeWorkflow: check unresolvedMethodArgs filters unresolved expressions from global args", async () => {
+  const service = new DefaultMethodExecutionService();
+
+  let capturedArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/check-filter"),
+    version: "1",
+    globalArguments: z.object({
+      name: z.string().optional(),
+      apiKey: z.string().optional(),
+    }),
+    methods: {
+      create: {
+        description: "Create resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures unresolvedMethodArgs",
+        appliesTo: ["create"],
+        execute: (context: MethodContext) => {
+          capturedArgs = context.unresolvedMethodArgs;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-filter",
+    globalArguments: {
+      name: "my-server",
+      apiKey: "${{ vault.secrets.api_key }}",
+    },
+  });
+
+  const { context } = createTestContext({ modelType: model.type });
+  await service.executeWorkflow(definition, model, "create", context);
+
+  assertEquals(capturedArgs?.name, "my-server");
+  assertEquals(capturedArgs?.apiKey, undefined);
+});

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -28,6 +28,7 @@ import type { DataQueryService } from "../data/data_query_service.ts";
 import {
   extractExpressions,
   stripExpressionFields,
+  valueContainsExpression,
 } from "../expressions/expression_parser.ts";
 import { detectEnvVarUsageInDefinition } from "./env_var_detector.ts";
 import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
@@ -386,6 +387,20 @@ export class DefaultModelValidationService implements ModelValidationService {
       }
 
       try {
+        const methodName = checkContext.method ?? "";
+        const rawMethodArgs = methodName
+          ? definition.getMethodArguments(methodName)
+          : {};
+        const filteredGlobalArgs: Record<string, unknown> = {};
+        for (
+          const [key, value] of Object.entries(definition.globalArguments)
+        ) {
+          if (valueContainsExpression(value)) {
+            continue;
+          }
+          filteredGlobalArgs[key] = value;
+        }
+
         const context = buildMethodContext(
           {
             dataRepository: checkContext.dataRepository,
@@ -405,7 +420,7 @@ export class DefaultModelValidationService implements ModelValidationService {
               version: definition.version,
               tags: definition.tags,
             },
-            methodName: checkContext.method ?? "",
+            methodName,
             logger: {
               debug() {},
               info() {},
@@ -417,6 +432,10 @@ export class DefaultModelValidationService implements ModelValidationService {
               },
             } as unknown as MethodContext["logger"],
             extensionFilesRoot: modelDef.extensionFilesRoot,
+            unresolvedMethodArgs: {
+              ...filteredGlobalArgs,
+              ...rawMethodArgs,
+            },
           },
         );
 

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -28,6 +28,7 @@ import { Definition, type DefinitionId } from "../definitions/definition.ts";
 import {
   defineModel,
   type LazyModelEntry,
+  type MethodContext,
   type ModelDefinition,
   modelRegistry,
 } from "./model.ts";
@@ -1713,4 +1714,50 @@ Deno.test("validateModel still rejects invalid types on provided globalArgs", as
   const { results } = await service.validateModel(definition, TypedModel);
   const globalResult = results.find((r) => r.name === "Global arguments");
   assertEquals(globalResult?.passed, false);
+});
+
+Deno.test("validateModel: check receives unresolvedMethodArgs with method arguments", async () => {
+  const service = new DefaultModelValidationService();
+
+  let capturedArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/check-args-validation"),
+    version: "1",
+    methods: {
+      forward: {
+        description: "Forward ports",
+        arguments: z.object({ spec: z.string() }),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "spec-valid": {
+        description: "Validates spec via unresolvedMethodArgs",
+        appliesTo: ["forward"],
+        execute: (context: MethodContext) => {
+          capturedArgs = context.unresolvedMethodArgs;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  const definition = Definition.create({
+    name: "test-forward",
+    globalArguments: {},
+    methods: {
+      forward: { arguments: { spec: "19090:localhost:22" } },
+    },
+  });
+
+  const { results } = await service.validateModel(
+    definition,
+    model,
+    undefined,
+    createCheckContext({ method: "forward" }),
+  );
+
+  const checkResult = results.find((r) => r.name === "Check: spec-valid");
+  assertEquals(checkResult?.passed, true);
+  assertEquals(capturedArgs?.spec, "19090:localhost:22");
 });


### PR DESCRIPTION
## Summary

- Pass `unresolvedMethodArgs` to pre-flight check context so checks can validate method arguments. The check context in `executeWorkflow()` now includes merged method args (per-method overriding filtered global args), matching the semantics of the `execute()` path.
- Apply the same fix to the validation service (`swamp model validate`) so checks see method args there too.
- Update `design/models.md` CheckDefinition docs with `unresolvedMethodArgs` usage and example.

Closes swamp-club#391

## Test Plan

- [x] 3 new unit tests in `method_execution_service_test.ts`: check receives args, method overrides global, `${{ }}` expressions filtered
- [x] 1 new unit test in `validation_service_test.ts`: check receives args via validate path
- [x] Reproduction test confirmed: previously failing check (`unresolvedMethodArgs?.spec` → `undefined`) now passes
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Full test suite: 6031 passed, 2 failed (pre-existing flakes in SIGINT handler and workflow delete integration test, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)