### PR TITLE
feat(extensions): add extension info command for registry metadata (#428)

### DIFF
--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -22,6 +22,7 @@ import { extensionPushCommand } from "./extension_push.ts";
 import { extensionPullCommand } from "./extension_pull.ts";
 import { extensionInstallCommand } from "./extension_install.ts";
 import { extensionFmtCommand } from "./extension_fmt.ts";
+import { extensionInfoCommand } from "./extension_info.ts";
 import { extensionQualityCommand } from "./extension_quality.ts";
 import { extensionRemoveCommand } from "./extension_rm.ts";
 import { extensionListCommand } from "./extension_list.ts";
@@ -43,6 +44,7 @@ export const extensionCommand = new Command()
     this.showHelp();
   })
   .command("push", extensionPushCommand)
+  .command("info", extensionInfoCommand)
   .command("fmt", extensionFmtCommand)
   .command("quality", extensionQualityCommand)
   .command("pull", extensionPullCommand)

--- a/src/cli/commands/extension_info.ts
+++ b/src/cli/commands/extension_info.ts
@@ -1,0 +1,65 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  consumeStream,
+  createExtensionInfoDeps,
+  createLibSwampContext,
+  extensionInfo,
+} from "../../libswamp/mod.ts";
+import { createExtensionInfoRenderer } from "../../presentation/renderers/extension_info.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const extensionInfoCommand = new Command()
+  .name("info")
+  .description(
+    "Show full registry metadata for a specific extension",
+  )
+  .example(
+    "Show extension info",
+    "swamp extension info @stack72/aws-ec2",
+  )
+  .example(
+    "JSON output",
+    "swamp extension info @stack72/aws-ec2 --json",
+  )
+  .arguments("<name:string>")
+  .action(
+    async function (options: AnyOptions, name: string) {
+      const cliCtx = createContext(options as GlobalOptions, [
+        "extension",
+        "info",
+      ]);
+
+      const credentials = await new AuthRepository().load();
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const deps = createExtensionInfoDeps(credentials?.apiKey);
+      const renderer = createExtensionInfoRenderer(cliCtx.outputMode);
+
+      await consumeStream(
+        extensionInfo(ctx, deps, { extensionName: name }),
+        renderer.handlers(),
+      );
+    },
+  );

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -50,6 +50,7 @@ import { createExtensionSearchRenderer } from "../../presentation/renderers/exte
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 
 /**
  * Resolves the registry server URL.
@@ -142,6 +143,7 @@ export const extensionSearchCommand = new Command()
       );
     }
 
+    const credentials = await new AuthRepository().load();
     const serverUrl = resolveServerUrl();
     const client = new ExtensionApiClient(serverUrl);
     const effectiveMode = interactiveOutputMode(ctx);
@@ -151,15 +153,18 @@ export const extensionSearchCommand = new Command()
 
     const deps: ExtensionSearchDeps = {
       searchExtensions: (params) =>
-        client.searchExtensions({
-          ...params,
-          sort: params.sort as
-            | "name"
-            | "relevance"
-            | "new"
-            | "updated"
-            | undefined,
-        }),
+        client.searchExtensions(
+          {
+            ...params,
+            sort: params.sort as
+              | "name"
+              | "relevance"
+              | "new"
+              | "updated"
+              | undefined,
+          },
+          credentials?.apiKey,
+        ),
     };
 
     const renderer = createExtensionSearchRenderer(effectiveMode);

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -59,11 +59,42 @@ export interface LatestVersionInfo {
   publishedAt: string;
 }
 
-/** Extension metadata. */
+/** Extension author metadata. */
+export interface ExtensionAuthor {
+  username: string;
+  displayName: string;
+}
+
+/** Quality score summary. */
+export interface ExtensionScoreSummary {
+  percentage: number;
+  grade: string;
+}
+
+/** Full extension metadata from the registry. */
 export interface ExtensionInfo {
+  id: string;
   name: string;
+  namespace: string | null;
   description: string;
+  repository: string | null;
+  homepageUrl: string | null;
+  license: string | null;
+  platforms: string[];
+  labels: string[];
+  contentTypes: string[];
+  contentNames: string[];
   latestVersion: string;
+  author: ExtensionAuthor | null;
+  createdAt: string;
+  updatedAt: string;
+  yankedAt: string | null;
+  yankReason: string | null;
+  repositoryVerified: boolean | null;
+  repositoryVerifiedAt: string | null;
+  repositoryVerifiedUrl: string | null;
+  pullCount: number;
+  score: ExtensionScoreSummary | null;
 }
 
 /** Parameters for the extension search endpoint. */
