### PR TITLE
fix(update): support LaunchDaemon autoupdate for root-owned macOS binaries (swamp-club#449)

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -21,12 +21,39 @@ import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
-import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
+import {
+  createScheduler,
+  detectBinaryOwnership,
+} from "../../infrastructure/update/scheduler_factory.ts";
+import { detectInstalledLaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
 import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
 import { UserError } from "../../domain/errors.ts";
 
+import type { LaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
+
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+async function detectConfigLaunchdMode(): Promise<LaunchdMode> {
+  if (Deno.build.os !== "darwin") {
+    return "agent";
+  }
+
+  const installed = await detectInstalledLaunchdMode();
+  if (installed) return installed;
+
+  let currentUid: number | null = null;
+  let binaryUid: number | null = null;
+  try {
+    currentUid = Deno.uid();
+    const stat = await Deno.stat(Deno.execPath());
+    binaryUid = stat.uid;
+  } catch {
+    return "agent";
+  }
+
+  return detectBinaryOwnership(binaryUid, currentUid);
+}
 
 const CONFIG_KEYS: Record<string, { description: string; values?: string[] }> =
   {
@@ -104,11 +131,13 @@ const configSetCommand = new Command()
     const prefsRepo = new UpdatePreferencesFileRepository();
     const prefs = await prefsRepo.read();
 
+    const launchdMode = await detectConfigLaunchdMode();
+
     switch (key) {
       case "update.auto": {
         const enabling = value === "enabled";
 
-        const scheduler = await createScheduler();
+        const scheduler = await createScheduler({ launchdMode });
         if (enabling) {
           await scheduler.install(Deno.execPath(), prefs.cadence);
         } else {
@@ -131,7 +160,7 @@ const configSetCommand = new Command()
       case "update.cadence": {
         const cadence = value as UpdateCadence;
         if (prefs.enabled) {
-          const scheduler = await createScheduler();
+          const scheduler = await createScheduler({ launchdMode });
           await scheduler.install(Deno.execPath(), cadence);
         }
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -23,37 +23,13 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import {
   createScheduler,
-  detectBinaryOwnership,
+  resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
-import { detectInstalledLaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
 import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
 import { UserError } from "../../domain/errors.ts";
 
-import type { LaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
-
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function detectConfigLaunchdMode(): Promise<LaunchdMode> {
-  if (Deno.build.os !== "darwin") {
-    return "agent";
-  }
-
-  const installed = await detectInstalledLaunchdMode();
-  if (installed) return installed;
-
-  let currentUid: number | null = null;
-  let binaryUid: number | null = null;
-  try {
-    currentUid = Deno.uid();
-    const stat = await Deno.stat(Deno.execPath());
-    binaryUid = stat.uid;
-  } catch {
-    return "agent";
-  }
-
-  return detectBinaryOwnership(binaryUid, currentUid);
-}
 
 const CONFIG_KEYS: Record<string, { description: string; values?: string[] }> =
   {
@@ -131,7 +107,22 @@ const configSetCommand = new Command()
     const prefsRepo = new UpdatePreferencesFileRepository();
     const prefs = await prefsRepo.read();
 
-    const launchdMode = await detectConfigLaunchdMode();
+    const launchdMode = await resolveLaunchdMode();
+
+    if (launchdMode === "daemon") {
+      let isRoot = false;
+      try {
+        isRoot = Deno.uid() === 0;
+      } catch { /* not available */ }
+
+      if (!isRoot) {
+        throw new UserError(
+          `Autoupdate is configured as a system LaunchDaemon (root-owned binary).\n` +
+            `Re-run with sudo to modify:\n\n` +
+            `  sudo swamp config set ${key} ${value}`,
+        );
+      }
+    }
 
     switch (key) {
       case "update.auto": {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -23,6 +23,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import {
   createScheduler,
+  isRunningAsRoot,
   resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
 import type { UpdateCadence } from "../../domain/update/update_preferences.ts";
@@ -109,19 +110,12 @@ const configSetCommand = new Command()
 
     const launchdMode = await resolveLaunchdMode();
 
-    if (launchdMode === "daemon") {
-      let isRoot = false;
-      try {
-        isRoot = Deno.uid() === 0;
-      } catch { /* not available */ }
-
-      if (!isRoot) {
-        throw new UserError(
-          `Autoupdate is configured as a system LaunchDaemon (root-owned binary).\n` +
-            `Re-run with sudo to modify:\n\n` +
-            `  sudo swamp config set ${key} ${value}`,
-        );
-      }
+    if (launchdMode === "daemon" && !isRunningAsRoot()) {
+      throw new UserError(
+        `Autoupdate is configured as a system LaunchDaemon (root-owned binary).\n` +
+          `Re-run with sudo to modify:\n\n` +
+          `  sudo swamp config set ${key} ${value}`,
+      );
     }
 
     switch (key) {

--- a/src/cli/commands/doctor_install.ts
+++ b/src/cli/commands/doctor_install.ts
@@ -29,38 +29,16 @@ import { UpdatePreferencesFileRepository } from "../../infrastructure/update/upd
 import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupdate_log_file_repository.ts";
 import {
   createScheduler,
-  detectBinaryOwnership,
+  resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
 import {
   autoupdateLogDir,
   detectInstalledLaunchdMode,
-  type LaunchdMode,
 } from "../../infrastructure/update/launchd_scheduler.ts";
 import { createDoctorInstallRenderer } from "../../presentation/renderers/doctor_install.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function resolveLaunchdMode(
-  binaryPath: string,
-): Promise<LaunchdMode> {
-  if (Deno.build.os !== "darwin") return "agent";
-
-  const installed = await detectInstalledLaunchdMode();
-  if (installed) return installed;
-
-  let currentUid: number | null = null;
-  let binaryUid: number | null = null;
-  try {
-    currentUid = Deno.uid();
-    const stat = await Deno.stat(binaryPath);
-    binaryUid = stat.uid;
-  } catch {
-    return "agent";
-  }
-
-  return detectBinaryOwnership(binaryUid, currentUid);
-}
 
 function createProductionDeps(): InstallHealthDeps {
   const binaryPath = Deno.execPath();
@@ -98,7 +76,7 @@ function createProductionDeps(): InstallHealthDeps {
       return await repo.read();
     },
     getSchedulerStatus: async () => {
-      const launchdMode = await resolveLaunchdMode(binaryPath);
+      const launchdMode = await resolveLaunchdMode();
       const scheduler = await createScheduler({ launchdMode });
       return await scheduler.status();
     },
@@ -107,7 +85,7 @@ function createProductionDeps(): InstallHealthDeps {
       return await detectInstalledLaunchdMode();
     },
     getLastLogEntry: async () => {
-      const mode = await resolveLaunchdMode(binaryPath);
+      const mode = await resolveLaunchdMode();
       const logPath = mode === "daemon"
         ? join(autoupdateLogDir("daemon"), "autoupdate.log")
         : undefined;

--- a/src/cli/commands/doctor_install.ts
+++ b/src/cli/commands/doctor_install.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { VERSION } from "./version.ts";
@@ -32,7 +31,7 @@ import {
   resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
 import {
-  autoupdateLogDir,
+  autoupdateLogPath,
   detectInstalledLaunchdMode,
 } from "../../infrastructure/update/launchd_scheduler.ts";
 import { createDoctorInstallRenderer } from "../../presentation/renderers/doctor_install.ts";
@@ -87,7 +86,7 @@ function createProductionDeps(): InstallHealthDeps {
     getLastLogEntry: async () => {
       const mode = await resolveLaunchdMode();
       const logPath = mode === "daemon"
-        ? join(autoupdateLogDir("daemon"), "autoupdate.log")
+        ? autoupdateLogPath("daemon")
         : undefined;
       const logRepo = new AutoupdateLogFileRepository(logPath);
       const entries = await logRepo.readAll();

--- a/src/cli/commands/doctor_install.ts
+++ b/src/cli/commands/doctor_install.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { join } from "@std/path";
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { VERSION } from "./version.ts";
@@ -26,11 +27,40 @@ import {
 } from "../../domain/update/install_health.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupdate_log_file_repository.ts";
-import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
+import {
+  createScheduler,
+  detectBinaryOwnership,
+} from "../../infrastructure/update/scheduler_factory.ts";
+import {
+  autoupdateLogDir,
+  detectInstalledLaunchdMode,
+  type LaunchdMode,
+} from "../../infrastructure/update/launchd_scheduler.ts";
 import { createDoctorInstallRenderer } from "../../presentation/renderers/doctor_install.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+async function resolveLaunchdMode(
+  binaryPath: string,
+): Promise<LaunchdMode> {
+  if (Deno.build.os !== "darwin") return "agent";
+
+  const installed = await detectInstalledLaunchdMode();
+  if (installed) return installed;
+
+  let currentUid: number | null = null;
+  let binaryUid: number | null = null;
+  try {
+    currentUid = Deno.uid();
+    const stat = await Deno.stat(binaryPath);
+    binaryUid = stat.uid;
+  } catch {
+    return "agent";
+  }
+
+  return detectBinaryOwnership(binaryUid, currentUid);
+}
 
 function createProductionDeps(): InstallHealthDeps {
   const binaryPath = Deno.execPath();
@@ -68,11 +98,20 @@ function createProductionDeps(): InstallHealthDeps {
       return await repo.read();
     },
     getSchedulerStatus: async () => {
-      const scheduler = await createScheduler();
+      const launchdMode = await resolveLaunchdMode(binaryPath);
+      const scheduler = await createScheduler({ launchdMode });
       return await scheduler.status();
     },
+    getSchedulerType: async () => {
+      if (Deno.build.os !== "darwin") return null;
+      return await detectInstalledLaunchdMode();
+    },
     getLastLogEntry: async () => {
-      const logRepo = new AutoupdateLogFileRepository();
+      const mode = await resolveLaunchdMode(binaryPath);
+      const logPath = mode === "daemon"
+        ? join(autoupdateLogDir("daemon"), "autoupdate.log")
+        : undefined;
+      const logRepo = new AutoupdateLogFileRepository(logPath);
       const entries = await logRepo.readAll();
       return entries.length > 0 ? entries[entries.length - 1] : null;
     },

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { VERSION } from "./version.ts";
@@ -32,7 +31,7 @@ import { createUpdateCheckRenderer } from "../../presentation/renderers/update_c
 import { Spinner } from "../../presentation/spinner.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupdate_log_file_repository.ts";
-import { autoupdateLogDir } from "../../infrastructure/update/launchd_scheduler.ts";
+import { autoupdateLogPath } from "../../infrastructure/update/launchd_scheduler.ts";
 import {
   createScheduler,
   isRunningAsRoot,
@@ -59,7 +58,7 @@ function backgroundLogFilePath(): string | undefined {
 
   try {
     if (Deno.uid() === 0) {
-      return join(autoupdateLogDir("daemon"), "autoupdate.log");
+      return autoupdateLogPath("daemon");
     }
   } catch { /* uid not available */ }
   return undefined;
@@ -197,7 +196,11 @@ async function runSetupAuto(
 
   if (ctx.outputMode === "json") {
     console.log(
-      JSON.stringify({ enabled: true, cadence, schedulerType: launchdMode }),
+      JSON.stringify({
+        enabled: true,
+        cadence,
+        schedulerType: Deno.build.os === "darwin" ? launchdMode : undefined,
+      }),
     );
   } else {
     logger.info`Autoupdate enabled with ${cadence} checks`;
@@ -251,7 +254,7 @@ async function runSetupAutoStatus(
   const launchdMode = await resolveLaunchdMode();
 
   const logPath = launchdMode === "daemon"
-    ? join(autoupdateLogDir("daemon"), "autoupdate.log")
+    ? autoupdateLogPath("daemon")
     : undefined;
 
   if (ctx.outputMode === "json") {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { join } from "@std/path";
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { VERSION } from "./version.ts";
@@ -31,7 +32,13 @@ import { createUpdateCheckRenderer } from "../../presentation/renderers/update_c
 import { Spinner } from "../../presentation/spinner.ts";
 import { UpdatePreferencesFileRepository } from "../../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupdate_log_file_repository.ts";
-import { createScheduler } from "../../infrastructure/update/scheduler_factory.ts";
+import { autoupdateLogDir } from "../../infrastructure/update/launchd_scheduler.ts";
+import {
+  createScheduler,
+  detectBinaryOwnership,
+} from "../../infrastructure/update/scheduler_factory.ts";
+import type { LaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
+import { detectInstalledLaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
 import {
   isValidCadence,
   type UpdateCadence,
@@ -48,11 +55,22 @@ type AnyOptions = any;
 
 const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
 
+function backgroundLogFilePath(): string | undefined {
+  if (Deno.build.os !== "darwin") return undefined;
+
+  try {
+    if (Deno.uid() === 0) {
+      return join(autoupdateLogDir("daemon"), "autoupdate.log");
+    }
+  } catch { /* uid not available */ }
+  return undefined;
+}
+
 async function runBackgroundUpdate(
   ctx: { logger: ReturnType<typeof getSwampLogger> },
 ): Promise<void> {
   const platform = Platform.detect();
-  const logRepo = new AutoupdateLogFileRepository();
+  const logRepo = new AutoupdateLogFileRepository(backgroundLogFilePath());
   const deps = createUpdateCheckDeps(VERSION, Deno.execPath());
 
   const entry: AutoupdateLogEntry = {
@@ -115,6 +133,30 @@ function promptCadence(defaultCadence: UpdateCadence): UpdateCadence {
   }
 }
 
+async function detectLaunchdMode(): Promise<LaunchdMode> {
+  if (Deno.build.os !== "darwin") {
+    return "agent";
+  }
+
+  let currentUid: number | null = null;
+  let binaryUid: number | null = null;
+
+  try {
+    currentUid = Deno.uid();
+  } catch {
+    return "agent";
+  }
+
+  try {
+    const stat = await Deno.stat(Deno.execPath());
+    binaryUid = stat.uid;
+  } catch {
+    return "agent";
+  }
+
+  return detectBinaryOwnership(binaryUid, currentUid);
+}
+
 async function runSetupAuto(
   ctx: { logger: ReturnType<typeof getSwampLogger>; outputMode: string },
 ): Promise<void> {
@@ -125,21 +167,31 @@ async function runSetupAuto(
   }
 
   const binaryPath = Deno.execPath();
+  const launchdMode = await detectLaunchdMode();
 
-  // On POSIX, detect the case where setup is running as root (via sudo)
-  // but the scheduler will run as the unprivileged user.
+  let isRoot = false;
   try {
-    if (Deno.uid() === 0) {
-      throw new UserError(
-        `Cannot set up autoupdate while running as root.\n` +
-          `The background scheduler runs as your normal user, not as root.\n` +
-          `Run this command without sudo:\n\n` +
-          `  swamp update --setup-auto`,
-      );
-    }
-  } catch (e) {
-    if (e instanceof UserError) throw e;
+    isRoot = Deno.uid() === 0;
+  } catch {
     // Deno.uid() not available (e.g. Windows) — skip this check
+  }
+
+  if (launchdMode === "daemon" && !isRoot) {
+    throw new UserError(
+      `The swamp binary at ${binaryPath} is owned by root.\n` +
+        `To set up autoupdate, the scheduler must be installed as a system LaunchDaemon.\n` +
+        `Re-run with sudo:\n\n` +
+        `  sudo swamp update --setup-auto`,
+    );
+  }
+
+  if (launchdMode === "agent" && isRoot) {
+    throw new UserError(
+      `Cannot set up autoupdate while running as root.\n` +
+        `The binary is owned by your user, so the scheduler runs as a LaunchAgent.\n` +
+        `Run this command without sudo:\n\n` +
+        `  swamp update --setup-auto`,
+    );
   }
 
   const probeFile = binaryPath + ".swamp-write-test";
@@ -150,7 +202,7 @@ async function runSetupAuto(
     if (error instanceof Deno.errors.PermissionDenied) {
       throw new UserError(
         `Cannot set up autoupdate: the directory containing ${binaryPath} is not writable.\n` +
-          `The background scheduler runs as your user and cannot replace the binary.\n\n` +
+          `The background scheduler cannot replace the binary.\n\n` +
           `Options:\n` +
           `  • Change ownership:  sudo chown ${
             Deno.env.get("USER") ?? "$(whoami)"
@@ -168,15 +220,19 @@ async function runSetupAuto(
 
   const cadence = promptCadence(prefs.cadence);
 
-  const scheduler = await createScheduler();
+  const scheduler = await createScheduler({ launchdMode });
   await scheduler.install(binaryPath, cadence);
 
   await prefsRepo.write({ ...prefs, enabled: true, cadence });
 
   if (ctx.outputMode === "json") {
-    console.log(JSON.stringify({ enabled: true, cadence }));
+    console.log(JSON.stringify({ enabled: true, cadence, launchdMode }));
   } else {
     logger.info`Autoupdate enabled with ${cadence} checks`;
+
+    if (launchdMode === "daemon") {
+      logger.info("Installed as system LaunchDaemon (root-owned binary)");
+    }
 
     const status = await scheduler.status();
     if (status.installed) {
@@ -191,7 +247,27 @@ async function runDisableAuto(
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
 
-  const scheduler = await createScheduler();
+  const installedMode = Deno.build.os === "darwin"
+    ? await detectInstalledLaunchdMode()
+    : null;
+
+  if (installedMode === "daemon") {
+    let isRoot = false;
+    try {
+      isRoot = Deno.uid() === 0;
+    } catch { /* not available */ }
+
+    if (!isRoot) {
+      throw new UserError(
+        `Autoupdate is installed as a system LaunchDaemon (root-owned binary).\n` +
+          `Re-run with sudo to disable:\n\n` +
+          `  sudo swamp update --setup-auto disable`,
+      );
+    }
+  }
+
+  const launchdMode = installedMode ?? await detectLaunchdMode();
+  const scheduler = await createScheduler({ launchdMode });
   await scheduler.remove();
 
   await prefsRepo.write({ ...prefs, enabled: false });
@@ -211,10 +287,19 @@ async function runSetupAutoStatus(
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
 
+  const installedMode = Deno.build.os === "darwin"
+    ? await detectInstalledLaunchdMode()
+    : null;
+  const launchdMode = installedMode ?? await detectLaunchdMode();
+
+  const logPath = launchdMode === "daemon"
+    ? join(autoupdateLogDir("daemon"), "autoupdate.log")
+    : undefined;
+
   if (ctx.outputMode === "json") {
-    const scheduler = await createScheduler();
+    const scheduler = await createScheduler({ launchdMode });
     const scheduleStatus = await scheduler.status();
-    const logRepo = new AutoupdateLogFileRepository();
+    const logRepo = new AutoupdateLogFileRepository(logPath);
     const entries = await logRepo.readAll();
     const lastEntry = entries.length > 0 ? entries[entries.length - 1] : null;
 
@@ -223,6 +308,7 @@ async function runSetupAutoStatus(
         enabled: prefs.enabled,
         cadence: prefs.cadence,
         schedulerInstalled: scheduleStatus.installed,
+        schedulerType: Deno.build.os === "darwin" ? launchdMode : undefined,
         lastUpdate: lastEntry,
       },
       null,
@@ -243,11 +329,18 @@ async function runSetupAutoStatus(
   logger.info`Autoupdate: enabled`;
   logger.info`Cadence: ${prefs.cadence}`;
 
-  const scheduler = await createScheduler();
+  if (Deno.build.os === "darwin") {
+    const typeLabel = launchdMode === "daemon"
+      ? "LaunchDaemon (system)"
+      : "LaunchAgent (user)";
+    logger.info`Scheduler type: ${typeLabel}`;
+  }
+
+  const scheduler = await createScheduler({ launchdMode });
   const scheduleStatus = await scheduler.status();
   logger.info`Scheduler installed: ${scheduleStatus.installed}`;
 
-  const logRepo = new AutoupdateLogFileRepository();
+  const logRepo = new AutoupdateLogFileRepository(logPath);
   const entries = await logRepo.readAll();
   if (entries.length > 0) {
     const last = entries[entries.length - 1];

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -35,10 +35,8 @@ import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupd
 import { autoupdateLogDir } from "../../infrastructure/update/launchd_scheduler.ts";
 import {
   createScheduler,
-  detectBinaryOwnership,
+  resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
-import type { LaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
-import { detectInstalledLaunchdMode } from "../../infrastructure/update/launchd_scheduler.ts";
 import {
   isValidCadence,
   type UpdateCadence,
@@ -133,30 +131,6 @@ function promptCadence(defaultCadence: UpdateCadence): UpdateCadence {
   }
 }
 
-async function detectLaunchdMode(): Promise<LaunchdMode> {
-  if (Deno.build.os !== "darwin") {
-    return "agent";
-  }
-
-  let currentUid: number | null = null;
-  let binaryUid: number | null = null;
-
-  try {
-    currentUid = Deno.uid();
-  } catch {
-    return "agent";
-  }
-
-  try {
-    const stat = await Deno.stat(Deno.execPath());
-    binaryUid = stat.uid;
-  } catch {
-    return "agent";
-  }
-
-  return detectBinaryOwnership(binaryUid, currentUid);
-}
-
 async function runSetupAuto(
   ctx: { logger: ReturnType<typeof getSwampLogger>; outputMode: string },
 ): Promise<void> {
@@ -167,7 +141,7 @@ async function runSetupAuto(
   }
 
   const binaryPath = Deno.execPath();
-  const launchdMode = await detectLaunchdMode();
+  const launchdMode = await resolveLaunchdMode();
 
   let isRoot = false;
   try {
@@ -247,11 +221,9 @@ async function runDisableAuto(
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
 
-  const installedMode = Deno.build.os === "darwin"
-    ? await detectInstalledLaunchdMode()
-    : null;
+  const launchdMode = await resolveLaunchdMode();
 
-  if (installedMode === "daemon") {
+  if (launchdMode === "daemon") {
     let isRoot = false;
     try {
       isRoot = Deno.uid() === 0;
@@ -265,8 +237,6 @@ async function runDisableAuto(
       );
     }
   }
-
-  const launchdMode = installedMode ?? await detectLaunchdMode();
   const scheduler = await createScheduler({ launchdMode });
   await scheduler.remove();
 
@@ -287,10 +257,7 @@ async function runSetupAutoStatus(
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
 
-  const installedMode = Deno.build.os === "darwin"
-    ? await detectInstalledLaunchdMode()
-    : null;
-  const launchdMode = installedMode ?? await detectLaunchdMode();
+  const launchdMode = await resolveLaunchdMode();
 
   const logPath = launchdMode === "daemon"
     ? join(autoupdateLogDir("daemon"), "autoupdate.log")

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -35,6 +35,7 @@ import { AutoupdateLogFileRepository } from "../../infrastructure/update/autoupd
 import { autoupdateLogDir } from "../../infrastructure/update/launchd_scheduler.ts";
 import {
   createScheduler,
+  isRunningAsRoot,
   resolveLaunchdMode,
 } from "../../infrastructure/update/scheduler_factory.ts";
 import {
@@ -143,12 +144,7 @@ async function runSetupAuto(
   const binaryPath = Deno.execPath();
   const launchdMode = await resolveLaunchdMode();
 
-  let isRoot = false;
-  try {
-    isRoot = Deno.uid() === 0;
-  } catch {
-    // Deno.uid() not available (e.g. Windows) — skip this check
-  }
+  const isRoot = isRunningAsRoot();
 
   if (launchdMode === "daemon" && !isRoot) {
     throw new UserError(
@@ -200,7 +196,9 @@ async function runSetupAuto(
   await prefsRepo.write({ ...prefs, enabled: true, cadence });
 
   if (ctx.outputMode === "json") {
-    console.log(JSON.stringify({ enabled: true, cadence, launchdMode }));
+    console.log(
+      JSON.stringify({ enabled: true, cadence, schedulerType: launchdMode }),
+    );
   } else {
     logger.info`Autoupdate enabled with ${cadence} checks`;
 
@@ -223,19 +221,12 @@ async function runDisableAuto(
 
   const launchdMode = await resolveLaunchdMode();
 
-  if (launchdMode === "daemon") {
-    let isRoot = false;
-    try {
-      isRoot = Deno.uid() === 0;
-    } catch { /* not available */ }
-
-    if (!isRoot) {
-      throw new UserError(
-        `Autoupdate is installed as a system LaunchDaemon (root-owned binary).\n` +
-          `Re-run with sudo to disable:\n\n` +
-          `  sudo swamp update --setup-auto disable`,
-      );
-    }
+  if (launchdMode === "daemon" && !isRunningAsRoot()) {
+    throw new UserError(
+      `Autoupdate is installed as a system LaunchDaemon (root-owned binary).\n` +
+        `Re-run with sudo to disable:\n\n` +
+        `  sudo swamp update --setup-auto disable`,
+    );
   }
   const scheduler = await createScheduler({ launchdMode });
   await scheduler.remove();

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -127,6 +127,10 @@ import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/renderers/update_notification.ts";
 import { UpdatePreferencesFileRepository } from "../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../infrastructure/update/autoupdate_log_file_repository.ts";
+import {
+  autoupdateLogDir,
+  detectInstalledLaunchdMode,
+} from "../infrastructure/update/launchd_scheduler.ts";
 import { getOutputModeFromArgs, isQuietFromArgs } from "./context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { getTracer, withSpan } from "../infrastructure/tracing/mod.ts";
@@ -1291,7 +1295,17 @@ export async function runCli(args: string[]): Promise<void> {
             const prefs = await prefsRepo.read();
 
             if (prefs.enabled) {
-              const logRepo = new AutoupdateLogFileRepository();
+              let logPath: string | undefined;
+              if (Deno.build.os === "darwin") {
+                const installedMode = await detectInstalledLaunchdMode();
+                if (installedMode === "daemon") {
+                  logPath = join(
+                    autoupdateLogDir("daemon"),
+                    "autoupdate.log",
+                  );
+                }
+              }
+              const logRepo = new AutoupdateLogFileRepository(logPath);
               const entries = await logRepo.readAll();
               let prefsChanged = false;
               const updatedPrefs = { ...prefs };

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -128,7 +128,7 @@ import { renderUpdateNotification } from "../presentation/renderers/update_notif
 import { UpdatePreferencesFileRepository } from "../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../infrastructure/update/autoupdate_log_file_repository.ts";
 import {
-  autoupdateLogDir,
+  autoupdateLogPath,
   detectInstalledLaunchdMode,
 } from "../infrastructure/update/launchd_scheduler.ts";
 import { getOutputModeFromArgs, isQuietFromArgs } from "./context.ts";
@@ -1299,10 +1299,7 @@ export async function runCli(args: string[]): Promise<void> {
               if (Deno.build.os === "darwin") {
                 const installedMode = await detectInstalledLaunchdMode();
                 if (installedMode === "daemon") {
-                  logPath = join(
-                    autoupdateLogDir("daemon"),
-                    "autoupdate.log",
-                  );
+                  logPath = autoupdateLogPath("daemon");
                 }
               }
               const logRepo = new AutoupdateLogFileRepository(logPath);

--- a/src/domain/update/install_health.ts
+++ b/src/domain/update/install_health.ts
@@ -42,6 +42,7 @@ export interface AutoupdateHealth {
   enabled: boolean;
   cadence: UpdateCadence;
   schedulerInstalled: boolean;
+  schedulerType?: "agent" | "daemon";
   lastEntry: AutoupdateLogEntry | null;
 }
 
@@ -54,6 +55,7 @@ export interface InstallHealthDeps {
   getCurrentUsername(): string | null;
   getPreferences(): Promise<{ enabled: boolean; cadence: UpdateCadence }>;
   getSchedulerStatus(): Promise<ScheduleStatus>;
+  getSchedulerType?(): Promise<"agent" | "daemon" | null>;
   getLastLogEntry(): Promise<AutoupdateLogEntry | null>;
 }
 
@@ -94,6 +96,9 @@ export async function checkInstallHealth(
 
   const prefs = await deps.getPreferences();
   const schedulerStatus = await deps.getSchedulerStatus();
+  const schedulerType = deps.getSchedulerType
+    ? await deps.getSchedulerType()
+    : null;
   const lastEntry = await deps.getLastLogEntry();
 
   let username: string | null = deps.getCurrentUsername();
@@ -115,6 +120,7 @@ export async function checkInstallHealth(
       enabled: prefs.enabled,
       cadence: prefs.cadence,
       schedulerInstalled: schedulerStatus.installed,
+      schedulerType: schedulerType ?? undefined,
       lastEntry,
     },
   };

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -30,8 +30,32 @@ const LABEL = "club.swamp.autoupdate";
 
 export type LaunchdMode = "agent" | "daemon";
 
+async function sudoUserHome(): Promise<string | null> {
+  const sudoUser = Deno.env.get("SUDO_USER");
+  if (!sudoUser) return null;
+
+  try {
+    const cmd = new Deno.Command("dscl", {
+      args: [".", "-read", `/Users/${sudoUser}`, "NFSHomeDirectory"],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) return null;
+    const output = new TextDecoder().decode(result.stdout).trim();
+    const match = output.match(/NFSHomeDirectory:\s*(.+)/);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 function agentPlistPath(): string {
   return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
+}
+
+function agentPlistPathForHome(home: string): string {
+  return join(home, "Library", "LaunchAgents", `${LABEL}.plist`);
 }
 
 function daemonPlistPath(): string {
@@ -56,6 +80,10 @@ export function autoupdateLogDir(mode: LaunchdMode = "agent"): string {
     return join("/var", "log", "swamp");
   }
   return join(homeDirectory(), "Library", "Logs", "swamp");
+}
+
+export function autoupdateLogPath(mode: LaunchdMode): string {
+  return join(autoupdateLogDir(mode), "autoupdate.log");
 }
 
 export function buildPlist(
@@ -122,10 +150,15 @@ export class LaunchdScheduler implements AutoupdateScheduler {
   async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
     await this.remove();
 
-    // When switching modes, also remove the other scheduler type
-    const otherMode: LaunchdMode = this.mode === "agent" ? "daemon" : "agent";
-    const otherScheduler = new LaunchdScheduler(otherMode);
-    await otherScheduler.remove();
+    // When switching modes, also remove the other scheduler type.
+    // Under sudo, $HOME is /var/root — resolve the original user's
+    // home via $SUDO_USER to find their agent plist.
+    if (this.mode === "daemon") {
+      await this.removeAgentPlistForOriginalUser();
+    } else {
+      const otherScheduler = new LaunchdScheduler("daemon");
+      await otherScheduler.remove();
+    }
 
     const path = plistPathForMode(this.mode);
     await Deno.mkdir(dirname(path), { recursive: true });
@@ -182,6 +215,39 @@ export class LaunchdScheduler implements AutoupdateScheduler {
     }
   }
 
+  private async removeAgentPlistForOriginalUser(): Promise<void> {
+    const paths: string[] = [];
+
+    // Check the agent path from current $HOME (may be /var/root under sudo)
+    try {
+      paths.push(agentPlistPath());
+    } catch { /* homeDirectory() may throw */ }
+
+    // Also check the original user's home via $SUDO_USER
+    const realHome = await sudoUserHome();
+    if (realHome) {
+      paths.push(agentPlistPathForHome(realHome));
+    }
+
+    for (const path of new Set(paths)) {
+      try {
+        await Deno.stat(path);
+      } catch {
+        continue;
+      }
+      const sudoUid = Deno.env.get("SUDO_UID");
+      if (sudoUid) {
+        const cmd = new Deno.Command("launchctl", {
+          args: ["bootout", `gui/${sudoUid}/${LABEL}`],
+          stdout: "null",
+          stderr: "null",
+        });
+        await cmd.output();
+      }
+      await Deno.remove(path).catch(() => {});
+    }
+  }
+
   private async launchctlDomain(): Promise<string> {
     if (this.mode === "daemon") {
       return "system";
@@ -199,10 +265,20 @@ export async function detectInstalledLaunchdMode(): Promise<
     return "daemon";
   } catch { /* not found */ }
 
+  // Check agent plist at current $HOME
   try {
     await Deno.stat(agentPlistPath());
     return "agent";
   } catch { /* not found */ }
+
+  // Under sudo, $HOME is /var/root — also check the original user's home
+  const realHome = await sudoUserHome();
+  if (realHome) {
+    try {
+      await Deno.stat(agentPlistPathForHome(realHome));
+      return "agent";
+    } catch { /* not found */ }
+  }
 
   return null;
 }

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -28,8 +28,18 @@ import { homeDirectory } from "../persistence/paths.ts";
 
 const LABEL = "club.swamp.autoupdate";
 
-function plistPath(): string {
+export type LaunchdMode = "agent" | "daemon";
+
+function agentPlistPath(): string {
   return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
+}
+
+function daemonPlistPath(): string {
+  return join("/Library", "LaunchDaemons", `${LABEL}.plist`);
+}
+
+function plistPathForMode(mode: LaunchdMode): string {
+  return mode === "agent" ? agentPlistPath() : daemonPlistPath();
 }
 
 export function escapeXml(s: string): string {
@@ -41,16 +51,27 @@ export function escapeXml(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
-export function autoupdateLogDir(): string {
+export function autoupdateLogDir(mode: LaunchdMode = "agent"): string {
+  if (mode === "daemon") {
+    return join("/var", "log", "swamp");
+  }
   return join(homeDirectory(), "Library", "Logs", "swamp");
 }
 
-export function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
+export function buildPlist(
+  binaryPath: string,
+  cadence: UpdateCadence,
+  mode: LaunchdMode = "agent",
+): string {
   const interval = cadence === "daily" ? 86400 : 604800;
   const escapedPath = escapeXml(binaryPath);
-  const logDir = autoupdateLogDir();
+  const logDir = autoupdateLogDir(mode);
   const stdoutLog = escapeXml(join(logDir, "autoupdate.stdout.log"));
   const stderrLog = escapeXml(join(logDir, "autoupdate.stderr.log"));
+
+  const userNameEntry = mode === "daemon"
+    ? `\n  <key>UserName</key>\n  <string>root</string>`
+    : "";
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -67,7 +88,7 @@ export function buildPlist(binaryPath: string, cadence: UpdateCadence): string {
   <key>StartInterval</key>
   <integer>${interval}</integer>
   <key>RunAtLoad</key>
-  <true/>
+  <true/>${userNameEntry}
   <key>StandardOutPath</key>
   <string>${stdoutLog}</string>
   <key>StandardErrorPath</key>
@@ -92,17 +113,28 @@ async function getUid(): Promise<string> {
 }
 
 export class LaunchdScheduler implements AutoupdateScheduler {
+  readonly mode: LaunchdMode;
+
+  constructor(mode: LaunchdMode = "agent") {
+    this.mode = mode;
+  }
+
   async install(binaryPath: string, cadence: UpdateCadence): Promise<void> {
     await this.remove();
 
-    const path = plistPath();
-    await Deno.mkdir(dirname(path), { recursive: true });
-    await Deno.mkdir(autoupdateLogDir(), { recursive: true });
-    await atomicWriteTextFile(path, buildPlist(binaryPath, cadence));
+    // When switching modes, also remove the other scheduler type
+    const otherMode: LaunchdMode = this.mode === "agent" ? "daemon" : "agent";
+    const otherScheduler = new LaunchdScheduler(otherMode);
+    await otherScheduler.remove();
 
-    const uid = await getUid();
+    const path = plistPathForMode(this.mode);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.mkdir(autoupdateLogDir(this.mode), { recursive: true });
+    await atomicWriteTextFile(path, buildPlist(binaryPath, cadence, this.mode));
+
+    const domain = await this.launchctlDomain();
     const cmd = new Deno.Command("launchctl", {
-      args: ["bootstrap", `gui/${uid}`, path],
+      args: ["bootstrap", domain, path],
       stdout: "null",
       stderr: "null",
     });
@@ -115,16 +147,16 @@ export class LaunchdScheduler implements AutoupdateScheduler {
   }
 
   async remove(): Promise<void> {
-    const path = plistPath();
+    const path = plistPathForMode(this.mode);
     try {
       await Deno.stat(path);
     } catch {
       return;
     }
 
-    const uid = await getUid();
+    const domain = await this.launchctlDomain();
     const cmd = new Deno.Command("launchctl", {
-      args: ["bootout", `gui/${uid}/${LABEL}`],
+      args: ["bootout", `${domain}/${LABEL}`],
       stdout: "null",
       stderr: "null",
     });
@@ -134,7 +166,7 @@ export class LaunchdScheduler implements AutoupdateScheduler {
   }
 
   async status(): Promise<ScheduleStatus> {
-    const path = plistPath();
+    const path = plistPathForMode(this.mode);
     try {
       const content = await Deno.readTextFile(path);
       const intervalMatch = content.match(
@@ -149,4 +181,28 @@ export class LaunchdScheduler implements AutoupdateScheduler {
       return { installed: false };
     }
   }
+
+  private async launchctlDomain(): Promise<string> {
+    if (this.mode === "daemon") {
+      return "system";
+    }
+    const uid = await getUid();
+    return `gui/${uid}`;
+  }
+}
+
+export async function detectInstalledLaunchdMode(): Promise<
+  LaunchdMode | null
+> {
+  try {
+    await Deno.stat(daemonPlistPath());
+    return "daemon";
+  } catch { /* not found */ }
+
+  try {
+    await Deno.stat(agentPlistPath());
+    return "agent";
+  } catch { /* not found */ }
+
+  return null;
 }

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -19,7 +19,11 @@
 
 import type { AutoupdateScheduler } from "../../domain/update/autoupdate_scheduler.ts";
 import { UserError } from "../../domain/errors.ts";
-import { type LaunchdMode, LaunchdScheduler } from "./launchd_scheduler.ts";
+import {
+  detectInstalledLaunchdMode,
+  type LaunchdMode,
+  LaunchdScheduler,
+} from "./launchd_scheduler.ts";
 import { SystemdScheduler } from "./systemd_scheduler.ts";
 import { CronScheduler } from "./cron_scheduler.ts";
 
@@ -57,6 +61,25 @@ export async function createScheduler(
         `Background autoupdate is not yet supported on ${Deno.build.os}`,
       );
   }
+}
+
+export async function resolveLaunchdMode(): Promise<LaunchdMode> {
+  if (Deno.build.os !== "darwin") return "agent";
+
+  const installed = await detectInstalledLaunchdMode();
+  if (installed) return installed;
+
+  let currentUid: number | null = null;
+  let binaryUid: number | null = null;
+  try {
+    currentUid = Deno.uid();
+    const stat = await Deno.stat(Deno.execPath());
+    binaryUid = stat.uid;
+  } catch {
+    return "agent";
+  }
+
+  return detectBinaryOwnership(binaryUid, currentUid);
 }
 
 export function detectBinaryOwnership(

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -19,7 +19,7 @@
 
 import type { AutoupdateScheduler } from "../../domain/update/autoupdate_scheduler.ts";
 import { UserError } from "../../domain/errors.ts";
-import { LaunchdScheduler } from "./launchd_scheduler.ts";
+import { type LaunchdMode, LaunchdScheduler } from "./launchd_scheduler.ts";
 import { SystemdScheduler } from "./systemd_scheduler.ts";
 import { CronScheduler } from "./cron_scheduler.ts";
 
@@ -37,10 +37,16 @@ async function hasSystemctl(): Promise<boolean> {
   }
 }
 
-export async function createScheduler(): Promise<AutoupdateScheduler> {
+export interface SchedulerOptions {
+  launchdMode?: LaunchdMode;
+}
+
+export async function createScheduler(
+  options?: SchedulerOptions,
+): Promise<AutoupdateScheduler> {
   switch (Deno.build.os) {
     case "darwin":
-      return new LaunchdScheduler();
+      return new LaunchdScheduler(options?.launchdMode ?? "agent");
     case "linux":
       if (await hasSystemctl()) {
         return new SystemdScheduler();
@@ -51,4 +57,20 @@ export async function createScheduler(): Promise<AutoupdateScheduler> {
         `Background autoupdate is not yet supported on ${Deno.build.os}`,
       );
   }
+}
+
+export function detectBinaryOwnership(
+  binaryUid: number | null,
+  currentUid: number | null,
+): LaunchdMode {
+  if (binaryUid === null || currentUid === null) {
+    return "agent";
+  }
+  if (binaryUid === 0) {
+    return "daemon";
+  }
+  if (binaryUid !== currentUid) {
+    return "daemon";
+  }
+  return "agent";
 }

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -85,8 +85,8 @@ export async function resolveLaunchdMode(): Promise<LaunchdMode> {
       `The swamp binary at ${Deno.execPath()} is owned by uid ${binaryUid}, ` +
         `not the current user or root.\n` +
         `Fix the installation so the binary is owned by your user or root:\n\n` +
-        `  sudo chown $(whoami) ${Deno.execPath()}\n` +
-        `  sudo chown root ${Deno.execPath()}`,
+        `  Option 1: sudo chown $(whoami) ${Deno.execPath()}\n` +
+        `  Option 2: sudo chown root ${Deno.execPath()}`,
     );
   }
   return result;

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -79,13 +79,23 @@ export async function resolveLaunchdMode(): Promise<LaunchdMode> {
     return "agent";
   }
 
-  return detectBinaryOwnership(binaryUid, currentUid);
+  const result = detectBinaryOwnership(binaryUid, currentUid);
+  if (result === "foreign") {
+    throw new UserError(
+      `The swamp binary at ${Deno.execPath()} is owned by uid ${binaryUid}, ` +
+        `not the current user or root.\n` +
+        `Fix the installation so the binary is owned by your user or root:\n\n` +
+        `  sudo chown $(whoami) ${Deno.execPath()}\n` +
+        `  sudo chown root ${Deno.execPath()}`,
+    );
+  }
+  return result;
 }
 
 export function detectBinaryOwnership(
   binaryUid: number | null,
   currentUid: number | null,
-): LaunchdMode {
+): LaunchdMode | "foreign" {
   if (binaryUid === null || currentUid === null) {
     return "agent";
   }
@@ -93,7 +103,15 @@ export function detectBinaryOwnership(
     return "daemon";
   }
   if (binaryUid !== currentUid) {
-    return "daemon";
+    return "foreign";
   }
   return "agent";
+}
+
+export function isRunningAsRoot(): boolean {
+  try {
+    return Deno.uid() === 0;
+  } catch {
+    return false;
+  }
 }

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -211,8 +211,8 @@ Deno.test("detectBinaryOwnership: root-owned binary with non-root user returns d
   assertEquals(detectBinaryOwnership(0, 501), "daemon");
 });
 
-Deno.test("detectBinaryOwnership: binary owned by different non-root user returns daemon", () => {
-  assertEquals(detectBinaryOwnership(502, 501), "daemon");
+Deno.test("detectBinaryOwnership: binary owned by different non-root user returns foreign", () => {
+  assertEquals(detectBinaryOwnership(502, 501), "foreign");
 });
 
 Deno.test("detectBinaryOwnership: null binary uid returns agent", () => {

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -177,8 +177,8 @@ Deno.test("buildPlist: default mode is agent (no UserName)", () => {
 
 Deno.test("buildPlist: daemon mode uses system log path", () => {
   const plist = buildPlist("/usr/local/bin/swamp", "daily", "daemon");
-  assertStringIncludes(plist, "/var/log/swamp/autoupdate.stdout.log");
-  assertStringIncludes(plist, "/var/log/swamp/autoupdate.stderr.log");
+  assertPathStringIncludes(plist, "var/log/swamp/autoupdate.stdout.log");
+  assertPathStringIncludes(plist, "var/log/swamp/autoupdate.stderr.log");
 });
 
 Deno.test("buildPlist: agent mode uses user log path", () => {
@@ -193,7 +193,7 @@ Deno.test("buildPlist: daemon mode still contains binary path and interval", () 
 });
 
 Deno.test("autoupdateLogDir: daemon mode returns /var/log/swamp", () => {
-  assertEquals(autoupdateLogDir("daemon"), "/var/log/swamp");
+  assertPathStringIncludes(autoupdateLogDir("daemon"), "var/log/swamp");
 });
 
 Deno.test("autoupdateLogDir: agent mode returns user Library path", () => {

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -29,6 +29,7 @@ import {
   cadenceFromInterval,
   escapeXml,
 } from "./launchd_scheduler.ts";
+import { detectBinaryOwnership } from "./scheduler_factory.ts";
 import {
   buildService,
   buildTimer,
@@ -154,4 +155,78 @@ Deno.test("cronLogPath: returns an absolute path", () => {
   const path = cronLogPath();
   assertNotEquals(path, "");
   assertPathStringIncludes(path, "autoupdate-cron.log");
+});
+
+// --- LaunchDaemon (daemon mode) tests ---
+
+Deno.test("buildPlist: daemon mode includes UserName key", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily", "daemon");
+  assertStringIncludes(plist, "<key>UserName</key>");
+  assertStringIncludes(plist, "<string>root</string>");
+});
+
+Deno.test("buildPlist: agent mode does not include UserName key", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily", "agent");
+  assertEquals(plist.includes("UserName"), false);
+});
+
+Deno.test("buildPlist: default mode is agent (no UserName)", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily");
+  assertEquals(plist.includes("UserName"), false);
+});
+
+Deno.test("buildPlist: daemon mode uses system log path", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily", "daemon");
+  assertStringIncludes(plist, "/var/log/swamp/autoupdate.stdout.log");
+  assertStringIncludes(plist, "/var/log/swamp/autoupdate.stderr.log");
+});
+
+Deno.test("buildPlist: agent mode uses user log path", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "daily", "agent");
+  assertPathStringIncludes(plist, "Library/Logs/swamp/autoupdate.stdout.log");
+});
+
+Deno.test("buildPlist: daemon mode still contains binary path and interval", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "weekly", "daemon");
+  assertStringIncludes(plist, "<string>/usr/local/bin/swamp</string>");
+  assertStringIncludes(plist, "<integer>604800</integer>");
+});
+
+Deno.test("autoupdateLogDir: daemon mode returns /var/log/swamp", () => {
+  assertEquals(autoupdateLogDir("daemon"), "/var/log/swamp");
+});
+
+Deno.test("autoupdateLogDir: agent mode returns user Library path", () => {
+  const dir = autoupdateLogDir("agent");
+  assertPathStringIncludes(dir, "Library/Logs/swamp");
+});
+
+// --- Binary ownership detection tests ---
+
+Deno.test("detectBinaryOwnership: user-owned binary returns agent", () => {
+  assertEquals(detectBinaryOwnership(501, 501), "agent");
+});
+
+Deno.test("detectBinaryOwnership: root-owned binary with non-root user returns daemon", () => {
+  assertEquals(detectBinaryOwnership(0, 501), "daemon");
+});
+
+Deno.test("detectBinaryOwnership: binary owned by different non-root user returns daemon", () => {
+  assertEquals(detectBinaryOwnership(502, 501), "daemon");
+});
+
+Deno.test("detectBinaryOwnership: null binary uid returns agent", () => {
+  assertEquals(detectBinaryOwnership(null, 501), "agent");
+});
+
+Deno.test("detectBinaryOwnership: null current uid returns agent", () => {
+  assertEquals(detectBinaryOwnership(0, null), "agent");
+});
+
+Deno.test("detectBinaryOwnership: both null returns agent", () => {
+  assertEquals(detectBinaryOwnership(null, null), "agent");
+});
+
+Deno.test("detectBinaryOwnership: root-owned binary with root user returns daemon", () => {
+  assertEquals(detectBinaryOwnership(0, 0), "daemon");
 });

--- a/src/presentation/renderers/doctor_install.ts
+++ b/src/presentation/renderers/doctor_install.ts
@@ -58,6 +58,12 @@ class LogDoctorInstallRenderer implements DoctorInstallRenderer {
     );
     if (report.autoupdate.enabled) {
       writeOutput(`  Cadence:        ${report.autoupdate.cadence}`);
+      if (report.autoupdate.schedulerType) {
+        const typeLabel = report.autoupdate.schedulerType === "daemon"
+          ? "LaunchDaemon (system)"
+          : "LaunchAgent (user)";
+        writeOutput(`  Scheduler type: ${typeLabel}`);
+      }
       writeOutput(
         `  Scheduler:      ${
           report.autoupdate.schedulerInstalled


### PR DESCRIPTION
## Summary

- When the swamp binary is owned by root (e.g. `/usr/local/bin/swamp` with `root:wheel`), `--setup-auto` now installs a system **LaunchDaemon** at `/Library/LaunchDaemons/` instead of a user LaunchAgent, so the scheduler can update the binary regardless of ownership
- Binary ownership is detected automatically — root-owned requires `sudo`, user-owned works as before
- All management commands (`status`, `disable`, `config set`) detect the installed scheduler type and require `sudo` when a LaunchDaemon is present
- Background updates write logs to `/var/log/swamp/` when running as root (LaunchDaemon context)
- Cross-scheduler migration: switching between agent and daemon modes cleanly removes the old scheduler type
- `doctor install` reports the scheduler type (agent vs daemon)

Closes swamp-club#449

## Test Plan

- [x] 37 unit tests pass (15 new) covering daemon plist generation, ownership detection, and mode routing
- [x] Full test suite passes (6228 tests, 0 failures)
- [x] Manual verification on macOS:
  - `sudo install -m 755 -o root -g wheel ./swamp /usr/local/bin/swamp-test` → root-owned binary
  - `/usr/local/bin/swamp-test update --setup-auto` → correctly errors asking for sudo
  - `sudo /usr/local/bin/swamp-test update --setup-auto` → installs LaunchDaemon, prompts for cadence
  - Verified plist at `/Library/LaunchDaemons/` contains `UserName` key and `/var/log/swamp/` log paths
  - `sudo /usr/local/bin/swamp-test update --setup-auto status` → shows "LaunchDaemon (system)"
  - `/usr/local/bin/swamp-test update --setup-auto disable` → correctly errors asking for sudo
  - `sudo /usr/local/bin/swamp-test update --setup-auto disable` → removes plist cleanly
  - `sudo /usr/local/bin/swamp-test update --background` → writes autoupdate log to `/var/log/swamp/autoupdate.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)