### PR TITLE
feat(data): add Namespace value object and config plumbing (swamp-club#464)

### DIFF
--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -464,6 +464,7 @@ export async function resolveDatastoreConfig(
           directories: ds.directories,
           exclude: ds.exclude,
           hydrationStrategy: ds.hydrationStrategy,
+          namespace: ds.namespace,
         };
       }
 
@@ -485,6 +486,7 @@ export async function resolveDatastoreConfig(
         path: expandEnvVars(ds.path),
         directories: ds.directories,
         exclude: ds.exclude,
+        namespace: ds.namespace,
       };
     }
 
@@ -541,6 +543,7 @@ export async function resolveDatastoreConfig(
       directories: ds.directories,
       exclude: ds.exclude,
       hydrationStrategy: ds.hydrationStrategy,
+      namespace: ds.namespace,
     };
   }
 

--- a/src/domain/data/mod.ts
+++ b/src/domain/data/mod.ts
@@ -49,3 +49,12 @@ export {
 } from "./workflow_data_service.ts";
 
 export { composeDataName } from "./composite_name.ts";
+
+export {
+  createNamespace,
+  isEmptyNamespace,
+  type Namespace,
+  type NamespacedModelName,
+  parseNamespacedModelName,
+  SOLO_NAMESPACE,
+} from "./namespace.ts";

--- a/src/domain/data/namespace.ts
+++ b/src/domain/data/namespace.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export type Namespace = string & { readonly _brand: unique symbol };
+
+const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const NAMESPACE_MAX_LENGTH = 64;
+
+export function createNamespace(slug: string): Namespace {
+  if (slug.length === 0) {
+    throw new Error("Namespace cannot be empty — use SOLO_NAMESPACE instead");
+  }
+  if (slug.length > NAMESPACE_MAX_LENGTH) {
+    throw new Error(
+      `Namespace must be at most ${NAMESPACE_MAX_LENGTH} characters, got ${slug.length}`,
+    );
+  }
+  if (!NAMESPACE_PATTERN.test(slug)) {
+    throw new Error(
+      `Namespace must match [a-z0-9][a-z0-9-]*: ${JSON.stringify(slug)}`,
+    );
+  }
+  return slug as Namespace;
+}
+
+export const SOLO_NAMESPACE: Namespace = "" as Namespace;
+
+export function isEmptyNamespace(ns: Namespace): boolean {
+  return ns === "";
+}
+
+export interface NamespacedModelName {
+  readonly namespace: string | undefined;
+  readonly modelName: string;
+}
+
+export function parseNamespacedModelName(input: string): NamespacedModelName {
+  const colonIndex = input.indexOf(":");
+  if (colonIndex === -1) {
+    return { namespace: undefined, modelName: input };
+  }
+
+  const namespace = input.slice(0, colonIndex);
+  const modelName = input.slice(colonIndex + 1);
+
+  if (modelName === "") {
+    throw new Error(
+      `Invalid namespaced model name: model name is empty in ${
+        JSON.stringify(input)
+      }`,
+    );
+  }
+
+  if (namespace === "") {
+    return { namespace: undefined, modelName };
+  }
+
+  return { namespace, modelName };
+}

