### PR TITLE
feat(datastore): add SyncContext and SyncCapabilities framework contracts (swamp-club#378)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -275,6 +275,52 @@ immediately (same directory). On S3 datastores, reads see whatever was last
 synced to the local cache by a write command; users can run
 `swamp datastore sync --pull` to refresh manually.
 
+### SyncContext and SyncCapabilities
+
+Extensions can advertise capabilities by implementing the optional
+`capabilities()` method on `DatastoreSyncService`:
+
+```typescript
+capabilities(): SyncCapabilities {
+  return { scopedSync: true };
+}
+```
+
+When `scopedSync` is `true`, swamp core passes a `SyncContext` to
+`pullChanged()` and `pushChanged()` containing the models being operated on:
+
+```typescript
+interface SyncContext {
+  models: ReadonlyArray<{ modelType: string; modelId: string }>;
+}
+```
+
+Extensions translate this domain context to their own storage model — S3
+extensions filter by key prefix, MongoDB extensions build a query filter, etc.
+
+**Capability gating.** Core only passes context when the extension advertises
+`scopedSync`. Extensions that don't implement `capabilities()` (or return
+`{ scopedSync: false }`) receive `pullChanged()` / `pushChanged()` with no
+arguments — exactly today's behavior.
+
+**Graceful degradation.** If `capabilities()` throws, core catches the error
+and falls back to full sync. The try/catch wraps only the `capabilities()` call,
+not pull/push.
+
+**Per-model loop behavior.** `acquireModelLocks` calls `pullChanged()` once
+per model in the lock acquisition loop. When `scopedSync` is `true`, each call
+receives a context containing only the current model whose lock was just
+acquired. The extension pulls exactly one model per call.
+
+**Push path.** The flush function calls `pushChanged()` once (not per-model)
+under the global lock. When `scopedSync` is `true`, context contains all
+deduplicated models.
+
+**Catalog rebuild invariant.** `synced = true` is set after `pullChanged()`
+succeeds on both the scoped and full paths. This boolean is returned in
+`{ flush, synced }` and checked at 8 call sites across the codebase to trigger
+`catalogStore.invalidate()`. It must never be skipped or moved.
+
 ### Zero-Diff Fast Path (Extension Guidance)
 
 At production scale, most sync invocations are "nothing to do" — the local

--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -21,6 +21,7 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.19";
 import type {
   DatastoreProvider,
+  DatastoreSyncService,
   DatastoreVerifier,
   DistributedLock,
 } from "./datastore_types.ts";
@@ -383,4 +384,93 @@ export async function assertVerifierConformance(
     "string",
     "result.datastoreType must be a string",
   );
