### PR TITLE
fix(workflow): align resume --json envelope and filter expired approvals

### DIFF
--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -24,6 +24,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 
@@ -76,6 +77,17 @@ export const workflowApprovalsCommand = new Command()
         const taskData = workflow.jobs
           .find((j) => j.name === waiting.jobName)?.steps
           .find((s) => s.name === waiting.stepName)?.task.data;
+
+        // A run whose approval deadline has lapsed is no longer actionable —
+        // `swamp workflow approve` would reject it — so apply the same
+        // deadline check here and drop expired entries from the listing.
+        const timeout = evaluateApprovalTimeout(
+          step?.startedAt,
+          taskData,
+          new Date(),
+        );
+        if (timeout?.expired) continue;
+
         const prompt = taskData && taskData.type === "manual_approval"
           ? taskData.prompt
           : undefined;

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -26,6 +26,7 @@ import {
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
+import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
@@ -98,20 +99,18 @@ export const workflowApproveCommand = new Command()
       {
         const wfJob = workflow.jobs.find((j) => j.name === jobName);
         const wfStep = wfJob?.steps.find((s) => s.name === stepName);
-        if (
-          wfStep?.task.data.type === "manual_approval" &&
-          wfStep.task.data.timeout &&
-          step.startedAt
-        ) {
-          const elapsedSeconds = (Date.now() - step.startedAt.getTime()) / 1000;
-          if (elapsedSeconds > wfStep.task.data.timeout) {
-            throw new UserError(
-              `Approval timed out: step "${stepName}" has been waiting ${
-                Math.round(elapsedSeconds)
-              }s ` +
-                `(timeout: ${wfStep.task.data.timeout}s)`,
-            );
-          }
+        const timeout = evaluateApprovalTimeout(
+          step.startedAt,
+          wfStep?.task.data,
+          new Date(),
+        );
+        if (timeout?.expired) {
+          throw new UserError(
+            `Approval timed out: step "${stepName}" has been waiting ${
+              Math.round(timeout.elapsedSeconds)
+            }s ` +
+              `(timeout: ${timeout.timeoutSeconds}s)`,
+          );
         }
       }
 

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -44,7 +44,10 @@ import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import { consumeStream } from "../../libswamp/mod.ts";
+import {
+  consumeStream,
+  mapWorkflowExecutionEvent,
+} from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { GIT_SHA } from "./version.ts";
 
@@ -178,7 +181,7 @@ export const workflowResumeCommand = new Command()
             swampSha: GIT_SHA,
           })
         ) {
-          yield event as WorkflowRunEvent;
+          yield mapWorkflowExecutionEvent(event, runRepo);
         }
       }
 

--- a/src/domain/workflows/approval_timeout.ts
+++ b/src/domain/workflows/approval_timeout.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { StepTaskData } from "./step_task.ts";
+
+/**
+ * Result of evaluating a manual-approval deadline for a suspended step.
+ */
+export interface ApprovalTimeout {
+  /** Whether the approval window has elapsed (`now > suspendedAt + timeout`). */
+  expired: boolean;
+  /** Seconds the step has been waiting for approval. */
+  elapsedSeconds: number;
+  /** The configured timeout, in seconds. */
+  timeoutSeconds: number;
+}
+
+/**
+ * Evaluates the manual-approval deadline for a suspended step.
+ *
+ * Returns `undefined` when the step has no approval deadline to enforce —
+ * either it is not a `manual_approval` task, has no `timeout` configured, or
+ * never recorded a start time. In those cases the approval never expires on
+ * its own.
+ *
+ * This is the single source of truth for the deadline check, shared by
+ * `workflow approve` (which rejects expired approvals) and
+ * `workflow approvals` (which filters them out of the actionable listing) so
+ * both apply the identical `now > suspendedAt + timeout` rule.
+ */
+export function evaluateApprovalTimeout(
+  startedAt: Date | undefined,
+  taskData: StepTaskData | undefined,
+  now: Date,
+): ApprovalTimeout | undefined {
+  if (
+    !startedAt ||
+    !taskData ||
+    taskData.type !== "manual_approval" ||
+    !taskData.timeout
+  ) {
+    return undefined;
+  }
+
+  const elapsedSeconds = (now.getTime() - startedAt.getTime()) / 1000;
+  return {
+    expired: elapsedSeconds > taskData.timeout,
+    elapsedSeconds,
+    timeoutSeconds: taskData.timeout,
+  };
+}

