### PR TITLE
feat(testing): add VaultAnnotationProvider conformance helpers

### DIFF
--- a/.claude/skills/swamp-extension/references/vault/testing.md
+++ b/.claude/skills/swamp-extension/references/vault/testing.md
@@ -48,6 +48,86 @@ stored keys, getName returns non-empty string. Test keys are prefixed with
 | `keyPrefix` | `"swamp-conformance-test-"` | Namespace for test keys |
 | `cleanup`   | `true`                      | Delete test keys after  |
 
+## Annotation Conformance
+
+For vaults that support `VaultAnnotationProvider`, two additional conformance
+helpers verify the annotation surface.
+
+### Annotation Export Conformance
+
+Verify that `createProvider` returns an object with annotation methods. Call
+this **after** `assertVaultExportConformance`:
+
+```typescript
+import {
+  assertVaultAnnotationExportConformance,
+  assertVaultExportConformance,
+} from "@systeminit/swamp-testing";
+import { vault } from "./my_vault.ts";
+
+Deno.test("vault export conforms with annotations", () => {
+  assertVaultExportConformance(vault, {
+    validConfigs: [{ region: "us-east-1" }],
+  });
+  assertVaultAnnotationExportConformance(vault, {
+    validConfigs: [{ region: "us-east-1" }],
+  });
+});
+```
+
+This verifies: the provider has `getAnnotation`, `putAnnotation`,
+`deleteAnnotation`, and `listAnnotations` methods.
+
+### Annotation Behavioral Conformance
+
+Test the full `VaultAnnotationProvider` contract:
+
+```typescript
+import { assertVaultAnnotationConformance } from "@systeminit/swamp-testing";
+
+Deno.test("vault annotation contract", async () => {
+  const provider = vault.createProvider("test", { region: "us-east-1" });
+  await assertVaultAnnotationConformance(provider);
+});
+```
+
+Tests: putAnnotation/getAnnotation roundtrip, getAnnotation returns null for
+unannotated key, deleteAnnotation clears annotations, listAnnotations includes
+annotated keys only, VaultAnnotation.merge() preserves existing fields,
+toData()/fromData() roundtrip, isEmpty() for empty annotations.
+
+| Option      | Default                     | Description                   |
+| ----------- | --------------------------- | ----------------------------- |
+| `keyPrefix` | `"swamp-conformance-test-"` | Namespace for test keys       |
+| `cleanup`   | `true`                      | Delete test annotations after |
+
+### VaultAnnotation Type
+
+The `VaultAnnotation` class and related types are exported from the testing
+package for use in extension code:
+
+```typescript
+import {
+  VaultAnnotation,
+  type VaultAnnotationData,
+  type VaultAnnotationProvider,
+} from "@systeminit/swamp-testing";
+
+// Create an annotation
+const annotation = VaultAnnotation.create({
+  url: "https://console.aws.amazon.com/...",
+  notes: "Production API key",
+  labels: { env: "prod", team: "platform" },
+});
+
+// Serialize/deserialize
+const data = annotation.toData();
+const restored = VaultAnnotation.fromData(data);
+
+// Merge preserves existing fields and adds new ones
+const updated = annotation.merge({ labels: { version: "2" } });
+```
+
 ## Mocking External Calls
 
 Test the exact production code path by intercepting at the runtime boundary. No

--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -84,14 +84,24 @@ export type {
   VaultTestContextResult,
 } from "./vault_test_context.ts";
 
