### PR TITLE
feat(shell): warn when vault expression is inside single quotes (swamp-club#406)

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -191,6 +191,27 @@ using single-quoted string arguments:
 ${{ vault.get('vault-name', 'vault-key') }}
 ```
 
+### Shell Quoting
+
+In `command/shell` model `run:` fields, vault expressions compile to shell
+environment-variable references (`${__SWAMP_VAULT_N}`). Single quotes prevent
+shell variable expansion, so wrapping a vault expression in single quotes
+silently produces the literal placeholder instead of the secret value. Always use
+double quotes:
+
+```yaml
+# correct — double quotes allow expansion
+run: |
+  PASSWORD="${{ vault.get(my-vault, DB_PASS) }}"
+
+# WRONG — single quotes prevent expansion
+run: |
+  PASSWORD='${{ vault.get(my-vault, DB_PASS) }}'
+```
+
+swamp emits a warning at execution time when it detects a vault sentinel inside
+single quotes.
+
 ### Vault Resolution Order
 
 The vault used for storing a sensitive field is resolved in this order:

--- a/integration/vault_cel_integration_test.ts
+++ b/integration/vault_cel_integration_test.ts
@@ -585,7 +585,7 @@ Deno.test("Vault CEL: secrets accessible in workflow execution", async () => {
       methods: {
         execute: {
           arguments: {
-            run: "echo '${{ vault.get(workflow-vault, WORKFLOW_SECRET) }}'",
+            run: 'echo "${{ vault.get(workflow-vault, WORKFLOW_SECRET) }}"',
           },
         },
       },

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -110,6 +110,16 @@ async function executeCommand(
     if (secretBag && !secretBag.isEmpty && context.unresolvedMethodArgs) {
       const unresolvedRun = context.unresolvedMethodArgs.run;
       if (typeof unresolvedRun === "string") {
+        const singleQuoted = secretBag.findSingleQuotedSentinels(
+          unresolvedRun,
+        );
+        if (singleQuoted.length > 0) {
+          context.onEvent?.({
+            type: "vault_single_quote_warning",
+            message:
+              "Vault secret expression inside single quotes will not be expanded by the shell — use double quotes instead",
+          });
+        }
         const resolved = shellStrategy.resolveSecrets(unresolvedRun, secretBag);
         shellCommand = resolved.command;
         shellEnv = { ...shellEnv, ...resolved.env };

--- a/src/domain/models/method_events.ts
+++ b/src/domain/models/method_events.ts
@@ -41,4 +41,8 @@ export type MethodExecutionEvent =
     specName: string;
     instanceName: string;
     error: string;
+  }
+  | {
+    type: "vault_single_quote_warning";
+    message: string;
   };

--- a/src/domain/vaults/vault_secret_bag.ts
+++ b/src/domain/vaults/vault_secret_bag.ts
@@ -17,19 +17,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+type QuoteContext = "unquoted" | "single" | "double";
+
 /**
- * Determines whether a position in a shell command string is inside double quotes.
- * Tracks single-quote and double-quote state, respecting backslash escapes outside
- * single quotes. Used by resolveForShell to decide whether to add quoting around
- * environment variable references.
+ * Returns the quoting context at a given position in a shell command string.
+ * Tracks single-quote and double-quote state, respecting backslash escapes
+ * outside single quotes.
  */
-function isInsideDoubleQuotes(str: string, position: number): boolean {
+export function getQuoteContext(str: string, position: number): QuoteContext {
   let inDouble = false;
   let inSingle = false;
   for (let i = 0; i < position; i++) {
     const ch = str[i];
     if (ch === "\\" && !inSingle) {
-      i++; // skip escaped character
+      i++;
       continue;
     }
     if (ch === "'" && !inDouble) {
@@ -38,7 +39,9 @@ function isInsideDoubleQuotes(str: string, position: number): boolean {
       inDouble = !inDouble;
     }
   }
-  return inDouble;
+  if (inSingle) return "single";
+  if (inDouble) return "double";
+  return "unquoted";
 }
 
 /**
@@ -75,6 +78,23 @@ export class VaultSecretBag {
   /** Whether this bag contains any secrets. */
   get isEmpty(): boolean {
     return this.secrets.size === 0;
+  }
+
+  /**
+   * Returns sentinel tokens that appear inside single quotes in the given
+   * command string. Single quotes prevent shell variable expansion, so an
+   * env-var reference injected inside single quotes will be treated as a
+   * literal string instead of being expanded to the secret value.
+   */
+  findSingleQuotedSentinels(command: string): string[] {
+    const found: string[] = [];
+    for (const sentinel of this.secrets.keys()) {
+      const pos = command.indexOf(sentinel);
+      if (pos !== -1 && getQuoteContext(command, pos) === "single") {
+        found.push(sentinel);
+      }
+    }
+    return found;
   }
 
   /**
@@ -132,7 +152,7 @@ export class VaultSecretBag {
       const pos = result.indexOf(sentinel);
       if (pos !== -1) {
         const envName = `__SWAMP_VAULT_${envIdx++}`;
-        const ref = isInsideDoubleQuotes(result, pos)
+        const ref = getQuoteContext(result, pos) === "double"
           ? `\${${envName}}`
           : `"\${${envName}}"`;
         result = result.split(sentinel).join(ref);
@@ -159,7 +179,7 @@ export class VaultSecretBag {
    *   against PowerShell's whitespace-splitting behavior when the
    *   resolved value is passed to a native (non-cmdlet) command.
    *
-   * Quote tracking reuses the POSIX `isInsideDoubleQuotes` helper.
+   * Quote tracking reuses the POSIX `getQuoteContext` helper.
    * PowerShell's escape character is a backtick rather than a
    * backslash, so commands authored with PowerShell-specific escape
    * sequences inside single quotes could mis-classify their context;
@@ -177,7 +197,7 @@ export class VaultSecretBag {
       const pos = result.indexOf(sentinel);
       if (pos !== -1) {
         const envName = `__SWAMP_VAULT_${envIdx++}`;
-        const ref = isInsideDoubleQuotes(result, pos)
+        const ref = getQuoteContext(result, pos) === "double"
           ? `$env:${envName}`
           : `"$env:${envName}"`;
         result = result.split(sentinel).join(ref);

--- a/src/domain/vaults/vault_secret_bag_test.ts
+++ b/src/domain/vaults/vault_secret_bag_test.ts
@@ -18,7 +18,56 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { getQuoteContext } from "./vault_secret_bag.ts";
 import { VaultSecretBag } from "./vault_secret_bag.ts";
+
+Deno.test("getQuoteContext", async (t) => {
+  await t.step("returns 'unquoted' for position outside any quotes", () => {
+    assertEquals(getQuoteContext("echo hello", 5), "unquoted");
+  });
+
+  await t.step("returns 'double' for position inside double quotes", () => {
+    assertEquals(getQuoteContext('echo "hello', 7), "double");
+  });
+
+  await t.step("returns 'single' for position inside single quotes", () => {
+    assertEquals(getQuoteContext("echo 'hello", 7), "single");
+  });
+
+  await t.step("returns 'unquoted' after closed double quotes", () => {
+    assertEquals(getQuoteContext('echo "hello" world', 14), "unquoted");
+  });
+
+  await t.step("returns 'unquoted' after closed single quotes", () => {
+    assertEquals(getQuoteContext("echo 'hello' world", 14), "unquoted");
+  });
+
+  await t.step("ignores escaped double quote outside single quotes", () => {
+    assertEquals(getQuoteContext('echo \\"hello', 8), "unquoted");
+  });
+
+  await t.step(
+    "does not treat backslash as escape inside single quotes",
+    () => {
+      assertEquals(getQuoteContext("echo '\\\"'rest", 10), "unquoted");
+    },
+  );
+
+  await t.step("handles mixed quoting contexts", () => {
+    const cmd = `echo "double" 'single' unquoted`;
+    assertEquals(getQuoteContext(cmd, 6), "double");
+    assertEquals(getQuoteContext(cmd, 16), "single");
+    assertEquals(getQuoteContext(cmd, 24), "unquoted");
+  });
+
+  await t.step("returns 'single' for position at start of content", () => {
+    assertEquals(getQuoteContext("'hello", 1), "single");
+  });
+
+  await t.step("returns 'unquoted' at position 0", () => {
+    assertEquals(getQuoteContext("'hello", 0), "unquoted");
+  });
+});
 
 Deno.test("VaultSecretBag", async (t) => {
   await t.step("addSecret: returns unique sentinel tokens", () => {
@@ -267,6 +316,71 @@ Deno.test("VaultSecretBag", async (t) => {
       const result = bag.resolveForPowerShell("Write-Output hello");
       assertEquals(result.command, "Write-Output hello");
       assertEquals(result.env, {});
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: detects sentinel inside single quotes",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("secret");
+      const cmd = `S='${sentinel}'`;
+      const found = bag.findSingleQuotedSentinels(cmd);
+      assertEquals(found, [sentinel]);
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: does not flag sentinel in double quotes",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("secret");
+      const cmd = `D="${sentinel}"`;
+      const found = bag.findSingleQuotedSentinels(cmd);
+      assertEquals(found, []);
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: does not flag unquoted sentinel",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("secret");
+      const cmd = `echo ${sentinel}`;
+      const found = bag.findSingleQuotedSentinels(cmd);
+      assertEquals(found, []);
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: detects only the single-quoted one among mixed",
+    () => {
+      const bag = new VaultSecretBag();
+      const s1 = bag.addSecret("good");
+      const s2 = bag.addSecret("bad");
+      const cmd = `D="${s1}"\nS='${s2}'`;
+      const found = bag.findSingleQuotedSentinels(cmd);
+      assertEquals(found, [s2]);
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: returns empty when no secrets exist",
+    () => {
+      const bag = new VaultSecretBag();
+      const found = bag.findSingleQuotedSentinels("echo 'hello'");
+      assertEquals(found, []);
+    },
+  );
+
+  await t.step(
+    "findSingleQuotedSentinels: handles multi-line scripts",
+    () => {
+      const bag = new VaultSecretBag();
+      const sentinel = bag.addSecret("secret");
+      const cmd = `#!/bin/sh\necho "safe"\nBROKEN='${sentinel}'\necho done`;
+      const found = bag.findSingleQuotedSentinels(cmd);
+      assertEquals(found, [sentinel]);
     },
   );
 });

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -133,6 +133,9 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
               },
             );
             break;
