### PR TITLE
feat(workflows): resolve modelType for direct-execution steps in validate

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -93,6 +93,7 @@ export interface ModelMethodResolver {
   resolve(
     modelIdOrName: string,
     methodName: string,
+    modelType?: string,
   ): Promise<MethodResolution>;
 }
 
@@ -387,6 +388,7 @@ export class DefaultWorkflowValidationService
                 modelRef,
                 taskData.methodName,
                 taskData.inputs,
+                taskData.modelType,
               ),
             );
           }
@@ -412,6 +414,7 @@ export class DefaultWorkflowValidationService
     modelIdOrName: string,
     methodName: string,
     inputs: Record<string, unknown> | undefined,
+    modelType?: string,
   ): Promise<WorkflowValidationResult[]> {
     const checkName =
       `Step inputs for '${stepName}' in job '${jobName}' (${modelIdOrName}.${methodName})`;
@@ -420,10 +423,14 @@ export class DefaultWorkflowValidationService
     if (modelIdOrName.includes("${{")) {
       return [WorkflowValidationResult.pass(checkName)];
     }
+    if (modelType?.includes("${{")) {
+      return [WorkflowValidationResult.pass(checkName)];
+    }
 
     const resolution = await this.methodResolver!.resolve(
       modelIdOrName,
       methodName,
+      modelType,
     );
 
     switch (resolution.status) {
@@ -438,7 +445,7 @@ export class DefaultWorkflowValidationService
         return [
           WorkflowValidationResult.pass(
             checkName +
-              " (model type not resolved, skipped)",
+              ` (model type '${resolution.modelType}' not resolved, skipped)`,
           ),
         ];
       case "method_not_found":

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -54,8 +54,23 @@ function mockResolver(
   responses: Record<string, MethodResolution>,
 ): ModelMethodResolver {
   return {
-    resolve(modelIdOrName, methodName) {
+    resolve(modelIdOrName, methodName, _modelType?) {
       const key = `${modelIdOrName}.${methodName}`;
+      return Promise.resolve(
+        responses[key] ?? { status: "model_not_found" as const },
+      );
+    },
+  };
+}
+
+function mockResolverWithType(
+  responses: Record<string, MethodResolution>,
+): ModelMethodResolver {
+  return {
+    resolve(_modelIdOrName, methodName, modelType?) {
+      const key = modelType
+        ? `type:${modelType}.${methodName}`
+        : `name:${_modelIdOrName}.${methodName}`;
       return Promise.resolve(
         responses[key] ?? { status: "model_not_found" as const },
       );
@@ -1100,6 +1115,142 @@ Deno.test("validateStepInputs: nested workflow with no required inputs passes", 
           Step.create({
             name: "step1",
             task: StepTask.workflow("simple-nested"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+});
+
+// --- Direct-execution step validation tests ---
+
+Deno.test("validateStepInputs: direct-execution step with resolved type and valid inputs passes", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.deploy": {
+      status: "resolved",
+      requiredArgs: ["region"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              "my-instance",
+              "deploy",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+  assertEquals(inputResult?.name.includes("skipped"), false);
+});
+
+Deno.test("validateStepInputs: direct-execution step with missing required args fails", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/test/model.deploy": {
+      status: "resolved",
+      requiredArgs: ["region", "version"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/test/model",
+              "my-instance",
+              "deploy",
+              { region: "us-east-1" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("version"), true);
+});
+
+Deno.test("validateStepInputs: direct-execution step with unresolvable type produces descriptive skip", async () => {
+  const resolver = mockResolverWithType({
+    "type:@swamp/nonexistent/type.deploy": {
+      status: "type_unresolvable",
+      modelType: "@swamp/nonexistent/type",
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "@swamp/nonexistent/type",
+              "my-instance",
+              "deploy",
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, true);
+  assertEquals(inputResult?.name.includes("not resolved"), true);
+  assertEquals(inputResult?.name.includes("model not found"), false);
+});
+
+Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips validation", async () => {
+  const resolver = mockResolverWithType({});
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.directExecution(
+              "${{ inputs.model_type }}",
+              "my-instance",
+              "deploy",
+              { region: "us-east-1" },
+            ),
           }),
         ],
       }),

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -21,6 +21,7 @@ import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowValidationResult } from "../../domain/workflows/validation_service.ts";
 import {
   DefaultWorkflowValidationService,
+  type MethodResolution,
   type ModelMethodResolver,
 } from "../../domain/workflows/validation_service.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
@@ -29,6 +30,7 @@ import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { zodToJsonSchema } from "../types/schema_helpers.ts";
@@ -94,7 +96,11 @@ function createModelMethodResolver(
   definitionRepo: YamlDefinitionRepository,
 ): ModelMethodResolver {
   return {
-    async resolve(modelIdOrName, methodName) {
+    async resolve(modelIdOrName, methodName, modelTypeArg?) {
+      if (modelTypeArg) {
+        return resolveByType(modelTypeArg, methodName);
+      }
+
       const lookupResult = await findDefinitionByIdOrName(
         definitionRepo,
         modelIdOrName,
@@ -136,6 +142,41 @@ function createModelMethodResolver(
       return { status: "resolved", requiredArgs, definitionProvidedArgs };
     },
   };
+}
+
+async function resolveByType(
+  typeArg: string,
+  methodName: string,
+): Promise<MethodResolution> {
+  const type = ModelType.create(typeArg);
+  const modelDef = await resolveModelType(type, getAutoResolver());
+  if (!modelDef) {
+    return { status: "type_unresolvable", modelType: type.normalized };
+  }
+
+  const method = modelDef.methods[methodName];
+  if (!method) {
+    return { status: "method_not_found", modelType: type.normalized };
+  }
+
+  const methodSchema = zodToJsonSchema(method.arguments) as {
+    required?: string[];
+  };
+  const methodRequired = methodSchema.required ?? [];
+
+  const globalRequired: string[] = [];
+  if (modelDef.globalArguments) {
+    const globalSchema = zodToJsonSchema(modelDef.globalArguments) as {
+      required?: string[];
+    };
+    globalRequired.push(...(globalSchema.required ?? []));
+  }
+
+  const requiredArgs = Array.from(
+    new Set([...methodRequired, ...globalRequired]),
+  );
+
+  return { status: "resolved", requiredArgs };
 }
 
 /** Wires real infrastructure into WorkflowValidateDeps. */


### PR DESCRIPTION
## Summary

Closes swamp-club#405.

- Extends `ModelMethodResolver` to accept an optional `modelType` parameter for type-based resolution
- When a workflow step uses direct type execution (`modelType` + `modelName`), the validator now resolves the type via `resolveModelType()` and validates step inputs against both `globalArguments` and method `arguments` schemas
- Replaces the misleading "model not found, skipped" message with actual input validation — wrong method names, typos in input keys, and missing required inputs are now caught at validate time
- Adds 4 unit tests covering: valid inputs pass, missing required args fail, unresolvable type descriptive skip, and CEL expression short-circuit

**Note:** This is a strictness increase. Existing workflows with latent errors in direct-execution step inputs will now fail `swamp workflow validate` where they previously passed silently. This is intentional — the issue specifically requested catch-at-validate-time confidence for direct execution.

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — formatting clean
- [x] `deno run test` — all 6061 tests pass, 0 failures
- [x] Manual verification with compiled binary:
  - Wrong method name → "Method 'run' not found on model type 'command/shell'"
  - Typo in input key → "Missing required inputs: run"
  - Correct inputs → 8/8 validations passed