### PR TITLE
fix(cli): reject unknown subcommands on `swamp repo` (swamp-club#394)

### DIFF
--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -107,23 +107,14 @@ Deno.test("vault type list is registered as a hidden subcommand", async () => {
   );
 });
 
-Deno.test("repo init is registered as a hidden subcommand", async () => {
+Deno.test("repo init is registered as a visible subcommand", async () => {
   const { repoCommand } = await import("./repo_init.ts");
 
-  // getCommand with second arg true includes hidden commands
-  const initCmd = repoCommand.getCommand("init", true);
-  assertEquals(
-    initCmd !== undefined,
-    true,
-    "init command should be registered",
-  );
-
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
   const visibleCommands = repoCommand.getCommands();
   const visibleInit = visibleCommands.find((c) => c.getName() === "init");
   assertEquals(
-    visibleInit,
-    undefined,
-    "init should not appear in visible commands",
+    visibleInit !== undefined,
+    true,
+    "init should appear in visible commands",
   );
 });

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -191,25 +191,9 @@ export const repoUpgradeCommand = new Command()
 
 export const repoCommand = new Command()
   .name("repo")
-  .description("Initialize a swamp repository (or manage existing ones)")
-  .arguments("[path:string]")
-  .option("-f, --force", "Reinitialize if already exists")
-  .type("aiTool", aiToolType)
-  .option("-t, --tool <tool:aiTool>", TOOL_FLAG_DESCRIPTION, { collect: true })
-  .action(repoInitAction)
-  .command(
-    "init",
-    new Command()
-      .description("Initialize a new swamp repository")
-      .hidden()
-      .arguments("[path:string]")
-      .option("-f, --force", "Reinitialize if already exists")
-      .type("aiTool", aiToolType)
-      .option(
-        "-t, --tool <tool:aiTool>",
-        TOOL_FLAG_DESCRIPTION,
-        { collect: true },
-      )
-      .action(repoInitAction),
-  )
+  .description("Manage swamp repositories")
+  .action(function () {
+    this.showHelp();
+  })
+  .command("init", repoInitCommand)
   .command("upgrade", repoUpgradeCommand);

--- a/src/cli/commands/repo_init_test.ts
+++ b/src/cli/commands/repo_init_test.ts
@@ -30,22 +30,14 @@ Deno.test("repoCommand module loads", async () => {
   assertEquals(repoCommand.getName(), "repo");
 });
 
-Deno.test("repoInitCommand is registered as hidden subcommand", async () => {
+Deno.test("repoInitCommand is registered as visible subcommand", async () => {
   const { repoCommand } = await import("./repo_init.ts");
-  // getCommand with second arg true includes hidden commands
-  const initCmd = repoCommand.getCommand("init", true);
-  assertEquals(
-    initCmd !== undefined,
-    true,
-    "init command should be registered",
-  );
-  // Verify it's hidden: not in getCommands() (which excludes hidden)
   const visibleCommands = repoCommand.getCommands();
   const visibleInit = visibleCommands.find((c) => c.getName() === "init");
   assertEquals(
-    visibleInit,
-    undefined,
-    "init should not appear in visible commands",
+    visibleInit !== undefined,
+    true,
+    "init should appear in visible commands",
   );
 });
 

--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -136,6 +136,16 @@ function buildContextSuggestions(
     suggestions.push(
       `swamp extension pull ${unknownName}`,
     );
+  } else if (parentName === "repo") {
+    suggestions.push(
+      `swamp repo init ${unknownName}`,
+    );
+    suggestions.push(
+      `swamp repo upgrade`,
+    );
+    suggestions.push(
+      `swamp update`,
+    );
   } else {
     // Generic: just list available subcommands
     const subcommands = getSubcommandNames(cmd);

--- a/src/cli/unknown_command_handler_test.ts
+++ b/src/cli/unknown_command_handler_test.ts
@@ -137,3 +137,17 @@ Deno.test("buildUnknownCommandMessage - vault context suggestions", () => {
   assertStringIncludes(msg, "swamp vault put my-vault");
   assertStringIncludes(msg, "swamp vault list-keys my-vault");
 });
+
+Deno.test("buildUnknownCommandMessage - repo context suggestions", () => {
+  const cmd = buildCommand("repo", ["init", "upgrade"]);
+  const msg = buildUnknownCommandMessage("my-project", cmd);
+  assertStringIncludes(msg, "swamp repo init my-project");
+  assertStringIncludes(msg, "swamp repo upgrade");
+  assertStringIncludes(msg, "swamp update");
+});
+
+Deno.test("buildUnknownCommandMessage - repo typo suggests upgrade", () => {
+  const cmd = buildCommand("repo", ["init", "upgrade"]);
+  const msg = buildUnknownCommandMessage("update", cmd);
+  assertStringIncludes(msg, 'Did you mean "upgrade"');
+});


### PR DESCRIPTION
## Summary

- Remove the default `.action(repoInitAction)` and positional `[path:string]` argument from the parent `repoCommand` so unknown subcommands like `swamp repo update` are no longer silently consumed as path arguments
- Make the `init` subcommand visible (was hidden behind the parent's default action)
- Add repo-specific context suggestions to the unknown command handler so typos produce helpful messages (e.g. `Did you mean "upgrade"?`)

Closes swamp-club#394

## Test Plan

- [x] `swamp repo update` now errors with `Unknown command "update". Did you mean "upgrade"?` (exit 2) instead of creating `./update/`
- [x] `swamp repo init` still works correctly
- [x] `swamp repo upgrade` still works correctly
- [x] `swamp repo` (bare) shows help listing both `init` and `upgrade`
- [x] Top-level `swamp init` alias is unaffected
- [x] All 6039 tests pass
- [x] Compiled binary verified against reproduction in scratch repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)