### PR TITLE
fix(workflows): wire markDirty hook through workflow execution path

### DIFF
--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -359,6 +359,7 @@ export const workflowRunCommand = new Command()
             unlocked.datastoreResolver.resolvePath(SWAMP_SUBDIRS.data),
             catalogStore,
             directResolver,
+            repoContext.markDirty,
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -57,6 +57,7 @@ import {
 } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { summarizeSyncError } from "../infrastructure/persistence/sync_error_diagnostic.ts";
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
+import { swampPath } from "../infrastructure/persistence/paths.ts";
 import {
   type DistributedLock,
   type LockInfo,
@@ -136,16 +137,27 @@ async function resolveCustomProvider(
  * normalize. Forward-slash on the wire is the cross-platform key
  * convention (matching `.datastore-index.json`); extensions consuming
  * `relPath` for disk access on Windows convert back to native separators.
+ *
+ * When the path is outside cacheRoot (e.g. repo-local `.swamp/outputs/`
+ * vs a remote cache at `~/.swamp/repos/<id>/`), the relative result starts
+ * with `..`. In that case we fall back to `relative(repoSwampDir, absPath)`
+ * — both trees share the same internal layout, so either root produces a
+ * usable cache-relative key.
  */
 function buildMarkDirtyHook(
   syncService: DatastoreSyncService,
   cacheRoot: string,
+  repoDir: string,
 ): MarkDirtyHook {
+  const repoSwampDir = swampPath(repoDir);
   return (absPath?: string) => {
     if (absPath === undefined) {
       return syncService.markDirty();
     }
-    const rel = relative(cacheRoot, absPath);
+    let rel = relative(cacheRoot, absPath);
+    if (rel.startsWith("..")) {
+      rel = relative(repoSwampDir, absPath);
+    }
     const relPath = SEPARATOR === "/" ? rel : rel.split(SEPARATOR).join("/");
     return syncService.markDirty({ relPath });
   };
@@ -485,7 +497,11 @@ export function requireInitializedRepo(
       datastoreResolver,
       markDirty: syncService && isCustomDatastoreConfig(datastoreConfig) &&
           datastoreConfig.cachePath
-        ? buildMarkDirtyHook(syncService, datastoreConfig.cachePath)
+        ? buildMarkDirtyHook(
+          syncService,
+          datastoreConfig.cachePath,
+          repoPath.value,
+        )
         : undefined,
       ...factoryConfig,
     });
@@ -617,7 +633,11 @@ export async function requireInitializedRepoUnlocked(
     datastoreResolver,
     markDirty: syncService && isCustomDatastoreConfig(datastoreConfig) &&
         datastoreConfig.cachePath
-      ? buildMarkDirtyHook(syncService, datastoreConfig.cachePath)
+      ? buildMarkDirtyHook(
+        syncService,
+        datastoreConfig.cachePath,
+        repoPath.value,
+      )
       : undefined,
     ...factoryConfig,
   });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -50,6 +50,7 @@ import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistenc
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import type { MarkDirtyHook } from "../datastore/datastore_sync_service.ts";
 import { DataQueryService } from "../data/data_query_service.ts";
 import {
   fromFileHandle,
@@ -252,6 +253,7 @@ export class DefaultStepExecutor implements StepExecutor {
   constructor(
     private readonly injectedDeps?: StepExecutorDeps,
     directTypeResolver?: DirectTypeResolver,
+    private readonly markDirty?: MarkDirtyHook,
   ) {
     this._directTypeResolver = directTypeResolver;
   }
@@ -267,6 +269,7 @@ export class DefaultStepExecutor implements StepExecutor {
     opts: {
       dataBaseDir?: string;
       catalogStore: CatalogStore;
+      markDirty?: MarkDirtyHook;
     },
   ): Promise<DefaultStepExecutor> {
     return new DefaultStepExecutor(
@@ -286,6 +289,7 @@ export class DefaultStepExecutor implements StepExecutor {
     const deps = await DefaultStepExecutor.buildDeps(ctx.repoDir, {
       dataBaseDir: ctx.dataBaseDir,
       catalogStore: ctx.catalogStore,
+      markDirty: this.markDirty,
     });
     if (this._directTypeResolver) {
       deps.directTypeResolver = this._directTypeResolver;
@@ -295,13 +299,18 @@ export class DefaultStepExecutor implements StepExecutor {
 
   private static async buildDeps(
     repoDir: string,
-    opts: { dataBaseDir?: string; catalogStore: CatalogStore },
+    opts: {
+      dataBaseDir?: string;
+      catalogStore: CatalogStore;
+      markDirty?: MarkDirtyHook;
+    },
   ): Promise<StepExecutorDeps> {
     const definitionRepo = new YamlDefinitionRepository(repoDir);
     const unifiedDataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       opts.dataBaseDir,
       opts.catalogStore,
+      opts.markDirty,
     );
     const dataQueryService = new DataQueryService(
       opts.catalogStore,
@@ -311,8 +320,12 @@ export class DefaultStepExecutor implements StepExecutor {
       definitionRepo,
       unifiedDataRepo,
       dataQueryService,
-      outputRepo: new YamlOutputRepository(repoDir),
-      evaluatedDefRepo: new YamlEvaluatedDefinitionRepository(repoDir),
+      outputRepo: new YamlOutputRepository(repoDir, undefined, opts.markDirty),
+      evaluatedDefRepo: new YamlEvaluatedDefinitionRepository(
+        repoDir,
+        undefined,
+        opts.markDirty,
+      ),
       methodExecutionService: new DefaultMethodExecutionService(),
       vaultService: await VaultService.fromRepository(repoDir),
       expressionEvaluator: new ExpressionEvaluationService(
@@ -1239,17 +1252,23 @@ export class WorkflowExecutionService {
     dataBaseDir: string | undefined,
     catalogStore: CatalogStore,
     private readonly directTypeResolver?: DirectTypeResolver,
+    private readonly markDirty?: MarkDirtyHook,
   ) {
     this.executor = executor ??
-      new DefaultStepExecutor(undefined, directTypeResolver);
+      new DefaultStepExecutor(undefined, directTypeResolver, markDirty);
     this.dataBaseDir = dataBaseDir;
     this.catalogStore = catalogStore;
     this.definitionRepo = new YamlDefinitionRepository(repoDir);
-    this.evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(repoDir);
+    this.evaluatedDefRepo = new YamlEvaluatedDefinitionRepository(
+      repoDir,
+      undefined,
+      markDirty,
+    );
     this.dataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       dataBaseDir,
       catalogStore,
+      markDirty,
     );
     const dataQueryService = new DataQueryService(catalogStore, this.dataRepo);
     this.modelResolver = new ModelResolver(this.definitionRepo, {
@@ -2160,6 +2179,8 @@ export class WorkflowExecutionService {
       this.executor,
       this.dataBaseDir,
       this.catalogStore,
+      undefined,
+      this.markDirty,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -264,6 +264,7 @@ export interface RepositoryContext {
   vaultConfigRepo: YamlVaultConfigRepository;
   catalogStore: CatalogStore;
   dataQueryService: DataQueryService;
+  markDirty?: MarkDirtyHook;
 }
 
 /**
@@ -376,5 +377,6 @@ export function createRepositoryContext(
     vaultConfigRepo,
     catalogStore,
     dataQueryService,
+    markDirty,
   };
 }

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -85,6 +85,8 @@ export async function createWorkflowRunDeps(
         undefined,
         undefined,
         catalogStore,
+        undefined,
+        repoContext.markDirty,
       ),
     catalogStore: repoContext.catalogStore,
     dataRepo: repoContext.unifiedDataRepo,

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -1603,6 +1603,8 @@ async function handleWorkflowRun(
         undefined,
         undefined,
         catalogStore,
+        undefined,
+        deps.repoContext.markDirty,
       ),
     catalogStore: deps.repoContext.catalogStore,
     dataRepo: deps.repoContext.unifiedDataRepo,


### PR DESCRIPTION
## Summary

- **Wire `markDirty` through `WorkflowExecutionService` and `DefaultStepExecutor`**: Both classes created their own repository instances (`FileSystemUnifiedDataRepository`, `YamlOutputRepository`, `YamlEvaluatedDefinitionRepository`) without the `markDirty` hook from `repoContext`. Workflow-executed model methods never notified the datastore sync service about dirty writes, while the same methods run via `model method run` (which uses `repoContext`'s hooked repos) worked correctly.
- **Fix `buildMarkDirtyHook` path computation for out-of-cache paths**: When a repo writes to `<repoDir>/.swamp/outputs/` but `cacheRoot` is `~/.swamp/repos/<id>/`, `relative(cacheRoot, absPath)` produces `../...` traversal. The hook now falls back to `relative(repoSwampDir, absPath)` when the result starts with `..`, since both trees share the same internal layout.
- **Expose `markDirty` on `RepositoryContext`** so all callers (`workflow_run.ts`, `serve/deps.ts`, `serve/open/http.ts`) can forward it when constructing `WorkflowExecutionService`. Nested child workflows also propagate the hook.

## Test plan

- [x] All 49 `execution_service_test.ts` tests pass
- [x] All 35 `repo_context_test.ts` tests pass
- [x] Full `deno check` passes with no type errors
- [x] `deno lint` and `deno fmt` clean
- [x] Binary compiles successfully
- [ ] Manual verification with a custom datastore (S3) to confirm workflow runs now trigger `markDirty` for data, outputs, and evaluated definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)