### PR TITLE
feat(extensions): version-drift advisory check for manifest vs model versions

### DIFF
--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -37,6 +37,7 @@ import {
   resolveExtensionFiles,
 } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
+import { checkVersionConsistency } from "../../domain/extensions/extension_quality_checker.ts";
 
 interface ExtensionFmtOptions extends GlobalOptions {
   repoDir?: string;
@@ -84,6 +85,7 @@ export const extensionFmtCommand = new Command()
       outputMode: cliCtx.outputMode,
     });
     const {
+      manifest,
       allModelFiles,
       allVaultFiles,
       allDriverFiles,
@@ -119,7 +121,16 @@ export const extensionFmtCommand = new Command()
       renderer.handlers(),
     );
 
-    // 5. Throw if quality checks failed
+    // 5. Check for version drift (advisory warning only)
+    const versionIssues = await checkVersionConsistency(
+      manifest.version,
+      allModelFiles,
+    );
+    for (const issue of versionIssues) {
+      cliCtx.logger.warn`${issue.output}`;
+    }
+
+    // 6. Throw if quality checks failed
     if (!renderer.passed()) {
       throw new UserError(renderer.failureMessage());
     }

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -126,8 +126,16 @@ export const extensionFmtCommand = new Command()
       manifest.version,
       allModelFiles,
     );
-    for (const issue of versionIssues) {
-      cliCtx.logger.warn`${issue.output}`;
+    if (versionIssues.length > 0) {
+      if (cliCtx.outputMode === "json") {
+        console.log(
+          JSON.stringify({ versionDriftWarnings: versionIssues }, null, 2),
+        );
+      } else {
+        for (const issue of versionIssues) {
+          cliCtx.logger.warn`${issue.output}`;
+        }
+      }
     }
 
     // 6. Throw if quality checks failed

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -127,15 +127,7 @@ export const extensionFmtCommand = new Command()
       allModelFiles,
     );
     if (versionIssues.length > 0) {
-      if (cliCtx.outputMode === "json") {
-        console.log(
-          JSON.stringify({ versionDriftWarnings: versionIssues }, null, 2),
-        );
-      } else {
-        for (const issue of versionIssues) {
-          cliCtx.logger.warn`${issue.output}`;
-        }
-      }
+      renderer.renderVersionDriftWarnings(versionIssues);
     }
 
     // 6. Throw if quality checks failed

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -47,7 +47,10 @@ import {
   renderExtensionPushCancelled,
 } from "../../presentation/renderers/extension_push.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
-import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
+import {
+  checkVersionConsistency,
+  type QualityIssue,
+} from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type {
   CollectiveMismatch,
@@ -473,6 +476,15 @@ export const extensionPushCommand = new Command()
           return;
         }
       }
+    }
+
+    // 6c. Version-drift check (advisory warning only)
+    const versionIssues = await checkVersionConsistency(
+      prepared.manifest.version,
+      allModelFiles,
+    );
+    if (versionIssues.length > 0) {
+      renderer.renderVersionDriftWarnings(versionIssues);
     }
 
     // 7. Dry run — stop here

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -216,7 +216,7 @@ function extractModelType(content: string): string | null {
  * Extracts the model version string.
  * Matches `version: "YYYY.MM.DD.N"` patterns.
  */
-function extractModelVersion(content: string): string | null {
+export function extractModelVersion(content: string): string | null {
   const match = content.match(/version:\s*["']([^"']+)["']/);
   return match ? match[1] : null;
 }

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -300,13 +300,7 @@ export async function checkExtensionQuality(
   };
 }
 
-/**
- * Checks whether model TypeScript files export a version that matches
- * the manifest version. Returns advisory QualityIssue entries for any
- * mismatches — callers should surface these as warnings, not errors,
- * since multi-model extensions may legitimately have models at
- * different versions.
- */
+/** Advisory check — warns on manifest/model version mismatch but never blocks. */
 export async function checkVersionConsistency(
   manifestVersion: string,
   modelFiles: string[],
@@ -317,7 +311,13 @@ export async function checkVersionConsistency(
     let content: string;
     try {
       content = await Deno.readTextFile(file);
-    } catch {
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        issues.push({
+          check: "version-drift",
+          output: `${basename(file)}: could not read file: ${e}`,
+        });
+      }
       continue;
     }
 
@@ -329,7 +329,8 @@ export async function checkVersionConsistency(
         check: "version-drift",
         output:
           `${basename(file)}: model version "${modelVersion}" differs from ` +
-          `manifest version "${manifestVersion}"`,
+          `manifest version "${manifestVersion}" ` +
+          `(update the model's version field to align)`,
       });
     }
   }

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -17,9 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { basename } from "@std/path";
+import { extractModelVersion } from "./extension_content_extractor.ts";
+
 /** A quality issue found during checking. */
 export interface QualityIssue {
-  check: "fmt" | "lint" | "dynamic-import";
+  check: "fmt" | "lint" | "dynamic-import" | "version-drift";
   output: string;
 }
 