-export type { VaultProvider } from "./vault_types.ts";
+export {
+  VaultAnnotation,
+  type VaultAnnotationData,
+  type VaultAnnotationProvider,
+  type VaultProvider,
+} from "./vault_types.ts";
 
 export {
+  assertVaultAnnotationConformance,
+  assertVaultAnnotationExportConformance,
   assertVaultConformance,
   assertVaultExportConformance,
 } from "./vault_conformance.ts";
 
 export type {
+  VaultAnnotationConformanceOptions,
+  VaultAnnotationExport,
+  VaultAnnotationExportConformanceOptions,
   VaultConformanceOptions,
   VaultExport,
   VaultExportConformanceOptions,

--- a/packages/testing/vault_conformance.ts
+++ b/packages/testing/vault_conformance.ts
@@ -19,7 +19,11 @@
 
 // deno-lint-ignore-file no-import-prefix
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.19";
-import type { VaultProvider } from "./vault_types.ts";
+import {
+  VaultAnnotation,
+  type VaultAnnotationProvider,
+  type VaultProvider,
+} from "./vault_types.ts";
 
 /**
  * The vault export shape that extension authors must produce.
@@ -261,6 +265,284 @@ export async function assertVaultConformance(
       for (const key of createdKeys) {
         try {
           await provider.put(key, "");
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+  }
+}
+
+/**
+ * The vault export shape for vaults that support annotations.
+ * Extends the base VaultExport with annotation provider methods.
+ */
+export interface VaultAnnotationExport {
+  type: string;
+  name: string;
+  description: string;
+  configSchema: { safeParse: (v: unknown) => { success: boolean } };
+  createProvider: (
+    name: string,
+    config: Record<string, unknown>,
+  ) => VaultProvider & VaultAnnotationProvider;
+}
+
+/** Options for vault annotation export conformance. */
+export interface VaultAnnotationExportConformanceOptions {
+  /** Configs that should pass schema validation. At least one required. */
+  validConfigs: Record<string, unknown>[];
+}
+
+/**
+ * Asserts that a vault export's createProvider returns an object that
+ * implements VaultAnnotationProvider methods.
+ *
+ * Call this **after** `assertVaultExportConformance` to additionally verify
+ * annotation support. This is a separate call because annotation support
+ * is opt-in — not all vault providers implement it.
+ *
+ * ```typescript
+ * import {
+ *   assertVaultExportConformance,
+ *   assertVaultAnnotationExportConformance,
+ * } from "@systeminit/swamp-testing";
+ * import { vault } from "./my_vault.ts";
+ *
+ * Deno.test("vault export conforms with annotations", () => {
+ *   assertVaultExportConformance(vault, {
+ *     validConfigs: [{ region: "us-east-1" }],
+ *   });
+ *   assertVaultAnnotationExportConformance(vault, {
+ *     validConfigs: [{ region: "us-east-1" }],
+ *   });
+ * });
+ * ```
+ */
+export function assertVaultAnnotationExportConformance(
+  vaultExport: VaultAnnotationExport,
+  options: VaultAnnotationExportConformanceOptions,
+): void {
+  assertEquals(
+    options.validConfigs.length > 0,
+    true,
+    "At least one valid config must be provided",
+  );
+
+  const provider = vaultExport.createProvider(
+    "annotation-conformance-test",
+    options.validConfigs[0],
+  );
+  assertExists(provider, "createProvider must return a provider");
+  assertEquals(
+    typeof provider.getAnnotation,
+    "function",
+    "provider must have getAnnotation()",
+  );
+  assertEquals(
+    typeof provider.putAnnotation,
+    "function",
+    "provider must have putAnnotation()",
+  );
+  assertEquals(
+    typeof provider.deleteAnnotation,
+    "function",
+    "provider must have deleteAnnotation()",
+  );
+  assertEquals(
+    typeof provider.listAnnotations,
+    "function",
+    "provider must have listAnnotations()",
+  );
+}
+
+/** Options for vault annotation behavioral conformance. */
+export interface VaultAnnotationConformanceOptions {
+  /** Prefix for test keys to avoid collisions (default: "swamp-conformance-test-"). */
+  keyPrefix?: string;
+  /** Delete test annotations after the test (default: true). */
+  cleanup?: boolean;
+}
+
+/**
+ * Asserts that a VaultAnnotationProvider implementation satisfies the
+ * behavioral contract.
+ *
+ * Tests: putAnnotation/getAnnotation roundtrip, getAnnotation returns null
+ * for unannotated key, deleteAnnotation clears annotations, listAnnotations
+ * includes annotated keys, VaultAnnotation.merge() preserves existing fields,
+ * toData()/fromData() roundtrip, isEmpty() for empty annotations.
+ *
+ * **Warning**: This hits real infrastructure. Test keys are prefixed and
+ * cleaned up by default.
+ *
+ * ```typescript
+ * import { assertVaultAnnotationConformance } from "@systeminit/swamp-testing";
+ *
+ * Deno.test("vault annotation contract", async () => {
+ *   const provider = vault.createProvider("test", { region: "us-east-1" });
+ *   await assertVaultAnnotationConformance(provider);
+ * });
+ * ```
+ */
+export async function assertVaultAnnotationConformance(
+  provider: VaultAnnotationProvider,
+  options?: VaultAnnotationConformanceOptions,
+): Promise<void> {
+  const prefix = options?.keyPrefix ?? "swamp-conformance-test-";
+  const cleanup = options?.cleanup ?? true;
+
+  const testKey1 = `${prefix}${crypto.randomUUID().slice(0, 8)}`;
+  const testKey2 = `${prefix}${crypto.randomUUID().slice(0, 8)}`;
+  const annotatedKeys: string[] = [];
+
+  try {
+    // getAnnotation returns null for unannotated key
+    const missing = await provider.getAnnotation(testKey1);
+    assertEquals(
+      missing,
+      null,
+      "getAnnotation() must return null for a key with no annotation",
+    );
+
+    // putAnnotation/getAnnotation roundtrip
+    const annotation1 = VaultAnnotation.create({
+      url: "https://example.com/secret-1",
+      notes: "conformance test annotation",
+      labels: { env: "test", team: "platform" },
+    });
+    await provider.putAnnotation(testKey1, annotation1);
+    annotatedKeys.push(testKey1);
+
+    const retrieved = await provider.getAnnotation(testKey1);
+    assertExists(
+      retrieved,
+      "getAnnotation() must return the annotation that was put",
+    );
+    assertEquals(
+      retrieved.url,
+      "https://example.com/secret-1",
+      "getAnnotation().url must match what was put",
+    );
+    assertEquals(
+      retrieved.notes,
+      "conformance test annotation",
+      "getAnnotation().notes must match what was put",
+    );
+    assertEquals(
+      retrieved.labels["env"],
+      "test",
+      "getAnnotation().labels must match what was put",
+    );
+    assertEquals(
+      retrieved.labels["team"],
+      "platform",
+      "getAnnotation().labels must match what was put",
+    );
+
+    // toData()/fromData() roundtrip
+    const data = retrieved.toData();
+    assertExists(data.updatedAt, "toData().updatedAt must exist");
+    const restored = VaultAnnotation.fromData(data);
+    assertEquals(
+      restored.url,
+      retrieved.url,
+      "fromData(toData()) must preserve url",
+    );
+    assertEquals(
+      restored.notes,
+      retrieved.notes,
+      "fromData(toData()) must preserve notes",
+    );
+
+    // merge() preserves existing fields and adds new ones
+    const merged = retrieved.merge({
+      labels: { version: "2" },
+    });
+    assertEquals(
+      merged.url,
+      retrieved.url,
+      "merge() must preserve unmodified fields",
+    );
+    assertEquals(
+      merged.labels["env"],
+      "test",
+      "merge() must preserve existing labels",
+    );
+    assertEquals(
+      merged.labels["version"],
+      "2",
+      "merge() must add new labels",
+    );
+
+    // isEmpty() returns true for empty annotations
+    const empty = VaultAnnotation.create({});
+    assertEquals(
+      empty.isEmpty(),
+      true,
+      "isEmpty() must return true for annotation with no fields",
+    );
+    assertEquals(
+      annotation1.isEmpty(),
+      false,
+      "isEmpty() must return false for annotation with fields",
+    );
+
+    // Second annotation on a different key
+    const annotation2 = VaultAnnotation.create({
+      notes: "second annotation",
+    });
+    await provider.putAnnotation(testKey2, annotation2);
+    annotatedKeys.push(testKey2);
+
+    // listAnnotations includes annotated keys
+    const annotations = await provider.listAnnotations();
+    assertEquals(
+      annotations instanceof Map,
+      true,
+      "listAnnotations() must return a Map",
+    );
+    assertEquals(
+      annotations.has(testKey1),
+      true,
+      `listAnnotations() must include "${testKey1}"`,
+    );
+    assertEquals(
+      annotations.has(testKey2),
+      true,
+      `listAnnotations() must include "${testKey2}"`,
+    );
+
+    // deleteAnnotation clears the annotation
+    await provider.deleteAnnotation(testKey1);
+    const afterDelete = await provider.getAnnotation(testKey1);
+    assertEquals(
+      afterDelete,
+      null,
+      "getAnnotation() must return null after deleteAnnotation()",
+    );
+
+    // listAnnotations no longer includes deleted key
+    const annotationsAfterDelete = await provider.listAnnotations();
+    assertEquals(
+      annotationsAfterDelete.has(testKey1),
+      false,
+      "listAnnotations() must not include deleted key",
+    );
+    assertEquals(
+      annotationsAfterDelete.has(testKey2),
+      true,
+      "listAnnotations() must still include non-deleted key",
+    );
+
+    // Remove testKey1 from cleanup list since it's already deleted
+    const idx = annotatedKeys.indexOf(testKey1);
+    if (idx !== -1) annotatedKeys.splice(idx, 1);
+  } finally {
+    if (cleanup) {
+      for (const key of annotatedKeys) {
+        try {
+          await provider.deleteAnnotation(key);
         } catch {
           // Ignore cleanup errors
         }

--- a/packages/testing/vault_conformance_test.ts
+++ b/packages/testing/vault_conformance_test.ts
@@ -17,12 +17,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertThrows } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
+  assertVaultAnnotationConformance,
+  assertVaultAnnotationExportConformance,
   assertVaultConformance,
   assertVaultExportConformance,
 } from "./vault_conformance.ts";
 import { createVaultTestContext } from "./vault_test_context.ts";
+import { VaultAnnotation } from "./vault_types.ts";
 
 // --- assertVaultExportConformance ---
 
@@ -145,4 +148,144 @@ Deno.test("assertVaultConformance: detects broken get (returns wrong value)", as
       throw e;
     }
   }
+});
+
+// --- assertVaultAnnotationExportConformance ---
+
+Deno.test("assertVaultAnnotationExportConformance: passes for valid export", () => {
+  const { vault, annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  const combined = { ...vault, ...annotationProvider! };
+  const validExport = {
+    type: "@test/my-vault",
+    name: "Test Vault",
+    description: "A test vault provider with annotations",
+    configSchema: {
+      safeParse: (v: unknown) => {
+        const obj = v as Record<string, unknown>;
+        return {
+          success: typeof obj?.region === "string" && obj.region !== "",
+        };
+      },
+    },
+    createProvider: (
+      _name: string,
+      _config: Record<string, unknown>,
+    ) => combined,
+  };
+
+  assertVaultAnnotationExportConformance(validExport, {
+    validConfigs: [{ region: "us-east-1" }],
+  });
+});
+
+Deno.test("assertVaultAnnotationExportConformance: fails when annotation methods missing", () => {
+  const { vault } = createVaultTestContext();
+  const noAnnotations = {
+    type: "@test/vault",
+    name: "Test",
+    description: "Test",
+    configSchema: { safeParse: () => ({ success: true }) },
+    createProvider: () => vault as ReturnType<typeof Object>,
+  };
+
+  assertThrows(
+    () =>
+      assertVaultAnnotationExportConformance(
+        noAnnotations as Parameters<
+          typeof assertVaultAnnotationExportConformance
+        >[0],
+        { validConfigs: [{}] },
+      ),
+    Error,
+    "getAnnotation",
+  );
+});
+
+// --- assertVaultAnnotationConformance ---
+
+Deno.test("assertVaultAnnotationConformance: passes for conforming in-memory provider", async () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  await assertVaultAnnotationConformance(annotationProvider!, {
+    cleanup: false,
+  });
+});
+
+Deno.test("assertVaultAnnotationConformance: detects broken getAnnotation (never returns null)", async () => {
+  const fallbackAnnotation = VaultAnnotation.create({ notes: "fallback" });
+  const brokenProvider = {
+    getAnnotation: () => Promise.resolve(fallbackAnnotation),
+    putAnnotation: () => Promise.resolve(),
+    deleteAnnotation: () => Promise.resolve(),
+    listAnnotations: () => Promise.resolve(new Map()),
+  };
+
+  try {
+    await assertVaultAnnotationConformance(brokenProvider, { cleanup: false });
+    throw new Error("Should have thrown");
+  } catch (e) {
+    if (e instanceof Error && e.message === "Should have thrown") {
+      throw e;
+    }
+    // Expected — getAnnotation should return null for unannotated key
+    // but this broken provider always returns a non-null value, which
+    // will fail the "must return null" assertion
+  }
+});
+
+Deno.test("assertVaultAnnotationConformance: detects broken deleteAnnotation (no-op)", async () => {
+  const annotations = new Map<string, VaultAnnotation>();
+  const brokenProvider = {
+    getAnnotation: (key: string) =>
+      Promise.resolve(annotations.get(key) ?? null),
+    putAnnotation: (key: string, ann: VaultAnnotation) => {
+      annotations.set(key, ann);
+      return Promise.resolve();
+    },
+    // deleteAnnotation is a no-op — doesn't actually delete
+    deleteAnnotation: () => Promise.resolve(),
+    listAnnotations: () => Promise.resolve(new Map(annotations)),
+  };
+
+  try {
+    await assertVaultAnnotationConformance(brokenProvider, { cleanup: false });
+    throw new Error("Should have thrown");
+  } catch (e) {
+    if (e instanceof Error && e.message === "Should have thrown") {
+      throw e;
+    }
+  }
+});
+
+Deno.test("assertVaultAnnotationConformance: VaultAnnotation value object behavior", () => {
+  // Verify the VaultAnnotation class works correctly in isolation
+  const ann = VaultAnnotation.create({
+    url: "https://example.com",
+    notes: "test",
+    labels: { env: "dev" },
+  });
+
+  assertEquals(ann.url, "https://example.com");
+  assertEquals(ann.notes, "test");
+  assertEquals(ann.labels["env"], "dev");
+  assertEquals(ann.isEmpty(), false);
+
+  // toData/fromData roundtrip
+  const data = ann.toData();
+  const restored = VaultAnnotation.fromData(data);
+  assertEquals(restored.url, ann.url);
+  assertEquals(restored.notes, ann.notes);
+  assertEquals(restored.labels["env"], ann.labels["env"]);
+
+  // merge preserves existing, adds new
+  const merged = ann.merge({ labels: { region: "us-east-1" } });
+  assertEquals(merged.labels["env"], "dev");
+  assertEquals(merged.labels["region"], "us-east-1");
+
+  // empty annotation
+  const empty = VaultAnnotation.create({});
+  assertEquals(empty.isEmpty(), true);
 });

