### PR TITLE
fix(models): redact sensitive global arguments in swamp model get (swamp-club#472)

### DIFF
--- a/design/reports.md
+++ b/design/reports.md
@@ -372,9 +372,10 @@ redactSensitiveArgs?(
 ): Record<string, unknown>;
 ```
 
-The helper uses `extractSensitiveFields` from
-`src/domain/models/sensitive_field_extractor.ts` to walk the model type's Zod
-schema, then deep-clones the args and replaces matching values with `"***"`.
+The helper delegates to the shared `redactSensitiveValues(schema, data)`
+primitive in `src/domain/models/sensitive_field_extractor.ts`, which walks the
+model type's Zod schema via `extractSensitiveFields`, deep-clones the args, and
+replaces matching values with `"***"`.
 
 - **Method/model scope** — looks up the schema via `modelRegistry.get(modelType)`
   and returns a redacted clone.
@@ -385,6 +386,15 @@ Reports that include argument values in their output should call
 `context.redactSensitiveArgs(args, kind)` to avoid persisting secrets. The
 builtin `@swamp/method-summary` report uses this for both global and method
 arguments.
+
+`redactSensitiveValues` is the single redaction primitive shared across the
+surfaces that honor the `sensitive: true` flag. `swamp model get` applies it to a
+model's global arguments in the libswamp read path
+(`src/libswamp/models/get.ts`) before assembling `ModelGetData`, so both the log
+and JSON renderers — and `swamp model search`, which routes through the same
+read path — display `"***"` instead of literal sensitive values. When the model
+type is unavailable the schema is unknown, so values pass through unredacted,
+matching the report path's "no schema found" behavior.
 
 Additionally, report contexts receive **pre-vault** arguments — args are
 captured before `resolveRuntimeExpressionsInDefinition` replaces vault

--- a/integration/model_get_sensitive_test.ts
+++ b/integration/model_get_sensitive_test.ts
@@ -1,0 +1,162 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for sensitive-argument redaction in `swamp model get`.
+ *
+ * Exercises the full read path: a literal sensitive global argument is persisted
+ * to disk via the real YamlDefinitionRepository, loaded back through the libswamp
+ * modelGet application service (which applies the shared redactSensitiveValues
+ * primitive), and projected by both the log and JSON renderers. Confirms the
+ * secret never reaches output in either mode, while non-sensitive values do.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
+import {
+  consumeStream,
+  modelGet,
+  type ModelGetData,
+  type ModelGetDeps,
+  type ModelGetEvent,
+} from "../src/libswamp/mod.ts";
+import { createModelGetRenderer } from "../src/presentation/renderers/model_get.ts";
+import { createLibSwampContext } from "../src/libswamp/context.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { findDefinitionByIdOrName } from "../src/domain/models/model_lookup.ts";
+import { initializeTestRepo } from "./test_helpers.ts";
+
+const SECRET = "SUPERSECRET123";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-model-get-sensitive-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+/** A minimal model type whose global args carry one sensitive field. */
+const modelDef = {
+  type: ModelType.create("test/sensitive-get"),
+  version: "2026.05.28.1",
+  globalArguments: z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    region: z.string(),
+  }),
+  methods: {},
+};
+
+async function captureRender(
+  data: ModelGetData,
+  mode: "log" | "json",
+): Promise<string> {
+  async function* stream(): AsyncGenerator<ModelGetEvent> {
+    yield { kind: "resolving" };
+    yield { kind: "completed", data };
+  }
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  // Both the log renderer (via writeOutput) and the JSON renderer emit through
+  // console.log, so capturing it covers both modes.
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    const renderer = createModelGetRenderer(mode);
+    await consumeStream(stream(), renderer.handlers());
+  } finally {
+    console.log = originalLog;
+  }
+  return logs.join("\n");
+}
+
+Deno.test("Integration: model get redacts a literal sensitive global argument in both output modes", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Persist a definition with a literal sensitive value (not a vault.get expr).
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    const definition = Definition.create({
+      name: "leaky-model",
+      globalArguments: { apiKey: SECRET, region: "us-east-1" },
+      methods: {},
+    });
+    await definitionRepo.save(modelDef.type, definition);
+
+    // Real lookup from disk; the model type schema supplies the sensitive flag.
+    const deps: ModelGetDeps = {
+      lookupDefinition: (idOrName) =>
+        findDefinitionByIdOrName(definitionRepo, idOrName),
+      getModelDef: () => modelDef,
+    };
+
+    const events: ModelGetEvent[] = [];
+    await consumeStream(
+      modelGet(createLibSwampContext(), deps, "leaky-model"),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          events.push(e);
+        },
+        error: (e) => {
+          throw new Error(`unexpected error: ${e.error.message}`);
+        },
+      },
+    );
+
+    const completed = events[0];
+    if (!completed || completed.kind !== "completed") {
+      throw new Error("expected a completed event");
+    }
+
+    // The read model carries the redacted value, not the secret.
+    assertEquals(completed.data.globalArguments, {
+      apiKey: "***",
+      region: "us-east-1",
+    });
+
+    // The secret still lives unredacted in the persisted definition — redaction
+    // happens at the read layer, so reloading the stored definition still shows
+    // the literal value.
+    const reloaded = await findDefinitionByIdOrName(
+      definitionRepo,
+      "leaky-model",
+    );
+    assertEquals(reloaded?.definition.globalArguments.apiKey, SECRET);
+
+    // Neither renderer emits the secret; both show "***" and the region.
+    for (const mode of ["log", "json"] as const) {
+      const output = await captureRender(completed.data, mode);
+      assertStringIncludes(output, "***");
+      assertStringIncludes(output, "us-east-1");
+      assertEquals(
+        output.includes(SECRET),
+        false,
+        `${mode} output leaked the secret`,
+      );
+    }
+  });
+});

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -180,6 +180,39 @@ export function extractSensitiveFields(
 }
 
 /**
+ * Returns a redacted clone of `data` with every field marked `{ sensitive: true }`
+ * in `schema` replaced by `"***"`.
+ *
+ * This is the canonical redaction primitive shared by every surface that must
+ * scrub sensitive values before display or persistence (reports, `model get`).
+ * It does not mutate the input — callers receive a deep clone. Only fields that
+ * are actually present in `data` are redacted; absent sensitive fields are left
+ * untouched. Nested sensitive fields are handled because `extractSensitiveFields`
+ * walks the schema recursively and returns dot-separated paths.
+ *
+ * @param schema - A Zod schema (typically a global-arguments or method-argument schema)
+ * @param data - The data object to redact
+ * @returns A deep clone of `data` with sensitive fields set to `"***"`
+ */
+export function redactSensitiveValues(
+  schema: z.ZodTypeAny,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const fields = extractSensitiveFields(schema);
+  if (fields.length === 0) {
+    return data;
+  }
+
+  const redacted = structuredClone(data);
+  for (const field of fields) {
+    if (getNestedValue(redacted, field.path) !== undefined) {
+      setNestedValue(redacted, field.path, "***");
+    }
+  }
+  return redacted;
+}
+
+/**
  * Extracts the runtime secret values from a data object based on its Zod schema.
  *
  * For each field marked `{ sensitive: true }` in the schema:

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -23,6 +23,7 @@ import {
   extractSensitiveFields,
   extractSensitiveFieldValues,
   getNestedValue,
+  redactSensitiveValues,
   setNestedValue,
 } from "./sensitive_field_extractor.ts";
 
@@ -268,4 +269,81 @@ Deno.test("setNestedValue: creates intermediate objects", () => {
     ((obj.a as Record<string, unknown>).b as Record<string, unknown>).c,
     "value",
   );
+});
+
+Deno.test("redactSensitiveValues: redacts top-level sensitive literal", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    name: z.string(),
+  });
+
+  const redacted = redactSensitiveValues(schema, {
+    apiKey: "SUPERSECRET123",
+    name: "hello",
+  });
+
+  assertEquals(redacted, { apiKey: "***", name: "hello" });
+});
+
+Deno.test("redactSensitiveValues: leaves non-sensitive fields untouched", () => {
+  const schema = z.object({
+    region: z.string(),
+  });
+
+  const redacted = redactSensitiveValues(schema, { region: "us-east-1" });
+
+  assertEquals(redacted, { region: "us-east-1" });
+});
+
+Deno.test("redactSensitiveValues: redacts nested sensitive field", () => {
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+    }),
+    name: z.string(),
+  });
+
+  const redacted = redactSensitiveValues(schema, {
+    credentials: { apiKey: "SECRET" },
+    name: "hello",
+  });
+
+  assertEquals(redacted, {
+    credentials: { apiKey: "***" },
+    name: "hello",
+  });
+});
+
+Deno.test("redactSensitiveValues: skips sensitive field absent from data", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }).optional(),
+    name: z.string(),
+  });
+
+  const redacted = redactSensitiveValues(schema, { name: "hello" });
+
+  assertEquals(redacted, { name: "hello" });
+});
+
+Deno.test("redactSensitiveValues: redacts vault.get() expressions too (blanket)", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  const redacted = redactSensitiveValues(schema, {
+    apiKey: '${{ vault.get("creds", "apiKey") }}',
+  });
+
+  assertEquals(redacted, { apiKey: "***" });
+});
+
+Deno.test("redactSensitiveValues: does not mutate the input", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+  const input = { apiKey: "SUPERSECRET123" };
+
+  redactSensitiveValues(schema, input);
+
+  assertEquals(input.apiKey, "SUPERSECRET123");
 });

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -26,11 +26,7 @@ import type { ModelType } from "../models/model_type.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
 import { DefaultDataWriter } from "../models/data_writer.ts";
 import { modelRegistry } from "../models/model.ts";
-import {
-  extractSensitiveFields,
-  getNestedValue,
-  setNestedValue,
-} from "../models/sensitive_field_extractor.ts";
+import { redactSensitiveValues } from "../models/sensitive_field_extractor.ts";
 import { buildReportErrorResult } from "./builtin/report_error_report.ts";
 
 /**
@@ -310,16 +306,7 @@ function buildRedactSensitiveArgs(
       : modelDef.methods[context.methodName]?.arguments;
     if (!schema) return args;
 
-    const fields = extractSensitiveFields(schema);
-    if (fields.length === 0) return args;
-
-    const redacted = structuredClone(args);
-    for (const field of fields) {
-      if (getNestedValue(redacted, field.path) !== undefined) {
-        setNestedValue(redacted, field.path, "***");
-      }
-    }
-    return redacted;
+    return redactSensitiveValues(schema, args);
   };
 }
 

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -22,6 +22,7 @@ import type { ModelDefinition } from "../../domain/models/model.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { redactSensitiveValues } from "../../domain/models/sensitive_field_extractor.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -100,13 +101,25 @@ export async function* modelGet(
       const { definition, type: modelType } = result;
       const modelDef = await deps.getModelDef(modelType);
 
+      // Redact global arguments marked `{ sensitive: true }` before they enter
+      // the read model, so every output mode (log, json) and every consumer of
+      // ModelGetData — including `model search` — inherits the redaction. When
+      // the model type is unavailable the schema is unknown, so values pass
+      // through unredacted (matching the report path's behavior).
+      const globalArguments = modelDef?.globalArguments
+        ? redactSensitiveValues(
+          modelDef.globalArguments,
+          definition.globalArguments,
+        )
+        : definition.globalArguments;
+
       const data: ModelGetData = {
         id: definition.id,
         name: definition.name,
         type: modelType.normalized,
         version: definition.version,
         tags: definition.tags,
-        globalArguments: definition.globalArguments,
+        globalArguments,
         typeVersion: modelDef?.version,
         globalArgumentsSchema: modelDef?.globalArguments
           ? zodToJsonSchema(modelDef.globalArguments)

--- a/src/libswamp/models/get_test.ts
+++ b/src/libswamp/models/get_test.ts
@@ -18,9 +18,18 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { z } from "zod";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import { modelGet, type ModelGetDeps, type ModelGetEvent } from "./get.ts";
+
+function completedData(events: ModelGetEvent[]) {
+  const completed = events.find((e) => e.kind === "completed");
+  if (!completed || completed.kind !== "completed") {
+    throw new Error("expected a completed event");
+  }
+  return completed.data;
+}
 
 function makeDeps(overrides: {
   lookupResult?: { definition: object; type: object } | null;
@@ -77,6 +86,62 @@ Deno.test("modelGet yields resolving -> completed with model data on success", a
       },
     },
   ]);
+});
+
+Deno.test("modelGet redacts sensitive global arguments when the schema is known", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: {
+        id: "def-2",
+        name: "secret-model",
+        version: 1,
+        tags: {},
+        globalArguments: { apiKey: "SUPERSECRET123", region: "us-east-1" },
+      },
+      type: { normalized: "acme/widget" },
+    },
+    modelDef: {
+      version: "2026.05.28.1",
+      globalArguments: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        region: z.string(),
+      }),
+      methods: {},
+    },
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "secret-model"),
+  );
+
+  assertEquals(completedData(events).globalArguments, {
+    apiKey: "***",
+    region: "us-east-1",
+  });
+});
+
+Deno.test("modelGet passes global arguments through unredacted when the model type is unavailable", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: {
+        id: "def-3",
+        name: "uninstalled-model",
+        version: 1,
+        tags: {},
+        globalArguments: { apiKey: "SUPERSECRET123" },
+      },
+      type: { normalized: "acme/widget" },
+    },
+    modelDef: undefined,
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "uninstalled-model"),
+  );
+
+  assertEquals(completedData(events).globalArguments, {
+    apiKey: "SUPERSECRET123",
+  });
 });
 
 Deno.test("modelGet yields resolving -> error with not_found when model does not exist", async () => {


### PR DESCRIPTION
## Summary

`swamp model get` printed global argument values marked `.meta({ sensitive: true })` verbatim in both log and JSON output, even though the same flag is honored for logs, reports, and storage. This is an information-disclosure gap for **literal/inline** sensitive values (vault-sourced args were already safe — `${{ vault.get(...) }}` is stored unevaluated). Fixes swamp-club#472.

### Changes

- **New shared primitive** `redactSensitiveValues(schema, data)` in `src/domain/models/sensitive_field_extractor.ts` — pure, deep-clones, replaces fields marked `sensitive: true` with `"***"`.
- **`src/libswamp/models/get.ts`** applies it to global arguments at the read layer before assembling `ModelGetData`, so **both** the log and JSON renderers — and `swamp model search`, which routes through `modelGet` — inherit the redaction from a single chokepoint.
- **`src/domain/reports/report_execution_service.ts`** `buildRedactSensitiveArgs` now delegates to the shared primitive, removing a duplicated security-sensitive loop so there is one auditable redaction function.
- Documented `model get` as a redaction surface in `design/reports.md`.

### Behavior notes (intentional)

- **Blanket `"***"`** for parity with the report path: `${{ vault.get(...) }}` expressions are masked too. This is a visible change for vault-sourced args (previously the expression was shown). Chosen for consistency and simplicity.
- **modelDef-unavailable pass-through**: when the model type isn't installed/loaded the schema is unknown, so values pass through unredacted — matching the report path's "no schema found" behavior.

### Scope

Kept to the `model get` read layer. A related at-rest gap (literal sensitive args stored unredacted in the definition YAML at `model create` time) is tracked separately in swamp-club#480.

## Test Plan

- **Unit** — `redactSensitiveValues`: top-level/nested/absent fields, vault-expr blanket redaction, no input mutation. `modelGet`: redacts when schema known, passes through when modelDef unavailable. Existing `report_execution_service_test.ts` (incl. array-typed sensitive args) passes unchanged as the consolidation regression guard.
- **Integration** — `integration/model_get_sensitive_test.ts`: persists a literal sensitive arg to disk, confirms it survives in the stored definition, and asserts both renderers emit `"***"` (never the secret) while preserving non-sensitive fields.
- **End-to-end** — recompiled the binary (`deno run compile`) and re-ran the original reproduction: `apiKey` now shows `***` in both log and `--json` modes; `name: hello` preserved.
- Full suite green (6406 passed, 0 failed); `deno check` / `lint` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)