@@ -295,4 +298,41 @@ export async function checkExtensionQuality(
     passed: issues.length === 0,
     issues,
   };
+}
+
+/**
+ * Checks whether model TypeScript files export a version that matches
+ * the manifest version. Returns advisory QualityIssue entries for any
+ * mismatches — callers should surface these as warnings, not errors,
+ * since multi-model extensions may legitimately have models at
+ * different versions.
+ */
+export async function checkVersionConsistency(
+  manifestVersion: string,
+  modelFiles: string[],
+): Promise<QualityIssue[]> {
+  const issues: QualityIssue[] = [];
+
+  for (const file of modelFiles) {
+    let content: string;
+    try {
+      content = await Deno.readTextFile(file);
+    } catch {
+      continue;
+    }
+
+    const modelVersion = extractModelVersion(content);
+    if (!modelVersion) continue;
+
+    if (modelVersion !== manifestVersion) {
+      issues.push({
+        check: "version-drift",
+        output:
+          `${basename(file)}: model version "${modelVersion}" differs from ` +
+          `manifest version "${manifestVersion}"`,
+      });
+    }
+  }
+
+  return issues;
 }

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -26,6 +26,19 @@ export interface QualityIssue {
   output: string;
 }
 
+export function qualityCheckLabel(check: QualityIssue["check"]): string {
+  switch (check) {
+    case "fmt":
+      return "Formatting";
+    case "lint":
+      return "Lint";
+    case "dynamic-import":
+      return "Dynamic import";
+    case "version-drift":
+      return "Version drift";
+  }
+}
+
 /** Result of the quality check. */
 export interface QualityCheckResult {
   passed: boolean;

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -41,7 +41,7 @@ async function withTempFiles(
     }
     await fn(tmpDir, paths);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 }
 

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -17,8 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import {
   checkExtensionQuality,

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -18,9 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import {
   checkExtensionQuality,
+  checkVersionConsistency,
   stripCommentsAndStrings,
 } from "./extension_quality_checker.ts";
 
@@ -402,4 +404,79 @@ Deno.test("stripCommentsAndStrings blanks template literal text", () => {
   const result = stripCommentsAndStrings(source);
   assertEquals(result.includes("import"), false);
   assertEquals(result.includes("const x"), true);
+});
+
+// ── checkVersionConsistency tests ────────────────────────────────────
+
+Deno.test("checkVersionConsistency: matching versions produce no issues", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'export const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: mismatched version reports drift", async () => {
+  await withTempFiles(
+    {
+      "model.ts":
+        'export const model = {\n  version: "2026.03.01.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      assertEquals(issues.length, 1);
+      assertEquals(issues[0].check, "version-drift");
+      assertStringIncludes(issues[0].output, "2026.03.01.1");
+      assertStringIncludes(issues[0].output, "2026.05.22.1");
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: multiple models with mixed versions", async () => {
+  await withTempFiles(
+    {
+      "model_a.ts":
+        'export const model = {\n  version: "2026.05.22.1",\n  type: "a",\n};\n',
+      "model_b.ts":
+        'export const model = {\n  version: "2026.04.10.2",\n  type: "b",\n};\n',
+      "model_c.ts":
+        'export const model = {\n  version: "2026.05.22.1",\n  type: "c",\n};\n',
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      assertEquals(issues.length, 1);
+      assertEquals(issues[0].check, "version-drift");
+      assertStringIncludes(issues[0].output, "model_b.ts");
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: files without version export are skipped", async () => {
+  await withTempFiles(
+    {
+      "helpers.ts":
+        "export function add(a: number, b: number): number {\n  return a + b;\n}\n",
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkVersionConsistency: empty file list produces no issues", async () => {
+  const issues = await checkVersionConsistency("2026.05.22.1", []);
+  assertEquals(issues, []);
+});
+
+Deno.test("checkVersionConsistency: nonexistent files are skipped", async () => {
+  const issues = await checkVersionConsistency("2026.05.22.1", [
+    "/tmp/does-not-exist-12345.ts",
+  ]);
+  assertEquals(issues, []);
 });

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -31,7 +31,6 @@ import type {
   SafetyIssue,
 } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityCheckResult } from "../../domain/extensions/extension_quality_checker.ts";
-import { checkVersionConsistency } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencySpecifier } from "../../domain/extensions/extension_dependency_extractor.ts";
 import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { ExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
@@ -605,15 +604,6 @@ export async function extensionPushPrepare(
         { qualityErrors: qualityResult.issues },
       );
     }
-  }
-
-  // 10a. Version-drift check (advisory warning only)
-  const versionIssues = await checkVersionConsistency(
-    input.manifest.version,
-    input.allModelFiles,
-  );
-  for (const issue of versionIssues) {
-    ctx.logger.warn`${issue.output}`;
   }
 
   // 11. Bundle entry points + build archive — skip on cache hit

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -31,6 +31,7 @@ import type {
   SafetyIssue,
 } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityCheckResult } from "../../domain/extensions/extension_quality_checker.ts";
+import { checkVersionConsistency } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencySpecifier } from "../../domain/extensions/extension_dependency_extractor.ts";
 import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { ExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
@@ -604,6 +605,15 @@ export async function extensionPushPrepare(
         { qualityErrors: qualityResult.issues },
       );
     }
+  }
+
+  // 10a. Version-drift check (advisory warning only)
+  const versionIssues = await checkVersionConsistency(
+    input.manifest.version,
+    input.allModelFiles,
+  );
+  for (const issue of versionIssues) {
+    ctx.logger.warn`${issue.output}`;
   }
 
   // 11. Bundle entry points + build archive — skip on cache hit