+          case "vault_single_quote_warning":
+            logger.warn(e.event.message);
+            break;
         }
       },
       data_artifact_saved: (e) => {
@@ -227,7 +230,15 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       evaluating_expressions: () => {},
       executing: () => {},
       method_output: () => {},
-      method_event: () => {},
+      method_event: (e) => {
+        if (e.event.type === "vault_single_quote_warning") {
+          console.log(JSON.stringify({
+            warning: "vault_single_quote",
+            modelName: e.modelName,
+            message: e.event.message,
+          }));
+        }
+      },
       data_artifact_saved: () => {},
       report_started: () => {},
       report_completed: () => {},

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -153,6 +153,9 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
               },
             );
             break;
+          case "vault_single_quote_warning":
+            logger.warn(e.event.message);
+            break;
         }
       },
       report_started: () => {},
@@ -252,7 +255,15 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       env_var_warning: () => {},
       method_executing: () => {},
       method_output: () => {},
-      method_event: () => {},
+      method_event: (e) => {
+        if (e.event.type === "vault_single_quote_warning") {
+          console.log(JSON.stringify({
+            warning: "vault_single_quote",
+            modelName: e.modelName,
+            message: e.event.message,
+          }));
+        }
+      },
       report_started: () => {},
       report_completed: () => {},
       report_failed: () => {},


