### PR TITLE
fix(models): refuse literal sensitive global arguments at rest (swamp-club#480)

### DIFF
--- a/integration/model_create_sensitive_test.ts
+++ b/integration/model_create_sensitive_test.ts
@@ -1,0 +1,198 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for the secrets-at-rest guard (swamp-club#480).
+ *
+ * Exercises the real create path end-to-end against a real
+ * YamlDefinitionRepository on disk: a literal value for a `{ sensitive: true }`
+ * global argument is refused (and nothing is written), while a `vault.get(...)`
+ * expression is persisted verbatim. Also drives the persistence chokepoint
+ * directly to prove that an out-of-band writer (e.g. a different command or a
+ * datastore sync) cannot land a literal secret on disk either.
+ */
+
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { z } from "zod";
+import {
+  consumeStream,
+  createLibSwampContext,
+  modelCreate,
+  type ModelCreateDeps,
+  type ModelCreateEvent,
+} from "../src/libswamp/mod.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { defineModel } from "../src/domain/models/model.ts";
+import { UserError } from "../src/domain/errors.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import type { ModelDefinition } from "../src/domain/models/model.ts";
+import { initializeTestRepo } from "./test_helpers.ts";
+
+const SENSITIVE_CREATE_TYPE = ModelType.create("test/sensitive-create");
+
+// Registered in the global registry so the persistence chokepoint
+// (YamlDefinitionRepository.save) can resolve the sensitive-field schema.
+const modelDef = defineModel({
+  type: SENSITIVE_CREATE_TYPE,
+  version: "2026.05.29.1",
+  globalArguments: z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    token: z.string().min(20).meta({ sensitive: true }).optional(),
+    region: z.string(),
+  }),
+  methods: {},
+}) as unknown as ModelDefinition;
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({
+    prefix: "swamp-model-create-sensitive-",
+  });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+/** Wires the real YamlDefinitionRepository into ModelCreateDeps. */
+function realDeps(repo: YamlDefinitionRepository): ModelCreateDeps {
+  return {
+    resolveModelType: () => Promise.resolve(modelDef),
+    findByNameGlobal: async (name) =>
+      (await repo.findByNameGlobal(name)) !== null,
+    getModelDef: () => modelDef,
+    createAndSave: async (type, name, typeVersion, globalArguments) => {
+      const definition = Definition.create({
+        name,
+        type: type.normalized,
+        typeVersion,
+        globalArguments,
+      });
+      await repo.save(type, definition);
+      return definition;
+    },
+    getPath: (type, id) => repo.getPath(type, id),
+    listAvailableTypes: () => [SENSITIVE_CREATE_TYPE.normalized],
+  };
+}
+
+async function runCreate(
+  deps: ModelCreateDeps,
+  name: string,
+  globalArguments: Record<string, unknown>,
+): Promise<ModelCreateEvent[]> {
+  const events: ModelCreateEvent[] = [];
+  await consumeStream(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: SENSITIVE_CREATE_TYPE.normalized,
+      name,
+      globalArguments,
+    }),
+    {
+      creating: () => {},
+      completed: (e) => {
+        events.push(e);
+      },
+      error: (e) => {
+        events.push(e);
+      },
+    },
+  );
+  return events;
+}
+
+Deno.test("Integration: model create refuses a literal sensitive global arg and writes no YAML", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    const repo = new YamlDefinitionRepository(repoDir);
+
+    const events = await runCreate(realDeps(repo), "leaky", {
+      apiKey: "SUPERSECRET123",
+      region: "us-east-1",
+    });
+
+    const last = events[events.length - 1];
+    assertEquals(last.kind, "error");
+
+    // Nothing was persisted — the secret never reached disk.
+    assertEquals(await repo.findByNameGlobal("leaky"), null);
+  });
+});
+
+Deno.test("Integration: model create persists a vault.get expression verbatim", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    const repo = new YamlDefinitionRepository(repoDir);
+    const expr = "${{ vault.get('creds', 'apiKey') }}";
+
+    const events = await runCreate(realDeps(repo), "vaulted", {
+      apiKey: expr,
+      region: "us-east-1",
+    });
+
+    assertEquals(events[events.length - 1].kind, "completed");
+
+    const stored = await repo.findByNameGlobal("vaulted");
+    assertNotEquals(stored, null);
+    assertEquals(stored!.definition.globalArguments.apiKey, expr);
+  });
+});
+
+Deno.test("Integration: model create accepts a vault.get expression for a constrained sensitive field (ADV-3)", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    const repo = new YamlDefinitionRepository(repoDir);
+    // The sentinel is shorter than the field's min(20); it must be accepted
+    // because expression fields are not schema-validated at create time.
+    const events = await runCreate(realDeps(repo), "constrained", {
+      apiKey: "${{ vault.get('creds', 'apiKey') }}",
+      token: "${{ vault.get('creds', 'token') }}",
+      region: "us-east-1",
+    });
+
+    assertEquals(events[events.length - 1].kind, "completed");
+    assertNotEquals(await repo.findByNameGlobal("constrained"), null);
+  });
+});
+
+Deno.test("Integration: the persistence chokepoint blocks an out-of-band writer", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    const repo = new YamlDefinitionRepository(repoDir);
+
+    // Simulate a writer that bypasses model create's early check (e.g. a
+    // different command path). The save() chokepoint must still refuse it.
+    const definition = Definition.create({
+      name: "smuggled",
+      type: SENSITIVE_CREATE_TYPE.normalized,
+      globalArguments: { apiKey: "SUPERSECRET123", region: "us-east-1" },
+    });
+
+    await assertRejects(
+      () => repo.save(SENSITIVE_CREATE_TYPE, definition),
+      UserError,
+    );
+    assertEquals(await repo.findByNameGlobal("smuggled"), null);
+  });
+});

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
+import { containsExpression } from "../expressions/expression_parser.ts";
 
 /**
  * Information about a sensitive field extracted from a Zod schema.
@@ -178,6 +179,113 @@ export function extractSensitiveFields(
 
   return results;
 }
+
+/**
+ * Determines whether a string is composed solely of CEL template expressions
+ * (one or more `${{ ... }}`) with only whitespace around or between them.
+ *
+ * Such a value carries no cleartext secret — the secret is resolved at runtime
+ * from a vault/env reference. A string mixing a literal with an expression
+ * (e.g. `prefix-${{ vault.get(...) }}`) is NOT expression-only: the literal
+ * portion would still be persisted in cleartext.
+ */
+function isExpressionOnly(value: string): boolean {
+  if (!containsExpression(value)) {
+    return false;
+  }
+  return value.replace(/\$\{\{.+?\}\}/g, "").trim() === "";
+}
+
+/**
+ * Reports whether a value supplied for a sensitive field is a literal secret
+ * that would be persisted in cleartext.
+ *
+ * - `undefined`/`null` and empty/whitespace-only strings carry no secret.
+ * - A string that is composed solely of `${{ ... }}` expressions (e.g. a
+ *   `vault.get(...)` reference) is resolved at runtime and is safe.
+ * - Any other present value — a non-expression string, a string mixing literal
+ *   text with an expression, or any number/boolean/array/object — is treated as
+ *   a literal secret. Non-string values cannot be expression references, so they
+ *   are always literals; this fails closed rather than risk leaking a typed
+ *   secret.
+ */
+function isLiteralSecret(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      return false;
+    }
+    return !isExpressionOnly(value);
+  }
+  return true;
+}
+
+/**
+ * Returns the dot-paths of global-argument fields marked `{ sensitive: true }`
+ * in `schema` whose value in `args` is a literal secret (see
+ * {@link isLiteralSecret}). An empty result means every sensitive global
+ * argument is either absent or a runtime expression and is safe to persist.
+ *
+ * This is the shared rule enforced at every seam that persists user-supplied
+ * `globalArguments` — primarily the persistence chokepoint
+ * (`YamlDefinitionRepository.save`), and additionally `model create` /
+ * direct-execution for an earlier, friendlier error. A literal value supplied
+ * for a sensitive global argument would otherwise be written in cleartext into
+ * the definition YAML.
+ *
+ * Sensitive fields nested inside non-object schemas (e.g. records/unions) are
+ * not detected — `extractSensitiveFields` only walks object shapes — so callers
+ * should treat this as a best-effort guard, consistent with the redaction
+ * primitives in this module.
+ *
+ * @param schema - The global-arguments Zod schema for the model type
+ * @param args - The supplied global-argument values
+ * @returns Dot-paths of sensitive fields holding a literal secret
+ */
+export function findLiteralSensitiveGlobalArgs(
+  schema: z.ZodTypeAny | undefined,
+  args: Record<string, unknown> | undefined,
+): string[] {
+  if (!schema || !args) {
+    return [];
+  }
+  const fields = extractSensitiveFields(schema);
+  if (fields.length === 0) {
+    return [];
+  }
+
+  const offending: string[] = [];
+  for (const field of fields) {
+    if (isLiteralSecret(getNestedValue(args, field.path))) {
+      offending.push(field.path);
+    }
+  }
+  return offending;
+}
+
+/**
+ * Builds the user-facing remediation message for one or more sensitive global
+ * arguments that were supplied as literal values. Shared by every call site so
+ * the guidance is identical whether the rejection comes from the persistence
+ * chokepoint, `model create`, or direct execution.
+ */
+export function literalSensitiveGlobalArgsMessage(paths: string[]): string {
+  const fieldList = paths.map((p) => `'${p}'`).join(", ");
+  const subject = paths.length > 1
+    ? `Global arguments ${fieldList} are`
+    : `Global argument ${fieldList} is`;
+  return (
+    `${subject} marked sensitive and cannot be set to a literal value — ` +
+    `it would be stored in cleartext in the definition YAML. Store the secret ` +
+    `in a vault and reference it with a vault.get expression, e.g. ` +
+    `--global-arg "apiKey=\${{ vault.get('my-vault', 'api-key') }}".`
+  );
+}
+
+/** Machine-readable error code for a rejected literal sensitive global argument. */
+export const LITERAL_SENSITIVE_GLOBAL_ARG_CODE = "literal_sensitive_global_arg";
 
 /**
  * Returns a redacted clone of `data` with every field marked `{ sensitive: true }`

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -17,12 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
   extractSensitiveFields,
   extractSensitiveFieldValues,
+  findLiteralSensitiveGlobalArgs,
   getNestedValue,
+  literalSensitiveGlobalArgsMessage,
   redactSensitiveValues,
   setNestedValue,
 } from "./sensitive_field_extractor.ts";
@@ -346,4 +348,161 @@ Deno.test("redactSensitiveValues: does not mutate the input", () => {
   redactSensitiveValues(schema, input);
 
   assertEquals(input.apiKey, "SUPERSECRET123");
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: flags a literal string secret", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    region: z.string(),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      apiKey: "SUPERSECRET123",
+      region: "us-east-1",
+    }),
+    ["apiKey"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: allows a pure vault.get expression", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      apiKey: "${{ vault.get('creds', 'apiKey') }}",
+    }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: allows multiple whitespace-separated expressions", () => {
+  const schema = z.object({
+    token: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      token: "${{ vault.get('a', 'x') }} ${{ vault.get('b', 'y') }}",
+    }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: refuses mixed literal + expression (partial leak)", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      apiKey: "prefix-${{ vault.get('creds', 'apiKey') }}",
+    }),
+    ["apiKey"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: refuses a non-string literal (number)", () => {
+  const schema = z.object({
+    secretPort: z.number().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, { secretPort: 5432 }),
+    ["secretPort"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: refuses a boolean literal", () => {
+  const schema = z.object({
+    secretFlag: z.boolean().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, { secretFlag: true }),
+    ["secretFlag"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: handles nested dot-paths", () => {
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+    }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      credentials: { apiKey: "SECRET" },
+    }),
+    ["credentials.apiKey"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: ignores non-sensitive literals", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    region: z.string(),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, { region: "us-east-1" }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: reports every offending field", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    apiSecret: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      apiKey: "AAA",
+      apiSecret: "BBB",
+    }),
+    ["apiKey", "apiSecret"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: skips empty / whitespace-only strings", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(findLiteralSensitiveGlobalArgs(schema, { apiKey: "" }), []);
+  assertEquals(findLiteralSensitiveGlobalArgs(schema, { apiKey: "   " }), []);
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: returns [] for undefined schema or args", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  assertEquals(findLiteralSensitiveGlobalArgs(undefined, { apiKey: "x" }), []);
+  assertEquals(findLiteralSensitiveGlobalArgs(schema, undefined), []);
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: returns [] for a non-object schema (documented residual)", () => {
+  // extractSensitiveFields only walks object shapes; a record schema is not
+  // inspected, so a sensitive value nested in it is not detected. This mirrors
+  // the redaction primitives' limitation and is an accepted best-effort gap.
+  const schema = z.record(z.string(), z.string());
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, { apiKey: "SECRET" }),
+    [],
+  );
+});
+
+Deno.test("literalSensitiveGlobalArgsMessage: names fields and gives vault remediation", () => {
+  const single = literalSensitiveGlobalArgsMessage(["apiKey"]);
+  assertStringIncludes(single, "'apiKey' is marked sensitive");
+  assertStringIncludes(single, "vault.get");
+
+  const multi = literalSensitiveGlobalArgsMessage(["apiKey", "apiSecret"]);
+  assertStringIncludes(multi, "'apiKey', 'apiSecret' are");
 });

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -34,6 +34,12 @@ import {
   type DefinitionId,
 } from "../../domain/definitions/definition.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  findLiteralSensitiveGlobalArgs,
+  LITERAL_SENSITIVE_GLOBAL_ARG_CODE,
+  literalSensitiveGlobalArgsMessage,
+} from "../../domain/models/sensitive_field_extractor.ts";
+import { UserError } from "../../domain/errors.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createDefinitionCreated,
@@ -322,8 +328,41 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     // Ensure type metadata is always present in persisted YAML
     data.type = type.normalized;
     await modelRegistry.ensureTypeLoaded(type);
-    const modelDef = modelRegistry.get(type);
+    let modelDef = modelRegistry.get(type);
+    // ensureTypeLoaded only imports types already registered as lazy. A command
+    // that never populated the registry (e.g. `model edit`, which resolves the
+    // type only from the YAML on disk) leaves an extension type unresolved here,
+    // which would silently bypass the sensitive-arg guard below. Fall back to a
+    // full extension load so the schema is available. ensureLoaded is memoized,
+    // so commands that already loaded the registry (create/run/serve) pay
+    // nothing, and this only does real work the first time an unloaded type is
+    // written.
+    if (!modelDef) {
+      await modelRegistry.ensureLoaded();
+      await modelRegistry.ensureTypeLoaded(type);
+      modelDef = modelRegistry.get(type);
+    }
     data.typeVersion = modelDef?.version ?? data.typeVersion;
+
+    // Fail closed before writing: a global argument marked `{ sensitive: true }`
+    // must never be persisted as a literal value — it would sit in cleartext in
+    // the definition YAML, readable by anyone with repo/filesystem access. This
+    // is the single chokepoint every source-definition writer funnels through
+    // (model create/edit/run/workflow auto-definitions and the serve API), so
+    // enforcing it here covers them all. Literal values must instead be supplied
+    // as a `vault.get(...)` expression, which is resolved at runtime and stored
+    // unevaluated. Throwing before the write leaves no partial file behind.
+    const leakedArgs = findLiteralSensitiveGlobalArgs(
+      modelDef?.globalArguments,
+      data.globalArguments,
+    );
+    if (leakedArgs.length > 0) {
+      throw new UserError(
+        literalSensitiveGlobalArgsMessage(leakedArgs),
+        LITERAL_SENSITIVE_GLOBAL_ARG_CODE,
+      );
+    }
+
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     const content = stringifyYaml(cleanData as Record<string, unknown>);

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -17,13 +17,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
+import { z } from "zod";
 import { YamlDefinitionRepository } from "./yaml_definition_repository.ts";
 import { Definition } from "../../domain/definitions/definition.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
+import { defineModel } from "../../domain/models/model.ts";
+import { UserError } from "../../domain/errors.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const tempDir = await Deno.makeTempDir();
@@ -558,5 +566,98 @@ Deno.test("YamlDefinitionRepository.findById falls back to secondary dir", async
     const found = await repo.findById(testType, def.id);
     assertNotEquals(found, null);
     assertEquals(found!.name, "by-id-def");
+  });
+});
+
+// --- Sensitive global-argument chokepoint guard ---
+//
+// save() is the single seam every source-definition writer funnels through, so
+// the guard that refuses a literal value for a `{ sensitive: true }` global
+// argument is enforced here. It resolves the schema from the model registry, so
+// these tests register a real type via defineModel.
+
+const SENSITIVE_SAVE_TYPE = ModelType.create("test/sensitive-save");
+defineModel({
+  type: SENSITIVE_SAVE_TYPE,
+  version: "2026.05.29.1",
+  globalArguments: z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+    region: z.string(),
+  }),
+  methods: {},
+});
+
+Deno.test("YamlDefinitionRepository.save refuses a literal sensitive global arg and writes no file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = Definition.create({
+      name: "leaky",
+      type: SENSITIVE_SAVE_TYPE.normalized,
+      globalArguments: { apiKey: "SUPERSECRET123", region: "us-east-1" },
+    });
+
+    const error = await assertRejects(
+      () => repo.save(SENSITIVE_SAVE_TYPE, definition),
+      UserError,
+    );
+    assertStringIncludes(error.message, "apiKey");
+    assertStringIncludes(error.message, "vault.get");
+
+    // Fail-closed before the write: nothing landed on disk.
+    assertEquals(await repo.findById(SENSITIVE_SAVE_TYPE, definition.id), null);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save accepts a vault.get expression for a sensitive global arg", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const expr = "${{ vault.get('creds', 'apiKey') }}";
+    const definition = Definition.create({
+      name: "vaulted",
+      type: SENSITIVE_SAVE_TYPE.normalized,
+      globalArguments: { apiKey: expr, region: "us-east-1" },
+    });
+
+    await repo.save(SENSITIVE_SAVE_TYPE, definition);
+
+    const loaded = await repo.findById(SENSITIVE_SAVE_TYPE, definition.id);
+    assertNotEquals(loaded, null);
+    // The expression is persisted verbatim, unevaluated.
+    assertEquals(loaded!.globalArguments.apiKey, expr);
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save is unaffected when no sensitive field carries a literal", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    const definition = Definition.create({
+      name: "no-secret",
+      type: SENSITIVE_SAVE_TYPE.normalized,
+      globalArguments: { region: "us-east-1" },
+    });
+
+    await repo.save(SENSITIVE_SAVE_TYPE, definition);
+
+    assertNotEquals(
+      await repo.findById(SENSITIVE_SAVE_TYPE, definition.id),
+      null,
+    );
+  });
+});
+
+Deno.test("YamlDefinitionRepository.save passes through an unregistered type (schema unknown)", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new YamlDefinitionRepository(dir);
+    // testType is not registered, so the schema is unknown and sensitivity
+    // cannot be determined — the write proceeds (matches model get behavior).
+    const definition = Definition.create({
+      name: "unknown-type",
+      type: testType.normalized,
+      globalArguments: { key: "value" },
+    });
+
+    await repo.save(testType, definition);
+
+    assertNotEquals(await repo.findById(testType, definition.id), null);
   });
 });

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -37,6 +37,11 @@ import {
   coerceMethodArgs,
   getObjectShape,
 } from "../../domain/models/zod_type_coercion.ts";
+import { stripExpressionFields } from "../../domain/expressions/expression_parser.ts";
+import {
+  findLiteralSensitiveGlobalArgs,
+  literalSensitiveGlobalArgsMessage,
+} from "../../domain/models/sensitive_field_extractor.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -180,21 +185,52 @@ export async function* modelCreate(
             return;
           }
         }
-        const result = globalArgsSchema.safeParse(globalArguments);
-        if (!result.success) {
-          const issues = result.error.issues.map((i) => {
-            const path = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
-            return `  ${path}${i.message}`;
-          }).join("\n");
+        // Validate only the static (non-expression) fields against the schema.
+        // Fields holding a `${{ ... }}` expression (e.g. a `vault.get(...)`
+        // reference) are resolved at runtime and validated then — running them
+        // through the schema now would reject a sentinel string against a
+        // constrained field (e.g. `z.string().min(20)`), making the vault
+        // remediation for a sensitive argument impossible. Mirrors the
+        // strip-then-validate behavior in validation_service.
+        const staticArgs = stripExpressionFields(globalArguments);
+        const hasExpressionArgs =
+          Object.keys(staticArgs).length < Object.keys(globalArguments).length;
+        if (!hasExpressionArgs) {
+          const result = globalArgsSchema.safeParse(globalArguments);
+          if (!result.success) {
+            const issues = result.error.issues.map((i) => {
+              const path = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+              return `  ${path}${i.message}`;
+            }).join("\n");
+            yield {
+              kind: "error",
+              error: validationFailed(
+                `Invalid global arguments for type '${modelType.normalized}':\n${issues}`,
+              ),
+            };
+            return;
+          }
+          globalArguments = result.data as Record<string, unknown>;
+        }
+
+        // Refuse a literal value for a sensitive global argument before it is
+        // persisted in cleartext. The persistence chokepoint
+        // (YamlDefinitionRepository.save) enforces this for every writer; doing
+        // it here as well gives `model create` a clean, typed error instead of
+        // a raw thrown one. Expression values (vault.get) pass through.
+        const leakedArgs = findLiteralSensitiveGlobalArgs(
+          modelDef.globalArguments,
+          globalArguments,
+        );
+        if (leakedArgs.length > 0) {
           yield {
             kind: "error",
             error: validationFailed(
-              `Invalid global arguments for type '${modelType.normalized}':\n${issues}`,
+              literalSensitiveGlobalArgsMessage(leakedArgs),
             ),
           };
           return;
         }
-        globalArguments = result.data as Record<string, unknown>;
       }
 
       // Create and save the definition

--- a/src/libswamp/models/create_test.ts
+++ b/src/libswamp/models/create_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
@@ -442,6 +442,112 @@ Deno.test("modelCreate: coerces Zod v3-style schema global arguments", async () 
       typeArg: "test/v3-schema",
       name: "my-model",
       globalArguments: { count: "42" },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+});
+
+Deno.test("modelCreate: refuses a literal value for a sensitive global arg and does not persist", async () => {
+  let saved = false;
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/sensitive" },
+      version: "1.0.0",
+      globalArguments: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        region: z.string(),
+      }),
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+    createAndSave: () => {
+      saved = true;
+      return Promise.resolve(
+        { id: "def-1", name: "my-model" } as unknown as Awaited<
+          ReturnType<ModelCreateDeps["createAndSave"]>
+        >,
+      );
+    },
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/sensitive",
+      name: "my-model",
+      globalArguments: { apiKey: "SUPERSECRET123", region: "us-east-1" },
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "apiKey");
+  assertStringIncludes(last.error.message, "vault.get");
+  // Fail-closed: the definition was never created/persisted.
+  assertEquals(saved, false);
+});
+
+Deno.test("modelCreate: accepts a vault.get expression for a sensitive global arg", async () => {
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/sensitive" },
+      version: "1.0.0",
+      globalArguments: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        region: z.string(),
+      }),
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/sensitive",
+      name: "my-model",
+      globalArguments: {
+        apiKey: "${{ vault.get('creds', 'apiKey') }}",
+        region: "us-east-1",
+      },
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+});
+
+Deno.test("modelCreate: accepts a vault.get expression for a CONSTRAINED sensitive field (ADV-3)", async () => {
+  // The vault.get sentinel is far shorter than min(20); without stripping
+  // expression fields before schema validation this would be wrongly rejected,
+  // making the vault remediation impossible.
+  const deps = makeDeps({
+    getModelDef: () => ({
+      type: { normalized: "test/sensitive-constrained" },
+      version: "1.0.0",
+      globalArguments: z.object({
+        apiKey: z.string().min(20).meta({ sensitive: true }),
+      }),
+      methods: {},
+      resources: {},
+    } as unknown as ModelDefinition),
+  });
+
+  const events = await collect<ModelCreateEvent>(
+    modelCreate(createLibSwampContext(), deps, {
+      typeArg: "test/sensitive-constrained",
+      name: "my-model",
+      globalArguments: { apiKey: "${{ vault.get('v', 'k') }}" },
     }),
   );
 

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -25,6 +25,11 @@ import {
   coerceMethodArgs,
   getObjectShape,
 } from "../../domain/models/zod_type_coercion.ts";
+import { stripExpressionFields } from "../../domain/expressions/expression_parser.ts";
+import {
+  findLiteralSensitiveGlobalArgs,
+  literalSensitiveGlobalArgsMessage,
+} from "../../domain/models/sensitive_field_extractor.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 
@@ -177,6 +182,18 @@ export async function resolveOrCreateDefinition(
       for (const [key, value] of Object.entries(routedGlobal)) {
         existing.definition.setGlobalArgument(key, value);
       }
+      const leakedArgs = findLiteralSensitiveGlobalArgs(
+        modelDef.globalArguments,
+        existing.definition.globalArguments,
+      );
+      if (leakedArgs.length > 0) {
+        return {
+          ok: false,
+          error: validationFailed(
+            literalSensitiveGlobalArgsMessage(leakedArgs),
+          ),
+        };
+      }
       await deps.saveDefinition(existing.type, existing.definition);
     }
 
@@ -204,7 +221,12 @@ export async function resolveOrCreateDefinition(
     const lenient = "partial" in schema && typeof schema.partial === "function"
       ? (schema.partial() as z.ZodTypeAny)
       : schema;
-    const result = lenient.safeParse(routed.globalArguments);
+    // Validate only the static fields. Fields holding a `${{ ... }}` expression
+    // (e.g. a `vault.get(...)` reference) are resolved and validated at runtime;
+    // checking them now would reject a sentinel string against a constrained
+    // field, blocking the vault remediation for a sensitive argument.
+    const staticArgs = stripExpressionFields(routed.globalArguments);
+    const result = lenient.safeParse(staticArgs);
     if (!result.success) {
       const issues = result.error.issues.map((i: z.ZodIssue) => {
         const path = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
@@ -217,6 +239,20 @@ export async function resolveOrCreateDefinition(
         ),
       };
     }
+  }
+
+  // Refuse a literal value for a sensitive global argument before persisting it
+  // in cleartext (enforced for every writer at the persistence chokepoint; done
+  // here too for a clean, typed error). Expression values (vault.get) pass.
+  const leakedArgs = findLiteralSensitiveGlobalArgs(
+    modelDef.globalArguments,
+    routed.globalArguments,
+  );
+  if (leakedArgs.length > 0) {
+    return {
+      ok: false,
+      error: validationFailed(literalSensitiveGlobalArgsMessage(leakedArgs)),
+    };
   }
 
   // Auto-create the definition

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -435,3 +435,119 @@ Deno.test("resolveOrCreateDefinition: still rejects invalid types on provided gl
     assertStringIncludes(result.error.message, "Invalid global arguments");
   }
 });
+
+Deno.test("resolveOrCreateDefinition: refuses a literal sensitive global arg on auto-create", async () => {
+  const modelDef = createTestModelDef(
+    z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      region: z.string(),
+    }),
+    { run: z.object({}) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "leaky",
+    "run",
+    { apiKey: "SUPERSECRET123", region: "us-east-1" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertStringIncludes(result.error.message, "apiKey");
+    assertStringIncludes(result.error.message, "vault.get");
+  }
+  assertEquals(saved, false);
+});
+
+Deno.test("resolveOrCreateDefinition: refuses a literal sensitive global arg on update", async () => {
+  const modelDef = createTestModelDef(
+    z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      region: z.string(),
+    }),
+    { run: z.object({}) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  const existingDef = Definition.create({
+    name: "existing-model",
+    type: "test/model",
+    typeVersion: "2026.01.01.1",
+    globalArguments: {
+      apiKey: "${{ vault.get('v', 'k') }}",
+      region: "us-west-2",
+    },
+  });
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({ definition: existingDef, type: resolvedType }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "existing-model",
+    "run",
+    { apiKey: "NOW-A-LITERAL", region: "us-west-2" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertStringIncludes(result.error.message, "apiKey");
+  }
+  assertEquals(saved, false);
+});
+
+Deno.test("resolveOrCreateDefinition: accepts a vault.get expression for a sensitive global arg", async () => {
+  const modelDef = createTestModelDef(
+    z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+      region: z.string(),
+    }),
+    { run: z.object({}) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "vaulted",
+    "run",
+    { apiKey: "${{ vault.get('creds', 'apiKey') }}", region: "us-east-1" },
+    resolvedType,
+    modelDef,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(saved, true);
+});

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -72,6 +72,7 @@ import { SecretRedactor } from "../../domain/secrets/mod.ts";
 import type { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import { UserError } from "../../domain/errors.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { createRepoMarkerLoader } from "../../infrastructure/persistence/repo_marker_loader.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
@@ -1190,9 +1191,12 @@ async function handleDefinitionUpdate(
   try {
     await deps.repoContext.definitionRepo.save(type, def);
   } catch (e) {
+    // A rejected sensitive-literal (and other UserErrors) is client input error,
+    // not a server fault — surface it as 4xx with the remediation message.
+    const status = e instanceof UserError ? 400 : 500;
     return Response.json(
       { error: { message: e instanceof Error ? e.message : String(e) } },
-      { status: 500 },
+      { status },
     );
   }
   return Response.json({


### PR DESCRIPTION
## Summary

A global argument marked `.meta({ sensitive: true })` set to a **literal** value (e.g. `swamp model create <type> <name> --global-arg apiKey=SECRET`) was persisted **in cleartext** into the definition YAML. Vaulting only ever applied to method-output resource data, never to a definition's `globalArguments` captured at write time. Sibling swamp-club#472 redacted only the `model get` *display*; the secret still lived unredacted on disk.

This enforces the invariant at the single persistence chokepoint — `YamlDefinitionRepository.save()` — so it covers **every** source-definition writer (model create, model edit, model run / workflow run auto-definitions, and the serve HTTP API), present and future. Literal values for sensitive global args are refused with a clear remediation message; `vault.get(...)` expressions (resolved at runtime, stored unevaluated) are allowed.

## What changed

- **New pure domain rule** `findLiteralSensitiveGlobalArgs` + shared message builder in `sensitive_field_extractor.ts`. Expression-only values are allowed; mixed `prefix-${{...}}` partial leaks and typed (number/boolean) literals are refused (fail closed). Non-object schemas are a documented best-effort residual (matches #472's redaction limitation).
- **Chokepoint guard** in `YamlDefinitionRepository.save()` — throws a `UserError` before any bytes are written. Resolves the type schema via the model registry, falling back to `ensureLoaded()` + `ensureTypeLoaded()` to promote lazily-registered **extension** types (required for `model edit`, which does not pre-load the registry).
- **Friendly early errors** in `model create` and direct execution, plus `stripExpressionFields` before schema validation so a `vault.get` expression validates for **constrained** sensitive fields (e.g. `z.string().min(20)`) — otherwise the recommended remediation would be rejected.
- **Serve** PATCH maps the rejection to a 4xx instead of 500.
- **Fail-closed for legacy defs:** re-saving a definition that already holds a cleartext literal is refused until the value is moved to a vault.

## Test Plan

- **Unit:** `sensitive_field_extractor_test.ts` (rule: literal/expression/mixed/typed/nested/non-object/empty), `yaml_definition_repository_test.ts` (chokepoint throws + no file written; vault.get persisted; unknown type passes through), `create_test.ts` and `direct_execution_test.ts` (early refusal + ADV-3 constrained-field acceptance).
- **Integration:** `integration/model_create_sensitive_test.ts` — end-to-end create (literal → error + no YAML on disk; vault.get → persisted verbatim; constrained-field expression accepted) plus the out-of-band chokepoint writer.
- **Full suite:** `deno run test` → 6433 passed, 0 failed. `deno check` / `lint` / `fmt` clean.
- **Clean-room CLI verification** (compiled binary, real extension type) — refused: `model create` literal, `model run` literal, `model edit` literal (chokepoint), mixed; accepted: `vault.get`, constrained-field `vault.get`; non-sensitive fields unaffected.

## Follow-ups (separate issues)

- Docs update in swamp-club `content/manual/reference/model-definitions.md`.
- Existing on-disk definitions with cleartext literals are not remediated (datastore-sync replication is out of band); a `doctor`/scan sweep is deferred.
- Integration test exercising the lazy extension-bundle resolution path (current automated tests use fully-registered `defineModel` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)