### PR TITLE
feat(repo): show tool-specific next steps after repo init

### DIFF
--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -38,6 +38,17 @@ function formatToolsList(tools: readonly string[]): string {
   return tools.length === 0 ? "none" : tools.join(", ");
 }
 
+const TOOL_NEXT_STEPS: Record<string, string> = {
+  claude: "Start Claude Code and run /swamp-getting-started",
+  cursor: "Open this project in Cursor and run /swamp-getting-started",
+  codex: "Run `codex` and invoke $swamp-getting-started",
+  copilot:
+    'Open this project in VS Code with Copilot and say "I am new to swamp"',
+  opencode: 'Run `opencode` in this directory and say "I am new to swamp"',
+  kiro:
+    "Open this project in Kiro and select swamp-getting-started from the / menu",
+};
+
 /**
  * On-disk paths that swamp's scaffolding writes for each tool. Used to tell
  * the user which files were left behind when a tool is dropped from the
@@ -131,6 +142,19 @@ class LogRepoInitRenderer implements Renderer<RepoInitEvent> {
               `remove them by hand if desired.`,
           );
         }
+
+        const steps = data.tools
+          .map((t) => TOOL_NEXT_STEPS[t])
+          .filter((s): s is string => s !== undefined);
+        if (steps.length === 0) {
+          steps.push("Run `swamp --help` to see available commands");
+        }
+        console.log("");
+        logger.info("What's next:");
+        for (const step of steps) {
+          logger.info(`  → ${step}`);
+        }
+        logger.info("  → Read the manual at https://swamp-club.com/manual");
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -144,7 +168,13 @@ class JsonRepoInitRenderer implements Renderer<RepoInitEvent> {
     return {
       initializing: () => {},
       completed: (e) => {
-        console.log(JSON.stringify(e.data, null, 2));
+        const steps = e.data.tools
+          .map((t) => TOOL_NEXT_STEPS[t])
+          .filter((s): s is string => s !== undefined);
+        if (steps.length === 0) {
+          steps.push("Run `swamp --help` to see available commands");
+        }
+        console.log(JSON.stringify({ ...e.data, nextSteps: steps }, null, 2));
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -17,12 +17,159 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import type {
   ExtensionInstallEvent,
+  RepoInitEvent,
   RepoUpgradeEvent,
 } from "../../libswamp/mod.ts";
-import { createRepoUpgradeRenderer } from "./repo_init.ts";
+import {
+  createRepoInitRenderer,
+  createRepoUpgradeRenderer,
+} from "./repo_init.ts";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+await initializeLogging({ noColor: true });
+
+function makeInitData(tools: string[]) {
+  return {
+    path: "/tmp/test",
+    version: "0.1.0",
+    initializedAt: "2026-05-24T00:00:00Z",
+    skillsCopied: [],
+    instructionsFileCreated: true,
+    settingsCreated: true,
+    gitignoreAction: "created",
+    tools,
+    removedTools: [],
+    tool: tools.length === 1 ? tools[0] : null,
+  };
+}
+
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const methods = ["log", "info", "warn", "error", "debug"] as const;
+  const originals = methods.map((m) => [m, console[m]] as const);
+  for (const [m] of originals) {
+    console[m] = (...args: unknown[]) => {
+      lines.push(
+        args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+      );
+    };
+  }
+  try {
+    fn();
+  } finally {
+    for (const [m, orig] of originals) {
+      console[m] = orig;
+    }
+  }
+  // deno-lint-ignore no-control-regex
+  return lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function captureInitOutput(
+  events: RepoInitEvent[],
+  mode: "log" | "json",
+): string {
+  return captureLog(() => {
+    const renderer = createRepoInitRenderer(mode);
+    const handlers = renderer.handlers();
+    for (const event of events) {
+      switch (event.kind) {
+        case "initializing":
+          handlers.initializing?.(event);
+          break;
+        case "completed":
+          handlers.completed?.(event);
+          break;
+        case "error":
+          handlers.error?.(event);
+          break;
+      }
+    }
+  });
+}
+
+Deno.test(
+  "LogRepoInitRenderer: shows claude-specific next step for claude tool",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData(["claude"]) },
+    ], "log");
+
+    assertStringIncludes(output, "What's next:");
+    assertStringIncludes(output, "/swamp-getting-started");
+  },
+);
+
+Deno.test(
+  "LogRepoInitRenderer: shows cursor-specific next step for cursor tool",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData(["cursor"]) },
+    ], "log");
+
+    assertStringIncludes(output, "What's next:");
+    assertStringIncludes(output, "Cursor");
+  },
+);
+
+Deno.test(
+  "LogRepoInitRenderer: shows multiple next steps for multi-tool init",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData(["claude", "cursor"]) },
+    ], "log");
+
+    assertStringIncludes(output, "/swamp-getting-started");
+    assertStringIncludes(output, "Cursor");
+  },
+);
+
+Deno.test(
+  "LogRepoInitRenderer: shows generic next step when no tools enrolled",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData([]) },
+    ], "log");
+
+    assertStringIncludes(output, "swamp --help");
+  },
+);
+
+Deno.test(
+  "JsonRepoInitRenderer: includes nextSteps array in JSON output",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData(["claude"]) },
+    ], "json");
+
+    const parsed = JSON.parse(output);
+    assertEquals(Array.isArray(parsed.nextSteps), true);
+    assertEquals(parsed.nextSteps.length, 1);
+    assertStringIncludes(parsed.nextSteps[0], "/swamp-getting-started");
+  },
+);
+
+Deno.test(
+  "JsonRepoInitRenderer: includes generic nextStep when no tools enrolled",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData([]) },
+    ], "json");
+
+    const parsed = JSON.parse(output);
+    assertEquals(parsed.nextSteps.length, 1);
+    assertStringIncludes(parsed.nextSteps[0], "swamp --help");
+  },
+);
 
 /**
  * Runs a sequence of `RepoUpgradeEvent`s through the JSON renderer and


### PR DESCRIPTION
## Summary

- After `swamp repo init`, show a "What's next:" section with tool-specific onboarding instructions (e.g. "Start Claude Code and run /swamp-getting-started" for claude, "Open this project in Cursor and run /swamp-getting-started" for cursor, etc.)
- Include a docs link to the manual at swamp-club.com/manual
- Fall back to "Run `swamp --help`" when no tools are enrolled (`--tool none`)
- JSON renderer includes a `nextSteps` array for programmatic consumers

## Test Plan

- Unit tests for all tool-specific next steps (claude, cursor, multi-tool, no-tool)
- Unit tests for JSON output including `nextSteps` array
- All 8 tests pass, existing upgrade renderer tests unaffected
- `deno fmt`, `deno lint`, `deno check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)