--- a/src/domain/workflows/approval_timeout_test.ts
+++ b/src/domain/workflows/approval_timeout_test.ts
@@ -1,0 +1,98 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { evaluateApprovalTimeout } from "./approval_timeout.ts";
+import type { StepTaskData } from "./step_task.ts";
+
+const gate = (timeout?: number): StepTaskData => ({
+  type: "manual_approval",
+  prompt: "Approve?",
+  timeout,
+});
+
+Deno.test("evaluateApprovalTimeout: reports expired once the deadline lapses", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T00:00:04.000Z");
+
+  const result = evaluateApprovalTimeout(startedAt, gate(1), now);
+
+  assertEquals(result, {
+    expired: true,
+    elapsedSeconds: 4,
+    timeoutSeconds: 1,
+  });
+});
+
+Deno.test("evaluateApprovalTimeout: not expired while inside the window", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T00:00:00.500Z");
+
+  const result = evaluateApprovalTimeout(startedAt, gate(1), now);
+
+  assertEquals(result, {
+    expired: false,
+    elapsedSeconds: 0.5,
+    timeoutSeconds: 1,
+  });
+});
+
+Deno.test("evaluateApprovalTimeout: exactly at the deadline is not yet expired", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T00:00:01.000Z");
+
+  const result = evaluateApprovalTimeout(startedAt, gate(1), now);
+
+  assertEquals(result?.expired, false);
+});
+
+Deno.test("evaluateApprovalTimeout: undefined when no timeout is configured", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T01:00:00.000Z");
+
+  assertEquals(
+    evaluateApprovalTimeout(startedAt, gate(undefined), now),
+    undefined,
+  );
+});
+
+Deno.test("evaluateApprovalTimeout: undefined when the step never started", () => {
+  const now = new Date("2026-05-29T01:00:00.000Z");
+
+  assertEquals(evaluateApprovalTimeout(undefined, gate(1), now), undefined);
+});
+
+Deno.test("evaluateApprovalTimeout: undefined for non-approval tasks", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T01:00:00.000Z");
+  const modelTask: StepTaskData = {
+    type: "model_method",
+    modelIdOrName: "shell-echo",
+    methodName: "execute",
+  };
+
+  assertEquals(evaluateApprovalTimeout(startedAt, modelTask, now), undefined);
+});
+
+Deno.test("evaluateApprovalTimeout: undefined when task data is absent", () => {
+  const startedAt = new Date("2026-05-29T00:00:00.000Z");
+  const now = new Date("2026-05-29T01:00:00.000Z");
+
+  assertEquals(evaluateApprovalTimeout(startedAt, undefined, now), undefined);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -63,6 +63,7 @@ export {
 export {
   extractStepArtifacts,
   inputValidationFailed,
+  mapWorkflowExecutionEvent,
   toRunData,
   workflowExecutionFailed,
   workflowNotFound,

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -372,11 +372,16 @@ export function toRunData(
 
 /**
  * Maps a domain WorkflowExecutionEvent to a libswamp WorkflowRunEvent.
+ *
+ * Shared by the `run` and `resume` paths so both emit the identical
+ * `WorkflowRunView` envelope — in particular, the canonical un-prefixed
+ * `status`/`startedAt`/`jobs` keys rather than the `WorkflowRun` class's
+ * private `_status` fields leaking through `JSON.stringify`.
  */
-function mapEvent(
+export function mapWorkflowExecutionEvent(
   event: WorkflowExecutionEvent,
-  deps: WorkflowRunDeps,
-  input: WorkflowRunInput,
+  runRepo: WorkflowRunRepository,
+  verbose?: boolean,
 ): WorkflowRunEvent {
   switch (event.kind) {
     case "started":
@@ -392,19 +397,19 @@ function mapEvent(
         })),
       };
     case "completed": {
-      const path = deps.runRepo.getPath(
+      const path = runRepo.getPath(
         createWorkflowId(event.run.workflowId),
         createWorkflowRunId(event.run.id),
       );
-      const data = toRunData(event.run, path, input.verbose);
+      const data = toRunData(event.run, path, verbose);
       return { kind: "completed", run: data };
     }
     case "suspended": {
-      const path = deps.runRepo.getPath(
+      const path = runRepo.getPath(
         createWorkflowId(event.run.workflowId),
         createWorkflowRunId(event.run.id),
       );
-      const data = toRunData(event.run, path, input.verbose);
+      const data = toRunData(event.run, path, verbose);
       return {
         kind: "suspended",
         run: data,
@@ -557,7 +562,11 @@ export async function* workflowRun(
             });
           }
 
-          let mapped = mapEvent(event, deps, resolvedInput);
+          let mapped = mapWorkflowExecutionEvent(
+            event,
+            deps.runRepo,
+            resolvedInput.verbose,
+          );
 
           // Per-method telemetry observer — runs alongside existing
           // event handling. Skipped when telemetry is disabled.


### PR DESCRIPTION
## Summary

Fixes two manual-approval JSON/listing inconsistencies surfaced while writing UAT coverage (swamp-uat #470).

### Issue 1 — `workflow resume --json` leaked `_status`-prefixed keys

`run --json` and `history get --json` map the domain `WorkflowRun` through libswamp's `toRunData()` into a plain `WorkflowRunView`, exposing canonical keys (`status`, `startedAt`, `jobs`, …). The `resume` command bypassed libswamp, consumed the domain `service.resume()` stream directly, and `yield`ed the raw `WorkflowRun` class instance — so `JSON.stringify` serialized its private fields (`_status`, `_startedAt`, `_jobs`, `_logFile`, `_tags`, `_workflowDataArtifacts`).

**Fix:** Promote the internal `mapEvent` to an exported `mapWorkflowExecutionEvent(event, runRepo, verbose?)` (lighter signature — only ever needed the run repo + verbose flag), export it from `libswamp/mod.ts`, and route the resume stream through it. All three paths now emit the identical envelope.

### Issue 2 — `workflow approvals` over-reported timed-out runs

The approval deadline check (`now > suspendedAt + timeout`) lived only inline in `workflow approve`, so `workflow approvals` kept listing expired gates as actionable.

**Fix:** Extract the single source of truth into a domain helper `evaluateApprovalTimeout(startedAt, taskData, now)` in `src/domain/workflows/approval_timeout.ts`. `approve` rejects expired gates with the same message; `approvals` now skips them (`if (timeout?.expired) continue`).

## ⚠️ UAT lockstep

swamp-uat #470 / PR #241 currently pins the old behavior. Both assertions must be updated in lockstep:
- resume-JSON: expect `status` (+ the `toRunData` envelope), not `_status`/`_startedAt`/…
- approvals-listing: expect an expired run to be **absent**

## Test Plan

- New unit tests: `src/domain/workflows/approval_timeout_test.ts` (7 cases — expired, in-window, exactly-at-deadline, no timeout, never-started, non-approval task, absent task data).
- `deno check`, `deno lint`, `deno fmt`, full suite (**6464 passed / 0 failed**), `deno run compile` — all green.
- Manual repro against the compiled binary:
  - `resume --json` now reports `status = succeeded` with keys `[duration, id, jobs, path, status, workflowId, workflowName]` (no underscores).
  - After a 1s deadline lapses: `approve` rejects with `Approval timed out…`, and `approvals --json` returns `{ "approvals": [] }`.
  - Positive regression: a gate with no timeout still lists normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)