### PR TITLE
fix(models): refresh auto-definition globalArguments on each direct-execution run (swamp-club#411)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -166,7 +166,10 @@ automatically routed between global arguments and method arguments using the
 type's schemas (method arguments take precedence on ambiguous keys).
 
 **Subsequent runs:** Finds `my-vpc`, verifies its type matches
-`@swamp/aws/ec2/vpc` (safety check), and runs. The same command is idempotent.
+`@swamp/aws/ec2/vpc` (safety check), and runs. If the routed global arguments
+differ from the stored definition, the definition is updated and persisted
+automatically — this ensures parameterized workflows that vary inputs per run
+always use the current values.
 
 **Storage:** Auto-created definitions live in `.swamp/auto-definitions/` (not
 `models/`). They are local runtime state, not git-tracked, and do not appear in

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -53,7 +53,7 @@ export type DirectExecutionResult =
     created: boolean;
     definitionPath: string;
     routedInputs: RoutedInputs;
-    globalArgsDiffer?: boolean;
+    globalArgsUpdated?: boolean;
   }
   | { ok: false; error: SwampError };
 
@@ -168,6 +168,18 @@ export async function resolveOrCreateDefinition(
         JSON.stringify(storedGlobal?.[k]) === JSON.stringify(v)
       );
 
+    if (globalArgsDiffer) {
+      for (const key of Object.keys(storedGlobal ?? {})) {
+        if (!(key in routedGlobal)) {
+          existing.definition.removeGlobalArgument(key);
+        }
+      }
+      for (const [key, value] of Object.entries(routedGlobal)) {
+        existing.definition.setGlobalArgument(key, value);
+      }
+      await deps.saveDefinition(existing.type, existing.definition);
+    }
+
     return {
       ok: true,
       definition: existing.definition,
@@ -179,7 +191,7 @@ export async function resolveOrCreateDefinition(
         existing.definition.id,
       ),
       routedInputs: routed,
-      globalArgsDiffer,
+      globalArgsUpdated: globalArgsDiffer,
     };
   }
 

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -197,7 +197,7 @@ Deno.test("resolveOrCreateDefinition: auto-creates definition with routed global
   }
 });
 
-Deno.test("resolveOrCreateDefinition: reuses existing definition with type match", async () => {
+Deno.test("resolveOrCreateDefinition: updates globalArgs when they differ on existing definition", async () => {
   const modelDef = createTestModelDef(
     z.object({ region: z.string() }),
     { run: z.object({ id: z.string() }) },
@@ -208,6 +208,99 @@ Deno.test("resolveOrCreateDefinition: reuses existing definition with type match
     type: "test/model",
     typeVersion: "2026.01.01.1",
     globalArguments: { region: "us-west-2" },
+  });
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({
+          definition: existingDef,
+          type: resolvedType,
+        }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "existing-model",
+    "run",
+    { region: "us-east-1", id: "abc" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, false);
+    assertEquals(result.definition.id, existingDef.id);
+    assertEquals(
+      result.definition.globalArguments as Record<string, unknown>,
+      { region: "us-east-1" },
+    );
+    assertEquals(result.globalArgsUpdated, true);
+    assertEquals(saved, true);
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: does not save when globalArgs match", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  const existingDef = Definition.create({
+    name: "existing-model",
+    type: "test/model",
+    typeVersion: "2026.01.01.1",
+    globalArguments: { region: "us-east-1" },
+  });
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({
+          definition: existingDef,
+          type: resolvedType,
+        }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "existing-model",
+    "run",
+    { region: "us-east-1", id: "abc" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, false);
+    assertEquals(result.globalArgsUpdated, false);
+    assertEquals(saved, false);
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: removes stale keys when globalArgs change", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  const existingDef = Definition.create({
+    name: "existing-model",
+    type: "test/model",
+    typeVersion: "2026.01.01.1",
+    globalArguments: { region: "us-west-2", staleKey: "leftover" },
   });
 
   const result = await resolveOrCreateDefinition(
@@ -231,8 +324,11 @@ Deno.test("resolveOrCreateDefinition: reuses existing definition with type match
 
   assertEquals(result.ok, true);
   if (result.ok) {
-    assertEquals(result.created, false);
-    assertEquals(result.definition.id, existingDef.id);
+    assertEquals(
+      result.definition.globalArguments as Record<string, unknown>,
+      { region: "us-east-1" },
+    );
+    assertEquals(result.globalArgsUpdated, true);
   }
 });
 

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -90,9 +90,8 @@ export type ModelMethodRunEvent =
     definitionPath: string;
   }
   | {
-    kind: "global_args_ignored";
+    kind: "global_args_updated";
     definitionName: string;
-    message: string;
   }
   | {
     kind: "model_resolved";
@@ -304,14 +303,10 @@ export async function* modelMethodRun(
           };
         }
 
-        if (result.globalArgsDiffer) {
+        if (result.globalArgsUpdated) {
           yield {
-            kind: "global_args_ignored",
+            kind: "global_args_updated",
             definitionName: result.definition.name,
-            message:
-              "Global argument inputs differ from the stored definition. " +
-              "The stored values are used. To update, delete the definition and re-run, " +
-              "or use 'model create' + 'model edit' for managed definitions.",
           };
         }
 

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -62,10 +62,10 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
           { path: e.definitionPath },
         );
       },
-      global_args_ignored: (e) => {
-        getRunLogger(this.modelName, this.methodName).warn(
-          "{message}",
-          { message: e.message },
+      global_args_updated: (e) => {
+        getRunLogger(this.modelName, this.methodName).info(
+          "Updated global arguments on definition {name}",
+          { name: e.definitionName },
         );
       },
       model_resolved: (e) => {
@@ -207,11 +207,10 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
           definitionPath: e.definitionPath,
         }));
       },
-      global_args_ignored: (e) => {
+      global_args_updated: (e) => {
         console.log(JSON.stringify({
-          warning: "global_args_ignored",
+          event: "global_args_updated",
           definitionName: e.definitionName,
-          message: e.message,
         }));
       },
       model_resolved: () => {},


### PR DESCRIPTION
## Summary

- When `resolveOrCreateDefinition` found an existing auto-definition, it returned stored `globalArguments` unchanged — even when new inputs differed. This made parameterized workflows silently reuse the first run's values forever.
- Now updates the definition in-place (removes stale keys, sets new values) and persists before returning when routed `globalArguments` differ from stored values.
- Replaces `global_args_ignored` warning with `global_args_updated` info event for observability.

Closes swamp-club#411

## Test Plan

- [x] Updated existing test to assert `globalArguments` are refreshed on reuse
- [x] Added test: `saveDefinition` called when globalArgs differ
- [x] Added test: `saveDefinition` NOT called when globalArgs match (no unnecessary writes)
- [x] Added test: stale keys removed when globalArgs change
- [x] Full test suite passes (6100 tests)
- [x] Verified fix against reproduction scenario: CLI direct-execution and workflow both update globalArgs on subsequent runs
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)