+}
+
+/** Options for sync service conformance. */
+export interface SyncServiceConformanceOptions {
+  /** Whether to assert that capabilities() returns scopedSync: true. */
+  expectScopedSync?: boolean;
+}
+
+/**
+ * Asserts that a DatastoreSyncService implementation satisfies the
+ * behavioral contract.
+ *
+ * Tests: pullChanged/pushChanged/markDirty exist and are callable.
+ * When `capabilities()` is present, validates it returns a well-formed
+ * `SyncCapabilities`. When `expectScopedSync` is true, asserts
+ * `scopedSync === true`.
+ *
+ * ```typescript
+ * import { assertSyncServiceConformance } from "@systeminit/swamp-testing";
+ *
+ * Deno.test("s3 sync service contract", async () => {
+ *   const syncService = provider.createSyncService!("/repo", "/cache");
+ *   await assertSyncServiceConformance(syncService);
+ * });
+ * ```
+ */
+export async function assertSyncServiceConformance(
+  syncService: DatastoreSyncService,
+  options?: SyncServiceConformanceOptions,
+): Promise<void> {
+  assertEquals(
+    typeof syncService.pullChanged,
+    "function",
+    "syncService must have pullChanged()",
+  );
+  assertEquals(
+    typeof syncService.pushChanged,
+    "function",
+    "syncService must have pushChanged()",
+  );
+  assertEquals(
+    typeof syncService.markDirty,
+    "function",
+    "syncService must have markDirty()",
+  );
+
+  await syncService.markDirty();
+
+  const pulled = await syncService.pullChanged();
+  if (pulled !== undefined) {
+    assertEquals(
+      typeof pulled,
+      "number",
+      "pullChanged() must return number or void",
+    );
+  }
+
+  const pushed = await syncService.pushChanged();
+  if (pushed !== undefined) {
+    assertEquals(
+      typeof pushed,
+      "number",
+      "pushChanged() must return number or void",
+    );
+  }
+
+  if (syncService.capabilities) {
+    assertEquals(
+      typeof syncService.capabilities,
+      "function",
+      "capabilities must be a function",
+    );
+
+    const caps = syncService.capabilities();
+    assertExists(caps, "capabilities() must return a value");
+    assertEquals(
+      typeof caps.scopedSync,
+      "boolean",
+      "capabilities().scopedSync must be a boolean",
+    );
+
+    if (options?.expectScopedSync) {
+      assertEquals(
+        caps.scopedSync,
+        true,
+        "capabilities().scopedSync must be true when expectScopedSync is set",
+      );
+    }
+  }
 }

--- a/packages/testing/datastore_conformance_test.ts
+++ b/packages/testing/datastore_conformance_test.ts
@@ -21,6 +21,7 @@ import { assertThrows } from "@std/assert";
 import {
   assertDatastoreExportConformance,
   assertLockConformance,
+  assertSyncServiceConformance,
   assertVerifierConformance,
 } from "./datastore_conformance.ts";
 import { createDatastoreTestContext } from "./datastore_test_context.ts";
@@ -91,4 +92,31 @@ Deno.test("assertVerifierConformance: passes for unhealthy verifier", async () =
   });
   const verifier = provider.createVerifier();
   await assertVerifierConformance(verifier);
+});
+
+// --- assertSyncServiceConformance ---
+
+Deno.test("assertSyncServiceConformance: passes for basic sync service", async () => {
+  const { provider } = createDatastoreTestContext({ withSyncService: true });
+  const syncService = provider.createSyncService!("/repo", "/cache");
+  await assertSyncServiceConformance(syncService);
+});
+
+Deno.test("assertSyncServiceConformance: passes for sync service with capabilities", async () => {
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ scopedSync: true }),
+  };
+  await assertSyncServiceConformance(syncService, { expectScopedSync: true });
+});
+
+Deno.test("assertSyncServiceConformance: passes without capabilities method", async () => {
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
+  };
+  await assertSyncServiceConformance(syncService);
 });

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -66,6 +66,16 @@ export interface DatastoreVerifier {
   verify(): Promise<DatastoreHealthResult>;
 }
 
