### PR TITLE
feat(http): attach user/device identity to swamp-club HTTP traffic (swamp-club#461)

### DIFF
--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -29,6 +29,7 @@ import { createAuthLoginRenderer } from "../../presentation/renderers/auth_login
 import { createContext, type GlobalOptions, isStdinTty } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 /** Resolve server URL: env var > default */
 function resolveServerUrl(): string {
@@ -79,7 +80,8 @@ export const authLoginCommand = new Command()
     const showSpinner = cliCtx.outputMode !== "json" && !useStdinFlow;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createAuthLoginDeps();
+    const identity = await loadIdentity();
+    const deps = createAuthLoginDeps(identity);
     const input: AuthLoginInput = {
       serverUrl,
       useBrowserFlow: !useStdinFlow,

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -26,6 +26,7 @@ import {
   whoami,
 } from "../../libswamp/mod.ts";
 import { createAuthWhoamiRenderer } from "../../presentation/renderers/auth_whoami.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -41,8 +42,10 @@ export const authWhoamiCommand = new Command()
     cliCtx.logger.debug("Executing auth whoami command");
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const identity = await loadIdentity();
     const deps = createAuthDeps({
       serverUrlOverride: Deno.env.get("SWAMP_CLUB_URL"),
+      identity,
     });
 
     const renderer = createAuthWhoamiRenderer(cliCtx.outputMode);

--- a/src/cli/commands/extension_info.ts
+++ b/src/cli/commands/extension_info.ts
@@ -26,7 +26,7 @@ import {
   extensionInfo,
 } from "../../libswamp/mod.ts";
 import { createExtensionInfoRenderer } from "../../presentation/renderers/extension_info.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -52,9 +52,9 @@ export const extensionInfoCommand = new Command()
         "info",
       ]);
 
-      const credentials = await new AuthRepository().load();
+      const identity = await loadIdentity();
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createExtensionInfoDeps(credentials?.apiKey);
+      const deps = createExtensionInfoDeps(identity.bearerToken, identity);
       const renderer = createExtensionInfoRenderer(cliCtx.outputMode);
 
       await consumeStream(

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -43,6 +43,7 @@ import {
   type EnrichedExtensionListEntry,
 } from "../../presentation/renderers/extension_list.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { loadIdentity } from "../load_identity.ts";
 import { FileExtensionUpdateCheckRepository } from "../../infrastructure/persistence/extension_update_check_repository.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 import {
@@ -142,7 +143,8 @@ export const extensionListCommand = new Command()
     if (enrich && baseEntries.length > 0) {
       const swampDir = join(resolve(repoDir), ".swamp");
       const cacheRepository = new FileExtensionUpdateCheckRepository(swampDir);
-      const apiClient = new ExtensionApiClient(resolveServerUrl());
+      const identity = await loadIdentity();
+      const apiClient = new ExtensionApiClient(resolveServerUrl(), identity);
       const freshnessDeps: ExtensionListFreshnessDeps = {
         getLatestVersion: async (name) => {
           try {

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -39,6 +39,7 @@ import {
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 import type { ExtensionUpdateStatus } from "../../domain/extensions/extension_update_service.ts";
 import { createExtensionOutdatedRenderer } from "../../presentation/renderers/extension_outdated.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -118,9 +119,11 @@ export const extensionOutdatedCommand = new Command()
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const identity = await loadIdentity();
     const deps = await createExtensionUpdateDeps({
       lockfilePath,
       serverUrl: resolveServerUrl(),
+      identity,
       // outdated is read-only — installation is wired but never invoked
       // because checkOnly=true short-circuits before any update path.
       installExtension: () => {

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -36,6 +36,7 @@ import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { loadIdentity } from "../load_identity.ts";
 import {
   ConflictError,
   consumeStream,
@@ -227,11 +228,13 @@ export const extensionPullCommand = new Command()
     );
     try {
       const serverUrl = resolveServerUrl();
+      const identity = await loadIdentity();
       const deps = await createExtensionPullDeps(
         serverUrl,
         lockfilePath,
         skillsDir,
         repoDir,
+        { identity },
       );
       const repository = new ExtensionRepository({
         catalog,

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -56,6 +56,7 @@ import type {
   CollectiveMismatch,
 } from "../../domain/extensions/extension_collective_validator.ts";
 import type { CompilationError, SwampError } from "../../libswamp/mod.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir?: string;
@@ -281,7 +282,8 @@ export const extensionPushCommand = new Command()
 
     // 3. Create libswamp context and deps
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const prepareDeps = createExtensionPushPrepareDeps();
+    const identity = await loadIdentity();
+    const prepareDeps = createExtensionPushPrepareDeps(identity);
     const renderer = createExtensionPushRenderer(cliCtx.outputMode);
     const cache = new ExtensionPackageCache(defaultPackageCacheRoot(repoDir));
 
@@ -509,7 +511,7 @@ export const extensionPushCommand = new Command()
     }
 
     // 9. Execute push
-    const executeDeps = createExtensionPushExecuteDeps();
+    const executeDeps = createExtensionPushExecuteDeps(identity);
     await consumeStream(
       extensionPush(ctx, executeDeps, {
         manifest: prepared.manifest,

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -40,6 +40,7 @@ import {
   resolveExtensionFiles,
 } from "../resolve_extension_files.ts";
 import { UserError } from "../../domain/errors.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 interface ExtensionQualityOptions extends GlobalOptions {
   repoDir?: string;
@@ -125,7 +126,8 @@ export const extensionQualityCommand = new Command()
       );
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const prepareDeps = createExtensionPushPrepareDeps();
+      const identity = await loadIdentity();
+      const prepareDeps = createExtensionPushPrepareDeps(identity);
       const cache = new ExtensionPackageCache(defaultPackageCacheRoot(repoDir));
       const deps = createExtensionQualityDeps(prepareDeps, cache);
       const renderer = createExtensionQualityRenderer(cliCtx.outputMode);

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -46,7 +46,7 @@ import { createExtensionSearchRenderer } from "../../presentation/renderers/exte
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 /**
  * Resolves the registry server URL.
@@ -139,9 +139,9 @@ export const extensionSearchCommand = new Command()
       );
     }
 
-    const credentials = await new AuthRepository().load();
+    const identity = await loadIdentity();
     const serverUrl = resolveServerUrl();
-    const client = new ExtensionApiClient(serverUrl);
+    const client = new ExtensionApiClient(serverUrl, identity);
     const effectiveMode = interactiveOutputMode(ctx);
     const libCtx = createLibSwampContext();
 
@@ -159,7 +159,7 @@ export const extensionSearchCommand = new Command()
               | "updated"
               | undefined,
           },
-          credentials?.apiKey,
+          identity.bearerToken,
         ),
     };
 

--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -32,6 +32,7 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -81,7 +82,8 @@ export const extensionUnyankCommand = new Command()
     const resolvedVersion = version ?? ref.version ?? null;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createExtensionUnyankDeps();
+    const identity = await loadIdentity();
+    const deps = createExtensionUnyankDeps(identity);
     const input = {
       extensionName: ref.name,
       version: resolvedVersion,

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -43,6 +43,7 @@ import { createExtensionUpdateRenderer } from "../../presentation/renderers/exte
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -114,9 +115,11 @@ export const extensionUpdateCommand = new Command()
       swampPath(repoDir, "_extension_catalog.db"),
     );
     try {
+      const identity = await loadIdentity();
       const deps = await createExtensionUpdateDeps({
         lockfilePath,
         serverUrl,
+        identity,
         installExtension: async (name: string, version: string) => {
           // Construct a fresh InstallContext per upgrade — captures a
           // current snapshot of the lockfile per the
@@ -128,6 +131,7 @@ export const extensionUpdateCommand = new Command()
             skillsDir,
             repoDir,
             force: true,
+            identity,
           });
           // Build a fresh ExtensionRepository per upgrade so its lockfile
           // snapshot lines up with the InstallContext's. Catalog is

--- a/src/cli/commands/extension_version.ts
+++ b/src/cli/commands/extension_version.ts
@@ -28,6 +28,7 @@ import {
   extensionVersion,
 } from "../../libswamp/mod.ts";
 import { createExtensionVersionRenderer } from "../../presentation/renderers/extension_version.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 interface ExtensionVersionOptions extends GlobalOptions {
   manifest?: string;
@@ -58,7 +59,8 @@ export const extensionVersionCommand = new Command()
       const extensionName = await resolveExtensionName(name, options.manifest);
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createExtensionVersionDeps();
+      const identity = await loadIdentity();
+      const deps = createExtensionVersionDeps(identity);
       const renderer = createExtensionVersionRenderer(cliCtx.outputMode);
 
       await consumeStream(

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -32,6 +32,7 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -82,7 +83,8 @@ export const extensionYankCommand = new Command()
     const resolvedVersion = version ?? ref.version ?? null;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createExtensionYankDeps();
+    const identity = await loadIdentity();
+    const deps = createExtensionYankDeps(identity);
     const input = {
       extensionName: ref.name,
       version: resolvedVersion,

--- a/src/cli/commands/issue_get.ts
+++ b/src/cli/commands/issue_get.ts
@@ -28,6 +28,7 @@ import {
 import { createIssueGetRenderer } from "../../presentation/renderers/issue_get.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import { loadIdentity } from "../load_identity.ts";
 import { UserError } from "../../domain/errors.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 
@@ -48,10 +49,11 @@ export const issueGetCommand = new Command()
     }
 
     const credentials = await new AuthRepository().load();
+    const identity = await loadIdentity();
     const serverUrl = credentials?.serverUrl ??
       Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
 
-    const client = new SwampClubClient(serverUrl);
+    const client = new SwampClubClient(serverUrl, identity);
     const deps: IssueGetDeps = {
       fetchIssue: async (num) => {
         const issue = await client.fetchIssue(credentials?.apiKey, num);

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -34,6 +34,7 @@ import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import { loadIdentity } from "../load_identity.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -145,7 +146,8 @@ export const issueRippleCommand = new Command()
 
     const libCtx = createLibSwampContext({ logger: ctx.logger });
     const renderer = createIssueCommentRenderer(ctx.outputMode);
-    const client = new SwampClubClient(credentials.serverUrl);
+    const identity = await loadIdentity();
+    const client = new SwampClubClient(credentials.serverUrl, identity);
     const deps: IssueCommentDeps = {
       submitToLab: async (input) => {
         const result = await client.submitComment(

--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -43,6 +43,7 @@ import {
 } from "../../presentation/renderers/issue_create.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import { loadIdentity } from "../load_identity.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
@@ -255,7 +256,11 @@ export async function submitIssue(
   }
 
   // Lab submission (both plain and @swamp-extension paths).
-  const client = new SwampClubClient(destination.credentials.serverUrl);
+  const identity = await loadIdentity();
+  const client = new SwampClubClient(
+    destination.credentials.serverUrl,
+    identity,
+  );
   const deps: IssueCreateDeps = {
     submitToLab: async (params) => {
       const result = await client.submitIssue(

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -33,6 +33,7 @@ import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { loadIdentity } from "../load_identity.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import {
@@ -176,8 +177,10 @@ export const openCommand = new Command()
       reportRegistry.ensureLoaded(),
     ]);
 
+    const identity = await loadIdentity();
     const extClient = new ExtensionApiClient(
       Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL,
+      identity,
     );
 
     const state: OpenServerState = {

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -24,6 +24,7 @@ import { resolveSkillsDir } from "../domain/repo/skill_dirs.ts";
 import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
 import { RepoMarkerRepository } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
+import { loadIdentity } from "./load_identity.ts";
 import {
   type ExtensionInstallDeps,
   LockfileRepository,
@@ -67,7 +68,8 @@ export async function createExtensionInstallDeps(
   const skillsDirRelative = relative(absoluteRepoDir, absoluteSkillsDir);
 
   const serverUrl = resolveServerUrl();
-  const client = new ExtensionApiClient(serverUrl);
+  const identity = await loadIdentity();
+  const client = new ExtensionApiClient(serverUrl, identity);
 
   return {
     lockfilePath,

--- a/src/cli/load_identity.ts
+++ b/src/cli/load_identity.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
+import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
+import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
+
+/**
+ * Resolve the device/user identity to attach to outbound swamp-club
+ * HTTP traffic. Returns `bearerToken` (the personal-key value from
+ * auth.json or SWAMP_API_KEY) when the user is authenticated, and
+ * `distinctId` (the per-device UUID from identity.json) when available.
+ *
+ * Either field may be undefined — anonymous-but-attributed flows (no
+ * login, only distinctId) and rare "no identity at all" flows
+ * (UserIdentityRepository read failed and no auth) are both supported
+ * by the downstream `ClientIdentity` shape.
+ *
+ * This helper is the composition root for identity. libswamp and the
+ * HTTP clients themselves never touch the file system to discover it.
+ */
+export async function loadIdentity(): Promise<ClientIdentity> {
+  const credentials = await new AuthRepository().load();
+  const distinctId = await new UserIdentityRepository().getUserId();
+  return {
+    bearerToken: credentials?.apiKey,
+    distinctId: distinctId ?? undefined,
+  };
+}

--- a/src/cli/load_identity.ts
+++ b/src/cli/load_identity.ts
@@ -34,12 +34,25 @@ import { UserIdentityRepository } from "../infrastructure/persistence/user_ident
  *
  * This helper is the composition root for identity. libswamp and the
  * HTTP clients themselves never touch the file system to discover it.
+ *
+ * Errors swallowed: AuthRepository.load() re-throws anything other
+ * than NotFound (including the "HOME environment variable is not set"
+ * thrown by getSwampConfigDir() on minimal Windows test envs that
+ * have USERPROFILE but no HOME). Identity resolution is best-effort
+ * — every CLI command runs through this, so a missing config-dir env
+ * must never crash the CLI. Returns `{}` on any failure.
  */
 export async function loadIdentity(): Promise<ClientIdentity> {
-  const credentials = await new AuthRepository().load();
+  let bearerToken: string | undefined;
+  try {
+    const credentials = await new AuthRepository().load();
+    bearerToken = credentials?.apiKey;
+  } catch {
+    bearerToken = undefined;
+  }
   const distinctId = await new UserIdentityRepository().getUserId();
   return {
-    bearerToken: credentials?.apiKey,
+    bearerToken,
     distinctId: distinctId ?? undefined,
   };
 }

--- a/src/cli/load_identity_test.ts
+++ b/src/cli/load_identity_test.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { loadIdentity } from "./load_identity.ts";
+
+Deno.test("loadIdentity returns empty identity when config dir is unresolvable", async () => {
+  // Reproduces the Windows test-env scenario where HOME is not set
+  // (Windows uses USERPROFILE; minimal test envs strip both). The CLI
+  // calls loadIdentity at startup for every command — if this throws,
+  // every command crashes with empty stdout. Must return `{}` safely.
+  const homeBefore = Deno.env.get("HOME");
+  const userProfileBefore = Deno.env.get("USERPROFILE");
+  const xdgBefore = Deno.env.get("XDG_CONFIG_HOME");
+  Deno.env.delete("HOME");
+  Deno.env.delete("USERPROFILE");
+  Deno.env.delete("XDG_CONFIG_HOME");
+  try {
+    const identity = await loadIdentity();
+    assertEquals(identity.bearerToken, undefined);
+    assertEquals(identity.distinctId, undefined);
+  } finally {
+    if (homeBefore !== undefined) Deno.env.set("HOME", homeBefore);
+    if (userProfileBefore !== undefined) {
+      Deno.env.set("USERPROFILE", userProfileBefore);
+    }
+    if (xdgBefore !== undefined) Deno.env.set("XDG_CONFIG_HOME", xdgBefore);
+  }
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -97,6 +97,8 @@ import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
 import { SKILL_DIRS } from "../domain/repo/skill_dirs.ts";
 import { ExtensionAutoResolver } from "../domain/extensions/extension_auto_resolver.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
+import { loadIdentity } from "./load_identity.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../domain/auth/auth_credentials.ts";
 import { setAutoResolver } from "./auto_resolver_context.ts";
 import {
@@ -391,6 +393,7 @@ export function configureExtensionAutoResolver(
   marker: RepoMarkerData | null,
   authCollectives: string[] | undefined,
   outputMode: "log" | "json",
+  identity: ClientIdentity = {},
 ): void {
   const trustedCollectives = resolveTrustedCollectives(marker, authCollectives);
   if (trustedCollectives.length === 0 || !marker) {
@@ -398,7 +401,7 @@ export function configureExtensionAutoResolver(
     return;
   }
   const serverUrl = Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
-  const extensionClient = new ExtensionApiClient(serverUrl);
+  const extensionClient = new ExtensionApiClient(serverUrl, identity);
   const modelsDir = resolveModelsDir(marker);
   const denoRuntime = new EmbeddedDenoRuntime();
   setAutoResolver(
@@ -1148,11 +1151,13 @@ export async function runCli(args: string[]): Promise<void> {
   }
 
   // Create auto-resolver for trusted collectives (merging membership collectives)
+  const autoResolverIdentity = await loadIdentity();
   configureExtensionAutoResolver(
     repoDir,
     marker,
     authCollectives,
     getOutputModeFromArgs(args),
+    autoResolverIdentity,
   );
 
   const cli = new Command()

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -44,6 +44,7 @@ import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 import { maybeAutoUpdateDatastoreExtension } from "../libswamp/extensions/datastore_auto_update.ts";
 import { FileExtensionUpdateCheckRepository } from "../infrastructure/persistence/extension_update_check_repository.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
+import { loadIdentity } from "./load_identity.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../domain/auth/auth_credentials.ts";
 import {
   detectLocalEditsForExtension,
@@ -98,7 +99,8 @@ async function maybeAutoUpdateSwampDatastore(
       path: lockfilePath,
     });
     const serverUrl = Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
-    const extensionClient = new ExtensionApiClient(serverUrl);
+    const identity = await loadIdentity();
+    const extensionClient = new ExtensionApiClient(serverUrl, identity);
     const cacheRepository = new FileExtensionUpdateCheckRepository(swampDir);
 
     const result = await maybeAutoUpdateDatastoreExtension(type, {

--- a/src/infrastructure/http/client_identity.ts
+++ b/src/infrastructure/http/client_identity.ts
@@ -1,0 +1,69 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Identity attached to every outbound request by a swamp-club HTTP client.
+ *
+ * Both fields are optional:
+ * - `bearerToken` adds `Authorization: Bearer <token>`. The value is the
+ *   `swamp_<personal-key>` written by `swamp auth login` and stored on
+ *   `AuthCredentials.apiKey`. Wire-rename happens at the composition
+ *   root — there is no second token field on `AuthCredentials`.
+ * - `distinctId` adds `Swamp-Distinct-Id: <uuid>`. The value is the
+ *   per-device UUID lazily created by `UserIdentityRepository.getUserId()`
+ *   and stored at `~/.config/swamp/identity.json`. The header name is
+ *   vendor-prefixed per RFC 6648 (no `X-` prefix).
+ */
+export interface ClientIdentity {
+  bearerToken?: string;
+  distinctId?: string;
+}
+
+/**
+ * Merge constructor-supplied identity into an outbound `RequestInit`'s
+ * headers, with caller-supplied headers taking precedence on conflict.
+ *
+ * Precedence is non-negotiable: identity headers are spread FIRST,
+ * caller's `init.headers` SECOND. This lets callers override the
+ * constructor identity on individual calls — e.g.
+ * `SwampClubClient.getCurrentUser` ships its own session-token
+ * `Authorization: Bearer …` and must keep working, and the existing
+ * `x-api-key` per-method paths in `ExtensionApiClient` are left intact.
+ *
+ * A future refactor that flips the spread order silently breaks both
+ * those flows. Don't.
+ */
+export function mergeIdentityHeaders(
+  identity: ClientIdentity,
+  callerHeaders: HeadersInit | undefined,
+): Headers {
+  const merged = new Headers();
+  if (identity.bearerToken) {
+    merged.set("Authorization", `Bearer ${identity.bearerToken}`);
+  }
+  if (identity.distinctId) {
+    merged.set("Swamp-Distinct-Id", identity.distinctId);
+  }
+  if (callerHeaders) {
+    new Headers(callerHeaders).forEach((value, key) => {
+      merged.set(key, value);
+    });
+  }
+  return merged;
+}

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -19,7 +19,13 @@
 
 import { UserError } from "../../domain/errors.ts";
 import type { ExtensionContentMetadata } from "../../domain/extensions/extension_content.ts";
+import {
+  type ClientIdentity,
+  mergeIdentityHeaders,
+} from "./client_identity.ts";
 import { parseRetryAfter, rateLimitError } from "./rate_limit.ts";
+
+export type { ClientIdentity };
 
 /** Metadata sent during push initiation and confirmation. */
 export interface PushMetadata {
@@ -155,7 +161,10 @@ export interface UnyankResult {
  * as SwampClubClient for auth operations.
  */
 export class ExtensionApiClient {
-  constructor(private readonly serverUrl: string) {}
+  constructor(
+    private readonly serverUrl: string,
+    private readonly identity: ClientIdentity = {},
+  ) {}
 
   /**
    * Pre-flight: check latest published version.
@@ -544,9 +553,15 @@ export class ExtensionApiClient {
 
   private async fetch(path: string, init: RequestInit): Promise<Response> {
     const url = `${this.serverUrl}${path}`;
+    // Merge identity headers FIRST so any caller-supplied header in
+    // init.headers wins on conflict. Required so per-call x-api-key /
+    // Authorization values from callers (e.g. push/yank, getCurrentUser)
+    // override the constructor identity.
+    const headers = mergeIdentityHeaders(this.identity, init.headers);
     try {
       return await fetch(url, {
         ...init,
+        headers,
         signal: init.signal ?? AbortSignal.timeout(15_000),
       });
     } catch (error) {

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -608,3 +608,195 @@ Deno.test("ExtensionApiClient: 429 on getDownloadUrl is preferred over 404 fallt
     await server.shutdown();
   }
 });
+
+// ── Identity header injection ─────────────────────────────────────────
+
+Deno.test("ExtensionApiClient sends both identity headers when constructed with bearerToken and distinctId", async () => {
+  const captured: Record<string, string | null> = {};
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return new Response(
+      JSON.stringify({
+        extensions: [],
+        meta: { total: 0, page: 1, perPage: 20 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+      { bearerToken: "swamp_test-key", distinctId: "device-uuid-abc" },
+    );
+    await client.searchExtensions({});
+    assertEquals(captured.authorization, "Bearer swamp_test-key");
+    assertEquals(captured.distinctId, "device-uuid-abc");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient sends only Swamp-Distinct-Id when bearerToken is absent", async () => {
+  const captured: Record<string, string | null> = {};
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return new Response(
+      JSON.stringify({
+        extensions: [],
+        meta: { total: 0, page: 1, perPage: 20 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+      { distinctId: "device-uuid-xyz" },
+    );
+    await client.searchExtensions({});
+    assertEquals(captured.authorization, null);
+    assertEquals(captured.distinctId, "device-uuid-xyz");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient sends no identity headers when constructed without identity", async () => {
+  const captured: Record<string, string | null> = {};
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return new Response(
+      JSON.stringify({
+        extensions: [],
+        meta: { total: 0, page: 1, perPage: 20 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+    );
+    await client.searchExtensions({});
+    assertEquals(captured.authorization, null);
+    assertEquals(captured.distinctId, null);
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient sends constructor bearer when no caller Authorization is set", async () => {
+  // Half (a) of the precedence contract: when nothing on the call sets
+  // Authorization, the constructor-supplied bearer goes out.
+  const captured: Record<string, string | null> = {};
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    captured.authorization = req.headers.get("authorization");
+    return new Response(
+      JSON.stringify({
+        extensions: [],
+        meta: { total: 0, page: 1, perPage: 20 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+      { bearerToken: "swamp_only-from-constructor" },
+    );
+    await client.searchExtensions({});
+    assertEquals(captured.authorization, "Bearer swamp_only-from-constructor");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient lets caller-supplied x-api-key coexist with constructor identity", async () => {
+  // Half (b) of the precedence contract: per-method `apiKey` paths
+  // (push/yank/etc.) set their own `x-api-key` header. Constructor
+  // identity adds Authorization Bearer + Swamp-Distinct-Id, but the
+  // caller's `x-api-key` is preserved unchanged.
+  const captured: Record<string, string | null> = {};
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.xApiKey = req.headers.get("x-api-key");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return new Response(
+      JSON.stringify({ message: "yanked" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${server.addr.port}`,
+      { bearerToken: "swamp_ctor", distinctId: "device-1" },
+    );
+    await client.yankExtension(
+      "@test/ext",
+      "2026.01.01.1",
+      "test reason",
+      "swamp_caller-key",
+    );
+    assertEquals(captured.xApiKey, "swamp_caller-key");
+    assertEquals(captured.authorization, "Bearer swamp_ctor");
+    assertEquals(captured.distinctId, "device-1");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("ExtensionApiClient.downloadArchive does NOT send identity headers to the S3 presigned URL", async () => {
+  // Locks in the S3 hop contract: identity headers attach to the
+  // swamp-club /download call, but the subsequent fetch of the
+  // presigned URL must be bare. Sending identity to S3 breaks the
+  // presigned signature and leaks the bearer to S3 access logs.
+  const swampClubHeaders: Record<string, string | null> = {};
+  const s3Headers: Record<string, string | null> = {};
+
+  const s3Server = Deno.serve({ port: 0, onListen: () => {} }, (req) => {
+    s3Headers.authorization = req.headers.get("authorization");
+    s3Headers.distinctId = req.headers.get("swamp-distinct-id");
+    return new Response(new Uint8Array([1, 2, 3, 4]), {
+      headers: { "content-type": "application/gzip" },
+    });
+  });
+  const s3Addr = s3Server.addr;
+  const s3Url = `http://localhost:${s3Addr.port}/presigned-archive.tar.gz`;
+
+  const swampClubServer = Deno.serve(
+    { port: 0, onListen: () => {} },
+    (req) => {
+      swampClubHeaders.authorization = req.headers.get("authorization");
+      swampClubHeaders.distinctId = req.headers.get("swamp-distinct-id");
+      // /download returns 302 with Location pointing at the presigned URL.
+      return new Response(null, {
+        status: 302,
+        headers: { location: s3Url },
+      });
+    },
+  );
+
+  try {
+    const client = new ExtensionApiClient(
+      `http://localhost:${swampClubServer.addr.port}`,
+      { bearerToken: "swamp_secret-key", distinctId: "device-leak-canary" },
+    );
+    const bytes = await client.downloadArchive("@test/ext", "2026.01.01.1");
+    assertEquals(bytes.length, 4);
+    // swamp-club hop carries identity.
+    assertEquals(
+      swampClubHeaders.authorization,
+      "Bearer swamp_secret-key",
+    );
+    assertEquals(swampClubHeaders.distinctId, "device-leak-canary");
+    // S3 hop is bare — no identity, no token leak.
+    assertEquals(s3Headers.authorization, null);
+    assertEquals(s3Headers.distinctId, null);
+  } finally {
+    await swampClubServer.shutdown();
+    await s3Server.shutdown();
+  }
+});

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -18,7 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../../domain/errors.ts";
+import {
+  type ClientIdentity,
+  mergeIdentityHeaders,
+} from "./client_identity.ts";
 import { parseRetryAfter, rateLimitError } from "./rate_limit.ts";
+
+export type { ClientIdentity };
 
 /** Response from BetterAuth sign-in endpoint. */
 export interface SignInResponse {
@@ -83,7 +89,10 @@ export interface FetchIssueResponse {
  * Used by auth commands to sign in, create API keys, and verify identity.
  */
 export class SwampClubClient {
-  constructor(private readonly serverUrl: string) {}
+  constructor(
+    private readonly serverUrl: string,
+    private readonly identity: ClientIdentity = {},
+  ) {}
 
   /**
    * Sign in with email/username and password.
@@ -355,8 +364,13 @@ export class SwampClubClient {
     const signal = callerSignal
       ? AbortSignal.any([callerSignal, timeoutSignal])
       : timeoutSignal;
+    // Merge identity headers FIRST so any caller-supplied header in
+    // init.headers wins on conflict. Required so per-call x-api-key /
+    // Authorization values (e.g. signIn, getCurrentUser session token,
+    // whoami) override the constructor identity.
+    const headers = mergeIdentityHeaders(this.identity, init.headers);
     try {
-      const res = await fetch(url, { ...init, signal });
+      const res = await fetch(url, { ...init, headers, signal });
       if (res.status === 429) {
         const retryAfter = parseRetryAfter(res.headers.get("retry-after"));
         await res.body?.cancel();

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -308,3 +308,117 @@ Deno.test("SwampClubClient - 429 without Retry-After still surfaces sign-in hint
     await mock.shutdown();
   }
 });
+
+// ── Identity header injection ─────────────────────────────────────────
+
+Deno.test("SwampClubClient sends both identity headers when constructed with bearerToken and distinctId", async () => {
+  const captured: Record<string, string | null> = {};
+  const mock = startMockServer((req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return Response.json({
+      issue: { number: 1, title: "x", type: "bug", status: "open" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`, {
+      bearerToken: "swamp_test-key",
+      distinctId: "device-uuid-abc",
+    });
+    await client.fetchIssue("swamp_test-key", 1);
+    assertEquals(captured.authorization, "Bearer swamp_test-key");
+    assertEquals(captured.distinctId, "device-uuid-abc");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient sends only Swamp-Distinct-Id when bearerToken is absent", async () => {
+  const captured: Record<string, string | null> = {};
+  const mock = startMockServer((req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return Response.json({
+      issue: { number: 1, title: "x", type: "bug", status: "open" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`, {
+      distinctId: "device-uuid-xyz",
+    });
+    await client.fetchIssue(undefined, 1);
+    assertEquals(captured.authorization, null);
+    assertEquals(captured.distinctId, "device-uuid-xyz");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient sends no identity headers when constructed without identity", async () => {
+  const captured: Record<string, string | null> = {};
+  const mock = startMockServer((req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return Response.json({
+      issue: { number: 1, title: "x", type: "bug", status: "open" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await client.fetchIssue(undefined, 1);
+    assertEquals(captured.authorization, null);
+    assertEquals(captured.distinctId, null);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient sends constructor bearer when no caller Authorization is set", async () => {
+  // Half (a) of the precedence contract: when nothing on the call sets
+  // Authorization, the constructor-supplied bearer goes out.
+  const captured: Record<string, string | null> = {};
+  const mock = startMockServer((req) => {
+    captured.authorization = req.headers.get("authorization");
+    return Response.json({
+      issue: { number: 1, title: "x", type: "bug", status: "open" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`, {
+      bearerToken: "swamp_only-from-constructor",
+    });
+    // fetchIssue passes apiKey via `x-api-key`, NOT Authorization, so the
+    // constructor's Authorization Bearer is the only one set on this call.
+    await client.fetchIssue(undefined, 1);
+    assertEquals(captured.authorization, "Bearer swamp_only-from-constructor");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient lets caller-supplied Authorization win over constructor identity", async () => {
+  // Half (b) of the precedence contract: createApiKey() sends its own
+  // Authorization header carrying the BetterAuth session token. That
+  // caller-supplied header must win over the constructor's personal-key
+  // bearer or the user-session flow breaks.
+  const captured: Record<string, string | null> = {};
+  const mock = startMockServer((req) => {
+    captured.authorization = req.headers.get("authorization");
+    captured.distinctId = req.headers.get("swamp-distinct-id");
+    return Response.json({ id: "key-id", key: "swamp_new-key" });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`, {
+      bearerToken: "swamp_ctor-bearer",
+      distinctId: "device-1",
+    });
+    await client.createApiKey("session-token-xyz", "my-laptop");
+    // Caller's session-token Authorization wins.
+    assertEquals(captured.authorization, "Bearer session-token-xyz");
+    // Constructor's distinctId still goes out — the caller didn't set
+    // Swamp-Distinct-Id, so there is no conflict.
+    assertEquals(captured.distinctId, "device-1");
+  } finally {
+    await mock.shutdown();
+  }
+});

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -22,6 +22,7 @@ import {
   getCollectives,
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { startCallbackServer } from "../../infrastructure/http/callback_server.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -140,8 +141,17 @@ async function readPassword(prompt: string): Promise<string> {
   }
 }
 
-/** Wires real infrastructure into AuthLoginDeps. */
-export function createAuthLoginDeps(): AuthLoginDeps {
+/**
+ * Wires real infrastructure into AuthLoginDeps.
+ *
+ * Identity is optional and bearerToken will normally be undefined here —
+ * the login flow runs *before* the user has a personal API key.
+ * distinctId is the per-device UUID and should be passed when available
+ * so the login handshake's HTTP traffic still attributes to a device.
+ */
+export function createAuthLoginDeps(
+  identity?: ClientIdentity,
+): AuthLoginDeps {
   const repo = new AuthRepository();
   return {
     openBrowser: async (url: string): Promise<string | null> => {
@@ -159,7 +169,7 @@ export function createAuthLoginDeps(): AuthLoginDeps {
     startCallbackServer: (state: string, serverUrl: string) =>
       startCallbackServer(state, serverUrl),
     signIn: async (serverUrl: string, username: string, password: string) => {
-      const client = new SwampClubClient(serverUrl);
+      const client = new SwampClubClient(serverUrl, identity);
       const result = await client.signIn(username, password);
       return { token: result.token, username: result.user.username };
     },
@@ -173,11 +183,11 @@ export function createAuthLoginDeps(): AuthLoginDeps {
       sessionToken: string,
       keyName: string,
     ) => {
-      const client = new SwampClubClient(serverUrl);
+      const client = new SwampClubClient(serverUrl, identity);
       return await client.createApiKey(sessionToken, keyName);
     },
     whoami: async (serverUrl: string, apiKey: string) => {
-      const client = new SwampClubClient(serverUrl);
+      const client = new SwampClubClient(serverUrl, identity);
       const result = await client.whoami(apiKey);
       return {
         username: result.username,

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -23,6 +23,7 @@ import {
   getCollectives,
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import {
   AuthRepository,
   type AuthRepositoryOptions,
@@ -71,6 +72,7 @@ export interface AuthDeps {
 export interface CreateAuthDepsOptions {
   serverUrlOverride?: string;
   repo?: AuthRepositoryOptions;
+  identity?: ClientIdentity;
 }
 
 /** Wires real infrastructure into AuthDeps. */
@@ -87,7 +89,7 @@ export function createAuthDeps(options: CreateAuthDepsOptions = {}): AuthDeps {
     saveCredentials: (credentials) =>
       getApiKey() ? Promise.resolve() : repo.save(credentials),
     fetchWhoami: (serverUrl, apiKey, signal) => {
-      const client = new SwampClubClient(serverUrl);
+      const client = new SwampClubClient(serverUrl, options.identity);
       return client.whoami(apiKey, signal);
     },
     serverUrlOverride: options.serverUrlOverride,

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -23,6 +23,7 @@ import type {
   ExtensionScoreSummary,
 } from "../../infrastructure/http/extension_api_client.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { resolveServerUrl } from "./pull.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -69,9 +70,10 @@ export interface ExtensionInfoDeps {
 
 export function createExtensionInfoDeps(
   apiKey?: string,
+  identity?: ClientIdentity,
 ): ExtensionInfoDeps {
   const serverUrl = resolveServerUrl();
-  const client = new ExtensionApiClient(serverUrl);
+  const client = new ExtensionApiClient(serverUrl, identity);
   return {
     getExtension: (name: string) => client.getExtension(name, apiKey),
   };

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -29,6 +29,7 @@ import { UserError } from "../../domain/errors.ts";
 import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { pruneOrphanFiles } from "../../infrastructure/persistence/directory_cleanup.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import type { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
@@ -1225,9 +1226,13 @@ export async function createExtensionPullDeps(
   lockfilePath: string,
   skillsDir: string,
   repoDir: string,
-  args?: { denoRuntime?: DenoRuntime; repository?: ExtensionRepository },
+  args?: {
+    denoRuntime?: DenoRuntime;
+    repository?: ExtensionRepository;
+    identity?: ClientIdentity;
+  },
 ): Promise<ExtensionPullDeps> {
-  const client = new ExtensionApiClient(serverUrl);
+  const client = new ExtensionApiClient(serverUrl, args?.identity);
   const lockfileRepository = await LockfileRepository.create(lockfilePath);
   return {
     getExtension: (name) => client.getExtension(name),
@@ -1258,9 +1263,10 @@ export async function createInstallContext(
     repoDir: string;
     force: boolean;
     logger?: Logger;
+    identity?: ClientIdentity;
   },
 ): Promise<InstallContext> {
-  const client = new ExtensionApiClient(serverUrl);
+  const client = new ExtensionApiClient(serverUrl, opts.identity);
   const lockfileRepository = await LockfileRepository.create(opts.lockfilePath);
   return {
     getExtension: (name) => client.getExtension(name),

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -304,6 +304,7 @@ import {
   SwampClubClient,
 } from "../../infrastructure/http/swamp_club_client.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
 import { checkExtensionQuality } from "../../domain/extensions/extension_quality_checker.ts";
 import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
@@ -318,7 +319,9 @@ function resolveServerUrl(): string {
 }
 
 /** Wires real infrastructure into ExtensionPushPrepareDeps. */
-export function createExtensionPushPrepareDeps(): ExtensionPushPrepareDeps {
+export function createExtensionPushPrepareDeps(
+  identity?: ClientIdentity,
+): ExtensionPushPrepareDeps {
   const authRepo = new AuthRepository();
   const denoRuntime = new EmbeddedDenoRuntime();
 
@@ -333,7 +336,7 @@ export function createExtensionPushPrepareDeps(): ExtensionPushPrepareDeps {
       };
     },
     fetchCollectives: async (serverUrl, apiKey) => {
-      const client = new SwampClubClient(serverUrl);
+      const client = new SwampClubClient(serverUrl, identity);
       const whoami = await client.whoami(apiKey);
       return getCollectives(whoami);
     },
@@ -345,7 +348,7 @@ export function createExtensionPushPrepareDeps(): ExtensionPushPrepareDeps {
     bundleEntryPoint: bundleExtension,
     ensureDenoPath: () => denoRuntime.ensureDeno(),
     getLatestVersion: async (serverUrl, name, apiKey) => {
-      const client = new ExtensionApiClient(serverUrl);
+      const client = new ExtensionApiClient(serverUrl, identity);
       const result = await client.getLatestVersion(name, apiKey);
       if (!result) return null;
       return { version: result.version };
@@ -354,7 +357,9 @@ export function createExtensionPushPrepareDeps(): ExtensionPushPrepareDeps {
 }
 
 /** Wires real infrastructure into ExtensionPushExecuteDeps. */
-export function createExtensionPushExecuteDeps(): ExtensionPushExecuteDeps {
+export function createExtensionPushExecuteDeps(
+  identity?: ClientIdentity,
+): ExtensionPushExecuteDeps {
   const authRepo = new AuthRepository();
 
   return {
@@ -367,16 +372,20 @@ export function createExtensionPushExecuteDeps(): ExtensionPushExecuteDeps {
       };
     },
     initiatePush: async (serverUrl, metadata, apiKey) => {
-      const client = new ExtensionApiClient(serverUrl);
+      const client = new ExtensionApiClient(serverUrl, identity);
       const result = await client.initiatePush(metadata, apiKey);
       return { uploadUrl: result.uploadUrl };
     },
     uploadArchive: async (uploadUrl, archiveBytes) => {
+      // No identity here — uploadArchive bypasses the client's fetch
+      // wrapper and PUTs directly to a presigned S3 URL. Sending
+      // identity headers to S3 breaks the presigned signature and
+      // would leak the bearer token to S3 access logs.
       const client = new ExtensionApiClient("");
       await client.uploadArchive(uploadUrl, archiveBytes);
     },
     confirmPush: async (serverUrl, metadata, apiKey) => {
-      const client = new ExtensionApiClient(serverUrl);
+      const client = new ExtensionApiClient(serverUrl, identity);
       return await client.confirmPush(metadata, apiKey);
     },
   };

--- a/src/libswamp/extensions/unyank.ts
+++ b/src/libswamp/extensions/unyank.ts
@@ -19,6 +19,7 @@
 
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notAuthenticated, validationFailed } from "../errors.ts";
@@ -73,7 +74,9 @@ export interface ExtensionUnyankDeps {
 }
 
 /** Wires real infrastructure into ExtensionUnyankDeps. */
-export function createExtensionUnyankDeps(): ExtensionUnyankDeps {
+export function createExtensionUnyankDeps(
+  identity?: ClientIdentity,
+): ExtensionUnyankDeps {
   const authRepo = new AuthRepository();
   return {
     loadCredentials: async () => {
@@ -91,7 +94,7 @@ export function createExtensionUnyankDeps(): ExtensionUnyankDeps {
       reason: string | null,
       apiKey: string,
     ) => {
-      const client = new ExtensionApiClient(serverUrl);
+      const client = new ExtensionApiClient(serverUrl, identity);
       await client.unyankExtension(name, version, reason, apiKey);
     },
   };

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -24,6 +24,7 @@ import {
   type ExtensionUpdateStatus,
 } from "../../domain/extensions/extension_update_service.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -88,6 +89,7 @@ export interface ExtensionUpdateDeps {
 export async function createExtensionUpdateDeps(options: {
   lockfilePath: string;
   serverUrl?: string;
+  identity?: ClientIdentity;
   installExtension: (
     name: string,
     version: string,
@@ -95,6 +97,7 @@ export async function createExtensionUpdateDeps(options: {
 }): Promise<ExtensionUpdateDeps> {
   const extensionClient = new ExtensionApiClient(
     options.serverUrl ?? resolveServerUrl(),
+    options.identity,
   );
   return {
     lockfileRepository: await LockfileRepository.create(options.lockfilePath),

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -19,6 +19,7 @@
 
 import { CalVer } from "../../domain/models/calver.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { resolveServerUrl } from "./pull.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -54,9 +55,11 @@ export interface ExtensionVersionDeps {
 }
 
 /** Wires real infrastructure into ExtensionVersionDeps. No authentication required. */
-export function createExtensionVersionDeps(): ExtensionVersionDeps {
+export function createExtensionVersionDeps(
+  identity?: ClientIdentity,
+): ExtensionVersionDeps {
   const serverUrl = resolveServerUrl();
-  const client = new ExtensionApiClient(serverUrl);
+  const client = new ExtensionApiClient(serverUrl, identity);
   return {
     getLatestVersion: async (name: string) => {
       const info = await client.getExtension(name);

--- a/src/libswamp/extensions/yank.ts
+++ b/src/libswamp/extensions/yank.ts
@@ -19,6 +19,7 @@
 
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notAuthenticated, validationFailed } from "../errors.ts";
@@ -67,7 +68,9 @@ export interface ExtensionYankDeps {
 }
 
 /** Wires real infrastructure into ExtensionYankDeps. */
-export function createExtensionYankDeps(): ExtensionYankDeps {
+export function createExtensionYankDeps(
+  identity?: ClientIdentity,
+): ExtensionYankDeps {
   const authRepo = new AuthRepository();
   return {
     loadCredentials: async () => {
@@ -85,7 +88,7 @@ export function createExtensionYankDeps(): ExtensionYankDeps {
       reason: string,
       apiKey: string,
     ) => {
-      const client = new ExtensionApiClient(serverUrl);
+      const client = new ExtensionApiClient(serverUrl, identity);
       await client.yankExtension(name, version, reason, apiKey);
     },
   };

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -87,6 +87,7 @@ import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { OPEN_UI_HTML } from "./ui.ts";
 import { FAVICON_SVG } from "./favicon.ts";
+import { loadIdentity } from "../../cli/load_identity.ts";
 
 const logger = getSwampLogger(["serve", "open"]);
 
@@ -1394,7 +1395,8 @@ async function handleHistory(
 
 async function handleWhoami(): Promise<Response> {
   const ctx = createLibSwampContext();
-  const deps = createAuthDeps();
+  const identity = await loadIdentity();
+  const deps = createAuthDeps({ identity });
   const fallbackOsUser = () =>
     Deno.env.get("USER") ?? Deno.env.get("USERNAME") ?? null;
   try {


### PR DESCRIPTION
## Summary

- Both `ExtensionApiClient` and `SwampClubClient` get an optional `identity` constructor arg. Their private `fetch()` wrappers now attach `Authorization: Bearer <token>` when the user is logged in and `Swamp-Distinct-Id: <uuid>` always.
- Identity is resolved once at the CLI composition root via a new `loadIdentity()` helper, then threaded through libswamp function signatures. libswamp itself never reads `auth.json` or `identity.json` — keeps the domain boundary clean.
- Header merge in the fetch wrapper is **caller-wins**: identity headers spread first, `init.headers` spread second. Preserves the per-method `x-api-key` paths and `SwampClubClient.getCurrentUser`'s session-token Bearer.
- Per-method `apiKey?` parameters are kept intact — this is purely additive.
- Closes swamp-club#461.

## Follow-up (separate, swamp-club repo)

This PR is the CLI half. The swamp-club server needs:
1. Middleware (`routes/_middleware.ts`) reads `Swamp-Distinct-Id`, stamps it on spans, prefers it over the per-request `anon_*` hash. Authorization-derived identity still wins; `Swamp-Distinct-Id` is treated as untrusted hint data.
2. Docs update at `content/manual/reference/api-key-authentication.md`.

Until that ships, the new header is silently dropped server-side. No CLI-visible breakage.

## Test plan

- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] `deno run test`: 6304 passed (1 unrelated pre-existing failure on `extension quality: missing README`, fails on `main` too)
- [x] `deno run compile`: binary builds
- [x] Unit tests cover both clients: bearerToken + distinctId, distinctId-only, neither, both halves of precedence contract (caller-wins and constructor-wins), and a two-mock-server regression test ensuring the S3 presigned-URL hop carries no identity headers (no token leak to S3 access logs)
- [ ] Manual smoke against local swamp-club: confirm `Authorization` + `Swamp-Distinct-Id` headers on outbound requests once swamp-club middleware lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)