### PR TITLE
fix(cli): only redirect extension console output to stderr in --json mode

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -74,6 +74,7 @@ import { reportKindAdapter } from "../domain/extensions/report_kind_adapter.ts";
 import { modelRegistry } from "../domain/models/model.ts";
 import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../domain/drivers/driver_type_registry.ts";
+import { setConsoleGuardJsonMode } from "../domain/drivers/console_guard.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
 import { reportRegistry } from "../domain/reports/report_registry.ts";
 
@@ -1169,6 +1170,8 @@ export async function runCli(args: string[]): Promise<void> {
     )
     .globalOption("--no-color", "Disable colored output")
     .globalAction(async function (options: GlobalOptions) {
+      setConsoleGuardJsonMode(options.json ?? false);
+
       const noColor = options.color === false ||
         Deno.env.get("NO_COLOR") !== undefined;
       if (noColor) {

--- a/src/domain/drivers/console_guard.ts
+++ b/src/domain/drivers/console_guard.ts
@@ -31,6 +31,12 @@ function writeStderr(line: string): void {
   Deno.stderr.writeSync(STDERR_WRITER.encode(line + "\n"));
 }
 
+let _jsonMode = false;
+
+export function setConsoleGuardJsonMode(enabled: boolean): void {
+  _jsonMode = enabled;
+}
+
 function formatArg(a: unknown): string {
   if (typeof a === "string") return a;
   if (typeof a === "number") return String(a);
@@ -44,11 +50,24 @@ function formatArg(a: unknown): string {
 let activeGuards = 0;
 const allActiveLogs: Set<string[]> = new Set();
 
+export interface ConsoleGuardOptions {
+  jsonMode?: boolean;
+}
+
 // Redirects console methods to a capture array during fn execution.
+// In JSON mode, captured output is replayed to stderr to prevent stdout
+// pollution. In non-JSON mode, console output flows to stdout normally.
 export async function withConsoleGuard<T>(
   fn: () => T | Promise<T>,
   logs: string[],
+  options?: ConsoleGuardOptions,
 ): Promise<T> {
+  const effectiveJsonMode = options?.jsonMode ?? _jsonMode;
+
+  if (!effectiveJsonMode) {
+    return await fn();
+  }
+
   allActiveLogs.add(logs);
   if (activeGuards === 0) {
     for (const method of CAPTURED_METHODS) {

--- a/src/domain/drivers/console_guard_test.ts
+++ b/src/domain/drivers/console_guard_test.ts
@@ -23,9 +23,13 @@ import { withConsoleGuard } from "./console_guard.ts";
 Deno.test("withConsoleGuard: captures console.log into logs array", async () => {
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    console.log("hello from extension");
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      console.log("hello from extension");
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(logs.length, 1);
   assertStringIncludes(logs[0], "hello from extension");
@@ -35,13 +39,17 @@ Deno.test("withConsoleGuard: captures console.log into logs array", async () => 
 Deno.test("withConsoleGuard: captures all console methods", async () => {
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    console.log("log msg");
-    console.info("info msg");
-    console.debug("debug msg");
-    console.warn("warn msg");
-    console.error("error msg");
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      console.log("log msg");
+      console.info("info msg");
+      console.debug("debug msg");
+      console.warn("warn msg");
+      console.error("error msg");
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(logs.length, 5);
   assertStringIncludes(logs[0], "[log] log msg");
@@ -55,9 +63,13 @@ Deno.test("withConsoleGuard: restores console after normal completion", async ()
   const originalLog = console.log;
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    // inside guard
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      // inside guard
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(console.log, originalLog);
 });
@@ -67,10 +79,14 @@ Deno.test("withConsoleGuard: restores console after throw", async () => {
   const logs: string[] = [];
 
   try {
-    await withConsoleGuard(() => {
-      console.log("before throw");
-      throw new Error("extension failure");
-    }, logs);
+    await withConsoleGuard(
+      () => {
+        console.log("before throw");
+        throw new Error("extension failure");
+      },
+      logs,
+      { jsonMode: true },
+    );
   } catch {
     // expected
   }
@@ -83,10 +99,14 @@ Deno.test("withConsoleGuard: restores console after throw", async () => {
 Deno.test("withConsoleGuard: returns the function result", async () => {
   const logs: string[] = [];
 
-  const result = await withConsoleGuard(() => {
-    console.log("working");
-    return 42;
-  }, logs);
+  const result = await withConsoleGuard(
+    () => {
+      console.log("working");
+      return 42;
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(result, 42);
 });
@@ -94,9 +114,13 @@ Deno.test("withConsoleGuard: returns the function result", async () => {
 Deno.test("withConsoleGuard: handles non-string arguments", async () => {
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    console.log("count:", 42, { key: "value" });
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      console.log("count:", 42, { key: "value" });
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(logs.length, 1);
   assertStringIncludes(logs[0], "count:");
@@ -107,11 +131,15 @@ Deno.test("withConsoleGuard: handles non-string arguments", async () => {
 Deno.test("withConsoleGuard: handles circular objects without throwing", async () => {
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    const obj: Record<string, unknown> = { name: "test" };
-    obj.self = obj;
-    console.log("circular:", obj);
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      const obj: Record<string, unknown> = { name: "test" };
+      obj.self = obj;
+      console.log("circular:", obj);
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(logs.length, 1);
   assertStringIncludes(logs[0], "[log] circular:");
@@ -121,9 +149,13 @@ Deno.test("withConsoleGuard: handles circular objects without throwing", async (
 Deno.test("withConsoleGuard: handles undefined and function arguments", async () => {
   const logs: string[] = [];
 
-  await withConsoleGuard(() => {
-    console.log("undef:", undefined, "fn:", () => {});
-  }, logs);
+  await withConsoleGuard(
+    () => {
+      console.log("undef:", undefined, "fn:", () => {});
+    },
+    logs,
+    { jsonMode: true },
+  );
 
   assertEquals(logs.length, 1);
   assertStringIncludes(logs[0], "undef:");
@@ -136,13 +168,36 @@ Deno.test("withConsoleGuard: concurrent guards restore console after both comple
   const logsB: string[] = [];
 
   await Promise.all([
-    withConsoleGuard(() => {
-      console.log("from A");
-    }, logsA),
-    withConsoleGuard(() => {
-      console.log("from B");
-    }, logsB),
+    withConsoleGuard(
+      () => {
+        console.log("from A");
+      },
+      logsA,
+      { jsonMode: true },
+    ),
+    withConsoleGuard(
+      () => {
+        console.log("from B");
+      },
+      logsB,
+      { jsonMode: true },
+    ),
   ]);
 
   assertEquals(console.log, originalLog);
+});
+
+Deno.test("withConsoleGuard: skips capture in non-JSON mode", async () => {
+  const logs: string[] = [];
+
+  const result = await withConsoleGuard(
+    () => {
+      return 99;
+    },
+    logs,
+    { jsonMode: false },
+  );
+
+  assertEquals(result, 99);
+  assertEquals(logs.length, 0);
 });

--- a/src/domain/drivers/mod.ts
+++ b/src/domain/drivers/mod.ts
@@ -53,5 +53,7 @@ export {
 
 export { DOCKER_RUNNER_SCRIPT } from "./docker_runner.ts";
 
+export { setConsoleGuardJsonMode } from "./console_guard.ts";
+
 export { ExtensionLoader } from "../extensions/extension_loader.ts";
 export { driverKindAdapter } from "../extensions/driver_kind_adapter.ts";


### PR DESCRIPTION
## Summary

- `withConsoleGuard()` (introduced in PR #1444) was unconditionally capturing all extension `console.*` calls and replaying them to stderr, even in normal log mode — breaking 5 UAT tests that expect extension output on stdout
- Made the guard output-mode-aware: in `--json` mode it captures and replays to stderr (preventing JSON pollution); in log mode it's a no-op so `console.log` flows to stdout naturally
- Added `setConsoleGuardJsonMode()` called from the CLI `globalAction` to wire the mode, plus a per-call `options.jsonMode` override for testability

## Test Plan

- [x] All 6208 existing tests pass (including console guard unit tests updated with `{ jsonMode: true }`)
- [x] New test: `withConsoleGuard: skips capture in non-JSON mode` verifies passthrough behavior
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [ ] UAT tests (cel_evaluate, extension_model, extension_vault, security_audit, vault_secrets) should now pass — extension console output appears on stdout again

🤖 Generated with [Claude Code](https://claude.com/claude-code)