### PR TITLE
feat(issue-lifecycle): add notify phase for external contributors

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -73,6 +73,25 @@ Read [references/implementation.md](references/implementation.md) after plan
 approval. Covers: signalling implementation start, doing the work, verifying
 fixes against the reproduction, creating the PR, and completing the issue.
 
+### Phase 5: Contributor Notification
+
+After `ship` or `complete`, the lifecycle enters the `notify` phase. This is
+where you decide whether to thank the issue author:
+
+- If the issue author is an **external contributor** (not a repo collaborator),
+  call `notify` to post a thank-you ripple mentioning them by handle.
+- If the issue author is a **collaborator**, call `skip_notify` to proceed
+  directly to done.
+
+Check collaborator status with:
+
+```
+gh api /repos/systeminit/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
+```
+
+If the author is NOT in the collaborator list, they are external — call
+`notify`. Otherwise call `skip_notify`.
+
 ## Classification Types
 
 The `triage` method classifies issues into one of three types (matching
@@ -119,17 +138,18 @@ Read the `phase` field from the response. **Do NOT call `start` to resume** —
 
 Use this table to determine what to do next:
 
-| Phase            | Action                                                                    |
-| ---------------- | ------------------------------------------------------------------------- |
-| `triaging`       | Read [references/triage.md](references/triage.md)                         |
-| `classified`     | Read [references/planning.md](references/planning.md)                     |
-| `plan_generated` | Read [references/adversarial-review.md](references/adversarial-review.md) |
-| `approved`       | Read [references/implementation.md](references/implementation.md)         |
-| `implementing`   | Link a PR with `link_pr` or call `complete`                               |
-| `pr_open`        | Wait 3 min, then check PR: `pr_merged` if merged, `pr_failed` if failed   |
-| `pr_failed`      | Fix the issue, then `link_pr` (new PR) or `implement` (major rework)      |
-| `releasing`      | Check release build: `ship` when done, or `complete` as fallback          |
-| `done`           | Nothing to do — lifecycle is complete                                     |
+| Phase            | Action                                                                     |
+| ---------------- | -------------------------------------------------------------------------- |
+| `triaging`       | Read [references/triage.md](references/triage.md)                          |
+| `classified`     | Read [references/planning.md](references/planning.md)                      |
+| `plan_generated` | Read [references/adversarial-review.md](references/adversarial-review.md)  |
+| `approved`       | Read [references/implementation.md](references/implementation.md)          |
+| `implementing`   | Link a PR with `link_pr` or call `complete`                                |
+| `pr_open`        | Wait 3 min, then check PR: `pr_merged` if merged, `pr_failed` if failed    |
+| `pr_failed`      | Fix the issue, then `link_pr` (new PR) or `implement` (major rework)       |
+| `releasing`      | Check release build: `ship` when done, or `complete` as fallback           |
+| `notify`         | Check if author is external: `notify` to thank them, `skip_notify` to skip |
+| `done`           | Nothing to do — lifecycle is complete                                      |
 
 The canonical phase list lives in the `TRANSITIONS` constant in
 `extensions/models/_lib/schemas.ts`.
@@ -154,11 +174,14 @@ When a PR has already merged and the lifecycle just needs to be marked done:
    ```
    swamp model @swamp/issue-lifecycle method run ship issue-<N>
    ```
-5. For quick close-out, `complete` still works from `implementing`, `pr_open`,
-   or `releasing`:
+5. If the phase is `notify`, check if the author is external and either thank
+   them or skip:
    ```
-   swamp model @swamp/issue-lifecycle method run complete issue-<N>
+   swamp model @swamp/issue-lifecycle method run notify issue-<N>
+   swamp model @swamp/issue-lifecycle method run skip_notify issue-<N>
    ```
+6. For quick close-out, `complete` still works from `implementing`, `pr_open`,
+   or `releasing` (transitions to `notify`, then use `notify` or `skip_notify`).
 
 ## Key Rules
 

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -121,8 +121,27 @@ Optionally pass release metadata:
 swamp model @swamp/issue-lifecycle method run ship issue-<N> --input releaseUrl=<URL> --input releaseNotes="Bug fix release"
 ```
 
-This transitions the phase to `done`, transitions the swamp-club status to
+This transitions the phase to `notify`, transitions the swamp-club status to
 `shipped`, and posts a `shipped` lifecycle entry.
 
 For quick close-out (e.g., the PR merged and you just want to wrap up),
-`complete` still works from `implementing`, `pr_open`, or `releasing`.
+`complete` still works from `implementing`, `pr_open`, or `releasing`
+(transitions to `notify`).
+
+## 6. Notify the Contributor
+
+After `ship` or `complete`, the phase is `notify`. Check whether the issue
+author is an external contributor:
+
+```
+gh api /repos/systeminit/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
+```
+
+- **External** (not a collaborator): call `notify` to post a thank-you ripple:
+  ```
+  swamp model @swamp/issue-lifecycle method run notify issue-<N>
+  ```
+- **Collaborator**: call `skip_notify` to proceed to done:
+  ```
+  swamp model @swamp/issue-lifecycle method run skip_notify issue-<N>
+  ```

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -46,6 +46,7 @@ export const Phase = z.enum([
   "pr_open",
   "pr_failed",
   "releasing",
+  "notify",
   "done",
 ]);
 
@@ -66,6 +67,7 @@ export const TRANSITIONS: Record<string, Phase[]> = {
     "pr_open",
     "pr_failed",
     "releasing",
+    "notify",
   ],
   triage: ["triaging"],
   plan: ["classified"],
@@ -79,6 +81,8 @@ export const TRANSITIONS: Record<string, Phase[]> = {
   pr_failed: ["pr_open"],
   ship: ["releasing"],
   complete: ["implementing", "pr_open", "releasing"],
+  notify: ["notify"],
+  skip_notify: ["notify"],
 };
 
 // ---------------------------------------------------------------------------
@@ -106,6 +110,9 @@ export const ContextSchema = z.object({
   body: z.string(),
   type: IssueType,
   status: z.string(),
+  author: z.string().optional().describe(
+    "Username of the issue author (opener). Optional for backwards compatibility with older context data.",
+  ),
   comments: z.array(
     z.object({
       author: z.string(),

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -17,18 +17,20 @@
 import { assertEquals } from "@std/assert";
 import { Phase, PullRequestSchema, TRANSITIONS } from "./schemas.ts";
 
-Deno.test("Phase: includes pr_open, pr_failed, releasing between implementing and done", () => {
+Deno.test("Phase: includes pr_open, pr_failed, releasing, notify between implementing and done", () => {
   const phases = Phase.options;
   const implementingIdx = phases.indexOf("implementing");
   const prOpenIdx = phases.indexOf("pr_open");
   const prFailedIdx = phases.indexOf("pr_failed");
   const releasingIdx = phases.indexOf("releasing");
+  const notifyIdx = phases.indexOf("notify");
   const doneIdx = phases.indexOf("done");
 
   assertEquals(prOpenIdx, implementingIdx + 1);
   assertEquals(prFailedIdx, prOpenIdx + 1);
   assertEquals(releasingIdx, prFailedIdx + 1);
-  assertEquals(doneIdx, releasingIdx + 1);
+  assertEquals(notifyIdx, releasingIdx + 1);
+  assertEquals(doneIdx, notifyIdx + 1);
 });
 
 Deno.test("TRANSITIONS: link_pr accepts implementing, pr_open, and pr_failed", () => {
@@ -41,11 +43,17 @@ Deno.test("TRANSITIONS: complete accepts implementing, pr_open, and releasing", 
   assertEquals(TRANSITIONS.complete, ["implementing", "pr_open", "releasing"]);
 });
 
-Deno.test("TRANSITIONS: start (resume) includes pr_open, pr_failed, and releasing", () => {
+Deno.test("TRANSITIONS: start (resume) includes pr_open, pr_failed, releasing, and notify", () => {
   const startPhases = TRANSITIONS.start;
   assertEquals(startPhases.includes("pr_open"), true);
   assertEquals(startPhases.includes("pr_failed"), true);
   assertEquals(startPhases.includes("releasing"), true);
+  assertEquals(startPhases.includes("notify"), true);
+});
+
+Deno.test("TRANSITIONS: notify and skip_notify accept only notify phase", () => {
+  assertEquals(TRANSITIONS.notify, ["notify"]);
+  assertEquals(TRANSITIONS.skip_notify, ["notify"]);
 });
 
 Deno.test("TRANSITIONS: link_pr is rejected from earlier lifecycle phases", () => {

--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -240,6 +240,41 @@ export class SwampClubClient {
     return match?.userId ?? null;
   }
 
+  /**
+   * Post a comment (ripple) on the issue. Returns the comment ID on success,
+   * or null if the request fails. Best-effort — callers should not gate on this.
+   */
+  async submitComment(body: string): Promise<string | null> {
+    try {
+      const url =
+        `${this.baseUrl}/api/v1/lab/issues/${this.issueNumber}/comments`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${this.#apiKey}`,
+        },
+        body: JSON.stringify({ body }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        this.log("swamp-club submit comment failed: {status} {text}", {
+          status: res.status,
+          text,
+        });
+        return null;
+      }
+      const data = await res.json() as { comment?: { id?: string } };
+      return data?.comment?.id ?? null;
+    } catch (err) {
+      this.log("swamp-club submit comment error: {error}", {
+        error: String(err),
+      });
+      return null;
+    }
+  }
+
   /** Update the issue's assignees. Best-effort (same as other PATCH helpers). */
   async updateAssignees(userIds: string[]): Promise<void> {
     await this.patchIssue({ assignees: userIds });

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -70,7 +70,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.04.12.1",
+  version: "2026.05.21.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -458,6 +458,7 @@ export const model = {
             body: issue.body,
             type: issue.type,
             status: issue.status,
+            author: issue.author,
             comments: issue.comments,
             fetchedAt: new Date().toISOString(),
           }),