@@ -244,6 +275,7 @@ export class ExtensionApiClient {
    */
   async searchExtensions(
     params: ExtensionSearchParams,
+    apiKey?: string,
   ): Promise<ExtensionSearchResponse> {
     const qs = new URLSearchParams();
     if (params.q) qs.set("q", params.q);
@@ -259,8 +291,9 @@ export class ExtensionApiClient {
 
     const query = qs.toString();
     const path = `/api/v1/extensions/search${query ? `?${query}` : ""}`;
+    const headers = apiKey ? this.authHeaders(apiKey) : {};
 
-    const res = await this.fetch(path, { method: "GET" });
+    const res = await this.fetch(path, { method: "GET", headers });
     await this.checkResponse(res);
     return await res.json();
   }

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  ExtensionAuthor,
+  ExtensionInfo,
+  ExtensionScoreSummary,
+} from "../../infrastructure/http/extension_api_client.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { resolveServerUrl } from "./pull.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface ExtensionInfoData {
+  id: string;
+  name: string;
+  namespace: string | null;
+  description: string;
+  repository: string | null;
+  homepageUrl: string | null;
+  license: string | null;
+  platforms: string[];
+  labels: string[];
+  contentTypes: string[];
+  contentNames: string[];
+  latestVersion: string;
+  author: ExtensionAuthor | null;
+  createdAt: string;
+  updatedAt: string;
+  yankedAt: string | null;
+  yankReason: string | null;
+  repositoryVerified: boolean | null;
+  repositoryVerifiedAt: string | null;
+  repositoryVerifiedUrl: string | null;
+  pullCount: number;
+  score: ExtensionScoreSummary | null;
+}
+
+export type ExtensionInfoEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: ExtensionInfoData }
+  | { kind: "not_found"; extensionName: string }
+  | { kind: "error"; error: SwampError };
+
+export interface ExtensionInfoInput {
+  extensionName: string;
+}
+
+export interface ExtensionInfoDeps {
+  getExtension: (name: string) => Promise<ExtensionInfo | null>;
+}
+
+export function createExtensionInfoDeps(
+  apiKey?: string,
+): ExtensionInfoDeps {
+  const serverUrl = resolveServerUrl();
+  const client = new ExtensionApiClient(serverUrl);
+  return {
+    getExtension: (name: string) => client.getExtension(name, apiKey),
+  };
+}
+
+export async function* extensionInfo(
+  _ctx: LibSwampContext,
+  deps: ExtensionInfoDeps,
+  input: ExtensionInfoInput,
+): AsyncIterable<ExtensionInfoEvent> {
+  yield* withGeneratorSpan(
+    "swamp.extension.info",
+    { "extension.name": input.extensionName },
+    (async function* () {
+      yield { kind: "resolving" as const };
+
+      try {
+        const info = await deps.getExtension(input.extensionName);
+
+        if (!info) {
+          yield {
+            kind: "not_found" as const,
+            extensionName: input.extensionName,
+          };
+          return;
+        }
+
+        yield {
+          kind: "completed" as const,
+          data: {
+            id: info.id,
+            name: info.name,
+            namespace: info.namespace,
+            description: info.description,
+            repository: info.repository,
+            homepageUrl: info.homepageUrl,
+            license: info.license,
+            platforms: info.platforms,
+            labels: info.labels,
+            contentTypes: info.contentTypes,
+            contentNames: info.contentNames,
+            latestVersion: info.latestVersion,
+            author: info.author,
+            createdAt: info.createdAt,
+            updatedAt: info.updatedAt,
+            yankedAt: info.yankedAt,
+            yankReason: info.yankReason,
+            repositoryVerified: info.repositoryVerified,
+            repositoryVerifiedAt: info.repositoryVerifiedAt,
+            repositoryVerifiedUrl: info.repositoryVerifiedUrl,
+            pullCount: info.pullCount,
+            score: info.score,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "info_lookup_failed",
+            message:
+              `Failed to look up info for ${input.extensionName}: ${message}`,
+          },
+        };
+      }
+    })(),
+  );
+}