--- a/src/presentation/renderers/extension_fmt.ts
+++ b/src/presentation/renderers/extension_fmt.ts
@@ -20,27 +20,18 @@
 import type { EventHandlers, ExtensionFmtEvent } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
-import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
+import {
+  qualityCheckLabel,
+  type QualityIssue,
+} from "../../domain/extensions/extension_quality_checker.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
-
-function checkLabel(check: QualityIssue["check"]): string {
-  switch (check) {
-    case "fmt":
-      return "Formatting";
-    case "lint":
-      return "Lint";
-    case "dynamic-import":
-      return "Dynamic import";
-    case "version-drift":
-      return "Version drift";
-  }
-}
 
 /** Renderer interface that also exposes pass/fail state for the CLI. */
 export interface ExtensionFmtRenderer extends Renderer<ExtensionFmtEvent> {
   passed(): boolean;
   failureMessage(): string;
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void;
 }
 
 class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
@@ -72,7 +63,7 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
               "Quality checks failed. Run 'swamp extension fmt <manifest-path>' to fix.";
             logger.error`Quality checks failed:`;
             for (const issue of data.issues) {
-              const label = checkLabel(issue.check);
+              const label = qualityCheckLabel(issue.check);
               logger.error`  ${label} issues:`;
               logger.error`${issue.output}`;
             }
@@ -88,7 +79,7 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
               "Some issues could not be auto-fixed. See above for details.";
             logger.error`Remaining issues that could not be auto-fixed:`;
             for (const issue of data.remainingIssues) {
-              const label = checkLabel(issue.check);
+              const label = qualityCheckLabel(issue.check);
               logger.error`  ${label} issues:`;
               logger.error`${issue.output}`;
             }
@@ -99,6 +90,14 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
         throw new UserError(e.error.message);
       },
     };
+  }
+
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
+    const logger = getSwampLogger(["extension", "fmt"]);
+    logger.warn`Version drift warnings (non-blocking):`;
+    for (const w of warnings) {
+      logger.warn`  ${w.output}`;
+    }
   }
 }
 
@@ -160,6 +159,12 @@ class JsonExtensionFmtRenderer implements ExtensionFmtRenderer {
         throw new UserError(e.error.message);
       },
     };
+  }
+
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
+    console.log(
+      JSON.stringify({ versionDriftWarnings: warnings }, null, 2),
+    );
   }
 }
 

--- a/src/presentation/renderers/extension_fmt.ts
+++ b/src/presentation/renderers/extension_fmt.ts
@@ -20,8 +20,22 @@
 import type { EventHandlers, ExtensionFmtEvent } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
