### PR TITLE
fix(cli): resolve @-prefixed direct execution for repo-local extension types (swamp-club#433)

### DIFF
--- a/integration/direct_type_execution_test.ts
+++ b/integration/direct_type_execution_test.ts
@@ -109,6 +109,24 @@ export const model = {
 };
 `;
 
+const LOCAL_TYPE_MODEL_CODE = `
+import { z } from "npm:zod@4";
+
+export const model = {
+  type: "sandbox/coder-server",
+  version: "2026.01.01.1",
+  methods: {
+    status: {
+      description: "Check server status",
+      arguments: z.object({}),
+      execute: async () => {
+        return { status: "running" };
+      },
+    },
+  },
+};
+`;
+
 // Regression test for swamp-club#349: direct type execution with @-prefixed
 // types must resolve locally without falling through to the auto-resolver.
 Deno.test("direct type execution: model @type resolves local extension without auto-resolver cascade", async () => {
@@ -203,6 +221,94 @@ Deno.test("direct type execution: workflow step with @type resolves local extens
       code,
       0,
       `Workflow with direct type execution failed: ${stderr}`,
+    );
+  });
+});
+
+// Regression test for swamp-club#433: direct type execution with @prefix must
+// resolve repo-local extensions whose types are registered without @.
+Deno.test("direct type execution: @prefix resolves repo-local type registered without @", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const extDir = join(repoDir, "extensions", "models");
+    await ensureDir(extDir);
+    await Deno.writeTextFile(
+      join(extDir, "sandbox_coder_server.ts"),
+      LOCAL_TYPE_MODEL_CODE,
+    );
+
+    const { code, stderr } = await runCliCommand(
+      [
+        "model",
+        "@sandbox/coder-server",
+        "method",
+        "run",
+        "status",
+        "my-server",
+        "--repo-dir",
+        repoDir,
+      ],
+      repoDir,
+    );
+
+    assertEquals(
+      code,
+      0,
+      `Direct type execution with local type failed: ${stderr}`,
+    );
+  });
+});
+
+// Verify the workflow path also handles the @-stripping fallback for local types.
+Deno.test("direct type execution: workflow step with @prefix resolves repo-local type without @", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const extDir = join(repoDir, "extensions", "models");
+    await ensureDir(extDir);
+    await Deno.writeTextFile(
+      join(extDir, "sandbox_coder_server.ts"),
+      LOCAL_TYPE_MODEL_CODE,
+    );
+
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "local-type-workflow",
+      jobs: [
+        Job.create({
+          name: "local-job",
+          steps: [
+            Step.create({
+              name: "local-step",
+              task: StepTask.directExecution(
+                "@sandbox/coder-server",
+                "wf-local-instance",
+                "status",
+                {},
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const { code, stderr } = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "local-type-workflow",
+        "--repo-dir",
+        repoDir,
+      ],
+      repoDir,
+    );
+
+    assertEquals(
+      code,
+      0,
+      `Workflow with local type direct execution failed: ${stderr}`,
     );
   });
 });

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -309,11 +309,26 @@ export const workflowRunCommand = new Command()
             inputs,
           ) => {
             const typeStr = typeArg;
-            const resolvedType = ModelType.create(typeStr);
-            const modelDef = await resolveModelType(
+            let resolvedType = ModelType.create(typeStr);
+            let modelDef = await resolveModelType(
               resolvedType,
               getAutoResolver(),
             );
+
+            // Fallback: @ is the CLI syntax marker but repo-local extensions
+            // register types without @. Try stripping it.
+            if (!modelDef && typeStr.startsWith("@")) {
+              const strippedType = ModelType.create(typeStr.slice(1));
+              const strippedDef = await resolveModelType(
+                strippedType,
+                getAutoResolver(),
+              );
+              if (strippedDef) {
+                resolvedType = strippedType;
+                modelDef = strippedDef;
+              }
+            }
+
             if (!modelDef) {
               throw new Error(
                 `Unknown model type: ${resolvedType.normalized}`,

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -251,11 +251,25 @@ export async function* modelMethodRun(
       if (input.typeArg && input.definitionName) {
         // Direct type execution path: auto-create-then-run
         const typeArg = input.typeArg;
-        const resolvedType = ModelType.create(typeArg);
+        let resolvedType = ModelType.create(typeArg);
 
-        const resolvedModelDef = await Promise.resolve(
+        let resolvedModelDef = await Promise.resolve(
           deps.getModelDef(resolvedType),
         );
+
+        // Fallback: the @ prefix is the CLI syntax marker for direct execution
+        // but repo-local extensions register types without @. Try stripping it.
+        if (!resolvedModelDef && typeArg.startsWith("@")) {
+          const strippedType = ModelType.create(typeArg.slice(1));
+          const strippedDef = await Promise.resolve(
+            deps.getModelDef(strippedType),
+          );
+          if (strippedDef) {
+            resolvedType = strippedType;
+            resolvedModelDef = strippedDef;
+          }
+        }
+
         if (!resolvedModelDef) {
           yield {
             kind: "error",

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -787,3 +787,49 @@ Deno.test("modelMethodRun: direct execution resolves @-prefixed type from regist
     assertEquals(autoCreated.modelType, "@myorg/custom-model");
   }
 });
+
+Deno.test("modelMethodRun: direct execution strips @ fallback for repo-local types", async () => {
+  const localType = ModelType.create("sandbox/coder-server");
+  const modelDef: ModelDefinition = {
+    type: localType,
+    version: "2026.01.01.1",
+    methods: {
+      status: {
+        description: "Check status",
+        arguments: z.object({}),
+        execute: (_args, _ctx) => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+
+  const deps: ModelMethodRunDeps = {
+    ...createTestDeps(null, undefined),
+    getModelDef: (type) => {
+      const key = typeof type === "string"
+        ? ModelType.create(type).normalized
+        : type.normalized;
+      if (key === localType.normalized) return modelDef;
+      return undefined;
+    },
+    createAndSaveDefinition: async (_type, _def) => {},
+    getDefinitionPath: (_type, id) => `/tmp/auto/${id}.yaml`,
+  };
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    modelMethodRun(ctx, deps, {
+      modelIdOrName: "my-server",
+      methodName: "status",
+      inputs: {},
+      lastEvaluated: false,
+      typeArg: "@sandbox/coder-server",
+      definitionName: "my-server",
+    }),
+  );
+
+  const autoCreated = events.find((e) => e.kind === "auto_created");
+  assertEquals(autoCreated !== undefined, true);
+  if (autoCreated && autoCreated.kind === "auto_created") {
+    assertEquals(autoCreated.modelType, "sandbox/coder-server");
+  }
+});


### PR DESCRIPTION
## Summary

- Direct type execution (`swamp model @type method run ...`) failed for repo-local extensions whose types are registered without the `@` prefix (e.g. `sandbox/coder-server`). The `@` is a CLI syntax marker but was being included in the registry lookup key, producing `Unknown model type: @sandbox/coder-server`.
- Added a fallback in both the model method run path (`src/libswamp/models/run.ts`) and the workflow direct type resolver (`src/cli/commands/workflow_run.ts`): when the `@`-prefixed lookup returns nothing, strip the `@` and retry. Published extensions (whose types include `@`) still resolve on the first attempt.
- Added unit test and integration tests covering both the model and workflow paths for repo-local types.

## Test Plan

- [x] Unit test: direct execution with `@namespace/type` resolves model registered as `namespace/type`
- [x] Integration test: model `@` direct execution resolves repo-local extension without `@` in type
- [x] Integration test: workflow step with `@` resolves repo-local extension without `@` in type
- [x] Existing regression tests for swamp-club#349 (`@`-prefixed published extensions) still pass
- [x] Verified fix against reproduction scenario (`/tmp/swamp-repro-issue-433`)
- [x] Full test suite: 6184 passed, 0 failed (1 unrelated flaky test excluded)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Closes swamp-club#433

🤖 Generated with [Claude Code](https://claude.com/claude-code)