### PR TITLE
feat(vaults): add first-class annotation support for vault secrets

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -8,7 +8,8 @@ description: >
   Triggers on "vault", "secret", "secrets", "swamp vault", "store secret",
   "get secret", "vault expression", "aws secrets manager", "credential
   storage", "vault create", "vault put", "vault read-secret", "vault list-keys",
-  "vault migrate".
+  "vault migrate", "vault annotate", "vault inspect", "annotation",
+  "annotate secret", "inspect secret".
 ---
 
 # Swamp Vault Skill
@@ -32,19 +33,22 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 
 ## Quick Reference
 
-| Task              | Command                                                |
-| ----------------- | ------------------------------------------------------ |
-| List vault types  | `swamp vault type search --json`                       |
-| Create a vault    | `swamp vault create <type> <name> --json`              |
-| Search vaults     | `swamp vault search [query] --json`                    |
-| Get vault details | `swamp vault get <name_or_id> --json`                  |
-| Edit vault config | `swamp vault edit <name_or_id>`                        |
-| Store a secret    | `swamp vault put <vault> KEY=VALUE --json`             |
-| Store from stdin  | `echo "val" \| swamp vault put <vault> KEY --json`     |
-| Store interactive | `swamp vault put <vault> KEY` (prompts for value)      |
-| Read a secret     | `swamp vault read-secret <vault> <key> --force --json` |
-| List secret keys  | `swamp vault list-keys <vault> --json`                 |
-| Migrate backend   | `swamp vault migrate <vault> --to-type <type>`         |
+| Task               | Command                                                |
+| ------------------ | ------------------------------------------------------ |
+| List vault types   | `swamp vault type search --json`                       |
+| Create a vault     | `swamp vault create <type> <name> --json`              |
+| Search vaults      | `swamp vault search [query] --json`                    |
+| Get vault details  | `swamp vault get <name_or_id> --json`                  |
+| Edit vault config  | `swamp vault edit <name_or_id>`                        |
+| Store a secret     | `swamp vault put <vault> KEY=VALUE --json`             |
+| Store from stdin   | `echo "val" \| swamp vault put <vault> KEY --json`     |
+| Store interactive  | `swamp vault put <vault> KEY` (prompts for value)      |
+| Read a secret      | `swamp vault read-secret <vault> <key> --force --json` |
+| List secret keys   | `swamp vault list-keys <vault> --json`                 |
+| Annotate a secret  | `swamp vault annotate <vault> <key> --url <u>`         |
+| Inspect annotation | `swamp vault inspect <vault> <key> --json`             |
+| Clear annotation   | `swamp vault annotate <vault> <key> --clear`           |
+| Migrate backend    | `swamp vault migrate <vault> --to-type <type>`         |
 
 ## Repository Structure
 
@@ -206,6 +210,51 @@ swamp vault list-keys dev-secrets --json
 {
   "vault": "dev-secrets",
   "keys": ["API_KEY", "DB_PASSWORD"]
+}
+```
+
+## Annotate Secrets
+
+Attach provenance metadata to a stored secret — URL, notes, and key=value
+labels. Annotations use merge semantics: only the fields you specify are
+updated, existing fields are preserved.
+
+```bash
+# Add a URL and notes
+swamp vault annotate my-vault API_KEY \
+  --url https://console.aws.com/iam \
+  --note "Production API key for service X"
+
+# Add labels
+swamp vault annotate my-vault API_KEY \
+  --label env=prod --label team=infra
+
+# Clear all annotations
+swamp vault annotate my-vault API_KEY --clear
+```
+
+## Inspect Secret Annotations
+
+View the metadata attached to a secret:
+
+```bash
+swamp vault inspect my-vault API_KEY --json
+```
+
+**Output shape (--json):**
+
+```json
+{
+  "vaultName": "my-vault",
+  "secretKey": "API_KEY",
+  "vaultType": "local_encryption",
+  "hasAnnotation": true,
+  "annotation": {
+    "url": "https://console.aws.com/iam",
+    "notes": "Production API key for service X",
+    "labels": { "env": "prod", "team": "infra" },
+    "updatedAt": "2026-05-22T21:00:00.000Z"
+  }
 }
 ```
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -87,8 +87,12 @@ encrypted `.meta.enc` files alongside the secret's `.enc` file:
 ```
 .swamp/secrets/local_encryption/{vault-name}/
   my-api-key.enc          # encrypted secret value
-  my-api-key.meta.enc     # encrypted annotation (same AES-GCM key)
+  .annotations/
+    my-api-key.enc        # encrypted annotation (same AES-GCM key)
 ```
+
+Annotations live in a `.annotations/` subdirectory to avoid filename collisions
+with secret keys that might end in `.meta` or similar suffixes.
 
 ### Annotation CLI
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -59,6 +59,48 @@ interface VaultProvider {
 }
 ```
 
+## Vault Annotation Provider Interface
+
+Vault providers can optionally support annotations — metadata attached to
+secrets (URL, notes, labels). Annotation support is opt-in: providers that
+implement `VaultAnnotationProvider` alongside `VaultProvider` gain annotation
+capabilities. Providers that don't implement it continue to work unchanged.
+
+```typescript
+interface VaultAnnotationProvider {
+  getAnnotation(secretKey: string): Promise<VaultAnnotation | null>;
+  putAnnotation(secretKey: string, annotation: VaultAnnotation): Promise<void>;
+  deleteAnnotation(secretKey: string): Promise<void>;
+  listAnnotations(): Promise<Map<string, VaultAnnotation>>;
+}
+```
+
+Detection is via runtime type guard (`isVaultAnnotationProvider()`), not
+compile-time typing. Extension vault providers opt in by having their
+`createProvider` return an object that implements both interfaces.
+
+### Annotation Storage (local_encryption)
+
+For the built-in `local_encryption` provider, annotations are stored as
+encrypted `.meta.enc` files alongside the secret's `.enc` file:
+
+```
+.swamp/secrets/local_encryption/{vault-name}/
+  my-api-key.enc          # encrypted secret value
+  my-api-key.meta.enc     # encrypted annotation (same AES-GCM key)
+```
+
+### Annotation CLI
+
+```
+swamp vault annotate <vault> <key> --url <u> --note <text> --label <k=v>
+swamp vault inspect <vault> <key>
+swamp vault annotate <vault> <key> --clear
+```
+
+Annotations use merge semantics: only the fields specified in flags are updated,
+existing fields are preserved. `--clear` removes all annotations.
+
 ## Expression Syntax
 
 Vaults are accessed in CEL expressions using the `vault.get()` and `vault.put()`

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -28,6 +28,8 @@ import { vaultGetCommand } from "./vault_get.ts";
 import { vaultDescribeCommand } from "./vault_describe.ts";
 import { vaultEditCommand } from "./vault_edit.ts";
 import { vaultPutCommand } from "./vault_put.ts";
+import { vaultAnnotateCommand } from "./vault_annotate.ts";
+import { vaultInspectCommand } from "./vault_inspect.ts";
 import { vaultListKeysCommand } from "./vault_list_keys.ts";
 import { vaultMigrateCommand } from "./vault_migrate.ts";
 import { vaultReadSecretCommand } from "./vault_read_secret.ts";
@@ -69,6 +71,8 @@ export const vaultCommand = new Command()
   .command("describe", vaultDescribeCommand)
   .command("edit", vaultEditCommand)
   .command("put", vaultPutCommand)
+  .command("annotate", vaultAnnotateCommand)
+  .command("inspect", vaultInspectCommand)
   .command("migrate", vaultMigrateCommand)
   .command("read-secret", vaultReadSecretCommand)
   .command("list-keys", vaultListKeysCommand)

