### PR TITLE
fix(issue-lifecycle): add missing upgrade migration for 2026.05.21.1

### DIFF
--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -129,8 +129,7 @@ export const model = {
     },
     {
       toVersion: "2026.05.21.1",
-      description:
-        "Add notify phase for external contributors. " +
+      description: "Add notify phase for external contributors. " +
         "ship() and complete() now transition to notify instead of done. " +
         "New notify method posts a thank-you ripple and transitions to done. " +
         "Issue data now includes author field.",

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -127,6 +127,15 @@ export const model = {
         "Best-effort — assignment failures are warnings, never errors.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.05.21.1",
+      description:
+        "Add notify phase for external contributors. " +
+        "ship() and complete() now transition to notify instead of done. " +
+        "New notify method posts a thank-you ripple and transitions to done. " +
+        "Issue data now includes author field.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
 
   resources: {


### PR DESCRIPTION
## Summary

- The notify phase commit (`a01de17e`) bumped the model version to `2026.05.21.1` but omitted the corresponding upgrade migration entry
- This caused a load-time error: `Last upgrade toVersion "2026.04.12.1" does not match model version "2026.05.21.1"`
- Adds the missing identity upgrade entry so the version chain is complete

## Test plan

- [ ] `deno check extensions/models/issue_lifecycle.ts` passes
- [ ] Model loads without version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)