--- a/src/libswamp/extensions/info_test.ts
+++ b/src/libswamp/extensions/info_test.ts
@@ -1,0 +1,170 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { ExtensionInfo } from "../../infrastructure/http/extension_api_client.ts";
+import {
+  extensionInfo,
+  type ExtensionInfoDeps,
+  type ExtensionInfoEvent,
+} from "./info.ts";
+
+function makeFullExtensionInfo(
+  overrides?: Partial<ExtensionInfo>,
+): ExtensionInfo {
+  return {
+    id: "abc123",
+    name: "@stack72/aws-ec2",
+    namespace: "@stack72",
+    description: "AWS EC2 model for swamp",
+    repository: "https://github.com/stack72/swamp-aws-ec2",
+    homepageUrl: "https://example.com",
+    license: "MIT",
+    platforms: ["aws"],
+    labels: ["networking", "compute"],
+    contentTypes: ["models"],
+    contentNames: ["aws-ec2"],
+    latestVersion: "2026.5.1",
+    author: { username: "stack72", displayName: "Paul Stack" },
+    createdAt: "2026-01-15T10:30:00.000Z",
+    updatedAt: "2026-05-20T14:22:00.000Z",
+    yankedAt: null,
+    yankReason: null,
+    repositoryVerified: true,
+    repositoryVerifiedAt: "2026-05-20T14:25:00.000Z",
+    repositoryVerifiedUrl: "https://github.com/stack72/swamp-aws-ec2",
+    pullCount: 142,
+    score: { percentage: 85, grade: "A" },
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  overrides?: Partial<ExtensionInfoDeps>,
+): ExtensionInfoDeps {
+  return {
+    getExtension: () => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+Deno.test("extensionInfo: returns full metadata when extension exists", async () => {
+  const info = makeFullExtensionInfo();
+  const deps = makeDeps({
+    getExtension: () => Promise.resolve(info),
+  });
+  const events = await collect<ExtensionInfoEvent>(
+    extensionInfo(createLibSwampContext(), deps, {
+      extensionName: "@stack72/aws-ec2",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+
+  const completed = events[1] as Extract<
+    ExtensionInfoEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.name, "@stack72/aws-ec2");
+  assertEquals(completed.data.namespace, "@stack72");
+  assertEquals(completed.data.author?.username, "stack72");
+  assertEquals(completed.data.platforms, ["aws"]);
+  assertEquals(completed.data.labels, ["networking", "compute"]);
+  assertEquals(completed.data.pullCount, 142);
+  assertEquals(completed.data.score?.grade, "A");
+  assertEquals(completed.data.repositoryVerified, true);
+});
+
+Deno.test("extensionInfo: handles nullable fields", async () => {
+  const info = makeFullExtensionInfo({
+    namespace: null,
+    repository: null,
+    homepageUrl: null,
+    license: null,
+    author: null,
+    yankedAt: null,
+    yankReason: null,
+    repositoryVerified: null,
+    repositoryVerifiedAt: null,
+    repositoryVerifiedUrl: null,
+    score: null,
+  });
+  const deps = makeDeps({
+    getExtension: () => Promise.resolve(info),
+  });
+  const events = await collect<ExtensionInfoEvent>(
+    extensionInfo(createLibSwampContext(), deps, {
+      extensionName: "some-ext",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    ExtensionInfoEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.author, null);
+  assertEquals(completed.data.repository, null);
+  assertEquals(completed.data.score, null);
+});
+
+Deno.test("extensionInfo: yields not_found when extension does not exist", async () => {
+  const deps = makeDeps({
+    getExtension: () => Promise.resolve(null),
+  });
+  const events = await collect<ExtensionInfoEvent>(
+    extensionInfo(createLibSwampContext(), deps, {
+      extensionName: "@foo/bar",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+
+  const notFound = events[1] as Extract<
+    ExtensionInfoEvent,
+    { kind: "not_found" }
+  >;
+  assertEquals(notFound.kind, "not_found");
+  assertEquals(notFound.extensionName, "@foo/bar");
+});
+
+Deno.test("extensionInfo: yields error event on API failure", async () => {
+  const deps = makeDeps({
+    getExtension: () => Promise.reject(new Error("Connection refused")),
+  });
+  const events = await collect<ExtensionInfoEvent>(
+    extensionInfo(createLibSwampContext(), deps, {
+      extensionName: "@myorg/broken",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  const errorEvent = events[1] as Extract<
+    ExtensionInfoEvent,
+    { kind: "error" }
+  >;
+  assertEquals(errorEvent.kind, "error");
+  assertEquals(errorEvent.error.code, "info_lookup_failed");
+  assertStringIncludes(errorEvent.error.message, "Connection refused");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -662,6 +662,14 @@ export {
   type ExtensionVersionInput,
 } from "./extensions/version.ts";
 export {
+  createExtensionInfoDeps,
+  extensionInfo,
+  type ExtensionInfoData,
+  type ExtensionInfoDeps,
+  type ExtensionInfoEvent,
+  type ExtensionInfoInput,
+} from "./extensions/info.ts";
+export {
   type DatastoreAutoUpdateDeps,
   type DatastoreAutoUpdateResult,
   maybeAutoUpdateDatastoreExtension,

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, ExtensionInfoEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function extractBasename(name: string): string {
+  const slash = name.indexOf("/");
+  return slash >= 0 ? name.slice(slash + 1) : name;
+}
+
+class LogExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
+  handlers(): EventHandlers<ExtensionInfoEvent> {
+    const logger = getSwampLogger(["extension", "info"]);
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        const d = e.data;
+
+        logger.info`${d.name} (${d.latestVersion})`;
+        logger.info`${d.description}`;
+        logger.info``;
+
+        if (d.author) {
+          logger
+            .info`Author:      ${d.author.displayName} (${d.author.username})`;
+        }
+        if (d.namespace) {
+          logger.info`Collective:  ${d.namespace}`;
+        }
+        if (d.license) {
+          logger.info`License:     ${d.license}`;
+        }
+        if (d.repository) {
+          const verified = d.repositoryVerified ? " (verified)" : "";
+          logger.info`Repository:  ${d.repository}${verified}`;
+        }
+        if (d.homepageUrl) {
+          logger.info`Homepage:    ${d.homepageUrl}`;
+        }
+
+        logger.info``;
+
+        if (d.platforms.length > 0) {
+          logger.info`Platforms:   ${d.platforms.join(", ")}`;
+        }
+        if (d.labels.length > 0) {
+          logger.info`Labels:      ${d.labels.join(", ")}`;
+        }
+        if (d.contentTypes.length > 0) {
+          logger.info`Contents:    ${d.contentTypes.join(", ")}`;
+        }
+        if (d.contentNames.length > 0) {
+          logger.info`Exports:     ${d.contentNames.join(", ")}`;
+        }
+
+        logger.info``;
+
+        logger.info`Downloads:   ${d.pullCount}`;
+        if (d.score) {
+          logger.info`Quality:     ${d.score.grade} (${d.score.percentage}%)`;
+        }
+
+        logger.info``;
+
+        logger.info`Created:     ${d.createdAt}`;
+        logger.info`Updated:     ${d.updatedAt}`;
+
+        if (d.yankedAt) {
+          logger.info``;
+          logger.warn`Yanked:      ${d.yankedAt}`;
+          if (d.yankReason) {
+            logger.warn`Reason:      ${d.yankReason}`;
+          }
+        }
+      },
+      not_found: (e) => {
+        const basename = extractBasename(e.extensionName);
+        throw new UserError(
+          `Extension ${e.extensionName} not found in the registry.\nTry: swamp extension search ${basename}`,
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
+  handlers(): EventHandlers<ExtensionInfoEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      not_found: (e) => {
+        throw new UserError(
+          `Extension ${e.extensionName} not found in the registry.`,
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createExtensionInfoRenderer(
+  mode: OutputMode,
+): Renderer<ExtensionInfoEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonExtensionInfoRenderer();
+    case "log":
+      return new LogExtensionInfoRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

- Add `swamp extension info <name>` command to fetch and display full registry metadata for a specific extension
- Widen `ExtensionInfo` interface to capture all fields the server returns (author, namespace, platforms, labels, content types, quality score, pull count, repository verification, yank state)
- Add optional authentication (via `AuthRepository`) to both `extension info` and `extension search` for higher rate limits
- Not-found responses show a helpful suggestion: `Try: swamp extension search <basename>`

Closes swamp-club#428

## Test Plan

- [x] 4 unit tests for the libswamp info operation (full metadata, nullable fields, not found, API error)
- [x] Existing search and version tests pass (no regressions from wider `ExtensionInfo`)
- [x] Full test suite passes (6195 tests)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)