### PR TITLE
feat(datastore): lazy hydration with metadata-only setup and transparent content download (swamp-club#440)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -452,6 +452,77 @@ itself has not changed. Cache integrity is the verifier's job; use
 `DatastoreVerifier.verify()` when integrity needs to be re-established, or
 `rm -rf` the cache and re-pull.
 
+### Lazy Hydration
+
+When `hydrationStrategy: "lazy"` is configured on a custom datastore, the
+initial pull downloads only metadata files (`metadata.yaml`, `latest` markers,
+partition indexes) and skips content files (`raw`) under `data/`. This gives
+full catalog visibility — `data list`, `data query`, and CEL expressions all
+work immediately — while deferring the expensive content download until the data
+is actually needed.
+
+#### How it works
+
+1. **Setup/initial pull**: The extension's `pullChanged` filters files by
+   suffix. Files ending in `/metadata.yaml` or `/latest` under `data/` are
+   downloaded. Files ending in `/raw` under `data/` are skipped, but their
+   parent directories are created so the catalog backfill walker (which uses
+   `readdir`) finds the version directories. Files outside `data/` (outputs,
+   workflow-runs, definitions-evaluated) are downloaded fully — they have no
+   metadata/raw split.
+
+2. **Model runs / workflow runs**: `acquireModelLocks` performs a scoped pull via
+   `pullChanged({ context })`. The pull reads the partition file, compares
+   against local files, sees `raw` is missing, and downloads it. No new code
+   needed — the existing Phase 2 scoped sync handles this.
+
+3. **`data get` (read-only, no sync)**: `UnifiedDataRepository.getContent()`
+   attempts to read the `raw` file. If missing and a `HydrateFileHook` is
+   wired, it calls the hook to download just that file from the remote, then
+   retries the read.
+
+#### `HydrateFileHook` contract
+
+`HydrateFileHook` mirrors `MarkDirtyHook` — a thin callback injected into
+repositories so they do not need a handle on the full sync service.
+Repositories pass an absolute path; the composition root in `repo_context.ts`
+wraps `DatastoreSyncService.hydrateFile` with path normalization
+(absolute → cache-relative, forward-slash-normalized). Same contract as
+`MarkDirtyHook` — repositories never convert paths themselves.
+
+- Wired in `requireInitializedRepo`, `requireInitializedRepoUnlocked`, and
+  `requireInitializedRepoReadOnly` (the read-only variant creates a lightweight
+  sync service without a lock, solely for single-file downloads).
+- Returns `true` if the file was downloaded, `false` if it does not exist on the
+  remote.
+- Implementations MUST write atomically (tmp + rename) to avoid partial reads
+  from concurrent consumers.
+
+#### `getContentSync` limitation
+
+`getContentSync()` is synchronous and cannot call the async `HydrateFileHook`.
+It is used in two places:
+
+- `data_record_mapper.ts` — query predicate attribute/content loading during
+  `data query --where` evaluation.
+- `model_resolver.ts` — CEL expression resolution during model runs.
+
+The `model_resolver.ts` path is safe: model runs go through `acquireModelLocks`
+→ scoped pull, which downloads `raw` files before CEL evaluation begins.
+
+The `data_record_mapper.ts` path means `data query` predicates referencing
+`attributes` or `content` on un-hydrated data will see `null` values. This is a
+documented limitation of lazy hydration — queries that filter only on metadata
+fields (tags, version, owner, etc.) work correctly.
+
+#### Configuration
+
+- `CustomDatastoreConfig.hydrationStrategy` — `"full"` (default) or `"lazy"`.
+- `SyncCapabilities.lazyHydration` — advertised by extensions that support
+  selective pull and single-file hydration.
+- `DatastoreSyncService.hydrateFile` — optional method; extensions without lazy
+  hydration do not implement it.
+
 ### Index
 
 A metadata index (`.datastore-index.json`) tracks all files in the S3 bucket.

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -74,6 +74,7 @@ export interface SyncContext {
 /** Capabilities a sync service advertises to swamp core. */
 export interface SyncCapabilities {
   scopedSync?: boolean;
+  lazyHydration?: boolean;
 }
 
 /** Options accepted by sync service methods. */
@@ -90,6 +91,12 @@ export interface DatastoreSyncOptions {
   relPath?: string;
   /** Domain-level sync context, passed when the extension advertises scopedSync. */
   context?: SyncContext;
+  /**
+   * When `true`, `pullChanged` should download only metadata files
+   * and skip content (`raw`) files under `data/`. Set by swamp core
+   * when `hydrationStrategy` is `"lazy"` on the initial pull.
+   */
+  metadataOnly?: boolean;
 }
 
 /** Interface for datastore synchronization services. */
@@ -99,6 +106,14 @@ export interface DatastoreSyncService {
   markDirty(options?: DatastoreSyncOptions): Promise<void>;
   /** Advertise what this sync service supports. */
   capabilities?(): SyncCapabilities;
+  /**
+   * Download a single file from the remote datastore by cache-relative path.
+   * Used for transparent content hydration when `hydrationStrategy` is `"lazy"`.
+   */
+  hydrateFile?(
+    relPath: string,
+    options?: DatastoreSyncOptions,
+  ): Promise<boolean>;
 }
 
 /**

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -75,14 +75,18 @@ export const dataGetCommand = new Command()
     ) {
       const cliCtx = createContext(options as GlobalOptions, ["data", "get"]);
 
-      const { repoDir, datastoreResolver } =
+      const { repoDir, repoContext, datastoreResolver } =
         await requireInitializedRepoReadOnly({
           repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataGetDeps(repoDir, datastoreResolver);
+      const deps = createDataGetDeps(
+        repoDir,
+        datastoreResolver,
+        repoContext.unifiedDataRepo,
+      );
 
       const renderer = createDataGetRenderer(cliCtx.outputMode);
       await consumeStream(

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -62,15 +62,20 @@ export const dataListCommand = new Command()
   .action(async function (options: AnyOptions, modelIdOrName?: string) {
     const cliCtx = createContext(options as GlobalOptions, ["data", "list"]);
 
-    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
-      {
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      },
-    );
+    const { repoDir, repoContext, datastoreResolver } =
+      await requireInitializedRepoReadOnly(
+        {
+          repoDir: resolveRepoDir(options.repoDir),
+          outputMode: cliCtx.outputMode,
+        },
+      );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDataListDeps(repoDir, datastoreResolver);
+    const deps = createDataListDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.unifiedDataRepo,
+    );
 
     const renderer = createDataListRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -58,14 +58,18 @@ export const dataVersionsCommand = new Command()
       cliCtx.logger
         .debug`Listing versions: model=${modelIdOrName}, name=${dataName}`;
 
-      const { repoDir, datastoreResolver } =
+      const { repoDir, repoContext, datastoreResolver } =
         await requireInitializedRepoReadOnly({
           repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataVersionsDeps(repoDir, datastoreResolver);
+      const deps = createDataVersionsDeps(
+        repoDir,
+        datastoreResolver,
+        repoContext.unifiedDataRepo,
+      );
 
       const renderer = createDataVersionsRenderer(cliCtx.outputMode);
       await consumeStream(

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -128,6 +128,10 @@ const datastoreSetupExtensionCommand = new Command()
     "--skip-migration",
     "Skip pushing local .swamp/ data to the remote (does not skip remote→local cache hydration, which always runs)",
   )
+  .option(
+    "--hydration-strategy <strategy:string>",
+    'Content download strategy: "full" (default, download everything) or "lazy" (metadata only, download content on demand)',
+  )
   .action(async function (options: AnyOptions, type: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
@@ -177,6 +181,19 @@ const datastoreSetupExtensionCommand = new Command()
     const deps = createDatastoreSetupDeps(repoDir);
     const renderer = createDatastoreSetupRenderer(cliCtx.outputMode);
 
+    const hydrationStrategy = options.hydrationStrategy as
+      | "full"
+      | "lazy"
+      | undefined;
+    if (
+      hydrationStrategy !== undefined && hydrationStrategy !== "full" &&
+      hydrationStrategy !== "lazy"
+    ) {
+      throw new UserError(
+        `Invalid --hydration-strategy: "${hydrationStrategy}". Must be "full" or "lazy".`,
+      );
+    }
+
     await consumeStream(
       datastoreSetupExtension(ctx, deps, {
         type: resolvedType,
@@ -184,6 +201,7 @@ const datastoreSetupExtensionCommand = new Command()
         repoDir,
         repoId: marker?.repoId,
         skipMigration: !!options.skipMigration,
+        hydrationStrategy,
       }),
       renderer.handlers(),
     );

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -72,6 +72,7 @@ import {
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
 import type {
   DatastoreSyncService,
+  HydrateFileHook,
   MarkDirtyHook,
   SyncCapabilities,
   SyncContext,
@@ -160,6 +161,23 @@ function buildMarkDirtyHook(
     }
     const relPath = SEPARATOR === "/" ? rel : rel.split(SEPARATOR).join("/");
     return syncService.markDirty({ relPath });
+  };
+}
+
+function buildHydrateFileHook(
+  syncService: DatastoreSyncService,
+  cacheRoot: string,
+  repoDir: string,
+): HydrateFileHook | undefined {
+  if (!syncService.hydrateFile) return undefined;
+  const repoSwampDir = swampPath(repoDir);
+  return (absPath: string) => {
+    let rel = relative(cacheRoot, absPath);
+    if (rel.startsWith("..")) {
+      rel = relative(repoSwampDir, absPath);
+    }
+    const relPath = SEPARATOR === "/" ? rel : rel.split(SEPARATOR).join("/");
+    return syncService.hydrateFile!(relPath);
   };
 }
 
@@ -266,11 +284,34 @@ export async function requireInitializedRepoReadOnly(
     datastoreConfig,
   );
 
+  // Sync service used solely for on-demand content hydration (no lock, no
+  // pull/push lifecycle). Only created when the extension advertises
+  // lazyHydration and the config enables it.
+  let hydrateFileHook: HydrateFileHook | undefined;
+
   // Verify datastore is accessible
   if (isCustomDatastoreConfig(datastoreConfig)) {
     // Ensure cache/datastore dir exists — no health check or lock on read-only path
     if (datastoreConfig.cachePath) {
       await ensureDir(datastoreConfig.cachePath);
+    }
+
+    if (
+      datastoreConfig.hydrationStrategy === "lazy" &&
+      datastoreConfig.cachePath
+    ) {
+      const provider = await resolveCustomProvider(datastoreConfig);
+      const syncService = provider.createSyncService?.(
+        repoPath.value,
+        datastoreConfig.cachePath,
+      );
+      if (syncService?.hydrateFile) {
+        hydrateFileHook = buildHydrateFileHook(
+          syncService,
+          datastoreConfig.cachePath,
+          repoPath.value,
+        );
+      }
     }
   } else if (datastoreConfig.type === "filesystem") {
     try {
@@ -325,6 +366,7 @@ export async function requireInitializedRepoReadOnly(
     yamlWorkflowsDir,
     vaultsDir,
     datastoreResolver,
+    hydrateFile: hydrateFileHook,
     ...factoryConfig,
   });
 
@@ -412,6 +454,7 @@ export function requireInitializedRepo(
         lock,
         label: datastoreConfig.type,
         syncTimeoutMs: resolveSyncTimeoutMs(datastoreConfig),
+        metadataOnly: datastoreConfig.hydrationStrategy === "lazy",
       });
       // Invalidate catalog after pull so next query backfills from fresh data
       if (registerService) {
@@ -498,6 +541,14 @@ export function requireInitializedRepo(
       markDirty: syncService && isCustomDatastoreConfig(datastoreConfig) &&
           datastoreConfig.cachePath
         ? buildMarkDirtyHook(
+          syncService,
+          datastoreConfig.cachePath,
+          repoPath.value,
+        )
+        : undefined,
+      hydrateFile: syncService && isCustomDatastoreConfig(datastoreConfig) &&
+          datastoreConfig.cachePath
+        ? buildHydrateFileHook(
           syncService,
           datastoreConfig.cachePath,
           repoPath.value,
@@ -634,6 +685,14 @@ export async function requireInitializedRepoUnlocked(
     markDirty: syncService && isCustomDatastoreConfig(datastoreConfig) &&
         datastoreConfig.cachePath
       ? buildMarkDirtyHook(
+        syncService,
+        datastoreConfig.cachePath,
+        repoPath.value,
+      )
+      : undefined,
+    hydrateFile: syncService && isCustomDatastoreConfig(datastoreConfig) &&
+        datastoreConfig.cachePath
+      ? buildHydrateFileHook(
         syncService,
         datastoreConfig.cachePath,
         repoPath.value,

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -849,6 +849,142 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "requireInitializedRepo - hydrateFile hook converts absolute path to cache-relative",
+  async () => {
+    const { datastoreTypeRegistry } = await import(
+      "../domain/datastore/datastore_type_registry.ts"
+    );
+    const { Data } = await import("../domain/data/data.ts");
+    const { ModelType } = await import("../domain/models/model_type.ts");
+
+    const typeName = "test-hydratefile-relpath";
+    const hydrateFileCalls: string[] = [];
+
+    if (!datastoreTypeRegistry.has(typeName)) {
+      datastoreTypeRegistry.register({
+        type: typeName,
+        name: "Test hydrateFile relPath wiring",
+        description:
+          "Captures hydrateFile relPath to assert absolute→cache-relative conversion",
+        isBuiltIn: false,
+        createProvider: () => ({
+          createLock: () => ({
+            acquire: () => Promise.resolve(),
+            release: () => Promise.resolve(),
+            withLock: <T>(fn: () => Promise<T>) => fn(),
+            inspect: () => Promise.resolve(null),
+            forceRelease: () => Promise.resolve(true),
+          }),
+          createVerifier: () => ({
+            verify: () =>
+              Promise.resolve({
+                healthy: true,
+                message: "ok",
+                latencyMs: 1,
+                datastoreType: typeName,
+              }),
+          }),
+          resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+          resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+          createSyncService: (_repoDir: string, cachePath: string) => ({
+            pullChanged: () => Promise.resolve(0),
+            pushChanged: () => Promise.resolve(0),
+            markDirty: () => Promise.resolve(),
+            hydrateFile: (relPath: string) => {
+              hydrateFileCalls.push(relPath);
+              // Write the file so getContent retries successfully
+              const absPath = join(cachePath, ...relPath.split("/"));
+              Deno.mkdirSync(join(absPath, ".."), { recursive: true });
+              Deno.writeFileSync(
+                absPath,
+                new TextEncoder().encode("hydrated"),
+              );
+              return Promise.resolve(true);
+            },
+            capabilities: () => ({ scopedSync: true, lazyHydration: true }),
+          }),
+        }),
+      });
+    }
+
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+      await configureExtensionDatastore(dir, typeName);
+
+      hydrateFileCalls.length = 0;
+
+      const repo = await requireInitializedRepo({
+        repoDir: dir,
+        outputMode: "json",
+        skipImplicitSync: true,
+      });
+
+      const testType = ModelType.create("test/hydrate");
+      const data = Data.create({
+        name: "hydrate-probe",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 100,
+        tags: { type: "test" },
+        ownerDefinition: {
+          ownerType: "manual",
+          ownerRef: "test-user",
+        },
+      });
+
+      // Save data then delete the raw file to simulate lazy hydration state
+      await repo.repoContext.unifiedDataRepo.save(
+        testType,
+        "model-h",
+        data,
+        new TextEncoder().encode("original"),
+      );
+      const contentPath = repo.repoContext.unifiedDataRepo.getContentPath(
+        testType,
+        "model-h",
+        "hydrate-probe",
+        1,
+      );
+      await Deno.remove(contentPath);
+
+      // getContent should trigger hydrateFile through the wired hook
+      const result = await repo.repoContext.unifiedDataRepo.getContent(
+        testType,
+        "model-h",
+        "hydrate-probe",
+        1,
+      );
+
+      assertExists(result);
+      assertEquals(new TextDecoder().decode(result), "hydrated");
+
+      // The hydrateFile call must receive a cache-relative, forward-slash path
+      assertEquals(hydrateFileCalls.length, 1);
+      const relPath = hydrateFileCalls[0];
+
+      // Must be cache-relative (not absolute)
+      if (relPath.startsWith("/") || relPath.includes(":")) {
+        throw new Error(
+          `hydrateFile relPath must be cache-relative, got: ${relPath}`,
+        );
+      }
+      // Must be forward-slash normalized
+      if (relPath.includes("\\")) {
+        throw new Error(
+          `hydrateFile relPath must be forward-slash normalized, got: ${relPath}`,
+        );
+      }
+      // Must include the data/ prefix so extensions can map to S3 keys
+      assertStringIncludes(relPath, "data/");
+      // Must end with /raw (the content file)
+      assertStringIncludes(relPath, "/raw");
+
+      await flushDatastoreSync();
+    });
+  },
+);
+
 // ============================================================================
 // waitForPerModelLocks Tests
 // ============================================================================

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -292,6 +292,10 @@ export async function parseDatastoreEnvVar(
           config,
           datastorePath,
           cachePath,
+          hydrationStrategy: config.hydrationStrategy as
+            | "full"
+            | "lazy"
+            | undefined,
         };
       }
 
@@ -362,6 +366,10 @@ export async function parseDatastoreEnvVar(
     config,
     datastorePath,
     cachePath,
+    hydrationStrategy: config.hydrationStrategy as
+      | "full"
+      | "lazy"
+      | undefined,
   };
 }
 
@@ -453,6 +461,7 @@ export async function resolveDatastoreConfig(
           cachePath,
           directories: ds.directories,
           exclude: ds.exclude,
+          hydrationStrategy: ds.hydrationStrategy,
         };
       }
 
@@ -529,6 +538,7 @@ export async function resolveDatastoreConfig(
       cachePath,
       directories: ds.directories,
       exclude: ds.exclude,
+      hydrationStrategy: ds.hydrationStrategy,
     };
   }
 

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -540,3 +540,88 @@ Deno.test("DataQueryService: select version without history opt-in returns lates
   assertEquals(versions, [3]);
   catalog.close();
 });
+
+Deno.test("DataQueryService: catalog backfill works with metadata-only files (no raw)", async () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-lazy-hydration-test-" });
+  try {
+    // Create the data directory structure with metadata.yaml + latest but NO raw file
+    // This simulates lazy hydration state after a metadata-only pull
+    const dataDir = join(
+      dir,
+      ".swamp",
+      "data",
+      "test",
+      "model",
+      "my-model-id",
+      "lazy-data",
+      "1",
+    );
+    ensureDirSync(dataDir);
+
+    // Write metadata.yaml with all required fields (id, version included)
+    const metadata = {
+      name: "lazy-data",
+      id: "00000000-0000-1000-8000-000000000001",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 100,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "lazy-model" },
+      ownerDefinition: {
+        ownerType: "model-method",
+        ownerRef: "test/model:run",
+      },
+      createdAt: "2026-01-15T10:00:00.000Z",
+      size: 42,
+      checksum: "abc123",
+    };
+    Deno.writeTextFileSync(
+      join(dataDir, "metadata.yaml"),
+      stringifyYaml(metadata as Record<string, unknown>),
+    );
+
+    // Write the latest marker pointing to version 1
+    const dataNameDir = join(
+      dir,
+      ".swamp",
+      "data",
+      "test",
+      "model",
+      "my-model-id",
+      "lazy-data",
+    );
+    Deno.writeTextFileSync(join(dataNameDir, "latest"), "1");
+
+    // Do NOT create a "raw" file — this is the key: lazy hydration skips raw
+
+    // Create catalog and repo with no pre-populated catalog (forces backfill)
+    const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+    const catalogObj = new CatalogStore(dbPath);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      dir,
+      undefined,
+      catalogObj,
+    );
+    const svc = new DataQueryService(catalogObj, dataRepo);
+
+    // Query with a predicate that doesn't need content — should trigger
+    // backfill from metadata.yaml and return the item
+    const results = await svc.query("true") as DataRecord[];
+    assertEquals(results.length, 1);
+    assertEquals(results[0].name, "lazy-data");
+    assertEquals(results[0].modelType, "test/model");
+    assertEquals(results[0].version, 1);
+    assertEquals(results[0].isLatest, true);
+    assertEquals(results[0].tags.type, "resource");
+    assertEquals(results[0].tags.modelName, "lazy-model");
+
+    catalogObj.close();
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+});

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -112,6 +112,18 @@ export interface CustomDatastoreConfig {
    * `resolveSyncTimeoutMs`.
    */
   readonly syncTimeoutMs?: number;
+  /**
+   * Controls how the initial pull populates the local cache.
+   *
+   * - `"full"` (default): download all files including content (`raw`).
+   * - `"lazy"`: download only metadata (`metadata.yaml`, `latest` markers,
+   *   partition indexes) and hydrate content on demand when first accessed.
+   *
+   * Lazy hydration gives full catalog visibility (`data list`, `data query`,
+   * CEL expressions) immediately while deferring the expensive content
+   * download until the data is actually needed.
+   */
+  readonly hydrationStrategy?: "full" | "lazy";
 }
 
 /**
@@ -144,6 +156,7 @@ export interface DatastoreConfigData {
   config?: Record<string, unknown>;
   directories?: string[];
   exclude?: string[];
+  hydrationStrategy?: "full" | "lazy";
 }
 
 /**

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -27,6 +27,7 @@ export interface SyncContext {
 /** Capabilities a sync service advertises to swamp core. */
 export interface SyncCapabilities {
   scopedSync?: boolean;
+  lazyHydration?: boolean;
 }
 
 /** Options accepted by sync service methods. */
@@ -61,6 +62,18 @@ export interface DatastoreSyncOptions {
   relPath?: string;
   /** Domain-level sync context, passed when the extension advertises scopedSync. */
   context?: SyncContext;
+  /**
+   * When `true`, `pullChanged` downloads only metadata files
+   * (`metadata.yaml`, `latest` markers, partition indexes) and skips
+   * content files (`raw`) under `data/`. Extensions that advertise
+   * `lazyHydration` in their capabilities SHOULD honor this flag;
+   * extensions that don't can safely ignore it.
+   *
+   * Set by swamp core when `hydrationStrategy` is `"lazy"` on the
+   * initial setup/hydration pull. Not set on subsequent scoped pulls
+   * (those always download everything the partition lists).
+   */
+  metadataOnly?: boolean;
 }
 
 /**
@@ -135,6 +148,30 @@ export interface DatastoreSyncService {
    *    set's contents.
    */
   markDirty(options?: DatastoreSyncOptions): Promise<void>;
+
+  /**
+   * Download a single file from the remote datastore by cache-relative path.
+   *
+   * Used for transparent content hydration when `hydrationStrategy` is
+   * `"lazy"`: the initial pull downloads only metadata files, and individual
+   * content files are fetched on demand when first accessed.
+   *
+   * Returns `true` if the file was downloaded successfully, `false` if the
+   * file does not exist on the remote. Implementations MUST write the file
+   * atomically (write to a temporary path, then rename) to avoid partial
+   * reads from concurrent consumers.
+   *
+   * `relPath` is forward-slash-normalized and cache-relative (same
+   * convention as `DatastoreSyncOptions.relPath`). Extensions consuming
+   * it for disk access on Windows MUST convert to native separators.
+   *
+   * Optional — extensions without lazy hydration support do not implement
+   * this method. Core checks for its presence before calling.
+   */
+  hydrateFile?(
+    relPath: string,
+    options?: DatastoreSyncOptions,
+  ): Promise<boolean>;
 }
 
 /** Direction of a sync operation. */
