### PR TITLE
fix(datastore): address review feedback on SyncCapabilities contracts (swamp-club#378)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -291,7 +291,7 @@ When `scopedSync` is `true`, swamp core passes a `SyncContext` to
 
 ```typescript
 interface SyncContext {
-  models: ReadonlyArray<{ modelType: string; modelId: string }>;
+  models?: ReadonlyArray<{ modelType: string; modelId: string }>;
 }
 ```
 

--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -459,11 +459,13 @@ export async function assertSyncServiceConformance(
 
     const caps = syncService.capabilities();
     assertExists(caps, "capabilities() must return a value");
-    assertEquals(
-      typeof caps.scopedSync,
-      "boolean",
-      "capabilities().scopedSync must be a boolean",
-    );
+    if (caps.scopedSync !== undefined) {
+      assertEquals(
+        typeof caps.scopedSync,
+        "boolean",
+        "capabilities().scopedSync must be a boolean when present",
+      );
+    }
 
     if (options?.expectScopedSync) {
       assertEquals(

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -874,6 +874,15 @@ export async function acquireModelLocks(
 
   const lockKeys: string[] = [];
 
+  let caps: SyncCapabilities | undefined;
+  if (customSyncService) {
+    try {
+      caps = customSyncService.capabilities?.();
+    } catch {
+      // Buggy extension — degrade to full sync
+    }
+  }
+
   for (const { modelType, modelId } of unique) {
     const key = `data/${modelType}/${modelId}/.lock`;
     // Use cached provider for custom types to avoid repeated registry lookups
@@ -939,13 +948,6 @@ export async function acquireModelLocks(
           id: modelId,
         });
 
-        let caps: SyncCapabilities | undefined;
-        try {
-          caps = customSyncService.capabilities?.();
-        } catch {
-          // Buggy extension — degrade to full sync
-        }
-
         if (caps?.scopedSync) {
           const context: SyncContext = {
             models: [{ modelType, modelId }],
@@ -979,13 +981,6 @@ export async function acquireModelLocks(
         try {
           await pushLock.acquire();
           logger.info`Pushing changes to datastore...`;
-
-          let caps: SyncCapabilities | undefined;
-          try {
-            caps = customSyncService.capabilities?.();
-          } catch {
-            // Buggy extension — degrade to full sync
-          }
 
           let pushed: number | void;
           if (caps?.scopedSync) {


### PR DESCRIPTION
## Summary

Follow-up to #1418 addressing review feedback:

- Hoist `capabilities()` above the per-model lock loop — called once instead of N times for the same static result
- Fix `assertSyncServiceConformance` to tolerate `undefined` `scopedSync` — the field is optional, so extensions returning only future capabilities (e.g. `{ lazyHydration: true }`) should not fail conformance
- Fix design doc to show `models?:` matching the actual optional type signature

## Test Plan

- All 35 `repo_context_test.ts` tests pass (including 4 SyncCapabilities tests)
- All 8 `datastore_conformance_test.ts` tests pass
- Full `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)