+import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+function checkLabel(check: QualityIssue["check"]): string {
+  switch (check) {
+    case "fmt":
+      return "Formatting";
+    case "lint":
+      return "Lint";
+    case "dynamic-import":
+      return "Dynamic import";
+    case "version-drift":
+      return "Version drift";
+  }
+}
 
 /** Renderer interface that also exposes pass/fail state for the CLI. */
 export interface ExtensionFmtRenderer extends Renderer<ExtensionFmtEvent> {
@@ -58,7 +72,7 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
               "Quality checks failed. Run 'swamp extension fmt <manifest-path>' to fix.";
             logger.error`Quality checks failed:`;
             for (const issue of data.issues) {
-              const label = issue.check === "fmt" ? "Formatting" : "Lint";
+              const label = checkLabel(issue.check);
               logger.error`  ${label} issues:`;
               logger.error`${issue.output}`;
             }
@@ -74,7 +88,7 @@ class LogExtensionFmtRenderer implements ExtensionFmtRenderer {
               "Some issues could not be auto-fixed. See above for details.";
             logger.error`Remaining issues that could not be auto-fixed:`;
             for (const issue of data.remainingIssues) {
-              const label = issue.check === "fmt" ? "Formatting" : "Lint";
+              const label = checkLabel(issue.check);
               logger.error`  ${label} issues:`;
               logger.error`${issue.output}`;
             }

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -27,7 +27,10 @@ import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import type { SafetyIssue } from "../../domain/extensions/extension_safety_analyzer.ts";
-import type { QualityIssue } from "../../domain/extensions/extension_quality_checker.ts";
+import {
+  qualityCheckLabel,
+  type QualityIssue,
+} from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { CollectiveMismatch } from "../../domain/extensions/extension_collective_validator.ts";
 import type { CompilationError } from "../../libswamp/mod.ts";
@@ -207,7 +210,7 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
   renderQualityErrors(issues: QualityIssue[]): void {
     this.logger.error`Quality checks failed (push blocked):`;
     for (const issue of issues) {
-      const label = issue.check === "fmt" ? "Formatting" : "Lint";
+      const label = qualityCheckLabel(issue.check);
       this.logger.error`  ${label} issues:`;
       this.logger.error`${issue.output}`;
     }

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -44,6 +44,7 @@ export interface ExtensionPushRenderer extends Renderer<ExtensionPushEvent> {
     mismatches: CollectiveMismatch[],
   ): void;
   renderQualityErrors(issues: QualityIssue[]): void;
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void;
   renderCompilationErrors(errors: CompilationError[]): void;
   renderDryRun(data: {
     name: string;
@@ -214,6 +215,13 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
       .error`Run 'swamp extension fmt <manifest-path>' to fix these issues.`;
   }
 
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
+    this.logger.warn`Version drift warnings (non-blocking):`;
+    for (const w of warnings) {
+      this.logger.warn`  ${w.output}`;
+    }
+  }
+
   renderCompilationErrors(errors: CompilationError[]): void {
     this.logger.error`Bundle compilation failed:`;
     for (const r of errors) {
@@ -304,6 +312,12 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
 
   renderQualityErrors(issues: QualityIssue[]): void {
     console.log(JSON.stringify({ qualityErrors: issues }, null, 2));
+  }
+
+  renderVersionDriftWarnings(warnings: QualityIssue[]): void {
+    console.log(
+      JSON.stringify({ versionDriftWarnings: warnings }, null, 2),
+    );
   }
 
   renderCompilationErrors(errors: CompilationError[]): void {


### PR DESCRIPTION
## Summary

- Adds `checkVersionConsistency()` that compares manifest.yaml version against each model's exported version string, surfacing mismatches as warnings during `swamp extension fmt` and `swamp extension push`
- Warnings are advisory only — never block fmt or push — since multi-model extensions may legitimately have models at different versions
- Fixes the renderer label mapping to explicitly handle all quality check types (`fmt`, `lint`, `dynamic-import`, `version-drift`) instead of defaulting non-fmt checks to "Lint"

Closes swamp-club#236

## Test Plan

- 6 new unit tests for `checkVersionConsistency` covering: matching versions, mismatched versions, multiple models with mixed versions, files without version exports, empty file list, nonexistent files
- Full test suite passes (6112 tests, 0 failures)
- Type checking, lint, and formatting all pass