### PR TITLE
fix(extensions): trust only swamp by default; pin auto-resolve to lockfile (swamp-club#465)

### DIFF
--- a/.claude/skills/swamp-extension/SKILL.md
+++ b/.claude/skills/swamp-extension/SKILL.md
@@ -43,8 +43,9 @@ via `swamp-extension-publish`.
 4. For local or private extensions, use `swamp extension source add <path>`.
 5. Only create a new extension if nothing fits.
 
-Trusted collectives (`@swamp/*`, `@si/*`, membership collectives) auto-resolve
-on first use — `swamp extension trust list` shows which.
+Trusted collectives auto-resolve on first use. Only `@swamp/*` is trusted by
+default; trust others explicitly with `swamp extension trust add <collective>`
+(`swamp extension trust list` shows which).
 
 **Never** use `command/shell` to wrap service integrations — build a dedicated
 model.

--- a/.claude/skills/swamp-extension/references/model/troubleshooting.md
+++ b/.claude/skills/swamp-extension/references/model/troubleshooting.md
@@ -237,9 +237,10 @@ for the canonical reference.
 
 ## Auto-Resolution Failures
 
-Extensions from trusted collectives (explicit `trustedCollectives` in
-`.swamp.yaml` plus your membership collectives) auto-resolve on first use. If
-auto-resolution fails:
+Extensions from trusted collectives (the explicit `trustedCollectives` list in
+`.swamp.yaml`; only `swamp` by default) auto-resolve on first use. Membership
+collectives are not trusted automatically — run
+`swamp extension trust add <collective>` first. If auto-resolution fails:
 
 | Symptom                       | Cause                                      | Fix                                                                              |
 | ----------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |

--- a/.claude/skills/swamp-model/references/troubleshooting.md
+++ b/.claude/skills/swamp-model/references/troubleshooting.md
@@ -213,9 +213,9 @@ to use that field.
    models/my_model.ts             # Wrong
    ```
 
-4. **Extension not auto-resolved** — types from trusted collectives (`@swamp/*`,
-   `@si/*`, and your membership collectives) auto-resolve on first use. If
-   resolution failed:
+4. **Extension not auto-resolved** — types from trusted collectives auto-resolve
+   on first use. Only `@swamp/*` is trusted by default; trust others explicitly
+   with `swamp extension trust add <collective>`. If resolution failed:
    - Check which collectives are trusted: `swamp extension trust list`
    - Check network connectivity (registry at swamp.club)
    - Check if extension exists: `swamp extension search <query>`

--- a/.claude/skills/swamp-repo/references/structure.md
+++ b/.claude/skills/swamp-repo/references/structure.md
@@ -112,18 +112,23 @@ workflowsDir: "extensions/workflows" # optional, default shown
 vaultsDir: "extensions/vaults" # optional, default shown
 driversDir: "extensions/drivers" # optional, default shown
 datastoresDir: "extensions/datastores" # optional, default shown
-trustedCollectives: # optional, default: ["swamp", "si"]
+trustedCollectives: # optional, default: ["swamp"]
   - swamp
-  - si
-trustMemberCollectives: true # optional, default: true
+  - myorg
+trustMemberCollectives: false # optional, default: false
 ```
 
 `trustedCollectives` controls which extension collectives auto-resolve on first
-use. The `swamp` and `si` collectives are trusted by default.
+use. Only the first-party `swamp` collective is trusted by default.
 
-Additionally, collectives the user belongs to (cached during `auth login` /
-`auth whoami`) are automatically trusted. Set `trustMemberCollectives: false` to
-disable this and only trust the explicit list.
+Collectives the user belongs to (cached during `auth login` / `auth whoami`) are
+NOT trusted automatically (swamp-club#465) — trust each one explicitly with
+`swamp extension trust add <collective>`. Set `trustMemberCollectives: true` to
+opt into trusting every membership collective at once. Once a collective is
+trusted, its extensions auto-resolve but are pinned to the version recorded in
+the committed `upstream_extensions.json` lockfile, so a trusted collective
+cannot silently push an updated version — moving versions requires an explicit
+`swamp extension pull` / `swamp extension update`.
 
 Manage trusted collectives via the CLI:
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -618,28 +618,39 @@ it, and continues.
 
 ### Trusted Collectives
 
-The `swamp` and `si` collectives are trusted by default. Extensions from
-`@swamp/*` and `@si/*` auto-resolve with no configuration required.
+Only the first-party `swamp` collective is trusted by default. Extensions from
+`@swamp/*` auto-resolve with no configuration required.
 
-Default trusted collectives: `["swamp", "si"]`.
+Default trusted collectives: `["swamp"]`.
 
-Additionally, collectives the user belongs to are automatically trusted. Membership
-collectives are cached in `auth.json` during `auth login` and `auth whoami`, and
-merged with the explicit list at CLI startup. This means if a user is a member of
-`@myorg`, extensions from `@myorg/*` auto-resolve without any configuration.
+**Membership collectives are NOT trusted automatically** (swamp-club#465).
+Belonging to a collective lets you _publish_ to it; it does not silently grant
+_install_ consent on the consumer side. A compromised or careless member
+publish must not be able to execute code in every repo that references the
+collective's types. To use a collective's extensions, trust it explicitly:
 
-Configurable via `trustedCollectives` in `.swamp.yaml`:
+```bash
+swamp extension trust add myorg
+```
+
+which records it in `trustedCollectives` in `.swamp.yaml`:
 
 ```yaml
 trustedCollectives:
   - swamp
-  - si
   - myorg
 ```
 
-Set `trustMemberCollectives: false` to disable membership-based trust and only
-use the explicit `trustedCollectives` list. Set `trustedCollectives` to `[]` and
-`trustMemberCollectives: false` to disable automatic resolution entirely.
+Membership collectives are cached in `auth.json` during `auth login` and
+`auth whoami`. To trust _every_ collective you belong to at once (the previous
+default behavior), opt in explicitly with `trustMemberCollectives: true` — but
+prefer trusting individual collectives. Set `trustedCollectives` to `[]` to
+disable automatic resolution entirely.
+
+Once a collective is trusted, its extensions auto-resolve, but the installed
+version is **pinned to the committed lockfile** — see
+[Version pinning on auto-resolve](#version-pinning-on-auto-resolve) below — so a
+trusted collective still cannot silently push an _updated_ version into a repo.
 
 #### CLI Management
 
@@ -649,8 +660,29 @@ Trusted collectives can be managed via the `swamp extension trust` commands:
 swamp extension trust list                # Show explicit, membership, and resolved collectives
 swamp extension trust add <collective>    # Add a collective to the trusted list
 swamp extension trust rm <collective>     # Remove a collective from the trusted list
-swamp extension trust auto-trust <on|off> # Enable/disable membership auto-trust
+swamp extension trust auto-trust <on|off> # Opt in/out of trusting all membership collectives
 ```
+
+### Version pinning on auto-resolve
+
+When auto-resolve installs an extension that already has an entry in the
+committed `upstream_extensions.json` lockfile, it installs the **pinned
+version** recorded there and verifies the download against the recorded
+**checksum** — the same integrity-anchored path `swamp extension install` uses —
+rather than fetching whatever is latest (swamp-club#465).
+
+This matters on a fresh checkout: `.swamp/pulled-extensions/` is gitignored but
+the lockfile is committed, so without pinning the first reference to a type
+would silently re-fetch the latest published version. Pinning means a trusted
+collective cannot push an unreviewed _update_ into a repo through auto-resolve —
+moving to a newer version requires an explicit `swamp extension pull` /
+`swamp extension update`. A checksum that no longer matches the registry
+(content drift) fails the install with actionable guidance instead of silently
+installing the changed bytes.
+
+The first-ever resolve of an extension (no lockfile entry yet) installs the
+latest version and writes the entry, which becomes the pin for subsequent
+resolves.
 
 ### Resolution Algorithm
 

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -142,12 +142,17 @@ export function createAutoResolveInstallerAdapter(
       const inspectLockfileRepo = await LockfileRepository.create(lockfilePath);
       const entry = inspectLockfileRepo.getEntry(extensionName);
       if (!entry) return { state: "missing" };
+      // A lockfile entry exists; carry its pinned version so the installer's
+      // progress output reports the version that will actually be installed
+      // (the install path pins to it) rather than registry-latest.
       const path = swampPath(repoDir, "pulled-extensions", extensionName);
       try {
         const stat = await Deno.stat(path);
-        if (!stat.isDirectory) return { state: "missing" };
+        if (!stat.isDirectory) {
+          return { state: "missing", lockedVersion: entry.version };
+        }
       } catch {
-        return { state: "missing" };
+        return { state: "missing", lockedVersion: entry.version };
       }
       // Pre-anchor lockfile entries (grandfather path in
       // UpstreamExtensionEntry) may omit `files`. Treat an absent or

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -47,6 +47,7 @@ import { modelRegistry } from "../domain/models/model.ts";
 import type { OutputMode } from "../presentation/output/output.ts";
 import {
   renderAutoResolveAlreadyInstalled,
+  renderAutoResolveCollectiveNotTrusted,
   renderAutoResolveInstalled,
   renderAutoResolveInstalling,
   renderAutoResolveNetworkError,
@@ -184,6 +185,20 @@ export function createAutoResolveInstallerAdapter(
         const lockfileRepository = await LockfileRepository.create(
           lockfilePath,
         );
+        // Honor the committed lockfile pin (swamp-club#465): when an entry
+        // already exists for this extension, install the recorded version and
+        // verify the download against the recorded checksum — the same
+        // integrity-anchored restore path `swamp extension install` uses —
+        // rather than silently fetching latest. This stops a fresh checkout
+        // (where .swamp/pulled-extensions is gitignored but the lockfile is
+        // committed) from pulling an unreviewed newer version. First-ever
+        // installs have no entry and fall back to latest (version: null),
+        // which then becomes the pin for next time.
+        const pinnedEntry = lockfileRepository.getEntry(extensionName);
+        const ref = {
+          name: extensionName,
+          version: pinnedEntry?.version ?? null,
+        };
         const installCtx = {
           getExtension,
           downloadArchive,
@@ -195,6 +210,9 @@ export function createAutoResolveInstallerAdapter(
           force: false,
           alreadyPulled: new Set<string>(),
           depth: 0,
+          ...(pinnedEntry?.checksum
+            ? { expectedChecksum: pinnedEntry.checksum }
+            : {}),
         };
         // W2 (commit 3): route through InstallExtensionService when an
         // ExtensionRepository is available so phase 8 fires (catalog
@@ -204,11 +222,8 @@ export function createAutoResolveInstallerAdapter(
         // catalog gets populated lazily on next loader pass.
         const result = repository !== undefined
           ? await new InstallExtensionService({ denoRuntime, repository })
-            .execute({ name: extensionName, version: null }, installCtx)
-          : await installExtension(
-            { name: extensionName, version: null },
-            installCtx,
-          );
+            .execute(ref, installCtx)
+          : await installExtension(ref, installCtx);
         if (!result) return null;
         return { version: result.version };
       } catch (error) {
@@ -352,6 +367,9 @@ export function createAutoResolveOutputAdapter(
       missing: string[],
     ) {
       renderAutoResolveTruncated(extension, path, missing, mode);
+    },
+    collectiveNotTrusted(collective: string, type: string) {
+      renderAutoResolveCollectiveNotTrusted(collective, type, mode);
     },
   };
 }

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -301,7 +301,9 @@ Deno.test("auto_resolver_adapters: inspectInstallation returns missing when dire
     });
 
     const result = await adapter.inspectInstallation("@fake/deleted-on-disk");
-    assertEquals(result, { state: "missing" });
+    // Carries the pinned version so the install progress line reports the
+    // version that will actually be installed (swamp-club#465).
+    assertEquals(result, { state: "missing", lockedVersion: "2026.01.01.1" });
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -65,7 +65,11 @@ export interface ExtensionInstallResultInfo {
  * Tri-state result describing the on-disk state of a pulled extension.
  *
  * - `missing`: no lockfile entry, or the per-extension directory does
- *   not exist. The auto-resolver should proceed to install.
+ *   not exist. The auto-resolver should proceed to install. When a lockfile
+ *   entry exists but the directory is absent (a fresh checkout, since
+ *   `.swamp/pulled-extensions` is gitignored), `lockedVersion` carries the
+ *   pinned version that will be installed — so progress output reports the
+ *   version that actually lands, not registry-latest (swamp-club#465).
  * - `intact`: lockfile entry exists, the directory exists, and every
  *   file listed in the lockfile is present on disk. If the type still
  *   failed to register, the cause is local (e.g. user edits with a
@@ -77,7 +81,7 @@ export interface ExtensionInstallResultInfo {
  *   swamp-club#133.
  */
 export type InstallationInspection =
-  | { state: "missing" }
+  | { state: "missing"; lockedVersion?: string }
   | { state: "intact"; path: string }
   | { state: "truncated"; path: string; missing: string[] };
 
@@ -410,9 +414,14 @@ export class ExtensionAutoResolver {
       );
       return false;
     }
