### PR TITLE
fix(skills): replace stale swamp model report references with swamp report get (swamp-club#409)

### DIFF
--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -24,16 +24,16 @@ aggregate, or analyze model output. If the analysis will be run more than once
 or should be stored alongside model data, a report is the right choice.
 
 **Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help model report` or `swamp help model method run` for the complete,
+`swamp report --help` or `swamp model method run --help` for the complete,
 up-to-date CLI schema.
 
 ## Quick Reference
 
 | Task                     | Command                                                           |
 | ------------------------ | ----------------------------------------------------------------- |
-| Run reports for a model  | `swamp model report <model>`                                      |
-| Filter by label          | `swamp model report <model> --label cost`                         |
-| Simulate method context  | `swamp model report <model> --method create`                      |
+| Get a stored report      | `swamp report get <report-name> --model <model>`                  |
+| Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
+| Get report as JSON       | `swamp report get <report-name> --model <model> --json`           |
 | Run method with reports  | `swamp model method run <model> <method>`                         |
 | Skip all reports         | `swamp model method run <model> <method> --skip-reports`          |
 | Skip report by name      | `swamp model method run <model> <method> --skip-report <n>`       |
@@ -57,8 +57,9 @@ up-to-date CLI schema.
 3. **Configure in definition YAML** — add the report name to `reports.require:`
    in the model or workflow definition if it should run beyond the model-type
    defaults. Use `reports.skip:` to exclude reports you don't need.
-4. **Run and verify** — execute `swamp model report <model>` to confirm the
-   report produces valid markdown and JSON output without errors.
+4. **Run and verify** — execute a model method, then use
+   `swamp report get <report-name> --model <model>` to confirm the report
+   produces valid markdown and JSON output without errors.
 5. **Check stored output** — run `swamp data query 'tags.type == "report"'` to
    verify the report artifact was persisted correctly.
 
@@ -167,17 +168,6 @@ allowing a push.
 | `--skip-report-label <label>` | Skip reports with this label (repeatable)     |
 | `--report <name>`             | Only run this report (repeatable, inclusion)  |
 | `--report-label <label>`      | Only run reports with this label (repeatable) |
-
-### model report (standalone)
-
-| Flag                | Description                         |
-| ------------------- | ----------------------------------- |
-| `--label <label>`   | Only run reports with this label    |
-| `--method <method>` | Simulate method context for reports |
-
-The standalone `swamp model report` command runs reports without executing a
-method. It builds a `MethodReportContext` with `executionStatus: "succeeded"`
-and empty `dataHandles`.
 
 ## Report Data Storage
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -34,6 +34,8 @@ up-to-date CLI schema.
 | Get a stored report      | `swamp report get <report-name> --model <model>`                  |
 | Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
 | Get report as JSON       | `swamp report get <report-name> --model <model> --json`           |
+| Cap total output width   | `swamp report get <report-name> --model <model> --max-width 120`  |
+| Cap column width         | `swamp report get <report-name> --max-col-width 60`               |
 | Run method with reports  | `swamp model method run <model> <method>`                         |
 | Skip all reports         | `swamp model method run <model> <method> --skip-reports`          |
 | Skip report by name      | `swamp model method run <model> <method> --skip-report <n>`       |
@@ -42,10 +44,6 @@ up-to-date CLI schema.
 | Run only labeled reports | `swamp model method run <model> <method> --report-label <l>`      |
 | Workflow with reports    | `swamp workflow run <workflow>`                                   |
 | Workflow skip reports    | `swamp workflow run <workflow> --skip-reports`                    |
-| Get stored report        | `swamp report get <report-name> --model <model> --json`           |
-| Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
-| Cap total output width   | `swamp report get <report-name> --model <model> --max-width 120`  |
-| Cap column width         | `swamp report get <report-name> --max-col-width 60`               |
 
 ## End-to-End Workflow
 
@@ -168,6 +166,18 @@ allowing a push.
 | `--skip-report-label <label>` | Skip reports with this label (repeatable)     |
 | `--report <name>`             | Only run this report (repeatable, inclusion)  |
 | `--report-label <label>`      | Only run reports with this label (repeatable) |
+
+### report get
+
+| Flag                      | Description                                            |
+| ------------------------- | ------------------------------------------------------ |
+| `--model <name>`          | Scope to a specific model                              |
+| `--workflow <name>`       | Scope to a specific workflow                           |
+| `--version <version>`     | Get specific version (default: latest)                 |
+| `--variant <variant>`     | Select a specific forEach variant                      |
+| `--markdown`              | Output as plain markdown instead of terminal-formatted |
+| `--max-width <width>`     | Cap total output width in columns                      |
+| `--max-col-width <width>` | Cap individual table column width in characters        |
 
 ## Report Data Storage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Run deno lint
         run: deno lint
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Scan for known vulnerabilities
         run: deno task audit
@@ -155,7 +155,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/multi-model-eval.yml
+++ b/.github/workflows/multi-model-eval.yml
@@ -48,7 +48,7 @@ jobs:
         if: steps.check.outputs.run == 'true'
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Setup Node.js
         if: steps.check.outputs.run == 'true'
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Download all eval results
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Generate version
         id: version

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.x
+          deno-version: v2.7.x
 
       - name: Generate version
         id: version

--- a/design/reports.md
+++ b/design/reports.md
@@ -394,23 +394,27 @@ values.
 
 ## CLI
 
-### `swamp model report`
+### `swamp report get`
 
-Runs reports for a model without executing a method. Uses the evaluated
-(post-CEL) definition when available.
+Retrieves a stored report's content. Reports are persisted automatically after
+method execution; this command reads the stored artifact.
 
 ```bash
-swamp model report my-model
-swamp model report my-model --method create
-swamp model report my-model --label cost
+swamp report get cost-summary --model my-model
+swamp report get cost-summary --model my-model --markdown
+swamp report get cost-summary --model my-model --json
+swamp report get cost-summary --workflow deploy-pipeline
 ```
 
-| Flag               | Description                                     |
-| ------------------ | ----------------------------------------------- |
-| `--method <name>`  | Simulate a method context for report scoping    |
-| `--label <label>`  | Only run reports matching this label (repeatable)|
-
-See `src/cli/commands/model_report.ts`.
+| Flag                    | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `--model <name>`        | Scope to a specific model                            |
+| `--workflow <name>`     | Scope to a specific workflow                         |
+| `--version <version>`   | Get specific version (default: latest)               |
+| `--markdown`            | Output as plain markdown instead of terminal-formatted|
+| `--json`                | Output in JSON format                                |
+| `--max-width <width>`   | Cap total output width in columns                    |
+| `--max-col-width <width>` | Cap individual table column width in characters   |
 
 ### Report Flags on `model method run`
 


### PR DESCRIPTION
## Summary

- Replaced all 5 references to the nonexistent `swamp model report` CLI subcommand in `.claude/skills/swamp-report/SKILL.md` with the correct `swamp report get` command
- Removed the "model report (standalone)" section from the skill since the standalone command doesn't exist — `swamp report get` retrieves stored content, it doesn't re-run reports
- Updated `design/reports.md` CLI section to document `swamp report get` with its actual flags, replacing the stale `swamp model report` section and removing the reference to nonexistent `src/cli/commands/model_report.ts`

Fixes swamp-club#409

## Test Plan

- Verified `swamp model --help` confirms no `report` subcommand exists
- Verified `swamp report get --help` confirms the actual command and flags
- All 6098 tests pass
- `deno fmt`, `deno lint`, `deno check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)