### PR TITLE
feat(extensions): add dependency trust-gating to push and quality scoring (swamp-club#395)

### DIFF
--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -139,7 +139,8 @@ swamp extension fmt manifest.yaml --check --json
 details.
 
 **Optional:** Run `swamp extension quality manifest.yaml --json` between States
-6 and 7 for a rubric score. See
+6 and 7 for a rubric score. This now includes dependency trust evaluation — npm
+dependencies are audited against OSV.dev advisories and trust signals. See
 [references/publishing.md](references/publishing.md#quality-self-check) for
 details.
 

--- a/.claude/skills/swamp-extension/SKILL.md
+++ b/.claude/skills/swamp-extension/SKILL.md
@@ -292,9 +292,12 @@ third-party score: **12/13 = 92% (Grade A)**.
 
 Key factors: README in `additionalFiles:`, LICENSE file, JSDoc coverage ≥80%,
 explicit return types, manifest `description:`, `repository:` URL on allowlisted
-host.
+host, dependency trust (no deprecated or vulnerable npm deps).
 
 Run `swamp extension quality manifest.yaml --json` for a local self-check.
+Dependency trust is evaluated automatically — npm dependencies are audited
+against OSV.dev advisories and trust signals (downloads, license, recency,
+maintainer count). HIGH/CRITICAL vulnerabilities block push.
 
 See [references/quality/rubric.md](references/quality/rubric.md) for the full
 rubric and [references/quality/templates.md](references/quality/templates.md)

--- a/design/extension.md
+++ b/design/extension.md
@@ -741,6 +741,38 @@ time and stored in the registry. During pull, the downloaded archive's checksum
 is verified against the registry. Legacy extensions that predate checksum
 support are marked as "unverified" but still allowed.
 
+## Dependency Trust Audit
+
+Extension source files are scanned for `npm:` and `jsr:` import specifiers
+during the push prepare phase. Each npm dependency is evaluated against trust
+gates adapted from `@bixu/wheelshop`:
+
+### Hard Errors (block push)
+
+- Deprecated packages
+- HIGH, CRITICAL, or UNKNOWN severity vulnerabilities (via OSV.dev)
+
+### Warnings (shown but don't block)
+
+- MEDIUM severity vulnerabilities
+- License not in the allowlist (MIT, Apache-2.0, BSD-2/3-Clause, ISC, 0BSD,
+  MPL-2.0, Unlicense, CC0-1.0)
+- No maintainers listed
+- Weekly downloads below 1,000
+- Last publish more than 24 months ago
+
+### jsr Dependencies
+
+jsr packages trust jsr's built-in enforcement (SPDX license requirement,
+provenance, no install scripts) and skip gates where data is unavailable.
+
+### Quality Rubric Factor
+
+Dependency trust is a rubric scoring factor (`dependency-trust`, worth 2
+points). It flows through both `swamp extension quality` (CLI) and swamp-club's
+server-side scorer. The factor earns points when all dependencies pass trust
+gates (no hard-error blockers).
+
 ## Registry
 
 Extensions are distributed through the swamp registry at `https://swamp-club.com`.

--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -180,7 +180,7 @@ past the floor without blowing the fixture up.
 }
 
 Deno.test(
-  "extension quality: fully-documented extension scores 12/12 (100%)",
+  "extension quality: fully-documented extension scores 14/14 (100%)",
   async () => {
     const tmpDir = await initTempRepo();
     try {
@@ -203,9 +203,9 @@ Deno.test(
       }
       const parsed = parseFirstJson(stdout);
       assertEquals(parsed.status, "passed");
-      assertEquals(parsed.rubricVersion, 2);
-      assertEquals(parsed.earnedPoints, 12);
-      assertEquals(parsed.maxEarnablePoints, 12);
+      assertEquals(parsed.rubricVersion, 3);
+      assertEquals(parsed.earnedPoints, 14);
+      assertEquals(parsed.maxEarnablePoints, 14);
       assertEquals(parsed.percentage, 100);
       assertEquals(parsed.allPassed, true);
 
@@ -456,7 +456,7 @@ Deno.test("extension quality: log mode renders per-factor lines", async () => {
     }
     // The renderer logs to stderr via logtape; check both streams.
     const combined = stdout + stderr;
-    assertStringIncludes(combined, "Rubric v2");
+    assertStringIncludes(combined, "Rubric v3");
     assertStringIncludes(combined, "has-readme");
     assertStringIncludes(combined, "fast-check");
     assertStringIncludes(combined, "symbols-docs");

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -48,6 +48,7 @@ import {
 } from "../../presentation/renderers/extension_push.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
+import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type {
   CollectiveMismatch,
 } from "../../domain/extensions/extension_collective_validator.ts";
@@ -336,6 +337,7 @@ export const extensionPushCommand = new Command()
         additionalFilePaths,
         binaryFilePaths,
         dryRun: options.dryRun ?? false,
+
         releaseNotes: options.releaseNotes,
         denoConfigPath,
         packageJsonDir,
@@ -345,7 +347,11 @@ export const extensionPushCommand = new Command()
       // Handle structured errors from the prepare phase with rich rendering
       if (isSwampError(error)) {
         const details = error.details as Record<string, unknown> | undefined;
-        if (details?.safetyErrors) {
+        if (details?.dependencyTrustErrors) {
+          renderer.renderDependencyTrustErrors(
+            details.dependencyTrustErrors as DependencyTrustIssue[],
+          );
+        } else if (details?.safetyErrors) {
           renderer.renderSafetyErrors(
             details.safetyErrors as SafetyIssue[],
           );
@@ -399,6 +405,7 @@ export const extensionPushCommand = new Command()
                   additionalFilePaths,
                   binaryFilePaths,
                   dryRun: options.dryRun ?? false,
+
                   releaseNotes: options.releaseNotes,
                   denoConfigPath,
                   packageJsonDir,
@@ -447,7 +454,14 @@ export const extensionPushCommand = new Command()
     // 5. Render resolved data
     renderer.renderResolved(prepared.resolvedData);
 
-    // 6. Handle safety warnings
+    // 6. Handle dependency trust warnings
+    if (prepared.dependencyTrustResult.warnings.length > 0) {
+      renderer.renderDependencyTrustWarnings(
+        prepared.dependencyTrustResult.warnings,
+      );
+    }
+
+    // 6b. Handle safety warnings
     if (prepared.safetyWarnings.length > 0) {
       renderer.renderSafetyWarnings(prepared.safetyWarnings);
       if (!options.yes && cliCtx.outputMode === "log") {

--- a/src/domain/extensions/extension_dependency_extractor.ts
+++ b/src/domain/extensions/extension_dependency_extractor.ts
@@ -24,10 +24,33 @@ export interface DependencySpecifier {
   sourceFile: string;
 }
 
-// Matches `from "npm:pkg@version"` or `from "jsr:@scope/name@version"`
-// Also handles import statements without `from` (side-effect imports).
-const IMPORT_SPECIFIER_RE =
+function stripComments(source: string): string {
+  let result = "";
+  let i = 0;
+  while (i < source.length) {
+    if (source[i] === "/" && source[i + 1] === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+    } else if (source[i] === "/" && source[i + 1] === "*") {
+      i += 2;
+      while (
+        i < source.length - 1 && !(source[i] === "*" && source[i + 1] === "/")
+      ) i++;
+      i += 2;
+    } else {
+      result += source[i];
+      i++;
+    }
+  }
+  return result;
+}
+
+// Matches static imports: `from "npm:..."` and side-effect `import "npm:..."`
+const STATIC_IMPORT_RE =
   /(?:from|import)\s+["'](?<specifier>(?:npm|jsr):[^"']+)["']/g;
+
+// Matches dynamic imports: `import("npm:...")`
+const DYNAMIC_IMPORT_RE =
+  /import\s*\(\s*["'](?<specifier>(?:npm|jsr):[^"']+)["']\s*\)/g;
 
 // Parses `npm:@scope/name@version`, `npm:name@version`, `npm:name`
 const NPM_SPECIFIER_RE =
@@ -67,18 +90,22 @@ export function extractSpecifiersFromSource(
 ): DependencySpecifier[] {
   const seen = new Set<string>();
   const results: DependencySpecifier[] = [];
+  const stripped = stripComments(source);
 
-  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
-    const raw = match.groups?.specifier;
-    if (!raw) continue;
-    const parsed = parseSpecifier(raw);
-    if (!parsed) continue;
+  for (const re of [STATIC_IMPORT_RE, DYNAMIC_IMPORT_RE]) {
+    re.lastIndex = 0;
+    for (const match of stripped.matchAll(re)) {
+      const raw = match.groups?.specifier;
+      if (!raw) continue;
+      const parsed = parseSpecifier(raw);
+      if (!parsed) continue;
 
-    const key = `${parsed.registry}:${parsed.name}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
+      const key = `${parsed.registry}:${parsed.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
 
-    results.push({ ...parsed, sourceFile });
+      results.push({ ...parsed, sourceFile });
+    }
   }
 
   return results;

--- a/src/domain/extensions/extension_dependency_extractor.ts
+++ b/src/domain/extensions/extension_dependency_extractor.ts
@@ -1,0 +1,109 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface DependencySpecifier {
+  name: string;
+  version: string | null;
+  registry: "npm" | "jsr";
+  sourceFile: string;
+}
+
+// Matches `from "npm:pkg@version"` or `from "jsr:@scope/name@version"`
+// Also handles import statements without `from` (side-effect imports).
+const IMPORT_SPECIFIER_RE =
+  /(?:from|import)\s+["'](?<specifier>(?:npm|jsr):[^"']+)["']/g;
+
+// Parses `npm:@scope/name@version`, `npm:name@version`, `npm:name`
+const NPM_SPECIFIER_RE =
+  /^npm:(?<name>(?:@[^/@]+\/)?[^/@]+)(?:@(?<version>[^/]+))?/;
+
+// Parses `jsr:@scope/name@version`, `jsr:@scope/name`
+const JSR_SPECIFIER_RE = /^jsr:(?<name>@[^/@]+\/[^/@]+)(?:@(?<version>[^/]+))?/;
+
+// zod is externalized by the bundler — not a real extension dependency
+const EXCLUDED_PACKAGES = new Set(["zod"]);
+
+function parseSpecifier(
+  raw: string,
+): { name: string; version: string | null; registry: "npm" | "jsr" } | null {
+  if (raw.startsWith("npm:")) {
+    const match = NPM_SPECIFIER_RE.exec(raw);
+    if (!match?.groups) return null;
+    const name = match.groups.name;
+    if (EXCLUDED_PACKAGES.has(name)) return null;
+    return { name, version: match.groups.version ?? null, registry: "npm" };
+  }
+  if (raw.startsWith("jsr:")) {
+    const match = JSR_SPECIFIER_RE.exec(raw);
+    if (!match?.groups) return null;
+    return {
+      name: match.groups.name,
+      version: match.groups.version ?? null,
+      registry: "jsr",
+    };
+  }
+  return null;
+}
+
+export function extractSpecifiersFromSource(
+  source: string,
+  sourceFile: string,
+): DependencySpecifier[] {
+  const seen = new Set<string>();
+  const results: DependencySpecifier[] = [];
+
+  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
+    const raw = match.groups?.specifier;
+    if (!raw) continue;
+    const parsed = parseSpecifier(raw);
+    if (!parsed) continue;
+
+    const key = `${parsed.registry}:${parsed.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    results.push({ ...parsed, sourceFile });
+  }
+
+  return results;
+}
+
+export async function extractDependencySpecifiers(
+  sourceFiles: string[],
+): Promise<DependencySpecifier[]> {
+  const seen = new Map<string, DependencySpecifier>();
+
+  for (const file of sourceFiles) {
+    if (!file.endsWith(".ts")) continue;
+    let source: string;
+    try {
+      source = await Deno.readTextFile(file);
+    } catch {
+      continue;
+    }
+    for (const spec of extractSpecifiersFromSource(source, file)) {
+      const key = `${spec.registry}:${spec.name}`;
+      if (!seen.has(key)) {
+        seen.set(key, spec);
+      }
+    }
+  }
+
+  return Array.from(seen.values());
+}

--- a/src/domain/extensions/extension_dependency_extractor.ts
+++ b/src/domain/extensions/extension_dependency_extractor.ts
@@ -25,23 +25,46 @@ export interface DependencySpecifier {
 }
 
 function stripComments(source: string): string {
-  let result = "";
-  let i = 0;
-  while (i < source.length) {
-    if (source[i] === "/" && source[i + 1] === "/") {
-      while (i < source.length && source[i] !== "\n") i++;
-    } else if (source[i] === "/" && source[i + 1] === "*") {
-      i += 2;
-      while (
-        i < source.length - 1 && !(source[i] === "*" && source[i + 1] === "/")
-      ) i++;
-      i += 2;
-    } else {
-      result += source[i];
-      i++;
+  const lines = source.split("\n");
+  const result: string[] = [];
+  let inBlockComment = false;
+
+  for (const line of lines) {
+    if (inBlockComment) {
+      const end = line.indexOf("*/");
+      if (end !== -1) {
+        inBlockComment = false;
+        result.push(line.slice(end + 2));
+      }
+      continue;
     }
+
+    const blockStart = line.indexOf("/*");
+    if (blockStart !== -1) {
+      const blockEnd = line.indexOf("*/", blockStart + 2);
+      if (blockEnd !== -1) {
+        result.push(line.slice(0, blockStart) + line.slice(blockEnd + 2));
+      } else {
+        inBlockComment = true;
+        result.push(line.slice(0, blockStart));
+      }
+      continue;
+    }
+
+    // Only strip // comments on lines containing import/export keywords
+    // to avoid false-stripping URLs in string literals
+    if (/\b(?:import|export)\b/.test(line)) {
+      const lineComment = line.indexOf("//");
+      if (lineComment !== -1) {
+        result.push(line.slice(0, lineComment));
+        continue;
+      }
+    }
+
+    result.push(line);
   }
-  return result;
+
+  return result.join("\n");
 }
 
 // Matches static imports: `from "npm:..."` and side-effect `import "npm:..."`

--- a/src/domain/extensions/extension_dependency_extractor_test.ts
+++ b/src/domain/extensions/extension_dependency_extractor_test.ts
@@ -1,0 +1,115 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { extractSpecifiersFromSource } from "./extension_dependency_extractor.ts";
+
+Deno.test("extractSpecifiersFromSource: extracts npm specifier with version", () => {
+  const source = `import { z } from "npm:zod@4";
+import axios from "npm:axios@1.7.2";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "axios");
+  assertEquals(result[0].version, "1.7.2");
+  assertEquals(result[0].registry, "npm");
+});
+
+Deno.test("extractSpecifiersFromSource: excludes zod (externalized)", () => {
+  const source = `import { z } from "npm:zod@4";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 0);
+});
+
+Deno.test("extractSpecifiersFromSource: extracts scoped npm packages", () => {
+  const source = `import { S3Client } from "npm:@aws-sdk/client-s3@3.600.0";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "@aws-sdk/client-s3");
+  assertEquals(result[0].version, "3.600.0");
+  assertEquals(result[0].registry, "npm");
+});
+
+Deno.test("extractSpecifiersFromSource: extracts jsr specifiers", () => {
+  const source = `import { parse } from "jsr:@std/semver@1.0.8";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "@std/semver");
+  assertEquals(result[0].version, "1.0.8");
+  assertEquals(result[0].registry, "jsr");
+});
+
+Deno.test("extractSpecifiersFromSource: handles missing version", () => {
+  const source = `import lodash from "npm:lodash-es";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "lodash-es");
+  assertEquals(result[0].version, null);
+  assertEquals(result[0].registry, "npm");
+});
+
+Deno.test("extractSpecifiersFromSource: deduplicates same package", () => {
+  const source = `import { foo } from "npm:axios@1.7.2";
+import { bar } from "npm:axios@1.7.2";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+});
+
+Deno.test("extractSpecifiersFromSource: extracts multiple packages", () => {
+  const source = `import { z } from "npm:zod@4";
+import mqtt from "npm:mqtt@5.10.3";
+import { parse } from "jsr:@std/semver@1.0.8";
+import { retry } from "npm:p-retry@6.2.0";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 3);
+  assertEquals(result[0].name, "mqtt");
+  assertEquals(result[1].name, "@std/semver");
+  assertEquals(result[2].name, "p-retry");
+});
+
+Deno.test("extractSpecifiersFromSource: ignores relative imports", () => {
+  const source = `import { helper } from "./helpers.ts";
+import { util } from "../utils/mod.ts";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 0);
+});
+
+Deno.test("extractSpecifiersFromSource: handles side-effect imports", () => {
+  const source = `import "npm:dotenv@16.4.5";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "dotenv");
+  assertEquals(result[0].version, "16.4.5");
+});
+
+Deno.test("extractSpecifiersFromSource: returns empty for no imports", () => {
+  const source = `const x = 42;
+export function hello() { return "world"; }`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 0);
+});

--- a/src/domain/extensions/extension_dependency_extractor_test.ts
+++ b/src/domain/extensions/extension_dependency_extractor_test.ts
@@ -106,6 +106,33 @@ Deno.test("extractSpecifiersFromSource: handles side-effect imports", () => {
   assertEquals(result[0].version, "16.4.5");
 });
 
+Deno.test("extractSpecifiersFromSource: extracts dynamic imports", () => {
+  const source = `const mod = await import("npm:untrusted-pkg@1.0");`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "untrusted-pkg");
+  assertEquals(result[0].version, "1.0");
+});
+
+Deno.test("extractSpecifiersFromSource: ignores commented-out imports", () => {
+  const source = `// import old from "npm:deprecated-pkg@1.0";
+import active from "npm:good-pkg@2.0";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "good-pkg");
+});
+
+Deno.test("extractSpecifiersFromSource: ignores block-commented imports", () => {
+  const source = `/* import old from "npm:deprecated-pkg@1.0"; */
+import active from "npm:good-pkg@2.0";`;
+  const result = extractSpecifiersFromSource(source, "model.ts");
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].name, "good-pkg");
+});
+
 Deno.test("extractSpecifiersFromSource: returns empty for no imports", () => {
   const source = `const x = 42;
 export function hello() { return "world"; }`;

--- a/src/domain/extensions/extension_dependency_trust_checker.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker.ts
@@ -33,13 +33,11 @@ export interface DependencyTrustResult {
 export interface TrustThresholds {
   minWeeklyDownloads: number;
   maxAgeMonths: number;
-  minMaintenance: number;
 }
 
 export const DEFAULT_TRUST_THRESHOLDS: TrustThresholds = {
   minWeeklyDownloads: 1000,
   maxAgeMonths: 24,
-  minMaintenance: 0.4,
 };
 
 const LICENSE_ALLOWLIST: ReadonlySet<string> = new Set([
@@ -101,9 +99,19 @@ function extractSeverity(vuln: Record<string, unknown>): string {
   }
   const sevArr = vuln.severity;
   if (Array.isArray(sevArr) && sevArr.length > 0) {
-    const first = sevArr[0] as Record<string, unknown>;
-    const score = Number(first.score);
-    if (Number.isFinite(score)) return cvssToSeverity(score);
+    for (const entry of sevArr) {
+      const obj = entry as Record<string, unknown>;
+      if (typeof obj.score === "number" && Number.isFinite(obj.score)) {
+        return cvssToSeverity(obj.score);
+      }
+      if (typeof obj.score === "string") {
+        const numeric = Number(obj.score);
+        if (Number.isFinite(numeric)) return cvssToSeverity(numeric);
+      }
+      if (typeof obj.baseScore === "number" && Number.isFinite(obj.baseScore)) {
+        return cvssToSeverity(obj.baseScore);
+      }
+    }
   }
   return "UNKNOWN";
 }
@@ -142,9 +150,13 @@ async function fetchWithTimeout(
   url: string,
   init: RequestInit,
   fetcher: Fetcher,
+  signal?: AbortSignal,
 ): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  if (signal) {
+    signal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
   try {
     return await fetcher(url, { ...init, signal: controller.signal });
   } finally {
@@ -156,17 +168,26 @@ async function queryOsvVulns(
   name: string,
   version: string,
   fetcher: Fetcher,
+  signal?: AbortSignal,
 ): Promise<OsvVuln[]> {
   try {
-    const resp = await fetchWithTimeout(OSV_QUERY_URL, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        package: { name, ecosystem: "npm" },
-        version,
-      }),
-    }, fetcher);
-    if (!resp.ok) return [];
+    const resp = await fetchWithTimeout(
+      OSV_QUERY_URL,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          package: { name, ecosystem: "npm" },
+          version,
+        }),
+      },
+      fetcher,
+      signal,
+    );
+    if (!resp.ok) {
+      await resp.body?.cancel();
+      return [];
+    }
     return normaliseVulns(await resp.json());
   } catch {
     return [];
@@ -176,15 +197,20 @@ async function queryOsvVulns(
 async function fetchNpmFacts(
   name: string,
   fetcher: Fetcher,
+  signal?: AbortSignal,
 ): Promise<NpmPackageFacts | null> {
   try {
-    const [manifestResp, downloadsResp] = await Promise.all([
-      fetchWithTimeout(`${NPM_REGISTRY_URL}/${name}/latest`, {}, fetcher),
-      fetchWithTimeout(`${NPM_DOWNLOADS_URL}/${name}`, {}, fetcher),
+    const [pkgResp, downloadsResp] = await Promise.all([
+      fetchWithTimeout(`${NPM_REGISTRY_URL}/${name}`, {}, fetcher, signal),
+      fetchWithTimeout(`${NPM_DOWNLOADS_URL}/${name}`, {}, fetcher, signal),
     ]);
 
-    if (!manifestResp.ok) return null;
-    const manifest = await manifestResp.json() as Record<string, unknown>;
+    if (!pkgResp.ok) {
+      await pkgResp.body?.cancel();
+      await downloadsResp.body?.cancel();
+      return null;
+    }
+    const pkgBody = await pkgResp.json() as Record<string, unknown>;
 
     let weeklyDownloads: number | null = null;
     if (downloadsResp.ok) {
@@ -196,8 +222,15 @@ async function fetchNpmFacts(
       await downloadsResp.body?.cancel();
     }
 
-    const version = String(manifest.version ?? "unknown");
-    const rawLicense = manifest.license;
+    const distTags = pkgBody["dist-tags"] as Record<string, string> | undefined;
+    const latestVersion = distTags?.latest ??
+      String(pkgBody.version ?? "unknown");
+    const versions = pkgBody.versions as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const latestManifest = versions?.[latestVersion];
+
+    const rawLicense = latestManifest?.license ?? pkgBody.license;
     const license = typeof rawLicense === "string"
       ? rawLicense
       : (rawLicense && typeof rawLicense === "object" &&
@@ -205,32 +238,15 @@ async function fetchNpmFacts(
       ? (rawLicense as Record<string, unknown>).type as string
       : null;
 
-    const deprecated = !!manifest.deprecated;
-    const maintainers = manifest.maintainers;
+    const deprecated = !!(latestManifest?.deprecated ?? pkgBody.deprecated);
+    const maintainers = latestManifest?.maintainers ?? pkgBody.maintainers;
     const maintainerCount = Array.isArray(maintainers) ? maintainers.length : 0;
 
-    let lastPublish: string | null = null;
-    try {
-      const pkgResp = await fetchWithTimeout(
-        `${NPM_REGISTRY_URL}/${name}`,
-        {},
-        fetcher,
-      );
-      if (pkgResp.ok) {
-        const pkgBody = await pkgResp.json() as Record<string, unknown>;
-        const time = pkgBody.time as Record<string, string> | undefined;
-        if (time) {
-          lastPublish = time[version] ?? time.modified ?? null;
-        }
-      } else {
-        await pkgResp.body?.cancel();
-      }
-    } catch {
-      // publish date is best-effort
-    }
+    const time = pkgBody.time as Record<string, string> | undefined;
+    const lastPublish = time?.[latestVersion] ?? time?.modified ?? null;
 
     return {
-      version,
+      version: latestVersion,
       license,
       deprecated,
       maintainerCount,
@@ -311,6 +327,7 @@ export async function checkDependencyTrust(
   specifiers: DependencySpecifier[],
   fetcher: Fetcher = fetch,
   thresholds: TrustThresholds = DEFAULT_TRUST_THRESHOLDS,
+  signal?: AbortSignal,
 ): Promise<DependencyTrustResult> {
   const allErrors: DependencyTrustIssue[] = [];
   const allWarnings: DependencyTrustIssue[] = [];
@@ -325,7 +342,7 @@ export async function checkDependencyTrust(
     const batch = npmSpecs.slice(i, i + CONCURRENCY);
     const results = await Promise.allSettled(
       batch.map(async (spec) => {
-        const facts = await fetchNpmFacts(spec.name, fetcher);
+        const facts = await fetchNpmFacts(spec.name, fetcher, signal);
         if (!facts) {
           allWarnings.push({
             dependency: spec.name,
@@ -335,7 +352,7 @@ export async function checkDependencyTrust(
         }
 
         const version = spec.version ?? facts.version;
-        const vulns = await queryOsvVulns(spec.name, version, fetcher);
+        const vulns = await queryOsvVulns(spec.name, version, fetcher, signal);
         const { errors, warnings } = evaluateNpmTrustGates(
           spec.name,
           facts,

--- a/src/domain/extensions/extension_dependency_trust_checker.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker.ts
@@ -24,9 +24,20 @@ export interface DependencyTrustIssue {
   message: string;
 }
 
+export interface DependencyAuditSummary {
+  name: string;
+  version: string;
+  registry: "npm" | "jsr";
+  license: string | null;
+  weeklyDownloads: number | null;
+  publishedAgo: string | null;
+  passed: boolean;
+}
+
 export interface DependencyTrustResult {
   errors: DependencyTrustIssue[];
   warnings: DependencyTrustIssue[];
+  audited: DependencyAuditSummary[];
   passed: boolean;
 }
 
@@ -381,6 +392,14 @@ export function evaluateNpmTrustGates(
   return { errors, warnings };
 }
 
+function formatAge(lastPublish: string | null): string | null {
+  if (!lastPublish) return null;
+  const months = monthsSince(lastPublish);
+  if (months <= 0) return "this month";
+  if (months === 1) return "1mo ago";
+  return `${months}mo ago`;
+}
+
 export async function checkDependencyTrust(
   specifiers: DependencySpecifier[],
   fetcher: Fetcher = fetch,
@@ -389,11 +408,22 @@ export async function checkDependencyTrust(
 ): Promise<DependencyTrustResult> {
   const allErrors: DependencyTrustIssue[] = [];
   const allWarnings: DependencyTrustIssue[] = [];
+  const audited: DependencyAuditSummary[] = [];
 
   const npmSpecs = specifiers.filter((s) => s.registry === "npm");
+  const jsrSpecs = specifiers.filter((s) => s.registry === "jsr");
 
-  // jsr packages trust jsr's built-in enforcement (SPDX license,
-  // provenance, no install scripts) — skip gates where data is unavailable
+  for (const spec of jsrSpecs) {
+    audited.push({
+      name: spec.name,
+      version: spec.version ?? "latest",
+      registry: "jsr",
+      license: null,
+      weeklyDownloads: null,
+      publishedAgo: null,
+      passed: true,
+    });
+  }
 
   const CONCURRENCY = 5;
   for (let i = 0; i < npmSpecs.length; i += CONCURRENCY) {
@@ -405,6 +435,15 @@ export async function checkDependencyTrust(
           allWarnings.push({
             dependency: spec.name,
             message: "could not fetch package metadata (API unreachable)",
+          });
+          audited.push({
+            name: spec.name,
+            version: spec.version ?? "unknown",
+            registry: "npm",
+            license: null,
+            weeklyDownloads: null,
+            publishedAgo: null,
+            passed: true,
           });
           return;
         }
@@ -419,6 +458,16 @@ export async function checkDependencyTrust(
         );
         allErrors.push(...errors);
         allWarnings.push(...warnings);
+
+        audited.push({
+          name: spec.name,
+          version,
+          registry: "npm",
+          license: facts.license,
+          weeklyDownloads: facts.weeklyDownloads,
+          publishedAgo: formatAge(facts.lastPublish),
+          passed: errors.length === 0,
+        });
       }),
     );
 
@@ -435,6 +484,7 @@ export async function checkDependencyTrust(
   return {
     errors: allErrors,
     warnings: allWarnings,
+    audited,
     passed: allErrors.length === 0,
   };
 }

--- a/src/domain/extensions/extension_dependency_trust_checker.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker.ts
@@ -1,0 +1,365 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { DependencySpecifier } from "./extension_dependency_extractor.ts";
+
+export interface DependencyTrustIssue {
+  dependency: string;
+  message: string;
+}
+
+export interface DependencyTrustResult {
+  errors: DependencyTrustIssue[];
+  warnings: DependencyTrustIssue[];
+  passed: boolean;
+}
+
+export interface TrustThresholds {
+  minWeeklyDownloads: number;
+  maxAgeMonths: number;
+  minMaintenance: number;
+}
+
+export const DEFAULT_TRUST_THRESHOLDS: TrustThresholds = {
+  minWeeklyDownloads: 1000,
+  maxAgeMonths: 24,
+  minMaintenance: 0.4,
+};
+
+const LICENSE_ALLOWLIST: ReadonlySet<string> = new Set([
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "0BSD",
+  "MPL-2.0",
+  "Unlicense",
+  "CC0-1.0",
+]);
+
+const OSV_QUERY_URL = "https://api.osv.dev/v1/query";
+const NPM_REGISTRY_URL = "https://registry.npmjs.org";
+const NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week";
+const FETCH_TIMEOUT_MS = 15_000;
+
+interface OsvVuln {
+  id: string;
+  severity: string;
+}
+
+interface NpmPackageFacts {
+  version: string;
+  license: string | null;
+  deprecated: boolean;
+  maintainerCount: number;
+  weeklyDownloads: number | null;
+  lastPublish: string | null;
+}
+
+export type Fetcher = (
+  url: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export function monthsSince(iso: string, now: Date = new Date()): number {
+  const then = new Date(iso);
+  const diffMs = now.getTime() - then.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24 * 30.44));
+}
+
+export function cvssToSeverity(score: number): string {
+  if (score >= 9.0) return "CRITICAL";
+  if (score >= 7.0) return "HIGH";
+  if (score >= 4.0) return "MEDIUM";
+  if (score > 0.0) return "LOW";
+  return "UNKNOWN";
+}
+
+function extractSeverity(vuln: Record<string, unknown>): string {
+  const dbSpecific = vuln.database_specific as
+    | Record<string, unknown>
+    | undefined;
+  if (dbSpecific && typeof dbSpecific.severity === "string") {
+    return String(dbSpecific.severity).toUpperCase();
+  }
+  const sevArr = vuln.severity;
+  if (Array.isArray(sevArr) && sevArr.length > 0) {
+    const first = sevArr[0] as Record<string, unknown>;
+    const score = Number(first.score);
+    if (Number.isFinite(score)) return cvssToSeverity(score);
+  }
+  return "UNKNOWN";
+}
+
+function normaliseVulns(body: unknown): OsvVuln[] {
+  if (!body || typeof body !== "object") return [];
+  const vulns = (body as Record<string, unknown>).vulns;
+  if (!Array.isArray(vulns)) return [];
+  return vulns.map((v) => {
+    const obj = v as Record<string, unknown>;
+    return {
+      id: String(obj.id ?? "OSV-UNKNOWN"),
+      severity: extractSeverity(obj),
+    };
+  });
+}
+
+export function parseSpdxLicense(
+  license: string | null | undefined,
+): string[] {
+  if (!license) return [];
+  return license
+    .replace(/[()]/g, " ")
+    .split(/\s+(?:AND|OR|WITH)\s+/i)
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+export function licenseAllowed(license: string | null | undefined): boolean {
+  const terms = parseSpdxLicense(license);
+  if (terms.length === 0) return false;
+  return terms.every((term) => LICENSE_ALLOWLIST.has(term));
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  fetcher: Fetcher,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetcher(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function queryOsvVulns(
+  name: string,
+  version: string,
+  fetcher: Fetcher,
+): Promise<OsvVuln[]> {
+  try {
+    const resp = await fetchWithTimeout(OSV_QUERY_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        package: { name, ecosystem: "npm" },
+        version,
+      }),
+    }, fetcher);
+    if (!resp.ok) return [];
+    return normaliseVulns(await resp.json());
+  } catch {
+    return [];
+  }
+}
+
+async function fetchNpmFacts(
+  name: string,
+  fetcher: Fetcher,
+): Promise<NpmPackageFacts | null> {
+  try {
+    const [manifestResp, downloadsResp] = await Promise.all([
+      fetchWithTimeout(`${NPM_REGISTRY_URL}/${name}/latest`, {}, fetcher),
+      fetchWithTimeout(`${NPM_DOWNLOADS_URL}/${name}`, {}, fetcher),
+    ]);
+
+    if (!manifestResp.ok) return null;
+    const manifest = await manifestResp.json() as Record<string, unknown>;
+
+    let weeklyDownloads: number | null = null;
+    if (downloadsResp.ok) {
+      const dlBody = await downloadsResp.json() as Record<string, unknown>;
+      if (typeof dlBody.downloads === "number") {
+        weeklyDownloads = dlBody.downloads;
+      }
+    } else {
+      await downloadsResp.body?.cancel();
+    }
+
+    const version = String(manifest.version ?? "unknown");
+    const rawLicense = manifest.license;
+    const license = typeof rawLicense === "string"
+      ? rawLicense
+      : (rawLicense && typeof rawLicense === "object" &&
+          typeof (rawLicense as Record<string, unknown>).type === "string")
+      ? (rawLicense as Record<string, unknown>).type as string
+      : null;
+
+    const deprecated = !!manifest.deprecated;
+    const maintainers = manifest.maintainers;
+    const maintainerCount = Array.isArray(maintainers) ? maintainers.length : 0;
+
+    let lastPublish: string | null = null;
+    try {
+      const pkgResp = await fetchWithTimeout(
+        `${NPM_REGISTRY_URL}/${name}`,
+        {},
+        fetcher,
+      );
+      if (pkgResp.ok) {
+        const pkgBody = await pkgResp.json() as Record<string, unknown>;
+        const time = pkgBody.time as Record<string, string> | undefined;
+        if (time) {
+          lastPublish = time[version] ?? time.modified ?? null;
+        }
+      } else {
+        await pkgResp.body?.cancel();
+      }
+    } catch {
+      // publish date is best-effort
+    }
+
+    return {
+      version,
+      license,
+      deprecated,
+      maintainerCount,
+      weeklyDownloads,
+      lastPublish,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function evaluateNpmTrustGates(
+  name: string,
+  facts: NpmPackageFacts,
+  vulns: OsvVuln[],
+  thresholds: TrustThresholds = DEFAULT_TRUST_THRESHOLDS,
+  now: Date = new Date(),
+): { errors: DependencyTrustIssue[]; warnings: DependencyTrustIssue[] } {
+  const errors: DependencyTrustIssue[] = [];
+  const warnings: DependencyTrustIssue[] = [];
+
+  if (facts.deprecated) {
+    errors.push({ dependency: name, message: "package is deprecated" });
+  }
+
+  for (const v of vulns) {
+    const sev = v.severity.toUpperCase();
+    if (sev === "HIGH" || sev === "CRITICAL" || sev === "UNKNOWN") {
+      errors.push({
+        dependency: name,
+        message: `vulnerability ${v.id} (${sev})`,
+      });
+    } else if (sev === "MEDIUM") {
+      warnings.push({
+        dependency: name,
+        message: `vulnerability ${v.id} (${sev})`,
+      });
+    }
+  }
+
+  if (!licenseAllowed(facts.license)) {
+    warnings.push({
+      dependency: name,
+      message: `license "${facts.license ?? "unknown"}" not in allowlist`,
+    });
+  }
+
+  if (facts.maintainerCount === 0) {
+    warnings.push({ dependency: name, message: "no maintainers listed" });
+  }
+
+  if (
+    facts.weeklyDownloads !== null &&
+    facts.weeklyDownloads < thresholds.minWeeklyDownloads
+  ) {
+    warnings.push({
+      dependency: name,
+      message:
+        `low weekly downloads (${facts.weeklyDownloads} < ${thresholds.minWeeklyDownloads})`,
+    });
+  }
+
+  if (facts.lastPublish) {
+    const ageMonths = monthsSince(facts.lastPublish, now);
+    if (ageMonths > thresholds.maxAgeMonths) {
+      warnings.push({
+        dependency: name,
+        message:
+          `last published ${ageMonths} months ago (threshold: ${thresholds.maxAgeMonths})`,
+      });
+    }
+  }
+
+  return { errors, warnings };
+}
+
+export async function checkDependencyTrust(
+  specifiers: DependencySpecifier[],
+  fetcher: Fetcher = fetch,
+  thresholds: TrustThresholds = DEFAULT_TRUST_THRESHOLDS,
+): Promise<DependencyTrustResult> {
+  const allErrors: DependencyTrustIssue[] = [];
+  const allWarnings: DependencyTrustIssue[] = [];
+
+  const npmSpecs = specifiers.filter((s) => s.registry === "npm");
+
+  // jsr packages trust jsr's built-in enforcement (SPDX license,
+  // provenance, no install scripts) — skip gates where data is unavailable
+
+  const CONCURRENCY = 5;
+  for (let i = 0; i < npmSpecs.length; i += CONCURRENCY) {
+    const batch = npmSpecs.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      batch.map(async (spec) => {
+        const facts = await fetchNpmFacts(spec.name, fetcher);
+        if (!facts) {
+          allWarnings.push({
+            dependency: spec.name,
+            message: "could not fetch package metadata (API unreachable)",
+          });
+          return;
+        }
+
+        const version = spec.version ?? facts.version;
+        const vulns = await queryOsvVulns(spec.name, version, fetcher);
+        const { errors, warnings } = evaluateNpmTrustGates(
+          spec.name,
+          facts,
+          vulns,
+          thresholds,
+        );
+        allErrors.push(...errors);
+        allWarnings.push(...warnings);
+      }),
+    );
+
+    for (const result of results) {
+      if (result.status === "rejected") {
+        allWarnings.push({
+          dependency: "unknown",
+          message: `audit check failed: ${String(result.reason)}`,
+        });
+      }
+    }
+  }
+
+  return {
+    errors: allErrors,
+    warnings: allWarnings,
+    passed: allErrors.length === 0,
+  };
+}

--- a/src/domain/extensions/extension_dependency_trust_checker.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker.ts
@@ -90,28 +90,86 @@ export function cvssToSeverity(score: number): string {
   return "UNKNOWN";
 }
 
+const CVSS_V3_AV: Record<string, number> = {
+  N: 0.85,
+  A: 0.62,
+  L: 0.55,
+  P: 0.20,
+};
+const CVSS_V3_AC: Record<string, number> = { L: 0.77, H: 0.44 };
+const CVSS_V3_PR_U: Record<string, number> = { N: 0.85, L: 0.62, H: 0.27 };
+const CVSS_V3_PR_C: Record<string, number> = { N: 0.85, L: 0.68, H: 0.50 };
+const CVSS_V3_UI: Record<string, number> = { N: 0.85, R: 0.62 };
+const CVSS_V3_CIA: Record<string, number> = { N: 0, L: 0.22, H: 0.56 };
+
+export function parseCvssV3BaseScore(vector: string): number | null {
+  if (!vector.startsWith("CVSS:3")) return null;
+  const parts: Record<string, string> = {};
+  for (const seg of vector.split("/")) {
+    const [k, v] = seg.split(":");
+    if (k && v) parts[k] = v;
+  }
+  const av = CVSS_V3_AV[parts.AV ?? ""];
+  const ac = CVSS_V3_AC[parts.AC ?? ""];
+  const scope = parts.S;
+  const pr = scope === "C"
+    ? CVSS_V3_PR_C[parts.PR ?? ""]
+    : CVSS_V3_PR_U[parts.PR ?? ""];
+  const ui = CVSS_V3_UI[parts.UI ?? ""];
+  const c = CVSS_V3_CIA[parts.C ?? ""];
+  const i = CVSS_V3_CIA[parts.I ?? ""];
+  const a = CVSS_V3_CIA[parts.A ?? ""];
+  if (
+    av == null || ac == null || pr == null || ui == null ||
+    c == null || i == null || a == null || !scope
+  ) {
+    return null;
+  }
+  const iss = 1 - (1 - c) * (1 - i) * (1 - a);
+  if (iss <= 0) return 0;
+  const exploitability = 8.22 * av * ac * pr * ui;
+  const impact = scope === "C"
+    ? 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15)
+    : 6.42 * iss;
+  if (impact <= 0) return 0;
+  const raw = scope === "C"
+    ? 1.08 * (impact + exploitability)
+    : impact + exploitability;
+  return Math.min(Math.ceil(raw * 10) / 10, 10);
+}
+
 function extractSeverity(vuln: Record<string, unknown>): string {
   const dbSpecific = vuln.database_specific as
     | Record<string, unknown>
     | undefined;
   if (dbSpecific && typeof dbSpecific.severity === "string") {
-    return String(dbSpecific.severity).toUpperCase();
+    const upper = dbSpecific.severity.toUpperCase();
+    if (upper === "MODERATE") return "MEDIUM";
+    return upper;
   }
   const sevArr = vuln.severity;
   if (Array.isArray(sevArr) && sevArr.length > 0) {
+    let highest: string = "UNKNOWN";
     for (const entry of sevArr) {
       const obj = entry as Record<string, unknown>;
-      if (typeof obj.score === "number" && Number.isFinite(obj.score)) {
-        return cvssToSeverity(obj.score);
+      let numeric: number | null = null;
+      if (typeof obj.score === "number") {
+        numeric = obj.score;
+      } else if (typeof obj.score === "string") {
+        numeric = parseCvssV3BaseScore(obj.score);
       }
-      if (typeof obj.score === "string") {
-        const numeric = Number(obj.score);
-        if (Number.isFinite(numeric)) return cvssToSeverity(numeric);
-      }
-      if (typeof obj.baseScore === "number" && Number.isFinite(obj.baseScore)) {
-        return cvssToSeverity(obj.baseScore);
+      if (numeric !== null) {
+        if (numeric >= 9.0) return "CRITICAL";
+        if (numeric >= 7.0) {
+          highest = "HIGH";
+        } else if (numeric >= 4.0 && highest !== "HIGH") {
+          highest = "MEDIUM";
+        } else if (numeric < 4.0 && highest === "UNKNOWN") {
+          highest = "LOW";
+        }
       }
     }
+    return highest;
   }
   return "UNKNOWN";
 }

--- a/src/domain/extensions/extension_dependency_trust_checker_test.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker_test.ts
@@ -27,6 +27,7 @@ import {
   type Fetcher,
   licenseAllowed,
   monthsSince,
+  parseCvssV3BaseScore,
   parseSpdxLicense,
 } from "./extension_dependency_trust_checker.ts";
 
@@ -52,6 +53,42 @@ Deno.test("monthsSince: computes months correctly", () => {
   assertEquals(monthsSince("2026-04-02T00:00:00Z", now), 1);
   // Large gap: ~900 days
   assertEquals(monthsSince("2024-01-01T00:00:00Z", now) > 25, true);
+});
+
+Deno.test("parseCvssV3BaseScore: parses CRITICAL vector", () => {
+  const score = parseCvssV3BaseScore(
+    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+  );
+  assertEquals(score !== null && score >= 9.0, true);
+});
+
+Deno.test("parseCvssV3BaseScore: parses LOW vector", () => {
+  const score = parseCvssV3BaseScore(
+    "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N",
+  );
+  assertEquals(score !== null && score < 4.0, true);
+});
+
+Deno.test("parseCvssV3BaseScore: returns null for non-CVSS string", () => {
+  assertEquals(parseCvssV3BaseScore("not a vector"), null);
+});
+
+Deno.test("evaluateNpmTrustGates: MODERATE GHSA severity is a warning", () => {
+  const { errors, warnings } = evaluateNpmTrustGates(
+    "test-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 2,
+      weeklyDownloads: 10000,
+      lastPublish: "2026-01-01T00:00:00Z",
+    },
+    [{ id: "GHSA-mod1", severity: "MEDIUM" }],
+  );
+  assertEquals(errors.length, 0);
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].message, "vulnerability GHSA-mod1 (MEDIUM)");
 });
 
 Deno.test("parseSpdxLicense: splits compound expressions", () => {

--- a/src/domain/extensions/extension_dependency_trust_checker_test.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker_test.ts
@@ -1,0 +1,355 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { DependencySpecifier } from "./extension_dependency_extractor.ts";
+import {
+  checkDependencyTrust,
+  cvssToSeverity,
+  DEFAULT_TRUST_THRESHOLDS,
+  evaluateNpmTrustGates,
+  type Fetcher,
+  licenseAllowed,
+  monthsSince,
+  parseSpdxLicense,
+} from "./extension_dependency_trust_checker.ts";
+
+// ── Pure function tests ─────────────────────────────────────────────────
+
+Deno.test("cvssToSeverity: maps scores correctly", () => {
+  assertEquals(cvssToSeverity(9.5), "CRITICAL");
+  assertEquals(cvssToSeverity(9.0), "CRITICAL");
+  assertEquals(cvssToSeverity(7.5), "HIGH");
+  assertEquals(cvssToSeverity(7.0), "HIGH");
+  assertEquals(cvssToSeverity(5.0), "MEDIUM");
+  assertEquals(cvssToSeverity(4.0), "MEDIUM");
+  assertEquals(cvssToSeverity(2.0), "LOW");
+  assertEquals(cvssToSeverity(0.0), "UNKNOWN");
+});
+
+Deno.test("monthsSince: computes months correctly", () => {
+  const now = new Date("2026-06-01T00:00:00Z");
+  assertEquals(monthsSince("2026-06-01T00:00:00Z", now), 0);
+  // 30 days is ~0.98 months → floors to 0
+  assertEquals(monthsSince("2026-05-02T00:00:00Z", now), 0);
+  // 60 days is ~1.97 months → floors to 1
+  assertEquals(monthsSince("2026-04-02T00:00:00Z", now), 1);
+  // Large gap: ~900 days
+  assertEquals(monthsSince("2024-01-01T00:00:00Z", now) > 25, true);
+});
+
+Deno.test("parseSpdxLicense: splits compound expressions", () => {
+  assertEquals(parseSpdxLicense("MIT"), ["MIT"]);
+  assertEquals(parseSpdxLicense("MIT OR Apache-2.0"), ["MIT", "Apache-2.0"]);
+  assertEquals(parseSpdxLicense("(MIT AND ISC)"), ["MIT", "ISC"]);
+  assertEquals(parseSpdxLicense(null), []);
+  assertEquals(parseSpdxLicense(""), []);
+});
+
+Deno.test("licenseAllowed: validates against allowlist", () => {
+  assertEquals(licenseAllowed("MIT"), true);
+  assertEquals(licenseAllowed("Apache-2.0"), true);
+  assertEquals(licenseAllowed("GPL-3.0"), false);
+  assertEquals(licenseAllowed("MIT OR Apache-2.0"), true);
+  assertEquals(licenseAllowed("MIT AND GPL-3.0"), false);
+  assertEquals(licenseAllowed(null), false);
+});
+
+// ── evaluateNpmTrustGates tests ─────────────────────────────────────────
+
+Deno.test("evaluateNpmTrustGates: passes for healthy package", () => {
+  const { errors, warnings } = evaluateNpmTrustGates(
+    "axios",
+    {
+      version: "1.7.2",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 3,
+      weeklyDownloads: 50_000_000,
+      lastPublish: "2026-04-01T00:00:00Z",
+    },
+    [],
+    DEFAULT_TRUST_THRESHOLDS,
+    new Date("2026-06-01T00:00:00Z"),
+  );
+  assertEquals(errors.length, 0);
+  assertEquals(warnings.length, 0);
+});
+
+Deno.test("evaluateNpmTrustGates: deprecated package is an error", () => {
+  const { errors } = evaluateNpmTrustGates(
+    "old-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: true,
+      maintainerCount: 1,
+      weeklyDownloads: 5000,
+      lastPublish: "2025-01-01T00:00:00Z",
+    },
+    [],
+  );
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0].message, "package is deprecated");
+});
+
+Deno.test("evaluateNpmTrustGates: HIGH vuln is an error", () => {
+  const { errors } = evaluateNpmTrustGates(
+    "vuln-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 2,
+      weeklyDownloads: 10000,
+      lastPublish: "2026-01-01T00:00:00Z",
+    },
+    [{ id: "GHSA-1234", severity: "HIGH" }],
+  );
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0].message, "vulnerability GHSA-1234 (HIGH)");
+});
+
+Deno.test("evaluateNpmTrustGates: MEDIUM vuln is a warning", () => {
+  const { errors, warnings } = evaluateNpmTrustGates(
+    "vuln-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 2,
+      weeklyDownloads: 10000,
+      lastPublish: "2026-01-01T00:00:00Z",
+    },
+    [{ id: "GHSA-5678", severity: "MEDIUM" }],
+  );
+  assertEquals(errors.length, 0);
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].message, "vulnerability GHSA-5678 (MEDIUM)");
+});
+
+Deno.test("evaluateNpmTrustGates: low downloads is a warning", () => {
+  const { warnings } = evaluateNpmTrustGates(
+    "niche-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 1,
+      weeklyDownloads: 50,
+      lastPublish: "2026-05-01T00:00:00Z",
+    },
+    [],
+  );
+  const dlWarning = warnings.find((w) => w.message.includes("downloads"));
+  assertEquals(dlWarning !== undefined, true);
+});
+
+Deno.test("evaluateNpmTrustGates: stale publish is a warning", () => {
+  const { warnings } = evaluateNpmTrustGates(
+    "stale-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 2,
+      weeklyDownloads: 5000,
+      lastPublish: "2023-01-01T00:00:00Z",
+    },
+    [],
+    DEFAULT_TRUST_THRESHOLDS,
+    new Date("2026-06-01T00:00:00Z"),
+  );
+  const staleWarning = warnings.find((w) => w.message.includes("months ago"));
+  assertEquals(staleWarning !== undefined, true);
+});
+
+Deno.test("evaluateNpmTrustGates: bad license is a warning", () => {
+  const { warnings } = evaluateNpmTrustGates(
+    "gpl-pkg",
+    {
+      version: "1.0.0",
+      license: "GPL-3.0",
+      deprecated: false,
+      maintainerCount: 2,
+      weeklyDownloads: 5000,
+      lastPublish: "2026-01-01T00:00:00Z",
+    },
+    [],
+  );
+  const licWarning = warnings.find((w) => w.message.includes("license"));
+  assertEquals(licWarning !== undefined, true);
+});
+
+Deno.test("evaluateNpmTrustGates: no maintainers is a warning", () => {
+  const { warnings } = evaluateNpmTrustGates(
+    "orphan-pkg",
+    {
+      version: "1.0.0",
+      license: "MIT",
+      deprecated: false,
+      maintainerCount: 0,
+      weeklyDownloads: 5000,
+      lastPublish: "2026-01-01T00:00:00Z",
+    },
+    [],
+  );
+  const maintWarning = warnings.find((w) =>
+    w.message.includes("no maintainers")
+  );
+  assertEquals(maintWarning !== undefined, true);
+});
+
+// ── Integration tests with mocked fetcher ───────────────────────────────
+
+function createMockFetcher(
+  responses: Record<string, { status: number; body: unknown }>,
+): Fetcher {
+  return (url: string | URL, _init?: RequestInit) => {
+    const urlStr = url.toString();
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (urlStr.includes(pattern)) {
+        return Promise.resolve(
+          new Response(JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+    }
+    return Promise.resolve(new Response("Not found", { status: 404 }));
+  };
+}
+
+Deno.test("checkDependencyTrust: passes for healthy npm package", async () => {
+  const specs: DependencySpecifier[] = [{
+    name: "axios",
+    version: "1.7.2",
+    registry: "npm",
+    sourceFile: "model.ts",
+  }];
+
+  const fetcher = createMockFetcher({
+    "registry.npmjs.org/axios/latest": {
+      status: 200,
+      body: {
+        version: "1.7.2",
+        license: "MIT",
+        maintainers: [{ name: "a" }, { name: "b" }],
+      },
+    },
+    "api.npmjs.org/downloads": {
+      status: 200,
+      body: { downloads: 50_000_000 },
+    },
+    "registry.npmjs.org/axios": {
+      status: 200,
+      body: { time: { "1.7.2": "2026-04-01T00:00:00Z" } },
+    },
+    "api.osv.dev": { status: 200, body: { vulns: [] } },
+  });
+
+  const result = await checkDependencyTrust(specs, fetcher);
+  assertEquals(result.passed, true);
+  assertEquals(result.errors.length, 0);
+});
+
+Deno.test("checkDependencyTrust: blocks on HIGH vulnerability", async () => {
+  const specs: DependencySpecifier[] = [{
+    name: "vulnerable-pkg",
+    version: "1.0.0",
+    registry: "npm",
+    sourceFile: "model.ts",
+  }];
+
+  const fetcher = createMockFetcher({
+    "registry.npmjs.org/vulnerable-pkg/latest": {
+      status: 200,
+      body: {
+        version: "1.0.0",
+        license: "MIT",
+        maintainers: [{ name: "a" }],
+      },
+    },
+    "api.npmjs.org/downloads": {
+      status: 200,
+      body: { downloads: 10000 },
+    },
+    "registry.npmjs.org/vulnerable-pkg": {
+      status: 200,
+      body: { time: { "1.0.0": "2026-01-01T00:00:00Z" } },
+    },
+    "api.osv.dev": {
+      status: 200,
+      body: {
+        vulns: [{
+          id: "GHSA-1234",
+          database_specific: { severity: "HIGH" },
+        }],
+      },
+    },
+  });
+
+  const result = await checkDependencyTrust(specs, fetcher);
+  assertEquals(result.passed, false);
+  assertEquals(result.errors.length, 1);
+});
+
+Deno.test("checkDependencyTrust: skips jsr packages (trusted)", async () => {
+  const specs: DependencySpecifier[] = [{
+    name: "@std/semver",
+    version: "1.0.8",
+    registry: "jsr",
+    sourceFile: "model.ts",
+  }];
+
+  const fetcher = createMockFetcher({});
+  const result = await checkDependencyTrust(specs, fetcher);
+  assertEquals(result.passed, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("checkDependencyTrust: graceful degradation on API failure", async () => {
+  const specs: DependencySpecifier[] = [{
+    name: "some-pkg",
+    version: "1.0.0",
+    registry: "npm",
+    sourceFile: "model.ts",
+  }];
+
+  const fetcher: Fetcher = () => {
+    return Promise.resolve(new Response("Internal error", { status: 500 }));
+  };
+
+  const result = await checkDependencyTrust(specs, fetcher);
+  assertEquals(result.passed, true);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(
+    result.warnings[0].message.includes("could not fetch"),
+    true,
+  );
+});
+
+Deno.test("checkDependencyTrust: empty specifiers passes", async () => {
+  const result = await checkDependencyTrust([], fetch);
+  assertEquals(result.passed, true);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.warnings.length, 0);
+});

--- a/src/domain/extensions/extension_dependency_trust_checker_test.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker_test.ts
@@ -246,21 +246,23 @@ Deno.test("checkDependencyTrust: passes for healthy npm package", async () => {
   }];
 
   const fetcher = createMockFetcher({
-    "registry.npmjs.org/axios/latest": {
+    "registry.npmjs.org/axios": {
       status: 200,
       body: {
-        version: "1.7.2",
-        license: "MIT",
-        maintainers: [{ name: "a" }, { name: "b" }],
+        "dist-tags": { latest: "1.7.2" },
+        versions: {
+          "1.7.2": {
+            version: "1.7.2",
+            license: "MIT",
+            maintainers: [{ name: "a" }, { name: "b" }],
+          },
+        },
+        time: { "1.7.2": "2026-04-01T00:00:00Z" },
       },
     },
     "api.npmjs.org/downloads": {
       status: 200,
       body: { downloads: 50_000_000 },
-    },
-    "registry.npmjs.org/axios": {
-      status: 200,
-      body: { time: { "1.7.2": "2026-04-01T00:00:00Z" } },
     },
     "api.osv.dev": { status: 200, body: { vulns: [] } },
   });
@@ -279,21 +281,23 @@ Deno.test("checkDependencyTrust: blocks on HIGH vulnerability", async () => {
   }];
 
   const fetcher = createMockFetcher({
-    "registry.npmjs.org/vulnerable-pkg/latest": {
+    "registry.npmjs.org/vulnerable-pkg": {
       status: 200,
       body: {
-        version: "1.0.0",
-        license: "MIT",
-        maintainers: [{ name: "a" }],
+        "dist-tags": { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            version: "1.0.0",
+            license: "MIT",
+            maintainers: [{ name: "a" }],
+          },
+        },
+        time: { "1.0.0": "2026-01-01T00:00:00Z" },
       },
     },
     "api.npmjs.org/downloads": {
       status: 200,
       body: { downloads: 10000 },
-    },
-    "registry.npmjs.org/vulnerable-pkg": {
-      status: 200,
-      body: { time: { "1.0.0": "2026-01-01T00:00:00Z" } },
     },
     "api.osv.dev": {
       status: 200,

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -51,7 +51,7 @@ import type { ExtensionManifest } from "./extension_manifest.ts";
  */
 
 /** Schema version. Matches swamp-club's RUBRIC_VERSION. */
-export const RUBRIC_VERSION = 2;
+export const RUBRIC_VERSION = 3;
 
 /**
  * Slow-type diagnostic codes emitted by `deno doc --lint`. When any of
@@ -191,6 +191,8 @@ export interface AnalysisFactors {
   readmeLength: number | null;
   readmeCodeBlockCount: number | null;
   hasLicenseFile: boolean;
+  dependencyTrustPassed: boolean;
+  dependencyTrustBlockerCount: number;
 }
 
 /**
@@ -204,6 +206,8 @@ export function computeAnalysisFactors(input: {
   hasLicenseFile: boolean;
   doc: DocOutput;
   rawLintOutput: string;
+  dependencyTrustPassed?: boolean;
+  dependencyTrustBlockerCount?: number;
 }): AnalysisFactors {
   const { entrypointUrls, readme, hasLicenseFile, doc, rawLintOutput } = input;
 
@@ -243,6 +247,8 @@ export function computeAnalysisFactors(input: {
     readmeLength,
     readmeCodeBlockCount,
     hasLicenseFile,
+    dependencyTrustPassed: input.dependencyTrustPassed ?? false,
+    dependencyTrustBlockerCount: input.dependencyTrustBlockerCount ?? 0,
   };
 }
 
@@ -380,6 +386,10 @@ export function composeScore(
           "codeberg.org, or bitbucket.org. Server will verify it resolves publicly.",
       },
     ),
+    dependencyTrustRow(
+      factors.dependencyTrustPassed,
+      factors.dependencyTrustBlockerCount,
+    ),
   ];
 
   const earned = rows.reduce((s, r) => s + r.earnedPoints, 0);
@@ -439,6 +449,25 @@ function richReadmeRow(
     remediation: earned
       ? undefined
       : `Expand README to ≥${RICH_README_MIN_LENGTH} chars with ≥${RICH_README_MIN_CODE_BLOCKS} fenced blocks.`,
+  };
+}
+
+function dependencyTrustRow(
+  passed: boolean,
+  blockerCount: number,
+): RubricFactor {
+  const remediation = blockerCount > 0
+    ? `${blockerCount} dependency blocker(s) found (deprecated packages or ` +
+      `HIGH/CRITICAL vulnerabilities). Run 'swamp extension quality' to see details, ` +
+      `then update or replace the flagged dependencies.`
+    : "Resolve dependency trust issues — run 'swamp extension quality' for details.";
+  return {
+    id: "dependency-trust",
+    label: "Dependencies pass trust gates",
+    earnedPoints: passed ? 2 : 0,
+    maxPoints: 2,
+    status: passed ? "earned" : "missing",
+    remediation: passed ? undefined : remediation,
   };
 }
 
@@ -552,6 +581,10 @@ export async function scoreExtensionTarball(
   tarballBytes: Uint8Array,
   manifest: ExtensionManifest,
   deps: RubricScoreDeps,
+  options?: {
+    dependencyTrustPassed?: boolean;
+    dependencyTrustBlockerCount?: number;
+  },
 ): Promise<RubricScore> {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_quality_" });
   try {
@@ -610,6 +643,8 @@ export async function scoreExtensionTarball(
       hasLicenseFile,
       doc,
       rawLintOutput: lintOutput,
+      dependencyTrustPassed: options?.dependencyTrustPassed,
+      dependencyTrustBlockerCount: options?.dependencyTrustBlockerCount,
     });
 
     return composeScore(analysisFactors, manifest);

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -458,9 +458,9 @@ function dependencyTrustRow(
 ): RubricFactor {
   const remediation = blockerCount > 0
     ? `${blockerCount} dependency blocker(s) found (deprecated packages or ` +
-      `HIGH/CRITICAL vulnerabilities). Run 'swamp extension quality' to see details, ` +
+      `HIGH/CRITICAL vulnerabilities). See the blocker details above, ` +
       `then update or replace the flagged dependencies.`
-    : "Resolve dependency trust issues — run 'swamp extension quality' for details.";
+    : "Resolve dependency trust issues — update or replace flagged dependencies.";
   return {
     id: "dependency-trust",
     label: "Dependencies pass trust gates",

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -64,8 +64,8 @@ function makeManifest(
 
 // ── Pure helper tests (mirror server analysis-factors_test.ts) ─────────
 
-Deno.test("RUBRIC_VERSION is 2 (matches swamp-club)", () => {
-  assertEquals(RUBRIC_VERSION, 2);
+Deno.test("RUBRIC_VERSION is 3 (matches swamp-club)", () => {
+  assertEquals(RUBRIC_VERSION, 3);
 });
 
 Deno.test("SLOW_TYPE_CODES contains expected codes", () => {
@@ -381,13 +381,15 @@ function factorsAllEarned(): Parameters<typeof composeScore>[0] {
     readmeLength: 800,
     readmeCodeBlockCount: 3,
     hasLicenseFile: true,
+    dependencyTrustPassed: true,
+    dependencyTrustBlockerCount: 0,
   };
 }
 
-Deno.test("composeScore: perfect extension earns 12/12 (100%)", () => {
+Deno.test("composeScore: perfect extension earns 14/14 (100%)", () => {
   const score = composeScore(factorsAllEarned(), makeManifest());
-  assertEquals(score.earnedPoints, 12);
-  assertEquals(score.maxEarnablePoints, 12);
+  assertEquals(score.earnedPoints, 14);
+  assertEquals(score.maxEarnablePoints, 14);
   assertEquals(score.percentage, 100);
   assertEquals(score.allPassed, true);
 });
@@ -526,17 +528,18 @@ Deno.test("composeScore: factor IDs and order match server", () => {
     "platforms",
     "has-license",
     "repository-verified",
+    "dependency-trust",
   ]);
 });
 
 Deno.test("composeScore: percentage floors (not rounds)", () => {
-  // 11/12 = 91.67 → floor = 91
+  // 13/14 = 92.86 → floor = 92
   const score = composeScore(
     { ...factorsAllEarned(), hasLicenseFile: false },
     makeManifest(),
   );
-  assertEquals(score.earnedPoints, 11);
-  assertEquals(score.percentage, 91);
+  assertEquals(score.earnedPoints, 13);
+  assertEquals(score.percentage, 92);
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -699,6 +702,8 @@ Deno.test(
       readmeLength: readme.length,
       readmeCodeBlockCount: 1,
       hasLicenseFile: false,
+      dependencyTrustPassed: false,
+      dependencyTrustBlockerCount: 0,
     });
   },
 );
@@ -829,6 +834,8 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
       readmeLength: null,
       readmeCodeBlockCount: null,
       hasLicenseFile: false,
+      dependencyTrustPassed: false,
+      dependencyTrustBlockerCount: 0,
     },
     makeManifest({
       description: "",
@@ -836,11 +843,11 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
       platforms: [],
     }),
   );
-  // Universal platforms earns 2 points (single platforms factor).
+  // Universal platforms earns 2 points only; dependency-trust fails.
   assertEquals(score.earnedPoints, 2);
-  assertEquals(score.percentage, Math.floor((2 * 100) / 12));
-  assertEquals(score.rubricVersion, 2);
-  assertEquals(score.factors.length, 9);
+  assertEquals(score.percentage, Math.floor((2 * 100) / 14));
+  assertEquals(score.rubricVersion, 3);
+  assertEquals(score.factors.length, 10);
   const byId = new Map(score.factors.map((f) => [f.id, f]));
   assertEquals(byId.get("platforms")?.status, "earned");
   assertEquals(byId.get("platforms")?.earnedPoints, 2);
@@ -853,19 +860,19 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
 
 Deno.test("[parity] composeScore: perfect score hits 100% without any verification badge", () => {
   const score = composeScore(factorsAllEarned(), makeManifest());
-  // 12/12
-  assertEquals(score.earnedPoints, 12);
+  // 14/14
+  assertEquals(score.earnedPoints, 14);
   assertEquals(score.percentage, 100);
   assertEquals(score.allPassed, true);
 });
 
-Deno.test("[parity] composeScore: percentage floors (11/12 → 91)", () => {
+Deno.test("[parity] composeScore: percentage floors (13/14 → 92)", () => {
   const score = composeScore(
     { ...factorsAllEarned(), hasLicenseFile: false },
     makeManifest(),
   );
-  assertEquals(score.earnedPoints, 11);
-  assertEquals(score.percentage, 91);
+  assertEquals(score.earnedPoints, 13);
+  assertEquals(score.percentage, 92);
 });
 
 Deno.test("[parity] composeScore: platforms factor earns 2 for any count", () => {
@@ -895,4 +902,27 @@ Deno.test("[parity] composeScore: platforms factor earns 2 for any count", () =>
   const m3 = new Map(s3.factors.map((f) => [f.id, f]));
   assertEquals(m3.get("platforms")?.status, "earned");
   assertEquals(m3.get("platforms")?.earnedPoints, 2);
+});
+
+Deno.test("composeScore: dependency-trust is worth 2 points when passing", () => {
+  const score = composeScore(factorsAllEarned(), makeManifest());
+  const factor = score.factors.find((f) => f.id === "dependency-trust")!;
+  assertEquals(factor.maxPoints, 2);
+  assertEquals(factor.earnedPoints, 2);
+  assertEquals(factor.status, "earned");
+});
+
+Deno.test("composeScore: dependency-trust fails with blockers", () => {
+  const score = composeScore(
+    {
+      ...factorsAllEarned(),
+      dependencyTrustPassed: false,
+      dependencyTrustBlockerCount: 3,
+    },
+    makeManifest(),
+  );
+  const factor = score.factors.find((f) => f.id === "dependency-trust")!;
+  assertEquals(factor.earnedPoints, 0);
+  assertEquals(factor.status, "missing");
+  assertStringIncludes(factor.remediation ?? "", "3 dependency blocker(s)");
 });

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -31,6 +31,8 @@ import type {
   SafetyIssue,
 } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityCheckResult } from "../../domain/extensions/extension_quality_checker.ts";
+import type { DependencySpecifier } from "../../domain/extensions/extension_dependency_extractor.ts";
+import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { ExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -171,6 +173,7 @@ export interface ExtensionPushPrepareInput {
 export interface ExtensionPushPrepared {
   resolvedData: ExtensionPushResolvedData;
   safetyWarnings: SafetyIssue[];
+  dependencyTrustResult: DependencyTrustResult;
   archiveBytes: Uint8Array;
   manifest: ExtensionManifest;
   contentMetadata: ExtensionContentMetadata | undefined;
@@ -244,6 +247,12 @@ export interface ExtensionPushPrepareDeps {
     denoPath: string,
     options?: { denoConfigPath?: string; packageJsonDir?: string },
   ) => Promise<string>;
+  extractDependencySpecifiers: (
+    sourceFiles: string[],
+  ) => Promise<DependencySpecifier[]>;
+  checkDependencyTrust: (
+    specifiers: DependencySpecifier[],
+  ) => Promise<DependencyTrustResult>;
   ensureDenoPath: () => Promise<string>;
   getLatestVersion: (
     serverUrl: string,
@@ -297,6 +306,8 @@ import {
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { checkExtensionQuality } from "../../domain/extensions/extension_quality_checker.ts";
+import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
+import { checkDependencyTrust } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import { bundleExtension } from "../../domain/models/bundle.ts";
 import { extractContentMetadata } from "../../domain/extensions/extension_content_extractor.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
@@ -329,6 +340,8 @@ export function createExtensionPushPrepareDeps(): ExtensionPushPrepareDeps {
     extractContentMetadata,
     analyzeExtensionSafety,
     checkExtensionQuality,
+    extractDependencySpecifiers,
+    checkDependencyTrust,
     bundleEntryPoint: bundleExtension,
     ensureDenoPath: () => denoRuntime.ensureDeno(),
     getLatestVersion: async (serverUrl, name, apiKey) => {
@@ -512,7 +525,30 @@ export async function extensionPushPrepare(
     );
   }
 
-  // 6b. Validate skills and populate content metadata
+  // 6b. Dependency trust audit
+  let dependencyTrustResult: DependencyTrustResult;
+  const sourceFiles = [
+    ...input.allModelFiles,
+    ...input.allVaultFiles,
+    ...input.allDriverFiles,
+    ...input.allDatastoreFiles,
+    ...input.allReportFiles,
+  ];
+  const specifiers = await deps.extractDependencySpecifiers(sourceFiles);
+  if (specifiers.length > 0) {
+    ctx.logger.debug`Auditing ${specifiers.length} dependency specifier(s)`;
+    dependencyTrustResult = await deps.checkDependencyTrust(specifiers);
+    if (dependencyTrustResult.errors.length > 0) {
+      throw validationFailed(
+        "Extension has dependency trust errors that must be resolved before pushing.",
+        { dependencyTrustErrors: dependencyTrustResult.errors },
+      );
+    }
+  } else {
+    dependencyTrustResult = { errors: [], warnings: [], passed: true };
+  }
+
+  // 6c. Validate skills and populate content metadata
   if (input.skillDirs.length > 0) {
     const skillResult = await validateExtensionSkills(input.skillDirs);
     if (skillResult.errors.length > 0) {
@@ -597,6 +633,7 @@ export async function extensionPushPrepare(
   return {
     resolvedData,
     safetyWarnings: safetyResult.warnings,
+    dependencyTrustResult,
     archiveBytes,
     manifest: input.manifest,
     contentMetadata,

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -525,7 +525,7 @@ export async function extensionPushPrepare(
     );
   }
 
-  // 6b. Dependency trust audit
+  // 7. Dependency trust audit
   let dependencyTrustResult: DependencyTrustResult;
   const sourceFiles = [
     ...input.allModelFiles,
@@ -545,10 +545,15 @@ export async function extensionPushPrepare(
       );
     }
   } else {
-    dependencyTrustResult = { errors: [], warnings: [], passed: true };
+    dependencyTrustResult = {
+      errors: [],
+      warnings: [],
+      audited: [],
+      passed: true,
+    };
   }
 
-  // 6c. Validate skills and populate content metadata
+  // 8. Validate skills and populate content metadata
   if (input.skillDirs.length > 0) {
     const skillResult = await validateExtensionSkills(input.skillDirs);
     if (skillResult.errors.length > 0) {
@@ -578,14 +583,14 @@ export async function extensionPushPrepare(
     }
   }
 
-  // 7. Resolve deno binary (only needed when building a fresh archive)
+  // 9. Resolve deno binary (only needed when building a fresh archive)
   const usingCachedArchive = input.cachedArchive !== undefined;
   let denoPath = "";
   if (!usingCachedArchive) {
     denoPath = await deps.ensureDenoPath();
   }
 
-  // 8. Quality checks — skip on cache hit (the cached archive was
+  // 10. Quality checks — skip on cache hit (the cached archive was
   // written only after quality checks passed)
   if (!usingCachedArchive) {
     const qualityResult = await deps.checkExtensionQuality(
@@ -601,7 +606,7 @@ export async function extensionPushPrepare(
     }
   }
 
-  // 9. Bundle entry points + build archive — skip on cache hit
+  // 11. Bundle entry points + build archive — skip on cache hit
   let totalBundles: number;
   let archiveBytes: Uint8Array;
   if (usingCachedArchive) {
@@ -615,7 +620,7 @@ export async function extensionPushPrepare(
     archiveBytes = built.archiveBytes;
   }
 
-  // 10. Check version (skip in dry-run)
+  // 12. Check version (skip in dry-run)
   if (!input.dryRun && credentials) {
     const latest = await deps.getLatestVersion(
       credentials.serverUrl,

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -87,7 +87,7 @@ function makePrepareDeps(
     checkExtensionQuality: () => Promise.resolve({ passed: true, issues: [] }),
     extractDependencySpecifiers: () => Promise.resolve([]),
     checkDependencyTrust: () =>
-      Promise.resolve({ errors: [], warnings: [], passed: true }),
+      Promise.resolve({ errors: [], warnings: [], audited: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -85,6 +85,9 @@ function makePrepareDeps(
       }),
     analyzeExtensionSafety: () => Promise.resolve({ errors: [], warnings: [] }),
     checkExtensionQuality: () => Promise.resolve({ passed: true, issues: [] }),
+    extractDependencySpecifiers: () => Promise.resolve([]),
+    checkDependencyTrust: () =>
+      Promise.resolve({ errors: [], warnings: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -117,7 +117,7 @@ function makePrepareDeps(
     checkExtensionQuality: () => Promise.resolve({ passed: true, issues: [] }),
     extractDependencySpecifiers: () => Promise.resolve([]),
     checkDependencyTrust: () =>
-      Promise.resolve({ errors: [], warnings: [], passed: true }),
+      Promise.resolve({ errors: [], warnings: [], audited: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -115,6 +115,9 @@ function makePrepareDeps(
       }),
     analyzeExtensionSafety: () => Promise.resolve({ errors: [], warnings: [] }),
     checkExtensionQuality: () => Promise.resolve({ passed: true, issues: [] }),
+    extractDependencySpecifiers: () => Promise.resolve([]),
+    checkDependencyTrust: () =>
+      Promise.resolve({ errors: [], warnings: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -32,11 +32,7 @@ import {
 import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
-import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
-import {
-  checkDependencyTrust,
-  type DependencyTrustResult,
-} from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import {
@@ -131,11 +127,18 @@ export async function* extensionQuality(
           ...input.prepareInput.allDatastoreFiles,
           ...input.prepareInput.allReportFiles,
         ];
-        const specifiers = await extractDependencySpecifiers(sourceFiles);
+        const specifiers = await deps.pushPrepareDeps
+          .extractDependencySpecifiers(sourceFiles);
         if (specifiers.length > 0) {
-          dependencyTrustResult = await checkDependencyTrust(specifiers);
+          dependencyTrustResult = await deps.pushPrepareDeps
+            .checkDependencyTrust(specifiers);
         } else {
-          dependencyTrustResult = { errors: [], warnings: [], passed: true };
+          dependencyTrustResult = {
+            errors: [],
+            warnings: [],
+            audited: [],
+            passed: true,
+          };
         }
       } else {
         yield { kind: "packaging" };

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -60,6 +60,7 @@ export interface ExtensionQualityData {
   cacheHash: string;
   archiveSize: number;
   cacheHit: boolean;
+  dependencyTrustResult: DependencyTrustResult;
 }
 
 /** Input to run a quality score. */
@@ -181,6 +182,7 @@ export async function* extensionQuality(
           cacheHash: hash,
           archiveSize: archiveBytes.length,
           cacheHit,
+          dependencyTrustResult,
         },
       };
     })(),

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -32,6 +32,11 @@ import {
 import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
+import {
+  checkDependencyTrust,
+  type DependencyTrustResult,
+} from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import {
@@ -108,6 +113,7 @@ export async function* extensionQuality(
 
       let archiveBytes: Uint8Array;
       let cacheHit = false;
+      let dependencyTrustResult: DependencyTrustResult | undefined = undefined;
 
       const cached = await deps.cache.get(hash);
       if (cached) {
@@ -116,6 +122,20 @@ export async function* extensionQuality(
         ctx.logger
           .debug`Cache hit: reusing ${cached.archiveBytes.length} bytes`;
         yield { kind: "cache_hit", hash };
+
+        const sourceFiles = [
+          ...input.prepareInput.allModelFiles,
+          ...input.prepareInput.allVaultFiles,
+          ...input.prepareInput.allDriverFiles,
+          ...input.prepareInput.allDatastoreFiles,
+          ...input.prepareInput.allReportFiles,
+        ];
+        const specifiers = await extractDependencySpecifiers(sourceFiles);
+        if (specifiers.length > 0) {
+          dependencyTrustResult = await checkDependencyTrust(specifiers);
+        } else {
+          dependencyTrustResult = { errors: [], warnings: [], passed: true };
+        }
       } else {
         yield { kind: "packaging" };
         let prepared: ExtensionPushPrepared;
@@ -130,6 +150,7 @@ export async function* extensionQuality(
           return;
         }
         archiveBytes = prepared.archiveBytes;
+        dependencyTrustResult = prepared.dependencyTrustResult;
         await deps.cache.put(hash, archiveBytes, {
           extensionName: input.prepareInput.manifest.name,
           extensionVersion: input.prepareInput.manifest.version,
@@ -145,6 +166,12 @@ export async function* extensionQuality(
         archiveBytes,
         input.prepareInput.manifest,
         scoreDeps,
+        dependencyTrustResult
+          ? {
+            dependencyTrustPassed: dependencyTrustResult.passed,
+            dependencyTrustBlockerCount: dependencyTrustResult.errors.length,
+          }
+          : undefined,
       );
 
       yield {

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -28,12 +28,15 @@ import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
+import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { CollectiveMismatch } from "../../domain/extensions/extension_collective_validator.ts";
 import type { CompilationError } from "../../libswamp/mod.ts";
 
 /** Extended renderer with methods for the prepare-phase outputs. */
 export interface ExtensionPushRenderer extends Renderer<ExtensionPushEvent> {
   renderResolved(data: ExtensionPushResolvedData): void;
+  renderDependencyTrustWarnings(warnings: DependencyTrustIssue[]): void;
+  renderDependencyTrustErrors(errors: DependencyTrustIssue[]): void;
   renderSafetyWarnings(warnings: SafetyIssue[]): void;
   renderSafetyErrors(errors: SafetyIssue[]): void;
   renderCollectiveErrors(
@@ -160,6 +163,20 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
     }
   }
 
+  renderDependencyTrustWarnings(warnings: DependencyTrustIssue[]): void {
+    this.logger.warn`Dependency trust warnings:`;
+    for (const w of warnings) {
+      this.logger.warn`  ${w.dependency}: ${w.message}`;
+    }
+  }
+
+  renderDependencyTrustErrors(errors: DependencyTrustIssue[]): void {
+    this.logger.error`Dependency trust errors (push blocked):`;
+    for (const e of errors) {
+      this.logger.error`  ${e.dependency}: ${e.message}`;
+    }
+  }
+
   renderSafetyWarnings(warnings: SafetyIssue[]): void {
     this.logger.warn`Safety warnings:`;
     for (const w of warnings) {
@@ -252,6 +269,16 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
 class JsonExtensionPushRenderer implements ExtensionPushRenderer {
   renderResolved(data: ExtensionPushResolvedData): void {
     console.log(JSON.stringify(data, null, 2));
+  }
+
+  renderDependencyTrustWarnings(warnings: DependencyTrustIssue[]): void {
+    console.log(
+      JSON.stringify({ dependencyTrustWarnings: warnings }, null, 2),
+    );
+  }
+
+  renderDependencyTrustErrors(errors: DependencyTrustIssue[]): void {
+    console.log(JSON.stringify({ dependencyTrustErrors: errors }, null, 2));
   }
 
   renderSafetyWarnings(warnings: SafetyIssue[]): void {

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -164,7 +164,7 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
   }
 
   renderDependencyTrustWarnings(warnings: DependencyTrustIssue[]): void {
-    this.logger.warn`Dependency trust warnings:`;
+    this.logger.warn`Dependency trust warnings (non-blocking):`;
     for (const w of warnings) {
       this.logger.warn`  ${w.dependency}: ${w.message}`;
     }
@@ -282,11 +282,11 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
   }
 
   renderSafetyWarnings(warnings: SafetyIssue[]): void {
-    console.log(JSON.stringify({ warnings }, null, 2));
+    console.log(JSON.stringify({ safetyWarnings: warnings }, null, 2));
   }
 
   renderSafetyErrors(errors: SafetyIssue[]): void {
-    console.log(JSON.stringify({ errors }, null, 2));
+    console.log(JSON.stringify({ safetyErrors: errors }, null, 2));
   }
 
   renderCollectiveErrors(

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -282,11 +282,11 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
   }
 
   renderSafetyWarnings(warnings: SafetyIssue[]): void {
-    console.log(JSON.stringify({ safetyWarnings: warnings }, null, 2));
+    console.log(JSON.stringify({ warnings }, null, 2));
   }
 
   renderSafetyErrors(errors: SafetyIssue[]): void {
-    console.log(JSON.stringify({ safetyErrors: errors }, null, 2));
+    console.log(JSON.stringify({ errors }, null, 2));
   }
 
   renderCollectiveErrors(

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -26,6 +26,12 @@ import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
+function formatDownloads(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
 /** Renderer interface that also reports pass/fail to the CLI. */
 export interface ExtensionQualityRenderer
   extends Renderer<ExtensionQualityEvent> {
@@ -74,8 +80,27 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
           }
         }
         const { dependencyTrustResult } = e.data;
+        if (dependencyTrustResult.audited.length > 0) {
+          for (const dep of dependencyTrustResult.audited) {
+            const mark = dep.passed ? "✓" : "✗";
+            const parts: string[] = [];
+            if (dep.registry === "jsr") {
+              parts.push("jsr (trusted)");
+            } else {
+              if (dep.license) parts.push(dep.license);
+              if (dep.weeklyDownloads !== null) {
+                parts.push(`${formatDownloads(dep.weeklyDownloads)}/week`);
+              }
+              if (dep.publishedAgo) parts.push(dep.publishedAgo);
+            }
+            const detail = parts.length > 0 ? ` — ${parts.join(", ")}` : "";
+            logger.info`      ${mark} ${dep.name}@${dep.version}${detail}`;
+          }
+        } else {
+          logger.info`      No npm/jsr dependencies to audit`;
+        }
         if (dependencyTrustResult.errors.length > 0) {
-          logger.error`Dependency trust blockers:`;
+          logger.error`Dependency trust blockers (push blocked):`;
           for (const err of dependencyTrustResult.errors) {
             logger.error`  ${err.dependency}: ${err.message}`;
           }
@@ -146,6 +171,7 @@ class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
             factors: score.factors,
             dependencyTrust: {
               passed: dependencyTrustResult.passed,
+              audited: dependencyTrustResult.audited,
               errors: dependencyTrustResult.errors,
               warnings: dependencyTrustResult.warnings,
             },

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -73,6 +73,19 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
             logger.info`      → ${factor.remediation}`;
           }
         }
+        const { dependencyTrustResult } = e.data;
+        if (dependencyTrustResult.errors.length > 0) {
+          logger.error`Dependency trust blockers:`;
+          for (const err of dependencyTrustResult.errors) {
+            logger.error`  ${err.dependency}: ${err.message}`;
+          }
+        }
+        if (dependencyTrustResult.warnings.length > 0) {
+          logger.warn`Dependency trust warnings (non-blocking):`;
+          for (const w of dependencyTrustResult.warnings) {
+            logger.warn`  ${w.dependency}: ${w.message}`;
+          }
+        }
         // `repository-verified` is a structural check on our side — the
         // server does the final HTTP HEAD to confirm the repo is public.
         // Surface that caveat so users know why their local "earned"
@@ -115,7 +128,13 @@ class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
       cache_hit: () => {},
       scoring: () => {},
       completed: (e) => {
-        const { score, cacheHash, archiveSize, cacheHit } = e.data;
+        const {
+          score,
+          cacheHash,
+          archiveSize,
+          cacheHit,
+          dependencyTrustResult,
+        } = e.data;
         console.log(JSON.stringify(
           {
             status: score.allPassed ? "passed" : "failed",
@@ -125,6 +144,11 @@ class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
             percentage: score.percentage,
             allPassed: score.allPassed,
             factors: score.factors,
+            dependencyTrust: {
+              passed: dependencyTrustResult.passed,
+              errors: dependencyTrustResult.errors,
+              warnings: dependencyTrustResult.warnings,
+            },
             cacheHash,
             archiveSize,
             cacheHit,


### PR DESCRIPTION
## Summary

- Add supply-chain trust gates that audit npm dependencies during `swamp extension push` and `swamp extension quality`, adapted from `@bixu/wheelshop`'s proven trust gates and `scripts/audit_deps.ts`'s OSV.dev pattern
- Extract `npm:`/`jsr:` import specifiers from extension source files, query OSV.dev for vulnerabilities and npm registry for trust signals (downloads, license, recency, maintenance, deprecation)
- Blocked dependencies (HIGH/CRITICAL vulns, deprecated packages) prevent push; warnings (MEDIUM vulns, low downloads, stale publish, bad license) are displayed but don't block
- Add `dependency-trust` rubric factor worth 2 points, bumping RUBRIC_VERSION to 3 — if the audit doesn't run (e.g. cache hit without re-audit), the factor defaults to `missing` (no free points)
- jsr packages trust jsr's built-in enforcement and skip gates where data is unavailable

### Sequencing note

**Depends on swamp-club#402** — the server-side scorer should ship RUBRIC_VERSION 3 first so registry scores match local scores from day one.

## Test Plan

- [x] 10 unit tests for `DependencySpecifierExtractor` (npm/jsr/bare specifiers, zod exclusion, deduplication)
- [x] 17 unit tests for `DependencyTrustChecker` (each trust gate, mocked HTTP, graceful degradation, empty specifiers)
- [x] 68 rubric scorer tests updated (RUBRIC_VERSION 3, new factor, point totals)
- [x] 6 extension quality integration tests pass (including cache hit re-audit)
- [x] Push test mocks updated with new deps interface
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` (6083 passed), `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)