### PR DESCRIPTION
## Summary

- Add a runtime warning when a `${{ vault.get(...) }}` expression is detected inside single quotes in a `command/shell` model's `run:` field. Single quotes prevent shell variable expansion, causing the secret to silently resolve to the literal env-var placeholder instead of the actual value.
- Refactor `isInsideDoubleQuotes` into `getQuoteContext` returning full quoting context, add `findSingleQuotedSentinels` to `VaultSecretBag`, and emit a `vault_single_quote_warning` `MethodExecutionEvent` from the shell model.
- Handle the warning in both log and JSON renderers for model runs and workflow runs.
- Add shell-quoting safety section to `design/vaults.md`.
- Fix an integration test that was using the broken single-quote pattern.

Closes swamp-club#406

## Test Plan

- [x] Unit tests for `getQuoteContext` (10 cases: unquoted, single, double, escaped, mixed)
- [x] Unit tests for `findSingleQuotedSentinels` (6 cases: single-quoted, double-quoted, unquoted, mixed, empty, multi-line)
- [x] All existing `VaultSecretBag` tests pass (resolveForShell/resolveForPowerShell behavior preserved)
- [x] Full test suite passes (6058 passed, 0 failed)
- [x] Manual verification: single-quote test emits warning, double-quote test does not
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)