### PR TITLE
fix(extensions): scope version-drift check to export const model body (swamp-club#453)

### DIFF
--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -213,11 +213,17 @@ function extractModelType(content: string): string | null {
 }
 
 /**
- * Extracts the model version string.
- * Matches `version: "YYYY.MM.DD.N"` patterns.
+ * Extracts the model version string from the `export const model` body.
  */
 export function extractModelVersion(content: string): string | null {
-  const match = content.match(/version:\s*["']([^"']+)["']/);
+  const modelExportMatch = content.match(/export\s+const\s+model\s*=\s*\{/);
+  if (!modelExportMatch || modelExportMatch.index === undefined) return null;
+
+  const bodyStart = modelExportMatch.index + modelExportMatch[0].length;
+  const body = extractBalancedBraces(content, bodyStart);
+  if (!body) return null;
+
+  const match = body.match(/version:\s*["']([^"']+)["']/);
   return match ? match[1] : null;
 }
 

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -73,6 +73,40 @@ Deno.test("extractContentMetadata extracts model type from ModelType.create", as
   }
 });
 
+Deno.test("extractContentMetadata extracts version from model export, not earlier literals", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "card.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        'const SCHEMA_TEMPLATE = { version: "1.0.0", fields: [] };',
+        "",
+        "export const model = {",
+        '  type: "@test/card",',
+        '  version: "2026.05.26.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "Run",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([modelFile], modelsDir, []);
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].version, "2026.05.26.1");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("extractContentMetadata extracts model type from string literal", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -420,6 +420,19 @@ Deno.test("checkVersionConsistency: matching versions produce no issues", async 
   );
 });
 
+Deno.test("checkVersionConsistency: earlier version literal does not cause false positive", async () => {
+  await withTempFiles(
+    {
+      "card.ts":
+        'const SCHEMA_TEMPLATE = { version: "1.0.0" };\n\nexport const model = {\n  version: "2026.05.22.1",\n  type: "test",\n};\n',
+    },
+    async (_dir, paths) => {
+      const issues = await checkVersionConsistency("2026.05.22.1", paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
 Deno.test("checkVersionConsistency: mismatched version reports drift", async () => {
   await withTempFiles(
     {


### PR DESCRIPTION
## Summary

- `extractModelVersion()` used an unscoped regex that matched the first
  `version:` literal in the entire file, causing false-positive drift
  warnings when a model file had an earlier object with a `version` property
- Scoped the search to the `export const model = { ... }` body using
  `extractBalancedBraces`, matching the pattern already used by
  `extractModelType()` since PR #916

## Test plan

- [x] Added extractor test: model file with earlier `version:` literal
  extracts the correct model version
- [x] Added version-drift test: earlier `version:` literal does not cause
  false-positive drift when `model.version` matches the manifest
- [x] Full test suite passes (6232 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Fixes: swamp-club#453