### PR TITLE
docs(skills): add extension deprecation to publish skill

### DIFF
--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: swamp-extension-publish
 description: >
-  Publish swamp extensions to the registry with an enforced state-machine
-  checklist that verifies repo initialization, authentication, manifest
-  validation, collective ownership, version bumping, formatting, and dry-run
-  before allowing a push. Do NOT use for creating extensions (that is
-  swamp-extension), improving quality scores (that is swamp-extension), or
-  smoke testing extensions before push (that is swamp-extension). Use when
-  publishing, pushing, or releasing extensions. Triggers on "publish
-  extension", "push extension", "extension push", "publish to registry",
-  "swamp extension push", "release extension", "prepare for publishing",
-  "extension-publish".
+  Publish swamp extensions to the registry and manage post-publication
+  lifecycle (deprecation). Enforces a state-machine checklist that verifies
+  repo initialization, authentication, manifest validation, collective
+  ownership, version bumping, formatting, and dry-run before allowing a push.
+  Also covers deprecating and undeprecating published extensions. Do NOT use
+  for creating extensions (that is swamp-extension), improving quality scores
+  (that is swamp-extension), or smoke testing extensions before push (that is
+  swamp-extension). Use when publishing, pushing, releasing, deprecating, or
+  undeprecating extensions. Triggers on "publish extension", "push extension",
+  "extension push", "publish to registry", "swamp extension push", "release
+  extension", "prepare for publishing", "extension-publish", "deprecate
+  extension", "undeprecate extension", "mark extension deprecated", "remove
+  deprecation", "extension deprecated", "superseded by".
 ---
 
 # Swamp Extension Publish
@@ -199,6 +202,44 @@ swamp extension push manifest.yaml --yes --json
 - Version already exists → bump the MICRO component and retry
 - Network error → check connectivity and retry
 - Auth error → re-run `swamp auth login` (go back to State 2)
+
+## Post-Publication: Deprecation
+
+Deprecate or undeprecate a published extension. Deprecated extensions remain
+pullable — this is a soft lifecycle signal, not a deletion.
+
+**Prerequisites:** Authenticated (`swamp auth whoami`) and authorized for the
+extension's collective.
+
+### Deprecate
+
+```bash
+swamp extension deprecate @collective/name --reason "No longer maintained" --json
+
+# Point users to a replacement
+swamp extension deprecate @collective/name \
+  --reason "Merged into collective extension" \
+  --superseded-by @other/replacement --json
+```
+
+| Option            | Required | Description                     |
+| ----------------- | -------- | ------------------------------- |
+| `--reason`        | Yes      | Why the extension is deprecated |
+| `--superseded-by` | No       | Replacement extension name      |
+| `-y, --yes`       | No       | Skip confirmation prompt        |
+
+### Undeprecate
+
+```bash
+swamp extension undeprecate @collective/name --json
+```
+
+Removes deprecation status. Accepts `-y, --yes` to skip confirmation.
+
+### Where deprecation surfaces
+
+`search` shows `[deprecated]`, `info` shows reason/successor/timestamp, `pull`
+prints a warning, `outdated` and `list --check-updates` flag the extension.
 
 ## References
 

--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -505,31 +505,34 @@ swamp extension version --manifest manifest.yaml --json
 
 ## Common Errors and Fixes
 
-| Error                           | Fix                                                                               |
-| ------------------------------- | --------------------------------------------------------------------------------- |
-| "Not a swamp repository"        | Run `swamp repo init --json` in the extension directory                           |
-| "Not authenticated"             | Run `swamp auth login` first                                                      |
-| "collective does not match"     | Manifest `name` must use `@your-username/...`                                     |
-| "CalVer format" error           | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)                                     |
-| "at least one model, workflow…" | Add a `models`, `workflows`, `vaults`, `drivers`, `datastores`, or `skills` array |
-| "Model file not found"          | Check path is relative to `extensions/models/`                                    |
-| "Workflow file not found"       | Check path is relative to `workflows/`                                            |
-| "eval() or new Function()"      | Remove dynamic code execution from your models                                    |
-| "Version already exists"        | Bump the MICRO component or let CLI auto-bump                                     |
-| "Missing manifestVersion"       | Add `manifestVersion: 1` to your manifest                                         |
-| "Bundle compilation failed"     | Fix TypeScript errors in your model files                                         |
+| Error                             | Fix                                                                               |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| "Not a swamp repository"          | Run `swamp repo init --json` in the extension directory                           |
+| "Not authenticated"               | Run `swamp auth login` first                                                      |
+| "collective does not match"       | Manifest `name` must use `@your-username/...`                                     |
+| "CalVer format" error             | Use `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`)                                     |
+| "at least one model, workflow…"   | Add a `models`, `workflows`, `vaults`, `drivers`, `datastores`, or `skills` array |
+| "Model file not found"            | Check path is relative to `extensions/models/`                                    |
+| "Workflow file not found"         | Check path is relative to `workflows/`                                            |
+| "eval() or new Function()"        | Remove dynamic code execution from your models                                    |
+| "Version already exists"          | Bump the MICRO component or let CLI auto-bump                                     |
+| "Missing manifestVersion"         | Add `manifestVersion: 1` to your manifest                                         |
+| "Bundle compilation failed"       | Fix TypeScript errors in your model files                                         |
+| "Extension is already deprecated" | Already deprecated — use `undeprecate` first if re-deprecating with new reason    |
+| "Extension is not deprecated"     | Nothing to undeprecate — extension is not currently deprecated                    |
 
 ## Related Skills
 
-| Need                               | Use Skill         |
-| ---------------------------------- | ----------------- |
-| Create custom models               | `swamp-extension` |
-| Create custom vaults               | `swamp-extension` |
-| Create custom datastores           | `swamp-extension` |
-| Create custom execution drivers    | `swamp-extension` |
-| Repository setup and management    | `swamp-repo`      |
-| Create reports                     | `swamp-report`    |
-| Quality scorecard & best practices | `swamp-extension` |
+| Need                               | Use Skill                 |
+| ---------------------------------- | ------------------------- |
+| Create custom models               | `swamp-extension`         |
+| Create custom vaults               | `swamp-extension`         |
+| Create custom datastores           | `swamp-extension`         |
+| Create custom execution drivers    | `swamp-extension`         |
+| Repository setup and management    | `swamp-repo`              |
+| Create reports                     | `swamp-report`            |
+| Quality scorecard & best practices | `swamp-extension`         |
+| Deprecate/undeprecate extensions   | `swamp-extension-publish` |
 
 ## Quality Self-Check
 


### PR DESCRIPTION
## Summary

- Adds extension deprecation/undeprecation documentation to the `swamp-extension-publish` skill
- Updates frontmatter triggers to include deprecation-related phrases
- Adds deprecation errors and related skills entry to `references/publishing.md`

The deprecation feature shipped in #1455 but wasn't covered in any skill. It fits naturally in `swamp-extension-publish` since deprecation is a registry operation sharing the same auth/collective context as push.

Passed `npx tessl skill review` at 97%.

## Test Plan

- [x] `deno fmt` passes on modified files
- [x] `npx tessl skill review .claude/skills/swamp-extension-publish` passes (97%)
- [ ] Verify skill triggers on "deprecate extension" in a fresh conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)