@@ -159,6 +196,26 @@ export type SyncDirection = "push" | "pull";
  * is documented on `DatastoreSyncService.markDirty`.
  */
 export type MarkDirtyHook = (relPath?: string) => Promise<void>;
+
+/**
+ * Callback invoked by repositories when content is missing from the local cache.
+ *
+ * Thin indirection over {@link DatastoreSyncService.hydrateFile} so repositories
+ * do not need a handle on the full sync service. Undefined when the datastore
+ * does not support lazy hydration — callers treat absence as "file is genuinely
+ * missing."
+ *
+ * **Internal vs public contract.** Repositories pass an absolute path —
+ * they don't have the cache root in scope. The composition root in
+ * `repo_context.ts` wraps this hook with a helper that converts the absolute
+ * path to a forward-slash cache-relative string and forwards it to
+ * {@link DatastoreSyncService.hydrateFile}. Same pattern as
+ * {@link MarkDirtyHook}.
+ *
+ * Returns `true` if the file was successfully downloaded, `false` if the
+ * file does not exist on the remote.
+ */
+export type HydrateFileHook = (absPath: string) => Promise<boolean>;
 
 /**
  * Thrown when a datastore sync operation exceeds the configured timeout.

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -67,6 +67,12 @@ export interface RegisterDatastoreSyncOptions {
    * service is registered.
    */
   syncTimeoutMs?: number;