--- a/packages/testing/vault_test_context.ts
+++ b/packages/testing/vault_test_context.ts
@@ -17,11 +17,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { VaultProvider } from "./vault_types.ts";
+import type {
+  VaultAnnotation,
+  VaultAnnotationProvider,
+  VaultProvider,
+} from "./vault_types.ts";
 
 /** A recorded vault operation for inspection. */
 export interface VaultOperation {
-  method: "get" | "put" | "list" | "getName";
+  method:
+    | "get"
+    | "put"
+    | "list"
+    | "getName"
+    | "getAnnotation"
+    | "putAnnotation"
+    | "deleteAnnotation"
+    | "listAnnotations";
   key?: string;
   value?: string;
   timestamp: number;
@@ -38,12 +50,16 @@ export interface VaultTestContextOptions {
    * If false, get() returns "" for missing keys.
    */
   throwOnMissing?: boolean;
+  /** If true, the vault also implements VaultAnnotationProvider (default: false). */
+  withAnnotations?: boolean;
 }
 
 /** The return value from createVaultTestContext. */
 export interface VaultTestContextResult {
   /** The VaultProvider to pass to code under test. */
   vault: VaultProvider;
+  /** The VaultAnnotationProvider if withAnnotations was true, otherwise undefined. */
+  annotationProvider: VaultAnnotationProvider | undefined;
   /** Returns all secrets currently stored in the vault. */
   getStoredSecrets(): Record<string, string>;
   /** Returns all vault operations recorded during the test. */
@@ -78,9 +94,11 @@ export function createVaultTestContext(
   const secrets = new Map<string, string>(
     Object.entries(options?.secrets ?? {}),
   );
+  const annotations = new Map<string, VaultAnnotation>();
   const operations: VaultOperation[] = [];
   const name = options?.name ?? "test-vault";
   const throwOnMissing = options?.throwOnMissing ?? true;
+  const withAnnotations = options?.withAnnotations ?? false;
 
   function record(
     method: VaultOperation["method"],
@@ -124,8 +142,39 @@ export function createVaultTestContext(
     },
   };
 
+  let annotationProvider: VaultAnnotationProvider | undefined;
+  if (withAnnotations) {
+    annotationProvider = {
+      getAnnotation(secretKey: string): Promise<VaultAnnotation | null> {
+        record("getAnnotation", secretKey);
+        return Promise.resolve(annotations.get(secretKey) ?? null);
+      },
+
+      putAnnotation(
+        secretKey: string,
+        annotation: VaultAnnotation,
+      ): Promise<void> {
+        record("putAnnotation", secretKey);
+        annotations.set(secretKey, annotation);
+        return Promise.resolve();
+      },
+
+      deleteAnnotation(secretKey: string): Promise<void> {
+        record("deleteAnnotation", secretKey);
+        annotations.delete(secretKey);
+        return Promise.resolve();
+      },
+
+      listAnnotations(): Promise<Map<string, VaultAnnotation>> {
+        record("listAnnotations");
+        return Promise.resolve(new Map(annotations));
+      },
+    };
+  }
+
   return {
     vault,
+    annotationProvider,
     getStoredSecrets: () => Object.fromEntries(secrets),
     getOperations: () => [...operations],
     getOperationsByMethod: (method) =>

--- a/packages/testing/vault_test_context_test.ts
+++ b/packages/testing/vault_test_context_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertRejects } from "@std/assert";
 import { createVaultTestContext } from "./vault_test_context.ts";
+import { VaultAnnotation } from "./vault_types.ts";
 
 Deno.test("createVaultTestContext: defaults to empty vault named test-vault", () => {
   const { vault, getStoredSecrets } = createVaultTestContext();
@@ -143,4 +144,88 @@ Deno.test("createVaultTestContext: getStoredSecrets returns a copy", async () =>
 
   assertEquals(Object.keys(snap1).length, 1);
   assertEquals(Object.keys(snap2).length, 2);
+});
+
+// --- Annotation support ---
+
+Deno.test("createVaultTestContext: annotationProvider is undefined by default", () => {
+  const { annotationProvider } = createVaultTestContext();
+  assertEquals(annotationProvider, undefined);
+});
+
+Deno.test("createVaultTestContext: annotationProvider is defined when withAnnotations is true", () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  assertEquals(annotationProvider !== undefined, true);
+});
+
+Deno.test("createVaultTestContext: getAnnotation returns null for missing key", async () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  const result = await annotationProvider!.getAnnotation("nonexistent");
+  assertEquals(result, null);
+});
+
+Deno.test("createVaultTestContext: putAnnotation/getAnnotation roundtrip", async () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  const annotation = VaultAnnotation.create({
+    url: "https://example.com",
+    notes: "test note",
+  });
+  await annotationProvider!.putAnnotation("key1", annotation);
+  const retrieved = await annotationProvider!.getAnnotation("key1");
+  assertEquals(retrieved?.url, "https://example.com");
+  assertEquals(retrieved?.notes, "test note");
+});
+
+Deno.test("createVaultTestContext: deleteAnnotation removes annotation", async () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  const annotation = VaultAnnotation.create({ notes: "to delete" });
+  await annotationProvider!.putAnnotation("key1", annotation);
+  await annotationProvider!.deleteAnnotation("key1");
+  const result = await annotationProvider!.getAnnotation("key1");
+  assertEquals(result, null);
+});
+
+Deno.test("createVaultTestContext: listAnnotations returns all annotations", async () => {
+  const { annotationProvider } = createVaultTestContext({
+    withAnnotations: true,
+  });
+  await annotationProvider!.putAnnotation(
+    "key1",
+    VaultAnnotation.create({ notes: "first" }),
+  );
+  await annotationProvider!.putAnnotation(
+    "key2",
+    VaultAnnotation.create({ notes: "second" }),
+  );
+  const all = await annotationProvider!.listAnnotations();
+  assertEquals(all.size, 2);
+  assertEquals(all.has("key1"), true);
+  assertEquals(all.has("key2"), true);
+});
+
+Deno.test("createVaultTestContext: annotation operations are recorded", async () => {
+  const { annotationProvider, getOperations, getOperationsByMethod } =
+    createVaultTestContext({ withAnnotations: true });
+
+  await annotationProvider!.putAnnotation(
+    "key1",
+    VaultAnnotation.create({ notes: "test" }),
+  );
+  await annotationProvider!.getAnnotation("key1");
+  await annotationProvider!.listAnnotations();
+  await annotationProvider!.deleteAnnotation("key1");
+
+  assertEquals(getOperations().length, 4);
+  assertEquals(getOperationsByMethod("putAnnotation").length, 1);
+  assertEquals(getOperationsByMethod("getAnnotation").length, 1);
+  assertEquals(getOperationsByMethod("listAnnotations").length, 1);
+  assertEquals(getOperationsByMethod("deleteAnnotation").length, 1);
 });