@@ -1486,12 +1487,12 @@ export const model = {
         const now = new Date().toISOString();
 
         const stateHandle = await context.writeResource("state", "state-main", {
-          phase: "done",
+          phase: "notify",
           issueNumber,
           updatedAt: now,
         });
 
-        context.logger.info("Shipped", {});
+        context.logger.info("Shipped — awaiting contributor notification", {});
 
         const sc = await createSwampClubClient(
           context.globalArgs,
@@ -1539,12 +1540,15 @@ export const model = {
         const { issueNumber } = context.globalArgs;
 
         const stateHandle = await context.writeResource("state", "state-main", {
-          phase: "done",
+          phase: "notify",
           issueNumber,
           updatedAt: new Date().toISOString(),
         });
 
-        context.logger.info("Issue lifecycle complete", {});
+        context.logger.info(
+          "Issue lifecycle complete — awaiting contributor notification",
+          {},
+        );
 
         const sc = await createSwampClubClient(
           context.globalArgs,
@@ -1560,6 +1564,140 @@ export const model = {
             isVerbose: false,
           });
           await sc.transitionStatus("shipped");
+        }
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+
+    notify: {
+      description:
+        "Thank an external contributor by posting a ripple on the issue " +
+        "mentioning them by handle. Transitions to done.",
+      arguments: z.object({
+        message: z.string().optional().describe(
+          "Custom thank-you message. If omitted, a default message is generated.",
+        ),
+      }),
+      execute: async (
+        args: { message?: string },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+
+        // Read the author from context, falling back to a re-fetch if missing.
+        let author: string | undefined;
+        const contextData = await context.readResource("context-main");
+        if (contextData && typeof contextData.author === "string") {
+          author = contextData.author;
+        }
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+
+        if (!author && sc) {
+          const issue = await sc.fetchIssue();
+          author = issue?.author;
+        }
+
+        if (author && author !== "unknown" && sc) {
+          const body = args.message ??
+            `Thanks @${author} for reporting this! The fix has been merged and a release is on its way. We appreciate your contribution to swamp.`;
+          await sc.submitComment(body);
+          context.logger.info(
+            "Posted thank-you ripple for @{author} on issue #{issueNumber}",
+            { author, issueNumber },
+          );
+        } else {
+          context.logger.warning(
+            "Could not determine issue author — skipping notification",
+            {},
+          );
+        }
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "done",
+          issueNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        if (sc) {
+          await sc.postLifecycleEntry({
+            step: "contributor_notified",
+            targetStatus: "shipped",
+            summary: author && author !== "unknown"
+              ? `Thanked @${author}`
+              : "Notification skipped (unknown author)",
+            emoji: "\u{1F64F}",
+            payload: { author: author ?? "unknown" },
+            isVerbose: false,
+          });
+        }
+
+        return { dataHandles: [stateHandle] };
+      },
+    },
+
+    skip_notify: {
+      description:
+        "Skip contributor notification and transition directly to done. " +
+        "Use when the issue author is a collaborator or notification is not needed.",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+
+        const stateHandle = await context.writeResource("state", "state-main", {
+          phase: "done",
+          issueNumber,
+          updatedAt: new Date().toISOString(),
+        });
+
+        context.logger.info("Contributor notification skipped", {});
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        if (sc) {
+          await sc.postLifecycleEntry({
+            step: "notification_skipped",
+            targetStatus: "shipped",
+            summary: "Contributor notification skipped",
+            emoji: "\u{23ED}\u{FE0F}",
+            payload: {},
+            isVerbose: false,
+          });
         }
 
         return { dataHandles: [stateHandle] };

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.04.12.1", () => {
-  assertEquals(model.version, "2026.04.12.1");
+Deno.test("model: version bumped to 2026.05.21.1", () => {
+  assertEquals(model.version, "2026.05.21.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -456,14 +456,14 @@ Deno.test("pr_failed: rejects empty reason via zod schema", async () => {
 // ship
 // ---------------------------------------------------------------------------
 
-Deno.test("ship: transitions state to done", async () => {
+Deno.test("ship: transitions state to notify", async () => {
   const { context, writes, restore } = await buildTestContext(42);
   try {
     await model.methods.ship.execute({}, context);
 
     const stateWrite = writes.find((w) => w.specName === "state");
     assertEquals(stateWrite !== undefined, true);
-    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.phase, "notify");
     assertEquals(stateWrite!.data.issueNumber, 42);
   } finally {
     await restore();
@@ -851,6 +851,64 @@ Deno.test("start: warns and skips assignment when assignees endpoint returns 403
   }
 });
 
+Deno.test("start: persists author in context-main", async () => {
+  const { context, writes, restore } = await buildStartTestContext(99, {
+    authUsername: "alice",
+    routes: [
+      {
+        urlIncludes: "/api/health",
+        response: { status: 200, body: { ok: true } },
+      },
+      {
+        urlIncludes: "/api/v1/lab/issues/99",
+        method: "GET",
+        response: {
+          status: 200,
+          body: {
+            issue: {
+              number: 99,
+              type: "bug",
+              status: "open",
+              title: "Test",
+              body: "Body",
+              authorUsername: "external-user",
+              comments: [],
+              assignees: [],
+            },
+          },
+        },
+      },
+      {
+        urlIncludes: "/api/v1/lab/issues/99",
+        method: "PATCH",
+        response: { status: 200, body: { issue: {} } },
+      },
+      {
+        urlIncludes: "/api/v1/lab/assignees",
+        method: "GET",
+        response: {
+          status: 200,
+          body: { assignees: [{ userId: "u1", username: "alice" }] },
+        },
+      },
+      {
+        urlIncludes: "/api/v1/lab/issues/99/lifecycle",
+        method: "POST",
+        response: { status: 200, body: {} },
+      },
+    ],
+  });
+  try {
+    await model.methods.start.execute({}, context);
+
+    const contextWrite = writes.find((w) => w.specName === "context");
+    assertEquals(contextWrite !== undefined, true);
+    assertEquals(contextWrite!.data.author, "external-user");
+  } finally {
+    await restore();
+  }
+});
+
 Deno.test("start: succeeds even when PATCH fails", async () => {
   const routes = happyRoutes({
     issueNumber: 99,
@@ -882,4 +940,116 @@ Deno.test("start: succeeds even when PATCH fails", async () => {
   } finally {
     await restore();
   }
+});
+
+// ---------------------------------------------------------------------------
+// notify
+// ---------------------------------------------------------------------------
+
+Deno.test("notify: transitions state to done and reads author from context", async () => {
+  const { context, writes, restore } = await buildTestContext(42, {
+    resources: {
+      "context-main": {
+        title: "Test",
+        body: "Body",
+        type: "bug",
+        status: "open",
+        author: "external-user",
+        comments: [],
+        fetchedAt: "2026-05-21T00:00:00.000Z",
+      },
+    },
+  });
+  try {
+    await model.methods.notify.execute({}, context);
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.issueNumber, 42);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("notify: transitions to done even when author is missing from context", async () => {
+  const { context, writes, restore } = await buildTestContext(42, {
+    resources: {
+      "context-main": {
+        title: "Test",
+        body: "Body",
+        type: "bug",
+        status: "open",
+        comments: [],
+        fetchedAt: "2026-05-21T00:00:00.000Z",
+      },
+    },
+  });
+  try {
+    await model.methods.notify.execute({}, context);
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "done");
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("notify: accepts custom message", async () => {
+  const { context, writes, restore } = await buildTestContext(42, {
+    resources: {
+      "context-main": {
+        title: "Test",
+        body: "Body",
+        type: "bug",
+        status: "open",
+        author: "contributor",
+        comments: [],
+        fetchedAt: "2026-05-21T00:00:00.000Z",
+      },
+    },
+  });
+  try {
+    await model.methods.notify.execute(
+      { message: "Custom thanks @contributor!" },
+      context,
+    );
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "done");
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// skip_notify
+// ---------------------------------------------------------------------------
+
+Deno.test("skip_notify: transitions state to done", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.skip_notify.execute({}, context);
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.issueNumber, 42);
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Model registration smoke tests (notify methods)
+// ---------------------------------------------------------------------------
+
+Deno.test("model: exposes notify method definition", () => {
+  assertEquals("notify" in model.methods, true);
+});
+
+Deno.test("model: exposes skip_notify method definition", () => {
+  assertEquals("skip_notify" in model.methods, true);
 });


### PR DESCRIPTION
## Summary

- Adds a `notify` phase to the issue-lifecycle state machine between `releasing` and `done`
- `ship()` and `complete()` now transition to `notify` instead of `done`
- New `notify` method posts a thank-you ripple mentioning the issue author by handle (for external contributors)
- New `skip_notify` method transitions directly to `done` (for collaborator-authored issues)
- Persists issue author in the context resource during `start()`
- Adds `submitComment` to the extension `SwampClubClient`

Closes swamp-club#386

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes
- [x] `deno run test` — 6045 passed, 0 failed
- [x] `deno run compile` — binary compiled
- [x] Verified swamp-club API accepts freeform lifecycle `step` values (no server-side changes needed)
- [x] Unit tests cover: notify transitions to done, skip_notify transitions to done, ship/complete transition to notify, start persists author, custom message support, missing author fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)