-    // inspection.state === "missing" — proceed to install.
+    // inspection.state === "missing" — proceed to install. Report the version
+    // that will actually be installed: the lockfile-pinned version when one
+    // exists (the installer honors it), otherwise registry-latest. Without
+    // this the progress line would announce latest while a pinned older
+    // version is what lands (swamp-club#465).
+    const versionToInstall = inspection.lockedVersion ?? version;
 
-    output.installing(extensionName, version, extInfo.description);
+    output.installing(extensionName, versionToInstall, extInfo.description);
 
     // Install the extension
     let installResult: ExtensionInstallResultInfo | null;

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -166,6 +166,12 @@ export interface ExtensionAutoResolverConfig {
 export class ExtensionAutoResolver {
   private readonly config: ExtensionAutoResolverConfig;
   private readonly resolving = new Set<string>();
+  /**
+   * Collectives already warned about as untrusted this process, so multiple
+   * types from the same untrusted collective surface the
+   * `swamp extension trust add` hint once rather than once per type.
+   */
+  private readonly warnedUntrusted = new Set<string>();
 
   constructor(config: ExtensionAutoResolverConfig) {
     this.config = config;
@@ -198,8 +204,14 @@ export class ExtensionAutoResolver {
       // Surface an actionable trust hint for `@collective/*` references so the
       // caller doesn't dead-end on an opaque "unknown type" error. Restricted
       // to user-namespace (`@`) types to avoid false positives on local or
-      // built-in `a/b` type names (swamp-club#465).
-      if (ModelType.isUserNamespace(normalizedType)) {
+      // built-in `a/b` type names, and emitted once per collective per process
+      // so multiple types from the same collective don't repeat it
+      // (swamp-club#465).
+      if (
+        ModelType.isUserNamespace(normalizedType) &&
+        !this.warnedUntrusted.has(collective)
+      ) {
+        this.warnedUntrusted.add(collective);
         this.config.output.collectiveNotTrusted(collective, normalizedType);
       }
       return false;

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -138,6 +138,14 @@ export interface AutoResolveOutputPort {
     path: string,
     missing: string[],
   ): void;
+  /**
+   * Emitted when a referenced `@collective/*` type cannot auto-resolve
+   * because its collective is not trusted (swamp-club#465). Membership
+   * collectives are not trusted by default; this surfaces the actionable
+   * `swamp extension trust add <collective>` opt-in instead of letting the
+   * caller fail with an opaque "unknown type" error.
+   */
+  collectiveNotTrusted(collective: string, type: string): void;
 }
 
 /**
@@ -187,6 +195,13 @@ export class ExtensionAutoResolver {
     if (!this.config.allowedCollectives.includes(collective)) {
       logger
         .debug`Collective '${collective}' not in trusted list, skipping auto-resolution`;
+      // Surface an actionable trust hint for `@collective/*` references so the
+      // caller doesn't dead-end on an opaque "unknown type" error. Restricted
+      // to user-namespace (`@`) types to avoid false positives on local or
+      // built-in `a/b` type names (swamp-club#465).
+      if (ModelType.isUserNamespace(normalizedType)) {
+        this.config.output.collectiveNotTrusted(collective, normalizedType);
+      }
       return false;
     }
 

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -684,3 +684,26 @@ Deno.test("ExtensionAutoResolver - untrusted collective hint is emitted once per
     "collectiveNotTrusted:myorg:@myorg/tools/widget",
   ]);
 });
+
+Deno.test("ExtensionAutoResolver - installing message reports the pinned version, not latest", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller(
+    true,
+    "2026.01.01.1", // installer reports the pinned version it installed
+    { state: "missing", lockedVersion: "2026.01.01.1" },
+  );
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup({
+      "@swamp/aws": { description: "AWS", latestVersion: "2026.09.09.9" },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@swamp/aws/ec2/instance");
+  assertEquals(result, true);
+  // "installing" must show the pinned version (from the lockfile), not latest.
+  assertEquals(output.calls[1], "installing:@swamp/aws@2026.01.01.1");
+  assertEquals(output.calls[2], "installed:@swamp/aws@2026.01.01.1:3");
+});

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -62,6 +62,9 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
         `alreadyInstalledTruncated:${ext}:${path}:${missing.join(",")}`,
       );
     },
+    collectiveNotTrusted(collective: string, type: string) {
+      calls.push(`collectiveNotTrusted:${collective}:${type}`);
+    },
   };
 }
 
@@ -137,7 +140,29 @@ Deno.test("ExtensionAutoResolver - skips non-allowlisted collectives", async () 
 
   const result = await resolver.resolve("@foo/bar/baz");
   assertEquals(result, false);
-  assertEquals(output.calls.length, 0); // No output — silently skipped
+  // Untrusted @collective/* references surface an actionable trust hint rather
+  // than installing or failing silently (swamp-club#465).
+  assertEquals(output.calls, ["collectiveNotTrusted:foo:@foo/bar/baz"]);
+});
+
+Deno.test("ExtensionAutoResolver - untrusted collective emits trust hint but does not install", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup({
+      "@myorg/tools": { description: "x", latestVersion: "2026.03.16.1" },
+    }),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@myorg/tools/widget");
+  assertEquals(result, false);
+  assertEquals(installer.installCalls, []);
+  assertEquals(output.calls, [
+    "collectiveNotTrusted:myorg:@myorg/tools/widget",
+  ]);
 });
 
 Deno.test("ExtensionAutoResolver - resolves via direct lookup", async () => {

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -665,3 +665,22 @@ Deno.test("ExtensionAutoResolver - 2-segment type generates full type as only ca
     "2-segment type should produce exactly one direct-lookup candidate (the full type)",
   );
 });
+
+Deno.test("ExtensionAutoResolver - untrusted collective hint is emitted once per collective", async () => {
+  const output = createMockOutput();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: createMockInstaller(),
+    output,
+  });
+
+  await resolver.resolve("@myorg/tools/widget");
+  await resolver.resolve("@myorg/tools/gizmo");
+  await resolver.resolve("@myorg/utils/helper");
+
+  // One hint for the whole collective, not one per referenced type.
+  assertEquals(output.calls, [
+    "collectiveNotTrusted:myorg:@myorg/tools/widget",
+  ]);
+});

--- a/src/libswamp/extensions/trust.ts
+++ b/src/libswamp/extensions/trust.ts
@@ -20,8 +20,14 @@
 import type { RepoMarkerData } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import type { SwampError } from "../errors.ts";
 
-/** Default trusted collectives when none are configured in .swamp.yaml. */
-export const DEFAULT_TRUSTED: string[] = ["swamp", "si"];
+/**
+ * Default trusted collectives when none are configured in .swamp.yaml. Only
+ * the first-party `swamp` collective is trusted by default. Every other
+ * collective — including ones the user is a member of — must be trusted
+ * explicitly via `swamp extension trust add <collective>` before its
+ * extensions will auto-resolve (swamp-club#465).
+ */
+export const DEFAULT_TRUSTED: string[] = ["swamp"];
 
 /** Result data for trust add/rm operations. */
 export interface TrustModifyData {
@@ -37,9 +43,14 @@ export type TrustModifyEvent =
   | { kind: "error"; error: SwampError };
 
 /**
- * Resolves the full list of trusted collectives by merging explicit
- * trustedCollectives from .swamp.yaml with the user's membership collectives
- * from cached auth credentials.
+ * Resolves the full list of trusted collectives.
+ *
+ * The explicit `trustedCollectives` list from .swamp.yaml (defaulting to
+ * {@link DEFAULT_TRUSTED}) is always trusted. Membership collectives from
+ * cached auth are NOT trusted by default — a user must opt in by setting
+ * `trustMemberCollectives: true`, which trusts every collective they belong
+ * to (swamp-club#465). Without that opt-in, only the explicit list resolves,
+ * so a compromised member collective cannot silently auto-resolve into a repo.
  */
 export function resolveTrustedCollectives(
   marker: RepoMarkerData | null,
@@ -47,13 +58,12 @@ export function resolveTrustedCollectives(
 ): string[] {
   const explicit = marker?.trustedCollectives ?? DEFAULT_TRUSTED;
 
-  // If opt-out is set, only use explicit list
-  if (marker?.trustMemberCollectives === false) {
-    return explicit;
-  }
-
-  // Merge membership collectives (deduplicated)
-  if (authCollectives && authCollectives.length > 0) {
+  // Membership collectives are trusted only when explicitly opted in.
+  if (
+    marker?.trustMemberCollectives === true &&
+    authCollectives &&
+    authCollectives.length > 0
+  ) {
     return [...new Set([...explicit, ...authCollectives])];
   }
 

--- a/src/libswamp/extensions/trust_add_test.ts
+++ b/src/libswamp/extensions/trust_add_test.ts
@@ -58,11 +58,11 @@ Deno.test("trust add adds a collective to the list", async () => {
       data: {
         action: "added",
         collective: "myorg",
-        trustedCollectives: ["swamp", "si", "myorg"],
+        trustedCollectives: ["swamp", "myorg"],
       },
     },
   ]);
-  assertEquals(writtenMarker?.trustedCollectives, ["swamp", "si", "myorg"]);
+  assertEquals(writtenMarker?.trustedCollectives, ["swamp", "myorg"]);
 });
 
 Deno.test("trust add errors on invalid collective name", async () => {
@@ -122,6 +122,6 @@ Deno.test("trust add initializes from defaults when trustedCollectives is undefi
     TrustModifyEvent,
     { kind: "completed" }
   >;
-  assertEquals(completed.data.trustedCollectives, ["swamp", "si", "neworg"]);
-  assertEquals(writtenMarker?.trustedCollectives, ["swamp", "si", "neworg"]);
+  assertEquals(completed.data.trustedCollectives, ["swamp", "neworg"]);
+  assertEquals(writtenMarker?.trustedCollectives, ["swamp", "neworg"]);
 });

--- a/src/libswamp/extensions/trust_list.ts
+++ b/src/libswamp/extensions/trust_list.ts
@@ -73,7 +73,9 @@ export async function* trustList(
   const authCollectives = await deps.loadAuthCollectives();
 
   const explicit = marker?.trustedCollectives ?? DEFAULT_TRUSTED;
-  const trustMemberCollectives = marker?.trustMemberCollectives !== false;
+  // Membership collectives are trusted only when explicitly opted in
+  // (swamp-club#465); the default is no membership trust.
+  const trustMemberCollectives = marker?.trustMemberCollectives === true;
   const resolved = resolveTrustedCollectives(marker, authCollectives);
 
   const membership = trustMemberCollectives && authCollectives

--- a/src/libswamp/extensions/trust_list_test.ts
+++ b/src/libswamp/extensions/trust_list_test.ts
@@ -54,10 +54,10 @@ Deno.test("trust list shows defaults when no marker exists", async () => {
     {
       kind: "completed",
       data: {
-        explicit: ["swamp", "si"],
+        explicit: ["swamp"],
         membership: [],
-        resolved: ["swamp", "si"],
-        trustMemberCollectives: true,
+        resolved: ["swamp"],
+        trustMemberCollectives: false,
       },
     },
   ]);
@@ -79,10 +79,10 @@ Deno.test("trust list shows explicit collectives from marker", async () => {
   assertEquals(completed.data.resolved, ["swamp", "si", "myorg"]);
 });
 
-Deno.test("trust list merges membership collectives", async () => {
+Deno.test("trust list merges membership collectives when opted in", async () => {
   const ctx = createLibSwampContext();
   const deps = makeDeps({
-    marker: baseMarker,
+    marker: { ...baseMarker, trustMemberCollectives: true },
     authCollectives: ["teamorg"],
   });
 
@@ -92,16 +92,16 @@ Deno.test("trust list merges membership collectives", async () => {
     TrustListEvent,
     { kind: "completed" }
   >;
-  assertEquals(completed.data.explicit, ["swamp", "si"]);
+  assertEquals(completed.data.explicit, ["swamp"]);
   assertEquals(completed.data.membership, ["teamorg"]);
-  assertEquals(completed.data.resolved, ["swamp", "si", "teamorg"]);
+  assertEquals(completed.data.resolved, ["swamp", "teamorg"]);
   assertEquals(completed.data.trustMemberCollectives, true);
 });
 
-Deno.test("trust list excludes membership when trustMemberCollectives is false", async () => {
+Deno.test("trust list excludes membership by default (no opt-in)", async () => {
   const ctx = createLibSwampContext();
   const deps = makeDeps({
-    marker: { ...baseMarker, trustMemberCollectives: false },
+    marker: baseMarker,
     authCollectives: ["teamorg"],
   });
 
@@ -112,14 +112,14 @@ Deno.test("trust list excludes membership when trustMemberCollectives is false",
     { kind: "completed" }
   >;
   assertEquals(completed.data.membership, []);
-  assertEquals(completed.data.resolved, ["swamp", "si"]);
+  assertEquals(completed.data.resolved, ["swamp"]);
   assertEquals(completed.data.trustMemberCollectives, false);
 });
 
-Deno.test("trust list deduplicates membership collectives that overlap with explicit", async () => {
+Deno.test("trust list deduplicates membership collectives that overlap with explicit when opted in", async () => {
   const ctx = createLibSwampContext();
   const deps = makeDeps({
-    marker: baseMarker,
+    marker: { ...baseMarker, trustMemberCollectives: true },
     authCollectives: ["swamp", "neworg"],
   });
 
@@ -130,5 +130,5 @@ Deno.test("trust list deduplicates membership collectives that overlap with expl
     { kind: "completed" }
   >;
   assertEquals(completed.data.membership, ["neworg"]);
-  assertEquals(completed.data.resolved, ["swamp", "si", "neworg"]);
+  assertEquals(completed.data.resolved, ["swamp", "neworg"]);
 });

--- a/src/libswamp/extensions/trust_test.ts
+++ b/src/libswamp/extensions/trust_test.ts
@@ -20,9 +20,9 @@
 import { assertEquals } from "@std/assert";
 import { resolveTrustedCollectives } from "./trust.ts";
 
-Deno.test("resolveTrustedCollectives returns defaults when no marker", () => {
+Deno.test("resolveTrustedCollectives returns swamp-only default when no marker", () => {
   const result = resolveTrustedCollectives(null);
-  assertEquals(result, ["swamp", "si"]);
+  assertEquals(result, ["swamp"]);
 });
 
 Deno.test("resolveTrustedCollectives returns explicit collectives from marker", () => {
@@ -35,22 +35,35 @@ Deno.test("resolveTrustedCollectives returns explicit collectives from marker", 
   assertEquals(result, ["myorg"]);
 });
 
-Deno.test("resolveTrustedCollectives merges auth collectives with defaults", () => {
+Deno.test("resolveTrustedCollectives does NOT trust membership collectives by default", () => {
+  // No trustMemberCollectives opt-in → auth collectives are ignored.
   const result = resolveTrustedCollectives(null, ["myorg", "other"]);
-  assertEquals(result, ["swamp", "si", "myorg", "other"]);
+  assertEquals(result, ["swamp"]);
 });
 
-Deno.test("resolveTrustedCollectives deduplicates merged collectives", () => {
+Deno.test("resolveTrustedCollectives merges membership collectives only when opted in", () => {
   const marker = {
     swampVersion: "0.1.0",
     initializedAt: "2024-01-01T00:00:00Z",
-    trustedCollectives: ["swamp", "si", "myorg"],
+    trustedCollectives: ["swamp"],
+    trustMemberCollectives: true,
   };
-  const result = resolveTrustedCollectives(marker, ["myorg", "neworg"]);
-  assertEquals(result, ["swamp", "si", "myorg", "neworg"]);
+  const result = resolveTrustedCollectives(marker, ["myorg", "other"]);
+  assertEquals(result, ["swamp", "myorg", "other"]);
 });
 
-Deno.test("resolveTrustedCollectives respects trustMemberCollectives false", () => {
+Deno.test("resolveTrustedCollectives deduplicates when opted in", () => {
+  const marker = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01T00:00:00Z",
+    trustedCollectives: ["swamp", "myorg"],
+    trustMemberCollectives: true,
+  };
+  const result = resolveTrustedCollectives(marker, ["myorg", "neworg"]);
+  assertEquals(result, ["swamp", "myorg", "neworg"]);
+});
+
+Deno.test("resolveTrustedCollectives ignores membership collectives when opt-in is false", () => {
   const marker = {
     swampVersion: "0.1.0",
     initializedAt: "2024-01-01T00:00:00Z",
@@ -61,14 +74,15 @@ Deno.test("resolveTrustedCollectives respects trustMemberCollectives false", () 
   assertEquals(result, ["swamp"]);
 });
 
-Deno.test("resolveTrustedCollectives merges when trustMemberCollectives is true", () => {
+Deno.test("resolveTrustedCollectives explicit trust add works without membership opt-in", () => {
+  // The opt-in escape hatch is per-collective: adding myorg to the explicit
+  // list trusts it without trusting every membership collective.
   const marker = {
     swampVersion: "0.1.0",
     initializedAt: "2024-01-01T00:00:00Z",
-    trustedCollectives: ["swamp"],
-    trustMemberCollectives: true,
+    trustedCollectives: ["swamp", "myorg"],
   };
-  const result = resolveTrustedCollectives(marker, ["myorg"]);
+  const result = resolveTrustedCollectives(marker, ["myorg", "other"]);
   assertEquals(result, ["swamp", "myorg"]);
 });
 
@@ -76,13 +90,14 @@ Deno.test("resolveTrustedCollectives handles undefined auth collectives", () => 
   const marker = {
     swampVersion: "0.1.0",
     initializedAt: "2024-01-01T00:00:00Z",
-    trustedCollectives: ["swamp", "si"],
+    trustedCollectives: ["swamp"],
+    trustMemberCollectives: true,
   };
   const result = resolveTrustedCollectives(marker, undefined);
-  assertEquals(result, ["swamp", "si"]);
+  assertEquals(result, ["swamp"]);
 });
 
 Deno.test("resolveTrustedCollectives handles empty auth collectives", () => {
   const result = resolveTrustedCollectives(null, []);
-  assertEquals(result, ["swamp", "si"]);
+  assertEquals(result, ["swamp"]);
 });

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -201,8 +201,9 @@ export function renderAutoResolveCollectiveNotTrusted(
     console.log(
       JSON.stringify({
         event: "auto_resolve",
-        status: "collective_not_trusted",
+        status: "failed",
         type,
+        reason: "collective_not_trusted",
         collective,
       }),
     );

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -187,6 +187,34 @@ export function renderAutoResolveTruncated(
 }
 
 /**
+ * Renders an actionable error when a referenced `@collective/*` type cannot
+ * auto-resolve because its collective is not trusted (swamp-club#465).
+ * Membership collectives are not trusted by default — this tells the user how
+ * to opt in instead of dead-ending on an opaque "unknown type" error.
+ */
+export function renderAutoResolveCollectiveNotTrusted(
+  collective: string,
+  type: string,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({
+        event: "auto_resolve",
+        status: "collective_not_trusted",
+        type,
+        collective,
+      }),
+    );
+  } else {
+    logger
+      .warn`Type ${type} is from collective ${collective}, which is not trusted, so it was not auto-resolved.`;
+    logger
+      .warn`To allow its extensions to auto-resolve, run: swamp extension trust add ${collective}`;
+  }
+}
+
+/**
  * Renders an error message when auto-resolution fails due to a network error.
  */
 export function renderAutoResolveNetworkError(


### PR DESCRIPTION
## Summary

Closes the install-consent gap reported in **swamp-club#465**.

Belonging to a collective granted *publish* access but also silently bypassed *install* consent: extensions from any collective the user was a member of auto-resolved, installed, and **executed** on first reference — no opt-in, no prompt. On a fresh checkout the lazy auto-resolve path fetched **latest**, ignoring the version pinned in the committed `upstream_extensions.json` lockfile, so a compromised or careless member publish (including an unreviewed *update*) could run arbitrary code in every consumer repo.

This was reproduced live against the registry before the fix (a membership collective's type silently installed + executed; a corrupted committed checksum was ignored by auto-resolve while `swamp extension install` rejected it).

## Changes

- **Trust only `swamp` by default.** Membership collectives are no longer auto-trusted. Trust each explicitly with `swamp extension trust add <collective>`, or opt into trusting all memberships with `trustMemberCollectives: true` (default is now `false`).
- **Honor the committed lockfile pin on auto-resolve.** When a lockfile entry exists, install the recorded version and verify the recorded checksum — the same integrity-anchored path `swamp extension install` uses — instead of fetching latest. A trusted collective therefore cannot silently push an *updated* version; moving versions requires an explicit `swamp extension pull` / `swamp extension update`.
- **Actionable error.** An untrusted `@collective/*` reference now emits a clear "run `swamp extension trust add <collective>`" message (log + structured `collective_not_trusted` json event) instead of an opaque "unknown type" error. No prompt — works identically for humans, CI, and agents.
- Updated `design/extension.md` and the relevant skill docs.

## Test Plan

- New/updated unit tests: trust provenance/defaults (`trust_test.ts`), `trust_list`/`add` semantics, resolver untrusted-collective hint, output adapter.
- `deno fmt --check`, `deno lint`, `deno check` clean; full suite passes (one unrelated flaky SIGINT timing test).
- **Live verification** against the registry: (a) untrusted member collective → no auto-resolve + actionable trust hint; (b) `trust add` → resolves + pins; (c) corrupted committed checksum on fresh checkout → checksum-mismatch failure, no silent update.

## Follow-ups (filed, not in scope)

- **swamp-club#478** — let users gate/pin the first-party `@swamp` datastore auto-update (separate, lower-risk first-party path).
- **swamp-club#481** — update the user-facing manual (`repository-configuration.md` defaults + version-pinning note; `how-swamp-works.md` clarifier). Should merge coordinated with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)