### PR TITLE
fix(serve): eagerly load extension registries and surface loader errors (swamp-club#463)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -34,6 +34,7 @@ import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -103,6 +104,7 @@ export const serveCommand = new Command()
       modelRegistry.ensureLoaded(),
       vaultTypeRegistry.ensureLoaded(),
       driverTypeRegistry.ensureLoaded(),
+      datastoreTypeRegistry.ensureLoaded(),
       reportRegistry.ensureLoaded(),
     ]);
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -30,6 +30,10 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -92,6 +96,15 @@ export const serveCommand = new Command()
       datastoreConfig,
       syncService,
     };
+
+    // Eagerly load extension registries so failures surface at startup
+    // rather than silently on first scheduled/webhook execution.
+    await Promise.all([
+      modelRegistry.ensureLoaded(),
+      vaultTypeRegistry.ensureLoaded(),
+      driverTypeRegistry.ensureLoaded(),
+      reportRegistry.ensureLoaded(),
+    ]);
 
     const ac = new AbortController();
     const enableSchedule = options.schedule !== false;

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -546,8 +546,12 @@ async function loadUserModels(
           .warn`Failed to load user model ${failure.file}: ${failure.error}`;
       }
     }
-  } catch {
-    // Not in a swamp repo or models dir doesn't exist — not an error
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    logger
+      .warn`Failed to load user model extensions: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
   }
 }
 
@@ -615,8 +619,12 @@ async function loadUserVaults(
           .warn`Failed to load user vault ${failure.file}: ${failure.error}`;
       }
     }
-  } catch {
-    // Not in a swamp repo or vaults dir doesn't exist — not an error
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    logger
+      .warn`Failed to load user vault extensions: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
   }
 }
 
@@ -680,8 +688,12 @@ async function loadUserDrivers(
           .warn`Failed to load user driver ${failure.file}: ${failure.error}`;
       }
     }
-  } catch {
-    // Not in a swamp repo or drivers dir doesn't exist — not an error
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    logger
+      .warn`Failed to load user driver extensions: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
   }
 }
 
@@ -746,8 +758,12 @@ async function loadUserDatastores(
           .warn`Failed to load user datastore ${failure.file}: ${failure.error}`;
       }
     }
-  } catch {
-    // Not in a swamp repo or datastores dir doesn't exist — not an error
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    logger
+      .warn`Failed to load user datastore extensions: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
   }
 }
 
@@ -811,8 +827,12 @@ async function loadUserReports(
           .warn`Failed to load user report ${failure.file}: ${failure.error}`;
       }
     }
-  } catch {
-    // Not in a swamp repo or reports dir doesn't exist — not an error
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    logger
+      .warn`Failed to load user report extensions: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace silent `catch {}` blocks in all 5 extension loader functions (`loadUserModels`, `loadUserVaults`, `loadUserDrivers`, `loadUserDatastores`, `loadUserReports`) with diagnostic warning logs so loader failures are visible in the serve process journal. `Deno.errors.NotFound` is still suppressed as the expected "no extensions directory" case.
- Eagerly call `ensureLoaded()` on all extension registries (`modelRegistry`, `vaultTypeRegistry`, `driverTypeRegistry`, `reportRegistry`) during `swamp serve` startup, before the scheduler and webhook services start. This surfaces loading failures at startup rather than silently on first scheduled/webhook execution.

Closes swamp-club#463

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 6325 tests pass (`deno run test`)
- [x] `deno run compile` succeeds
- [x] Manual verification: compiled binary with pulled extension (`@swamp/aws/cognito`), scheduled workflow — serve starts, eagerly loads extensions, scheduled run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)