### PR TITLE
fix(extensions): evict stale bundles on layout mismatch and repair broken pulled extensions (swamp-club#468)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -963,6 +963,33 @@ extension on top of itself — cross-extension collisions cannot happen.
 macOS resource fork files (`._*`) are skipped during both push (via
 `COPYFILE_DISABLE=1`) and pull.
 
+### Bundle staleness and recovery
+
+Bundles can become stale after a swamp upgrade when `BUNDLE_LAYOUT_VERSION`
+changes. The `ExtensionLoader.buildIndex` invalidation guards detect the
+layout-version mismatch and evict stale bundle files from disk before
+reconciliation runs. This prevents the `bundleWithCache` fallback from reusing
+bundles compiled against an incompatible runtime.
+
+Pulled extensions cannot rebundle locally — they use bare specifiers (e.g.,
+`from "zod"`) and ship without a `deno.json`, so `deno bundle` always fails.
+They rely entirely on pre-built bundles shipped with the registry package. When
+a stale bundle is evicted, the extension enters `BundleBuildFailed` state and
+becomes unavailable until re-pulled.
+
+Recovery paths:
+
+- **`swamp doctor extensions --repair`** detects pulled extensions in
+  `BundleBuildFailed` or `ValidationFailed` state and re-pulls them from the
+  registry automatically.
+- **`swamp extension pull <name> --force`** manually re-downloads the extension
+  including its pre-built bundle.
+- **User-facing warning:** `registerLazyFromCatalog` warns when extensions are
+  skipped due to failure states, directing users to the recovery commands.
+
+`BUNDLE_LAYOUT_VERSION` must be bumped whenever a change to the bundler, runtime
+interface, or zod global shape would make existing bundles incompatible.
+
 ## Layout Migration
 
 Existing repos that installed extensions under older layouts migrate via

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -48,13 +48,17 @@ import { isAbsolute, join, relative, resolve } from "@std/path";
 import {
   buildAggregateState,
   consumeStream,
+  createExtensionPullDeps,
   doctorExtensions,
   type DoctorRegistryDeps,
   ReconcileFromDiskService,
   type ReconcileTransition,
   repairExtensions,
+  resolveServerUrl,
 } from "../../libswamp/mod.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
+import { pullExtension } from "./extension_pull.ts";
+import { loadIdentity } from "../load_identity.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
@@ -316,10 +320,62 @@ export const doctorExtensionsCommand = new Command()
               lockfileRepository: repairLockfileRepo,
               repoRoot: repoDir,
             });
