### PR TITLE
feat(workflow): add manual_approval step type with suspend/approve/resume (swamp-club#369)

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -37,6 +37,10 @@ run.
 | Run a workflow     | `swamp workflow run <id_or_name>`                             |
 | Run with inputs    | `swamp workflow run <id_or_name> --input key=value`           |
 | Run from stdin     | `echo '{"k":"v"}' \| swamp workflow run <id_or_name> --stdin` |
+| Approve step       | `swamp workflow approve <workflow> <step>`                    |
+| Reject step        | `swamp workflow reject <workflow> <step>`                     |
+| Resume workflow    | `swamp workflow resume <workflow>`                            |
+| List approvals     | `swamp workflow approvals --json`                             |
 | View run history   | `swamp workflow history search --json`                        |
 | Get latest run     | `swamp workflow history get <workflow> --json`                |
 | View run logs      | `swamp workflow history logs <run_or_workflow> --json`        |
@@ -494,7 +498,7 @@ steps:
 
 ## Step Task Types
 
-Steps support two task types:
+Steps support three task types:
 
 **`model_method`** — prefer `modelType` + `modelName` (direct type execution)
 for dynamic inputs. Use `modelIdOrName` only for persistent definitions with CEL
@@ -532,6 +536,24 @@ task:
 ```
 
 Nested workflows have a max depth of 10 and cycle detection is enforced.
+
+**`manual_approval`** - Suspend workflow and wait for operator approval:
+
+```yaml
+task:
+  type: manual_approval
+  prompt: "Verify SSH access before proceeding"
+  timeout: 3600 # Optional: seconds before approve is rejected
+```
+
+The workflow suspends to disk. Approve, reject, or resume from CLI:
+
+```
+swamp workflow approve <workflow-name> <step-name>
+swamp workflow reject  <workflow-name> <step-name> --reason "Not ready"
+swamp workflow resume  <workflow-name>
+swamp workflow approvals  # list all pending approvals
+```
 
 ## Working with Vaults
 

--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -40,7 +40,7 @@ run.
 | Approve step       | `swamp workflow approve <workflow> <step>`                    |
 | Reject step        | `swamp workflow reject <workflow> <step>`                     |
 | Resume workflow    | `swamp workflow resume <workflow>`                            |
-| List approvals     | `swamp workflow approvals --json`                             |
+| List approvals     | `swamp workflow approvals`                                    |
 | View run history   | `swamp workflow history search --json`                        |
 | Get latest run     | `swamp workflow history get <workflow> --json`                |
 | View run logs      | `swamp workflow history logs <run_or_workflow> --json`        |

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -71,6 +71,50 @@ For `forEach` steps, `modelName` supports CEL template expressions:
       host: ${{ self.host }}
 ```
 
+### Manual Approval (`manual_approval`)
+
+Suspends workflow execution at a step boundary and persists the run to disk. The
+operator (or another user) approves or rejects via CLI, then the original
+operator resumes the workflow to continue executing remaining steps.
+
+```yaml
+steps:
+  - name: verify-ssh
+    task:
+      type: manual_approval
+      prompt: "Verify Tailscale SSH access from your laptop before proceeding"
+      timeout: 3600
+```
+
+**Fields:**
+
+- `prompt` (required, string) — message displayed to the operator.
+- `timeout` (optional, number) — seconds. Checked at approve time against the
+  suspension timestamp. When expired, approve is rejected.
+
+**Lifecycle: suspend → approve → resume**
+
+1. `swamp workflow run` executes until hitting a `manual_approval` step. The step
+   is marked `waiting_approval`, the run is saved as `suspended`, and the CLI
+   exits.
+2. `swamp workflow approve <workflow> <step>` marks the step as succeeded in the
+   persisted run record. Lightweight — no execution, any authorized user.
+3. `swamp workflow resume <workflow>` re-enters the executor, skips completed
+   steps, and runs remaining pending steps.
+
+`swamp workflow reject <workflow> <step>` marks the step as failed and the run as
+failed. No resume needed.
+
+`swamp workflow approvals` lists all suspended runs awaiting approval.
+
+**Persistence:** The run record survives process restarts. The approval and
+resume can happen from any machine with access to the repo (or synced
+datastore).
+
+**forEach compatibility:** A `forEach` expansion of a `manual_approval` step
+creates N parallel approval gates, each independently approvable via its expanded
+step name.
+
 ## Concurrency Limits
 
 By default, all jobs in a topological level and all steps in a topological level

--- a/integration/workflow_approval_test.ts
+++ b/integration/workflow_approval_test.ts
@@ -1,0 +1,196 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { TriggerCondition } from "../src/domain/workflows/trigger_condition.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../src/infrastructure/persistence/yaml_workflow_run_repository.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-approval-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    "models",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    "workflows",
+    ".swamp/workflow-runs",
+    "vaults",
+    ".swamp/secrets",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+
+  const markerData = {
+    swampVersion: "0.0.0",
+    initializedAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(markerData as Record<string, unknown>),
+  );
+}
+
+Deno.test("Workflow: manual_approval step task schema round-trips through YAML", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const workflow = Workflow.create({
+      name: "approval-test",
+      jobs: [
+        Job.create({
+          name: "gate",
+          steps: [
+            Step.create({
+              name: "verify-deploy",
+              task: StepTask.manualApproval(
+                "Verify the deployment is healthy",
+                300,
+              ),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const repo = new YamlWorkflowRepository(repoDir);
+    await repo.save(workflow);
+
+    const loaded = await repo.findById(workflow.id);
+    assertEquals(loaded?.name, "approval-test");
+
+    const step = loaded!.jobs[0].steps[0];
+    assertEquals(step.task.isManualApproval(), true);
+    assertEquals(step.task.data.type, "manual_approval");
+    if (step.task.data.type === "manual_approval") {
+      assertEquals(step.task.data.prompt, "Verify the deployment is healthy");
+      assertEquals(step.task.data.timeout, 300);
+    }
+  });
+});
+
+Deno.test("Workflow: manual_approval with dependencies round-trips", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const workflow = Workflow.create({
+      name: "gated-deploy",
+      jobs: [
+        Job.create({
+          name: "build-and-deploy",
+          steps: [
+            Step.create({
+              name: "build",
+              task: StepTask.model("builder", "execute"),
+            }),
+            Step.create({
+              name: "approval-gate",
+              task: StepTask.manualApproval("Verify build before deploy"),
+              dependsOn: [
+                {
+                  step: "build",
+                  condition: TriggerCondition.succeeded(),
+                },
+              ],
+            }),
+            Step.create({
+              name: "deploy",
+              task: StepTask.model("deployer", "execute"),
+              dependsOn: [
+                {
+                  step: "approval-gate",
+                  condition: TriggerCondition.succeeded(),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const repo = new YamlWorkflowRepository(repoDir);
+    await repo.save(workflow);
+
+    const loaded = await repo.findById(workflow.id);
+    assertEquals(loaded!.jobs[0].steps.length, 3);
+    assertEquals(loaded!.jobs[0].steps[1].task.isManualApproval(), true);
+    assertEquals(loaded!.jobs[0].steps[2].task.isModelMethod(), true);
+  });
+});
+
+Deno.test("Workflow: suspended run persists and round-trips", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const workflow = Workflow.create({
+      name: "suspend-test",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "step1",
+              task: StepTask.model("m", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    await workflowRepo.save(workflow);
+
+    const { WorkflowRun } = await import(
+      "../src/domain/workflows/workflow_run.ts"
+    );
+    const run = WorkflowRun.create(workflow);
+    run.start();
+
+    const job = run.getJob("job1")!;
+    job.start();
+    const step = job.getStep("step1")!;
+    step.start();
+    step.waitForApproval();
+    run.suspend();
+
+    const runRepo = new YamlWorkflowRunRepository(repoDir);
+    await runRepo.save(workflow.id, run);
+
+    const loaded = await runRepo.findById(workflow.id, run.id);
+    assertEquals(loaded!.status, "suspended");
+    const loadedStep = loaded!.getJob("job1")!.getStep("step1")!;
+    assertEquals(loadedStep.status, "waiting_approval");
+  });
+});

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -32,6 +32,10 @@ import {
 } from "./workflow_search.ts";
 import { workflowRunCommand } from "./workflow_run.ts";
 import { workflowSchemaCommand } from "./workflow_schema.ts";
+import { workflowApproveCommand } from "./workflow_approve.ts";
+import { workflowRejectCommand } from "./workflow_reject.ts";
+import { workflowResumeCommand } from "./workflow_resume.ts";
+import { workflowApprovalsCommand } from "./workflow_approvals.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const workflowCommand = new Command()
@@ -48,6 +52,10 @@ export const workflowCommand = new Command()
   .command("validate", workflowValidateCommand)
   .command("search", workflowSearchCommand)
   .command("run", workflowRunCommand)
+  .command("approve", workflowApproveCommand)
+  .command("reject", workflowRejectCommand)
+  .command("resume", workflowResumeCommand)
+  .command("approvals", workflowApprovalsCommand)
   .command("schema", workflowSchemaCommand)
   .command(
     "list",

--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -107,10 +107,15 @@ export const workflowApprovalsCommand = new Command()
           );
           cliCtx.logger.info(
             "  swamp workflow approve {workflowName} {stepName}",
-            {
-              workflowName: item.workflowName,
-              stepName: item.stepName,
-            },
+            { workflowName: item.workflowName, stepName: item.stepName },
+          );
+          cliCtx.logger.info(
+            "  swamp workflow reject  {workflowName} {stepName}",
+            { workflowName: item.workflowName, stepName: item.stepName },
+          );
+          cliCtx.logger.info(
+            "  After approval: swamp workflow resume {workflowName}",
+            { workflowName: item.workflowName },
           );
         }
       }

--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -1,0 +1,118 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowApprovalsCommand = new Command()
+  .name("approvals")
+  .description("List all workflow runs awaiting manual approval")
+  .example("List pending approvals", "swamp workflow approvals")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "workflow",
+      "approvals",
+    ]);
+
+    const { repoDir } = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const workflowRepo = new YamlWorkflowRepository(repoDir);
+    const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+    const workflows = await workflowRepo.findAll();
+
+    interface PendingApproval {
+      workflowName: string;
+      runId: string;
+      stepName: string;
+      suspendedAt: string | undefined;
+      prompt: string | undefined;
+    }
+
+    const pending: PendingApproval[] = [];
+
+    for (const workflow of workflows) {
+      const runs = await runRepo.findAllByWorkflowId(workflow.id);
+      for (const run of runs) {
+        if (run.status !== "suspended") continue;
+        const waiting = run.findWaitingApprovalStep();
+        if (!waiting) continue;
+
+        const job = run.getJob(waiting.jobName);
+        const step = job?.getStep(waiting.stepName);
+        const taskData = workflow.jobs
+          .find((j) => j.name === waiting.jobName)?.steps
+          .find((s) => s.name === waiting.stepName)?.task.data;
+        const prompt = taskData && taskData.type === "manual_approval"
+          ? taskData.prompt
+          : undefined;
+
+        pending.push({
+          workflowName: workflow.name,
+          runId: run.id,
+          stepName: waiting.stepName,
+          suspendedAt: step?.startedAt?.toISOString(),
+          prompt,
+        });
+      }
+    }
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({ approvals: pending }, null, 2));
+    } else {
+      if (pending.length === 0) {
+        cliCtx.logger.info("No workflows awaiting approval");
+      } else {
+        for (const item of pending) {
+          cliCtx.logger.info(
+            "{workflowName} / {stepName} — {prompt}",
+            {
+              workflowName: item.workflowName,
+              stepName: item.stepName,
+              prompt: item.prompt ?? "(no prompt)",
+            },
+          );
+          cliCtx.logger.info(
+            "  swamp workflow approve {workflowName} {stepName}",
+            {
+              workflowName: item.workflowName,
+              stepName: item.stepName,
+            },
+          );
+        }
+      }
+    }
+  });

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -70,7 +70,7 @@ export const workflowApproveCommand = new Command()
       const workflowRepo = new YamlWorkflowRepository(repoDir);
       const runRepo = new YamlWorkflowRunRepository(repoDir);
 
-      const { run, workflowName } = await resolveSuspendedRun(
+      const { run, workflowName, workflow } = await resolveSuspendedRun(
         workflowRepo,
         runRepo,
         workflowIdOrName,
@@ -95,11 +95,7 @@ export const workflowApproveCommand = new Command()
         );
       }
 
-      const workflow = await workflowRepo.findByName(workflowIdOrName) ??
-        await workflowRepo.findById(
-          createWorkflowId(workflowIdOrName),
-        );
-      if (workflow) {
+      {
         const wfJob = workflow.jobs.find((j) => j.name === jobName);
         const wfStep = wfJob?.steps.find((s) => s.name === stepName);
         if (
@@ -142,7 +138,8 @@ export const workflowApproveCommand = new Command()
       } else {
         cliCtx.logger
           .info`Approved step ${stepName} in workflow ${workflowName}`;
-        cliCtx.logger.info`Run: swamp workflow resume ${workflowName}`;
+        cliCtx.logger
+          .info`After approval: swamp workflow resume ${workflowName}`;
       }
     },
   );

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -1,0 +1,140 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowApproveCommand = new Command()
+  .name("approve")
+  .description("Approve a manual approval step in a suspended workflow run")
+  .example(
+    "Approve by workflow name",
+    "swamp workflow approve deploy-with-gate verify-build",
+  )
+  .example(
+    "Approve with reason",
+    "swamp workflow approve deploy-with-gate verify-build --reason 'Verified'",
+  )
+  .arguments("<workflow_id_or_name:string> <step_name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--reason <reason:string>", "Reason for approval")
+  .action(
+    async function (
+      options: AnyOptions,
+      workflowIdOrName: string,
+      stepName: string,
+    ) {
+      const cliCtx = createContext(options as GlobalOptions, [
+        "workflow",
+        "approve",
+      ]);
+
+      const { repoDir } = await requireInitializedRepo({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+      const workflowRepo = new YamlWorkflowRepository(repoDir);
+      const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+      const { run, workflowName } = await resolveSuspendedRun(
+        workflowRepo,
+        runRepo,
+        workflowIdOrName,
+      );
+
+      const waiting = run.findWaitingApprovalStep();
+      if (!waiting || waiting.stepName !== stepName) {
+        throw new UserError(
+          `Step "${stepName}" is not awaiting approval in the suspended run`,
+        );
+      }
+
+      const job = run.getJob(waiting.jobName);
+      const step = job?.getStep(stepName);
+      if (!step) {
+        throw new UserError(`Step "${stepName}" not found in run`);
+      }
+
+      const workflow = await workflowRepo.findByName(workflowIdOrName) ??
+        await workflowRepo.findById(
+          createWorkflowId(workflowIdOrName),
+        );
+      if (workflow) {
+        const wfJob = workflow.jobs.find((j) => j.name === waiting.jobName);
+        const wfStep = wfJob?.steps.find((s) => s.name === stepName);
+        if (
+          wfStep?.task.data.type === "manual_approval" &&
+          wfStep.task.data.timeout &&
+          step.startedAt
+        ) {
+          const elapsedSeconds = (Date.now() - step.startedAt.getTime()) / 1000;
+          if (elapsedSeconds > wfStep.task.data.timeout) {
+            throw new UserError(
+              `Approval timed out: step "${stepName}" has been waiting ${
+                Math.round(elapsedSeconds)
+              }s ` +
+                `(timeout: ${wfStep.task.data.timeout}s)`,
+            );
+          }
+        }
+      }
+
+      const decidedBy = Deno.env.get("USER") ??
+        Deno.env.get("USERNAME") ?? "unknown";
+      step.recordApprovalDecision({
+        approved: true,
+        reason: options.reason,
+        decidedBy,
+        decidedAt: new Date().toISOString(),
+      });
+      step.succeed();
+      await runRepo.save(createWorkflowId(run.workflowId), run);
+
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify({
+          runId: run.id,
+          workflowName,
+          stepName,
+          approved: true,
+          reason: options.reason ?? null,
+        }));
+      } else {
+        cliCtx.logger
+          .info`Approved step ${stepName} in workflow ${workflowName}`;
+        cliCtx.logger.info`Run: swamp workflow resume ${workflowName}`;
+      }
+    },
+  );

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -50,6 +50,7 @@ export const workflowApproveCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--reason <reason:string>", "Reason for approval")
+  .option("--run <run_id:string>", "Target a specific run ID")
   .action(
     async function (
       options: AnyOptions,
@@ -73,19 +74,25 @@ export const workflowApproveCommand = new Command()
         workflowRepo,
         runRepo,
         workflowIdOrName,
+        options.run,
       );
 
-      const waiting = run.findWaitingApprovalStep();
-      if (!waiting || waiting.stepName !== stepName) {
+      let step:
+        | import("../../domain/workflows/workflow_run.ts").StepRun
+        | undefined;
+      let jobName: string | undefined;
+      for (const job of run.jobs) {
+        const s = job.getStep(stepName);
+        if (s && s.status === "waiting_approval") {
+          step = s;
+          jobName = job.jobName;
+          break;
+        }
+      }
+      if (!step || !jobName) {
         throw new UserError(
           `Step "${stepName}" is not awaiting approval in the suspended run`,
         );
-      }
-
-      const job = run.getJob(waiting.jobName);
-      const step = job?.getStep(stepName);
-      if (!step) {
-        throw new UserError(`Step "${stepName}" not found in run`);
       }
 
       const workflow = await workflowRepo.findByName(workflowIdOrName) ??
@@ -93,7 +100,7 @@ export const workflowApproveCommand = new Command()
           createWorkflowId(workflowIdOrName),
         );
       if (workflow) {
-        const wfJob = workflow.jobs.find((j) => j.name === waiting.jobName);
+        const wfJob = workflow.jobs.find((j) => j.name === jobName);
         const wfStep = wfJob?.steps.find((s) => s.name === stepName);
         if (
           wfStep?.task.data.type === "manual_approval" &&
@@ -129,6 +136,7 @@ export const workflowApproveCommand = new Command()
           workflowName,
           stepName,
           approved: true,
+          decidedBy,
           reason: options.reason ?? null,
         }));
       } else {

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -50,6 +50,7 @@ export const workflowRejectCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--reason <reason:string>", "Reason for rejection")
+  .option("--run <run_id:string>", "Target a specific run ID")
   .action(
     async function (
       options: AnyOptions,
@@ -73,19 +74,27 @@ export const workflowRejectCommand = new Command()
         workflowRepo,
         runRepo,
         workflowIdOrName,
+        options.run,
       );
 
-      const waiting = run.findWaitingApprovalStep();
-      if (!waiting || waiting.stepName !== stepName) {
+      let step:
+        | import("../../domain/workflows/workflow_run.ts").StepRun
+        | undefined;
+      let matchedJob:
+        | import("../../domain/workflows/workflow_run.ts").JobRun
+        | undefined;
+      for (const job of run.jobs) {
+        const s = job.getStep(stepName);
+        if (s && s.status === "waiting_approval") {
+          step = s;
+          matchedJob = job;
+          break;
+        }
+      }
+      if (!step || !matchedJob) {
         throw new UserError(
           `Step "${stepName}" is not awaiting approval in the suspended run`,
         );
-      }
-
-      const job = run.getJob(waiting.jobName);
-      const step = job?.getStep(stepName);
-      if (!step) {
-        throw new UserError(`Step "${stepName}" not found in run`);
       }
 
       const decidedBy = Deno.env.get("USER") ??
@@ -97,7 +106,7 @@ export const workflowRejectCommand = new Command()
         decidedAt: new Date().toISOString(),
       });
       step.fail(options.reason ?? "Approval rejected");
-      job!.fail();
+      matchedJob.fail();
       run.complete();
       await runRepo.save(createWorkflowId(workflowId), run);
 
@@ -107,11 +116,13 @@ export const workflowRejectCommand = new Command()
           workflowName,
           stepName,
           approved: false,
+          decidedBy,
           reason: options.reason ?? null,
         }));
       } else {
         cliCtx.logger
           .info`Rejected step ${stepName} in workflow ${workflowName}`;
+        cliCtx.logger.info("Workflow run marked as failed.");
       }
     },
   );

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -1,0 +1,117 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowRejectCommand = new Command()
+  .name("reject")
+  .description("Reject a manual approval step in a suspended workflow run")
+  .example(
+    "Reject a step",
+    "swamp workflow reject deploy-with-gate verify-build",
+  )
+  .example(
+    "Reject with reason",
+    "swamp workflow reject deploy-with-gate verify-build --reason 'Not ready'",
+  )
+  .arguments("<workflow_id_or_name:string> <step_name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--reason <reason:string>", "Reason for rejection")
+  .action(
+    async function (
+      options: AnyOptions,
+      workflowIdOrName: string,
+      stepName: string,
+    ) {
+      const cliCtx = createContext(options as GlobalOptions, [
+        "workflow",
+        "reject",
+      ]);
+
+      const { repoDir } = await requireInitializedRepo({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+      const workflowRepo = new YamlWorkflowRepository(repoDir);
+      const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+      const { run, workflowName, workflowId } = await resolveSuspendedRun(
+        workflowRepo,
+        runRepo,
+        workflowIdOrName,
+      );
+
+      const waiting = run.findWaitingApprovalStep();
+      if (!waiting || waiting.stepName !== stepName) {
+        throw new UserError(
+          `Step "${stepName}" is not awaiting approval in the suspended run`,
+        );
+      }
+
+      const job = run.getJob(waiting.jobName);
+      const step = job?.getStep(stepName);
+      if (!step) {
+        throw new UserError(`Step "${stepName}" not found in run`);
+      }
+
+      const decidedBy = Deno.env.get("USER") ??
+        Deno.env.get("USERNAME") ?? "unknown";
+      step.recordApprovalDecision({
+        approved: false,
+        reason: options.reason,
+        decidedBy,
+        decidedAt: new Date().toISOString(),
+      });
+      step.fail(options.reason ?? "Approval rejected");
+      job!.fail();
+      run.complete();
+      await runRepo.save(createWorkflowId(workflowId), run);
+
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify({
+          runId: run.id,
+          workflowName,
+          stepName,
+          approved: false,
+          reason: options.reason ?? null,
+        }));
+      } else {
+        cliCtx.logger
+          .info`Rejected step ${stepName} in workflow ${workflowName}`;
+      }
+    },
+  );

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -118,6 +118,7 @@ export const workflowRejectCommand = new Command()
           approved: false,
           decidedBy,
           reason: options.reason ?? null,