--- a/src/cli/commands/vault_annotate.ts
+++ b/src/cli/commands/vault_annotate.ts
@@ -1,0 +1,140 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createVaultAnnotateDeps,
+  vaultAnnotate,
+} from "../../libswamp/mod.ts";
+import { createVaultAnnotateRenderer } from "../../presentation/renderers/vault_annotate.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+
+export function parseLabels(
+  labels: string[] | undefined,
+): Record<string, string> | undefined {
+  if (!labels || labels.length === 0) return undefined;
+  const result: Record<string, string> = {};
+  for (const label of labels) {
+    const eqIndex = label.indexOf("=");
+    if (eqIndex === -1) {
+      throw new UserError(
+        `Invalid label format: '${label}'. Expected key=value.`,
+      );
+    }
+    const key = label.substring(0, eqIndex);
+    const value = label.substring(eqIndex + 1);
+    if (key.length === 0) {
+      throw new UserError(
+        `Invalid label: key cannot be empty in '${label}'.`,
+      );
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const vaultAnnotateCommand = new Command()
+  .name("annotate")
+  .description(
+    `Annotate a vault secret with metadata.
+
+Attaches provenance metadata (URL, notes, labels) to an existing secret.
+Annotations use merge semantics: only the fields you specify are updated,
+existing fields are preserved. Use --clear to remove all annotations.`,
+  )
+  .arguments("<vault_name:string> <key:string>")
+  .example(
+    "Add a URL and notes",
+    'swamp vault annotate my-vault API_KEY --url https://console.aws.com/iam --note "Production API key"',
+  )
+  .example(
+    "Add labels",
+    "swamp vault annotate my-vault API_KEY --label env=prod --label team=infra",
+  )
+  .example(
+    "Clear all annotations",
+    "swamp vault annotate my-vault API_KEY --clear",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--url <url:string>", "URL associated with this secret")
+  .option("--note <note:string>", "Free-text notes about this secret")
+  .option(
+    "--label <label:string>",
+    "Key=value label (repeatable)",
+    { collect: true },
+  )
+  .option("--clear", "Remove all annotations from this secret")
+  .action(async function (
+    options: AnyOptions,
+    vaultName: string,
+    key: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "vault",
+      "annotate",
+    ]);
+    cliCtx.logger.debug`Annotating secret in vault: ${vaultName}`;
+
+    const { repoDir, repoContext } = await requireInitializedRepo({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const clear = options.clear === true;
+    const labels = parseLabels(options.label);
+
+    if (
+      !clear && options.url === undefined && options.note === undefined &&
+      labels === undefined
+    ) {
+      throw new UserError(
+        "No annotation fields specified. Use --url, --note, --label, or --clear.",
+      );
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createVaultAnnotateDeps(repoDir, repoContext.eventBus);
+
+    const renderer = createVaultAnnotateRenderer(cliCtx.outputMode);
+    await consumeStream(
+      vaultAnnotate(ctx, deps, {
+        vaultName,
+        key,
+        url: options.url,
+        notes: options.note,
+        labels,
+        clear,
+      }),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/vault_annotate_test.ts
+++ b/src/cli/commands/vault_annotate_test.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { parseLabels } from "./vault_annotate.ts";
+import { UserError } from "../../domain/errors.ts";
+
+Deno.test("parseLabels: undefined input returns undefined", () => {
+  const result = parseLabels(undefined);
+  assertEquals(result, undefined);
+});
+
+Deno.test("parseLabels: empty array returns undefined", () => {
+  const result = parseLabels([]);
+  assertEquals(result, undefined);
+});
+
+Deno.test("parseLabels: single label parses correctly", () => {
+  const result = parseLabels(["env=prod"]);
+  assertEquals(result, { env: "prod" });
+});
+
+Deno.test("parseLabels: multiple labels parse correctly", () => {
+  const result = parseLabels(["env=prod", "team=infra", "region=us-east-1"]);
+  assertEquals(result, { env: "prod", team: "infra", region: "us-east-1" });
+});
+
+Deno.test("parseLabels: label with multiple = signs keeps value intact", () => {
+  const result = parseLabels(["key=val=ue"]);
+  assertEquals(result, { key: "val=ue" });
+});
+
+Deno.test("parseLabels: empty key throws UserError", () => {
+  assertThrows(
+    () => parseLabels(["=value"]),
+    UserError,
+    "key cannot be empty",
+  );
+});
+
+Deno.test("parseLabels: missing = sign throws UserError", () => {
+  assertThrows(
+    () => parseLabels(["noequalssign"]),
+    UserError,
+    "Expected key=value",
+  );
+});
+
+Deno.test("parseLabels: empty value is allowed", () => {
+  const result = parseLabels(["key="]);
+  assertEquals(result, { key: "" });
+});

--- a/src/cli/commands/vault_inspect.ts
+++ b/src/cli/commands/vault_inspect.ts
@@ -1,0 +1,84 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createVaultInspectDeps,
+  vaultInspect,
+} from "../../libswamp/mod.ts";
+import { createVaultInspectRenderer } from "../../presentation/renderers/vault_inspect.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const vaultInspectCommand = new Command()
+  .name("inspect")
+  .description(
+    `Show annotations for a vault secret.
+
+Displays the metadata (URL, notes, labels) attached to a secret
+via \`swamp vault annotate\`.`,
+  )
+  .arguments("<vault_name:string> <key:string>")
+  .example(
+    "Inspect a secret's annotations",
+    "swamp vault inspect my-vault API_KEY",
+  )
+  .example(
+    "JSON output",
+    "swamp vault inspect my-vault API_KEY --json",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (
+    options: AnyOptions,
+    vaultName: string,
+    key: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "vault",
+      "inspect",
+    ]);
+    cliCtx.logger
+      .debug`Inspecting annotation for secret in vault: ${vaultName}`;
+
+    const { repoDir } = await requireInitializedRepo({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createVaultInspectDeps(repoDir);
+
+    const renderer = createVaultInspectRenderer(cliCtx.outputMode);
+    await consumeStream(
+      vaultInspect(ctx, deps, vaultName, key),
+      renderer.handlers(),
+    );
+  });

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -189,7 +189,8 @@ export type RepositoryEvent =
   | VaultUpdated
   | VaultDeleted
   | VaultSecretUpdated
-  | VaultSecretRead;
+  | VaultSecretRead
+  | VaultSecretAnnotated;
 
 /**
  * Event type discriminator values.
@@ -539,6 +540,39 @@ export function createVaultSecretRead(
     vaultType,
     vaultName,
     secretKey,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Emitted when a secret's annotation is updated in a vault.
+ */
+export interface VaultSecretAnnotated extends DomainEvent {
+  readonly type: "VaultSecretAnnotated";
+  readonly vaultId: string;
+  readonly vaultType: string;
+  readonly vaultName: string;
+  readonly secretKey: string;
+  readonly annotationFields: readonly string[];
+}
+
+/**
+ * Creates a VaultSecretAnnotated event.
+ */
+export function createVaultSecretAnnotated(
+  vaultId: string,
+  vaultType: string,
+  vaultName: string,
+  secretKey: string,
+  annotationFields: string[],
+): VaultSecretAnnotated {
+  return {
+    type: "VaultSecretAnnotated",
+    vaultId,
+    vaultType,
+    vaultName,
+    secretKey,
+    annotationFields,
     timestamp: new Date(),
   };
 }

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -138,10 +138,7 @@ export class LocalEncryptionVaultProvider
 
     try {
       for await (const entry of Deno.readDir(this.vaultDir)) {
-        if (
-          entry.isFile && entry.name.endsWith(".enc") &&
-          !entry.name.endsWith(".meta.enc")
-        ) {
+        if (entry.isFile && entry.name.endsWith(".enc")) {
           const keyName = entry.name.slice(0, -4);
           secretKeys.push(keyName);
         }
@@ -161,9 +158,17 @@ export class LocalEncryptionVaultProvider
     return secretKeys.sort();
   }
 
+  private get annotationsDir(): string {
+    return join(this.vaultDir, ".annotations");
+  }
+
+  private annotationPath(secretKey: string): string {
+    return join(this.annotationsDir, `${secretKey}.enc`);
+  }
+
   async getAnnotation(secretKey: string): Promise<VaultAnnotation | null> {
     this.validateSecretKey(secretKey);
-    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+    const metaPath = this.annotationPath(secretKey);
 
     try {
       const encryptedContent = await Deno.readTextFile(metaPath);
@@ -188,14 +193,14 @@ export class LocalEncryptionVaultProvider
     annotation: VaultAnnotation,
   ): Promise<void> {
     this.validateSecretKey(secretKey);
-    await this.ensureVaultDirectory();
+    await this.ensureAnnotationsDirectory();
 
     const json = JSON.stringify(annotation.toData());
     const salt = crypto.getRandomValues(new Uint8Array(16));
     const masterKey = await this.getMasterKey(this.arrayBufferToBase64(salt));
     const encryptedData = await this.encrypt(json, masterKey, salt);
 
-    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+    const metaPath = this.annotationPath(secretKey);
     await assertSafePath(metaPath, this.secretsBoundary);
     await atomicWriteTextFile(
       metaPath,
@@ -206,7 +211,8 @@ export class LocalEncryptionVaultProvider
 
   async deleteAnnotation(secretKey: string): Promise<void> {
     this.validateSecretKey(secretKey);
-    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+    const metaPath = this.annotationPath(secretKey);
+    await assertSafePath(metaPath, this.secretsBoundary);
     try {
       await Deno.remove(metaPath);
     } catch (error) {
@@ -223,9 +229,9 @@ export class LocalEncryptionVaultProvider
   async listAnnotations(): Promise<Map<string, VaultAnnotation>> {
     const annotations = new Map<string, VaultAnnotation>();
     try {
-      for await (const entry of Deno.readDir(this.vaultDir)) {
-        if (entry.isFile && entry.name.endsWith(".meta.enc")) {
-          const keyName = entry.name.slice(0, -".meta.enc".length);
+      for await (const entry of Deno.readDir(this.annotationsDir)) {
+        if (entry.isFile && entry.name.endsWith(".enc")) {
+          const keyName = entry.name.slice(0, -4);
           const annotation = await this.getAnnotation(keyName);
           if (annotation) {
             annotations.set(keyName, annotation);
@@ -243,6 +249,22 @@ export class LocalEncryptionVaultProvider
       );
     }
     return annotations;
+  }
+
+  private async ensureAnnotationsDirectory(): Promise<void> {
+    const dir = this.annotationsDir;
+    await assertSafePath(dir, this.secretsBoundary);
+    try {
+      await Deno.mkdir(dir, { recursive: true, mode: 0o700 });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.AlreadyExists)) {
+        throw new Error(
+          `Failed to create annotations directory '${dir}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
   }
 
   /**

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -20,6 +20,8 @@
 import { join } from "@std/path";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import type { VaultProvider } from "./vault_provider.ts";
+import type { VaultAnnotationProvider } from "./vault_annotation.ts";
+import { VaultAnnotation } from "./vault_annotation.ts";
 import {
   SWAMP_SUBDIRS,
   swampPath,
@@ -60,7 +62,8 @@ interface EncryptedData {
  * Uses Web Crypto API with AES-GCM encryption and SSH key-based key derivation.
  * Supports both SSH private key files and auto-generated encryption keys.
  */
-export class LocalEncryptionVaultProvider implements VaultProvider {
+export class LocalEncryptionVaultProvider
+  implements VaultProvider, VaultAnnotationProvider {
   private readonly name: string;
   private readonly config: LocalEncryptionConfig;
   private readonly vaultDir: string;
@@ -135,8 +138,10 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
 
     try {
       for await (const entry of Deno.readDir(this.vaultDir)) {
-        if (entry.isFile && entry.name.endsWith(".enc")) {
-          // Remove the .enc extension to get the secret key name
+        if (
+          entry.isFile && entry.name.endsWith(".enc") &&
+          !entry.name.endsWith(".meta.enc")
+        ) {
           const keyName = entry.name.slice(0, -4);
           secretKeys.push(keyName);
         }
@@ -154,6 +159,90 @@ export class LocalEncryptionVaultProvider implements VaultProvider {
     }
 
     return secretKeys.sort();
+  }
+
+  async getAnnotation(secretKey: string): Promise<VaultAnnotation | null> {
+    this.validateSecretKey(secretKey);
+    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+
+    try {
+      const encryptedContent = await Deno.readTextFile(metaPath);
+      const encryptedData: EncryptedData = JSON.parse(encryptedContent);
+      const masterKey = await this.getMasterKey(encryptedData.salt);
+      const json = await this.decrypt(encryptedData, masterKey);
+      return VaultAnnotation.fromData(JSON.parse(json));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw new Error(
+        `Failed to read annotation for '${secretKey}': ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  async putAnnotation(
+    secretKey: string,
+    annotation: VaultAnnotation,
+  ): Promise<void> {
+    this.validateSecretKey(secretKey);
+    await this.ensureVaultDirectory();
+
+    const json = JSON.stringify(annotation.toData());
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const masterKey = await this.getMasterKey(this.arrayBufferToBase64(salt));
+    const encryptedData = await this.encrypt(json, masterKey, salt);
+
+    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+    await assertSafePath(metaPath, this.secretsBoundary);
+    await atomicWriteTextFile(
+      metaPath,
+      JSON.stringify(encryptedData, null, 2),
+      { mode: 0o600 },
+    );
+  }
+
+  async deleteAnnotation(secretKey: string): Promise<void> {
+    this.validateSecretKey(secretKey);
+    const metaPath = join(this.vaultDir, `${secretKey}.meta.enc`);
+    try {
+      await Deno.remove(metaPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw new Error(
+          `Failed to delete annotation for '${secretKey}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  }
+
+  async listAnnotations(): Promise<Map<string, VaultAnnotation>> {
+    const annotations = new Map<string, VaultAnnotation>();
+    try {
+      for await (const entry of Deno.readDir(this.vaultDir)) {
+        if (entry.isFile && entry.name.endsWith(".meta.enc")) {
+          const keyName = entry.name.slice(0, -".meta.enc".length);
+          const annotation = await this.getAnnotation(keyName);
+          if (annotation) {
+            annotations.set(keyName, annotation);
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return annotations;
+      }
+      throw new Error(
+        `Failed to list annotations in vault '${this.name}': ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return annotations;
   }
 
   /**

--- a/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
@@ -1,0 +1,168 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  type LocalEncryptionConfig,
+  LocalEncryptionVaultProvider,
+} from "./local_encryption_vault_provider.ts";
+import { VaultAnnotation } from "./vault_annotation.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({
+    prefix: "swamp-local-vault-annotation-test-",
+  });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+function createVault(
+  name: string,
+  baseDir: string,
+): LocalEncryptionVaultProvider {
+  const config: LocalEncryptionConfig = {
+    auto_generate: true,
+    base_dir: baseDir,
+  };
+  return new LocalEncryptionVaultProvider(name, config);
+}
+
+Deno.test("putAnnotation + getAnnotation: round-trip encrypt/decrypt", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("round-trip-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    const annotation = VaultAnnotation.create({
+      url: "https://console.aws.amazon.com/secretsmanager",
+      notes: "Production API key for payment service",
+      labels: { env: "prod", team: "payments" },
+    });
+
+    await vault.putAnnotation("my-secret", annotation);
+    const retrieved = await vault.getAnnotation("my-secret");
+
+    assertEquals(retrieved !== null, true);
+    assertEquals(
+      retrieved!.url,
+      "https://console.aws.amazon.com/secretsmanager",
+    );
+    assertEquals(retrieved!.notes, "Production API key for payment service");
+    assertEquals(retrieved!.labels, { env: "prod", team: "payments" });
+  });
+});
+
+Deno.test("getAnnotation: returns null when no annotation exists", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("no-annotation-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    const annotation = await vault.getAnnotation("my-secret");
+    assertEquals(annotation, null);
+  });
+});
+
+Deno.test("deleteAnnotation: idempotent when annotation does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("delete-idempotent-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    // Should not throw when deleting a non-existent annotation
+    await vault.deleteAnnotation("my-secret");
+
+    // Verify it is still null
+    const annotation = await vault.getAnnotation("my-secret");
+    assertEquals(annotation, null);
+  });
+});
+
+Deno.test("listAnnotations: returns correct map of annotations", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("list-annotations-vault", dir);
+    await vault.put("secret-a", "value-a");
+    await vault.put("secret-b", "value-b");
+    await vault.put("secret-c", "value-c");
+
+    const annotationA = VaultAnnotation.create({
+      url: "https://a.example.com",
+      notes: "First secret",
+    });
+    const annotationB = VaultAnnotation.create({
+      labels: { env: "staging" },
+    });
+
+    await vault.putAnnotation("secret-a", annotationA);
+    await vault.putAnnotation("secret-b", annotationB);
+    // secret-c has no annotation
+
+    const annotations = await vault.listAnnotations();
+    assertEquals(annotations.size, 2);
+    assertEquals(annotations.has("secret-a"), true);
+    assertEquals(annotations.has("secret-b"), true);
+    assertEquals(annotations.has("secret-c"), false);
+
+    assertEquals(annotations.get("secret-a")!.url, "https://a.example.com");
+    assertEquals(annotations.get("secret-a")!.notes, "First secret");
+    assertEquals(annotations.get("secret-b")!.labels, { env: "staging" });
+  });
+});
+
+Deno.test("listAnnotations: returns empty map when no annotations exist", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("empty-annotations-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    const annotations = await vault.listAnnotations();
+    assertEquals(annotations.size, 0);
+  });
+});
+
+Deno.test("putAnnotation: overwrites existing annotation", async () => {
+  await withTempDir(async (dir) => {
+    const vault = createVault("overwrite-vault", dir);
+    await vault.put("my-secret", "secret-value");
+
+    const original = VaultAnnotation.create({
+      url: "https://old.example.com",
+      notes: "Original note",
+      labels: { env: "dev" },
+    });
+    await vault.putAnnotation("my-secret", original);
+
+    // Verify original was stored
+    const first = await vault.getAnnotation("my-secret");
+    assertEquals(first!.url, "https://old.example.com");
+    assertEquals(first!.notes, "Original note");
+
+    const updated = VaultAnnotation.create({
+      url: "https://new.example.com",
+      notes: "Updated note",
+      labels: { env: "prod", region: "us-east-1" },
+    });
+    await vault.putAnnotation("my-secret", updated);
+
+    // Verify overwrite took effect
+    const second = await vault.getAnnotation("my-secret");
+    assertEquals(second!.url, "https://new.example.com");
+    assertEquals(second!.notes, "Updated note");
+    assertEquals(second!.labels, { env: "prod", region: "us-east-1" });
+  });
+});

--- a/src/domain/vaults/vault_annotation.ts
+++ b/src/domain/vaults/vault_annotation.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Serializable representation of a vault annotation.
+ */
+export interface VaultAnnotationData {
+  url?: string;
+  notes?: string;
+  labels?: Record<string, string>;
+  updatedAt: string;
+}
+
+/**
+ * Value object representing metadata attached to a vault secret.
+ */
+export class VaultAnnotation {
+  readonly url: string | undefined;
+  readonly notes: string | undefined;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly updatedAt: Date;
+
+  private constructor(
+    url: string | undefined,
+    notes: string | undefined,
+    labels: Record<string, string>,
+    updatedAt: Date,
+  ) {
+    this.url = url;
+    this.notes = notes;
+    this.labels = Object.freeze({ ...labels });
+    this.updatedAt = updatedAt;
+  }
+
+  static create(fields: {
+    url?: string;
+    notes?: string;
+    labels?: Record<string, string>;
+  }): VaultAnnotation {
+    return new VaultAnnotation(
+      fields.url,
+      fields.notes,
+      fields.labels ?? {},
+      new Date(),
+    );
+  }
+
+  static fromData(data: VaultAnnotationData): VaultAnnotation {
+    return new VaultAnnotation(
+      data.url,
+      data.notes,
+      data.labels ?? {},
+      new Date(data.updatedAt),
+    );
+  }
+
+  toData(): VaultAnnotationData {
+    const data: VaultAnnotationData = {
+      updatedAt: this.updatedAt.toISOString(),
+    };
+    if (this.url !== undefined) data.url = this.url;
+    if (this.notes !== undefined) data.notes = this.notes;
+    if (Object.keys(this.labels).length > 0) {
+      data.labels = { ...this.labels };
+    }
+    return data;
+  }
+
+  merge(updates: {
+    url?: string;
+    notes?: string;
+    labels?: Record<string, string>;
+  }): VaultAnnotation {
+    return new VaultAnnotation(
+      updates.url !== undefined ? updates.url : this.url,
+      updates.notes !== undefined ? updates.notes : this.notes,
+      updates.labels !== undefined
+        ? { ...this.labels, ...updates.labels }
+        : { ...this.labels },
+      new Date(),
+    );
+  }
+
+  isEmpty(): boolean {
+    return this.url === undefined &&
+      this.notes === undefined &&
+      Object.keys(this.labels).length === 0;
+  }
+
+  equals(other: VaultAnnotation): boolean {
+    if (this.url !== other.url) return false;
+    if (this.notes !== other.notes) return false;
+    const thisKeys = Object.keys(this.labels).sort();
+    const otherKeys = Object.keys(other.labels).sort();
+    if (thisKeys.length !== otherKeys.length) return false;
+    for (let i = 0; i < thisKeys.length; i++) {
+      if (thisKeys[i] !== otherKeys[i]) return false;
+      if (this.labels[thisKeys[i]] !== other.labels[otherKeys[i]]) return false;
+    }
+    return true;
+  }
+}
+
+/**
+ * Interface for vault providers that support secret annotations.
+ * Separate from VaultProvider — providers opt in by implementing both.
+ */
+export interface VaultAnnotationProvider {
+  getAnnotation(secretKey: string): Promise<VaultAnnotation | null>;
+  putAnnotation(
+    secretKey: string,
+    annotation: VaultAnnotation,
+  ): Promise<void>;
+  deleteAnnotation(secretKey: string): Promise<void>;
+  listAnnotations(): Promise<Map<string, VaultAnnotation>>;
+}
+
+/**
+ * Type guard to check if a vault provider supports annotations.
+ */
+export function isVaultAnnotationProvider(
+  provider: unknown,
+): provider is VaultAnnotationProvider {
+  if (typeof provider !== "object" || provider === null) return false;
+  const obj = provider as Record<string, unknown>;
+  return typeof obj.getAnnotation === "function" &&
+    typeof obj.putAnnotation === "function" &&
+    typeof obj.deleteAnnotation === "function" &&
+    typeof obj.listAnnotations === "function";
+}

--- a/src/domain/vaults/vault_annotation_test.ts
+++ b/src/domain/vaults/vault_annotation_test.ts
@@ -1,0 +1,144 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  isVaultAnnotationProvider,
+  VaultAnnotation,
+} from "./vault_annotation.ts";
+
+Deno.test("VaultAnnotation.create: sets fields and defaults", () => {
+  const a = VaultAnnotation.create({
+    url: "https://example.com",
+    notes: "test note",
+    labels: { env: "prod" },
+  });
+  assertEquals(a.url, "https://example.com");
+  assertEquals(a.notes, "test note");
+  assertEquals(a.labels, { env: "prod" });
+});
+
+Deno.test("VaultAnnotation.create: defaults labels to empty", () => {
+  const a = VaultAnnotation.create({ url: "https://example.com" });
+  assertEquals(a.labels, {});
+  assertEquals(a.notes, undefined);
+});
+
+Deno.test("VaultAnnotation.toData: round-trips through fromData", () => {
+  const original = VaultAnnotation.create({
+    url: "https://example.com",
+    notes: "a note",
+    labels: { team: "infra", env: "staging" },
+  });
+  const data = original.toData();
+  const restored = VaultAnnotation.fromData(data);
+  assertEquals(restored.url, original.url);
+  assertEquals(restored.notes, original.notes);
+  assertEquals(restored.labels, original.labels);
+});
+
+Deno.test("VaultAnnotation.toData: omits undefined fields", () => {
+  const a = VaultAnnotation.create({});
+  const data = a.toData();
+  assertEquals(data.url, undefined);
+  assertEquals(data.notes, undefined);
+  assertEquals(data.labels, undefined);
+  assertEquals(typeof data.updatedAt, "string");
+});
+
+Deno.test("VaultAnnotation.merge: updates specified fields only", () => {
+  const original = VaultAnnotation.create({
+    url: "https://old.com",
+    notes: "original note",
+    labels: { env: "prod" },
+  });
+  const merged = original.merge({ url: "https://new.com" });
+  assertEquals(merged.url, "https://new.com");
+  assertEquals(merged.notes, "original note");
+  assertEquals(merged.labels, { env: "prod" });
+});
+
+Deno.test("VaultAnnotation.merge: merges labels additively", () => {
+  const original = VaultAnnotation.create({
+    labels: { env: "prod", team: "infra" },
+  });
+  const merged = original.merge({ labels: { team: "platform", region: "us" } });
+  assertEquals(merged.labels, {
+    env: "prod",
+    team: "platform",
+    region: "us",
+  });
+});
+
+Deno.test("VaultAnnotation.isEmpty: true when no fields set", () => {
+  const a = VaultAnnotation.create({});
+  assertEquals(a.isEmpty(), true);
+});
+
+Deno.test("VaultAnnotation.isEmpty: false when url set", () => {
+  const a = VaultAnnotation.create({ url: "https://example.com" });
+  assertEquals(a.isEmpty(), false);
+});
+
+Deno.test("VaultAnnotation.equals: true for same content", () => {
+  const a = VaultAnnotation.create({
+    url: "https://example.com",
+    labels: { a: "1", b: "2" },
+  });
+  const b = VaultAnnotation.create({
+    url: "https://example.com",
+    labels: { b: "2", a: "1" },
+  });
+  assertEquals(a.equals(b), true);
+});
+
+Deno.test("VaultAnnotation.equals: false for different content", () => {
+  const a = VaultAnnotation.create({ url: "https://a.com" });
+  const b = VaultAnnotation.create({ url: "https://b.com" });
+  assertEquals(a.equals(b), false);
+});
+
+Deno.test("VaultAnnotation.labels: is frozen", () => {
+  const a = VaultAnnotation.create({ labels: { env: "prod" } });
+  assertEquals(Object.isFrozen(a.labels), true);
+});
+
+Deno.test("isVaultAnnotationProvider: true for valid provider", () => {
+  const provider = {
+    getAnnotation: () => Promise.resolve(null),
+    putAnnotation: () => Promise.resolve(),
+    deleteAnnotation: () => Promise.resolve(),
+    listAnnotations: () => Promise.resolve(new Map()),
+  };
+  assertEquals(isVaultAnnotationProvider(provider), true);
+});
+
+Deno.test("isVaultAnnotationProvider: false for plain VaultProvider", () => {
+  const provider = {
+    get: () => Promise.resolve("secret"),
+    put: () => Promise.resolve(),
+    list: () => Promise.resolve([]),
+    getName: () => "test",
+  };
+  assertEquals(isVaultAnnotationProvider(provider), false);
+});
+
+Deno.test("isVaultAnnotationProvider: false for null", () => {
+  assertEquals(isVaultAnnotationProvider(null), false);
+});

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -19,6 +19,10 @@
 
 import { getLogger } from "@logtape/logtape";
 import type { VaultConfiguration, VaultProvider } from "./vault_provider.ts";
+import {
+  isVaultAnnotationProvider,
+  type VaultAnnotation,
+} from "./vault_annotation.ts";
 import { getVaultTypes, RENAMED_VAULT_TYPES } from "./vault_types.ts";
 import { vaultTypeRegistry } from "./vault_type_registry.ts";
 import { resolveVaultType } from "../extensions/extension_auto_resolver.ts";
@@ -210,6 +214,60 @@ export class VaultService {
     }
 
     return await provider.list();
+  }
+
+  async getAnnotation(
+    vaultName: string,
+    secretKey: string,
+  ): Promise<VaultAnnotation | null> {
+    const provider = this.requireAnnotationProvider(vaultName);
+    return await provider.getAnnotation(secretKey);
+  }
+
+  async putAnnotation(
+    vaultName: string,
+    secretKey: string,
+    annotation: VaultAnnotation,
+  ): Promise<void> {
+    const provider = this.requireAnnotationProvider(vaultName);
+    await provider.putAnnotation(secretKey, annotation);
+  }
+
+  async deleteAnnotation(
+    vaultName: string,
+    secretKey: string,
+  ): Promise<void> {
+    const provider = this.requireAnnotationProvider(vaultName);
+    await provider.deleteAnnotation(secretKey);
+  }
+
+  supportsAnnotations(vaultName: string): boolean {
+    const provider = this.providers.get(vaultName);
+    if (!provider) return false;
+    return isVaultAnnotationProvider(provider);
+  }
+
+  private requireAnnotationProvider(vaultName: string) {
+    const provider = this.providers.get(vaultName);
+    if (!provider) {
+      const availableVaults = Array.from(this.providers.keys());
+      if (availableVaults.length === 0) {
+        throw new Error(
+          `Vault '${vaultName}' not found. No vaults are configured.`,
+        );
+      }
+      throw new Error(
+        `Vault '${vaultName}' not found. Available vaults: ${
+          availableVaults.join(", ")
+        }`,
+      );
+    }
+    if (!isVaultAnnotationProvider(provider)) {
+      throw new Error(
+        `Vault '${vaultName}' (type: ${provider.getName()}) does not support annotations`,
+      );
+    }
+    return provider;
   }
 
   /**

--- a/src/domain/vaults/vault_service_annotation_test.ts
+++ b/src/domain/vaults/vault_service_annotation_test.ts
@@ -1,0 +1,178 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { VaultService } from "./vault_service.ts";
+import { VaultAnnotation } from "./vault_annotation.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({
+    prefix: "swamp-vault-service-annotation-test-",
+  });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+function createServiceWithLocalVault(
+  vaultName: string,
+  baseDir: string,
+): VaultService {
+  const service = new VaultService();
+  service.registerVault({
+    name: vaultName,
+    type: "local_encryption",
+    config: { auto_generate: true, base_dir: baseDir },
+  });
+  return service;
+}
+
+Deno.test("getAnnotation: delegates to provider", async () => {
+  await withTempDir(async (dir) => {
+    const service = createServiceWithLocalVault("test-vault", dir);
+    await service.put("test-vault", "my-key", "my-value");
+
+    const annotation = VaultAnnotation.create({
+      url: "https://example.com",
+      notes: "test note",
+    });
+    await service.putAnnotation("test-vault", "my-key", annotation);
+
+    const retrieved = await service.getAnnotation("test-vault", "my-key");
+    assertEquals(retrieved !== null, true);
+    assertEquals(retrieved!.url, "https://example.com");
+    assertEquals(retrieved!.notes, "test note");
+  });
+});
+
+Deno.test("putAnnotation: delegates to provider", async () => {
+  await withTempDir(async (dir) => {
+    const service = createServiceWithLocalVault("test-vault", dir);
+    await service.put("test-vault", "my-key", "my-value");
+
+    const annotation = VaultAnnotation.create({
+      labels: { env: "prod" },
+    });
+    await service.putAnnotation("test-vault", "my-key", annotation);
+
+    // Verify the annotation was stored by reading it back
+    const retrieved = await service.getAnnotation("test-vault", "my-key");
+    assertEquals(retrieved !== null, true);
+    assertEquals(retrieved!.labels, { env: "prod" });
+  });
+});
+
+Deno.test("deleteAnnotation: delegates to provider", async () => {
+  await withTempDir(async (dir) => {
+    const service = createServiceWithLocalVault("test-vault", dir);
+    await service.put("test-vault", "my-key", "my-value");
+
+    const annotation = VaultAnnotation.create({ notes: "to be deleted" });
+    await service.putAnnotation("test-vault", "my-key", annotation);
+
+    // Delete the annotation
+    await service.deleteAnnotation("test-vault", "my-key");
+
+    // Verify it is gone
+    const retrieved = await service.getAnnotation("test-vault", "my-key");
+    assertEquals(retrieved, null);
+  });
+});
+
+Deno.test("supportsAnnotations: returns true for annotation-capable provider", () => {
+  const service = new VaultService();
+  service.registerVault({
+    name: "local-vault",
+    type: "local_encryption",
+    config: { auto_generate: true },
+  });
+
+  assertEquals(service.supportsAnnotations("local-vault"), true);
+});
+
+Deno.test("supportsAnnotations: returns false for plain VaultProvider", () => {
+  const service = new VaultService();
+  service.registerVault({
+    name: "mock-vault",
+    type: "mock",
+    config: {},
+  });
+
+  assertEquals(service.supportsAnnotations("mock-vault"), false);
+});
+
+Deno.test("supportsAnnotations: returns false for non-existent vault", () => {
+  const service = new VaultService();
+
+  assertEquals(service.supportsAnnotations("non-existent"), false);
+});
+
+Deno.test("requireAnnotationProvider: throws when vault not found with no vaults configured", async () => {
+  const service = new VaultService();
+
+  const error = await assertRejects(
+    () => service.getAnnotation("missing-vault", "some-key"),
+    Error,
+  );
+
+  assertStringIncludes(
+    error.message,
+    "Vault 'missing-vault' not found. No vaults are configured.",
+  );
+});
+
+Deno.test("requireAnnotationProvider: throws when vault not found with other vaults available", async () => {
+  const service = new VaultService();
+  service.registerVault({
+    name: "existing-vault",
+    type: "mock",
+    config: {},
+  });
+
+  const error = await assertRejects(
+    () => service.getAnnotation("missing-vault", "some-key"),
+    Error,
+  );
+
+  assertStringIncludes(
+    error.message,
+    "Vault 'missing-vault' not found. Available vaults: existing-vault",
+  );
+});
+
+Deno.test("requireAnnotationProvider: throws when provider does not support annotations", async () => {
+  const service = new VaultService();
+  service.registerVault({
+    name: "mock-vault",
+    type: "mock",
+    config: {},
+  });
+
+  const error = await assertRejects(
+    () => service.getAnnotation("mock-vault", "some-key"),
+    Error,
+  );
+
+  assertStringIncludes(
+    error.message,
+    "does not support annotations",
+  );
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -883,6 +883,27 @@ export {
   vaultPutPreview,
 } from "./vaults/put.ts";
 
+// Vault annotate operations
+export {
+  createVaultAnnotateDeps,
+  vaultAnnotate,
+  type VaultAnnotateConfigInfo,
+  type VaultAnnotateData,
+  type VaultAnnotateDeps,
+  type VaultAnnotateEvent,
+  type VaultAnnotateInput,
+} from "./vaults/annotate.ts";
+
+// Vault inspect operations
+export {
+  createVaultInspectDeps,
+  vaultInspect,
+  type VaultInspectConfigInfo,
+  type VaultInspectData,
+  type VaultInspectDeps,
+  type VaultInspectEvent,
+} from "./vaults/inspect.ts";
+
 // Data GC operations
 export {
   createDataGcDeps,

--- a/src/libswamp/vaults/annotate.ts
+++ b/src/libswamp/vaults/annotate.ts
@@ -1,0 +1,259 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { createVaultSecretAnnotated } from "../../domain/events/types.ts";
+import type { EventBus } from "../../domain/events/event_bus.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { notFound, validationFailed } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface VaultAnnotateConfigInfo {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface VaultAnnotateData {
+  vaultName: string;
+  secretKey: string;
+  vaultType: string;
+  fieldsUpdated: string[];
+  cleared: boolean;
+  timestamp: string;
+}
+
+export type VaultAnnotateEvent =
+  | { kind: "annotating" }
+  | { kind: "completed"; data: VaultAnnotateData }
+  | { kind: "error"; error: SwampError };
+
+export interface VaultAnnotateInput {
+  vaultName: string;
+  key: string;
+  url?: string;
+  notes?: string;
+  labels?: Record<string, string>;
+  clear: boolean;
+}
+
+export interface VaultAnnotateDeps {
+  findVault: (name: string) => Promise<VaultAnnotateConfigInfo | null>;
+  listVaultNames: () => Promise<string[]>;
+  secretExists: (vaultName: string, key: string) => Promise<boolean>;
+  supportsAnnotations: (vaultName: string) => boolean;
+  getAnnotation: (
+    vaultName: string,
+    key: string,
+  ) => Promise<VaultAnnotation | null>;
+  putAnnotation: (
+    vaultName: string,
+    key: string,
+    annotation: VaultAnnotation,
+  ) => Promise<void>;
+  deleteAnnotation: (vaultName: string, key: string) => Promise<void>;
+  publishSecretAnnotated: (
+    vaultId: string,
+    vaultType: string,
+    vaultName: string,
+    key: string,
+    fields: string[],
+  ) => Promise<void>;
+}
+
+export function createVaultAnnotateDeps(
+  repoDir: string,
+  eventBus: EventBus,
+): VaultAnnotateDeps {
+  const vaultConfigRepo = new YamlVaultConfigRepository(repoDir);
+  let vaultServicePromise: Promise<VaultService> | null = null;
+
+  const getVaultService = () => {
+    if (!vaultServicePromise) {
+      vaultServicePromise = VaultService.fromRepository(repoDir);
+    }
+    return vaultServicePromise;
+  };
+
+  return {
+    findVault: (name) => vaultConfigRepo.findByName(name),
+    listVaultNames: async () => {
+      const all = await vaultConfigRepo.findAll();
+      return all.map((v) => v.name);
+    },
+    secretExists: async (vaultName, key) => {
+      const svc = await getVaultService();
+      try {
+        await svc.get(vaultName, key);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    supportsAnnotations: (_vaultName) => {
+      return true;
+    },
+    getAnnotation: async (vaultName, key) => {
+      const svc = await getVaultService();
+      return await svc.getAnnotation(vaultName, key);
+    },
+    putAnnotation: async (vaultName, key, annotation) => {
+      const svc = await getVaultService();
+      await svc.putAnnotation(vaultName, key, annotation);
+    },
+    deleteAnnotation: async (vaultName, key) => {
+      const svc = await getVaultService();
+      await svc.deleteAnnotation(vaultName, key);
+    },
+    publishSecretAnnotated: async (
+      vaultId,
+      vaultType,
+      vaultName,
+      key,
+      fields,
+    ) => {
+      const event = createVaultSecretAnnotated(
+        vaultId,
+        vaultType,
+        vaultName,
+        key,
+        fields,
+      );
+      await eventBus.publish(event);
+    },
+  };
+}
+
+export async function* vaultAnnotate(
+  ctx: LibSwampContext,
+  deps: VaultAnnotateDeps,
+  input: VaultAnnotateInput,
+): AsyncIterable<VaultAnnotateEvent> {
+  yield* withGeneratorSpan(
+    "swamp.vault.annotate",
+    {},
+    (async function* () {
+      yield { kind: "annotating" };
+
+      const config = await deps.findVault(input.vaultName);
+      if (!config) {
+        const names = await deps.listVaultNames();
+        if (names.length === 0) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `${input.vaultName}. No vaults are configured.`,
+            ),
+          };
+        } else {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `${input.vaultName}. Available vaults: ${names.join(", ")}`,
+            ),
+          };
+        }
+        return;
+      }
+
+      const exists = await deps.secretExists(input.vaultName, input.key);
+      if (!exists) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Secret '${input.key}' does not exist in vault '${input.vaultName}'. Store a secret first with: swamp vault put ${input.vaultName} ${input.key}`,
+          ),
+        };
+        return;
+      }
+
+      if (input.clear) {
+        await deps.deleteAnnotation(input.vaultName, input.key);
+        ctx.logger.debug`Cleared annotation for ${input.key}`;
+
+        await deps.publishSecretAnnotated(
+          config.id,
+          config.type,
+          config.name,
+          input.key,
+          [],
+        );
+
+        yield {
+          kind: "completed",
+          data: {
+            vaultName: input.vaultName,
+            secretKey: input.key,
+            vaultType: config.type,
+            fieldsUpdated: [],
+            cleared: true,
+            timestamp: new Date().toISOString(),
+          },
+        };
+        return;
+      }
+
+      const fieldsUpdated: string[] = [];
+      if (input.url !== undefined) fieldsUpdated.push("url");
+      if (input.notes !== undefined) fieldsUpdated.push("notes");
+      if (input.labels !== undefined) fieldsUpdated.push("labels");
+
+      const existing = await deps.getAnnotation(input.vaultName, input.key);
+      const annotation = existing
+        ? existing.merge({
+          url: input.url,
+          notes: input.notes,
+          labels: input.labels,
+        })
+        : VaultAnnotation.create({
+          url: input.url,
+          notes: input.notes,
+          labels: input.labels,
+        });
+
+      await deps.putAnnotation(input.vaultName, input.key, annotation);
+      ctx.logger.debug`Annotation updated for ${input.key}`;
+
+      await deps.publishSecretAnnotated(
+        config.id,
+        config.type,
+        config.name,
+        input.key,
+        fieldsUpdated,
+      );
+
+      yield {
+        kind: "completed",
+        data: {
+          vaultName: input.vaultName,
+          secretKey: input.key,
+          vaultType: config.type,
+          fieldsUpdated,
+          cleared: false,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/vaults/annotate.ts
+++ b/src/libswamp/vaults/annotate.ts
@@ -60,7 +60,7 @@ export interface VaultAnnotateDeps {
   findVault: (name: string) => Promise<VaultAnnotateConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
   secretExists: (vaultName: string, key: string) => Promise<boolean>;
-  supportsAnnotations: (vaultName: string) => boolean;
+  supportsAnnotations: (vaultName: string) => Promise<boolean>;
   getAnnotation: (
     vaultName: string,
     key: string,
@@ -109,8 +109,9 @@ export function createVaultAnnotateDeps(
         return false;
       }
     },
-    supportsAnnotations: (_vaultName) => {
-      return true;
+    supportsAnnotations: async (vaultName) => {
+      const svc = await getVaultService();
+      return svc.supportsAnnotations(vaultName);
     },
     getAnnotation: async (vaultName, key) => {
       const svc = await getVaultService();
@@ -183,6 +184,29 @@ export async function* vaultAnnotate(
           kind: "error",
           error: validationFailed(
             `Secret '${input.key}' does not exist in vault '${input.vaultName}'. Store a secret first with: swamp vault put ${input.vaultName} ${input.key}`,
+          ),
+        };
+        return;
+      }
+
+      if (!await deps.supportsAnnotations(input.vaultName)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Vault '${input.vaultName}' (type: ${config.type}) does not support annotations`,
+          ),
+        };
+        return;
+      }
+
+      if (
+        !input.clear && input.url === undefined &&
+        input.notes === undefined && input.labels === undefined
+      ) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "No annotation fields specified. Use --url, --note, --label, or --clear.",
           ),
         };
         return;

--- a/src/libswamp/vaults/annotate_test.ts
+++ b/src/libswamp/vaults/annotate_test.ts
@@ -1,0 +1,295 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { VaultAnnotation } from "../../domain/vaults/vault_annotation.ts";
+import {
+  vaultAnnotate,
+  type VaultAnnotateDeps,
+  type VaultAnnotateEvent,
+} from "./annotate.ts";
+
+function makeDeps(
+  overrides: Partial<VaultAnnotateDeps> = {},
+): VaultAnnotateDeps {
+  return {
+    findVault: () =>
+      Promise.resolve({ id: "v1", name: "my-vault", type: "env" }),
+    listVaultNames: () => Promise.resolve(["my-vault"]),
+    secretExists: () => Promise.resolve(true),
+    supportsAnnotations: () => Promise.resolve(true),
+    getAnnotation: () => Promise.resolve(null),
+    putAnnotation: () => Promise.resolve(),
+    deleteAnnotation: () => Promise.resolve(),
+    publishSecretAnnotated: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+Deno.test("vaultAnnotate: yields not_found when no vaults configured", async () => {
+  const deps = makeDeps({
+    findVault: () => Promise.resolve(null),
+    listVaultNames: () => Promise.resolve([]),
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "missing",
+      key: "SECRET",
+      url: "https://example.com",
+      clear: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
+  assertStringIncludes(last.error.message, "No vaults are configured");
+});
+
+Deno.test("vaultAnnotate: yields not_found with available vault names", async () => {
+  const deps = makeDeps({
+    findVault: () => Promise.resolve(null),
+    listVaultNames: () => Promise.resolve(["other-vault", "prod-vault"]),
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "missing",
+      key: "SECRET",
+      url: "https://example.com",
+      clear: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
+  assertStringIncludes(last.error.message, "other-vault, prod-vault");
+});
+
+Deno.test("vaultAnnotate: yields validation_failed when secret does not exist", async () => {
+  const deps = makeDeps({
+    secretExists: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "MISSING_KEY",
+      url: "https://example.com",
+      clear: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "MISSING_KEY");
+  assertStringIncludes(last.error.message, "does not exist");
+});
+
+Deno.test("vaultAnnotate: yields validation_failed when annotations not supported", async () => {
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "SECRET",
+      url: "https://example.com",
+      clear: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "does not support annotations");
+});
+
+Deno.test("vaultAnnotate: yields validation_failed when no fields specified", async () => {
+  const deps = makeDeps();
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "SECRET",
+      clear: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "No annotation fields specified");
+});
+
+Deno.test("vaultAnnotate: creates new annotation successfully", async () => {
+  let savedVault = "";
+  let savedKey = "";
+  let savedAnnotation: VaultAnnotation | null = null;
+  let publishedFields: string[] = [];
+
+  const deps = makeDeps({
+    putAnnotation: (_vault, key, annotation) => {
+      savedVault = _vault;
+      savedKey = key;
+      savedAnnotation = annotation;
+      return Promise.resolve();
+    },
+    publishSecretAnnotated: (_id, _type, _name, _key, fields) => {
+      publishedFields = fields;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      url: "https://console.aws.amazon.com",
+      notes: "Production API key",
+      labels: { env: "prod" },
+      clear: false,
+    }),
+  );
+
+  assertEquals(events[0].kind, "annotating");
+  const completed = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.vaultName, "my-vault");
+  assertEquals(completed.data.secretKey, "API_KEY");
+  assertEquals(completed.data.vaultType, "env");
+  assertEquals(completed.data.cleared, false);
+  assertEquals(completed.data.fieldsUpdated, ["url", "notes", "labels"]);
+
+  assertEquals(savedVault, "my-vault");
+  assertEquals(savedKey, "API_KEY");
+  assertEquals(savedAnnotation!.url, "https://console.aws.amazon.com");
+  assertEquals(savedAnnotation!.notes, "Production API key");
+  assertEquals(savedAnnotation!.labels, { env: "prod" });
+  assertEquals(publishedFields, ["url", "notes", "labels"]);
+});
+
+Deno.test("vaultAnnotate: merges with existing annotation", async () => {
+  let savedAnnotation: VaultAnnotation | null = null;
+
+  const existing = VaultAnnotation.create({
+    url: "https://old.example.com",
+    notes: "Old notes",
+    labels: { env: "staging" },
+  });
+
+  const deps = makeDeps({
+    getAnnotation: () => Promise.resolve(existing),
+    putAnnotation: (_vault, _key, annotation) => {
+      savedAnnotation = annotation;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      url: "https://new.example.com",
+      labels: { region: "us-east-1" },
+      clear: false,
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.fieldsUpdated, ["url", "labels"]);
+  assertEquals(completed.data.cleared, false);
+
+  // URL should be updated
+  assertEquals(savedAnnotation!.url, "https://new.example.com");
+  // Notes should be preserved from existing
+  assertEquals(savedAnnotation!.notes, "Old notes");
+  // Labels should be merged
+  assertEquals(savedAnnotation!.labels.env, "staging");
+  assertEquals(savedAnnotation!.labels.region, "us-east-1");
+});
+
+Deno.test("vaultAnnotate: clears annotation successfully", async () => {
+  let deletedVault = "";
+  let deletedKey = "";
+  let publishedFields: string[] | null = null;
+
+  const deps = makeDeps({
+    deleteAnnotation: (vault, key) => {
+      deletedVault = vault;
+      deletedKey = key;
+      return Promise.resolve();
+    },
+    publishSecretAnnotated: (_id, _type, _name, _key, fields) => {
+      publishedFields = fields;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultAnnotateEvent>(
+    vaultAnnotate(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+      clear: true,
+    }),
+  );
+
+  assertEquals(events[0].kind, "annotating");
+  const completed = events[events.length - 1] as Extract<
+    VaultAnnotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.vaultName, "my-vault");
+  assertEquals(completed.data.secretKey, "API_KEY");
+  assertEquals(completed.data.cleared, true);
+  assertEquals(completed.data.fieldsUpdated, []);
+
+  assertEquals(deletedVault, "my-vault");
+  assertEquals(deletedKey, "API_KEY");
+  assertEquals(publishedFields, []);
+});

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -48,6 +48,7 @@ export interface VaultInspectDeps {
   findVault: (name: string) => Promise<VaultInspectConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
   secretExists: (vaultName: string, key: string) => Promise<boolean>;
+  supportsAnnotations: (vaultName: string) => Promise<boolean>;
   getAnnotation: (
     vaultName: string,
     key: string,
@@ -79,6 +80,10 @@ export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
       } catch {
         return false;
       }
+    },
+    supportsAnnotations: async (vaultName) => {
+      const svc = await getVaultService();
+      return svc.supportsAnnotations(vaultName);
     },
     getAnnotation: async (vaultName, key) => {
       const svc = await getVaultService();
@@ -129,6 +134,16 @@ export async function* vaultInspect(
           kind: "error",
           error: validationFailed(
             `Secret '${secretKey}' does not exist in vault '${vaultName}'. Store a secret first with: swamp vault put ${vaultName} ${secretKey}`,
+          ),
+        };
+        return;
+      }
+
+      if (!await deps.supportsAnnotations(vaultName)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Vault '${vaultName}' (type: ${config.type}) does not support annotations`,
           ),
         };
         return;

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultAnnotationData } from "../../domain/vaults/vault_annotation.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { notFound, validationFailed } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface VaultInspectConfigInfo {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface VaultInspectData {
+  vaultName: string;
+  secretKey: string;
+  vaultType: string;
+  hasAnnotation: boolean;
+  annotation: VaultAnnotationData | null;
+}
+
+export type VaultInspectEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: VaultInspectData }
+  | { kind: "error"; error: SwampError };
+
+export interface VaultInspectDeps {
+  findVault: (name: string) => Promise<VaultInspectConfigInfo | null>;
+  listVaultNames: () => Promise<string[]>;
+  secretExists: (vaultName: string, key: string) => Promise<boolean>;
+  getAnnotation: (
+    vaultName: string,
+    key: string,
+  ) => Promise<VaultAnnotationData | null>;
+}
+
+export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
+  const vaultConfigRepo = new YamlVaultConfigRepository(repoDir);
+  let vaultServicePromise: Promise<VaultService> | null = null;
+
+  const getVaultService = () => {
+    if (!vaultServicePromise) {
+      vaultServicePromise = VaultService.fromRepository(repoDir);
+    }
+    return vaultServicePromise;
+  };
+
+  return {
+    findVault: (name) => vaultConfigRepo.findByName(name),
+    listVaultNames: async () => {
+      const all = await vaultConfigRepo.findAll();
+      return all.map((v) => v.name);
+    },
+    secretExists: async (vaultName, key) => {
+      const svc = await getVaultService();
+      try {
+        await svc.get(vaultName, key);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    getAnnotation: async (vaultName, key) => {
+      const svc = await getVaultService();
+      const annotation = await svc.getAnnotation(vaultName, key);
+      return annotation?.toData() ?? null;
+    },
+  };
+}
+
+export async function* vaultInspect(
+  ctx: LibSwampContext,
+  deps: VaultInspectDeps,
+  vaultName: string,
+  secretKey: string,
+): AsyncIterable<VaultInspectEvent> {
+  yield* withGeneratorSpan(
+    "swamp.vault.inspect",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const config = await deps.findVault(vaultName);
+      if (!config) {
+        const names = await deps.listVaultNames();
+        if (names.length === 0) {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `${vaultName}. No vaults are configured.`,
+            ),
+          };
+        } else {
+          yield {
+            kind: "error",
+            error: notFound(
+              "Vault",
+              `${vaultName}. Available vaults: ${names.join(", ")}`,
+            ),
+          };
+        }
+        return;
+      }
+
+      const exists = await deps.secretExists(vaultName, secretKey);
+      if (!exists) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Secret '${secretKey}' does not exist in vault '${vaultName}'.`,
+          ),
+        };
+        return;
+      }
+
+      const annotation = await deps.getAnnotation(vaultName, secretKey);
+      ctx.logger.debug`Retrieved annotation for ${secretKey}`;
+
+      yield {
+        kind: "completed",
+        data: {
+          vaultName,
+          secretKey,
+          vaultType: config.type,
+          hasAnnotation: annotation !== null,
+          annotation,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -128,7 +128,7 @@ export async function* vaultInspect(
         yield {
           kind: "error",
           error: validationFailed(
-            `Secret '${secretKey}' does not exist in vault '${vaultName}'.`,
+            `Secret '${secretKey}' does not exist in vault '${vaultName}'. Store a secret first with: swamp vault put ${vaultName} ${secretKey}`,
           ),
         };
         return;

--- a/src/libswamp/vaults/inspect_test.ts
+++ b/src/libswamp/vaults/inspect_test.ts
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { VaultAnnotationData } from "../../domain/vaults/vault_annotation.ts";
+import {
+  vaultInspect,
+  type VaultInspectDeps,
+  type VaultInspectEvent,
+} from "./inspect.ts";
+
+function makeDeps(
+  overrides: Partial<VaultInspectDeps> = {},
+): VaultInspectDeps {
+  return {
+    findVault: () =>
+      Promise.resolve({ id: "v1", name: "my-vault", type: "env" }),
+    listVaultNames: () => Promise.resolve(["my-vault"]),
+    secretExists: () => Promise.resolve(true),
+    getAnnotation: () => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+Deno.test("vaultInspect: yields not_found when vault does not exist", async () => {
+  const deps = makeDeps({
+    findVault: () => Promise.resolve(null),
+    listVaultNames: () => Promise.resolve(["other-vault"]),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "missing", "SECRET"),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
+  assertStringIncludes(last.error.message, "other-vault");
+});
+
+Deno.test("vaultInspect: yields validation_failed when secret does not exist", async () => {
+  const deps = makeDeps({
+    secretExists: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "MISSING_KEY"),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "MISSING_KEY");
+  assertStringIncludes(last.error.message, "does not exist");
+});
+
+Deno.test("vaultInspect: yields completed with annotation data", async () => {
+  const annotationData: VaultAnnotationData = {
+    url: "https://console.aws.amazon.com",
+    notes: "Production API key",
+    labels: { env: "prod", region: "us-east-1" },
+    updatedAt: "2026-01-15T10:30:00.000Z",
+  };
+
+  const deps = makeDeps({
+    getAnnotation: () => Promise.resolve(annotationData),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  assertEquals(events[0].kind, "resolving");
+  const completed = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.vaultName, "my-vault");
+  assertEquals(completed.data.secretKey, "API_KEY");
+  assertEquals(completed.data.vaultType, "env");
+  assertEquals(completed.data.hasAnnotation, true);
+  assertEquals(completed.data.annotation, annotationData);
+});
+
+Deno.test("vaultInspect: yields completed with no annotation", async () => {
+  const deps = makeDeps({
+    getAnnotation: () => Promise.resolve(null),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  assertEquals(events[0].kind, "resolving");
+  const completed = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.vaultName, "my-vault");
+  assertEquals(completed.data.secretKey, "API_KEY");
+  assertEquals(completed.data.vaultType, "env");
+  assertEquals(completed.data.hasAnnotation, false);
+  assertEquals(completed.data.annotation, null);
+});

--- a/src/libswamp/vaults/inspect_test.ts
+++ b/src/libswamp/vaults/inspect_test.ts
@@ -35,6 +35,7 @@ function makeDeps(
       Promise.resolve({ id: "v1", name: "my-vault", type: "env" }),
     listVaultNames: () => Promise.resolve(["my-vault"]),
     secretExists: () => Promise.resolve(true),
+    supportsAnnotations: () => Promise.resolve(true),
     getAnnotation: () => Promise.resolve(null),
     ...overrides,
   };
@@ -76,6 +77,24 @@ Deno.test("vaultInspect: yields validation_failed when secret does not exist", a
   assertEquals(last.error.code, "validation_failed");
   assertStringIncludes(last.error.message, "MISSING_KEY");
   assertStringIncludes(last.error.message, "does not exist");
+});
+
+Deno.test("vaultInspect: yields validation_failed when annotations not supported", async () => {
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "does not support annotations");
 });
 
 Deno.test("vaultInspect: yields completed with annotation data", async () => {

--- a/src/presentation/renderers/vault_annotate.ts
+++ b/src/presentation/renderers/vault_annotate.ts
@@ -1,0 +1,72 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, VaultAnnotateEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogVaultAnnotateRenderer implements Renderer<VaultAnnotateEvent> {
+  handlers(): EventHandlers<VaultAnnotateEvent> {
+    const logger = getSwampLogger(["vault", "annotate"]);
+    return {
+      annotating: () => {},
+      completed: (e) => {
+        if (e.data.cleared) {
+          logger
+            .info`Cleared annotation for ${e.data.secretKey} in vault ${e.data.vaultName}`;
+        } else {
+          logger
+            .info`Annotated ${e.data.secretKey} in vault ${e.data.vaultName} (fields: ${
+            e.data.fieldsUpdated.join(", ")
+          })`;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonVaultAnnotateRenderer implements Renderer<VaultAnnotateEvent> {
+  handlers(): EventHandlers<VaultAnnotateEvent> {
+    return {
+      annotating: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createVaultAnnotateRenderer(
+  mode: OutputMode,
+): Renderer<VaultAnnotateEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonVaultAnnotateRenderer();
+    case "log":
+      return new LogVaultAnnotateRenderer();
+  }
+}

--- a/src/presentation/renderers/vault_inspect.ts
+++ b/src/presentation/renderers/vault_inspect.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, VaultInspectEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogVaultInspectRenderer implements Renderer<VaultInspectEvent> {
+  handlers(): EventHandlers<VaultInspectEvent> {
+    const logger = getSwampLogger(["vault", "inspect"]);
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        if (!e.data.hasAnnotation || !e.data.annotation) {
+          logger
+            .info`No annotation found for ${e.data.secretKey} in vault ${e.data.vaultName}`;
+          return;
+        }
+        const a = e.data.annotation;
+        logger
+          .info`Annotation for ${e.data.secretKey} in vault ${e.data.vaultName}:`;
+        if (a.url) logger.info`  url: ${a.url}`;
+        if (a.notes) logger.info`  notes: ${a.notes}`;
+        if (a.labels && Object.keys(a.labels).length > 0) {
+          for (const [k, v] of Object.entries(a.labels)) {
+            logger.info`  label: ${k}=${v}`;
+          }
+        }
+        logger.info`  updated: ${a.updatedAt}`;
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonVaultInspectRenderer implements Renderer<VaultInspectEvent> {
+  handlers(): EventHandlers<VaultInspectEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createVaultInspectRenderer(
+  mode: OutputMode,
+): Renderer<VaultInspectEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonVaultInspectRenderer();
+    case "log":
+      return new LogVaultInspectRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

Closes swamp-club#412.

- Adds `swamp vault annotate <vault> <key>` to attach provenance metadata (URL, notes, labels) to vault secrets
- Adds `swamp vault inspect <vault> <key>` to view annotations
- Introduces `VaultAnnotationProvider` as a separate opt-in interface from `VaultProvider` — extension providers opt in via duck typing at runtime, no breaking changes
- Built-in `local_encryption` provider stores annotations as encrypted `.meta.enc` files alongside `.enc` secrets using the same AES-256-GCM encryption
- Annotations use merge semantics: only specified fields are updated, existing fields are preserved. `--clear` flag removes all annotations
- Adds `VaultSecretAnnotated` domain event for audit trail

## Test Plan

- [x] 14 unit tests for `VaultAnnotation` value object (create, merge, equals, fromData/toData round-trip, isEmpty, labels frozen, type guard)
- [x] Full test suite passes (612 tests, 0 failures)
- [x] Type checking passes (`deno check`)
- [x] Linting passes (`deno lint`)
- [x] Formatting passes (`deno fmt --check`)
- [x] Security review: no vulnerabilities found — annotation files use same path traversal protection (`validateSecretKey`, `assertSafePath`) and encryption as secrets
- [x] Binary compiles (`deno run compile`)
- [x] Skill review passes (`npx tessl skill review` — 94%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)