+            const repullExtension = async (name: string): Promise<boolean> => {
+              try {
+                const serverUrl = resolveServerUrl();
+                const identity = await loadIdentity();
+                const pullLockfileRepo = await LockfileRepository.create(
+                  lockfilePath,
+                );
+                const tool = resolvePrimaryTool(marker);
+                const skillsDir = resolveSkillsDir(repoDir, tool);
+                const denoRuntime = new EmbeddedDenoRuntime();
+                const pullCatalog = new ExtensionCatalogStore(catalogDbPath);
+                try {
+                  const pullRepo = new ExtensionRepository({
+                    catalog: pullCatalog,
+                    lockfileRepository: pullLockfileRepo,
+                    repoRoot: repoDir,
+                    localManifestIdentity: readLocalManifestIdentity(repoDir),
+                  });
+                  const deps = await createExtensionPullDeps(
+                    serverUrl,
+                    lockfilePath,
+                    skillsDir,
+                    repoDir,
+                    { identity },
+                  );
+                  await pullExtension(
+                    { name, version: null },
+                    {
+                      getExtension: deps.getExtension,
+                      downloadArchive: deps.downloadArchive,
+                      getChecksum: deps.getChecksum,
+                      logger: cliCtx.logger,
+                      lockfileRepository: deps.lockfileRepository,
+                      skillsDir,
+                      repoDir,
+                      force: true,
+                      outputMode: cliCtx.outputMode,
+                      alreadyPulled: new Set(),
+                      depth: 0,
+                      denoRuntime,
+                      repository: pullRepo,
+                    },
+                  );
+                  return true;
+                } finally {
+                  pullCatalog.close();
+                }
+              } catch {
+                return false;
+              }
+            };
             try {
               return repairExtensions({
                 aggregateReport,
                 deleteBySourcePaths: (paths) => repo.deleteBySourcePaths(paths),
+                repullExtension,
                 apply: !dryRun,
               });
             } finally {

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -298,6 +298,10 @@ export class ExtensionLoader {
       this.logger
         .warn`Catalog invalidated for ${this.adapter.kind} rescan: ${guard.reason}`;
       catalog.invalidate(this.adapter.kind);
+
+      if (guard.reason === "layout-version-mismatch") {
+        await this.evictStaleBundles();
+      }
     }
 
     if (catalog.isPopulated(this.adapter.kind)) {
@@ -702,14 +706,28 @@ export class ExtensionLoader {
   }
 
   private registerLazyFromCatalog(catalog: ExtensionCatalogStore): void {
+    const skippedExtensions = new Set<string>();
     for (const kind of this.adapter.catalogKinds) {
       if (kind !== this.adapter.catalogKinds[0]) continue;
       const entries = catalog.findByKind(kind);
       for (const entry of entries) {
-        if (entry.state === "ValidationFailed") continue;
+        if (
+          entry.state === "ValidationFailed" ||
+          entry.state === "BundleBuildFailed"
+        ) {
+          const name = entry.extension_name || entry.type_normalized;
+          if (name && !skippedExtensions.has(name)) {
+            skippedExtensions.add(name);
+          }
+          continue;
+        }
         if (!entry.type_normalized) continue;
         this.adapter.registerLazy(entry);
       }
+    }
+    for (const name of skippedExtensions) {
+      this.logger
+        .warn`Extension ${name} has broken bundles and is not available. Run 'swamp doctor extensions --repair' or 'swamp extension pull ${name} --force' to fix.`;
     }
   }
 
@@ -935,6 +953,21 @@ export class ExtensionLoader {
       this.adapter.bundleSubdir,
       ...segments,
     );
+  }
+
+  private async evictStaleBundles(): Promise<void> {
+    const bundleDir = this.resolveBundlePath();
+    if (!bundleDir) return;
+    try {
+      await Deno.remove(bundleDir, { recursive: true });
+      this.logger
+        .info`Evicted stale bundles for ${this.adapter.kind}: ${bundleDir}`;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        this.logger
+          .warn`Failed to evict stale bundles for ${this.adapter.kind}: ${error}`;
+      }
+    }
   }
 
   private getBundlePath(relativePath: string, baseDir: string): string {

--- a/src/libswamp/extensions/doctor_repair.ts
+++ b/src/libswamp/extensions/doctor_repair.ts
@@ -22,7 +22,10 @@ import type { DoctorAggregateReport } from "./doctor_aggregate.ts";
 
 const logger = getLogger(["swamp", "doctor", "repair"]);
 
-export type RepairOperationKind = "catalog-row-pruned" | "bundle-file-evicted";
+export type RepairOperationKind =
+  | "catalog-row-pruned"
+  | "bundle-file-evicted"
+  | "pulled-extension-repulled";
 
 export interface RepairOperation {
   readonly kind: RepairOperationKind;
@@ -35,20 +38,24 @@ export interface RepairReport {
   readonly operations: readonly RepairOperation[];
   readonly prunedRowCount: number;
   readonly evictedFileCount: number;
+  readonly repulledExtensionCount: number;
 }
 
 export interface RepairDeps {
   readonly aggregateReport: DoctorAggregateReport;
   readonly deleteBySourcePaths: (paths: readonly string[]) => number;
+  readonly repullExtension?: (name: string) => Promise<boolean>;
   readonly apply: boolean;
 }
 
 /**
  * Computes and optionally executes repair operations based on the
- * aggregate state report. Only touches cleanup-eligible state:
+ * aggregate state report. Handles three categories:
  *
  * - Catalog rows in Tombstoned state (no transitions out; safe to prune).
  * - Bundle files not referenced by any catalog row.
+ * - Pulled extensions with BundleBuildFailed or ValidationFailed sources
+ *   (re-pulled from registry to restore pre-built bundles).
  *
  * NEVER touches Indexed, Bundled, or OrphanedBundleOnly rows.
  * OrphanedBundleOnly is excluded because those rows still reference a
@@ -90,8 +97,26 @@ export async function repairExtensions(
     });
   }
 
+  // Phase 3: Identify pulled extensions with broken bundles.
+  const extensionsToRepull = new Set<string>();
+  for (const agg of report.aggregates) {
+    if (agg.origin !== "pulled") continue;
+    const failedCount = (agg.stateDistribution.BundleBuildFailed ?? 0) +
+      (agg.stateDistribution.ValidationFailed ?? 0);
+    if (failedCount > 0) {
+      extensionsToRepull.add(agg.name);
+      operations.push({
+        kind: "pulled-extension-repulled",
+        path: agg.name,
+        reason:
+          `Pulled extension has ${failedCount} broken bundle(s) — re-pulling from registry`,
+      });
+    }
+  }
+
   let actualPruned = rowsToPrune.length;
   let actualEvicted = filesToEvict.length;
+  let actualRepulled = extensionsToRepull.size;
 
   if (deps.apply) {
     if (rowsToPrune.length > 0) {
@@ -110,6 +135,24 @@ export async function repairExtensions(
         }
       }
     }
+    if (deps.repullExtension) {
+      actualRepulled = 0;
+      for (const name of extensionsToRepull) {
+        try {
+          const ok = await deps.repullExtension(name);
+          if (ok) {
+            actualRepulled++;
+            logger.info`Re-pulled extension: ${name}`;
+          } else {
+            logger
+              .warn`Failed to re-pull extension ${name} — run 'swamp extension pull ${name} --force' manually`;
+          }
+        } catch (error) {
+          logger
+            .warn`Failed to re-pull extension ${name}: ${error}`;
+        }
+      }
+    }
   }
 
   return {
@@ -117,5 +160,6 @@ export async function repairExtensions(
     operations,
     prunedRowCount: actualPruned,
     evictedFileCount: actualEvicted,
+    repulledExtensionCount: actualRepulled,
   };
 }

--- a/src/libswamp/extensions/doctor_repair_test.ts
+++ b/src/libswamp/extensions/doctor_repair_test.ts
@@ -237,4 +237,219 @@ Deno.test("repairExtensions: idempotent — clean state yields zero operations",
   assertEquals(result.operations.length, 0);
   assertEquals(result.prunedRowCount, 0);
   assertEquals(result.evictedFileCount, 0);
+  assertEquals(result.repulledExtensionCount, 0);
+});
+
+Deno.test("repairExtensions: identifies pulled extensions with BundleBuildFailed for re-pull", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "@swamp/ssh",
+        version: "2026.05.25.1",
+        origin: "pulled",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 1,
+          ValidationFailed: 0,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  const repulled: string[] = [];
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    repullExtension: (name) => {
+      repulled.push(name);
+      return Promise.resolve(true);
+    },
+    apply: true,
+  });
+
+  assertEquals(result.repulledExtensionCount, 1);
+  assertEquals(repulled, ["@swamp/ssh"]);
+  assertEquals(
+    result.operations.some((op) => op.kind === "pulled-extension-repulled"),
+    true,
+  );
+});
+
+Deno.test("repairExtensions: identifies pulled extensions with ValidationFailed for re-pull", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "@swamp/ssh",
+        version: "2026.05.25.1",
+        origin: "pulled",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 0,
+          ValidationFailed: 1,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  const repulled: string[] = [];
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    repullExtension: (name) => {
+      repulled.push(name);
+      return Promise.resolve(true);
+    },
+    apply: true,
+  });
+
+  assertEquals(result.repulledExtensionCount, 1);
+  assertEquals(repulled, ["@swamp/ssh"]);
+});
+
+Deno.test("repairExtensions: skips local extensions with broken bundles", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "my-local-model",
+        version: "1.0.0",
+        origin: "local",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 1,
+          ValidationFailed: 0,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  const repulled: string[] = [];
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    repullExtension: (name) => {
+      repulled.push(name);
+      return Promise.resolve(true);
+    },
+    apply: true,
+  });
+
+  assertEquals(result.repulledExtensionCount, 0);
+  assertEquals(repulled, []);
+});
+
+Deno.test("repairExtensions: handles re-pull failure gracefully", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "@swamp/ssh",
+        version: "2026.05.25.1",
+        origin: "pulled",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 1,
+          ValidationFailed: 0,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    repullExtension: () => Promise.resolve(false),
+    apply: true,
+  });
+
+  assertEquals(result.repulledExtensionCount, 0);
+});
+
+Deno.test("repairExtensions: dry-run does not call repullExtension", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "@swamp/ssh",
+        version: "2026.05.25.1",
+        origin: "pulled",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 1,
+          ValidationFailed: 0,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  let repullCalled = false;
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    repullExtension: () => {
+      repullCalled = true;
+      return Promise.resolve(true);
+    },
+    apply: false,
+  });
+
+  assertEquals(result.mode, "dry-run");
+  assertEquals(result.repulledExtensionCount, 1);
+  assertFalse(repullCalled);
+});
+
+Deno.test("repairExtensions: works without repullExtension callback", async () => {
+  const report = makeEmptyReport({
+    aggregates: [
+      {
+        name: "@swamp/ssh",
+        version: "2026.05.25.1",
+        origin: "pulled",
+        sourceCount: 1,
+        stateDistribution: {
+          Indexed: 0,
+          Bundled: 0,
+          BundleBuildFailed: 1,
+          ValidationFailed: 0,
+          EntryPointUnreadable: 0,
+          OrphanedBundleOnly: 0,
+          Tombstoned: 0,
+        },
+      },
+    ],
+  });
+
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => 0,
+    apply: true,
+  });
+
+  assertEquals(result.repulledExtensionCount, 1);
+  assertEquals(
+    result.operations.some((op) => op.kind === "pulled-extension-repulled"),
+    true,
+  );
 });

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -190,19 +190,34 @@ function renderRepairLog(report: RepairReport): void {
   }
 
   const pastTense = report.mode === "applied";
-  writeOutput(
-    `  ${report.prunedRowCount} catalog row(s) ${
+  const parts = [
+    `${report.prunedRowCount} catalog row(s) ${
       pastTense ? "pruned" : "to prune"
-    }, ${report.evictedFileCount} bundle file(s) ${
+    }`,
+    `${report.evictedFileCount} bundle file(s) ${
       pastTense ? "evicted" : "to evict"
     }`,
-  );
+  ];
+  if (report.repulledExtensionCount > 0) {
+    parts.push(
+      `${report.repulledExtensionCount} extension(s) ${
+        pastTense ? "re-pulled" : "to re-pull"
+      }`,
+    );
+  }
+  writeOutput(`  ${parts.join(", ")}`);
   writeOutput("");
 
   for (const op of report.operations) {
-    const icon = op.kind === "catalog-row-pruned" ? "x" : "-";
+    const icon = op.kind === "catalog-row-pruned"
+      ? "x"
+      : op.kind === "pulled-extension-repulled"
+      ? "+"
+      : "-";
     const label = op.kind === "catalog-row-pruned"
       ? dim("[row]")
+      : op.kind === "pulled-extension-repulled"
+      ? dim("[pull]")
       : dim("[file]");
     writeOutput(`  ${icon} ${label} ${op.path}`);
     writeOutput(`     ${dim(op.reason)}`);


### PR DESCRIPTION
## Summary

- Evict stale bundle files from disk when the `BUNDLE_LAYOUT_VERSION` invalidation guard fires in `ExtensionLoader.buildIndex`, preventing the `bundleWithCache` fallback from silently reusing incompatible cached bundles
- Extend `doctor --repair` to detect pulled extensions in `BundleBuildFailed` or `ValidationFailed` state and re-pull them from the registry (pulled extensions with bare specifiers cannot rebundle locally)
- Add user-facing warning in `registerLazyFromCatalog` when extensions are skipped due to failure states, directing users to `doctor --repair` or `extension pull --force`

## Test Plan

- 7 new unit tests for doctor repair re-pull behavior (origin filtering, failure handling, dry-run, backward compat)
- Full test suite passes (6373 tests, 0 failures)
- Verified against reproduction at `/tmp/swamp-repro-issue-468`:
  1. Deleted bundle → model disappeared with new user-facing warning
  2. Ran `doctor extensions --repair --force` → extension re-pulled from registry
  3. Model loads correctly after repair