### PR TITLE
fix(skills): prefer community extensions over local types in decision order (swamp-club#396)

### DIFF
--- a/.claude/skills/swamp-extension/SKILL.md
+++ b/.claude/skills/swamp-extension/SKILL.md
@@ -34,12 +34,17 @@ via `swamp-extension-publish`.
 
 ## Before Creating an Extension
 
-1. `swamp model type search <query>` / `swamp extension search <query>` — does a
-   built-in or community extension already cover it? Use it. Stop.
-2. Trusted collectives (`@swamp/*`, `@si/*`, membership collectives)
-   auto-resolve on first use — `swamp extension trust list` shows which.
-3. For local or private extensions, use `swamp extension source add <path>`.
-4. Only create a new extension if nothing fits.
+1. `swamp extension search <query>` — does a community extension already cover
+   it? Prefer `@swamp/*` official extensions first. Install with
+   `swamp extension pull <package>` and use it. Stop.
+2. `swamp model type search <query>` — check built-in/installed local types.
+3. Extend an existing type (including `@swamp` extensions) if it covers the
+   domain but lacks the method you need.
+4. For local or private extensions, use `swamp extension source add <path>`.
+5. Only create a new extension if nothing fits.
+
+Trusted collectives (`@swamp/*`, `@si/*`, membership collectives) auto-resolve
+on first use — `swamp extension trust list` shows which.
 
 **Never** use `command/shell` to wrap service integrations — build a dedicated
 model.

--- a/.claude/skills/swamp-extension/references/model/scenarios.md
+++ b/.claude/skills/swamp-extension/references/model/scenarios.md
@@ -27,8 +27,8 @@ End-to-end scenarios showing how to build custom extension models.
 ### Decision Tree
 
 ```
-swamp model type search Stripe → no local results
 swamp extension search Stripe → no community extension
+swamp model type search Stripe → no local results
 No existing model → Create extension model
 Need typed input validation → Define Zod schemas
 Store response data for CEL access → Use writeResource
@@ -202,8 +202,8 @@ globalArguments:
 ### Decision Tree
 
 ```
-swamp model type search S3 → no local results
 swamp extension search S3 → no community extension
+swamp model type search S3 → no local results
 No existing model → Create extension model
 Full lifecycle management → create, update, delete methods
 Update reads existing state → Use context.readResource
@@ -517,8 +517,8 @@ jobs:
 ### Decision Tree
 
 ```
-swamp model type search VPC → no local results
 swamp extension search VPC → no community extension
+swamp model type search VPC → no local results
 No existing model → Create extension model
 Discover multiple resources → Factory model pattern
 Each resource needs unique ID → Dynamic instance names
@@ -671,6 +671,7 @@ jobs:
 ### Decision Tree
 
 ```
+swamp extension search shell → no community extension
 swamp model type search command/shell → exists locally
 Want to add methods, not create new type → export const extension
 Cannot change schema → Only add new methods
@@ -782,7 +783,6 @@ Nothing — a community extension already exists.
 ### Decision Tree
 
 ```
-swamp model type search DigitalOcean → no local results
 swamp extension search DigitalOcean → found @swamp/digitalocean
 Community extension exists → Install and use it
 swamp extension pull @swamp/digitalocean → installs the extension
@@ -790,27 +790,20 @@ swamp extension pull @swamp/digitalocean → installs the extension
 
 ### Step-by-Step
 
-**1. Search local types**
-
-```bash
-swamp model type search DigitalOcean --json
-# No results
-```
-
-**2. Search community extensions**
+**1. Search community extensions**
 
 ```bash
 swamp extension search DigitalOcean --json
 # Found: @swamp/digitalocean
 ```
 
-**3. Install the community extension**
+**2. Install the community extension**
 
 ```bash
 swamp extension pull @swamp/digitalocean
 ```
 
-**4. Use the installed model type**
+**3. Use the installed model type**
 
 ```bash
 swamp model type search DigitalOcean --json
@@ -826,5 +819,7 @@ swamp model create @swamp/digitalocean-droplet my-droplet --json
 
 - The agent does NOT offer to create a custom extension model
 - The agent installs the community extension and uses it directly
+- If the extension lacks a needed method, the agent extends it rather than
+  building from scratch
 - The agent only creates a custom model if the community extension is missing or
   does not cover the needed functionality

--- a/.claude/skills/swamp-getting-started/SKILL.md
+++ b/.claude/skills/swamp-getting-started/SKILL.md
@@ -49,10 +49,12 @@ matching skill (`swamp-model`, `swamp-workflow`, `swamp-vault`, etc.).
 
 **Verify:** The user described a goal. Then find a model type:
 
-1. `swamp model type search <keywords> --json`
-2. If nothing local: `swamp extension search <keywords> --json`
-3. If an extension matches: `swamp extension pull <package>`
-4. If nothing exists, offer a custom extension via `swamp-extension`. Use
+1. `swamp extension search <keywords> --json` — prefer `@swamp/*` official
+   extensions first
+2. If an extension matches: `swamp extension pull <package>`
+3. `swamp model type search <keywords> --json` — check local/installed types
+4. Extend an existing type if it covers the domain but lacks the method you need
+5. If nothing exists, offer a custom extension via `swamp-extension`. Use
    `command/shell` only for genuine one-off ad-hoc commands.
 
 Store the goal — use it to name the model and tailor later examples.

--- a/.claude/skills/swamp-model/SKILL.md
+++ b/.claude/skills/swamp-model/SKILL.md
@@ -518,11 +518,11 @@ run concurrently. See
 
 **Steps:**
 
-1. **Search** for the right type: `swamp model type search "shell" --json`
-2. **Search community** if no local type:
-   `swamp extension search <query> --json` — if a matching extension exists,
-   install it with `swamp extension pull <package>` instead of building from
-   scratch
+1. **Search community extensions** first:
+   `swamp extension search <query> --json` — prefer `@swamp/*` official
+   extensions. If a match exists, install with `swamp extension pull <package>`
+   instead of building from scratch
+2. **Search local types**: `swamp model type search "shell" --json`
 3. **Describe** to understand the schema:
    `swamp model type describe command/shell --json`
 4. **Create** an input file: `swamp model create command/shell my-shell --json`

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -779,7 +779,7 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 
 ## Rules
 
-1. **Search before you build.** When automating AWS, APIs, or any external service: (a) search local types with \`swamp model type search <query>\`, (b) search community extensions with \`swamp extension search <query>\`, (c) if a community extension exists, install it with \`swamp extension pull <package>\` instead of building from scratch, (d) only create a custom extension model in \`extensions/models/\` if nothing exists. ${
+1. **Search before you build.** When automating AWS, APIs, or any external service: (a) search community extensions with \`swamp extension search <query>\` — prefer \`@swamp/*\` official extensions first, (b) search local/installed types with \`swamp model type search <query>\`, (c) if a community extension exists, install it with \`swamp extension pull <package>\` instead of building from scratch, (d) extend an existing type if it covers the domain but lacks the method you need, (e) only create a custom extension model in \`extensions/models/\` as a last resort. ${
       skillAction("swamp-extension", "Use")
     } for guidance. The \`command/shell\` model is ONLY for ad-hoc one-off shell commands, NEVER for wrapping CLI tools or building integrations.
 2. **Extend, don't be clever.** When a model covers the domain but lacks the method you need, extend it with \`export const extension\` — don't bypass it with shell scripts, CLI tools, or multi-step hacks. One method, one purpose. Use \`swamp model type describe <type> --json\` to check available methods.


### PR DESCRIPTION
## Summary

- Reorder extension decision guidance across 5 files so community/registry extensions (`swamp extension search`) are searched **before** local types (`swamp model type search`), with explicit preference for `@swamp/*` official extensions
- Add explicit "extend an existing type" step — `@swamp` extensions aren't exhaustive, so extending them is preferred over building from scratch
- Files changed: managed CLAUDE.md template (`repo_service.ts`), `swamp-extension` SKILL.md + scenarios.md, `swamp-model` SKILL.md, `swamp-getting-started` SKILL.md

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 6103 tests pass, 0 failed
- [x] `npx tessl skill review` — swamp-model 93%, swamp-extension 94%, swamp-getting-started 97%
- [x] Verified all 5 scenario decision trees in scenarios.md are consistently reordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)