### PR TITLE
fix(extensions): break circular dependency when datastore extension is not yet installed (swamp-club#445)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -616,9 +616,11 @@ swamp extension trust auto-trust <on|off> # Enable/disable membership auto-trust
 ### Resolution Algorithm
 
 1. **Local registry** — check if the type is already registered locally.
-2. **Direct lookup** — strip trailing path segments from the type to derive the
-   extension name (e.g., `@swamp/aws/ec2/instance` → `@swamp/aws/ec2` →
-   `@swamp/aws`) and look up each candidate directly in the registry.
+2. **Direct lookup** — try the full type as an extension name first, then strip
+   trailing path segments to derive shorter candidates (e.g.,
+   `@swamp/aws/ec2/instance` → `@swamp/aws/ec2/instance` → `@swamp/aws/ec2` →
+   `@swamp/aws`). For two-segment types like `@keeb/mongodb-datastore`, the full
+   type is the only candidate — stripping further would leave a bare collective.
 3. **Search fallback** — if direct lookup fails, search the registry for
    matching extensions.
 

--- a/integration/auto_resolver_truncated_test.ts
+++ b/integration/auto_resolver_truncated_test.ts
@@ -164,11 +164,13 @@ Deno.test("integration: auto-resolver surfaces truncated error and leaves the tr
         allowedCollectives: ["test"],
         extensionLookup: {
           getExtension: (name: string) =>
-            Promise.resolve({
-              name,
-              description: "Truncated fixture",
-              latestVersion: "2026.01.01.1",
-            }),
+            name === extensionName
+              ? Promise.resolve({
+                name,
+                description: "Truncated fixture",
+                latestVersion: "2026.01.01.1",
+              })
+              : Promise.resolve(null),
           searchExtensions: () => Promise.resolve({ extensions: [] }),
         },
         extensionInstaller: adapter,

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -31,12 +31,8 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  RepoMarkerRepository,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
@@ -191,23 +187,17 @@ export const extensionPullCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);
     ctx.logger.debug`Starting extension pull`;
 
-    // 1. Validate repo
-    const repoDir = resolveRepoDir(options.repoDir);
-    await requireInitializedRepo({
-      repoDir,
-      outputMode: ctx.outputMode,
-    });
+    // 1. Validate repo (lightweight — no datastore resolution, so pulling
+    // the repo's own datastore extension doesn't circular-fail; see #445)
+    const { repoDir, marker } = await requireRepoMarker(
+      resolveRepoDir(options.repoDir),
+    );
 
     // 2. Parse extension reference
     const ref = parseExtensionRef(extension);
 
     // 3. Validate name format
     validateExtensionName(ref.name);
-
-    // 4. Resolve lockfile path (stays in committed extensions/models/ dir)
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const marker = await markerRepo.read(repoPath);
     const modelsDir = resolveModelsDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -24,12 +24,8 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  RepoMarkerRepository,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
 import {
   consumeStream,
   createExtensionRmDeps,
@@ -78,20 +74,13 @@ export const extensionRemoveCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["extension", "rm"]);
     ctx.logger.debug`Starting extension remove`;
 
-    const repoDir = resolveRepoDir(options.repoDir);
-    await requireInitializedRepo({
-      repoDir,
-      outputMode: ctx.outputMode,
-    });
+    const { repoDir, marker } = await requireRepoMarker(
+      resolveRepoDir(options.repoDir),
+    );
 
     // Parse extension reference (ignore version if provided)
     const ref = parseExtensionRef(extension);
     validateExtensionName(ref.name);
-
-    // Resolve models dir from .swamp.yaml
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const marker = await markerRepo.read(repoPath);
     const modelsDir = resolveModelsDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -24,12 +24,8 @@ import {
   type GlobalOptions,
   interactiveOutputMode,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  RepoMarkerRepository,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
   ExtensionApiClient,
@@ -190,16 +186,9 @@ export const extensionSearchCommand = new Command()
     const action = renderer.selectedAction();
 
     if (selected && action === "install") {
-      // Install writes files to the repo, so acquire the datastore lock
-      const repoDir = ".";
-      await requireInitializedRepo({
-        repoDir,
-        outputMode: ctx.outputMode,
-      });
-
-      const repoPath = RepoPath.create(repoDir);
-      const markerRepo = new RepoMarkerRepository();
-      const marker = await markerRepo.read(repoPath);
+      // Extension install writes to local files only (pulled-extensions/,
+      // lockfile) — no datastore needed; see #445.
+      const { repoDir, marker } = await requireRepoMarker(".");
       const modelsDir = resolveModelsDir(marker);
       const absoluteModelsDir = resolve(repoDir, modelsDir);
       const lockfilePath = join(

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -24,12 +24,8 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import {
-  RepoMarkerRepository,
-} from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { createInstallContext, parseExtensionRef } from "./extension_pull.ts";
 import {
   consumeStream,
@@ -74,17 +70,11 @@ export const extensionUpdateCommand = new Command()
     ]);
     cliCtx.logger.debug`Starting extension update`;
 
-    // 1. Validate repo
-    const repoDir = resolveRepoDir(options.repoDir);
-    await requireInitializedRepo({
-      repoDir,
-      outputMode: cliCtx.outputMode,
-    });
-
-    // 2. Resolve dirs from .swamp.yaml
-    const repoPath = RepoPath.create(repoDir);
-    const markerRepo = new RepoMarkerRepository();
-    const marker = await markerRepo.read(repoPath);
+    // 1. Validate repo (lightweight — no datastore resolution, so updating
+    // the repo's own datastore extension doesn't circular-fail; see #445)
+    const { repoDir, marker } = await requireRepoMarker(
+      resolveRepoDir(options.repoDir),
+    );
     const modelsDir = resolveModelsDir(marker);
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -248,6 +248,49 @@ export async function resolveDatastoreForRepo(
 }
 
 /**
+ * Result of lightweight repo marker validation.
+ * Contains just the repo directory and marker — no datastore config,
+ * lock, or sync. Used by extension commands that manage local files
+ * and don't need the datastore.
+ */
+export interface RepoMarkerResult {
+  repoDir: string;
+  marker: RepoMarkerData | null;
+}
+
+/**
+ * Validates that a directory is an initialized swamp repository and reads
+ * the repo marker, without resolving the datastore config, acquiring locks,
+ * or registering sync.
+ *
+ * Use this for extension management commands (pull, update, rm, search)
+ * that operate on local files in pulled-extensions/ and don't interact
+ * with the datastore.
+ *
+ * @param repoDir - The repository directory to validate
+ * @returns The validated repo directory and marker
+ * @throws UserError if not initialized
+ */
+export async function requireRepoMarker(
+  repoDir: string,
+): Promise<RepoMarkerResult> {
+  const repoPath = RepoPath.create(repoDir);
+  const service = new RepoService(VERSION);
+  const isInit = await service.isInitialized(repoPath);
+
+  if (!isInit) {
+    throw new UserError(
+      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
+    );
+  }
+
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(repoPath);
+
+  return { repoDir: repoPath.value, marker };
+}
+
+/**
  * Validates that a directory is an initialized swamp repository without
  * acquiring the datastore lock or performing sync operations.
  *

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -284,12 +284,22 @@ export class ExtensionAutoResolver {
   }
 
   /**
-   * Builds candidate extension names by stripping trailing segments.
+   * Builds candidate extension names by trying the full type first, then
+   * stripping trailing segments.
    * For "@swamp/aws/ec2/instance":
-   *   ["@swamp/aws/ec2", "@swamp/aws"]
+   *   ["@swamp/aws/ec2/instance", "@swamp/aws/ec2", "@swamp/aws"]
+   * For "@keeb/mongodb-datastore":
+   *   ["@keeb/mongodb-datastore"]
    */
   private buildCandidateNames(normalizedType: string): string[] {
     const candidates: string[] = [];
+
+    if (ModelType.getSegmentCount(normalizedType) >= 2) {
+      const full = normalizedType.startsWith("@")
+        ? normalizedType
+        : `@${normalizedType}`;
+      candidates.push(full);
+    }
 
     let current = normalizedType;
     while (true) {

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -190,8 +190,9 @@ Deno.test("ExtensionAutoResolver - tries intermediate candidates before shorter 
   });
 
   await resolver.resolve("@swamp/aws/ec2/instance");
-  // Should try @swamp/aws/ec2 first, then @swamp/aws
-  assertEquals(lookupCalls[0], "@swamp/aws/ec2");
+  // Full type tried first, then stripped candidates longest-to-shortest
+  assertEquals(lookupCalls[0], "@swamp/aws/ec2/instance");
+  assertEquals(lookupCalls[1], "@swamp/aws/ec2");
 });
 
 Deno.test("ExtensionAutoResolver - falls back to search when direct lookup fails", async () => {
@@ -552,9 +553,8 @@ Deno.test("ExtensionAutoResolver - buildCandidateNames preserves forward-slash s
   });
 
   // Input is `@user/aws/ec2`; with collective "user" allowlisted, we
-  // expect the candidate progression `@user/aws` (single intermediate
-  // because dropping one more segment would land below the 2-segment
-  // floor).
+  // expect the candidate progression `@user/aws/ec2` (full type),
+  // then `@user/aws` (stripped).
   await resolver.resolve("@user/aws/ec2");
 
   // Every observed candidate must be forward-slash separated.
@@ -577,11 +577,66 @@ Deno.test("ExtensionAutoResolver - buildCandidateNames preserves forward-slash s
       `candidate must remain @-prefixed; got: ${candidate}`,
     );
   }
-  // Pin the specific candidate so a refactor that flattens or extends
-  // the segmentation rule will fail.
+  // Pin candidates: full type first, then stripped.
+  assertEquals(
+    lookupCalls.includes("@user/aws/ec2"),
+    true,
+    `expected @user/aws/ec2 among candidates; got: ${
+      JSON.stringify(lookupCalls)
+    }`,
+  );
   assertEquals(
     lookupCalls.includes("@user/aws"),
     true,
     `expected @user/aws among candidates; got: ${JSON.stringify(lookupCalls)}`,
+  );
+});
+
+// --- Issue #445: 2-segment datastore types must be tried as direct candidates ---
+
+Deno.test("ExtensionAutoResolver - resolves 2-segment datastore type via direct lookup", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["keeb"],
+    extensionLookup: createMockLookup({
+      "@keeb/mongodb-datastore": {
+        description: "MongoDB datastore",
+        latestVersion: "2026.05.01.1",
+      },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@keeb/mongodb-datastore");
+  assertEquals(result, true);
+  assertEquals(installer.installCalls, ["@keeb/mongodb-datastore"]);
+});
+
+Deno.test("ExtensionAutoResolver - 2-segment type generates full type as only candidate", async () => {
+  const lookupCalls: string[] = [];
+  const lookup: ExtensionLookupPort = {
+    getExtension(name: string) {
+      lookupCalls.push(name);
+      return Promise.resolve(null);
+    },
+    searchExtensions() {
+      return Promise.resolve({ extensions: [] });
+    },
+  };
+
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["keeb"],
+    extensionLookup: lookup,
+    extensionInstaller: createMockInstaller(),
+    output: createMockOutput(),
+  });
+
+  await resolver.resolve("@keeb/mongodb-datastore");
+  assertEquals(
+    lookupCalls,
+    ["@keeb/mongodb-datastore"],
+    "2-segment type should produce exactly one direct-lookup candidate (the full type)",
   );
 });


