### PR TITLE
feat(data): giga-swamp phase 3 — namespace-aware layout + per-namespace locking (swamp-club#486)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -217,6 +217,29 @@ extension datastores (e.g., S3), this returns `{datastorePath}/{subdir}/...`
 (typically the local cache path). The `DefaultDatastorePathResolver`
 pre-compiles exclude patterns at construction time.
 
+### Namespace prefixing (giga-swamp)
+
+When a `namespace` is configured (giga-swamp multi-repo shared datastores), the
+resolver prepends it as the **outermost** segment of the datastore tier:
+`{base}/{namespace}/{subdir}/...` — never `{base}/{subdir}/{namespace}/...`.
+This is applied at the single `datastorePath()` chokepoint, so it covers every
+datastore-tier subdir uniformly. Solo mode (empty namespace) produces
+byte-identical paths to a non-namespaced repo — no prefix, no stray separator.
+The local tier (`localPath`, `.swamp/`) is never namespaced.
+
+Two things are deliberately **not** namespaced:
+
+- **The `_catalog.db` catalog** is repo-local at `{repoDir}/.swamp/data/`,
+  resolved via the centralized `catalogDbPath` helper (not `resolvePath`).
+  Under a shared datastore each repo owns a private catalog, so per-repo
+  full-replace backfill never clobbers another repo's rows; the catalog's
+  `namespace` column distinguishes own rows from foreign rows pulled in a later
+  phase.
+- **Secrets and vault bundles** are written through `swampPath`/`localPath`
+  (`.swamp/secrets`, `.swamp/vault-bundles`), never through `resolvePath`, so
+  the namespace prefix cannot reach them — vaults stay repo-local by
+  construction.
+
 ## Remote Datastore Sync
 
 When a remote datastore (e.g., S3 via `@swamp/s3-datastore`) is configured,
@@ -606,9 +629,33 @@ atomic lock acquisition with background heartbeat.
 ### FileLock
 
 Uses advisory lockfiles (`Deno.open({ createNew: true })`) for atomic
-check-and-create. The lockfile is at `{datastorePath}/.datastore.lock`. A
-background heartbeat rewrites the lockfile content with a fresh timestamp.
-Stale locks (where `acquiredAt + ttlMs < now`) are removed and retried.
+check-and-create. The lockfile is at `{datastorePath}/.datastore.lock` in solo
+mode. A background heartbeat rewrites the lockfile content with a fresh
+timestamp. Stale locks (where `acquiredAt + ttlMs < now`) are removed and
+retried.
+
+When a `namespace` is configured, the **global** lock key moves to
+`{datastorePath}/.locks/{namespace}.lock` (`datastoreGlobalLockOptions`), so two
+repos writing to different namespaces of a shared datastore never contend on
+structural commands. `FileLock` lazily creates the `.locks/` directory on first
+acquire. This is a lock-**path** change only — the lifecycle protocol below is
+unchanged. Per-model lock keys (`data/{type}/{modelId}/.lock`) are **not**
+namespaced: model ids are UUIDs, so they are already globally unique across
+namespaces.
+
+Known cosmetic consequence of leaving per-model lock keys un-namespaced: in a
+namespaced repo the lock lives at `{datastore}/data/{type}/{modelId}/.lock`
+(un-namespaced tier) while the data it guards lives at
+`{datastore}/{namespace}/data/{type}/{modelId}/...`. Because `FileLock.acquire`
+runs `ensureDir(dirname(lockPath))`, acquiring the lock leaves an **empty**
+`{datastore}/data/{type}/{modelId}/` directory behind in the un-namespaced
+tier after release. This is harmless — no data, no catalog rows, and `data
+list`/`data query` (which read the repo-local catalog) are unaffected; the
+empty dirs are never confused with data because they contain no `raw`/metadata.
+Co-locating the lock with the namespaced data would require namespace-scoping
+`parseModelLockKey`/`scanModelLocks`/`waitForPerModelLocks` (which anchor on
+`data` as the first path segment), so it is deferred to the per-model lock
+namespacing work rather than expanding this phase's scope for a cosmetic issue.
 
 ### Lock Lifecycle
 
@@ -621,10 +668,23 @@ lifecycle as a global singleton:
 Per-model commands (`model method run`, `workflow run`) acquire only
 per-model locks via `acquireModelLocks`; they do not acquire the global
 lock but do `inspect()` it to wait out any in-flight structural command.
-When a stale global lock is observed during this wait, `acquireModelLocks`
-calls `forceRelease(expectedNonce)` to clear it — without this, the
-post-acquire TOCTOU re-check would re-detect the same stale lock on every
-iteration and recurse indefinitely.
+The `inspect()` must target the **same** namespaced global-lock key the
+structural command acquires (`datastoreGlobalLockOptions`); otherwise the
+drain coordination would inspect a different lock than the one held and
+silently become a no-op in namespaced mode. When a stale global lock is
+observed during this wait, `acquireModelLocks` calls
+`forceRelease(expectedNonce)` to clear it — without this, the post-acquire
+TOCTOU re-check would re-detect the same stale lock on every iteration and
+recurse indefinitely.
+
+Because per-model lock keys are not namespaced, `waitForPerModelLocks`
+(which walks the datastore root) drains in-flight per-model writers across
+**all** namespaces, not just the structural command's own. This is a
+conservative over-wait, not a correctness issue: data dirs are
+namespace-partitioned, catalogs are repo-local, and global locks are
+namespaced, so there is no shared mutable state for a cross-namespace writer
+to corrupt. Structural commands are infrequent; namespacing per-model locks
+can be revisited if real contention appears.
 
 #### Symmetric Drain (structural commands)
 

--- a/integration/giga_swamp_namespace_layout_test.ts
+++ b/integration/giga_swamp_namespace_layout_test.ts
@@ -1,0 +1,221 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for the giga-swamp Phase 3 filesystem layout.
+ *
+ * Phase 3 makes the datastore storage layout namespace-aware: a configured
+ * namespace lands data under `{datastore}/{namespace}/data/...` while the
+ * catalog stays repo-local at `{repoDir}/.swamp/data/_catalog.db`. Solo mode
+ * (no namespace) must be byte-identical to before. These tests wire the path
+ * resolver, repository, and catalog together exactly as `repo_context` does
+ * and assert the resulting on-disk layout.
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { existsSync } from "@std/fs";
+import { Data } from "../src/domain/data/data.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import { DataQueryService } from "../src/domain/data/data_query_service.ts";
+import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/default_datastore_path_resolver.ts";
+import {
+  catalogDbPath,
+  namespaceFromResolver,
+} from "../src/infrastructure/persistence/repository_factory.ts";
+import type { DatastoreConfig } from "../src/domain/datastore/datastore_config.ts";
+import type { DataRecord } from "../src/domain/data/data_record.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-giga-layout-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+const type = ModelType.create("test/model");
+
+function makeData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", modelName: "ingest", specName: "result" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test/model:m",
+    },
+  });
+}
+
+/**
+ * Wires resolver + repo + catalog exactly as repo_context does, writes one
+ * data item, and returns the on-disk anchors plus the queried rows so each
+ * test can assert the layout.
+ */
+async function writeOneItem(
+  repoDir: string,
+  config: DatastoreConfig,
+): Promise<{
+  modelId: string;
+  dataBaseDir: string;
+  catalogPath: string;
+  rows: DataRecord[];
+}> {
+  const resolver = new DefaultDatastorePathResolver(repoDir, config);
+  const dataBaseDir = resolver.resolvePath("data");
+  const catalogPath = catalogDbPath(repoDir, resolver);
+  const modelId = crypto.randomUUID();
+
+  const catalog = new CatalogStore(catalogPath);
+  try {
+    const repo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      dataBaseDir,
+      catalog,
+      undefined,
+      undefined,
+      namespaceFromResolver(resolver),
+    );
+    await repo.save(
+      type,
+      modelId,
+      makeData("alpha"),
+      new TextEncoder().encode('{"k":1}'),
+    );
+    const service = new DataQueryService(catalog, repo);
+    const rows = await service.query('modelName == "ingest"') as DataRecord[];
+    return { modelId, dataBaseDir, catalogPath, rows };
+  } finally {
+    catalog.close();
+  }
+}
+
+Deno.test("giga-swamp layout: namespaced repo lands data under {ds}/{namespace}/data and stamps the namespace", async () => {
+  await withTempDir(async (repoDir) => {
+    const dsDir = join(repoDir, "external-ds");
+    const config: DatastoreConfig = {
+      type: "filesystem",
+      path: dsDir,
+      namespace: "infra",
+    };
+
+    const { modelId, dataBaseDir, catalogPath, rows } = await writeOneItem(
+      repoDir,
+      config,
+    );
+
+    // Data base dir is the namespaced tier: {ds}/infra/data.
+    assertEquals(dataBaseDir, join(dsDir, "infra", "data"));
+    // The model's data directory exists under the namespaced path...
+    assertEquals(
+      existsSync(join(dsDir, "infra", "data", type.normalized, modelId)),
+      true,
+    );
+    // ...and NOTHING is written to the un-namespaced {ds}/data tier.
+    assertEquals(existsSync(join(dsDir, "data")), false);
+
+    // The catalog is repo-local, never in the (possibly shared) datastore.
+    assertEquals(catalogPath, join(repoDir, ".swamp", "data", "_catalog.db"));
+    assertEquals(existsSync(catalogPath), true);
+    assertEquals(
+      existsSync(join(dsDir, "infra", "data", "_catalog.db")),
+      false,
+    );
+
+    // Catalog rows carry the configured namespace.
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].namespace, "infra");
+  });
+});
+
+Deno.test("giga-swamp layout: solo mode is byte-identical (data in {ds}/data, repo-local catalog)", async () => {
+  await withTempDir(async (repoDir) => {
+    const dsDir = join(repoDir, "external-ds");
+    const config: DatastoreConfig = { type: "filesystem", path: dsDir };
+
+    const { modelId, dataBaseDir, catalogPath, rows } = await writeOneItem(
+      repoDir,
+      config,
+    );
+
+    // No prefix: data lands directly under {ds}/data.
+    assertEquals(dataBaseDir, join(dsDir, "data"));
+    assertEquals(
+      existsSync(join(dsDir, "data", type.normalized, modelId)),
+      true,
+    );
+    // Catalog is repo-local (matches the default-repo location today).
+    assertEquals(catalogPath, join(repoDir, ".swamp", "data", "_catalog.db"));
+    assertEquals(existsSync(catalogPath), true);
+
+    // Solo rows carry the empty namespace.
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].namespace, "");
+  });
+});
+
+Deno.test("giga-swamp layout: two namespaces sharing a datastore keep data and catalogs separate", async () => {
+  await withTempDir(async (root) => {
+    // One shared datastore, two repos with different namespaces.
+    const dsDir = join(root, "shared-ds");
+    const repoA = join(root, "repo-a");
+    const repoB = join(root, "repo-b");
+
+    const a = await writeOneItem(repoA, {
+      type: "filesystem",
+      path: dsDir,
+      namespace: "infra",
+    });
+    const b = await writeOneItem(repoB, {
+      type: "filesystem",
+      path: dsDir,
+      namespace: "security",
+    });
+
+    // Data is partitioned by namespace under the shared datastore.
+    assertEquals(
+      existsSync(join(dsDir, "infra", "data", type.normalized, a.modelId)),
+      true,
+    );
+    assertEquals(
+      existsSync(join(dsDir, "security", "data", type.normalized, b.modelId)),
+      true,
+    );
+
+    // Each repo owns a private catalog — no shared file to clobber.
+    assertEquals(a.catalogPath, join(repoA, ".swamp", "data", "_catalog.db"));
+    assertEquals(b.catalogPath, join(repoB, ".swamp", "data", "_catalog.db"));
+    assertEquals(a.catalogPath === b.catalogPath, false);
+
+    // Each repo's catalog sees only its own namespace's row.
+    assertEquals(a.rows.map((r) => r.namespace), ["infra"]);
+    assertEquals(b.rows.map((r) => r.namespace), ["security"]);
+  });
+});

