### PR TITLE
fix(skills): add JSDoc to extension Quick Starts and surface quality at publish time

### DIFF
--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -25,7 +25,7 @@ passed.
 
 ```
 start → repo_verified → auth_verified → manifest_validated
-      → versioned → formatted → dry_run_passed → pushed
+      → versioned → formatted → quality_checked → dry_run_passed → pushed
 ```
 
 ## State 1: repo_verified
@@ -138,11 +138,26 @@ swamp extension fmt manifest.yaml --check --json
 [references/publishing.md](references/publishing.md#extension-formatting) for
 details.
 
-**Optional:** Run `swamp extension quality manifest.yaml --json` between States
-6 and 7 for a rubric score. This now includes dependency trust evaluation — npm
-dependencies are audited against OSV.dev advisories and trust signals. See
-[references/publishing.md](references/publishing.md#quality-self-check) for
-details.
+## State 6b: quality_checked
+
+Show the extension's quality score before proceeding. This step is
+**non-blocking** — it does not gate the next state. The score is informational
+so the author sees where they stand before publishing.
+
+**Gate:** State 6 passed (formatting clean).
+
+**Action:**
+
+```bash
+swamp extension quality manifest.yaml --json
+```
+
+**Present:** Show the score and grade to the user (e.g. "Quality: 10/15 (67%),
+Grade B"). If any factors are unearned, list them so the author can decide
+whether to address them. Do not require or suggest they must fix anything —
+these are the author's choices.
+
+**Advance:** Always proceed to State 7 regardless of the score.
 
 ## State 7: dry_run_passed
 

--- a/.claude/skills/swamp-extension/SKILL.md
+++ b/.claude/skills/swamp-extension/SKILL.md
@@ -77,6 +77,11 @@ the start — placeholder prefixes like `@local/` are rejected during push.
 ### Model
 
 ```typescript
+/**
+ * Processes input messages and stores the result.
+ *
+ * @module
+ */
 // extensions/models/my_model.ts
 import { z } from "npm:zod@4";
 
@@ -90,6 +95,7 @@ const OutputSchema = z.object({
   timestamp: z.iso.datetime(),
 });
 
+/** Model definition for processing input messages. */
 export const model = {
   type: "@myorg/my-model",
   version: "2026.02.09.1",
@@ -122,6 +128,11 @@ export const model = {
 ### Vault
 
 ```typescript
+/**
+ * Custom vault provider for retrieving secrets from a backend.
+ *
+ * @module
+ */
 // extensions/vaults/my-vault/mod.ts
 import { z } from "npm:zod@4";
 
@@ -130,6 +141,7 @@ const ConfigSchema = z.object({
   token: z.string(),
 });
 
+/** Vault provider definition. */
 export const vault = {
   type: "@myorg/my-vault",
   name: "My Custom Vault",
@@ -154,6 +166,11 @@ export const vault = {
 ### Driver
 
 ```typescript
+/**
+ * Custom execution driver for running methods on a remote host.
+ *
+ * @module
+ */
 // extensions/drivers/my-driver/mod.ts
 import { z } from "npm:zod@4";
 
@@ -162,6 +179,7 @@ const ConfigSchema = z.object({
   port: z.number().default(22),
 });
 
+/** Execution driver definition. */
 export const driver = {
   type: "@myorg/my-driver",
   name: "My Custom Driver",
@@ -197,6 +215,11 @@ export const driver = {
 ### Datastore
 
 ```typescript
+/**
+ * Custom datastore provider for storing runtime data in a backend.
+ *
+ * @module
+ */
 // extensions/datastores/my-store/mod.ts
 import { z } from "npm:zod@4";
 
@@ -205,6 +228,7 @@ const ConfigSchema = z.object({
   bucket: z.string(),
 });
 
+/** Datastore provider definition. */
 export const datastore = {
   type: "@myorg/my-store",
   name: "My Custom Store",


### PR DESCRIPTION
## Summary

Closes swamp-club#348.

- Added `@module` JSDoc blocks and per-export JSDoc comments to all 4 Quick Start templates (model, vault, driver, datastore) in the `swamp-extension` skill so generated code passes the `symbols-docs` quality factor by default
- Promoted quality scoring in the `swamp-extension-publish` skill from an optional aside to a visible, non-blocking State 6b step that shows the score before dry-run — awareness, not enforcement

## Test plan

- [ ] Verify `npx tessl skill review .claude/skills/swamp-extension` passes
- [ ] Verify `npx tessl skill review .claude/skills/swamp-extension-publish` passes
- [ ] Verify `deno fmt --check` passes on both skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)