### PR TITLE
fix(reports): improve error diagnostics for non-string ModelType inputs

### DIFF
--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -38,6 +38,13 @@ export class ModelType {
    * @throws Error if the raw type is empty or invalid
    */
   static create(rawType: string): ModelType {
+    if (typeof rawType !== "string") {
+      throw new TypeError(
+        `ModelType.create() expected a string but received ${typeof rawType}: ${
+          String(rawType)
+        }`,
+      );
+    }
     const trimmed = rawType.trim();
     if (trimmed.length === 0) {
       throw new Error("Model type cannot be empty");

--- a/src/domain/models/model_type_test.ts
+++ b/src/domain/models/model_type_test.ts
@@ -214,3 +214,41 @@ Deno.test("ModelType.create: multi-segment input always normalizes with forward 
   assertEquals(t2.normalized.includes("/"), true);
   assertEquals(t2.normalized.includes("\\"), false);
 });
+
+// --- Non-string input guard tests ---
+
+Deno.test("ModelType.create: throws TypeError for undefined input", () => {
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => ModelType.create(undefined as any),
+    TypeError,
+    "ModelType.create() expected a string but received undefined",
+  );
+});
+
+Deno.test("ModelType.create: throws TypeError for null input", () => {
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => ModelType.create(null as any),
+    TypeError,
+    "ModelType.create() expected a string but received object",
+  );
+});
+
+Deno.test("ModelType.create: throws TypeError for number input", () => {
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => ModelType.create(42 as any),
+    TypeError,
+    "ModelType.create() expected a string but received number: 42",
+  );
+});
+
+Deno.test("ModelType.create: throws TypeError for object input", () => {
+  assertThrows(
+    // deno-lint-ignore no-explicit-any
+    () => ModelType.create({ raw: "test" } as any),
+    TypeError,
+    "ModelType.create() expected a string but received object",
+  );
+});

--- a/src/domain/reports/builtin/report_error_report.ts
+++ b/src/domain/reports/builtin/report_error_report.ts
@@ -24,8 +24,9 @@ export function buildReportErrorResult(
   reportName: string,
   scope: ReportScope,
   errorMessage: string,
+  errorStack?: string,
 ): ReportResult {
-  const markdown = [
+  const lines = [
     `# Report Error: ${reportName}`,
     "",
     `The report \`${reportName}\` (scope: ${scope}) threw an error during execution.`,
@@ -33,13 +34,20 @@ export function buildReportErrorResult(
     "## Error",
     "",
     errorMessage,
-  ].join("\n");
+  ];
+
+  if (errorStack) {
+    lines.push("", "## Stack Trace", "", "```", errorStack, "```");
+  }
+
+  const markdown = lines.join("\n");
 
   const json: Record<string, unknown> = {
     error: true,
     reportName,
     scope,
     message: errorMessage,
+    ...(errorStack ? { stack: errorStack } : {}),
   };
 
   return { markdown, json };

--- a/src/domain/reports/builtin/report_error_report_test.ts
+++ b/src/domain/reports/builtin/report_error_report_test.ts
@@ -57,3 +57,39 @@ Deno.test("buildReportErrorResult: works for method scope", () => {
   assertEquals(result.json.scope, "method");
   assertEquals(result.json.reportName, "@org/cost-check");
 });
+
+Deno.test("buildReportErrorResult: includes stack trace in markdown when provided", () => {
+  const stack =
+    "TypeError: foo\n    at bar (file.ts:10:5)\n    at baz (file.ts:20:3)";
+  const result = buildReportErrorResult(
+    "@example/my-audit",
+    "workflow",
+    "foo",
+    stack,
+  );
+
+  assertStringIncludes(result.markdown, "## Stack Trace");
+  assertStringIncludes(result.markdown, stack);
+});
+
+Deno.test("buildReportErrorResult: includes stack in json when provided", () => {
+  const stack = "TypeError: foo\n    at bar (file.ts:10:5)";
+  const result = buildReportErrorResult(
+    "@example/my-audit",
+    "workflow",
+    "foo",
+    stack,
+  );
+
+  assertEquals(result.json.stack, stack);
+});
+
+Deno.test("buildReportErrorResult: omits stack from json when not provided", () => {
+  const result = buildReportErrorResult(
+    "@example/my-audit",
+    "workflow",
+    "foo",
+  );
+
+  assertEquals(result.json.stack, undefined);
+});

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -427,6 +427,7 @@ export async function executeReports(
       const errorMessage = error instanceof Error
         ? error.message
         : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
 
       // Persist a fallback error artifact so diagnostic data is not lost.
       let errorDataHandles: DataHandle[] | undefined;
@@ -435,6 +436,7 @@ export async function executeReports(
           name,
           report.scope,
           errorMessage,
+          errorStack,
         );
         errorDataHandles = await persistReportData(
           context.dataRepository,


### PR DESCRIPTION
## Summary

- `ModelType.create()` now throws a clear `TypeError` with the actual type and value when called with a non-string argument, replacing the cryptic `rawType.trim is not a function`
- Report error artifacts now persist the full error stack trace alongside the message in both markdown and JSON output, making extension report failures diagnosable from `swamp report get`

## Root Cause

Extension reports that access `context.modelType` on a `WorkflowReportContext` (which doesn't have that field) get `undefined`, which flows through `getContent()` → `coerceModelType()` → `ModelType.create(undefined)` → crash. The framework didn't guard against non-string inputs, and persisted errors only captured `.message` — no stack trace.

## Changes

| File | Change |
|------|--------|
| `src/domain/models/model_type.ts` | Runtime type guard in `create()` — clear `TypeError` for non-string inputs |
| `src/domain/models/model_type_test.ts` | 4 new tests: undefined, null, number, object |
| `src/domain/reports/builtin/report_error_report.ts` | `buildReportErrorResult` accepts optional `errorStack`, renders in markdown + json |
| `src/domain/reports/builtin/report_error_report_test.ts` | 3 new tests for stack inclusion/omission |
| `src/domain/reports/report_execution_service.ts` | Catch block captures `error.stack`, passes to error report builder |

## Test plan

- [x] 6237 tests pass
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run compile` succeeds
- [x] Reproduced with custom workflow-scope report: before fix shows `"rawType.trim is not a function"`, after fix shows `"ModelType.create() expected a string but received undefined: undefined"` with full stack trace in persisted artifact

Closes swamp-club#454

🤖 Generated with [Claude Code](https://claude.com/claude-code)