+  /**
+   * When `true`, the initial pull passes `{ metadataOnly: true }` to
+   * `pullChanged`, signalling the extension to skip content files.
+   * Used when `hydrationStrategy` is `"lazy"`.
+   */
+  metadataOnly?: boolean;
 }
 
 /** Internal entry tracking a single lock/sync pair. */
@@ -234,7 +240,7 @@ export async function registerDatastoreSyncNamed(
   key: string,
   options: RegisterDatastoreSyncOptions,
 ): Promise<void> {
-  const { service, lock } = options;
+  const { service, lock, metadataOnly } = options;
   const label = options.label ?? "datastore";
   const syncTimeoutMs = options.syncTimeoutMs ?? DEFAULT_SYNC_TIMEOUT_MS;
   const entry: SyncEntry = { service, lock, label, syncTimeoutMs };
@@ -300,7 +306,11 @@ export async function registerDatastoreSyncNamed(
         label,
         "pull",
         syncTimeoutMs,
-        (signal) => service.pullChanged({ signal }),
+        (signal) =>
+          service.pullChanged({
+            signal,
+            ...(metadataOnly ? { metadataOnly } : {}),
+          }),
       );
       if (pulled && pulled > 0) {
         syncSpan.setAttribute("sync.file_count", pulled);

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -64,7 +64,10 @@ import type { RepoIndexService } from "../../domain/repo/repo_index_service.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlVaultConfigRepository } from "./yaml_vault_config_repository.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
-import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
+import type {
+  HydrateFileHook,
+  MarkDirtyHook,
+} from "../../domain/datastore/datastore_sync_service.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
 import { CatalogStore } from "./catalog_store.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
@@ -246,6 +249,7 @@ export interface RepositoryFactoryConfig {
    * correct for datastores without a fast-path. See `design/datastores.md`.
    */
   markDirty?: MarkDirtyHook;
+  hydrateFile?: HydrateFileHook;
 }
 
 /**
@@ -286,6 +290,7 @@ export function createRepositoryContext(
     vaultsDir,
     datastoreResolver,
     markDirty,
+    hydrateFile,
   } = config;
 
   // Helper to resolve datastore-tier base directories
@@ -343,6 +348,7 @@ export function createRepositoryContext(
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
     markDirty,
+    hydrateFile,
   );
 
   // Construct the query service alongside its dependencies so consumers

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -37,7 +37,10 @@ import {
   ModelType,
   type ModelTypeInput,
 } from "../../domain/models/model_type.ts";
-import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
+import type {
+  HydrateFileHook,
+  MarkDirtyHook,
+} from "../../domain/datastore/datastore_sync_service.ts";
 import type { CatalogStore } from "./catalog_store.ts";
 import {
   type GarbageCollectionResult,
@@ -76,6 +79,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     baseDir: string | undefined,
     private readonly catalogStore: CatalogStore,
     private readonly markDirty?: MarkDirtyHook,
+    private readonly hydrateFile?: HydrateFileHook,
   ) {
     this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.data);
   }
@@ -674,6 +678,12 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       return await Deno.readFile(contentPath);
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
+        if (this.hydrateFile) {
+          const hydrated = await this.hydrateFile(contentPath);
+          if (hydrated) {
+            return await Deno.readFile(contentPath);
+          }
+        }
         return null;
       }
       throw error;

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -918,3 +918,129 @@ Deno.test("findAllForModel: accepts string type parameter", async () => {
     }
   }
 });
+
+Deno.test("getContent: calls hydrateFile hook when raw file is missing", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const expectedContent = new TextEncoder().encode("hydrated-content");
+
+    const hydrateFile = async (absPath: string): Promise<boolean> => {
+      // Hook receives absolute path (same pattern as MarkDirtyHook)
+      await Deno.mkdir(join(absPath, ".."), { recursive: true });
+      await Deno.writeFile(absPath, expectedContent);
+      return true;
+    };
+
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      undefined,
+      hydrateFile,
+    );
+
+    // Create a data item with content, then delete the raw file to simulate
+    // lazy hydration state (metadata exists but raw is missing)
+    const data = makeData("hydrate-test");
+    await repo.save(testType, "model-1", data, expectedContent);
+    const contentPath = repo.getContentPath(
+      testType,
+      "model-1",
+      "hydrate-test",
+      1,
+    );
+    await Deno.remove(contentPath);
+
+    // getContent should call hydrateFile and return the content
+    const result = await repo.getContent(
+      testType,
+      "model-1",
+      "hydrate-test",
+      1,
+    );
+    assertExists(result);
+    assertEquals(new TextDecoder().decode(result), "hydrated-content");
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("getContent: returns null when hydrateFile returns false", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+
+    const hydrateFile = (_absPath: string): Promise<boolean> => {
+      return Promise.resolve(false);
+    };
+
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      undefined,
+      hydrateFile,
+    );
+
+    // Create a data item then delete the raw file
+    const data = makeData("hydrate-fail");
+    const content = new TextEncoder().encode("temp");
+    await repo.save(testType, "model-1", data, content);
+    const contentPath = repo.getContentPath(
+      testType,
+      "model-1",
+      "hydrate-fail",
+      1,
+    );
+    await Deno.remove(contentPath);
+
+    // getContent should return null since hydrateFile returned false
+    const result = await repo.getContent(
+      testType,
+      "model-1",
+      "hydrate-fail",
+      1,
+    );
+    assertEquals(result, null);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("getContent: returns null without hook when raw file is missing", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+
+    // Create a data item then delete the raw file
+    const data = makeData("no-hook");
+    const content = new TextEncoder().encode("temp");
+    await repo.save(testType, "model-1", data, content);
+    const contentPath = repo.getContentPath(testType, "model-1", "no-hook", 1);
+    await Deno.remove(contentPath);
+
+    // Without hydrateFile hook, getContent returns null
+    const result = await repo.getContent(testType, "model-1", "no-hook", 1);
+    assertEquals(result, null);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});

--- a/src/libswamp/data/get.ts
+++ b/src/libswamp/data/get.ts
@@ -171,11 +171,12 @@ export interface DataGetDeps {
 export function createDataGetDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataGetDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -161,11 +161,12 @@ export interface DataListDeps {
 export function createDataListDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataListDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/data/versions.ts
+++ b/src/libswamp/data/versions.ts
@@ -88,11 +88,12 @@ export interface DataVersionsDeps {
 export function createDataVersionsDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataVersionsDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -240,6 +240,7 @@ export interface DatastoreSetupExtensionInput {
   repoDir: string;
   repoId?: string;
   skipMigration: boolean;
+  hydrationStrategy?: "full" | "lazy";
 }
 
 /** Sets up an extension-provided datastore. */
@@ -404,7 +405,13 @@ export async function* datastoreSetupExtension(
             input.type,
             "pull",
             timeoutMs,
-            (signal) => syncService.pullChanged({ signal }),
+            (signal) =>
+              syncService.pullChanged({
+                signal,
+                ...(input.hydrationStrategy === "lazy"
+                  ? { metadataOnly: true }
+                  : {}),
+              }),
           );
           filesPulled = typeof pulled === "number" ? pulled : 0;
           ctx.logger.debug`Hydration complete: ${filesPulled} file(s) pulled`;
@@ -440,6 +447,9 @@ export async function* datastoreSetupExtension(
         await deps.updateRepoConfig(input.repoDir, {
           type: input.type,
           config: input.config,
+          ...(input.hydrationStrategy
+            ? { hydrationStrategy: input.hydrationStrategy }
+            : {}),
         });
       }
 


### PR DESCRIPTION
## Summary

- Add framework support for lazy hydration: `hydrationStrategy: "lazy"` makes the initial datastore pull download only metadata files, skipping content (`raw`) files. Catalog works immediately; content hydrates transparently on first access.
- New `HydrateFileHook` (mirrors `MarkDirtyHook`) injected into `UnifiedDataRepository` — `getContent()` calls the hook when `raw` is missing, downloads the file, retries the read.
- New `--hydration-strategy` CLI flag on `swamp datastore setup extension` writes the strategy at the datastore level in `.swamp.yaml`.
- `metadataOnly` option on `DatastoreSyncOptions` signals extensions to skip content during pull.
- `data get`, `data list`, `data versions` commands now use the hooked `repoContext.unifiedDataRepo` instead of creating fresh unhooked instances.
- Design doc updated with lazy hydration architecture, `HydrateFileHook` contract, and `getContentSync` limitation.

## Test plan

- [x] 3 unit tests: `HydrateFileHook` fires on missing raw, returns null when hook returns false, returns null without hook
- [x] 1 integration test: `buildHydrateFileHook` wiring through `requireInitializedRepo` — verifies the sync service receives cache-relative, forward-slash-normalized, `data/`-prefixed paths
- [x] 1 integration test: catalog backfill with metadata-only files (no raw) produces correct results
- [x] Full test suite: 6211 passed, 0 failed
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [x] CLI binary benchmarks: no regression on full-hydration code path (hook is undefined, never fires)

Fixes swamp-club#440

🤖 Generated with [Claude Code](https://claude.com/claude-code)