--- a/src/cli/commands/datastore_compact.ts
+++ b/src/cli/commands/datastore_compact.ts
@@ -31,12 +31,10 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
 import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
-import { join } from "@std/path";
+  catalogDbPath,
+  createCatalogStore,
+} from "../../infrastructure/persistence/repository_factory.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -70,16 +68,16 @@ export const datastoreCompactCommand = new Command()
     });
 
     const catalogStore = createCatalogStore(repoDir, datastoreResolver);
-    const dataBaseDir = datastoreResolver?.resolvePath(SWAMP_SUBDIRS.data) ??
-      swampPath(repoDir, SWAMP_SUBDIRS.data);
-    const catalogDbPath = join(dataBaseDir, "_catalog.db");
+    // Use the centralized catalog-path helper — the catalog is repo-local and
+    // its location must match createCatalogStore exactly, never be recomputed.
+    const dbPath = catalogDbPath(repoDir, datastoreResolver);
 
     const deps: DatastoreCompactDeps = {
       checkpoint: () => catalogStore.checkpoint(),
       vacuum: () => catalogStore.vacuum(),
       catalogDbSize: async () => {
         try {
-          const stat = await Deno.stat(catalogDbPath);
+          const stat = await Deno.stat(dbPath);
           return stat.size;
         } catch {
           return 0;

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -167,6 +167,7 @@ export const workflowResumeCommand = new Command()
         repoContext.catalogStore,
         directResolver,
         repoContext.markDirty,
+        repoContext.unifiedDataRepo.namespace,
       );
 
       const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -375,6 +375,7 @@ export const workflowRunCommand = new Command()
             catalogStore,
             directResolver,
             repoContext.markDirty,
+            repoContext.unifiedDataRepo.namespace,
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -61,6 +61,7 @@ import { swampPath } from "../infrastructure/persistence/paths.ts";
 import {
   type DistributedLock,
   type LockInfo,
+  type LockOptions,
   LockTimeoutError,
 } from "../domain/datastore/distributed_lock.ts";
 import {
@@ -485,7 +486,10 @@ export function requireInitializedRepo(
     // Verify datastore is accessible
     if (isCustomDatastoreConfig(datastoreConfig)) {
       const provider = await resolveCustomProvider(datastoreConfig);
-      const lock = provider.createLock(datastoreConfig.datastorePath);
+      const lock = provider.createLock(
+        datastoreConfig.datastorePath,
+        datastoreGlobalLockOptions(datastoreConfig),
+      );
 
       // If the custom provider supports sync, register sync service too
       syncService = datastoreConfig.cachePath
@@ -553,7 +557,10 @@ export function requireInitializedRepo(
       // first drain may have acquired a per-model lock between the drain
       // ending and this acquisition, so its in-flight write would still
       // race our structural work.
-      const lock = new FileLock(datastoreConfig.path);
+      const lock = new FileLock(
+        datastoreConfig.path,
+        datastoreGlobalLockOptions(datastoreConfig),
+      );
       await registerDatastoreSync({ lock });
 
       // Second drain: with the global lock now held, wait for any such
@@ -954,8 +961,15 @@ export async function acquireModelLocks(
 
   // Wait for global lock to be released (if held by a structural command).
   // Use the cached provider for custom types so all locks share the same instance.
+  // The inspected key MUST match the namespaced key the structural command
+  // acquires (datastoreGlobalLockOptions), or the symmetric drain silently
+  // coordinates against the wrong lock. createDatastoreLock applies the same
+  // options for the filesystem branch.
   const globalLock = customProvider && isCustomDatastoreConfig(config)
-    ? customProvider.createLock(config.datastorePath)
+    ? customProvider.createLock(
+      config.datastorePath,
+      datastoreGlobalLockOptions(config),
+    )
     : await createDatastoreLock(config);
   const globalInfo = await globalLock.inspect();
   if (globalInfo) {
@@ -986,7 +1000,7 @@ export async function acquireModelLocks(
       const globalElapsed = Date.now() - globalWaitStart;
       if (globalElapsed >= globalMaxWaitMs) {
         throw new LockTimeoutError(
-          ".datastore.lock",
+          datastoreGlobalLockOptions(config)?.lockKey ?? ".datastore.lock",
           info,
           globalElapsed,
         );
@@ -1066,7 +1080,7 @@ export async function acquireModelLocks(
         const retryElapsed = Date.now() - retryWaitStart;
         if (retryElapsed >= retryMaxWaitMs) {
           throw new LockTimeoutError(
-            ".datastore.lock",
+            datastoreGlobalLockOptions(config)?.lockKey ?? ".datastore.lock",
             info,
             retryElapsed,
           );
@@ -1116,7 +1130,10 @@ export async function acquireModelLocks(
       if (
         customSyncService && customProvider && isCustomDatastoreConfig(config)
       ) {
-        const pushLock = customProvider.createLock(config.datastorePath);
+        const pushLock = customProvider.createLock(
+          config.datastorePath,
+          datastoreGlobalLockOptions(config),
+        );
         try {
           await pushLock.acquire();
           logger.info`Pushing changes to datastore...`;
@@ -1164,6 +1181,33 @@ export async function acquireModelLocks(
 }
 
 /**
+ * Lock options selecting the global datastore lock for a config's namespace
+ * (giga-swamp Phase 3).
+ *
+ * Solo mode (no namespace) returns `undefined`, so the lock falls back to the
+ * single shared `.datastore.lock` — byte-identical to before. When a namespace
+ * is configured, the global lock moves to `.locks/{namespace}.lock` so repos
+ * sharing a datastore never contend on structural commands. This is a PATH
+ * change only: the lock lifecycle (symmetric drain, TOCTOU rechecks) is
+ * unchanged. `FileLock` lazily creates the `.locks/` directory on first
+ * acquire via `ensureDir(dirname(lockPath))`.
+ *
+ * Every construction of the GLOBAL datastore lock — the structural-command
+ * acquire, the `acquireModelLocks` drain-coordination inspect, the per-model
+ * flush push lock, and the breakglass status/release commands — must pass
+ * these options so they all agree on the same namespaced key. A mismatch
+ * would make the symmetric drain silently inspect a different lock than the
+ * one held.
+ */
+export function datastoreGlobalLockOptions(
+  config: DatastoreConfig,
+): LockOptions | undefined {
+  const namespace = config.namespace ?? "";
+  if (namespace.length === 0) return undefined;
+  return { lockKey: `.locks/${namespace}.lock` };
+}
+
+/**
  * Creates the appropriate distributed lock for a datastore configuration.
  *
  * Used by the lock breakglass commands to inspect/release locks without
@@ -1172,9 +1216,10 @@ export async function acquireModelLocks(
 export async function createDatastoreLock(
   config: DatastoreConfig,
 ): Promise<DistributedLock> {
+  const options = datastoreGlobalLockOptions(config);
   if (isCustomDatastoreConfig(config)) {
     const provider = await resolveCustomProvider(config);
-    return provider.createLock(config.datastorePath);
+    return provider.createLock(config.datastorePath, options);
   }
-  return new FileLock(config.path);
+  return new FileLock(config.path, options);
 }

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -29,6 +29,7 @@ import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import {
   acquireModelLocks,
   createModelLock,
+  datastoreGlobalLockOptions,
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
   requireInitializedRepoUnlocked,
@@ -37,7 +38,10 @@ import {
   waitForPerModelLocks,
 } from "./repo_context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
-import { isCustomDatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import {
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../domain/datastore/datastore_config.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
 import { UserError } from "../domain/errors.ts";
@@ -1552,5 +1556,42 @@ Deno.test("acquireModelLocks - scopedSync deduplicates models in context", async
     );
 
     await lockResult.flush();
+  });
+});
+
+// ── Giga-swamp per-namespace global lock (Phase 3) ──────────────────────────
+
+Deno.test("datastoreGlobalLockOptions: solo mode falls back to the single .datastore.lock", () => {
+  const solo: DatastoreConfig = { type: "filesystem", path: "/ds" };
+  const explicitEmpty: DatastoreConfig = {
+    type: "filesystem",
+    path: "/ds",
+    namespace: "",
+  };
+  // undefined → FileLock uses the default `.datastore.lock` key.
+  assertEquals(datastoreGlobalLockOptions(solo), undefined);
+  assertEquals(datastoreGlobalLockOptions(explicitEmpty), undefined);
+});
+
+Deno.test("datastoreGlobalLockOptions: namespaced repo uses .locks/{namespace}.lock", () => {
+  const config: DatastoreConfig = {
+    type: "filesystem",
+    path: "/ds",
+    namespace: "infra",
+  };
+  assertEquals(datastoreGlobalLockOptions(config), {
+    lockKey: ".locks/infra.lock",
+  });
+});
+
+Deno.test("datastoreGlobalLockOptions: applies to custom datastores too", () => {
+  const config: DatastoreConfig = {
+    type: "s3",
+    config: { bucket: "b" },
+    datastorePath: "/cache",
+    namespace: "security",
+  };
+  assertEquals(datastoreGlobalLockOptions(config), {
+    lockKey: ".locks/security.lock",
   });
 });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -53,6 +53,7 @@ import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persiste
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { type Namespace, SOLO_NAMESPACE } from "../data/namespace.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import type { MarkDirtyHook } from "../datastore/datastore_sync_service.ts";
 import { DataQueryService } from "../data/data_query_service.ts";
@@ -200,6 +201,12 @@ export interface StepExecutionContext {
   dataBaseDir?: string;
   /** Catalog store for write-through indexing */
   catalogStore: CatalogStore;
+  /**
+   * Giga-swamp namespace stamped on data this step writes. Defaults to
+   * SOLO_NAMESPACE when unset, keeping the catalog stamp in lockstep with the
+   * namespaced data path.
+   */
+  namespace?: Namespace;
 }
 
 /**
@@ -296,6 +303,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir?: string;
       catalogStore: CatalogStore;
       markDirty?: MarkDirtyHook;
+      namespace?: Namespace;
     },
   ): Promise<DefaultStepExecutor> {
     return new DefaultStepExecutor(
@@ -316,6 +324,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir: ctx.dataBaseDir,
       catalogStore: ctx.catalogStore,
       markDirty: this.markDirty,
+      namespace: ctx.namespace,
     });
     if (this._directTypeResolver) {
       deps.directTypeResolver = this._directTypeResolver;
@@ -329,6 +338,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir?: string;
       catalogStore: CatalogStore;
       markDirty?: MarkDirtyHook;
+      namespace?: Namespace;
     },
   ): Promise<StepExecutorDeps> {
     const definitionRepo = new YamlDefinitionRepository(repoDir);
@@ -337,6 +347,8 @@ export class DefaultStepExecutor implements StepExecutor {
       opts.dataBaseDir,
       opts.catalogStore,
       opts.markDirty,
+      undefined,
+      opts.namespace ?? SOLO_NAMESPACE,
     );
     const dataQueryService = new DataQueryService(
       opts.catalogStore,
@@ -1279,6 +1291,7 @@ export class WorkflowExecutionService {
     catalogStore: CatalogStore,
     private readonly directTypeResolver?: DirectTypeResolver,
     private readonly markDirty?: MarkDirtyHook,
+    private readonly namespace: Namespace = SOLO_NAMESPACE,
   ) {
     this.executor = executor ??
       new DefaultStepExecutor(undefined, directTypeResolver, markDirty);
@@ -1295,6 +1308,8 @@ export class WorkflowExecutionService {
       dataBaseDir,
       catalogStore,
       markDirty,
+      undefined,
+      namespace,
     );
     const dataQueryService = new DataQueryService(catalogStore, this.dataRepo);
     this.modelResolver = new ModelResolver(this.definitionRepo, {
@@ -2292,6 +2307,7 @@ export class WorkflowExecutionService {
           skipAllChecks: options.skipAllChecks,
           dataBaseDir: this.dataBaseDir,
           catalogStore: this.catalogStore,
+          namespace: this.namespace,
         };
         return this.executor.execute(step, ctx);
       });
@@ -2520,6 +2536,7 @@ export class WorkflowExecutionService {
       this.catalogStore,
       undefined,
       this.markDirty,
+      this.namespace,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/infrastructure/persistence/default_datastore_path_resolver.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver.ts
@@ -43,12 +43,20 @@ export class DefaultDatastorePathResolver implements DatastorePathResolver {
   private readonly datastoreSubdirs: ReadonlySet<string>;
   private readonly compiledExclude: ReturnType<typeof compilePatterns>;
   private readonly datastoreBasePath: string;
+  /**
+   * Giga-swamp namespace slug. When non-empty, it is prepended as the
+   * outermost segment of every datastore-tier path so repos sharing a
+   * datastore land their data under `{datastore}/{namespace}/...`. Empty
+   * string is solo mode: paths are byte-identical to a non-namespaced repo.
+   */
+  private readonly namespace: string;
 
   constructor(repoDir: string, datastoreConfig: DatastoreConfig) {
     this.repoDir = repoDir;
     this.datastoreConfig = datastoreConfig;
     this.datastoreSubdirs = new Set(getDatastoreDirectories(datastoreConfig));
     this.compiledExclude = compilePatterns(datastoreConfig.exclude ?? []);
+    this.namespace = datastoreConfig.namespace ?? "";
 
     // Determine the base path for the datastore
     if (isCustomDatastoreConfig(datastoreConfig)) {
@@ -68,6 +76,14 @@ export class DefaultDatastorePathResolver implements DatastorePathResolver {
   }
 
   datastorePath(...segments: string[]): string {
+    // Giga-swamp: the namespace is the OUTERMOST segment of the datastore
+    // tier — `{base}/{namespace}/data/...`, never `{base}/data/{namespace}/`.
+    // Solo mode (empty namespace) produces byte-identical paths to before.
+    // Built with `join` so an empty namespace can never slip a stray
+    // separator into the result.
+    if (this.namespace.length > 0) {
+      return join(this.datastoreBasePath, this.namespace, ...segments);
+    }
     return join(this.datastoreBasePath, ...segments);
   }
 

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -254,3 +254,92 @@ Deno.test("DefaultDatastorePathResolver - filesystem datastore resolves bundles 
     "/repo/.swamp/bundles/2e4ea9ae/aws/logs.js",
   );
 });
+
+// ── Giga-swamp namespace prefixing (Phase 3) ────────────────────────────────
+
+Deno.test("DefaultDatastorePathResolver - namespace prepends as outermost datastore segment", () => {
+  const config: DatastoreConfig = {
+    type: "filesystem",
+    path: "/data/store",
+    namespace: "infra",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // {base}/{namespace}/data/... — NOT {base}/data/{namespace}/...
+  assertPathEquals(
+    resolver.datastorePath("data", "aws/ec2/vpc"),
+    "/data/store/infra/data/aws/ec2/vpc",
+  );
+  assertPathEquals(
+    resolver.resolvePath("data", "aws/ec2/vpc"),
+    "/data/store/infra/data/aws/ec2/vpc",
+  );
+});
+
+Deno.test("DefaultDatastorePathResolver - empty namespace is byte-identical to solo mode", () => {
+  const solo: DatastoreConfig = { type: "filesystem", path: "/data/store" };
+  const explicit: DatastoreConfig = {
+    type: "filesystem",
+    path: "/data/store",
+    namespace: "",
+  };
+  const soloResolver = new DefaultDatastorePathResolver("/repo", solo);
+  const explicitResolver = new DefaultDatastorePathResolver("/repo", explicit);
+
+  // No prefix, no leading separator, no double slash.
+  assertPathEquals(soloResolver.datastorePath("data"), "/data/store/data");
+  assertPathEquals(explicitResolver.datastorePath("data"), "/data/store/data");
+  assertPathEquals(
+    explicitResolver.resolvePath("outputs", "run-1"),
+    "/data/store/outputs/run-1",
+  );
+});
+
+Deno.test("DefaultDatastorePathResolver - namespace never affects localPath (.swamp)", () => {
+  const config: DatastoreConfig = {
+    type: "filesystem",
+    path: "/data/store",
+    namespace: "security",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // The repo-local tier is private to the repo and never namespaced.
+  assertPathEquals(
+    resolver.localPath("secrets", "vault", "key"),
+    "/repo/.swamp/secrets/vault/key",
+  );
+});
+
+Deno.test("DefaultDatastorePathResolver - namespace prefixes the custom-datastore cache tier", () => {
+  const config: DatastoreConfig = {
+    type: "s3",
+    config: { bucket: "my-bucket" },
+    datastorePath: "/home/user/.swamp/repos/abc",
+    cachePath: "/home/user/.swamp/repos/abc",
+    namespace: "platform",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // Cache mirrors the namespaced remote layout so sync needs no translation.
+  assertPathEquals(
+    resolver.resolvePath("data", "result"),
+    "/home/user/.swamp/repos/abc/platform/data/result",
+  );
+});
+
+Deno.test("DefaultDatastorePathResolver - exclude patterns match the un-prefixed relative path under a namespace", () => {
+  const config: DatastoreConfig = {
+    type: "filesystem",
+    path: "/data/store",
+    namespace: "infra",
+    exclude: ["data/scratch/**"],
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // Excluded paths fall back to local tier (and are therefore not namespaced).
+  assertPathEquals(
+    resolver.resolvePath("data", "scratch", "tmp.json"),
+    "/repo/.swamp/data/scratch/tmp.json",
+  );
+  // Non-excluded data is namespaced in the datastore tier.
+  assertPathEquals(
+    resolver.resolvePath("data", "keep", "v.json"),
+    "/data/store/infra/data/keep/v.json",
+  );
+});

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
 import { FileLock } from "./file_lock.ts";
 import type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
@@ -272,5 +273,53 @@ Deno.test("FileLock - custom lock key", async () => {
     assertEquals(stat.isFile, true);
 
     await lock.release();
+  });
+});
+
+Deno.test("FileLock - namespaced lock key lazily creates the .locks directory", async () => {
+  await withTempDir(async (dir) => {
+    // Giga-swamp per-namespace global lock key: `.locks/{namespace}.lock`.
+    const lock = new FileLock(dir, {
+      lockKey: ".locks/infra.lock",
+      ttlMs: 5000,
+    });
+
+    // The `.locks` directory must NOT exist before acquisition.
+    await assertRejects(() => Deno.stat(join(dir, ".locks")));
+
+    await lock.acquire();
+
+    // Acquiring lazily creates `.locks/` and the namespaced lock file.
+    const dirStat = await Deno.stat(join(dir, ".locks"));
+    assertEquals(dirStat.isDirectory, true);
+    const fileStat = await Deno.stat(join(dir, ".locks", "infra.lock"));
+    assertEquals(fileStat.isFile, true);
+
+    await lock.release();
+  });
+});
+
+Deno.test("FileLock - different namespaces acquire their locks concurrently", async () => {
+  await withTempDir(async (dir) => {
+    // Two repos sharing a datastore but in different namespaces must not
+    // contend on the global lock.
+    const infra = new FileLock(dir, {
+      lockKey: ".locks/infra.lock",
+      ttlMs: 5000,
+    });
+    const security = new FileLock(dir, {
+      lockKey: ".locks/security.lock",
+      ttlMs: 5000,
+    });
+
+    await infra.acquire();
+    // Acquiring the other namespace's lock must not block on infra's lock.
+    await security.acquire();
+
+    assertEquals((await infra.inspect()) !== null, true);
+    assertEquals((await security.inspect()) !== null, true);
+
+    await infra.release();
+    await security.release();
   });
 });

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -83,6 +83,52 @@ import { join } from "@std/path";
 // =============================================================================
 
 /**
+ * Resolves the on-disk path of the `_catalog.db` SQLite read-model.
+ *
+ * The catalog is **repo-local**: it always lives under the repo's own
+ * `.swamp/data/` directory, never in the (possibly shared, possibly
+ * namespaced) datastore tier. Under giga-swamp, multiple repos can share a
+ * single datastore; a per-repo catalog lets each one own a private index
+ * instead of clobbering the others' rows via full-replace backfill. The
+ * resolver's `localPath` is never namespace-prefixed, so this is identical
+ * across solo and namespaced repos.
+ *
+ * This is the single source of truth for the catalog path — callers that need
+ * the path (e.g. `datastore compact`) must use this helper rather than
+ * recomputing it, so the location can never silently drift.
+ *
+ * @param repoDir - The repository directory path
+ * @param datastoreResolver - Optional datastore path resolver
+ * @returns The absolute path to `_catalog.db`
+ */
+export function catalogDbPath(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): string {
+  const dataBaseDir = datastoreResolver?.localPath(SWAMP_SUBDIRS.data) ??
+    swampPath(repoDir, SWAMP_SUBDIRS.data);
+  return join(dataBaseDir, "_catalog.db");
+}
+
+/**
+ * Derives the giga-swamp {@link Namespace} value from a datastore path
+ * resolver's config.
+ *
+ * Construction sites that build a {@link FileSystemUnifiedDataRepository}
+ * directly (outside {@link createRepositoryContext}) use this so the catalog
+ * namespace stamp stays in lockstep with the namespaced data path the same
+ * resolver produces. Returns {@link SOLO_NAMESPACE} when no namespace is
+ * configured. Centralizing the derivation keeps the ~13 direct sites from
+ * drifting into a split-brain (namespaced path, solo stamp, or vice versa).
+ */
+export function namespaceFromResolver(
+  datastoreResolver?: DatastorePathResolver,
+): Namespace {
+  const slug = datastoreResolver?.config().namespace ?? "";
+  return slug.length > 0 ? createNamespace(slug) : SOLO_NAMESPACE;
+}
+
+/**
  * Creates a CatalogStore for the given repository.
  *
  * Centralizes the three-step pattern: resolve data base dir, build DB path,
@@ -97,10 +143,7 @@ export function createCatalogStore(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
 ): CatalogStore {
-  const dataBaseDir = datastoreResolver?.resolvePath(SWAMP_SUBDIRS.data) ??
-    swampPath(repoDir, SWAMP_SUBDIRS.data);
-  const catalogDbPath = join(dataBaseDir, "_catalog.db");
-  return new CatalogStore(catalogDbPath);
+  return new CatalogStore(catalogDbPath(repoDir, datastoreResolver));
 }
 
 // =============================================================================

--- a/src/infrastructure/persistence/repository_factory_test.ts
+++ b/src/infrastructure/persistence/repository_factory_test.ts
@@ -20,14 +20,19 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import {
+  catalogDbPath,
   createRepositoryContext,
   createUnifiedDataRepository,
+  namespaceFromResolver,
 } from "./repository_factory.ts";
 import { CatalogStore } from "./catalog_store.ts";
 import {
   createNamespace,
   SOLO_NAMESPACE,
 } from "../../domain/data/namespace.ts";
+import { DefaultDatastorePathResolver } from "./default_datastore_path_resolver.ts";
+import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
 
 function tempRepoDir(): string {
   return Deno.makeTempDirSync({ prefix: "swamp-factory-test-" });
@@ -88,4 +93,74 @@ Deno.test("createUnifiedDataRepository: defaults to SOLO_NAMESPACE", () => {
   const repo = createUnifiedDataRepository(dir, catalog);
   assertEquals(repo.namespace, SOLO_NAMESPACE);
   catalog.close();
+});
+
+// ── Giga-swamp catalog is repo-local (Phase 3, Decision 1a) ─────────────────
+
+Deno.test("catalogDbPath: repo-local for a default (no datastore) repo", () => {
+  assertPathEquals(catalogDbPath("/repo"), "/repo/.swamp/data/_catalog.db");
+});
+
+Deno.test("catalogDbPath: repo-local even with an external filesystem datastore", () => {
+  const config: DatastoreConfig = { type: "filesystem", path: "/shared/ds" };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  // Catalog stays under .swamp/data — NOT in the (shared) datastore dir.
+  assertPathEquals(
+    catalogDbPath("/repo", resolver),
+    "/repo/.swamp/data/_catalog.db",
+  );
+});
+
+Deno.test("catalogDbPath: repo-local and identical with vs without a namespace", () => {
+  const solo: DatastoreConfig = { type: "filesystem", path: "/shared/ds" };
+  const namespaced: DatastoreConfig = {
+    type: "filesystem",
+    path: "/shared/ds",
+    namespace: "infra",
+  };
+  const soloPath = catalogDbPath(
+    "/repo",
+    new DefaultDatastorePathResolver("/repo", solo),
+  );
+  const nsPath = catalogDbPath(
+    "/repo",
+    new DefaultDatastorePathResolver("/repo", namespaced),
+  );
+  assertPathEquals(soloPath, "/repo/.swamp/data/_catalog.db");
+  // The namespace must NOT partition or relocate the catalog.
+  assertPathEquals(nsPath, soloPath);
+});
+
+Deno.test("catalogDbPath: repo-local for a custom (S3) datastore", () => {
+  const config: DatastoreConfig = {
+    type: "s3",
+    config: { bucket: "b" },
+    datastorePath: "/home/user/.swamp/repos/abc",
+    cachePath: "/home/user/.swamp/repos/abc",
+    namespace: "platform",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  assertPathEquals(
+    catalogDbPath("/repo", resolver),
+    "/repo/.swamp/data/_catalog.db",
+  );
+});
+
+Deno.test("namespaceFromResolver: derives the configured namespace value", () => {
+  const config: DatastoreConfig = {
+    type: "filesystem",
+    path: "/ds",
+    namespace: "security",
+  };
+  const resolver = new DefaultDatastorePathResolver("/repo", config);
+  assertEquals(namespaceFromResolver(resolver), createNamespace("security"));
+});
+
+Deno.test("namespaceFromResolver: SOLO_NAMESPACE for no resolver or empty namespace", () => {
+  assertEquals(namespaceFromResolver(undefined), SOLO_NAMESPACE);
+  const solo = new DefaultDatastorePathResolver("/repo", {
+    type: "filesystem",
+    path: "/ds",
+  });
+  assertEquals(namespaceFromResolver(solo), SOLO_NAMESPACE);
 });

--- a/src/libswamp/data/delete.ts
+++ b/src/libswamp/data/delete.ts
@@ -25,7 +25,10 @@ import {
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -87,6 +90,9 @@ export function createDataDeleteDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   const service = new DataDeleteService(dataRepo, definitionRepo);

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -26,7 +26,10 @@ import {
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -106,6 +109,9 @@ export function createDataGcDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,

--- a/src/libswamp/data/get.ts
+++ b/src/libswamp/data/get.ts
@@ -30,7 +30,10 @@ import {
   SWAMP_SUBDIRS,
   toRelativePath,
 } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -180,6 +183,9 @@ export function createDataGetDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   const runRepo = new YamlWorkflowRunRepository(

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -27,7 +27,10 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -170,6 +173,9 @@ export function createDataListDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   const runRepo = new YamlWorkflowRunRepository(

--- a/src/libswamp/data/rename.ts
+++ b/src/libswamp/data/rename.ts
@@ -24,7 +24,10 @@ import {
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -77,6 +80,9 @@ export function createDataRenameDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   const service = new DataRenameService(dataRepo, definitionRepo);

--- a/src/libswamp/data/versions.ts
+++ b/src/libswamp/data/versions.ts
@@ -23,7 +23,10 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
@@ -97,6 +100,9 @@ export function createDataVersionsDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   return {
     lookupDefinition: (idOrName) =>

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -27,7 +27,10 @@ import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_wo
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import { createModelOutputId } from "../../domain/models/model_output.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -110,6 +113,9 @@ export function createModelDeleteDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const outputRepo = new YamlOutputRepository(
     repoDir,

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -30,7 +30,10 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
@@ -98,6 +101,9 @@ export function createModelEvaluateDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const evaluationService = new ExpressionEvaluationService(

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -31,7 +31,10 @@ import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_outp
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -116,6 +119,9 @@ export function createModelOutputDataDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   return {
     isPartialId,

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -26,7 +26,10 @@ import {
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
@@ -92,6 +95,9 @@ export function createModelOutputLogsDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   return {
     isPartialId,

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -29,7 +29,10 @@ import {
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
@@ -129,6 +132,9 @@ export function createModelValidateDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const validationService = new DefaultModelValidationService();

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -31,7 +31,10 @@ import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistenc
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound } from "../errors.ts";
 import type { ReportSearchEvent, StoredReportSummary } from "./report_views.ts";
@@ -85,6 +88,9 @@ export async function createReportSearchDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   return {

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -41,7 +41,10 @@ import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistenc
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
-import { createCatalogStore } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -120,6 +123,9 @@ export function createWorkflowEvaluateDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
   );
   const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -87,6 +87,7 @@ export async function createWorkflowRunDeps(
         catalogStore,
         undefined,
         repoContext.markDirty,
+        repoContext.unifiedDataRepo.namespace,
       ),
     catalogStore: repoContext.catalogStore,
     dataRepo: repoContext.unifiedDataRepo,

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -1611,6 +1611,7 @@ async function handleWorkflowRun(
         catalogStore,
         undefined,
         deps.repoContext.markDirty,
+        deps.repoContext.unifiedDataRepo.namespace,
       ),
     catalogStore: deps.repoContext.catalogStore,
     dataRepo: deps.repoContext.unifiedDataRepo,


### PR DESCRIPTION
## Summary

Phase 3 of giga-swamp (multi-repo shared datastores). It makes the datastore **storage layout namespace-aware** so repos sharing a datastore land data under `{datastore}/{namespace}/` and don't block each other on structural commands. **Solo mode (empty namespace) is byte-identical to before** — the regression gate.

Builds on Phase 1 (Namespace value object + config) and Phase 2 (catalog v4 + repository + DataRecord).

### What changed
- **Path resolver** — `DefaultDatastorePathResolver` prepends `{namespace}/` as the *outermost* datastore-tier segment via the single `datastorePath()` chokepoint (`@std/path` join; no prefix in solo mode).
- **Repo-local catalog** — new centralized `catalogDbPath()` helper resolves `_catalog.db` to `.swamp/data/` regardless of namespace (used by `createCatalogStore` *and* `datastore compact`, so the path can't drift). Each repo owns a private catalog, so per-repo full-replace backfill never clobbers another repo's rows.
- **Per-namespace global lock** — `.locks/{namespace}.lock` via a namespace-aware `createDatastoreLock` + `datastoreGlobalLockOptions`, routed through every global-lock site **including the `acquireModelLocks` drain inspect**, so the symmetric-drain protocol stays correct in namespaced mode. Per-model locks are left un-namespaced (model ids are UUIDs → already globally unique).
- **Namespace threading** — the namespace value flows through the 13 direct `FileSystemUnifiedDataRepository` construction sites (via a shared `namespaceFromResolver()` helper) and the 2 `execution_service` sites + their callers, keeping catalog stamping in lockstep with the namespaced data path.

### Boundaries (deliberately out of scope)
No CEL/query changes (Phase 4), no CLI columns/namespace commands (Phase 5), no sync changes (Phase 6), no existing-data migration (Phase 7), no `DEFAULT_DATASTORE_SUBDIRS`/`markDirty` changes. Secrets/vault-bundles are repo-local by construction (never routed through `resolvePath`). One known cosmetic artifact documented in `design/datastores.md`: in namespaced mode the un-namespaced per-model lock leaves empty `{ds}/data/{type}/{id}/` dirs behind (no data, correctness-safe).

## Test Plan

- `deno check` / `deno lint` / `deno fmt --check` clean; `deno run test` **6471 passed / 0 failed**.
- New: 11 unit tests (resolver namespace prefixing + solo-identical + exclude-pattern guard; repo-local `catalogDbPath` across default/external-fs/namespaced/custom; `namespaceFromResolver`; namespaced `FileLock` lazy `.locks/` + concurrent acquire; `datastoreGlobalLockOptions`) and a 3-case integration test (`giga_swamp_namespace_layout_test.ts`).
- Compiled-binary smoke:
  - **Solo** — data at `{ds}/data/` (no prefix), no `.locks/`, `data query` → `namespace: ""`.
  - **Namespaced** — data at `{ds}/infra/data/...`, `data list`/`query` stamped `namespace: "infra"`, repo-local catalog, `.locks/` created.
  - **Catalog relocation migration** — pre-Phase-3 binary wrote data (catalog at old `{ds}/data/_catalog.db`); new binary transparently rebuilt it repo-local with **identical** query results and intact content; old catalog orphaned harmlessly.
  - **Live MinIO (S3)** — namespace is the outermost key prefix (`giga/infra/data/...`); local cache mirrors the remote layout; catalog not synced.

Closes swamp-club#486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)