### PR TITLE
feat(workflow): support --input on workflow resume (swamp-club#467)

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -39,7 +39,7 @@ run.
 | Run from stdin     | `echo '{"k":"v"}' \| swamp workflow run <id_or_name> --stdin` |
 | Approve step       | `swamp workflow approve <workflow> <step>`                    |
 | Reject step        | `swamp workflow reject <workflow> <step>`                     |
-| Resume workflow    | `swamp workflow resume <workflow>`                            |
+| Resume workflow    | `swamp workflow resume <workflow> [--input k=v]`              |
 | List approvals     | `swamp workflow approvals`                                    |
 | View run history   | `swamp workflow history search --json`                        |
 | Get latest run     | `swamp workflow history get <workflow> --json`                |
@@ -552,8 +552,17 @@ The workflow suspends to disk. Approve, reject, or resume from CLI:
 swamp workflow approve <workflow-name> <step-name>
 swamp workflow reject  <workflow-name> <step-name> --reason "Not ready"
 swamp workflow resume  <workflow-name>
+swamp workflow resume  <workflow-name> --input authKey=tskey-abc123
 swamp workflow approvals  # list all pending approvals
 ```
+
+Resume accepts `--input`/`--input-file`/`--stdin` (same parsing as
+`workflow run`). Resume inputs merge over the inputs the run had when it
+suspended, with a resume `--input` winning on a key collision. Evaluation stays
+strict, so a workflow must declare the inputs it references at run time: declare
+the input at run (e.g. a placeholder) and supply or override its value at
+resume. The run record records the resume input key names (not values) for
+audit.
 
 ## Working with Vaults
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -107,6 +107,26 @@ failed. No resume needed.
 
 `swamp workflow approvals` lists all suspended runs awaiting approval.
 
+**Resume inputs (`--input`):** `swamp workflow resume` accepts `--input`,
+`--input-file`, and `--stdin` (same parsing as `swamp workflow run`). These let
+an operator supply values that were not available at the original run time —
+elevated credentials, environment-specific overrides, or a freshly minted auth
+key issued during the gate. Resume inputs **merge** over the inputs captured
+when the run suspended: existing keys are preserved and a resume `--input` wins
+on a key collision. The merged set is placed on the expression context before
+evaluation, so post-gate `inputs.*` expressions resolve to the updated values.
+Workflow evaluation remains **strict**: a workflow must declare (at run time)
+every input it references, so the pattern is _declare the input at run, supply
+or override its value at resume_ — e.g. start with `authKey` set to a
+placeholder and pass the real key at resume. For audit, the run record captures
+the **key names** of resume-time inputs (never their values, so secrets are not
+written to the persisted run).
+
+**Input persistence:** A run's effective inputs are persisted to the run record
+when it **suspends** (not at run start), so steps after the gate can resolve
+`inputs.*` on resume. Runs that never suspend do not write their input values to
+disk.
+
 **Persistence:** The run record survives process restarts. The approval and
 resume can happen from any machine with access to the repo (or synced
 datastore).

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -25,7 +25,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { assertPathStringIncludes } from "../src/infrastructure/persistence/path_test_helpers.ts";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
-import { stringify as stringifyYaml } from "@std/yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { CLI_ARGS } from "./test_helpers.ts";
 import { Workflow } from "../src/domain/workflows/workflow.ts";
 import { Job } from "../src/domain/workflows/job.ts";
@@ -1948,5 +1948,223 @@ Deno.test("CLI: workflow run detects direct workflow cycle", async () => {
       true,
       `Self-calling workflow should fail. stdout: ${result.stdout}`,
     );
+  });
+});
+
+// workflow resume --input tests (issue #467)
+
+Deno.test("CLI: workflow resume --input merges override inputs into the resumed run", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // Shell model whose command echoes the inputs so resolved values are
+    // observable in the step output.
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    await definitionRepo.save(
+      SHELL_MODEL_TYPE,
+      Definition.create({ name: "deployer", methods: {} }),
+    );
+
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "deploy-with-gate",
+      jobs: [
+        Job.create({
+          name: "rollout",
+          steps: [
+            Step.create({
+              name: "verify",
+              task: StepTask.manualApproval("Verify before hardening"),
+            }),
+            Step.create({
+              name: "harden",
+              // Both inputs are declared at the original run; resume supplies
+              // updated values that the merge applies.
+              task: StepTask.model("deployer", "execute", {
+                run:
+                  "echo RESOLVED region=${{ inputs.region }} authKey=${{ inputs.authKey }}",
+              }),
+              dependsOn: [
+                { step: "verify", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await repo.save(workflow);
+
+    // Original run declares both inputs (authKey as a placeholder); suspends
+    // at the gate.
+    const runResult = await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "deploy-with-gate",
+        "--input",
+        "region=us-east",
+        "--input",
+        "authKey=PENDING",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      runResult.code,
+      0,
+      `run should suspend cleanly. stderr: ${runResult.stderr}`,
+    );
+    assertStringIncludes(runResult.stdout, "approvalRequired");
+
+    // Approve the gate.
+    const approveResult = await runCliCommand(
+      [
+        "workflow",
+        "approve",
+        "deploy-with-gate",
+        "verify",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(approveResult.code, 0, approveResult.stderr);
+
+    // Resume with an override (region) and a brand-new resume-only input.
+    const resumeResult = await runCliCommand(
+      [
+        "workflow",
+        "resume",
+        "deploy-with-gate",
+        "--input",
+        "region=us-west",
+        "--input",
+        "authKey=tskey-abc123",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(
+      resumeResult.code,
+      0,
+      `resume should succeed. stderr: ${resumeResult.stderr}`,
+    );
+    assertStringIncludes(JSON.parse(resumeResult.stdout).status, "succeeded");
+
+    // The shell step's output shows the merged inputs resolved through CEL:
+    // both region and authKey overridden by the resume inputs.
+    const dataResult = await runCliCommand(
+      ["data", "get", "deployer", "log", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+    assertEquals(dataResult.code, 0, dataResult.stderr);
+    assertStringIncludes(
+      JSON.parse(dataResult.stdout).content as string,
+      "RESOLVED region=us-west authKey=tskey-abc123",
+    );
+
+    // The run record's audit fields record the resume input KEY NAMES, never
+    // the values. (The resolved step command may legitimately contain the
+    // value because the user echoed it — that is the user's choice and a
+    // separate concern from this feature's audit trail.)
+    const runsDir = join(repoDir, ".swamp", "workflow-runs", workflow.id);
+    let runYaml = "";
+    for await (const entry of Deno.readDir(runsDir)) {
+      if (entry.isFile && entry.name.endsWith(".yaml")) {
+        runYaml = await Deno.readTextFile(join(runsDir, entry.name));
+      }
+    }
+    const record = parseYaml(runYaml) as {
+      inputs?: Record<string, unknown>;
+      resumeInputs?: string[];
+    };
+    // Audit: resume input key names only.
+    assertEquals([...(record.resumeInputs ?? [])].sort(), [
+      "authKey",
+      "region",
+    ]);
+    // The persisted inputs (captured at suspend) hold the original declared
+    // values, not the resume-time overrides.
+    assertEquals(record.inputs, { region: "us-east", authKey: "PENDING" });
+  });
+});
+
+Deno.test("CLI: workflow resume rejects multi-item stdin", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    await definitionRepo.save(
+      SHELL_MODEL_TYPE,
+      Definition.create({ name: "deployer", methods: {} }),
+    );
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "gate-only",
+      jobs: [
+        Job.create({
+          name: "rollout",
+          steps: [
+            Step.create({
+              name: "verify",
+              task: StepTask.manualApproval("Verify"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await repo.save(workflow);
+
+    await runCliCommand(
+      ["workflow", "run", "gate-only", "--repo-dir", repoDir, "--json"],
+      Deno.cwd(),
+    );
+    await runCliCommand(
+      [
+        "workflow",
+        "approve",
+        "gate-only",
+        "verify",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    // Two NDJSON items on stdin — resume targets a single run, so this errors.
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        ...CLI_ARGS,
+        "workflow",
+        "resume",
+        "gate-only",
+        "--stdin",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "piped",
+      cwd: Deno.cwd(),
+    });
+    const child = command.spawn();
+    const writer = child.stdin.getWriter();
+    await writer.write(
+      new TextEncoder().encode('{"a":1}\n{"b":2}\n'),
+    );
+    await writer.close();
+    const { code, stdout, stderr } = await child.output();
+    const output = new TextDecoder().decode(stdout) +
+      new TextDecoder().decode(stderr);
+
+    assertEquals(code !== 0, true, "multi-item stdin should be rejected");
+    assertStringIncludes(output, "single run");
   });
 });

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -2063,10 +2063,11 @@ Deno.test("CLI: workflow resume --input merges override inputs into the resumed 
       Deno.cwd(),
     );
     assertEquals(dataResult.code, 0, dataResult.stderr);
-    assertStringIncludes(
-      JSON.parse(dataResult.stdout).content as string,
-      "RESOLVED region=us-west authKey=tskey-abc123",
-    );
+    // Assert the resolved values individually — `echo` separates tokens with
+    // newlines rather than spaces on Windows, so don't match the whole line.
+    const hardenOutput = JSON.parse(dataResult.stdout).content as string;
+    assertStringIncludes(hardenOutput, "region=us-west");
+    assertStringIncludes(hardenOutput, "authKey=tskey-abc123");
 
     // The run record's audit fields record the resume input KEY NAMES, never
     // the values. (The resolved step command may legitimately contain the

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -2168,3 +2168,92 @@ Deno.test("CLI: workflow resume rejects multi-item stdin", async () => {
     assertStringIncludes(output, "single run");
   });
 });
+
+Deno.test("CLI: workflow resume warns which inputs are overridden vs added", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    const definitionRepo = new YamlDefinitionRepository(repoDir);
+    await definitionRepo.save(
+      SHELL_MODEL_TYPE,
+      Definition.create({ name: "deployer", methods: {} }),
+    );
+    const repo = new YamlWorkflowRepository(repoDir);
+    const workflow = Workflow.create({
+      name: "warn-gate",
+      jobs: [
+        Job.create({
+          name: "rollout",
+          steps: [
+            Step.create({
+              name: "verify",
+              task: StepTask.manualApproval("Verify"),
+            }),
+            Step.create({
+              name: "harden",
+              // Does not echo any input, so the only place a value could
+              // appear in output is the warning — which must not leak it.
+              task: StepTask.model("deployer", "execute", {
+                run: "echo hardened",
+              }),
+              dependsOn: [
+                { step: "verify", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await repo.save(workflow);
+
+    await runCliCommand(
+      [
+        "workflow",
+        "run",
+        "warn-gate",
+        "--input",
+        "region=us-east",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+    await runCliCommand(
+      [
+        "workflow",
+        "approve",
+        "warn-gate",
+        "verify",
+        "--repo-dir",
+        repoDir,
+        "--json",
+      ],
+      Deno.cwd(),
+    );
+
+    // Resume in log mode: override the declared `region` and add an unreferenced
+    // `extra` key. The warning lists key names only — never values.
+    const resume = await runCliCommand(
+      [
+        "workflow",
+        "resume",
+        "warn-gate",
+        "--input",
+        "region=us-west",
+        "--input",
+        "extra=ignored",
+        "--repo-dir",
+        repoDir,
+      ],
+      Deno.cwd(),
+    );
+
+    const output = resume.stdout + resume.stderr;
+    assertStringIncludes(output, 'overriding existing input(s): "region"');
+    assertStringIncludes(output, 'adding input(s): "extra"');
+    // Key names only — the values are never logged.
+    assertEquals(output.includes("us-west"), false);
+    assertEquals(output.includes("ignored"), false);
+  });
+});

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -50,6 +50,8 @@ import {
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { GIT_SHA } from "./version.ts";
+import { deepMerge, parseInputs, parseStdinContent } from "../input_parser.ts";
+import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -61,6 +63,10 @@ export const workflowResumeCommand = new Command()
     "Resume by workflow name",
     "swamp workflow resume deploy-with-gate",
   )
+  .example(
+    "Resume with an override input minted during the gate",
+    "swamp workflow resume deploy-with-gate --input authKey=tskey-abc123",
+  )
   .arguments("<workflow_id_or_name:string>")
   .option(
     "--repo-dir <dir:string>",
@@ -68,6 +74,18 @@ export const workflowResumeCommand = new Command()
   )
   .option("--driver <driver:string>", "Override execution driver")
   .option("--run <run_id:string>", "Target a specific run ID")
+  .option(
+    "--input <value:string>",
+    "Override/additional input for the resumed run (key=value or JSON); merged over the original run inputs",
+    { collect: true },
+  )
+  .option(
+    "--input-file <file:string>",
+    "Override inputs from a YAML file (cannot combine with --stdin)",
+  )
+  .option("--stdin", "Read override inputs from stdin (piped data)", {
+    default: false,
+  })
   .action(
     async function (
       options: AnyOptions,
@@ -83,6 +101,36 @@ export const workflowResumeCommand = new Command()
           repoDir: resolveRepoDir(options.repoDir),
           outputMode: cliCtx.outputMode,
         });
+
+      // Parse override inputs. Resume targets a single run, so unlike
+      // `workflow run` (which fans out one run per stdin item) stdin must
+      // resolve to a single override set.
+      const stdinContent = options.stdin ? await readStdin() : null;
+      let stdinInputs: Record<string, unknown> = {};
+      if (stdinContent !== null) {
+        if (options.inputFile) {
+          throw new UserError("Cannot combine --stdin with --input-file.");
+        }
+        const stdinItems = parseStdinContent(stdinContent);
+        if (stdinItems.length > 1) {
+          throw new UserError(
+            `--stdin provided ${stdinItems.length} items, but resume targets a single run. ` +
+              `Provide a single inputs object on stdin.`,
+          );
+        }
+        stdinInputs = stdinItems[0] ?? {};
+      }
+
+      const { inputs: cliInputs } = await parseInputs({
+        input: options.input as string[] | undefined,
+        inputFile: stdinContent !== null
+          ? undefined
+          : options.inputFile as string | undefined,
+      });
+
+      const resumeInputs = Object.keys(stdinInputs).length > 0
+        ? deepMerge(stdinInputs, cliInputs)
+        : cliInputs;
 
       const workflowRepo = new YamlWorkflowRepository(repoDir);
       const runRepo = new YamlWorkflowRunRepository(repoDir);
@@ -180,6 +228,7 @@ export const workflowResumeCommand = new Command()
             signal: AbortSignal.timeout(600_000),
             driver: options.driver,
             swampSha: GIT_SHA,
+            inputs: resumeInputs,
           })
         ) {
           yield mapWorkflowExecutionEvent(event, runRepo);

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -150,6 +150,25 @@ export const workflowResumeCommand = new Command()
         );
       }
 
+      // Surface what the resume inputs do to the run's inputs. Key names only —
+      // values may be secrets and are never logged. Overrides (a resume key
+      // that collides with an existing input) are warned; purely-additive keys
+      // are info.
+      const resumeKeys = Object.keys(resumeInputs);
+      if (resumeKeys.length > 0) {
+        const overridden = resumeKeys.filter((key) => key in run.inputs);
+        const added = resumeKeys.filter((key) => !(key in run.inputs));
+        if (overridden.length > 0) {
+          cliCtx.logger
+            .warn`Resume overriding existing input(s): ${
+            overridden.join(", ")
+          }`;
+        }
+        if (added.length > 0) {
+          cliCtx.logger.info`Resume adding input(s): ${added.join(", ")}`;
+        }
+      }
+
       const directResolver: DirectTypeResolver = async (
         typeArg,
         defName,

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -20,9 +20,12 @@
 import { parse as parseYaml } from "@std/yaml";
 import { UserError } from "../domain/errors.ts";
 import { homeDirectory } from "../infrastructure/persistence/paths.ts";
+import { deepMerge } from "../domain/inputs/input_merge.ts";
 
 // Re-export coerceInputTypes from domain layer for backward compatibility
 export { coerceInputTypes } from "../domain/inputs/input_coercion.ts";
+// Re-export deepMerge from domain layer for backward compatibility
+export { deepMerge } from "../domain/inputs/input_merge.ts";
 
 /**
  * Result of parsing inputs.
@@ -168,37 +171,6 @@ export async function parseKeyValueInputs(
   }
 
   return result;
-}
-
-/**
- * Deep merges two objects. Override values take precedence.
- * Only merges plain objects recursively; arrays and primitives are replaced.
- */
-export function deepMerge(
-  base: Record<string, unknown>,
-  overrides: Record<string, unknown>,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = { ...base };
-
-  for (const [key, overrideValue] of Object.entries(overrides)) {
-    const baseValue = result[key];
-    if (
-      isPlainObject(baseValue) && isPlainObject(overrideValue)
-    ) {
-      result[key] = deepMerge(
-        baseValue as Record<string, unknown>,
-        overrideValue as Record<string, unknown>,
-      );
-    } else {
-      result[key] = overrideValue;
-    }
-  }
-
-  return result;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/src/domain/inputs/input_merge.ts
+++ b/src/domain/inputs/input_merge.ts
@@ -1,0 +1,49 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Deep merges two objects. Override values take precedence.
+ * Only merges plain objects recursively; arrays and primitives are replaced.
+ */
+export function deepMerge(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+
+  for (const [key, overrideValue] of Object.entries(overrides)) {
+    const baseValue = result[key];
+    if (
+      isPlainObject(baseValue) && isPlainObject(overrideValue)
+    ) {
+      result[key] = deepMerge(
+        baseValue as Record<string, unknown>,
+        overrideValue as Record<string, unknown>,
+      );
+    } else {
+      result[key] = overrideValue;
+    }
+  }
+
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/domain/inputs/input_merge_test.ts
+++ b/src/domain/inputs/input_merge_test.ts
@@ -1,0 +1,65 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { deepMerge } from "./input_merge.ts";
+
+Deno.test("deepMerge: overrides take precedence over base for scalar keys", () => {
+  const result = deepMerge({ a: 1, b: 2 }, { b: 3, c: 4 });
+  assertEquals(result, { a: 1, b: 3, c: 4 });
+});
+
+Deno.test("deepMerge: new keys in overrides are additive", () => {
+  const result = deepMerge({ region: "us-east" }, { authKey: "tskey-abc123" });
+  assertEquals(result, { region: "us-east", authKey: "tskey-abc123" });
+});
+
+Deno.test("deepMerge: nested plain objects merge recursively", () => {
+  const result = deepMerge(
+    { server: { host: "localhost", port: 8080 } },
+    { server: { port: 9090 } },
+  );
+  assertEquals(result, { server: { host: "localhost", port: 9090 } });
+});
+
+Deno.test("deepMerge: arrays are replaced, not merged", () => {
+  const result = deepMerge({ tags: ["a", "b"] }, { tags: ["c"] });
+  assertEquals(result, { tags: ["c"] });
+});
+
+Deno.test("deepMerge: a plain object override replaces a non-object base", () => {
+  const result = deepMerge({ value: 5 }, { value: { nested: true } });
+  assertEquals(result, { value: { nested: true } });
+});
+
+Deno.test("deepMerge: a scalar override replaces an object base", () => {
+  const result = deepMerge({ value: { nested: true } }, { value: 5 });
+  assertEquals(result, { value: 5 });
+});
+
+Deno.test("deepMerge: does not mutate the base object", () => {
+  const base = { a: { b: 1 } };
+  deepMerge(base, { a: { c: 2 } });
+  assertEquals(base, { a: { b: 1 } });
+});
+
+Deno.test("deepMerge: empty overrides returns a copy of base", () => {
+  const result = deepMerge({ a: 1 }, {});
+  assertEquals(result, { a: 1 });
+});

--- a/src/domain/inputs/mod.ts
+++ b/src/domain/inputs/mod.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 export { coerceInputTypes } from "./input_coercion.ts";
+export { deepMerge } from "./input_merge.ts";
 export {
   type InputValidationError,
   type InputValidationResult,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -25,6 +25,7 @@ import {
   ForEachExpansionService,
 } from "./for_each_expansion_service.ts";
 import { coerceToSuffix } from "./data_suffix.ts";
+import { deepMerge } from "../inputs/input_merge.ts";
 // deno-lint-ignore verbatim-module-syntax
 import { JobRun, WorkflowRun } from "./workflow_run.ts";
 import {
@@ -1713,6 +1714,8 @@ export class WorkflowExecutionService {
       runtimeTags?: Record<string, string>;
       reportFilterOptions?: ReportFilterOptions;
       swampSha?: string;
+      /** Additional/override inputs supplied at resume time (CLI --input). */
+      inputs?: Record<string, unknown>;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
     const workflow = await this.workflowRepo.findByName(workflowIdOrName) ??
@@ -1742,10 +1745,26 @@ export class WorkflowExecutionService {
       );
     }
 
+    // Record the key names of any resume-time inputs for audit (never the
+    // values — they may be secrets such as a freshly minted auth key). Done
+    // before the save below so the audit trail persists immediately.
+    const resumeInputs = options?.inputs ?? {};
+    if (Object.keys(resumeInputs).length > 0) {
+      existingRun.recordResumeInputs(Object.keys(resumeInputs));
+    }
+
     existingRun.resumeFromSuspended();
     await this.saveRun(workflow.id, existingRun);
 
     const expressionContext = await this.modelResolver.buildContext();
+
+    // Merge resume-time inputs over the inputs captured when the run suspended.
+    // Resume overrides win on key collision; new keys are additive. Set before
+    // evaluation so workflow- and step-level `inputs.*` expressions resolve.
+    expressionContext.inputs = deepMerge(
+      { ...existingRun.inputs },
+      resumeInputs,
+    );
 
     const evaluator = new WorkflowExpressionEvaluator(
       new CelEvaluator(),
@@ -2233,7 +2252,11 @@ export class WorkflowExecutionService {
           prompt: task.prompt,
           timeout: task.timeout,
         };
-        run.suspend();
+        // Capture the effective workflow inputs so steps after the gate can
+        // resolve `inputs.*` once the run is resumed. This is the manual_approval
+        // branch, which runs before any step-level input augmentation, so
+        // `inputs` here is the clean workflow-level set.
+        run.suspend(stepExprContext?.inputs);
         await this.saveRun(workflow.id, run);
         throw new WorkflowSuspendedError(
           job.name,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3177,3 +3177,124 @@ Deno.test(
     }
   },
 );
+
+// Issue #467: resume --input merges override inputs over the inputs captured
+// when the run suspended.
+Deno.test("resume merges override inputs over the suspended run's inputs", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    // Captures the expression context seen by the post-gate step.
+    class ContextCapturingExecutor implements StepExecutor {
+      captured: Array<{ step: Step; ctx: StepExecutionContext }> = [];
+      execute(step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.captured.push({ step, ctx });
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new ContextCapturingExecutor();
+
+    // Gate suspends the run; the deploy step after it consumes inputs.* once
+    // resumed.
+    const workflow = Workflow.create({
+      name: "deploy-with-gate",
+      jobs: [
+        Job.create({
+          name: "rollout",
+          steps: [
+            Step.create({
+              name: "verify",
+              task: StepTask.manualApproval("Verify SSH before harden"),
+            }),
+            Step.create({
+              name: "harden",
+              task: StepTask.model("harden-model", "run", {
+                // Both inputs are declared at the original run (strict
+                // evaluation requires referenced inputs to exist). Resume
+                // supplies updated values that the merge applies.
+                region: "${{ inputs.region }}",
+                authKey: "${{ inputs.authKey }}",
+              }),
+              dependsOn: [
+                { step: "verify", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    // Original run declares all referenced inputs; authKey starts as a
+    // placeholder whose real value is only minted during the gate.
+    const suspended = await service.execute(workflow.name, {
+      inputs: { region: "us-east", env: "prod", authKey: "PENDING" },
+    });
+
+    assertEquals(suspended.status, "suspended");
+    // Effective inputs are captured at suspend so they survive to resume.
+    assertEquals(suspended.inputs, {
+      region: "us-east",
+      env: "prod",
+      authKey: "PENDING",
+    });
+    assertEquals(suspended.resumeInputs, []);
+    // The gate has not reached the executor.
+    assertEquals(executor.captured.length, 0);
+
+    // Approve: mark the gate step succeeded so resume can proceed.
+    const toApprove = await runRepo.findById(workflow.id, suspended.id);
+    const waiting = toApprove!.findWaitingApprovalStep()!;
+    toApprove!.getJob(waiting.jobName)!.getStep(waiting.stepName)!.succeed();
+    await runRepo.save(workflow.id, toApprove!);
+
+    // Resume with the freshly minted auth key and a region override.
+    let resumedRun: WorkflowRun | undefined;
+    for await (
+      const event of service.resume(workflow.name, suspended.id, {
+        inputs: { region: "us-west", authKey: "tskey-abc123" },
+      })
+    ) {
+      if (event.kind === "completed") resumedRun = event.run;
+    }
+
+    assertEquals(resumedRun?.status, "succeeded");
+
+    // The harden step ran and saw the merged inputs: resume overrides win on
+    // `region` and `authKey`, while the original `env` is preserved.
+    assertEquals(executor.captured.length, 1);
+    assertEquals(executor.captured[0].step.name, "harden");
+    assertEquals(executor.captured[0].ctx.expressionContext?.inputs, {
+      region: "us-west",
+      env: "prod",
+      authKey: "tskey-abc123",
+    });
+
+    // The overrides propagate into the resolved task inputs forwarded to the
+    // step: both `region` and `authKey` resolved to the resume values.
+    const hardenTask = executor.captured[0].step.task.data;
+    if (hardenTask.type === "model_method") {
+      assertEquals(hardenTask.inputs?.region, "us-west");
+      assertEquals(hardenTask.inputs?.authKey, "tskey-abc123");
+    }
+
+    // Audit records only the resume-time KEY NAMES, never the secret values.
+    const persisted = await runRepo.findById(workflow.id, suspended.id);
+    assertEquals([...persisted!.resumeInputs].sort(), ["authKey", "region"]);
+    assertEquals(
+      JSON.stringify(persisted!.resumeInputs).includes("tskey-abc123"),
+      false,
+    );
+  });
+});

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -103,6 +103,14 @@ export const WorkflowRunSchema = z.object({
   workflowDataArtifacts: z.array(DataArtifactRefSchema).optional(),
   logFile: z.string().optional(),
   tags: z.record(z.string(), z.string()).default({}),
+  // Effective workflow inputs captured when a run suspends, so post-resume
+  // steps can resolve `inputs.*`. Optional for backward compatibility with
+  // runs persisted before this field existed.
+  inputs: z.record(z.string(), z.unknown()).optional(),
+  // Key NAMES of inputs supplied at resume time, recorded for audit. Values are
+  // deliberately NOT persisted to avoid writing secrets (e.g. a freshly minted
+  // auth key) to the plaintext run record.
+  resumeInputs: z.array(z.string()).optional(),
 });
 
 /**
@@ -472,6 +480,8 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _logFile: string | undefined,
     private readonly _tags: Record<string, string>,
     private _workflowDataArtifacts: DataArtifactRef[] = [],
+    private _inputs: Record<string, unknown> = {},
+    private _resumeInputs: string[] = [],
   ) {}
 
   /**
@@ -521,6 +531,8 @@ export class WorkflowRun implements TriggerEvaluationContext {
       validated.logFile,
       validated.tags,
       validated.workflowDataArtifacts ?? [],
+      validated.inputs ?? {},
+      validated.resumeInputs ?? [],
     );
   }
 
@@ -614,9 +626,45 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   /**
    * Marks the workflow run as suspended (waiting for manual approval).
+   *
+   * The effective workflow inputs are captured here so that, on resume, steps
+   * that run after the gate can still resolve `inputs.*`. Inputs are recorded
+   * only at suspend (not at run creation) so runs that never suspend never
+   * write their input values to the persisted run record.
    */
-  suspend(): void {
+  suspend(inputs?: Record<string, unknown>): void {
     this._status = "suspended";
+    if (inputs) {
+      this._inputs = inputs;
+    }
+  }
+
+  /**
+   * The effective workflow inputs persisted when this run last suspended.
+   * Empty for runs that have never suspended.
+   */
+  get inputs(): Readonly<Record<string, unknown>> {
+    return this._inputs;
+  }
+
+  /**
+   * The key names of inputs supplied across resume invocations, for audit.
+   * Values are never recorded.
+   */
+  get resumeInputs(): ReadonlyArray<string> {
+    return this._resumeInputs;
+  }
+
+  /**
+   * Records the key names of inputs supplied at resume time. Appends and
+   * de-duplicates so multiple resume cycles accumulate a complete audit trail.
+   */
+  recordResumeInputs(keys: string[]): void {
+    for (const key of keys) {
+      if (!this._resumeInputs.includes(key)) {
+        this._resumeInputs.push(key);
+      }
+    }
   }
 
   /**
@@ -662,6 +710,12 @@ export class WorkflowRun implements TriggerEvaluationContext {
       data.workflowDataArtifacts = this._workflowDataArtifacts.map((a) => ({
         ...a,
       }));
+    }
+    if (Object.keys(this._inputs).length > 0) {
+      data.inputs = { ...this._inputs };
+    }
+    if (this._resumeInputs.length > 0) {
+      data.resumeInputs = [...this._resumeInputs];
     }
     return data;
   }

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -635,3 +635,85 @@ Deno.test("WorkflowRun: findWaitingApprovalStep returns undefined when none wait
   run.start();
   assertEquals(run.findWaitingApprovalStep(), undefined);
 });
+
+// WorkflowRun inputs / resumeInputs tests
+
+Deno.test("WorkflowRun: a fresh run has empty inputs and resumeInputs", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  assertEquals(run.inputs, {});
+  assertEquals(run.resumeInputs, []);
+});
+
+Deno.test("WorkflowRun.suspend captures the effective inputs", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.start();
+  run.suspend({ region: "us-east", count: 3 });
+  assertEquals(run.status, "suspended");
+  assertEquals(run.inputs, { region: "us-east", count: 3 });
+});
+
+Deno.test("WorkflowRun.suspend without inputs leaves inputs empty", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.start();
+  run.suspend();
+  assertEquals(run.status, "suspended");
+  assertEquals(run.inputs, {});
+});
+
+Deno.test("WorkflowRun.recordResumeInputs appends and de-duplicates key names", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.recordResumeInputs(["authKey", "region"]);
+  run.recordResumeInputs(["authKey", "token"]);
+  assertEquals(run.resumeInputs, ["authKey", "region", "token"]);
+});
+
+Deno.test("WorkflowRun.toData omits inputs and resumeInputs when empty", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.start();
+  const data = run.toData();
+  assertEquals("inputs" in data, false);
+  assertEquals("resumeInputs" in data, false);
+});
+
+Deno.test("WorkflowRun.toData includes inputs and resumeInputs when present", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.start();
+  run.suspend({ region: "us-east" });
+  run.recordResumeInputs(["authKey"]);
+  const data = run.toData();
+  assertEquals(data.inputs, { region: "us-east" });
+  assertEquals(data.resumeInputs, ["authKey"]);
+});
+
+Deno.test("WorkflowRun: inputs and resumeInputs round-trip through fromData/toData", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.start();
+  run.suspend({ region: "us-east", nested: { a: 1 } });
+  run.recordResumeInputs(["authKey", "region"]);
+
+  const restored = WorkflowRun.fromData(run.toData());
+  assertEquals(restored.inputs, { region: "us-east", nested: { a: 1 } });
+  assertEquals(restored.resumeInputs, ["authKey", "region"]);
+});
+
+Deno.test("WorkflowRun.fromData tolerates legacy records lacking inputs/resumeInputs", () => {
+  // A run persisted before these fields existed.
+  const legacy = {
+    id: "550e8400-e29b-41d4-a716-446655440099",
+    workflowId: "550e8400-e29b-41d4-a716-446655440000",
+    workflowName: "test-workflow",
+    status: "suspended" as const,
+    startedAt: new Date().toISOString(),
+    jobs: [
+      {
+        jobName: "job1",
+        status: "running" as const,
+        steps: [{ stepName: "step1", status: "waiting_approval" as const }],
+      },
+    ],
+  };
+
+  const run = WorkflowRun.fromData(legacy);
+  assertEquals(run.inputs, {});
+  assertEquals(run.resumeInputs, []);
+});


### PR DESCRIPTION
## Summary

Adds `--input`/`--input-file`/`--stdin` support to `swamp workflow resume` (follow-up to swamp-club#369, manual_approval gates). Operators can supply or override input values that change between the suspend and resume phases — e.g. a freshly minted auth key issued during a verification gate.

### Behaviour
- **Inputs are persisted when a run suspends** (not at run start), so post-gate steps can resolve `inputs.*` on resume. Runs that never suspend write no input values to disk.
- **Resume inputs deep-merge over the persisted inputs**: existing keys are preserved, and a resume `--input` wins on a key collision. The merge base is the full original input set, so a plain `swamp workflow resume` needs **no** inputs re-passed — you only type the deltas.
- **Audit**: the run record records the *key names* of resume-time inputs, never their values (so secrets aren't written to the persisted run).
- **Evaluation stays strict** — no change to how any workflow evaluates. A workflow must declare the inputs it references at run time; the pattern is *declare-at-run, supply/override-at-resume*. (Resolves the issue's two open questions: override-wins merge semantics + key-name audit.)

### Mechanics
- `WorkflowRun` aggregate gains optional `inputs` and `resumeInputs` fields (backward compatible — legacy run records round-trip unchanged).
- `deepMerge` relocated from `src/cli/input_parser.ts` to a domain module (`src/domain/inputs/input_merge.ts`), re-exported so existing callers (`workflow run`, `model method run`) are unaffected.
- `resume()` merges inputs onto the expression context and records resume key names; the resume CLI command parses inputs and rejects multi-item stdin (resume targets a single run).

### Notes for reviewers
- The only new on-disk behaviour: original input *values* are written to the run record **when a run suspends**. If a secret is passed as a raw `--input` (rather than a vault expression), that value lands in the suspended run YAML. Bounded to suspended runs; the audit field is key-names-only; vault expressions sidestep it.

## Test Plan
- **Unit**: `input_merge` (merge/override/additive/nesting), `WorkflowRun` inputs + resumeInputs round-trip incl. legacy records lacking the fields.
- **Service**: `execution_service` suspend → approve → resume merge (override wins, original preserved); no inputs persisted for non-suspended runs.
- **CLI integration**: `workflow resume --input` end-to-end (resolved through CEL), multi-item stdin guard.
- **Full suite**: 6490 passed, 0 failed. `deno check`/`lint`/`fmt` clean.
- **Live**: verified on a compiled binary — declare→suspend→resume-override merges correctly; resume with no `--input` restores the original inputs; an undeclared referenced input fails fast at evaluation (strict, unchanged).
- **UAT**: `systeminit/swamp-uat` workflow suite 12/12 against the compiled binary; full `uat:cli` serial shows no regressions (the only failures reproduce identically on the unmodified `main` binary).
- Follow-ups filed: swamp-uat#242 (UAT resume coverage) and a swamp-club docs request for `content/manual/reference/workflows.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)