### PR DESCRIPTION
## Summary

- Extension commands (`pull`, `update`, `rm`, `search`) called `requireInitializedRepo()` which forced full datastore type resolution before any work began. When the configured datastore IS the extension being installed (first-install scenario), this created a circular dependency error: `Unknown datastore type "@keeb/mongodb-datastore" in .swamp.yaml. Available types: filesystem`
- Replaced `requireInitializedRepo()` with a lightweight `requireRepoMarker()` that validates the repo marker exists without resolving the datastore config, acquiring locks, or registering sync — none of which extension commands need
- Fixed the auto-resolver's `buildCandidateNames` to include the full type as the first direct-lookup candidate. Previously, 2-segment types like `@keeb/mongodb-datastore` stripped to `@keeb` (1 segment, below the ≥2 threshold), generating zero candidates and falling through to unreliable search

## Test plan

- [x] Added unit tests for 2-segment datastore type resolution via direct lookup
- [x] Added unit test verifying 2-segment types generate the full type as the only candidate
- [x] Updated existing candidate-ordering and forward-slash tests for new full-type-first behavior
- [x] Fixed integration test with overly-permissive mock that masked the truncated-extension path
- [x] Reproduced the bug with minio + s3-datastore: configured `.swamp.yaml` with uninstalled datastore type, verified `extension pull` failed before fix and succeeded after
- [x] Full test suite passes (6215 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Closes swamp-club#445

🤖 Generated with [Claude Code](https://claude.com/claude-code)