### PR TITLE
fix(serve): surface actionable warning when HOME is unset (swamp-club#463)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -43,7 +43,16 @@ const logger = getSwampLogger(["serve"]);
 
 export const serveCommand = new Command()
   .name("serve")
-  .description("Start a WebSocket API server for workflow and model execution")
+  .description(
+    "Start a WebSocket API server for workflow and model execution.\n\n" +
+      "Service deployments: swamp loads all extensions — including " +
+      "already-pulled repo extensions — through an embedded runtime under the " +
+      "user's home directory (~/.swamp). When running under a service manager " +
+      "such as systemd, ensure HOME (or USERPROFILE on Windows) is set in the " +
+      "unit environment, e.g. `Environment=HOME=/root`. Without it, scheduled " +
+      'workflow runs fail with "Unknown model type" for pulled extension ' +
+      "types.",
+  )
   .example("Start server", "swamp serve")
   .example("Custom port", "swamp serve --port 8080")
   .example(

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Initialize logging for tests
@@ -30,10 +30,14 @@ Deno.test("serveCommand module loads", async () => {
 
 Deno.test("serveCommand has correct description", async () => {
   const { serveCommand } = await import("./serve.ts");
-  assertEquals(
-    serveCommand.getDescription(),
+  const description = serveCommand.getDescription();
+  assertStringIncludes(
+    description,
     "Start a WebSocket API server for workflow and model execution",
   );
+  // Service deployments need HOME set; the description documents this so the
+  // guidance is discoverable via `swamp serve --help` (see swamp-club#463).
+  assertStringIncludes(description, "HOME");
 });
 
 Deno.test("serveCommand has --port option", async () => {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -86,6 +86,7 @@ import "../domain/datastore/datastore_types.ts";
 // Import builtin reports to trigger registration
 import "../domain/reports/builtin/mod.ts";
 import { EmbeddedDenoRuntime } from "../infrastructure/runtime/embedded_deno_runtime.ts";
+import { homeDirectoryIsSet } from "../infrastructure/persistence/paths.ts";
 import { ReconcileFromDiskService } from "../libswamp/mod.ts";
 import {
   type RepoMarkerData,
@@ -260,6 +261,31 @@ export async function configureExtensionLoaders(
   extensionsDir?: string,
 ): Promise<void> {
   const effectiveExtDir = extensionsDir ?? repoDir;
+
+  // Every extension — including already-pulled repo bundles — is loaded
+  // through an embedded runtime that lives under the user's home directory
+  // (~/.swamp). When neither HOME nor USERPROFILE is set (common for
+  // service managers like systemd that start swamp serve without HOME), that
+  // resolution throws deep inside each loader and surfaces as five
+  // misleading "Failed to load user X extensions" warnings, followed by
+  // "Unknown model type" at run time. Detect the condition once, up front,
+  // and emit a single actionable warning instead.
+  if (!homeDirectoryIsSet()) {
+    deferredWarnings.push({
+      kind: "extensions",
+      file: "",
+      error:
+        "Extension loading is unavailable: no home directory found (neither " +
+        "HOME nor USERPROFILE is set). swamp loads all extensions — including " +
+        "already-pulled repo extensions — through an embedded runtime under " +
+        "~/.swamp, which requires a home directory. If you run swamp under a " +
+        "service manager such as systemd, set HOME (or USERPROFILE) in the " +
+        "unit environment, e.g. `Environment=HOME=/root`. Until then, pulled " +
+        "and user extensions are unavailable and workflows that reference " +
+        'them fail with "Unknown model type".',
+    });
+  }
+
   const denoRuntime = new EmbeddedDenoRuntime();
   const sourceModelsDirs = collectDirsForKind(resolvedSources, "models");
   const sourceVaultsDirs = collectDirsForKind(resolvedSources, "vaults");
@@ -466,6 +492,16 @@ export interface DeferredWarning {
 }
 
 /**
+ * Detects the "neither HOME nor USERPROFILE is set" failure raised by the
+ * home-directory path helpers. Used to suppress the misleading per-kind
+ * loader warnings in favour of the single actionable warning emitted by
+ * {@link configureExtensionLoaders}.
+ */
+function isMissingHomeError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("home directory");
+}
+
+/**
  * Load user models from configured directory.
  * Uses the bundle catalog for lazy per-bundle loading when available.
  */
@@ -548,6 +584,9 @@ async function loadUserModels(
     }
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return;
+    // configureExtensionLoaders already emitted one actionable warning for
+    // the missing-home case; suppress the misleading per-kind duplicate.
+    if (isMissingHomeError(error)) return;
     logger
       .warn`Failed to load user model extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -621,6 +660,7 @@ async function loadUserVaults(
     }
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return;
+    if (isMissingHomeError(error)) return;
     logger
       .warn`Failed to load user vault extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -690,6 +730,7 @@ async function loadUserDrivers(
     }
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return;
+    if (isMissingHomeError(error)) return;
     logger
       .warn`Failed to load user driver extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -760,6 +801,7 @@ async function loadUserDatastores(
     }
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return;
+    if (isMissingHomeError(error)) return;
     logger
       .warn`Failed to load user datastore extensions: ${
       error instanceof Error ? error.message : String(error)
@@ -829,6 +871,7 @@ async function loadUserReports(
     }
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) return;
+    if (isMissingHomeError(error)) return;
     logger
       .warn`Failed to load user report extensions: ${
       error instanceof Error ? error.message : String(error)

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -223,6 +223,22 @@ export function homeDirectory(): string {
 }
 
 /**
+ * Reports whether a home directory can be resolved from the environment.
+ *
+ * Mirrors the resolution order of {@link homeDirectory} (HOME then
+ * USERPROFILE) but returns a boolean instead of throwing. Useful for
+ * callers that want to surface a precise, actionable message *before* a
+ * home-dependent path resolution fails deep in the call stack — notably the
+ * extension loaders, whose embedded runtime lives under `~/.swamp` and is
+ * required to load every extension, including already-pulled repo bundles.
+ *
+ * @returns true when HOME or USERPROFILE is set, false otherwise
+ */
+export function homeDirectoryIsSet(): boolean {
+  return Boolean(Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE"));
+}
+
+/**
  * Returns the user-level swamp data directory (`~/.swamp/`).
  *
  * This directory stores operational data like installed binaries and

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -23,6 +23,7 @@ import {
   getSwampConfigDir,
   getSwampDataDir,
   homeDirectory,
+  homeDirectoryIsSet,
   SWAMP_DATA_DIR,
   SWAMP_MARKER_FILE,
   SWAMP_SUBDIRS,
@@ -292,6 +293,54 @@ Deno.test("homeDirectory: throws when neither HOME nor USERPROFILE is set", () =
       Error,
       "Cannot determine home directory: neither HOME nor USERPROFILE is set",
     );
+  } finally {
+    if (originalHome !== undefined) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+    if (originalProfile !== undefined) {
+      Deno.env.set("USERPROFILE", originalProfile);
+    } else Deno.env.delete("USERPROFILE");
+  }
+});
+
+Deno.test("homeDirectoryIsSet: true when HOME is set", () => {
+  const originalHome = Deno.env.get("HOME");
+  const originalProfile = Deno.env.get("USERPROFILE");
+  try {
+    Deno.env.set("HOME", "/home/testuser");
+    Deno.env.delete("USERPROFILE");
+    assertEquals(homeDirectoryIsSet(), true);
+  } finally {
+    if (originalHome !== undefined) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+    if (originalProfile !== undefined) {
+      Deno.env.set("USERPROFILE", originalProfile);
+    } else Deno.env.delete("USERPROFILE");
+  }
+});
+
+Deno.test("homeDirectoryIsSet: true when only USERPROFILE is set", () => {
+  const originalHome = Deno.env.get("HOME");
+  const originalProfile = Deno.env.get("USERPROFILE");
+  try {
+    Deno.env.delete("HOME");
+    Deno.env.set("USERPROFILE", "C:\\Users\\testuser");
+    assertEquals(homeDirectoryIsSet(), true);
+  } finally {
+    if (originalHome !== undefined) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+    if (originalProfile !== undefined) {
+      Deno.env.set("USERPROFILE", originalProfile);
+    } else Deno.env.delete("USERPROFILE");
+  }
+});
+
+Deno.test("homeDirectoryIsSet: false when neither HOME nor USERPROFILE is set", () => {
+  const originalHome = Deno.env.get("HOME");
+  const originalProfile = Deno.env.get("USERPROFILE");
+  try {
+    Deno.env.delete("HOME");
+    Deno.env.delete("USERPROFILE");
+    assertEquals(homeDirectoryIsSet(), false);
   } finally {
     if (originalHome !== undefined) Deno.env.set("HOME", originalHome);
     else Deno.env.delete("HOME");


### PR DESCRIPTION
## Summary

Follow-up to #1458 for swamp-club#463. The reporter confirmed the root cause: their systemd unit ran `swamp serve` with no `HOME`/`USERPROFILE`. Because the embedded runtime that loads **every** extension — including already-pulled repo bundles — lives under `~/.swamp`, home-directory resolution threw deep inside each loader. This surfaced as five misleading `Failed to load user X extensions` warnings, then `Unknown model type` when scheduled workflows fired. Setting `HOME=/root` fixed it for them.

This change makes that failure **diagnosable** instead of changing path resolution:

- `paths.ts` — add `homeDirectoryIsSet()` helper (boolean, mirrors `homeDirectory()` resolution order without throwing).
- `mod.ts` — `configureExtensionLoaders` detects the missing-home case once, up front, and emits a **single actionable warning** naming the real cause and the fix (`Environment=HOME=/root`). The five per-kind loaders suppress their misleading duplicate via `isMissingHomeError`.
- `serve.ts` — command description documents the HOME requirement for service deployments, discoverable via `swamp serve --help`.

This is a diagnosability + docs fix by design — it does **not** make headless serve load extensions without HOME. Operators still set HOME; they now get told so clearly instead of via five confusing warnings.

## Test Plan

- `deno check main.ts`, `deno fmt --check`, `deno lint` — all clean.
- `deno run test` — full suite: `6429 passed | 0 failed | 28 ignored`.
- New unit tests: `homeDirectoryIsSet` (3 cases in `paths_test.ts`); `serve_test.ts` updated to assert HOME guidance is in the description.
- Behavioral, on a freshly-compiled binary:
  - **No-HOME `swamp serve`** → 1 actionable warning, 0 misleading warnings, server starts (the actual bug path).
  - **HOME-set happy path** → resolves pulled `@swamp/issue-lifecycle` with 0 warnings (no regression to normal loading).
- Verified on macOS; logic is env-var-based (no OS-specific paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)