--- a/packages/testing/vault_types.ts
+++ b/packages/testing/vault_types.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Extension-author-facing subset of swamp's VaultProvider.
+ * Extension-author-facing subset of swamp's vault types.
  *
  * These types mirror the fields that extension vault implementations
  * actually use. A CI test in the main swamp repo verifies structural
@@ -39,4 +39,114 @@ export interface VaultProvider {
   list(): Promise<string[]>;
   /** Gets the name/type of this vault provider. */
   getName(): string;
+}
+
+/** Serializable representation of a vault annotation. */
+export interface VaultAnnotationData {
+  url?: string;
+  notes?: string;
+  labels?: Record<string, string>;
+  updatedAt: string;
+}
+
+/** Value object representing metadata attached to a vault secret. */
+export class VaultAnnotation {
+  readonly url: string | undefined;
+  readonly notes: string | undefined;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly updatedAt: Date;
+
+  private constructor(
+    url: string | undefined,
+    notes: string | undefined,
+    labels: Record<string, string>,
+    updatedAt: Date,
+  ) {
+    this.url = url;
+    this.notes = notes;
+    this.labels = Object.freeze({ ...labels });
+    this.updatedAt = updatedAt;
+  }
+
+  static create(fields: {
+    url?: string;
+    notes?: string;
+    labels?: Record<string, string>;
+  }): VaultAnnotation {
+    return new VaultAnnotation(
+      fields.url,
+      fields.notes,
+      fields.labels ?? {},
+      new Date(),
+    );
+  }
+
+  static fromData(data: VaultAnnotationData): VaultAnnotation {
+    return new VaultAnnotation(
+      data.url,
+      data.notes,
+      data.labels ?? {},
+      new Date(data.updatedAt),
+    );
+  }
+
+  toData(): VaultAnnotationData {
+    const data: VaultAnnotationData = {
+      updatedAt: this.updatedAt.toISOString(),
+    };
+    if (this.url !== undefined) data.url = this.url;
+    if (this.notes !== undefined) data.notes = this.notes;
+    if (Object.keys(this.labels).length > 0) {
+      data.labels = { ...this.labels };
+    }
+    return data;
+  }
+
+  merge(updates: {
+    url?: string;
+    notes?: string;
+    labels?: Record<string, string>;
+  }): VaultAnnotation {
+    return new VaultAnnotation(
+      updates.url !== undefined ? updates.url : this.url,
+      updates.notes !== undefined ? updates.notes : this.notes,
+      updates.labels !== undefined
+        ? { ...this.labels, ...updates.labels }
+        : { ...this.labels },
+      new Date(),
+    );
+  }
+
+  isEmpty(): boolean {
+    return this.url === undefined &&
+      this.notes === undefined &&
+      Object.keys(this.labels).length === 0;
+  }
+
+  equals(other: VaultAnnotation): boolean {
+    if (this.url !== other.url) return false;
+    if (this.notes !== other.notes) return false;
+    const thisKeys = Object.keys(this.labels).sort();
+    const otherKeys = Object.keys(other.labels).sort();
+    if (thisKeys.length !== otherKeys.length) return false;
+    for (let i = 0; i < thisKeys.length; i++) {
+      if (thisKeys[i] !== otherKeys[i]) return false;
+      if (this.labels[thisKeys[i]] !== other.labels[otherKeys[i]]) return false;
+    }
+    return true;
+  }
+}
+
+/**
+ * Interface for vault providers that support secret annotations.
+ * Separate from VaultProvider — providers opt in by implementing both.
+ */
+export interface VaultAnnotationProvider {
+  getAnnotation(secretKey: string): Promise<VaultAnnotation | null>;
+  putAnnotation(
+    secretKey: string,
+    annotation: VaultAnnotation,
+  ): Promise<void>;
+  deleteAnnotation(secretKey: string): Promise<void>;
+  listAnnotations(): Promise<Map<string, VaultAnnotation>>;
 }