+/** Describes what a sync operation is about. */
+export interface SyncContext {
+  models?: ReadonlyArray<{ modelType: string; modelId: string }>;
+}
+
+/** Capabilities a sync service advertises to swamp core. */
+export interface SyncCapabilities {
+  scopedSync?: boolean;
+}
+
 /** Options accepted by sync service methods. */
 export interface DatastoreSyncOptions {
   signal?: AbortSignal;
@@ -78,6 +88,8 @@ export interface DatastoreSyncOptions {
    * `DatastoreSyncService.markDirty` JSDoc for the full contract.
    */
   relPath?: string;
+  /** Domain-level sync context, passed when the extension advertises scopedSync. */
+  context?: SyncContext;
 }
 
 /** Interface for datastore synchronization services. */
@@ -85,6 +97,8 @@ export interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   markDirty(options?: DatastoreSyncOptions): Promise<void>;
+  /** Advertise what this sync service supports. */
+  capabilities?(): SyncCapabilities;
 }
 
 /**

--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -111,22 +111,27 @@ export type {
 export type {
   DatastoreHealthResult,
   DatastoreProvider,
+  DatastoreSyncOptions,
   DatastoreSyncService,
   DatastoreVerifier,
   DistributedLock,
   LockInfo,
   LockOptions,
+  SyncCapabilities,
+  SyncContext,
 } from "./datastore_types.ts";
 
 export {
   assertDatastoreExportConformance,
   assertLockConformance,
+  assertSyncServiceConformance,
   assertVerifierConformance,
 } from "./datastore_conformance.ts";
 
 export type {
   DatastoreExport,
   DatastoreExportConformanceOptions,
+  SyncServiceConformanceOptions,
 } from "./datastore_conformance.ts";
 
 // --- Drivers ---

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -72,6 +72,8 @@ import type { DatastoreProvider } from "../domain/datastore/datastore_provider.t
 import type {
   DatastoreSyncService,
   MarkDirtyHook,
+  SyncCapabilities,
+  SyncContext,
 } from "../domain/datastore/datastore_sync_service.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
@@ -936,7 +938,22 @@ export async function acquireModelLocks(
           type: modelType,
           id: modelId,
         });
-        await customSyncService.pullChanged();
+
+        let caps: SyncCapabilities | undefined;
+        try {
+          caps = customSyncService.capabilities?.();
+        } catch {
+          // Buggy extension — degrade to full sync
+        }
+
+        if (caps?.scopedSync) {
+          const context: SyncContext = {
+            models: [{ modelType, modelId }],
+          };
+          await customSyncService.pullChanged({ context });
+        } else {
+          await customSyncService.pullChanged();
+        }
         synced = true;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -962,7 +979,21 @@ export async function acquireModelLocks(
         try {
           await pushLock.acquire();
           logger.info`Pushing changes to datastore...`;
-          const pushed = await customSyncService.pushChanged();
+
+          let caps: SyncCapabilities | undefined;
+          try {
+            caps = customSyncService.capabilities?.();
+          } catch {
+            // Buggy extension — degrade to full sync
+          }
+
+          let pushed: number | void;
+          if (caps?.scopedSync) {
+            const context: SyncContext = { models: unique };
+            pushed = await customSyncService.pushChanged({ context });
+          } else {
+            pushed = await customSyncService.pushChanged();
+          }
           if (pushed && pushed > 0) {
             logger.info("Pushed {count} file(s) to datastore", {
               count: pushed,

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -1077,3 +1082,325 @@ Deno.test(
     });
   },
 );
+
+// ============================================================================
+// acquireModelLocks SyncCapabilities Tests
+// ============================================================================
+
+Deno.test("acquireModelLocks - scopedSync passes SyncContext to pull and push", async () => {
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  const typeName = "test-scoped-sync";
+  const pullArgs: unknown[] = [];
+  const pushArgs: unknown[] = [];
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test scoped sync",
+      description: "Test extension for scoped sync capability",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: (options?: unknown) => {
+            pullArgs.push(options);
+            return Promise.resolve(0);
+          },
+          pushChanged: (options?: unknown) => {
+            pushArgs.push(options);
+            return Promise.resolve(0);
+          },
+          markDirty: () => Promise.resolve(),
+          capabilities: () => ({ scopedSync: true }),
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullArgs.length = 0;
+    pushArgs.length = 0;
+
+    const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+    const lockResult = await acquireModelLocks(datastoreConfig, [
+      { modelType: "aws-ec2", modelId: "server-1" },
+    ], dir);
+
+    assertEquals(lockResult.synced, true);
+    assertEquals(pullArgs.length, 1);
+
+    const pullOpts = pullArgs[0] as {
+      context?: { models: Array<{ modelType: string; modelId: string }> };
+    };
+    assertExists(pullOpts?.context, "pullChanged must receive context");
+    assertEquals(pullOpts.context.models.length, 1);
+    assertEquals(pullOpts.context.models[0].modelType, "aws-ec2");
+    assertEquals(pullOpts.context.models[0].modelId, "server-1");
+
+    await lockResult.flush();
+
+    assertEquals(pushArgs.length, 1);
+    const pushOpts = pushArgs[0] as {
+      context?: { models: Array<{ modelType: string; modelId: string }> };
+    };
+    assertExists(pushOpts?.context, "pushChanged must receive context");
+    assertEquals(pushOpts.context.models.length, 1);
+  });
+});
+
+Deno.test("acquireModelLocks - no capabilities calls pull/push with no args", async () => {
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  const typeName = "test-no-caps";
+  const pullArgs: unknown[] = [];
+  const pushArgs: unknown[] = [];
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test no capabilities",
+      description: "Test extension without capabilities method",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: (...args: unknown[]) => {
+            pullArgs.push(args);
+            return Promise.resolve(0);
+          },
+          pushChanged: (...args: unknown[]) => {
+            pushArgs.push(args);
+            return Promise.resolve(0);
+          },
+          markDirty: () => Promise.resolve(),
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullArgs.length = 0;
+    pushArgs.length = 0;
+
+    const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+    const lockResult = await acquireModelLocks(datastoreConfig, [
+      { modelType: "aws-ec2", modelId: "server-1" },
+    ], dir);
+
+    assertEquals(lockResult.synced, true);
+    assertEquals(pullArgs.length, 1);
+    assertEquals(
+      (pullArgs[0] as unknown[]).length,
+      0,
+      "pullChanged must be called with no arguments when capabilities absent",
+    );
+
+    await lockResult.flush();
+
+    assertEquals(pushArgs.length, 1);
+    assertEquals(
+      (pushArgs[0] as unknown[]).length,
+      0,
+      "pushChanged must be called with no arguments when capabilities absent",
+    );
+  });
+});
+
+Deno.test("acquireModelLocks - buggy capabilities degrades to full sync", async () => {
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  const typeName = "test-buggy-caps";
+  const pullArgs: unknown[] = [];
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test buggy capabilities",
+      description: "Test extension whose capabilities() throws",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: (...args: unknown[]) => {
+            pullArgs.push(args);
+            return Promise.resolve(0);
+          },
+          pushChanged: () => Promise.resolve(0),
+          markDirty: () => Promise.resolve(),
+          capabilities: () => {
+            throw new Error("buggy extension");
+          },
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullArgs.length = 0;
+
+    const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+    const lockResult = await acquireModelLocks(datastoreConfig, [
+      { modelType: "aws-ec2", modelId: "server-1" },
+    ], dir);
+
+    assertEquals(lockResult.synced, true);
+    assertEquals(pullArgs.length, 1);
+    assertEquals(
+      (pullArgs[0] as unknown[]).length,
+      0,
+      "pullChanged must be called with no arguments when capabilities throws",
+    );
+
+    await lockResult.flush();
+  });
+});
+
+Deno.test("acquireModelLocks - scopedSync deduplicates models in context", async () => {
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  const typeName = "test-scoped-dedup";
+  const pullArgs: unknown[] = [];
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test scoped dedup",
+      description: "Test extension for scoped sync deduplication",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => Promise.resolve(),
+          release: () => Promise.resolve(),
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: (options?: unknown) => {
+            pullArgs.push(options);
+            return Promise.resolve(0);
+          },
+          pushChanged: () => Promise.resolve(0),
+          markDirty: () => Promise.resolve(),
+          capabilities: () => ({ scopedSync: true }),
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+    await configureExtensionDatastore(dir, typeName);
+
+    pullArgs.length = 0;
+
+    const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+    const lockResult = await acquireModelLocks(datastoreConfig, [
+      { modelType: "aws-ec2", modelId: "server-1" },
+      { modelType: "aws-ec2", modelId: "server-1" },
+      { modelType: "aws-ec2", modelId: "server-2" },
+    ], dir);
+
+    assertEquals(lockResult.synced, true);
+    // unique deduplicates to 2 models, so 2 pull calls
+    assertEquals(pullArgs.length, 2);
+
+    const firstPull = pullArgs[0] as { context?: { models: unknown[] } };
+    assertExists(firstPull?.context, "pullChanged must receive context");
+    assertEquals(
+      firstPull.context.models.length,
+      1,
+      "each pull call must receive only the current model",
+    );
+
+    const secondPull = pullArgs[1] as { context?: { models: unknown[] } };
+    assertExists(secondPull?.context, "pullChanged must receive context");
+    assertEquals(
+      secondPull.context.models.length,
+      1,
+      "each pull call must receive only the current model",
+    );
+
+    await lockResult.flush();
+  });
+});

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -19,6 +19,16 @@
 
 import { UserError } from "../errors.ts";
 
+/** Describes what a sync operation is about. */
+export interface SyncContext {
+  models?: ReadonlyArray<{ modelType: string; modelId: string }>;
+}
+
+/** Capabilities a sync service advertises to swamp core. */
+export interface SyncCapabilities {
+  scopedSync?: boolean;
+}
+
 /** Options accepted by sync service methods. */
 export interface DatastoreSyncOptions {
   /**
@@ -49,6 +59,8 @@ export interface DatastoreSyncOptions {
    * or push consume it.)
    */
   relPath?: string;
+  /** Domain-level sync context, passed when the extension advertises scopedSync. */
+  context?: SyncContext;
 }
 
 /**
@@ -62,6 +74,8 @@ export interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   /** Push changed files from the local cache to the remote datastore. */
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
+  /** Advertise what this sync service supports. */
+  capabilities?(): SyncCapabilities;
   /**
    * Signal that the local cache has uncommitted work.
    *

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -50,6 +50,8 @@ export {
   type DatastoreSyncOptions,
   type DatastoreSyncService,
   type MarkDirtyHook,
+  type SyncCapabilities,
+  type SyncContext,
   type SyncDirection,
   SyncTimeoutError,
 } from "./datastore_sync_service.ts";


### PR DESCRIPTION
## Summary

- Add `SyncContext` and `SyncCapabilities` framework contracts to the datastore sync API — Phase 1 of the datastore efficiency overhaul
- `SyncContext` describes what a sync operation is about (models being operated on); each extension translates domain context to its own storage model (S3 → key prefix, MongoDB → query filter, etc.)
- `SyncCapabilities` lets sync services advertise `scopedSync` support; all fields optional for forward compatibility (Phase 3 adds `lazyHydration`)
- Wire through `acquireModelLocks` with capability gating: scoped pull passes per-model context, scoped push passes all models; else branches call with no args (zero change for existing extensions)
- `capabilities()` wrapped in try/catch — buggy extensions degrade to full sync, not crash
- Mirror types in `@systeminit/swamp-testing` (`datastore_types.ts`) and add `assertSyncServiceConformance()` so extension authors can verify their capabilities implementation
- `synced = true` assignment and all 8 `catalogStore.invalidate()` call sites untouched — catalog rebuild invariant preserved

## Test Plan

- 4 new `acquireModelLocks` tests in `repo_context_test.ts`:
  - `scopedSync` extension receives per-model `SyncContext` on pull, all models on push
  - Extension without `capabilities()` gets no-arg pull/push (regression guard)
  - Extension whose `capabilities()` throws degrades to full sync
  - Duplicate models deduplicated in context
- 3 new conformance tests in `datastore_conformance_test.ts`:
  - Basic sync service (no capabilities)
  - Sync service with capabilities (scopedSync: true)
  - Sync service without capabilities method
- All 6044 existing tests pass, `deno check`, `deno lint`, `deno fmt` clean
- Design doc updated in `design/datastores.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)