### PR TITLE
fix(repo): detect orphaned .swamp/ without .swamp.yaml marker (swamp-club#460)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1125,7 +1125,7 @@ export async function runCli(args: string[]): Promise<void> {
   // Warnings are logged directly by the loaders (logging is initialized
   // by the time ensureLoaded() runs inside command .action() handlers).
   const deferredWarnings: DeferredWarning[] = [];
-  if (commandNeedsLoaderSetup(args)) {
+  if (commandNeedsLoaderSetup(args) && marker !== null) {
     const loaderSpan = getTracer().startSpan(
       "swamp.cli.configure_extension_loaders",
     );

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -222,6 +222,24 @@ export interface DatastoreResolutionResult {
   marker: RepoMarkerData | null;
 }
 
+async function throwRepoNotInitialized(
+  service: RepoService,
+  repoPath: RepoPath,
+): Promise<never> {
+  if (await service.hasOrphanedSwampDir(repoPath)) {
+    throw new UserError(
+      `Found a .swamp/ directory at ${repoPath.value} but no .swamp.yaml marker — ` +
+        "the repository appears partially initialized or corrupted. " +
+        "If you previously used a remote datastore, re-initializing with " +
+        "'swamp repo init' will not reconnect to it. Restore .swamp.yaml " +
+        "from version control or re-initialize with the correct --datastore flag.",
+    );
+  }
+  throw new UserError(
+    `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
+  );
+}
+
 export async function resolveDatastoreForRepo(
   repoDir: string,
 ): Promise<DatastoreResolutionResult> {
@@ -230,9 +248,7 @@ export async function resolveDatastoreForRepo(
   const isInit = await service.isInitialized(repoPath);
 
   if (!isInit) {
-    throw new UserError(
-      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
-    );
+    await throwRepoNotInitialized(service, repoPath);
   }
 
   const markerRepo = new RepoMarkerRepository();
@@ -279,9 +295,7 @@ export async function requireRepoMarker(
   const isInit = await service.isInitialized(repoPath);
 
   if (!isInit) {
-    throw new UserError(
-      `Not a swamp repository: ${repoPath.value}. To initialize a new repository, run 'swamp repo init', or specify an existing repository with 'swamp <command> --repo-dir /path/to/repo'.`,
-    );
+    await throwRepoNotInitialized(service, repoPath);
   }
 
   const markerRepo = new RepoMarkerRepository();

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -337,11 +337,9 @@ Deno.test("requireInitializedRepoReadOnly - passes factory config", async () => 
 // Marker File Edge Cases
 // ============================================================================
 
-Deno.test("requireInitializedRepo - checks .swamp marker file", async () => {
+Deno.test("requireInitializedRepo - orphaned .swamp/ without marker reports distinct error", async () => {
   await withTempDir(async (dir) => {
-    // Create a directory with some files but NOT a valid swamp repo
     await ensureDir(join(dir, ".swamp"));
-    // Missing the marker file, so it should not be considered initialized
 
     const error = await assertRejects(
       () =>
@@ -352,7 +350,23 @@ Deno.test("requireInitializedRepo - checks .swamp marker file", async () => {
       UserError,
     );
 
-    assertStringIncludes(error.message, "Not a swamp repository");
+    assertStringIncludes(error.message, "Found a .swamp/ directory");
+    assertStringIncludes(error.message, "no .swamp.yaml marker");
+    assertStringIncludes(error.message, "remote datastore");
+  });
+});
+
+Deno.test("resolveDatastoreForRepo - orphaned .swamp/ without marker reports distinct error", async () => {
+  await withTempDir(async (dir) => {
+    await ensureDir(join(dir, ".swamp"));
+
+    const error = await assertRejects(
+      () => resolveDatastoreForRepo(dir),
+      UserError,
+    );
+
+    assertStringIncludes(error.message, "Found a .swamp/ directory");
+    assertStringIncludes(error.message, "no .swamp.yaml marker");
   });
 });
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -216,6 +216,19 @@ export class RepoService {
   }
 
   /**
+   * Checks whether a `.swamp/` runtime directory exists without a
+   * `.swamp.yaml` marker — i.e. a partially initialized or corrupted repo.
+   */
+  async hasOrphanedSwampDir(repoPath: RepoPath): Promise<boolean> {
+    try {
+      const stat = await Deno.stat(swampPath(repoPath.value));
+      return stat.isDirectory;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Initializes a new swamp repository.
    *
    * @param repoPath - The path to initialize
@@ -315,6 +328,15 @@ export class RepoService {
     const existingMarker = await this.markerRepo.read(repoPath);
 
     if (!existingMarker) {
+      if (await this.hasOrphanedSwampDir(repoPath)) {
+        throw new UserError(
+          `Found a .swamp/ directory at ${repoPath.value} but no .swamp.yaml marker — ` +
+            "the repository appears partially initialized or corrupted. " +
+            "If you previously used a remote datastore, re-initializing with " +
+            "'swamp repo init' will not reconnect to it. Restore .swamp.yaml " +
+            "from version control or re-initialize with the correct --datastore flag.",
+        );
+      }
       throw new UserError(
         `Not a swamp repository: ${repoPath.value}. Run 'swamp repo init' first.`,
       );

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { detectSupersededSkills, RepoService } from "./repo_service.ts";
 import { RepoPath } from "./repo_path.ts";
@@ -2510,4 +2511,55 @@ Deno.test("detectSupersededSkills: detects superseded skill directories", async 
 Deno.test("detectSupersededSkills: returns empty for nonexistent directory", async () => {
   const result = await detectSupersededSkills("/tmp/nonexistent-dir-326");
   assertEquals(result, []);
+});
+
+// ============================================================================
+// hasOrphanedSwampDir Tests
+// ============================================================================
+
+Deno.test("hasOrphanedSwampDir: returns true when .swamp/ exists without .swamp.yaml", async () => {
+  await withTempDir(async (tempDir) => {
+    await ensureDir(join(tempDir, ".swamp"));
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    assertEquals(await service.hasOrphanedSwampDir(repoPath), true);
+  });
+});
+
+Deno.test("hasOrphanedSwampDir: returns false when neither .swamp/ nor .swamp.yaml exist", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    assertEquals(await service.hasOrphanedSwampDir(repoPath), false);
+  });
+});
+
+Deno.test("hasOrphanedSwampDir: returns true even when fully initialized (caller gates on isInitialized first)", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath);
+
+    assertEquals(await service.hasOrphanedSwampDir(repoPath), true);
+  });
+});
+
+Deno.test("upgrade: throws orphan-specific error when .swamp/ exists without marker", async () => {
+  await withTempDir(async (tempDir) => {
+    await ensureDir(join(tempDir, ".swamp"));
+
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    const error = await assertRejects(
+      () => service.upgrade(repoPath),
+      Error,
+    );
+
+    assertStringIncludes(error.message, "Found a .swamp/ directory");
+    assertStringIncludes(error.message, "no .swamp.yaml marker");
+  });
 });


### PR DESCRIPTION
## Summary
- When a `.swamp/` directory exists without a `.swamp.yaml` marker, reports a distinct error warning about partial/corrupted repo state and remote datastore risks, instead of the generic "Not a swamp repository" message
- Fixes extension loader setup (`configureExtensionLoaders`) creating `.swamp/` as a side effect in non-repo directories by gating on the marker being present
- Adds `hasOrphanedSwampDir()` to `RepoService` for orphan detection, used by `resolveDatastoreForRepo()`, `requireRepoMarker()`, and `upgrade()`

## Test plan
- [x] Unit tests for `hasOrphanedSwampDir()` — orphaned, missing, and initialized cases
- [x] Unit tests for orphan-specific error in `resolveDatastoreForRepo()` and `requireInitializedRepo()`
- [x] Unit test for orphan-specific error in `RepoService.upgrade()`
- [x] Manual verification: orphaned `.swamp/` → distinct error
- [x] Manual verification: no repo at all → generic error (unchanged), no `.swamp/` created
- [x] Manual verification: `extension search` in fresh dir no longer creates `.swamp/`
- [x] Full test suite passes (6330 passed, 0 failed)

Fixes: swamp-club#460

🤖 Generated with [Claude Code](https://claude.com/claude-code)