+          runStatus: "failed",
         }));
       } else {
         cliCtx.logger

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -163,6 +163,7 @@ export const workflowResumeCommand = new Command()
         datastoreResolver?.resolvePath(SWAMP_SUBDIRS.data),
         repoContext.catalogStore,
         directResolver,
+        repoContext.markDirty,
       );
 
       const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -45,7 +45,7 @@ import { resolveModelType } from "../../domain/extensions/extension_auto_resolve
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { consumeStream } from "../../libswamp/mod.ts";
-import type { WorkflowRunEvent } from "../../libswamp/workflows/run.ts";
+import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { GIT_SHA } from "./version.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -64,6 +64,7 @@ export const workflowResumeCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--driver <driver:string>", "Override execution driver")
+  .option("--run <run_id:string>", "Target a specific run ID")
   .action(
     async function (
       options: AnyOptions,
@@ -87,6 +88,7 @@ export const workflowResumeCommand = new Command()
         workflowRepo,
         runRepo,
         workflowIdOrName,
+        options.run,
       );
 
       const waiting = run.findWaitingApprovalStep();

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -1,0 +1,188 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
+import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  type DirectTypeResolver,
+  WorkflowExecutionService,
+} from "../../domain/workflows/execution_service.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
+import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import type { DefinitionId } from "../../domain/definitions/definition.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../auto_resolver_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { consumeStream } from "../../libswamp/mod.ts";
+import type { WorkflowRunEvent } from "../../libswamp/workflows/run.ts";
+import { GIT_SHA } from "./version.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const workflowResumeCommand = new Command()
+  .name("resume")
+  .description("Resume a suspended workflow run after approval")
+  .example(
+    "Resume by workflow name",
+    "swamp workflow resume deploy-with-gate",
+  )
+  .arguments("<workflow_id_or_name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--driver <driver:string>", "Override execution driver")
+  .action(
+    async function (
+      options: AnyOptions,
+      workflowIdOrName: string,
+    ) {
+      const cliCtx = createContext(options as GlobalOptions, [
+        "workflow",
+        "resume",
+      ]);
+
+      const { repoDir, repoContext, datastoreResolver } =
+        await requireInitializedRepo({
+          repoDir: resolveRepoDir(options.repoDir),
+          outputMode: cliCtx.outputMode,
+        });
+
+      const workflowRepo = new YamlWorkflowRepository(repoDir);
+      const runRepo = new YamlWorkflowRunRepository(repoDir);
+
+      const { run, workflowName } = await resolveSuspendedRun(
+        workflowRepo,
+        runRepo,
+        workflowIdOrName,
+      );
+
+      const waiting = run.findWaitingApprovalStep();
+      if (waiting) {
+        throw new UserError(
+          `Step "${waiting.stepName}" is still awaiting approval. ` +
+            `Run "swamp workflow approve ${workflowName} ${waiting.stepName}" first.`,
+        );
+      }
+
+      const directResolver: DirectTypeResolver = async (
+        typeArg,
+        defName,
+        methodName,
+        inputs,
+      ) => {
+        let resolvedType = ModelType.create(typeArg);
+        let modelDef = await resolveModelType(
+          resolvedType,
+          getAutoResolver(),
+        );
+        if (!modelDef && typeArg.startsWith("@")) {
+          const strippedType = ModelType.create(typeArg.slice(1));
+          const strippedDef = await resolveModelType(
+            strippedType,
+            getAutoResolver(),
+          );
+          if (strippedDef) {
+            resolvedType = strippedType;
+            modelDef = strippedDef;
+          }
+        }
+        if (!modelDef) {
+          throw new Error(`Unknown model type: ${resolvedType.normalized}`);
+        }
+        const autoDefRepo = new YamlDefinitionRepository(
+          repoDir,
+          undefined,
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          false,
+        );
+        const result = await resolveOrCreateDefinition(
+          {
+            lookupDefinition: (name) =>
+              findDefinitionByIdOrName(repoContext.definitionRepo, name),
+            getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+            saveDefinition: (type, def) => autoDefRepo.save(type, def),
+            getDefinitionPath: (type, id) =>
+              autoDefRepo.getPath(type, id as DefinitionId),
+          },
+          typeArg,
+          defName,
+          methodName,
+          inputs,
+          resolvedType,
+          modelDef,
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        return {
+          definition: result.definition,
+          modelType: result.modelType,
+          created: result.created,
+          routedMethodInputs: result.routedInputs.methodArguments,
+        };
+      };
+
+      const service = new WorkflowExecutionService(
+        workflowRepo,
+        runRepo,
+        repoDir,
+        undefined,
+        datastoreResolver?.resolvePath(SWAMP_SUBDIRS.data),
+        repoContext.catalogStore,
+        directResolver,
+      );
+
+      const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
+        workflowName,
+      });
+
+      async function* resumeGenerator(): AsyncGenerator<WorkflowRunEvent> {
+        for await (
+          const event of service.resume(workflowName, run.id, {
+            signal: AbortSignal.timeout(600_000),
+            driver: options.driver,
+            swampSha: GIT_SHA,
+          })
+        ) {
+          yield event as WorkflowRunEvent;
+        }
+      }
+
+      await consumeStream(resumeGenerator(), renderer.handlers());
+
+      if (renderer.workflowFailed()) {
+        Deno.exitCode = 1;
+      }
+    },
+  );

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -62,6 +62,14 @@ export type WorkflowExecutionEvent =
   }
   | { kind: "step_skipped"; jobId: string; stepId: string }
   | {
+    kind: "approval_requested";
+    runId: string;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
+  | {
     kind: "step_failed";
     jobId: string;
     stepId: string;
@@ -150,4 +158,12 @@ export type WorkflowExecutionEvent =
     jobId?: string;
     stepId?: string;
   }
-  | { kind: "completed"; run: WorkflowRun };
+  | { kind: "completed"; run: WorkflowRun }
+  | {
+    kind: "suspended";
+    run: WorkflowRun;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -31,7 +31,11 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
-import { createWorkflowId, type WorkflowId } from "./workflow_id.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+  type WorkflowId,
+} from "./workflow_id.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
@@ -112,6 +116,22 @@ import {
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_marker_loader.ts";
 import { extractSensitiveFieldValues } from "../models/sensitive_field_extractor.ts";
+
+/**
+ * Thrown when a manual_approval step suspends the workflow.
+ * Caught by the run() generator to yield a suspended terminal event.
+ */
+export class WorkflowSuspendedError extends Error {
+  constructor(
+    readonly jobId: string,
+    readonly stepId: string,
+    readonly prompt: string,
+    readonly timeout?: number,
+  ) {
+    super(`Workflow suspended at step "${stepId}" — awaiting manual approval`);
+    this.name = "WorkflowSuspendedError";
+  }
+}
 
 /**
  * Context for step execution.
@@ -1314,6 +1334,7 @@ export class WorkflowExecutionService {
       attributes: { "workflow.name": idOrName },
     });
 
+    let workflowRun: WorkflowRun | undefined;
     try {
       const wfSetupSpan = tracer.startSpan("swamp.workflow.setup");
       let workflow: Workflow;
@@ -1389,6 +1410,7 @@ export class WorkflowExecutionService {
           ...(options?.runtimeTags ?? {}),
         };
         run = WorkflowRun.create(workflow, mergedTags);
+        workflowRun = run;
 
         // workflowRunId is set here for backward compat; the structured
         // run namespace is populated after run.start() below so that
@@ -1585,6 +1607,19 @@ export class WorkflowExecutionService {
       }
       runSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
+      if (error instanceof WorkflowSuspendedError && workflowRun) {
+        yield {
+          kind: "suspended" as const,
+          run: workflowRun,
+          jobId: error.jobId,
+          stepId: error.stepId,
+          prompt: error.prompt,
+          timeout: error.timeout,
+        };
+        runSpan.setStatus({ code: SpanStatusCode.OK });
+        runSpan.end();
+        return;
+      }
       runSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),
@@ -1616,6 +1651,209 @@ export class WorkflowExecutionService {
     }
     if (!result) throw new Error("Workflow run did not complete");
     return result;
+  }
+
+  /**
+   * Resumes a suspended workflow run from the point where it was paused.
+   * The approval step must already be marked as succeeded (by the approve command).
+   * Skips completed/failed/skipped steps and executes remaining pending ones.
+   */
+  async *resume(
+    workflowIdOrName: string,
+    runId: string,
+    options?: {
+      signal?: AbortSignal;
+      driver?: string;
+      runtimeTags?: Record<string, string>;
+      reportFilterOptions?: ReportFilterOptions;
+      swampSha?: string;
+    },
+  ): AsyncGenerator<WorkflowExecutionEvent> {
+    const workflow = await this.workflowRepo.findByName(workflowIdOrName) ??
+      await this.workflowRepo.findById(createWorkflowId(workflowIdOrName));
+    if (!workflow) {
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+    }
+
+    const existingRun = await this.runRepo.findById(
+      workflow.id,
+      createWorkflowRunId(runId),
+    );
+    if (!existingRun) {
+      throw new UserError(`Workflow run not found: ${runId}`);
+    }
+    if (existingRun.status !== "suspended") {
+      throw new UserError(
+        `Run ${runId} is not suspended (status: ${existingRun.status})`,
+      );
+    }
+
+    const waiting = existingRun.findWaitingApprovalStep();
+    if (waiting) {
+      throw new UserError(
+        `Step "${waiting.stepName}" in job "${waiting.jobName}" is still awaiting approval. ` +
+          `Run "swamp workflow approve ${workflowIdOrName} ${waiting.stepName}" first.`,
+      );
+    }
+
+    existingRun.resumeFromSuspended();
+    await this.saveRun(workflow.id, existingRun);
+
+    const expressionContext = await this.modelResolver.buildContext();
+    if (options?.runtimeTags) {
+      expressionContext.inputs = expressionContext.inputs ?? {};
+    }
+
+    const evaluator = new WorkflowExpressionEvaluator(
+      new CelEvaluator(),
+    );
+    const evaluated = await evaluator.evaluate(workflow, expressionContext);
+    const resolvedWorkflow = evaluated.workflow;
+
+    const secretRedactor = new SecretRedactor();
+
+    // Re-register the log file sink so resume output is captured
+    const workflowLogPath = existingRun.logFile ??
+      join(
+        swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns),
+        workflow.id,
+        `workflow-run-${existingRun.id}.log`,
+      );
+    const workflowLogCategory: string[] = [];
+    await runFileSink.register(
+      workflowLogCategory,
+      workflowLogPath,
+      secretRedactor,
+      swampPath(this.repoDir),
+    );
+
+    yield {
+      kind: "started",
+      runId: existingRun.id,
+      workflowName: resolvedWorkflow.name,
+      logPath: workflowLogPath,
+      jobs: resolvedWorkflow.jobs.map((job) => ({
+        id: job.name,
+        stepCount: job.steps.length,
+        dependsOn: job.getDependencyNames(),
+      })),
+    };
+
+    const stepOpts: StepOptions = {
+      workflowTags: resolvedWorkflow.tags,
+      runtimeTags: options?.runtimeTags,
+      secretRedactor,
+      signal: options?.signal,
+      driver: options?.driver,
+      reportFilterOptions: options?.reportFilterOptions,
+      swampSha: options?.swampSha,
+    };
+
+    const jobNodes: GraphNode[] = resolvedWorkflow.jobs.map((job) => ({
+      name: job.name,
+      weight: job.weight,
+      dependencies: job.getDependencyNames(),
+    }));
+    const sortedJobs = this.sortService.sort(jobNodes);
+    const jobConcurrency = resolvedWorkflow.concurrency;
+
+    const modelInfoByStep = new Map<
+      string,
+      {
+        modelName: string;
+        modelType: string;
+        modelId: string;
+        methodName: string;
+      }
+    >();
+    const stepStatuses = new Map<string, "succeeded" | "failed" | "skipped">();
+    const stepJobNames = new Map<string, string>();
+    const dataHandlesByStep = new Map<
+      string,
+      import("../models/model.ts").DataHandle[]
+    >();
+
+    try {
+      for (const level of sortedJobs.levels) {
+        const jobStreams = level.map((jobName: string) => {
+          const jobRun = existingRun.getJob(jobName);
+          if (
+            jobRun &&
+            (jobRun.status === "succeeded" || jobRun.status === "failed" ||
+              jobRun.status === "skipped")
+          ) {
+            return (async function* () {})();
+          }
+          return this.runJob(
+            resolvedWorkflow,
+            existingRun,
+            jobName,
+            expressionContext,
+            stepOpts,
+          );
+        });
+        for await (
+          const event of mergeWithConcurrency(
+            jobStreams,
+            jobConcurrency,
+            options?.signal,
+          )
+        ) {
+          if (event.kind === "model_resolved") {
+            const key = `${event.jobId}:${event.stepId}`;
+            modelInfoByStep.set(key, {
+              modelName: event.modelName,
+              modelType: event.modelType,
+              modelId: event.modelId,
+              methodName: event.methodName,
+            });
+            stepJobNames.set(key, event.jobId);
+          } else if (event.kind === "step_completed") {
+            const key = `${event.jobId}:${event.stepId}`;
+            stepStatuses.set(key, "succeeded");
+            if (event.dataHandles) {
+              dataHandlesByStep.set(key, event.dataHandles);
+            }
+          } else if (event.kind === "step_failed") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "failed");
+          } else if (event.kind === "step_skipped") {
+            stepStatuses.set(`${event.jobId}:${event.stepId}`, "skipped");
+          }
+          yield event as WorkflowExecutionEvent;
+        }
+        await this.saveRun(workflow.id, existingRun);
+      }
+
+      existingRun.complete();
+
+      yield* this.runWorkflowReports(
+        resolvedWorkflow,
+        existingRun,
+        modelInfoByStep,
+        stepStatuses,
+        stepJobNames,
+        dataHandlesByStep,
+        options?.reportFilterOptions,
+      );
+
+      yield { kind: "completed", run: existingRun };
+      await this.saveRun(workflow.id, existingRun);
+      runFileSink.unregister(workflowLogCategory);
+    } catch (error) {
+      runFileSink.unregister(workflowLogCategory);
+      if (error instanceof WorkflowSuspendedError) {
+        yield {
+          kind: "suspended" as const,
+          run: existingRun,
+          jobId: error.jobId,
+          stepId: error.stepId,
+          prompt: error.prompt,
+          timeout: error.timeout,
+        };
+        return;
+      }
+      throw error;
+    }
   }
 
   private async *runJob(
@@ -1650,8 +1888,10 @@ export class WorkflowExecutionService {
         return;
       }
 
-      // Start job
-      jobRun.start();
+      // Start job (skip if already running from a resumed suspended run)
+      if (jobRun.status !== "running") {
+        jobRun.start();
+      }
       yield { kind: "job_started", jobId: jobName };
 
       // Expand forEach steps if we have expression context.
@@ -1843,6 +2083,16 @@ export class WorkflowExecutionService {
       jobRun.addExpandedStep(stepName);
       stepRun = jobRun.getStep(stepName);
     }
+    // Skip steps that already completed (during resume from suspended state)
+    if (
+      stepRun &&
+      (stepRun.status === "succeeded" || stepRun.status === "failed" ||
+        stepRun.status === "skipped")
+    ) {
+      stepSpan.end();
+      return;
+    }
+
     if (!stepRun) {
       stepSpan.end();
       throw new Error(`Step run not found: ${stepName}`);
@@ -1892,6 +2142,27 @@ export class WorkflowExecutionService {
       }
 
       const task = step.task.data;
+
+      // Handle manual approval tasks — suspend the workflow
+      if (task.type === "manual_approval") {
+        stepRun.waitForApproval();
+        yield {
+          kind: "approval_requested",
+          runId: run.id,
+          jobId: job.name,
+          stepId: stepName,
+          prompt: task.prompt,
+          timeout: task.timeout,
+        };
+        run.suspend();
+        await this.saveRun(workflow.id, run);
+        throw new WorkflowSuspendedError(
+          job.name,
+          stepName,
+          task.prompt,
+          task.timeout,
+        );
+      }
 
       // Handle workflow tasks inline to forward nested workflow events
       if (task.type === "workflow") {
@@ -2041,6 +2312,10 @@ export class WorkflowExecutionService {
         dataHandles: stepDataHandles,
       };
     } catch (error) {
+      if (error instanceof WorkflowSuspendedError) {
+        stepSpan.end();
+        throw error;
+      }
       // Record data artifacts that were written before the throw so they
       // survive in the workflow run record for later data get --workflow.
       const errorArtifacts = (error as Record<string, unknown>).dataArtifacts as

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -118,8 +118,14 @@ import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_ma
 import { extractSensitiveFieldValues } from "../models/sensitive_field_extractor.ts";
 
 /**
- * Thrown when a manual_approval step suspends the workflow.
- * Caught by the run() generator to yield a suspended terminal event.
+ * Thrown when a manual_approval step suspends the workflow. Uses an
+ * exception for control flow because the generator stack (runStep →
+ * runJob → merge → run) has no other way to unwind cleanly — yield
+ * can only travel one frame up, but suspension must exit the entire
+ * execution. Caught by run() and resume() to yield the terminal
+ * suspended event. Also re-detected after mergeWithConcurrency via
+ * run.status === "suspended" since merge() swallows errors from
+ * parallel streams.
  */
 export class WorkflowSuspendedError extends Error {
   constructor(
@@ -1335,13 +1341,13 @@ export class WorkflowExecutionService {
     });
 
     let workflowRun: WorkflowRun | undefined;
+    let workflowLogCategory: string[] | undefined;
     try {
       const wfSetupSpan = tracer.startSpan("swamp.workflow.setup");
       let workflow: Workflow;
       let expressionContext: ExpressionContext | undefined;
       let run: WorkflowRun;
       let workflowLogPath: string;
-      let workflowLogCategory: string[];
       const secretRedactor = new SecretRedactor();
 
       try {
@@ -1630,6 +1636,9 @@ export class WorkflowExecutionService {
       runSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
       if (error instanceof WorkflowSuspendedError && workflowRun) {
+        if (workflowLogCategory) {
+          runFileSink.unregister(workflowLogCategory);
+        }
         yield {
           kind: "suspended" as const,
           run: workflowRun,
@@ -1639,7 +1648,6 @@ export class WorkflowExecutionService {
           timeout: error.timeout,
         };
         runSpan.setStatus({ code: SpanStatusCode.OK });
-        runSpan.end();
         return;
       }
       runSpan.setStatus({
@@ -1670,6 +1678,7 @@ export class WorkflowExecutionService {
     let result: WorkflowRun | undefined;
     for await (const event of this.run(idOrName, options)) {
       if (event.kind === "completed") result = event.run;
+      if (event.kind === "suspended") result = event.run;
     }
     if (!result) throw new Error("Workflow run did not complete");
     return result;
@@ -1722,9 +1731,6 @@ export class WorkflowExecutionService {
     await this.saveRun(workflow.id, existingRun);
 
     const expressionContext = await this.modelResolver.buildContext();
-    if (options?.runtimeTags) {
-      expressionContext.inputs = expressionContext.inputs ?? {};
-    }
 
     const evaluator = new WorkflowExpressionEvaluator(
       new CelEvaluator(),

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1566,6 +1566,28 @@ export class WorkflowExecutionService {
           yield event;
         }
         await this.saveRun(workflow.id, run);
+
+        // If a manual_approval step suspended the run during parallel
+        // execution, merge() swallows the WorkflowSuspendedError. Detect
+        // this by checking the run status and re-throwing so the outer
+        // catch handler yields the suspended terminal event.
+        if (run.status === "suspended") {
+          const waiting = run.findWaitingApprovalStep();
+          if (waiting) {
+            const wfStep = workflow.jobs
+              .find((j) => j.name === waiting.jobName)?.steps
+              .find((s) => s.name === waiting.stepName);
+            const taskData = wfStep?.task.data;
+            throw new WorkflowSuspendedError(
+              waiting.jobName,
+              waiting.stepName,
+              taskData?.type === "manual_approval" ? taskData.prompt : "",
+              taskData?.type === "manual_approval"
+                ? taskData.timeout
+                : undefined,
+            );
+          }
+        }
       }
 
       // Complete workflow
@@ -1822,6 +1844,24 @@ export class WorkflowExecutionService {
           yield event as WorkflowExecutionEvent;
         }
         await this.saveRun(workflow.id, existingRun);
+
+        if (existingRun.status === "suspended") {
+          const waiting = existingRun.findWaitingApprovalStep();
+          if (waiting) {
+            const wfStep = resolvedWorkflow.jobs
+              .find((j) => j.name === waiting.jobName)?.steps
+              .find((s) => s.name === waiting.stepName);
+            const taskData = wfStep?.task.data;
+            throw new WorkflowSuspendedError(
+              waiting.jobName,
+              waiting.stepName,
+              taskData?.type === "manual_approval" ? taskData.prompt : "",
+              taskData?.type === "manual_approval"
+                ? taskData.timeout
+                : undefined,
+            );
+          }
+        }
       }
 
       existingRun.complete();
@@ -2018,6 +2058,24 @@ export class WorkflowExecutionService {
           yield event;
           if (event.kind === "step_failed" && !event.allowedFailure) {
             jobFailed = true;
+          }
+        }
+
+        if (run.status === "suspended") {
+          const waiting = run.findWaitingApprovalStep();
+          if (waiting) {
+            const wfStep = workflow.jobs
+              .find((j) => j.name === job.name)?.steps
+              .find((s) => s.name === waiting.stepName);
+            const taskData = wfStep?.task.data;
+            throw new WorkflowSuspendedError(
+              job.name,
+              waiting.stepName,
+              taskData?.type === "manual_approval" ? taskData.prompt : "",
+              taskData?.type === "manual_approval"
+                ? taskData.timeout
+                : undefined,
+            );
           }
         }
       }

--- a/src/domain/workflows/expression_evaluators_test.ts
+++ b/src/domain/workflows/expression_evaluators_test.ts
@@ -134,7 +134,8 @@ Deno.test("WorkflowExpressionEvaluator: skips run.* (resolved at step execution 
   const result = await evaluator.evaluate(workflow, emptyContext());
   assertEquals(result.expressionsEvaluated, 0);
   const step = result.workflow.jobs[0].steps[0];
-  const inputs = step.task.data.inputs ?? {};
+  const inputs = ("inputs" in step.task.data ? step.task.data.inputs : {}) ??
+    {};
   assertEquals(inputs["resourceKey"], "vms-${{ run.id }}");
   assertEquals(inputs["wfName"], "${{ run.workflowName }}");
 });
@@ -160,7 +161,8 @@ Deno.test("WorkflowExpressionEvaluator: skips bare workflowRunId (resolved at st
   const result = await evaluator.evaluate(workflow, emptyContext());
   assertEquals(result.expressionsEvaluated, 0);
   const step = result.workflow.jobs[0].steps[0];
-  const inputs = step.task.data.inputs ?? {};
+  const inputs = ("inputs" in step.task.data ? step.task.data.inputs : {}) ??
+    {};
   assertEquals(inputs["runId"], "${{ workflowRunId }}");
 });
 

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -40,6 +40,11 @@ const StepTaskRawSchema = z.discriminatedUnion("type", [
     workflowIdOrName: z.string().min(1),
     inputs: z.record(z.string(), z.unknown()).optional(),
   }),
+  z.object({
+    type: z.literal("manual_approval"),
+    prompt: z.string().min(1),
+    timeout: z.number().positive().optional(),
+  }),
 ]);
 
 /**
@@ -180,6 +185,20 @@ export class StepTask {
   }
 
   /**
+   * Creates a manual approval task.
+   */
+  static manualApproval(
+    prompt: string,
+    timeout?: number,
+  ): StepTask {
+    return new StepTask({
+      type: "manual_approval",
+      prompt,
+      timeout,
+    });
+  }
+
+  /**
    * Returns true if this is a model method task.
    */
   isModelMethod(): boolean {
@@ -199,6 +218,13 @@ export class StepTask {
    */
   isWorkflow(): boolean {
     return this.data.type === "workflow";
+  }
+
+  /**
+   * Returns true if this is a manual approval task.
+   */
+  isManualApproval(): boolean {
+    return this.data.type === "manual_approval";
   }
 
   /**

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -284,6 +284,69 @@ Deno.test("StepTaskSchema rejects neither modelIdOrName nor modelType", () => {
   );
 });
 
+// Manual approval tests
+
+Deno.test("StepTask.manualApproval creates manual approval task", () => {
+  const task = StepTask.manualApproval("Verify SSH access before proceeding");
+  assertEquals(task.data, {
+    type: "manual_approval",
+    prompt: "Verify SSH access before proceeding",
+    timeout: undefined,
+  });
+  assertEquals(task.isManualApproval(), true);
+  assertEquals(task.isModelMethod(), false);
+  assertEquals(task.isWorkflow(), false);
+});
+
+Deno.test("StepTask.manualApproval creates task with timeout", () => {
+  const task = StepTask.manualApproval("Approve deployment", 3600);
+  assertEquals(task.data, {
+    type: "manual_approval",
+    prompt: "Approve deployment",
+    timeout: 3600,
+  });
+});
+
+Deno.test("StepTask.fromData creates manual approval task", () => {
+  const task = StepTask.fromData({
+    type: "manual_approval",
+    prompt: "Check the dashboard",
+  });
+  assertEquals(task.isManualApproval(), true);
+});
+
+Deno.test("StepTask.toData returns correct structure for manual approval task", () => {
+  const task = StepTask.manualApproval("Verify deploy", 300);
+  const data = task.toData();
+  assertEquals(data, {
+    type: "manual_approval",
+    prompt: "Verify deploy",
+    timeout: 300,
+  });
+});
+
+Deno.test("StepTask.equals returns true for identical manual approval tasks", () => {
+  const task1 = StepTask.manualApproval("Check", 60);
+  const task2 = StepTask.manualApproval("Check", 60);
+  assertEquals(task1.equals(task2), true);
+});
+
+Deno.test("StepTaskSchema rejects empty prompt for manual_approval", () => {
+  assertThrows(() => {
+    StepTaskSchema.parse({ type: "manual_approval", prompt: "" });
+  });
+});
+
+Deno.test("StepTaskSchema rejects negative timeout for manual_approval", () => {
+  assertThrows(() => {
+    StepTaskSchema.parse({
+      type: "manual_approval",
+      prompt: "Check",
+      timeout: -1,
+    });
+  });
+});
+
 Deno.test("StepTaskSchema throws clear error for arguments instead of inputs", () => {
   assertThrows(
     () => {

--- a/src/domain/workflows/suspended_run_resolver.ts
+++ b/src/domain/workflows/suspended_run_resolver.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { WorkflowRun } from "./workflow_run.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "./repositories.ts";
+import { createWorkflowId } from "./workflow_id.ts";
+import { UserError } from "../errors.ts";
+
+export interface SuspendedRunInfo {
+  workflowName: string;
+  workflowId: string;
+  run: WorkflowRun;
+}
+
+export async function resolveSuspendedRun(
+  workflowRepo: WorkflowRepository,
+  runRepo: WorkflowRunRepository,
+  workflowIdOrName: string,
+): Promise<SuspendedRunInfo> {
+  const workflow = await workflowRepo.findByName(workflowIdOrName) ??
+    await workflowRepo.findById(createWorkflowId(workflowIdOrName));
+  if (!workflow) {
+    throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+  }
+
+  const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
+  const suspendedRuns = allRuns.filter((r) => r.status === "suspended");
+
+  if (suspendedRuns.length === 0) {
+    throw new UserError(
+      `No suspended runs found for workflow "${workflow.name}"`,
+    );
+  }
+  if (suspendedRuns.length > 1) {
+    const ids = suspendedRuns.map((r) => r.id).join(", ");
+    throw new UserError(
+      `Multiple suspended runs found for workflow "${workflow.name}": ${ids}. ` +
+        `Specify a run ID instead of the workflow name.`,
+    );
+  }
+
+  return {
+    workflowName: workflow.name,
+    workflowId: workflow.id,
+    run: suspendedRuns[0],
+  };
+}

--- a/src/domain/workflows/suspended_run_resolver.ts
+++ b/src/domain/workflows/suspended_run_resolver.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { Workflow } from "./workflow.ts";
 import type { WorkflowRun } from "./workflow_run.ts";
 import type {
   WorkflowRepository,
@@ -28,6 +29,7 @@ import { UserError } from "../errors.ts";
 export interface SuspendedRunInfo {
   workflowName: string;
   workflowId: string;
+  workflow: Workflow;
   run: WorkflowRun;
 }
 
@@ -56,7 +58,12 @@ export async function resolveSuspendedRun(
         `Run ${runId} is not suspended (status: ${run.status})`,
       );
     }
-    return { workflowName: workflow.name, workflowId: workflow.id, run };
+    return {
+      workflowName: workflow.name,
+      workflowId: workflow.id,
+      workflow,
+      run,
+    };
   }
 
   const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
@@ -78,6 +85,7 @@ export async function resolveSuspendedRun(
   return {
     workflowName: workflow.name,
     workflowId: workflow.id,
+    workflow,
     run: suspendedRuns[0],
   };
 }

--- a/src/domain/workflows/suspended_run_resolver.ts
+++ b/src/domain/workflows/suspended_run_resolver.ts
@@ -22,7 +22,7 @@ import type {
   WorkflowRepository,
   WorkflowRunRepository,
 } from "./repositories.ts";
-import { createWorkflowId } from "./workflow_id.ts";
+import { createWorkflowId, createWorkflowRunId } from "./workflow_id.ts";
 import { UserError } from "../errors.ts";
 
 export interface SuspendedRunInfo {
@@ -35,11 +35,28 @@ export async function resolveSuspendedRun(
   workflowRepo: WorkflowRepository,
   runRepo: WorkflowRunRepository,
   workflowIdOrName: string,
+  runId?: string,
 ): Promise<SuspendedRunInfo> {
   const workflow = await workflowRepo.findByName(workflowIdOrName) ??
     await workflowRepo.findById(createWorkflowId(workflowIdOrName));
   if (!workflow) {
     throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+  }
+
+  if (runId) {
+    const run = await runRepo.findById(
+      workflow.id,
+      createWorkflowRunId(runId),
+    );
+    if (!run) {
+      throw new UserError(`Workflow run not found: ${runId}`);
+    }
+    if (run.status !== "suspended") {
+      throw new UserError(
+        `Run ${runId} is not suspended (status: ${run.status})`,
+      );
+    }
+    return { workflowName: workflow.name, workflowId: workflow.id, run };
   }
 
   const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
@@ -51,10 +68,10 @@ export async function resolveSuspendedRun(
     );
   }
   if (suspendedRuns.length > 1) {
-    const ids = suspendedRuns.map((r) => r.id).join(", ");
+    const ids = suspendedRuns.map((r) => r.id).join("\n  ");
     throw new UserError(
-      `Multiple suspended runs found for workflow "${workflow.name}": ${ids}. ` +
-        `Specify a run ID instead of the workflow name.`,
+      `Multiple suspended runs found for workflow "${workflow.name}":\n  ${ids}\n` +
+        `Use --run <run-id> to specify which run to target.`,
     );
   }
 

--- a/src/domain/workflows/suspended_run_resolver_test.ts
+++ b/src/domain/workflows/suspended_run_resolver_test.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { resolveSuspendedRun } from "./suspended_run_resolver.ts";
+import { Workflow } from "./workflow.ts";
+import { Job } from "./job.ts";
+import { Step } from "./step.ts";
+import { StepTask } from "./step_task.ts";
+import { WorkflowRun } from "./workflow_run.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "./repositories.ts";
+import type { WorkflowId, WorkflowRunId } from "./workflow_id.ts";
+
+function createWorkflow(name: string): Workflow {
+  return Workflow.create({
+    name,
+    jobs: [
+      Job.create({
+        name: "j",
+        steps: [Step.create({ name: "s", task: StepTask.model("m", "run") })],
+      }),
+    ],
+  });
+}
+
+function createSuspendedRun(workflow: Workflow): WorkflowRun {
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.suspend();
+  return run;
+}
+
+function stubRepos(
+  workflow: Workflow | null,
+  runs: WorkflowRun[],
+): { workflowRepo: WorkflowRepository; runRepo: WorkflowRunRepository } {
+  return {
+    workflowRepo: {
+      findByName: (name: string) =>
+        Promise.resolve(workflow?.name === name ? workflow : null),
+      findById: (_id: WorkflowId) => Promise.resolve(workflow),
+      findAll: () => Promise.resolve(workflow ? [workflow] : []),
+      save: () => Promise.resolve(),
+      delete: () => Promise.resolve(),
+      getPath: () => "",
+    } as unknown as WorkflowRepository,
+    runRepo: {
+      findAllByWorkflowId: () => Promise.resolve(runs),
+      findById: (_wfId: WorkflowId, runId: WorkflowRunId) =>
+        Promise.resolve(
+          runs.find((r) => r.id === (runId as string)) ?? null,
+        ),
+      save: () => Promise.resolve(),
+    } as unknown as WorkflowRunRepository,
+  };
+}
+
+Deno.test("resolveSuspendedRun: returns single suspended run by name", async () => {
+  const wf = createWorkflow("test-wf");
+  const run = createSuspendedRun(wf);
+  const { workflowRepo, runRepo } = stubRepos(wf, [run]);
+
+  const result = await resolveSuspendedRun(workflowRepo, runRepo, "test-wf");
+  assertEquals(result.workflowName, "test-wf");
+  assertEquals(result.run.id, run.id);
+  assertEquals(result.workflow.name, "test-wf");
+});
+
+Deno.test("resolveSuspendedRun: throws when workflow not found", async () => {
+  const { workflowRepo, runRepo } = stubRepos(null, []);
+
+  await assertRejects(
+    () => resolveSuspendedRun(workflowRepo, runRepo, "nonexistent"),
+    Error,
+    "Workflow not found",
+  );
+});
+
+Deno.test("resolveSuspendedRun: throws when no suspended runs", async () => {
+  const wf = createWorkflow("test-wf");
+  const run = WorkflowRun.create(wf);
+  run.start();
+  run.complete();
+  const { workflowRepo, runRepo } = stubRepos(wf, [run]);
+
+  await assertRejects(
+    () => resolveSuspendedRun(workflowRepo, runRepo, "test-wf"),
+    Error,
+    "No suspended runs found",
+  );
+});
+
+Deno.test("resolveSuspendedRun: throws when multiple suspended runs", async () => {
+  const wf = createWorkflow("test-wf");
+  const run1 = createSuspendedRun(wf);
+  const run2 = createSuspendedRun(wf);
+  const { workflowRepo, runRepo } = stubRepos(wf, [run1, run2]);
+
+  await assertRejects(
+    () => resolveSuspendedRun(workflowRepo, runRepo, "test-wf"),
+    Error,
+    "--run <run-id>",
+  );
+});
+
+Deno.test("resolveSuspendedRun: --run targets specific run", async () => {
+  const wf = createWorkflow("test-wf");
+  const run1 = createSuspendedRun(wf);
+  const run2 = createSuspendedRun(wf);
+  const { workflowRepo, runRepo } = stubRepos(wf, [run1, run2]);
+
+  const result = await resolveSuspendedRun(
+    workflowRepo,
+    runRepo,
+    "test-wf",
+    run2.id,
+  );
+  assertEquals(result.run.id, run2.id);
+});
+
+Deno.test("resolveSuspendedRun: --run rejects non-suspended run", async () => {
+  const wf = createWorkflow("test-wf");
+  const run = WorkflowRun.create(wf);
+  run.start();
+  run.complete();
+  const { workflowRepo, runRepo } = stubRepos(wf, [run]);
+
+  await assertRejects(
+    () => resolveSuspendedRun(workflowRepo, runRepo, "test-wf", run.id),
+    Error,
+    "not suspended",
+  );
+});

--- a/src/domain/workflows/trigger_condition.ts
+++ b/src/domain/workflows/trigger_condition.ts
@@ -82,6 +82,7 @@ export type TriggerConditionData =
 export type RunStatus =
   | "pending"
   | "running"
+  | "waiting_approval"
   | "succeeded"
   | "failed"
   | "skipped";

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -28,17 +28,37 @@ import { DataArtifactRefSchema } from "../models/model_output.ts";
 import type { DataArtifactRef } from "../models/model_output.ts";
 
 /**
+ * Zod schema for an approval decision recorded on a manual_approval step.
+ */
+export const ApprovalDecisionSchema = z.object({
+  approved: z.boolean(),
+  reason: z.string().optional(),
+  decidedBy: z.string().optional(),
+  decidedAt: z.string().datetime(),
+});
+
+export type ApprovalDecisionData = z.infer<typeof ApprovalDecisionSchema>;
+
+/**
  * Zod schema for step run.
  */
 export const StepRunSchema = z.object({
   stepName: z.string().min(1),
-  status: z.enum(["pending", "running", "succeeded", "failed", "skipped"]),
+  status: z.enum([
+    "pending",
+    "running",
+    "waiting_approval",
+    "succeeded",
+    "failed",
+    "skipped",
+  ]),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   error: z.string().optional(),
   output: z.unknown().optional(),
   dataArtifacts: z.array(DataArtifactRefSchema).optional(),
   allowedFailure: z.boolean().optional(),
+  approvalDecision: ApprovalDecisionSchema.optional(),
 });
 
 /**
@@ -51,7 +71,14 @@ export type StepRunData = z.infer<typeof StepRunSchema>;
  */
 export const JobRunSchema = z.object({
   jobName: z.string().min(1),
-  status: z.enum(["pending", "running", "succeeded", "failed", "skipped"]),
+  status: z.enum([
+    "pending",
+    "running",
+    "waiting_approval",
+    "succeeded",
+    "failed",
+    "skipped",
+  ]),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   steps: z.array(StepRunSchema),
@@ -69,7 +96,7 @@ export const WorkflowRunSchema = z.object({
   id: z.string().uuid(),
   workflowId: z.string().uuid(),
   workflowName: z.string().min(1),
-  status: z.enum(["pending", "running", "succeeded", "failed"]),
+  status: z.enum(["pending", "running", "suspended", "succeeded", "failed"]),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   jobs: z.array(JobRunSchema),
@@ -101,6 +128,7 @@ export class StepRun {
     private _output: unknown,
     private _dataArtifacts: DataArtifactRef[] = [],
     private _allowedFailure: boolean = false,
+    private _approvalDecision: ApprovalDecisionData | undefined = undefined,
   ) {}
 
   /**
@@ -133,6 +161,7 @@ export class StepRun {
       validated.output,
       validated.dataArtifacts ?? [],
       validated.allowedFailure ?? false,
+      validated.approvalDecision,
     );
   }
 
@@ -170,6 +199,17 @@ export class StepRun {
     return this._allowedFailure;
   }
 
+  get approvalDecision(): ApprovalDecisionData | undefined {
+    return this._approvalDecision;
+  }
+
+  /**
+   * Records an approval or rejection decision on this step.
+   */
+  recordApprovalDecision(decision: ApprovalDecisionData): void {
+    this._approvalDecision = decision;
+  }
+
   /**
    * Marks this step's failure as allowed.
    */
@@ -190,6 +230,13 @@ export class StepRun {
   start(): void {
     this._status = "running";
     this._startedAt = new Date();
+  }
+
+  /**
+   * Marks the step as waiting for manual approval.
+   */
+  waitForApproval(): void {
+    this._status = "waiting_approval";
   }
 
   /**
@@ -237,6 +284,9 @@ export class StepRun {
     }
     if (this._allowedFailure) {
       data.allowedFailure = true;
+    }
+    if (this._approvalDecision) {
+      data.approvalDecision = { ...this._approvalDecision };
     }
     return data;
   }
@@ -410,7 +460,12 @@ export class WorkflowRun implements TriggerEvaluationContext {
     readonly id: WorkflowRunId,
     readonly workflowId: string,
     readonly workflowName: string,
-    private _status: "pending" | "running" | "succeeded" | "failed",
+    private _status:
+      | "pending"
+      | "running"
+      | "suspended"
+      | "succeeded"
+      | "failed",
     private _startedAt: Date | undefined,
     private _completedAt: Date | undefined,
     private _jobs: JobRun[],
@@ -469,7 +524,12 @@ export class WorkflowRun implements TriggerEvaluationContext {
     );
   }
 
-  get status(): "pending" | "running" | "succeeded" | "failed" {
+  get status():
+    | "pending"
+    | "running"
+    | "suspended"
+    | "succeeded"
+    | "failed" {
     return this._status;
   }
 
@@ -550,6 +610,35 @@ export class WorkflowRun implements TriggerEvaluationContext {
     const anyFailed = this._jobs.some((j) => j.status === "failed");
     this._status = anyFailed ? "failed" : "succeeded";
     this._completedAt = new Date();
+  }
+
+  /**
+   * Marks the workflow run as suspended (waiting for manual approval).
+   */
+  suspend(): void {
+    this._status = "suspended";
+  }
+
+  /**
+   * Resumes a suspended workflow run without overwriting startedAt.
+   */
+  resumeFromSuspended(): void {
+    this._status = "running";
+    this._completedAt = undefined;
+  }
+
+  /**
+   * Finds the step that is currently waiting for approval.
+   */
+  findWaitingApprovalStep(): { jobName: string; stepName: string } | undefined {
+    for (const job of this._jobs) {
+      for (const step of job.steps) {
+        if (step.status === "waiting_approval") {
+          return { jobName: job.jobName, stepName: step.stepName };
+        }
+      }
+    }
+    return undefined;
   }
 
   /**

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -560,3 +560,78 @@ Deno.test("WorkflowRun roundtrip preserves workflowDataArtifacts", () => {
     "@swamp/workflow-summary",
   );
 });
+
+// Manual approval state transition tests
+
+Deno.test("StepRun: waitForApproval transitions from running to waiting_approval", () => {
+  const step = StepRun.pending("approval-step");
+  step.start();
+  assertEquals(step.status, "running");
+  step.waitForApproval();
+  assertEquals(step.status, "waiting_approval");
+});
+
+Deno.test("StepRun: succeed from waiting_approval transitions to succeeded", () => {
+  const step = StepRun.pending("approval-step");
+  step.start();
+  step.waitForApproval();
+  step.succeed();
+  assertEquals(step.status, "succeeded");
+});
+
+Deno.test("StepRun: fail from waiting_approval transitions to failed", () => {
+  const step = StepRun.pending("approval-step");
+  step.start();
+  step.waitForApproval();
+  step.fail("Approval rejected");
+  assertEquals(step.status, "failed");
+  assertEquals(step.error, "Approval rejected");
+});
+
+Deno.test("StepRun: waiting_approval round-trips through serialization", () => {
+  const step = StepRun.pending("approval-step");
+  step.start();
+  step.waitForApproval();
+  const data = step.toData();
+  assertEquals(data.status, "waiting_approval");
+  const restored = StepRun.fromData(data);
+  assertEquals(restored.status, "waiting_approval");
+});
+
+Deno.test("WorkflowRun: suspend sets status to suspended", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.suspend();
+  assertEquals(run.status, "suspended");
+});
+
+Deno.test("WorkflowRun: suspended round-trips through serialization", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.suspend();
+  const data = run.toData();
+  assertEquals(data.status, "suspended");
+  const restored = WorkflowRun.fromData(data);
+  assertEquals(restored.status, "suspended");
+});
+
+Deno.test("WorkflowRun: findWaitingApprovalStep finds the correct step", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  const job = run.getJob("job1")!;
+  const step = job.getStep("step1")!;
+  step.start();
+  step.waitForApproval();
+  const found = run.findWaitingApprovalStep();
+  assertEquals(found, { jobName: "job1", stepName: "step1" });
+});
+
+Deno.test("WorkflowRun: findWaitingApprovalStep returns undefined when none waiting", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  assertEquals(run.findWaitingApprovalStep(), undefined);
+});

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -83,6 +83,14 @@ export type WorkflowRunEvent =
   | { kind: "step_completed"; jobId: string; stepId: string }
   | { kind: "step_skipped"; jobId: string; stepId: string }
   | {
+    kind: "approval_requested";
+    runId: string;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
+  | {
     kind: "step_failed";
     jobId: string;
     stepId: string;
@@ -168,6 +176,14 @@ export type WorkflowRunEvent =
     stepId?: string;
   }
   | { kind: "completed"; run: WorkflowRunView }
+  | {
+    kind: "suspended";
+    run: WorkflowRunView;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
   | { kind: "error"; error: SwampError };
 
 /**
@@ -383,12 +399,28 @@ function mapEvent(
       const data = toRunData(event.run, path, input.verbose);
       return { kind: "completed", run: data };
     }
+    case "suspended": {
+      const path = deps.runRepo.getPath(
+        createWorkflowId(event.run.workflowId),
+        createWorkflowRunId(event.run.id),
+      );
+      const data = toRunData(event.run, path, input.verbose);
+      return {
+        kind: "suspended",
+        run: data,
+        jobId: event.jobId,
+        stepId: event.stepId,
+        prompt: event.prompt,
+        timeout: event.timeout,
+      };
+    }
     case "job_started":
     case "job_completed":
     case "job_skipped":
     case "step_started":
     case "step_completed":
     case "step_skipped":
+    case "approval_requested":
     case "step_failed":
     case "model_resolved":
     case "env_var_warning":
@@ -533,7 +565,10 @@ export async function* workflowRun(
             await telemetryBridge.observe(mapped);
           }
 
-          if (mapped.kind === "completed" && reportResults.length > 0) {
+          if (
+            (mapped.kind === "completed" || mapped.kind === "suspended") &&
+            reportResults.length > 0
+          ) {
             mapped = {
               ...mapped,
               run: { ...mapped.run, reports: reportResults },

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -47,7 +47,13 @@ export interface DataArtifactRefData {
 
 export interface StepRunView {
   name: string;
-  status: "pending" | "running" | "succeeded" | "failed" | "skipped";
+  status:
+    | "pending"
+    | "running"
+    | "waiting_approval"
+    | "succeeded"
+    | "failed"
+    | "skipped";
   error?: string;
   duration?: number;
   /** Output ID if this step produced an output (for model methods) */
@@ -62,7 +68,13 @@ export interface StepRunView {
 
 export interface JobRunView {
   name: string;
-  status: "pending" | "running" | "succeeded" | "failed" | "skipped";
+  status:
+    | "pending"
+    | "running"
+    | "waiting_approval"
+    | "succeeded"
+    | "failed"
+    | "skipped";
   steps: StepRunView[];
   duration?: number;
 }
@@ -71,7 +83,7 @@ export interface WorkflowRunView {
   id: string;
   workflowId: string;
   workflowName: string;
-  status: "pending" | "running" | "succeeded" | "failed";
+  status: "pending" | "running" | "suspended" | "succeeded" | "failed";
   jobs: JobRunView[];
   duration?: number;
   path?: string;

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -311,7 +311,19 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
         console.log(JSON.stringify(e.run, null, 2));
       },
       suspended: (e) => {
-        console.log(JSON.stringify(e.run, null, 2));
+        console.log(JSON.stringify(
+          {
+            ...e.run,
+            approvalRequired: {
+              stepId: e.stepId,
+              jobId: e.jobId,
+              prompt: e.prompt,
+              timeout: e.timeout,
+            },
+          },
+          null,
+          2,
+        ));
       },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -96,6 +96,24 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
           { error: e.error },
         );
       },
+      approval_requested: (e) => {
+        const logger = getWorkflowRunLogger(
+          this.workflowName,
+          e.jobId,
+          e.stepId,
+        );
+        logger.info("Awaiting manual approval: {prompt}", {
+          prompt: e.prompt,
+        });
+        logger.info(
+          "To approve: swamp workflow approve {workflowName} {stepName}",
+          { workflowName: this.workflowName, stepName: e.stepId },
+        );
+        logger.info(
+          "To reject:  swamp workflow reject {workflowName} {stepName}",
+          { workflowName: this.workflowName, stepName: e.stepId },
+        );
+      },
       model_resolved: (e) => {
         getRunLogger(e.modelName, e.methodName).info(
           "Found model {name} ({type})",
@@ -189,6 +207,26 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
           this.renderDataArtifactHints(e.run, wfLogger);
         }
       },
+      suspended: (e) => {
+        const wfLogger = getWorkflowRunLogger(this.workflowName);
+        wfLogger.info("Workflow suspended — awaiting approval on step {step}", {
+          step: e.stepId,
+        });
+        wfLogger.info("");
+        wfLogger.info(
+          "  swamp workflow approve {workflowName} {stepName}",
+          { workflowName: this.workflowName, stepName: e.stepId },
+        );
+        wfLogger.info(
+          "  swamp workflow reject  {workflowName} {stepName}",
+          { workflowName: this.workflowName, stepName: e.stepId },
+        );
+        wfLogger.info("");
+        wfLogger.info(
+          "After approval: swamp workflow resume {workflowName}",
+          { workflowName: this.workflowName },
+        );
+      },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);
       },
@@ -251,6 +289,7 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       step_completed: () => {},
       step_skipped: () => {},
       step_failed: () => {},
+      approval_requested: () => {},
       model_resolved: () => {},
       env_var_warning: () => {},
       method_executing: () => {},
@@ -269,6 +308,9 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       report_failed: () => {},
       completed: (e) => {
         if (e.run.status === "failed") this._failed = true;
+        console.log(JSON.stringify(e.run, null, 2));
+      },
+      suspended: (e) => {
         console.log(JSON.stringify(e.run, null, 2));
       },
       error: (e) => {

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -84,11 +84,18 @@ function renderLogWorkflowRun(data: WorkflowRunView): void {
 }
 
 function statusIcon(
-  status: "pending" | "running" | "succeeded" | "failed" | "skipped",
+  status:
+    | "pending"
+    | "running"
+    | "waiting_approval"
+    | "succeeded"
+    | "failed"
+    | "skipped",
 ): string {
   const icons: Record<string, string> = {
     pending: "\u25CB",
     running: "\u25D0",
+    waiting_approval: "\u23F8",
     succeeded: "\u2713",
     failed: "\u2717",
     skipped: "\u2298",

--- a/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
@@ -27,6 +27,7 @@ interface StatusIconProps {
     | "waiting"
     | "blocked"
     | "running"
+    | "waiting_approval"
     | "completed"
     | "failed"
     | "skipped"
@@ -43,6 +44,8 @@ export function StatusIcon({ status, spinnerFrame }: StatusIconProps) {
       return <Text color="red">✗</Text>;
     case "running":
       return <Text color="cyan">{(spinnerFrame ?? "\u280B") + " "}</Text>;
+    case "waiting_approval":
+      return <Text color="yellow">\u23F8</Text>;
     case "pending":
     case "waiting":
     case "blocked":

--- a/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
@@ -46,10 +46,15 @@ export function StepLine({ step, prefix }: StepLineProps) {
 
   const duration = elapsed > 0 ? formatDuration(elapsed) : "";
 
+  const approvalHint = step.status === "waiting_approval" && step.approvalPrompt
+    ? ` — ${step.approvalPrompt}`
+    : "";
+
   return (
     <Box>
       <Text dimColor>{prefix}</Text>
       <Text>{label}</Text>
+      {approvalHint ? <Text color="yellow">{approvalHint}</Text> : null}
       <Box flexGrow={1} />
       <Text>
         <StatusIcon status={step.status} spinnerFrame={spinnerFrame} />

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -93,7 +93,20 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
       suspended: (e) => {
         forward(e);
         this.bridge.close();
-        setTimeout(() => this.cleanup?.(), 100);
+        setTimeout(() => {
+          this.cleanup?.();
+          const wf = this.workflowName;
+          const step = e.stepId;
+          console.log("");
+          console.log(
+            `Workflow suspended — awaiting approval on step "${step}"`,
+          );
+          console.log("");
+          console.log(`  swamp workflow approve ${wf} ${step}`);
+          console.log(`  swamp workflow reject  ${wf} ${step}`);
+          console.log("");
+          console.log(`After approval: swamp workflow resume ${wf}`);
+        }, 100);
       },
       error: (e) => {
         forward(e);

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -75,6 +75,7 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
       step_completed: forward,
       step_skipped: forward,
       step_failed: forward,
+      approval_requested: forward,
       model_resolved: forward,
       env_var_warning: forward,
       method_executing: forward,
@@ -87,7 +88,11 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
         if (e.run.status === "failed") this._failed = true;
         forward(e);
         this.bridge.close();
-        // Allow brief render cycle for the final frame
+        setTimeout(() => this.cleanup?.(), 100);
+      },
+      suspended: (e) => {
+        forward(e);
+        this.bridge.close();
         setTimeout(() => this.cleanup?.(), 100);
       },
       error: (e) => {

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -39,7 +39,13 @@ export type StepReport =
 
 export interface StepState {
   id: string;
-  status: "pending" | "running" | "completed" | "failed" | "skipped";
+  status:
+    | "pending"
+    | "running"
+    | "waiting_approval"
+    | "completed"
+    | "failed"
+    | "skipped";
   modelName: string | null;
   methodName: string | null;
   startedAt: number | null;
@@ -47,6 +53,7 @@ export interface StepState {
   error: string | null;
   allowedFailure: boolean;
   reports: StepReport[];
+  approvalPrompt: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -171,6 +178,7 @@ function getOrCreateStep(job: JobState, stepId: string): StepState {
     error: null,
     allowedFailure: false,
     reports: [],
+    approvalPrompt: null,
   };
 }
 
@@ -571,11 +579,38 @@ function treeReducerSingle(
       };
     }
 
+    case "approval_requested": {
+      const job = state.jobs.get(event.jobId);
+      if (!job) return state;
+
+      const step = job.steps.get(event.stepId) ??
+        getOrCreateStep(job, event.stepId);
+      const steps = new Map(job.steps);
+      steps.set(event.stepId, {
+        ...step,
+        status: "waiting_approval",
+        approvalPrompt: event.prompt,
+      });
+
+      const jobs = updateJob(state.jobs, event.jobId, { steps });
+      return { ...state, jobs };
+    }
+
     case "completed": {
       return {
         ...state,
         phase: "done",
         failed: event.run.status === "failed",
+        finalRun: event.run,
+        activeReport: null,
+      };
+    }
+
+    case "suspended": {
+      return {
+        ...state,
+        phase: "done",
+        failed: false,
         finalRun: event.run,
         activeReport: null,
       };


### PR DESCRIPTION
## Summary

Adds a `manual_approval` step task type that suspends workflow execution at a step boundary, persists the run to disk, and exits cleanly. A separate user can approve or reject via CLI, then the original operator resumes the workflow to continue.

This addresses the core request in swamp-club#369: a first-class pause primitive for multi-phase rollouts with operator gates, putting swamp on par with Argo Workflows' `suspend`, AWS Step Functions' wait-for-token, and Jenkins Pipeline's `input`.

### New YAML task type

```yaml
- name: verify-ssh
  task:
    type: manual_approval
    prompt: "Verify Tailscale SSH access before proceeding"
    timeout: 3600
```

### New CLI commands

| Command | Description |
|---------|-------------|
| `swamp workflow approve <workflow> <step>` | Approve a suspended step (lightweight, any user) |
| `swamp workflow reject <workflow> <step>` | Reject a step and fail the run |
| `swamp workflow resume <workflow>` | Resume execution after approval (operator) |
| `swamp workflow approvals` | List all workflows awaiting approval |

### Architecture: suspend → approve → resume

1. `swamp workflow run` executes until hitting a `manual_approval` step → saves run as `suspended` → prints approve/reject/resume commands → **exits**
2. `swamp workflow approve` marks the step as succeeded in the persisted run record (lightweight — no execution)
3. `swamp workflow resume` re-enters the executor, skips completed steps, runs remaining pending steps

Key design decisions:
- **Persist to disk, not block in memory** — survives process restarts, shareable across users/machines
- **Approve is lightweight, resume is heavyweight** — the approver doesn't need the execution environment
- **Workflow-name resolution** — all commands accept workflow name instead of UUIDs
- **ApprovalDecision audit trail** — persists who approved, when, and why
- **Timeout enforcement** — checked at approve time against the suspension timestamp

### Changes

- **Schema**: `manual_approval` variant in StepTask discriminated union with `prompt` and `timeout` fields
- **State machine**: `waiting_approval` step status, `suspended` workflow run status, `ApprovalDecision` data on step run records
- **Execution**: `WorkflowSuspendedError` propagation through generator stack, `resume()` method on `WorkflowExecutionService` that rebuilds expression context and skips completed steps
- **Events**: `approval_requested` and `suspended` events across domain/libswamp/presentation layers
- **Presentation**: pause icon, approval prompt display, suspend/resume output in log/JSON/TUI modes

### Follow-up issues

- swamp-club#466: HTTP approval endpoints for swamp serve
- swamp-club#467: `--input` flags on workflow resume for elevated permissions
- swamp-club#470: UAT test coverage for new commands
- Docs issue filed for reference/how-to/explanation updates

## Test Plan

- Unit tests: StepTask manual_approval parsing (7 tests), StepRun waiting_approval transitions (4 tests), WorkflowRun suspend/resume round-trip (4 tests)
- Integration tests: YAML round-trip, dependency chain round-trip, suspended run persistence
- Manual UAT in /tmp repo:
  - ✅ Full approve cycle: run → suspend → approve → resume → deploy → succeeded
  - ✅ Reject cycle: run → suspend → reject → run failed
  - ✅ Resume without approval: clear error with exact approve command
  - ✅ Approvals listing with prompt and copy-paste commands
  - ✅ Timeout enforcement at approve time
  - ✅ ApprovalDecision persisted (who, when, why)
  - ✅ startedAt preserved across suspend/resume
  - ✅ Log file captured during resume
  - ✅ Workflow-scope reports run on resume
  - ✅ JSON output mode for all commands
- Full test suite: 6348 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)