### PR TITLE
feat(extensions): honor paths.base for skills and support multi-tool resolution (swamp-club#459)

### DIFF
--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -48,26 +48,26 @@ dependencies:
 
 ### Field Reference
 
-| Field             | Required | Description                                                                                                                                       |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `manifestVersion` | Yes      | Must be `1`                                                                                                                                       |
-| `name`            | Yes      | Scoped name: `@collective/name` or `@collective/name/sub/path` (lowercase, hyphens, underscores)                                                  |
-| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                                                                                                 |
-| `description`     | No       | Human-readable description                                                                                                                        |
-| `repository`      | No       | HTTPS URL of the upstream repository. Required for users to file issues via `swamp issue --extension` — `swamp extension push` warns when absent. |
-| `paths.base`      | No       | Path resolution mode for typed keys + `additionalFiles`. `typedDir` (default) or `manifest`. See "Path resolution".                               |
-| `models`          | No*      | Model file paths. Resolved via `paths.base`.                                                                                                      |
-| `workflows`       | No*      | Workflow file paths. Workflows use a multi-base lookup and ignore `paths.base`.                                                                   |
-| `vaults`          | No*      | Vault file paths. Resolved via `paths.base`.                                                                                                      |
-| `drivers`         | No*      | Driver file paths. Resolved via `paths.base`.                                                                                                     |
-| `datastores`      | No*      | Datastore file paths. Resolved via `paths.base`.                                                                                                  |
-| `reports`         | No*      | Report file paths. Resolved via `paths.base`.                                                                                                     |
-| `skills`          | No*      | Skill directory names resolved from the tool's skill directory (e.g., `.claude/skills/`). Skills ignore `paths.base`.                             |
-| `include`         | No       | Helper TypeScript files copied alongside models without bundling. Resolved via `paths.base`.                                                      |
-| `additionalFiles` | No       | Extra files (README, LICENSE, etc.) relative to the manifest's own directory.                                                                     |
-| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                                                                     |
-| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                                                                      |
-| `dependencies`    | No       | Other extensions this one depends on                                                                                                              |
+| Field             | Required | Description                                                                                                                                                   |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manifestVersion` | Yes      | Must be `1`                                                                                                                                                   |
+| `name`            | Yes      | Scoped name: `@collective/name` or `@collective/name/sub/path` (lowercase, hyphens, underscores)                                                              |
+| `version`         | Yes      | CalVer format: `YYYY.MM.DD.MICRO`                                                                                                                             |
+| `description`     | No       | Human-readable description                                                                                                                                    |
+| `repository`      | No       | HTTPS URL of the upstream repository. Required for users to file issues via `swamp issue --extension` — `swamp extension push` warns when absent.             |
+| `paths.base`      | No       | Path resolution mode for typed keys + `additionalFiles`. `typedDir` (default) or `manifest`. See "Path resolution".                                           |
+| `models`          | No*      | Model file paths. Resolved via `paths.base`.                                                                                                                  |
+| `workflows`       | No*      | Workflow file paths. Workflows use a multi-base lookup and ignore `paths.base`.                                                                               |
+| `vaults`          | No*      | Vault file paths. Resolved via `paths.base`.                                                                                                                  |
+| `drivers`         | No*      | Driver file paths. Resolved via `paths.base`.                                                                                                                 |
+| `datastores`      | No*      | Datastore file paths. Resolved via `paths.base`.                                                                                                              |
+| `reports`         | No*      | Report file paths. Resolved via `paths.base`.                                                                                                                 |
+| `skills`          | No*      | Skill directory names. Honours `paths.base: manifest` (manifest-relative first, then project-local, then global). Multi-tool repos search all enrolled tools. |
+| `include`         | No       | Helper TypeScript files copied alongside models without bundling. Resolved via `paths.base`.                                                                  |
+| `additionalFiles` | No       | Extra files (README, LICENSE, etc.) relative to the manifest's own directory.                                                                                 |
+| `platforms`       | No       | OS/architecture hints (e.g. `darwin-aarch64`, `linux-x86_64`)                                                                                                 |
+| `labels`          | No       | Categorization labels (e.g. `aws`, `kubernetes`, `security`)                                                                                                  |
+| `dependencies`    | No       | Other extensions this one depends on                                                                                                                          |
 
 *At least one of `models`, `workflows`, `vaults`, `drivers`, `datastores`,
 `reports`, or `skills` must be present with entries.
@@ -198,8 +198,11 @@ additionalFiles:
 - The archive layout under each typed dir mirrors your manifest entries
   verbatim: `models: [echo.ts]` lands at `extension/models/echo.ts` in the
   archive (not at `extension/models/my-ext/echo.ts`).
-- Workflows and skills keep their own multi-base lookup. `paths.base` does not
-  apply to those keys.
+- Workflows keep their own multi-base lookup. `paths.base` does not apply to
+  workflows.
+- Skills honour `paths.base: manifest` — manifest-relative directories are
+  searched first, then project-local, then global. All enrolled tools are
+  searched at each level.
 
 ### Name Rules
 

--- a/.claude/skills/swamp-extension/references/model/skills.md
+++ b/.claude/skills/swamp-extension/references/model/skills.md
@@ -99,12 +99,15 @@ dependencies:
   - "@webframp/redmine"
 ```
 
-Each entry is a skill directory name resolved from:
+Each entry is a skill directory name resolved in priority order:
 
-1. **Project-local skill directory** — e.g., `.claude/skills/create-story/`
-2. **Global skill directory** — e.g., `~/.claude/skills/create-story/`
+1. **Manifest-relative** (only when `paths.base: manifest`) — e.g.,
+   `sub/.claude/skills/create-story/` where `sub/` is the manifest's directory
+2. **Project-local skill directory** — e.g., `.claude/skills/create-story/`
+3. **Global skill directory** — e.g., `~/.claude/skills/create-story/`
 
-The tool determines the skill directory path:
+In multi-tool repos, all enrolled tools' directories are searched at each
+priority level. The tool determines the skill directory path:
 
 | Tool     | Skill Directory   |
 | -------- | ----------------- |

--- a/design/extension.md
+++ b/design/extension.md
@@ -214,11 +214,14 @@ containing `..` or starting with `/`.
   Resolved via `paths.base`.
 - `reports`: Array of relative paths to TypeScript report files. Resolved
   via `paths.base`.
-- `skills`: Array of skill directory names resolved from the tool's skill
-  directory (e.g., `.claude/skills/`). Each directory must contain a `SKILL.md`
-  with YAML frontmatter declaring `name` and `description`. Skills are passive
-  markdown guidance documents — swamp never executes them. Skills are not
-  affected by `paths.base`.
+- `skills`: Array of skill directory names. Each directory must contain a
+  `SKILL.md` with YAML frontmatter declaring `name` and `description`. Skills
+  are passive markdown guidance documents — swamp never executes them. Under
+  `paths.base: manifest`, skills resolve relative to the manifest's own
+  directory first (e.g., `sub/.claude/skills/<name>/`), then fall back to the
+  repo-root skill directory and global user-level directory. Under the default
+  `paths.base: typedDir`, skills resolve from repo-root and global only. In
+  multi-tool repos, all enrolled tools' skill directories are searched.
 - `include`: Array of relative paths to TypeScript files that should be
   included in the archive alongside models but not bundled. Used for
   helper scripts that are executed via `Deno.Command` subprocess rather
@@ -276,10 +279,14 @@ The `paths.base` field selects the directory typed-key entries
   `extensions/models/myext/manifest.yaml` next to `myext/echo.ts` and
   `myext/README.md`).
 
