### PR TITLE
fix(data): reject trailing hyphens in Namespace and empty input in parser (swamp-club#464)

### DIFF
--- a/src/domain/data/namespace.ts
+++ b/src/domain/data/namespace.ts
@@ -19,7 +19,7 @@
 
 export type Namespace = string & { readonly _brand: unique symbol };
 
-const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const NAMESPACE_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 const NAMESPACE_MAX_LENGTH = 64;
 
 export function createNamespace(slug: string): Namespace {
@@ -51,6 +51,10 @@ export interface NamespacedModelName {
 }
 
 export function parseNamespacedModelName(input: string): NamespacedModelName {
+  if (input === "") {
+    throw new Error("Invalid namespaced model name: input is empty");
+  }
+
   const colonIndex = input.indexOf(":");
   if (colonIndex === -1) {
     return { namespace: undefined, modelName: input };

--- a/src/domain/data/namespace_test.ts
+++ b/src/domain/data/namespace_test.ts
@@ -108,6 +108,22 @@ Deno.test("createNamespace: throws on leading hyphen", () => {
   );
 });
 
+Deno.test("createNamespace: throws on trailing hyphen", () => {
+  assertThrows(
+    () => createNamespace("infra-"),
+    Error,
+    "Namespace must match",
+  );
+});
+
+Deno.test("createNamespace: throws on consecutive hyphens at end", () => {
+  assertThrows(
+    () => createNamespace("team--"),
+    Error,
+    "Namespace must match",
+  );
+});
+
 Deno.test("createNamespace: throws on slash", () => {
   assertThrows(
     () => createNamespace("a/b"),
@@ -186,6 +202,14 @@ Deno.test("parseNamespacedModelName: throws on empty model name", () => {
     () => parseNamespacedModelName("ns:"),
     Error,
     "model name is empty",
+  );
+});
+
+Deno.test("parseNamespacedModelName: throws on empty input", () => {
+  assertThrows(
+    () => parseNamespacedModelName(""),
+    Error,
+    "input is empty",
   );
 });
 


### PR DESCRIPTION
## Summary

Address two medium findings from the CI adversarial review on #1462:

- **Trailing-hyphen rejection**: tighten Namespace regex from `[a-z0-9][a-z0-9-]*` to `[a-z0-9]([a-z0-9-]*[a-z0-9])?` — `"infra-"` and `"team--"` are now rejected. Prevents non-canonical paths when phase 2 interpolates namespaces into S3 keys and filesystem paths.
- **Empty input guard**: `parseNamespacedModelName("")` now throws instead of silently returning an empty model name. Matches the existing throw behavior for `"ns:"`.

## Test Plan

- [x] 3 new tests: trailing hyphen, consecutive hyphens at end, empty input
- [x] All 6367 tests pass (31 namespace tests, 6336 existing unchanged)
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)