### PR TITLE
docs(readme): clarify in-place update wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ an external API.
 
 ### Update
 
-Swamp can update itself:
+Swamp can update itself in place:
 
 ```bash
 swamp update


### PR DESCRIPTION
## Summary

Trivial single-line wording tweak to the README's Update section: "update itself" → "update itself in place".

## Why

Need a merged PR to trigger the release pipeline so I can smoke-test the dual-publish path landed in [systeminit/swamp-uat#228](https://github.com/systeminit/swamp-uat/pull/228), which dual-writes release binaries to DO Spaces (\`artifacts-swamp-club\`) alongside AWS S3 (\`si-artifacts-prod\`) during the AWS→DO migration window.

After merge:
- swamp's release.yml builds binaries + creates a GitHub Release.
- Dispatches \`run-uat\` to swamp-uat with the new version.
- swamp-uat's uat.yml then runs \`upload_binaries.sh\`, which should upload to BOTH AWS and DO this time.
- I'll verify the DO bucket gets the versioned tarballs + .sha256 + stable copies for all 4 platforms.

## Test plan

- [ ] CI passes
- [ ] Merge triggers release.yml; new version published as a GitHub Release with binaries attached
- [ ] swamp-uat run-uat workflow fires for the new version
- [ ] AWS \`si-artifacts-prod\` gets the usual versioned + stable-redirect objects (no regression)
- [ ] DO \`artifacts-swamp-club\` gets versioned tarballs + .sha256 for all 4 platforms
- [ ] DO bucket has literal-copy stable tarballs at \`swamp/stable/binary/<os>/<arch>/swamp-stable-binary-<os>-<arch>.tar.gz\` matching the versioned tarball byte-for-byte
- [ ] \`curl https://artifacts.swamp-club.com/swamp/stable/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz\` returns 200 + valid tarball
- [ ] Cloudflare cache purge step reports success

🤖 Generated with [Claude Code](https://claude.com/claude-code)