### PR TITLE
fix(telemetry): correct kiro/opencode/codex harness detection env vars (swamp-club#413)

### DIFF
--- a/src/domain/telemetry/agent_harness_detection.ts
+++ b/src/domain/telemetry/agent_harness_detection.ts
@@ -52,7 +52,6 @@ interface SpecificSignal {
  * first matching entry wins.
  */
 const SPECIFIC_HARNESS_SIGNALS: readonly SpecificSignal[] = [
-  // Tier-1: well-attested.
   {
     tool: "claude",
     predicate: (env) =>
@@ -63,23 +62,41 @@ const SPECIFIC_HARNESS_SIGNALS: readonly SpecificSignal[] = [
     predicate: (env) =>
       env.TERM_PROGRAM === "cursor" || env.CURSOR_TRACE_ID !== undefined,
   },
-  // Tier-2: best-effort. Refine these as harness vendors publish stable
-  // markers.
-  // TODO(swamp-club#292): confirm Kiro's published env signature.
+  // Confirmed against upstream — see swamp-club#413.
+  // `TERM_PROGRAM=kiro` covers IDE-terminal sessions; `AGENT_CONTEXT_OUT` is
+  // a FIFO path Kiro CLI exports only when its agent is driving a shell
+  // command (see kiro.dev/docs/cli/reference/built-in-tools/). The name is
+  // less vendor-specific than other markers in this list — if a future
+  // harness collides on `AGENT_CONTEXT_OUT`, narrow this predicate then.
   {
     tool: "kiro",
-    predicate: (env) => env.TERM_PROGRAM === "kiro" || env.KIRO_AGENT === "1",
+    predicate: (env) =>
+      env.TERM_PROGRAM === "kiro" ||
+      (env.AGENT_CONTEXT_OUT !== undefined && env.AGENT_CONTEXT_OUT !== ""),
   },
-  // TODO(swamp-club#292): confirm OpenCode's published env signature.
+  // Confirmed against upstream — see swamp-club#413.
+  // opencode sets `OPENCODE=1` at process startup
+  // (anomalyco/opencode packages/opencode/src/index.ts), inherited by every
+  // child process. It also sets `AGENT=1`, so even when this predicate fires
+  // first the generic fallback would have caught the session anonymously.
   {
     tool: "opencode",
-    predicate: (env) =>
-      env.OPENCODE_VERSION !== undefined || env.TERM_PROGRAM === "opencode",
+    predicate: (env) => env.OPENCODE === "1",
   },
-  // TODO(swamp-club#292): confirm Codex's published env signature.
+  // Confirmed against upstream — see swamp-club#413.
+  // Codex `env_clear()`s before each shell-tool spawn and re-adds only its
+  // sandbox markers (openai/codex codex-rs/core/src/spawn.rs and
+  // sandboxing/mod.rs): `CODEX_SANDBOX_NETWORK_DISABLED=1` on any platform
+  // when network sandbox is enabled, and `CODEX_SANDBOX=seatbelt` on macOS.
+  // Known blind spot: if a user runs codex with sandbox fully disabled
+  // (e.g. `--dangerously-bypass-approvals-and-sandbox`), neither var is set
+  // and codex is undetectable from a child process. That requires upstream
+  // to expose a stable identity env var — not fixable from our side.
   {
     tool: "codex",
-    predicate: (env) => env.CODEX_AGENT_HARNESS === "1",
+    predicate: (env) =>
+      env.CODEX_SANDBOX_NETWORK_DISABLED === "1" ||
+      env.CODEX_SANDBOX !== undefined,
   },
 ];
 
@@ -96,9 +113,10 @@ export const RELEVANT_ENV_VARS: readonly string[] = [
   "CLAUDE_CODE_ENTRYPOINT",
   "TERM_PROGRAM",
   "CURSOR_TRACE_ID",
-  "KIRO_AGENT",
-  "OPENCODE_VERSION",
-  "CODEX_AGENT_HARNESS",
+  "AGENT_CONTEXT_OUT",
+  "OPENCODE",
+  "CODEX_SANDBOX_NETWORK_DISABLED",
+  "CODEX_SANDBOX",
   ...GENERIC_AGENT_SIGNALS,
 ];
 

--- a/src/domain/telemetry/agent_harness_detection_test.ts
+++ b/src/domain/telemetry/agent_harness_detection_test.ts
@@ -59,29 +59,62 @@ Deno.test("detectAgentHarness: kiro via TERM_PROGRAM=kiro", () => {
   assertEquals(result.agentSessionDetected, true);
 });
 
-Deno.test("detectAgentHarness: kiro via KIRO_AGENT=1", () => {
-  const result = detectAgentHarness({ KIRO_AGENT: "1" });
+Deno.test("detectAgentHarness: kiro via AGENT_CONTEXT_OUT FIFO path", () => {
+  const result = detectAgentHarness({
+    AGENT_CONTEXT_OUT: "/tmp/kiro-agent-ctx.fifo",
+  });
   assertEquals(result.detectedAiTool, "kiro");
   assertEquals(result.agentSessionDetected, true);
 });
 
-Deno.test("detectAgentHarness: opencode via OPENCODE_VERSION", () => {
-  const result = detectAgentHarness({ OPENCODE_VERSION: "0.1.0" });
+Deno.test(
+  "detectAgentHarness: empty AGENT_CONTEXT_OUT does not match kiro",
+  () => {
+    const result = detectAgentHarness({ AGENT_CONTEXT_OUT: "" });
+    assertEquals(result.detectedAiTool, undefined);
+    assertEquals(result.agentSessionDetected, false);
+  },
+);
+
+Deno.test("detectAgentHarness: opencode via OPENCODE=1", () => {
+  const result = detectAgentHarness({ OPENCODE: "1" });
   assertEquals(result.detectedAiTool, "opencode");
   assertEquals(result.agentSessionDetected, true);
 });
 
-Deno.test("detectAgentHarness: opencode via TERM_PROGRAM=opencode", () => {
-  const result = detectAgentHarness({ TERM_PROGRAM: "opencode" });
-  assertEquals(result.detectedAiTool, "opencode");
-  assertEquals(result.agentSessionDetected, true);
+Deno.test("detectAgentHarness: OPENCODE=0 does not match opencode", () => {
+  const result = detectAgentHarness({ OPENCODE: "0" });
+  assertEquals(result.detectedAiTool, undefined);
+  assertEquals(result.agentSessionDetected, false);
 });
 
-Deno.test("detectAgentHarness: codex via CODEX_AGENT_HARNESS=1", () => {
-  const result = detectAgentHarness({ CODEX_AGENT_HARNESS: "1" });
+Deno.test(
+  "detectAgentHarness: codex via CODEX_SANDBOX_NETWORK_DISABLED=1",
+  () => {
+    const result = detectAgentHarness({ CODEX_SANDBOX_NETWORK_DISABLED: "1" });
+    assertEquals(result.detectedAiTool, "codex");
+    assertEquals(result.agentSessionDetected, true);
+  },
+);
+
+Deno.test("detectAgentHarness: codex via CODEX_SANDBOX=seatbelt", () => {
+  const result = detectAgentHarness({ CODEX_SANDBOX: "seatbelt" });
   assertEquals(result.detectedAiTool, "codex");
   assertEquals(result.agentSessionDetected, true);
 });
+
+// Codex env_clear()s before each shell-tool spawn and only re-adds sandbox
+// markers. When a user disables sandboxing entirely, no codex-identifying
+// env var survives — this test codifies that blind spot so future
+// contributors don't try to invent more signals without upstream cooperation.
+Deno.test(
+  "detectAgentHarness: codex without sandbox is undetectable",
+  () => {
+    const result = detectAgentHarness({});
+    assertEquals(result.detectedAiTool, undefined);
+    assertEquals(result.agentSessionDetected, false);
+  },
+);
 
 Deno.test("detectAgentHarness: generic AGENT fallback fires without specific match", () => {
   const result = detectAgentHarness({ AGENT: "1" });
@@ -136,9 +169,10 @@ Deno.test("RELEVANT_ENV_VARS contains every key any signal references", () => {
     "CLAUDE_CODE_ENTRYPOINT",
     "TERM_PROGRAM",
     "CURSOR_TRACE_ID",
-    "KIRO_AGENT",
-    "OPENCODE_VERSION",
-    "CODEX_AGENT_HARNESS",
+    "AGENT_CONTEXT_OUT",
+    "OPENCODE",
+    "CODEX_SANDBOX_NETWORK_DISABLED",
+    "CODEX_SANDBOX",
     "AGENT",
     "AI_AGENT",
     "IS_AGENT",


### PR DESCRIPTION
## Summary

The harness detection added in #1342 (swamp-club#292) shipped with fabricated env vars for kiro, opencode, and codex. Telemetry only ever named Claude (and Cursor); every other harness fell through to the generic `AGENT`/`AI_AGENT` fallback or went undetected. This PR replaces the fabricated predicates with vars confirmed against each harness's upstream source.

## Per-harness corrections

**opencode** (`anomalyco/opencode` `packages/opencode/src/index.ts:109-110`)
```ts
process.env.AGENT = "1"
process.env.OPENCODE = "1"
process.env.OPENCODE_PID = String(process.pid)
```
- `OPENCODE_VERSION` was a build-time constant baked into the binary, never a runtime export.
- `TERM_PROGRAM=opencode` is never set (opencode doesn't override TERM_PROGRAM).
- Predicate is now `env.OPENCODE === "1"`.

**codex** (`openai/codex` `codex-rs/core/src/spawn.rs` + `sandboxing/mod.rs`)
```rust
if !network_sandbox_policy.is_enabled() {
    cmd.env(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR, "1");
}
#[cfg(target_os = \"macos\")]
if sandbox == SandboxType::MacosSeatbelt {
    env.insert(CODEX_SANDBOX_ENV_VAR.to_string(), \"seatbelt\".to_string());
}
```
- Codex `env_clear()`s before each shell-tool spawn; parent env doesn't propagate.
- `CODEX_AGENT_HARNESS` is fabricated.
- Predicate is now `env.CODEX_SANDBOX_NETWORK_DISABLED === \"1\" || env.CODEX_SANDBOX !== undefined`.
- **Known blind spot** (documented in code): codex run with sandbox fully disabled (e.g. `--dangerously-bypass-approvals-and-sandbox`) is undetectable from a child process — requires upstream to expose a stable identity env var.

**kiro** (kiro.dev/docs/cli/reference/built-in-tools/)
- `TERM_PROGRAM=kiro` (correct, kept) covers IDE-terminal sessions.
- `KIRO_AGENT` is fabricated.
- Adds `AGENT_CONTEXT_OUT` (a FIFO path Kiro CLI exports only when its agent is driving a shell command) to catch the agent-driven case.

## Other changes

- `RELEVANT_ENV_VARS` whitelist updated to match (removes `KIRO_AGENT`, `OPENCODE_VERSION`, `CODEX_AGENT_HARNESS`; adds `OPENCODE`, `AGENT_CONTEXT_OUT`, `CODEX_SANDBOX_NETWORK_DISABLED`, `CODEX_SANDBOX`). `src/cli/telemetry_integration.ts:projectEnvSnapshot` iterates over the whitelist generically — no caller change needed.
- The three `TODO(swamp-club#292)` comments are replaced with `Confirmed against upstream — see swamp-club#413` plus source citations, so the breadcrumb survives in the file.
- Unit tests rewritten: previously they asserted against the fabricated env vars (passing against fiction) and would have kept passing under any wrong implementation. New tests cover each real env var, the empty-string and `=0` negatives, and codify the codex no-sandbox blind spot.

## Test Plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt --check` clean
- [x] `deno run test src/domain/telemetry/agent_harness_detection_test.ts` — 21/21 pass
- [x] `deno run test integration/telemetry_invocation_context_test.ts` — passes
- [x] `deno run test` — 6100 passed, 0 failed
- [x] `deno run compile` — binary built

🤖 Generated with [Claude Code](https://claude.com/claude-code)