-Workflows and skills keep their bespoke multi-base lookup (workflows
-fall back from the indexer dir to the extension workflows dir; skills
-look up project-local then global). `paths.base` does not apply to
-those keys.
+Workflows keep their bespoke multi-base lookup (fall back from the
+indexer dir to the extension workflows dir). `paths.base` does not
+apply to workflows.
+
+Skills honour `paths.base: manifest` — when set, the manifest's own
+directory is searched first (e.g. `sub/.claude/skills/<name>/`), then
+project-local, then global. All enrolled tools are searched, not just
+the primary tool.
 
 The on-wire manifest in the archive preserves the field strings
 verbatim — no path rewriting, no normalization. WYSIWYG between what

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -46,7 +46,6 @@ import { resolveDriversDir } from "./resolve_drivers_dir.ts";
 import { resolveDatastoresDir } from "./resolve_datastores_dir.ts";
 import { resolveReportsDir } from "./resolve_reports_dir.ts";
 import { SKILL_DIRS } from "../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
 
 export interface ResolveExtensionFilesContext {
   repoDir: string;
@@ -417,48 +416,61 @@ export async function resolveExtensionFiles(
   const skillDirs: Array<{ name: string; absolutePath: string }> = [];
   const allSkillFiles: string[] = [];
   if (manifest.skills.length > 0) {
-    const tool = resolvePrimaryTool(marker);
-    const projectSkillDir = SKILL_DIRS[tool]
-      ? resolve(repoDir, SKILL_DIRS[tool])
-      : null;
-
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const home = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE");
-    const globalSkillDir = home && SKILL_DIRS[tool]
-      ? join(home, SKILL_DIRS[tool])
-      : null;
 
-    if (!projectSkillDir && !globalSkillDir) {
+    // Build deduplicated candidate base directories in priority order:
+    // manifest-relative (if paths.base=manifest) > project-local > global
+    const seen = new Set<string>();
+    const candidateBases: string[] = [];
+    const addCandidate = (dir: string) => {
+      if (!seen.has(dir)) {
+        seen.add(dir);
+        candidateBases.push(dir);
+      }
+    };
+
+    for (const tool of tools) {
+      const rel = SKILL_DIRS[tool];
+      if (!rel) continue;
+      if (useManifestBase) addCandidate(resolve(manifestDir, rel));
+    }
+    for (const tool of tools) {
+      const rel = SKILL_DIRS[tool];
+      if (!rel) continue;
+      addCandidate(resolve(repoDir, rel));
+    }
+    for (const tool of tools) {
+      const rel = SKILL_DIRS[tool];
+      if (!rel || !home) continue;
+      addCandidate(join(home, rel));
+    }
+
+    if (candidateBases.length === 0) {
       throw new UserError(
-        `Cannot package skills when tool is '${tool}'. Set a tool with: swamp repo upgrade --tool <claude|cursor|kiro|opencode|codex>`,
+        `Cannot package skills: no enrolled tools have skill directories. Set a tool with: swamp repo upgrade --tool <claude|cursor|kiro|opencode|codex>`,
       );
     }
 
     for (const skillName of manifest.skills) {
       let skillPath: string | null = null;
 
-      // Try project-local first
-      if (projectSkillDir) {
-        const candidate = join(projectSkillDir, skillName);
+      for (const base of candidateBases) {
+        const candidate = join(base, skillName);
         try {
           const stat = await Deno.stat(candidate);
-          if (stat.isDirectory) skillPath = candidate;
+          if (stat.isDirectory) {
+            skillPath = candidate;
+            break;
+          }
         } catch { /* not found here */ }
       }
 
-      // Fall back to global
-      if (!skillPath && globalSkillDir) {
-        const candidate = join(globalSkillDir, skillName);
-        try {
-          const stat = await Deno.stat(candidate);
-          if (stat.isDirectory) skillPath = candidate;
-        } catch { /* not found here either */ }
-      }
-
       if (!skillPath) {
-        const locations = [projectSkillDir, globalSkillDir].filter(Boolean)
-          .join(" and ");
         throw new UserError(
-          `Skill directory not found: ${skillName} (looked in ${locations})`,
+          `Skill directory not found: ${skillName} (looked in ${
+            candidateBases.join(", ")
+          })`,
         );
       }
 

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -928,3 +928,233 @@ Deno.test("resolveExtensionFiles: rejects .js file with UserError", async () => 
     );
   });
 });
+
+// ── skill resolution with paths.base and multi-tool ──────────────────────
+
+async function withTempRepoWithTools(
+  tools: string[],
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-resolve-ext-test-" });
+  try {
+    await Deno.writeTextFile(
+      join(dir, ".swamp.yaml"),
+      stringifyYaml({ swampVersion: "0.1.0", tools }),
+    );
+    await Deno.mkdir(join(dir, "extensions", "models"), { recursive: true });
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+const MINIMAL_SKILL_MD = `---
+name: demo-skill
+description: A demo skill for testing
+---
+
+Demo skill content.
+`;
+
+async function createSkillDir(
+  baseDir: string,
+  skillName: string,
+): Promise<void> {
+  const skillDir = join(baseDir, skillName);
+  await Deno.mkdir(skillDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(skillDir, "SKILL.md"),
+    MINIMAL_SKILL_MD.replace("demo-skill", skillName),
+  );
+}
+
+Deno.test("resolveExtensionFiles paths.base=manifest resolves skills from manifest-relative dir", async () => {
+  await withTempRepoWithTools(["claude"], async (dir) => {
+    const subdir = join(dir, "sub");
+    await Deno.mkdir(subdir, { recursive: true });
+
+    await createSkillDir(join(subdir, ".claude", "skills"), "my-skill");
+
+    await Deno.writeTextFile(
+      join(subdir, "model.ts"),
+      'export const name = "model";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/skill-manifest-base",
+        version: "2026.05.28.1",
+        paths: { base: "manifest" },
+        models: ["model.ts"],
+        skills: ["my-skill"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.skillDirs.length, 1);
+    assertEquals(result.skillDirs[0].name, "my-skill");
+    assertEquals(
+      result.skillDirs[0].absolutePath,
+      join(subdir, ".claude", "skills", "my-skill"),
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles default paths.base resolves skills from repo root", async () => {
+  await withTempRepoWithTools(["claude"], async (dir) => {
+    await createSkillDir(join(dir, ".claude", "skills"), "root-skill");
+
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/skill-typeddir",
+        version: "2026.05.28.1",
+        models: ["dummy.ts"],
+        skills: ["root-skill"],
+      }),
+    );
+    await Deno.writeTextFile(
+      join(dir, "extensions", "models", "dummy.ts"),
+      'export const name = "dummy";',
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.skillDirs.length, 1);
+    assertEquals(result.skillDirs[0].name, "root-skill");
+    assertEquals(
+      result.skillDirs[0].absolutePath,
+      join(dir, ".claude", "skills", "root-skill"),
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=manifest prefers manifest-relative over repo root", async () => {
+  await withTempRepoWithTools(["claude"], async (dir) => {
+    const subdir = join(dir, "sub");
+    await Deno.mkdir(subdir, { recursive: true });
+
+    // Skill exists in both locations
+    await createSkillDir(join(dir, ".claude", "skills"), "shared-skill");
+    await createSkillDir(join(subdir, ".claude", "skills"), "shared-skill");
+
+    await Deno.writeTextFile(
+      join(subdir, "model.ts"),
+      'export const name = "model";',
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/skill-precedence",
+        version: "2026.05.28.1",
+        paths: { base: "manifest" },
+        models: ["model.ts"],
+        skills: ["shared-skill"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.skillDirs.length, 1);
+    assertEquals(
+      result.skillDirs[0].absolutePath,
+      join(subdir, ".claude", "skills", "shared-skill"),
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles multi-tool repo finds skill in secondary tool dir", async () => {
+  await withTempRepoWithTools(["claude", "cursor"], async (dir) => {
+    // Skill only exists in .cursor/skills, not .claude/skills
+    await createSkillDir(join(dir, ".cursor", "skills"), "cursor-skill");
+
+    await Deno.writeTextFile(
+      join(dir, "extensions", "models", "dummy.ts"),
+      'export const name = "dummy";',
+    );
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/skill-multitool",
+        version: "2026.05.28.1",
+        skills: ["cursor-skill"],
+        models: ["dummy.ts"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.skillDirs.length, 1);
+    assertEquals(result.skillDirs[0].name, "cursor-skill");
+    assertEquals(
+      result.skillDirs[0].absolutePath,
+      join(dir, ".cursor", "skills", "cursor-skill"),
+    );
+  });
+});
+
+Deno.test("resolveExtensionFiles multi-tool deduplicates shared SKILL_DIRS paths", async () => {
+  // opencode and codex both map to .agents/skills
+  await withTempRepoWithTools(["opencode", "codex"], async (dir) => {
+    await createSkillDir(join(dir, ".agents", "skills"), "agent-skill");
+
+    await Deno.writeTextFile(
+      join(dir, "extensions", "models", "dummy.ts"),
+      'export const name = "dummy";',
+    );
+    const manifestPath = join(dir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/skill-dedup",
+        version: "2026.05.28.1",
+        skills: ["agent-skill"],
+        models: ["dummy.ts"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+    });
+
+    assertEquals(result.skillDirs.length, 1);
+    assertEquals(result.skillDirs[0].name, "agent-skill");
+    assertEquals(
+      result.skillDirs[0].absolutePath,
+      join(dir, ".agents", "skills", "agent-skill"),
+    );
+  });
+});

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -57,10 +57,14 @@ const safePathString = z.string().refine(isSafeRelativePath, {
  *   per-extension-subdir layouts where manifest, source, README, and
  *   LICENSE all live alongside each other.
  *
- * Workflows and skills keep their own multi-base resolution (workflows
- * fall back from the indexer dir to the extension workflows dir;
- * skills look up project-local then global). `paths.base` does not
- * apply to those keys.
+ * Workflows keep their own multi-base resolution (fall back from the
+ * indexer dir to the extension workflows dir). `paths.base` does not
+ * apply to workflows.
+ *
+ * Skills honour `paths.base: manifest` — when set, the manifest's own
+ * directory is searched first (e.g. `<manifestDir>/.claude/skills/`),
+ * before project-local and global skill directories. All enrolled
+ * tools are searched, not just the primary tool.
  */
 const PathsBaseSchema = z.enum(["typedDir", "manifest"]);
 

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -327,6 +327,97 @@ Deno.test(
 );
 
 Deno.test(
+  "round-trip: paths.base=manifest bundles skills from manifest-relative dir",
+  async () => {
+    const src = await Deno.makeTempDir({ prefix: "rt-skill-src-" });
+    const dst = await Deno.makeTempDir({ prefix: "rt-skill-dst-" });
+    try {
+      // Per-extension-subdir layout with a skill next to the manifest.
+      const extDir = join(src, "sub");
+      await Deno.mkdir(extDir, { recursive: true });
+      await Deno.writeTextFile(
+        join(extDir, "echo.ts"),
+        'export const model = { type: "@t/skill-rt", version: "1.0.0" };',
+      );
+
+      // Skill lives at sub/.claude/skills/my-skill/
+      const skillDir = join(extDir, ".claude", "skills", "my-skill");
+      await Deno.mkdir(skillDir, { recursive: true });
+      await Deno.writeTextFile(
+        join(skillDir, "SKILL.md"),
+        "---\nname: my-skill\ndescription: test skill\n---\n\nSkill body.\n",
+      );
+      const refDir = join(skillDir, "references");
+      await Deno.mkdir(refDir, { recursive: true });
+      await Deno.writeTextFile(join(refDir, "detail.md"), "# Detail");
+
+      const manifest = makeManifest({
+        paths: { base: "manifest" },
+        models: ["echo.ts"],
+        skills: ["my-skill"],
+      });
+
+      const input: ExtensionPushPrepareInput = {
+        manifest,
+        repoDir: src,
+        modelsDir: extDir,
+        allModelFiles: [join(extDir, "echo.ts")],
+        modelEntryPoints: [join(extDir, "echo.ts")],
+        vaultsDir: extDir,
+        allVaultFiles: [],
+        vaultEntryPoints: [],
+        driversDir: extDir,
+        allDriverFiles: [],
+        driverEntryPoints: [],
+        datastoresDir: extDir,
+        allDatastoreFiles: [],
+        datastoreEntryPoints: [],
+        reportsDir: extDir,
+        allReportFiles: [],
+        reportEntryPoints: [],
+        workflowFiles: [],
+        skillDirs: [{ name: "my-skill", absolutePath: skillDir }],
+        allSkillFiles: [
+          join(skillDir, "SKILL.md"),
+          join(refDir, "detail.md"),
+        ],
+        includeFilePaths: [],
+        additionalFilePaths: [],
+        binaryFilePaths: [],
+        dryRun: true,
+      };
+
+      const ctx = createLibSwampContext();
+      const prepared = await extensionPushPrepare(
+        ctx,
+        makePrepareDeps(),
+        input,
+      );
+
+      await untarArchiveTo(prepared.archiveBytes, dst);
+
+      // Skill files land under extension/skills/<name>/ with structure preserved.
+      const archiveSkillDir = join(dst, "extension", "skills", "my-skill");
+      await Deno.stat(join(archiveSkillDir, "SKILL.md"));
+      await Deno.stat(join(archiveSkillDir, "references", "detail.md"));
+
+      const skillContent = await Deno.readTextFile(
+        join(archiveSkillDir, "SKILL.md"),
+      );
+      assertEquals(skillContent.includes("name: my-skill"), true);
+
+      const refContent = await Deno.readTextFile(
+        join(archiveSkillDir, "references", "detail.md"),
+      );
+      assertEquals(refContent, "# Detail");
+    } finally {
+      await Deno.remove(src, { recursive: true }).catch(() => {});
+      await Deno.remove(dst, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
   "round-trip: binaries field survives push → extract in archive manifest",
   async () => {
     const { parse: parseYaml } = await import("@std/yaml");


### PR DESCRIPTION
## Summary

- Skill resolution during `extension push` / `extension quality` now honours `paths.base: manifest` — when set, skill directories are searched relative to the manifest's own directory first (e.g. `sub/.claude/skills/<name>/`), enabling self-contained skill-bundling extensions in monorepo layouts
- All enrolled tools are now searched (not just the primary tool), so a dual-tool repo (e.g. `claude` + `cursor`) finds skills in any enrolled tool's directory
- Search order: manifest-relative (all tools) → project-local (all tools) → global (all tools), with shared `SKILL_DIRS` paths deduplicated
- Error messages now list all searched directories across all tools for better diagnostics

Fixes swamp-club#459

## Test plan

- [x] 5 new unit tests in `resolve_extension_files_test.ts` (manifest-relative, default, precedence, multi-tool, deduplication)
- [x] 1 new integration test in `push_pull_roundtrip_test.ts` (manifest-relative skills survive archive roundtrip)
- [x] Full test suite passes (6336/6336)
- [x] Manual verification with compiled binary against 6 dry-run scenarios:
  - Default `paths.base` with skill at repo root
  - `paths.base: manifest` with skill at manifest-relative dir
  - Precedence: manifest-relative wins over repo root
  - Multi-tool: skill in secondary tool dir (`.cursor/skills/`)
  - Missing skill: error lists all searched directories
  - `paths.base: manifest` + multi-tool + secondary tool dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)