--- a/src/domain/data/namespace_test.ts
+++ b/src/domain/data/namespace_test.ts
@@ -1,0 +1,200 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  createNamespace,
+  isEmptyNamespace,
+  parseNamespacedModelName,
+  SOLO_NAMESPACE,
+} from "./namespace.ts";
+
+// --- createNamespace validation ---
+
+Deno.test("createNamespace: accepts valid lowercase slug", () => {
+  assertEquals(createNamespace("infra") as string, "infra");
+});
+
+Deno.test("createNamespace: accepts slug with digits", () => {
+  assertEquals(createNamespace("team42") as string, "team42");
+});
+
+Deno.test("createNamespace: accepts slug with hyphens", () => {
+  assertEquals(createNamespace("security-prod") as string, "security-prod");
+});
+
+Deno.test("createNamespace: accepts slug starting with digit", () => {
+  assertEquals(createNamespace("1team") as string, "1team");
+});
+
+Deno.test("createNamespace: accepts single character", () => {
+  assertEquals(createNamespace("a") as string, "a");
+});
+
+Deno.test("createNamespace: accepts maximum length (64 chars)", () => {
+  const slug = "a".repeat(64);
+  assertEquals(createNamespace(slug) as string, slug);
+});
+
+Deno.test("createNamespace: throws on empty string", () => {
+  assertThrows(
+    () => createNamespace(""),
+    Error,
+    "Namespace cannot be empty",
+  );
+});
+
+Deno.test("createNamespace: throws on exceeding max length", () => {
+  assertThrows(
+    () => createNamespace("a".repeat(65)),
+    Error,
+    "Namespace must be at most 64 characters",
+  );
+});
+
+Deno.test("createNamespace: throws on uppercase letters", () => {
+  assertThrows(
+    () => createNamespace("Infra"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on underscores", () => {
+  assertThrows(
+    () => createNamespace("my_ns"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on dots", () => {
+  assertThrows(
+    () => createNamespace("my.ns"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on spaces", () => {
+  assertThrows(
+    () => createNamespace("my ns"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on leading hyphen", () => {
+  assertThrows(
+    () => createNamespace("-infra"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on slash", () => {
+  assertThrows(
+    () => createNamespace("a/b"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on colon", () => {
+  assertThrows(
+    () => createNamespace("a:b"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+// --- SOLO_NAMESPACE ---
+
+Deno.test("SOLO_NAMESPACE: is empty string", () => {
+  assertEquals(SOLO_NAMESPACE as string, "");
+});
+
+Deno.test("SOLO_NAMESPACE: isEmptyNamespace returns true", () => {
+  assertEquals(isEmptyNamespace(SOLO_NAMESPACE), true);
+});
+
+// --- isEmptyNamespace ---
+
+Deno.test("isEmptyNamespace: returns false for non-empty namespace", () => {
+  assertEquals(isEmptyNamespace(createNamespace("infra")), false);
+});
+
+// --- Equality ---
+
+Deno.test("createNamespace: equal slugs produce identical values", () => {
+  const a = createNamespace("infra");
+  const b = createNamespace("infra");
+  assertEquals(a === b, true);
+});
+
+Deno.test("createNamespace: different slugs are not equal", () => {
+  const a = createNamespace("infra");
+  const b = createNamespace("security");
+  assertEquals(a === b, false);
+});
+
+// --- parseNamespacedModelName ---
+
+Deno.test("parseNamespacedModelName: returns undefined namespace when no colon", () => {
+  const result = parseNamespacedModelName("scanner");
+  assertEquals(result, { namespace: undefined, modelName: "scanner" });
+});
+
+Deno.test("parseNamespacedModelName: splits on first colon", () => {
+  const result = parseNamespacedModelName("security:scanner");
+  assertEquals(result, { namespace: "security", modelName: "scanner" });
+});
+
+Deno.test("parseNamespacedModelName: handles wildcard namespace", () => {
+  const result = parseNamespacedModelName("*:scanner");
+  assertEquals(result, { namespace: "*", modelName: "scanner" });
+});
+
+Deno.test("parseNamespacedModelName: multiple colons — first colon wins", () => {
+  const result = parseNamespacedModelName("a:b:c");
+  assertEquals(result, { namespace: "a", modelName: "b:c" });
+});
+
+Deno.test("parseNamespacedModelName: empty prefix treated as no namespace", () => {
+  const result = parseNamespacedModelName(":model");
+  assertEquals(result, { namespace: undefined, modelName: "model" });
+});
+
+Deno.test("parseNamespacedModelName: throws on empty model name", () => {
+  assertThrows(
+    () => parseNamespacedModelName("ns:"),
+    Error,
+    "model name is empty",
+  );
+});
+
+Deno.test("parseNamespacedModelName: handles model name with slashes", () => {
+  const result = parseNamespacedModelName("infra:@swamp/echo");
+  assertEquals(result, { namespace: "infra", modelName: "@swamp/echo" });
+});
+
+Deno.test("parseNamespacedModelName: plain model name with no special chars", () => {
+  const result = parseNamespacedModelName("my-model");
+  assertEquals(result, { namespace: undefined, modelName: "my-model" });
+});

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -91,6 +91,8 @@ export interface FilesystemDatastoreConfig {
   readonly directories?: string[];
   /** Gitignore-style patterns to exclude files from the datastore */
   readonly exclude?: string[];
+  /** Namespace for giga-swamp multi-repo shared datastores */
+  readonly namespace?: string;
 }
 
 /**
@@ -124,6 +126,8 @@ export interface CustomDatastoreConfig {
    * download until the data is actually needed.
    */
   readonly hydrationStrategy?: "full" | "lazy";
+  /** Namespace for giga-swamp multi-repo shared datastores */
+  readonly namespace?: string;
 }
 
 /**
@@ -157,6 +161,7 @@ export interface DatastoreConfigData {
   directories?: string[];
   exclude?: string[];
   hydrationStrategy?: "full" | "lazy";
+  namespace?: string;
 }
 
 /**

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -305,6 +305,14 @@ export {
   type ProjectedData,
 } from "./data/query.ts";
 export type { DataRecord } from "../domain/data/data_record.ts";
+export {
+  createNamespace,
+  isEmptyNamespace,
+  type Namespace,
+  type NamespacedModelName,
+  parseNamespacedModelName,
+  SOLO_NAMESPACE,
+} from "../domain/data/namespace.ts";
 
 // Extension trust operations
 export {


### PR DESCRIPTION
## Summary

Giga-swamp phase 1: introduce the `Namespace` branded type for multi-repo shared datastores.

- **Namespace value object** (`src/domain/data/namespace.ts`): branded type with `createNamespace()` factory (`[a-z0-9][a-z0-9-]*`, 1–64 chars), `SOLO_NAMESPACE` sentinel for solo mode, `isEmptyNamespace()` helper
- **`parseNamespacedModelName()` parser**: splits `security:scanner` → `{namespace: "security", modelName: "scanner"}`, handles wildcard `*:model`, first-colon-wins for multiple colons, throws on empty model name
- **Config plumbing**: optional `namespace?: string` on `DatastoreConfigData`, `FilesystemDatastoreConfig`, `CustomDatastoreConfig`; threaded through 3 YAML resolution paths in `resolve_datastore.ts`
- **Barrel exports**: re-exported from `src/domain/data/mod.ts` and `src/libswamp/mod.ts`
- **28 unit tests** covering validation, sentinel, equality, and parser edge cases

Deliberately inert — nothing consumes namespace yet. Solo mode is identical to before. This establishes the domain concept so phases 2–7 can build on it.

Closes swamp-club#464

## Test Plan

- [x] 28 new unit tests for Namespace and parseNamespacedModelName (all pass)
- [x] All 6358 existing tests pass unchanged (solo mode invariant holds)
- [x] `deno check` — no type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)