--- a/src/domain/vaults/testing_package_compat_test.ts
+++ b/src/domain/vaults/testing_package_compat_test.ts
@@ -26,7 +26,16 @@
  */
 
 import type { VaultProvider as CanonicalVaultProvider } from "./vault_provider.ts";
-import type { VaultProvider as TestingVaultProvider } from "../../../packages/testing/vault_types.ts";
+import type {
+  VaultAnnotationData as CanonicalVaultAnnotationData,
+  VaultAnnotationProvider as CanonicalVaultAnnotationProvider,
+} from "./vault_annotation.ts";
+import type {
+  VaultAnnotation as TestingVaultAnnotation,
+  VaultAnnotationData as TestingVaultAnnotationData,
+  VaultAnnotationProvider as TestingVaultAnnotationProvider,
+  VaultProvider as TestingVaultProvider,
+} from "../../../packages/testing/vault_types.ts";
 
 // VaultProvider: verify the testing type's methods match the canonical type.
 function _checkVaultProviderFields(vault: TestingVaultProvider) {
@@ -45,6 +54,63 @@ function _checkVaultProviderFields(vault: TestingVaultProvider) {
   void [_getResult, _putResult, _listResult, _getNameResult];
 }
 
+// VaultAnnotationProvider: verify the testing type's methods match the canonical type.
+function _checkVaultAnnotationProviderFields(
+  provider: TestingVaultAnnotationProvider,
+) {
+  const _getAnnotation: ReturnType<
+    CanonicalVaultAnnotationProvider["getAnnotation"]
+  > = provider.getAnnotation("key") as ReturnType<
+    CanonicalVaultAnnotationProvider["getAnnotation"]
+  >;
+  const _putAnnotation: ReturnType<
+    CanonicalVaultAnnotationProvider["putAnnotation"]
+  > = provider.putAnnotation(
+    "key",
+    {} as TestingVaultAnnotation,
+  );
+  const _deleteAnnotation: ReturnType<
+    CanonicalVaultAnnotationProvider["deleteAnnotation"]
+  > = provider.deleteAnnotation("key");
+  const _listAnnotations: ReturnType<
+    CanonicalVaultAnnotationProvider["listAnnotations"]
+  > = provider.listAnnotations() as ReturnType<
+    CanonicalVaultAnnotationProvider["listAnnotations"]
+  >;
+
+  void [_getAnnotation, _putAnnotation, _deleteAnnotation, _listAnnotations];
+}
+
+// VaultAnnotationData: verify field compatibility.
+function _checkVaultAnnotationDataFields(data: TestingVaultAnnotationData) {
+  const _canonical: CanonicalVaultAnnotationData = {
+    updatedAt: data.updatedAt,
+    url: data.url,
+    notes: data.notes,
+    labels: data.labels,
+  };
+
+  void _canonical;
+}
+
+// VaultAnnotation: verify instance method compatibility.
+function _checkVaultAnnotationMethods(annotation: TestingVaultAnnotation) {
+  const _toData: CanonicalVaultAnnotationData = annotation
+    .toData() as CanonicalVaultAnnotationData;
+  const _isEmpty: boolean = annotation.isEmpty();
+  const _url: string | undefined = annotation.url;
+  const _notes: string | undefined = annotation.notes;
+  const _labels: Readonly<Record<string, string>> = annotation.labels;
+  const _updatedAt: Date = annotation.updatedAt;
+
+  void [_toData, _isEmpty, _url, _notes, _labels, _updatedAt];
+}
+
 Deno.test("testing package vault types: compile-time compatibility check", () => {
-  void [_checkVaultProviderFields];
+  void [
+    _checkVaultProviderFields,
+    _checkVaultAnnotationProviderFields,
+    _checkVaultAnnotationDataFields,
+    _checkVaultAnnotationMethods,
+  ];
 });


### PR DESCRIPTION
## Summary

- Add `assertVaultAnnotationExportConformance` and `assertVaultAnnotationConformance` to `@systeminit/swamp-testing`, mirroring the existing `VaultProvider` conformance pattern for annotation support
- Export `VaultAnnotation` class, `VaultAnnotationData` interface, and `VaultAnnotationProvider` interface from the testing package so extension authors don't need to define them locally
- Extend `createVaultTestContext` with optional `withAnnotations` flag for in-memory annotation testing
- Add compile-time compatibility test ensuring annotation types stay in sync with domain types

## Test Plan

- [x] `deno check` — all files type-check cleanly
- [x] `deno lint` — no lint errors
- [x] `deno fmt` — all files formatted
- [x] `deno run test` — 6175 tests pass, 0 failures
- [x] `deno run compile` — binary compiles successfully
- [x] New conformance tests verify pass/fail behavior for both structural and behavioral checks
- [x] Compile-time compat test in `src/domain/vaults/testing_package_compat_test.ts` verifies annotation type parity with domain types

Closes #419