### PR TITLE
feat(doctor): scan definitions for cleartext sensitive global args (swamp-club#483)

### DIFF
--- a/design/doctor-secrets.md
+++ b/design/doctor-secrets.md
@@ -1,0 +1,71 @@
+# Doctor Secrets — cleartext sensitive-argument scan
+
+`swamp doctor secrets` is a read-only diagnostic that reports model
+definitions whose `sensitive: true` global arguments hold a **cleartext
+literal** value instead of a `vault.get(...)` expression. It emits per-finding
+remediation guidance in both log and JSON output modes and exits non-zero when
+any leak is found, so CI can gate on it.
+
+## Why it exists
+
+swamp-club#480 (PR #1469) added a guard at the single persistence chokepoint —
+`YamlDefinitionRepository.save()` — that refuses to write a literal value for a
+sensitive global argument. That guard only protects **new** writes. Two gaps
+remain that a write-time guard cannot close:
+
+1. **Legacy definitions** authored before the guard still hold the secret in
+   cleartext until they are re-saved.
+2. **Datastore sync / migration** copies definition YAML byte-for-byte, so a
+   cleartext literal authored on an older swamp or another machine can land on
+   disk without passing through `save()`.
+
+`doctor secrets` is the detection half: it scans what is already on disk and
+points the user at the fix. It does **not** remediate automatically — it
+reports, and the user migrates the secret to a vault and re-saves.
+
+## What it scans
+
+It enumerates two definition trees:
+
+- The source-of-truth definitions under `models/`. These are the
+  datastore-synced files — a literal authored elsewhere lands here after a
+  pull, so scanning the working tree covers synced/pulled definitions.
+- The locally auto-created definitions under `.swamp/auto-definitions`.
+
+The public `findAllGlobal()` only walks its own `baseDir`, so the deps point a
+second repository at the auto-definitions tree and concatenate the results.
+
+## The rule it applies
+
+Detection reuses the **same** pure domain rule the write-time guard enforces:
+`findLiteralSensitiveGlobalArgs` in
+`src/domain/models/sensitive_field_extractor.ts`. What the scan surfaces is
+therefore exactly what a re-save would now refuse. Remediation guidance is
+built by `buildSensitiveArgRemediations`, the structured sibling of the guard's
+`literalSensitiveGlobalArgsMessage`: both point at the same fix (store the
+secret in a vault, reference it with `vault.get(...)`), but the scan returns
+per-path vault coordinates a renderer can print as concrete commands.
+
+## Read-only and value-free
+
+- **Read-only.** The scan never calls `save()`, so it never trips the at-rest
+  guard and never mutates a definition.
+- **Value-free.** Neither output mode — nor the structured finding payload —
+  ever carries the cleartext secret. Findings and remediation guidance contain
+  only the field path and the suggested vault name/key.
+
+## Best-effort residual
+
+Detection depends on resolving each definition's type schema through the model
+registry to know which global args are sensitive. When a type cannot be
+resolved (e.g. an extension that is not installed locally), the definition is
+reported as **unresolved** — an advisory warning rather than a silent skip — so
+the scan never implies it vouched for a definition it could not assess. This
+mirrors the object-shape-only limitation of the redaction primitives in the
+same module.
+
+## Out of scope
+
+This scan covers **model** definitions. Guarding datastore sync at write time,
+and covering workflow-definition global arguments, are deliberately not part of
+this command.

--- a/integration/doctor_secrets_test.ts
+++ b/integration/doctor_secrets_test.ts
@@ -1,0 +1,219 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for `doctor secrets`: exercises the real service against a
+ * real on-disk repository and the real model registry. It plants a cleartext
+ * sensitive global argument on disk the way a legacy or datastore-synced
+ * definition would carry one (bypassing the at-rest guard, which only fires on
+ * `save()`), then asserts the scan flags it without ever echoing the secret.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { dirname, join, relative } from "@std/path";
+import { ensureDir, walk } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { z } from "zod";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { modelRegistry } from "../src/domain/models/model.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  collect,
+  createDoctorSecretsDeps,
+  createLibSwampContext,
+  doctorSecrets,
+  type DoctorSecretsEvent,
+} from "../src/libswamp/mod.ts";
+
+const CLEARTEXT = "PLAINTEXT_SECRET_VALUE";
+const VAULT_EXPR = "${{ vault.get('v', 'k') }}";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-doctor-secrets-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function findYamlForId(dir: string, id: string): Promise<string> {
+  for await (const entry of walk(dir, { exts: [".yaml"] })) {
+    if (entry.isFile && entry.name === `${id}.yaml`) {
+      return entry.path;
+    }
+  }
+  throw new Error(`no yaml for id ${id} under ${dir}`);
+}
+
+Deno.test("doctor secrets: flags a planted cleartext sensitive arg on disk", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+
+    const typeName = `@test-doctor-secrets/creds-${
+      crypto.randomUUID().slice(0, 8)
+    }`;
+    const modelType = ModelType.create(typeName);
+    modelRegistry.register({
+      type: modelType,
+      version: "2026.01.01.1",
+      globalArguments: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        region: z.string(),
+      }),
+      resources: {},
+      methods: {},
+    });
+
+    const repo = new YamlDefinitionRepository(repoDir);
+
+    // A clean definition (vault.get expression) is allowed through save() and
+    // establishes the on-disk type directory layout.
+    const clean = Definition.create({
+      name: "clean-creds",
+      type: modelType.normalized,
+      globalArguments: { apiKey: VAULT_EXPR, region: "eu-west-1" },
+    });
+    await repo.save(modelType, clean);
+
+    // Plant a definition holding a cleartext literal by writing the YAML
+    // directly — the at-rest guard fires on save(), so a legacy or
+    // datastore-synced file is exactly how such a value reaches disk.
+    const typeDir = dirname(
+      await findYamlForId(join(repoDir, "models"), clean.id),
+    );
+    const leakyId = crypto.randomUUID();
+    await Deno.writeTextFile(
+      join(typeDir, `${leakyId}.yaml`),
+      stringifyYaml({
+        id: leakyId,
+        name: "leaky-creds",
+        version: 1,
+        type: modelType.normalized,
+        tags: {},
+        globalArguments: { apiKey: CLEARTEXT, region: "us-east-1" },
+      }),
+    );
+
+    const deps = await createDoctorSecretsDeps(repoDir);
+    const events = await collect<DoctorSecretsEvent>(
+      doctorSecrets(createLibSwampContext(), deps),
+    );
+
+    const completed = events.find((e) => e.kind === "completed");
+    if (!completed || completed.kind !== "completed") {
+      throw new Error("expected a completed event");
+    }
+    const { data } = completed;
+
+    assertEquals(data.scanned, 2);
+    assertEquals(data.findings.length, 1);
+    assertEquals(data.findings[0].definitionName, "leaky-creds");
+    assertEquals(data.findings[0].leakedPaths, ["apiKey"]);
+    assertEquals(data.findings[0].remediations[0].path, "apiKey");
+    assertStringIncludes(
+      data.findings[0].remediations[0].expression,
+      "vault.get",
+    );
+
+    // The secret must never appear anywhere in the scan output.
+    assertEquals(JSON.stringify(data).includes(CLEARTEXT), false);
+  });
+});
+
+Deno.test("doctor secrets: also scans auto-definitions, not just models/", async () => {
+  await withTempDir(async (repoDir) => {
+    await ensureDir(join(repoDir, "models"));
+
+    const typeName = `@test-doctor-secrets/auto-${
+      crypto.randomUUID().slice(0, 8)
+    }`;
+    const modelType = ModelType.create(typeName);
+    modelRegistry.register({
+      type: modelType,
+      version: "2026.01.01.1",
+      globalArguments: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        region: z.string(),
+      }),
+      resources: {},
+      methods: {},
+    });
+
+    const repo = new YamlDefinitionRepository(repoDir);
+
+    // Save a clean definition under models/ to discover the type's on-disk
+    // directory layout (mirrored under the auto-definitions tree).
+    const clean = Definition.create({
+      name: "clean-creds",
+      type: modelType.normalized,
+      globalArguments: { apiKey: VAULT_EXPR, region: "eu-west-1" },
+    });
+    await repo.save(modelType, clean);
+    const typeDirRel = relative(
+      join(repoDir, "models"),
+      dirname(await findYamlForId(join(repoDir, "models"), clean.id)),
+    );
+
+    // Plant a cleartext leak in .swamp/auto-definitions — the tree that holds
+    // model/workflow-run auto-created definitions, which findAllGlobal() alone
+    // does not walk.
+    const autoTypeDir = join(
+      repoDir,
+      ".swamp",
+      "auto-definitions",
+      typeDirRel,
+    );
+    await ensureDir(autoTypeDir);
+    const leakyId = crypto.randomUUID();
+    await Deno.writeTextFile(
+      join(autoTypeDir, `${leakyId}.yaml`),
+      stringifyYaml({
+        id: leakyId,
+        name: "auto-leaky-creds",
+        version: 1,
+        type: modelType.normalized,
+        tags: {},
+        globalArguments: { apiKey: CLEARTEXT, region: "us-east-1" },
+      }),
+    );
+
+    const deps = await createDoctorSecretsDeps(repoDir);
+    const events = await collect<DoctorSecretsEvent>(
+      doctorSecrets(createLibSwampContext(), deps),
+    );
+    const completed = events.find((e) => e.kind === "completed");
+    if (!completed || completed.kind !== "completed") {
+      throw new Error("expected a completed event");
+    }
+    const { data } = completed;
+
+    // Both the clean models/ def and the leaky auto-definition were scanned.
+    assertEquals(data.scanned, 2);
+    assertEquals(data.findings.length, 1);
+    assertEquals(data.findings[0].definitionName, "auto-leaky-creds");
+    assertEquals(data.findings[0].leakedPaths, ["apiKey"]);
+    assertEquals(JSON.stringify(data).includes(CLEARTEXT), false);
+  });
+});

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -22,6 +22,7 @@ import { groupCommandAction } from "../group_action.ts";
 import { doctorAuditCommand } from "./doctor_audit.ts";
 import { doctorExtensionsCommand } from "./doctor_extensions.ts";
 import { doctorInstallCommand } from "./doctor_install.ts";
+import { doctorSecretsCommand } from "./doctor_secrets.ts";
 import { doctorWorkflowsCommand } from "./doctor_workflows.ts";
 
 export const doctorCommand = new Command()
@@ -48,6 +49,10 @@ export const doctorCommand = new Command()
     "Check that workflow YAML files load cleanly",
     "swamp doctor workflows",
   )
+  .example(
+    "Scan for cleartext sensitive global arguments",
+    "swamp doctor secrets",
+  )
   // `--repo-dir` is accepted on the top-level command for consistency
   // with subcommands and other repo-scoped commands. The top-level
   // action only shows help; subcommands consume the option.
@@ -59,4 +64,5 @@ export const doctorCommand = new Command()
   .command("audit", doctorAuditCommand)
   .command("extensions", doctorExtensionsCommand)
   .command("install", doctorInstallCommand)
+  .command("secrets", doctorSecretsCommand)
   .command("workflows", doctorWorkflowsCommand);

--- a/src/cli/commands/doctor_secrets.ts
+++ b/src/cli/commands/doctor_secrets.ts
@@ -1,0 +1,81 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// `swamp doctor secrets` — read-only scan that reports model definitions
+// whose `sensitive: true` global arguments hold a cleartext literal value
+// (left on disk before the at-rest guard, or arriving via datastore sync,
+// which copies definition YAML byte-for-byte and bypasses the save-time
+// guard). Reporting only: it prints value-free vault remediation guidance and
+// exits non-zero when a leak is found so CI can gate on it.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createDoctorSecretsDeps,
+  createLibSwampContext,
+  doctorSecrets,
+} from "../../libswamp/mod.ts";
+import { createDoctorSecretsRenderer } from "../../presentation/renderers/doctor_secrets.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const doctorSecretsCommand = new Command()
+  .description(
+    "Scan model definitions for cleartext sensitive global arguments and " +
+      "report how to migrate each to a vault.",
+  )
+  .example("Scan this repo's definitions", "swamp doctor secrets")
+  .example("Machine-readable output for CI", "swamp doctor secrets --json")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "doctor",
+      "secrets",
+    ]);
+    cliCtx.logger.debug("Executing doctor secrets command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    // Same gate as the other doctor subcommands — fails loudly outside a repo.
+    await resolveDatastoreForRepo(repoDir);
+
+    const libCtx = createLibSwampContext();
+    const deps = await createDoctorSecretsDeps(repoDir);
+    const renderer = createDoctorSecretsRenderer(cliCtx.outputMode);
+
+    await consumeStream(
+      doctorSecrets(libCtx, deps),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("doctor secrets command completed");
+
+    if (renderer.overallStatus === "fail") {
+      Deno.exit(1);
+    }
+  });

--- a/src/cli/commands/doctor_secrets_test.ts
+++ b/src/cli/commands/doctor_secrets_test.ts
@@ -1,0 +1,44 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("doctorSecretsCommand module loads", async () => {
+  const mod = await import("./doctor_secrets.ts");
+  assertEquals(typeof mod.doctorSecretsCommand, "object");
+});
+
+Deno.test("doctorSecretsCommand is registered as subcommand of doctorCommand", async () => {
+  const { doctorCommand } = await import("./doctor.ts");
+  const commands = doctorCommand.getCommands();
+  const secretsCmd = commands.find((c) => c.getName() === "secrets");
+  assertEquals(secretsCmd !== undefined, true);
+});
+
+Deno.test("doctorSecretsCommand has --repo-dir option", async () => {
+  const { doctorSecretsCommand } = await import("./doctor_secrets.ts");
+  const names = doctorSecretsCommand.getOptions().map((o) => o.name);
+  assertEquals(names.includes("repo-dir"), true);
+});

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -288,6 +288,66 @@ export function literalSensitiveGlobalArgsMessage(paths: string[]): string {
 export const LITERAL_SENSITIVE_GLOBAL_ARG_CODE = "literal_sensitive_global_arg";
 
 /**
+ * Value-free remediation guidance for a single sensitive global argument found
+ * holding a cleartext literal. Carries only the field path and the vault
+ * coordinates to migrate the secret to — never the secret value itself.
+ */
+export interface SensitiveArgRemediation {
+  /** Dot-path of the offending sensitive global argument. */
+  path: string;
+  /** Suggested vault name to store the secret under. */
+  vaultName: string;
+  /** Suggested vault key to store the secret under. */
+  vaultKey: string;
+  /** The `vault.get(...)` expression to set as the argument's value. */
+  expression: string;
+}
+
+/** Fallback vault name used when a sensitive field declares no `vaultName`. */
+const DEFAULT_REMEDIATION_VAULT = "my-vault";
+
+/**
+ * Builds value-free remediation guidance for sensitive global arguments that
+ * were found holding a literal secret (see {@link findLiteralSensitiveGlobalArgs}).
+ *
+ * This is the structured sibling of {@link literalSensitiveGlobalArgsMessage}:
+ * both point the user at the same fix — store the secret in a vault and
+ * reference it with a `vault.get(...)` expression — but this returns per-path
+ * coordinates a diagnostic can render as concrete commands.
+ *
+ * The output never contains the secret value: only the field path and the
+ * suggested vault name/key. When a field declares `vaultName`/`vaultKey`
+ * metadata, those are used; otherwise the vault name falls back to
+ * `"my-vault"` and the key to the field's leaf path segment.
+ *
+ * @param leakedPaths - Dot-paths returned by `findLiteralSensitiveGlobalArgs`
+ * @param schema - The global-arguments schema, read for vault metadata overrides
+ * @returns One remediation per leaked path, in input order
+ */
+export function buildSensitiveArgRemediations(
+  leakedPaths: string[],
+  schema?: z.ZodTypeAny,
+): SensitiveArgRemediation[] {
+  const fieldsByPath = new Map<string, SensitiveFieldInfo>();
+  if (schema) {
+    for (const field of extractSensitiveFields(schema)) {
+      fieldsByPath.set(field.path, field);
+    }
+  }
+  return leakedPaths.map((path) => {
+    const meta = fieldsByPath.get(path);
+    const vaultName = meta?.vaultName ?? DEFAULT_REMEDIATION_VAULT;
+    const vaultKey = meta?.vaultKey ?? path.split(".").at(-1) ?? path;
+    return {
+      path,
+      vaultName,
+      vaultKey,
+      expression: `\${{ vault.get('${vaultName}', '${vaultKey}') }}`,
+    };
+  });
+}
+
+/**
  * Returns a redacted clone of `data` with every field marked `{ sensitive: true }`
  * in `schema` replaced by `"***"`.
  *

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
+  buildSensitiveArgRemediations,
   extractSensitiveFields,
   extractSensitiveFieldValues,
   findLiteralSensitiveGlobalArgs,
@@ -505,4 +506,66 @@ Deno.test("literalSensitiveGlobalArgsMessage: names fields and gives vault remed
 
   const multi = literalSensitiveGlobalArgsMessage(["apiKey", "apiSecret"]);
   assertStringIncludes(multi, "'apiKey', 'apiSecret' are");
+});
+
+Deno.test("buildSensitiveArgRemediations: derives vault key from leaf path segment", () => {
+  const schema = z.object({
+    credentials: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+    }),
+  });
+
+  const remediations = buildSensitiveArgRemediations(
+    ["credentials.apiKey"],
+    schema,
+  );
+
+  assertEquals(remediations.length, 1);
+  assertEquals(remediations[0].path, "credentials.apiKey");
+  assertEquals(remediations[0].vaultName, "my-vault");
+  assertEquals(remediations[0].vaultKey, "apiKey");
+  assertEquals(
+    remediations[0].expression,
+    "${{ vault.get('my-vault', 'apiKey') }}",
+  );
+});
+
+Deno.test("buildSensitiveArgRemediations: honors vaultName/vaultKey metadata overrides", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({
+      sensitive: true,
+      vaultName: "prod-creds",
+      vaultKey: "stripe-key",
+    }),
+  });
+
+  const remediations = buildSensitiveArgRemediations(["apiKey"], schema);
+
+  assertEquals(remediations[0].vaultName, "prod-creds");
+  assertEquals(remediations[0].vaultKey, "stripe-key");
+  assertEquals(
+    remediations[0].expression,
+    "${{ vault.get('prod-creds', 'stripe-key') }}",
+  );
+});
+
+Deno.test("buildSensitiveArgRemediations: never contains the secret value", () => {
+  const schema = z.object({
+    apiKey: z.string().meta({ sensitive: true }),
+  });
+
+  const remediations = buildSensitiveArgRemediations(["apiKey"], schema);
+
+  // The builder only ever receives field paths, never values — assert the
+  // rendered guidance carries no secret material.
+  const serialized = JSON.stringify(remediations);
+  assertEquals(serialized.includes("SUPERSECRET"), false);
+  assertStringIncludes(remediations[0].expression, "vault.get");
+});
+
+Deno.test("buildSensitiveArgRemediations: falls back to my-vault without a schema", () => {
+  const remediations = buildSensitiveArgRemediations(["apiKey"]);
+
+  assertEquals(remediations[0].vaultName, "my-vault");
+  assertEquals(remediations[0].vaultKey, "apiKey");
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -193,6 +193,16 @@ export {
   type ModelSearchItem,
 } from "./models/search.ts";
 export {
+  createDoctorSecretsDeps,
+  doctorSecrets,
+  type DoctorSecretsData,
+  type DoctorSecretsDeps,
+  type DoctorSecretsEvent,
+  type SensitiveArgRemediation,
+  type SensitiveLeakFinding,
+  type UnresolvedDefinition,
+} from "./models/doctor_secrets.ts";
+export {
   modelOutputSearch,
   type ModelOutputSearchData,
   type ModelOutputSearchDeps,

--- a/src/libswamp/models/doctor_secrets.ts
+++ b/src/libswamp/models/doctor_secrets.ts
@@ -1,0 +1,189 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Definition } from "../../domain/definitions/definition.ts";
+import type { ModelDefinition } from "../../domain/models/model.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import {
+  buildSensitiveArgRemediations,
+  findLiteralSensitiveGlobalArgs,
+  type SensitiveArgRemediation,
+} from "../../domain/models/sensitive_field_extractor.ts";
+
+export type { SensitiveArgRemediation };
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/**
+ * A definition holding one or more sensitive global arguments as cleartext
+ * literals. The remediation guidance is value-free — it never echoes the
+ * offending secret, only the field path and the vault coordinates to migrate
+ * the value to.
+ */
+export interface SensitiveLeakFinding {
+  definitionId: string;
+  definitionName: string;
+  type: string;
+  /** Dot-paths of the sensitive global args holding a literal secret. */
+  leakedPaths: string[];
+  /** Per-path remediation guidance. */
+  remediations: SensitiveArgRemediation[];
+}
+
+/**
+ * A definition whose type schema could not be resolved, so its sensitive
+ * global args could not be assessed. Reported (not silently skipped) because it
+ * is a best-effort residual: a missing/unloadable extension type means the scan
+ * cannot vouch for that definition.
+ */
+export interface UnresolvedDefinition {
+  definitionId: string;
+  definitionName: string;
+  type: string;
+}
+
+/** Outcome of a `doctor secrets` scan. */
+export interface DoctorSecretsData {
+  /** Total definitions inspected (across models/ and auto-definitions). */
+  scanned: number;
+  findings: SensitiveLeakFinding[];
+  unresolved: UnresolvedDefinition[];
+}
+
+export type DoctorSecretsEvent =
+  | { kind: "scanning" }
+  | { kind: "completed"; data: DoctorSecretsData }
+  | { kind: "error"; error: SwampError };
+
+/** Dependencies for the `doctor secrets` scan. */
+export interface DoctorSecretsDeps {
+  /** Enumerates every definition to scan, paired with its model type. */
+  findAllDefinitions: () => Promise<
+    { definition: Definition; type: ModelType }[]
+  >;
+  /** Resolves the model definition (and thus the schema) for a type. */
+  getModelDef: (
+    type: ModelType,
+  ) => ModelDefinition | undefined | Promise<ModelDefinition | undefined>;
+}
+
+/**
+ * Wires real infrastructure into {@link DoctorSecretsDeps}.
+ *
+ * Scans two trees: the source-of-truth definitions under `models/` (these are
+ * the datastore-synced files — a literal authored on another machine lands here
+ * after a pull) and the locally auto-created definitions under
+ * `.swamp/auto-definitions`. The public `findAllGlobal()` only walks its own
+ * `baseDir`, so a second repository is pointed at the auto-definitions tree to
+ * cover both without changing shared enumeration behaviour.
+ */
+export async function createDoctorSecretsDeps(
+  repoDir: string,
+): Promise<DoctorSecretsDeps> {
+  await modelRegistry.ensureLoaded();
+  const primaryRepo = new YamlDefinitionRepository(repoDir);
+  const autoRepo = new YamlDefinitionRepository(
+    repoDir,
+    undefined,
+    swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+    false,
+  );
+  return {
+    findAllDefinitions: async () => {
+      const [primary, auto] = await Promise.all([
+        primaryRepo.findAllGlobal(),
+        autoRepo.findAllGlobal(),
+      ]);
+      return [...primary, ...auto];
+    },
+    getModelDef: async (type) => {
+      await modelRegistry.ensureTypeLoaded(type);
+      return modelRegistry.get(type);
+    },
+  };
+}
+
+/**
+ * Read-only scan that reports definitions whose `sensitive: true` global
+ * arguments hold a cleartext literal value. It reuses the same domain rule
+ * (`findLiteralSensitiveGlobalArgs`) that the persistence chokepoint enforces
+ * at write time, so what this surfaces is exactly what a re-save would now
+ * refuse. It never writes — reporting only, with value-free remediation
+ * guidance the caller can render.
+ */
+export async function* doctorSecrets(
+  _ctx: LibSwampContext,
+  deps: DoctorSecretsDeps,
+): AsyncGenerator<DoctorSecretsEvent> {
+  yield* withGeneratorSpan(
+    "swamp.doctor.secrets",
+    {},
+    (async function* () {
+      yield { kind: "scanning" };
+
+      const all = await deps.findAllDefinitions();
+      const findings: SensitiveLeakFinding[] = [];
+      const unresolved: UnresolvedDefinition[] = [];
+
+      for (const { definition, type } of all) {
+        const modelDef = await deps.getModelDef(type);
+        if (!modelDef) {
+          // Best-effort residual: without the type schema we cannot know which
+          // global args are sensitive, so flag it rather than skip silently.
+          unresolved.push({
+            definitionId: definition.id,
+            definitionName: definition.name,
+            type: type.normalized,
+          });
+          continue;
+        }
+
+        const leakedPaths = findLiteralSensitiveGlobalArgs(
+          modelDef.globalArguments,
+          definition.globalArguments,
+        );
+        if (leakedPaths.length > 0) {
+          findings.push({
+            definitionId: definition.id,
+            definitionName: definition.name,
+            type: type.normalized,
+            leakedPaths,
+            remediations: buildSensitiveArgRemediations(
+              leakedPaths,
+              modelDef.globalArguments,
+            ),
+          });
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: { scanned: all.length, findings, unresolved },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/models/doctor_secrets_test.ts
+++ b/src/libswamp/models/doctor_secrets_test.ts
@@ -1,0 +1,206 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  doctorSecrets,
+  type DoctorSecretsDeps,
+  type DoctorSecretsEvent,
+} from "./doctor_secrets.ts";
+
+const SECRET = "SUPERSECRET123";
+
+const sensitiveSchema = z.object({
+  apiKey: z.string().meta({ sensitive: true }),
+  region: z.string(),
+});
+
+type DefStub = {
+  id: string;
+  name: string;
+  globalArguments: Record<string, unknown>;
+};
+
+function makeDeps(
+  definitions: { definition: DefStub; type: string }[],
+  modelDefForType: (type: string) => object | undefined,
+): DoctorSecretsDeps {
+  return {
+    findAllDefinitions: () =>
+      Promise.resolve(
+        definitions.map(({ definition, type }) => ({
+          definition,
+          type: { normalized: type },
+        })) as Awaited<ReturnType<DoctorSecretsDeps["findAllDefinitions"]>>,
+      ),
+    getModelDef:
+      ((type: { normalized: string }) =>
+        modelDefForType(type.normalized)) as DoctorSecretsDeps["getModelDef"],
+  };
+}
+
+function completedData(events: DoctorSecretsEvent[]) {
+  const completed = events.find((e) => e.kind === "completed");
+  if (!completed || completed.kind !== "completed") {
+    throw new Error("expected a completed event");
+  }
+  return completed.data;
+}
+
+Deno.test("doctorSecrets: yields scanning then completed", async () => {
+  const deps = makeDeps([], () => undefined);
+  const events = await collect<DoctorSecretsEvent>(
+    doctorSecrets(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events[0], { kind: "scanning" });
+  assertEquals(events.at(-1)?.kind, "completed");
+});
+
+Deno.test("doctorSecrets: flags a definition with a cleartext sensitive arg", async () => {
+  const deps = makeDeps(
+    [{
+      definition: {
+        id: "def-1",
+        name: "my-creds",
+        globalArguments: { apiKey: SECRET, region: "us-east-1" },
+      },
+      type: "acme/api",
+    }],
+    () => ({ globalArguments: sensitiveSchema }),
+  );
+
+  const events = await collect<DoctorSecretsEvent>(
+    doctorSecrets(createLibSwampContext(), deps),
+  );
+  const data = completedData(events);
+
+  assertEquals(data.scanned, 1);
+  assertEquals(data.findings.length, 1);
+  assertEquals(data.findings[0].definitionName, "my-creds");
+  assertEquals(data.findings[0].leakedPaths, ["apiKey"]);
+  assertEquals(data.unresolved.length, 0);
+});
+
+Deno.test("doctorSecrets: never includes the secret value in findings", async () => {
+  const deps = makeDeps(
+    [{
+      definition: {
+        id: "def-1",
+        name: "my-creds",
+        globalArguments: { apiKey: SECRET, region: "us-east-1" },
+      },
+      type: "acme/api",
+    }],
+    () => ({ globalArguments: sensitiveSchema }),
+  );
+
+  const events = await collect<DoctorSecretsEvent>(
+    doctorSecrets(createLibSwampContext(), deps),
+  );
+
+  // The entire completed payload must be free of the cleartext secret.
+  assertEquals(JSON.stringify(completedData(events)).includes(SECRET), false);
+});
+
+Deno.test("doctorSecrets: ignores a vault.get expression value", async () => {
+  const deps = makeDeps(
+    [{
+      definition: {
+        id: "def-1",
+        name: "safe-creds",
+        globalArguments: {
+          apiKey: "${{ vault.get('creds', 'apiKey') }}",
+          region: "us-east-1",
+        },
+      },
+      type: "acme/api",
+    }],
+    () => ({ globalArguments: sensitiveSchema }),
+  );
+
+  const data = completedData(
+    await collect<DoctorSecretsEvent>(
+      doctorSecrets(createLibSwampContext(), deps),
+    ),
+  );
+
+  assertEquals(data.findings.length, 0);
+});
+
+Deno.test("doctorSecrets: reports definitions whose type cannot be resolved", async () => {
+  const deps = makeDeps(
+    [{
+      definition: {
+        id: "def-1",
+        name: "orphan",
+        globalArguments: { apiKey: SECRET },
+      },
+      type: "missing/extension",
+    }],
+    () => undefined,
+  );
+
+  const data = completedData(
+    await collect<DoctorSecretsEvent>(
+      doctorSecrets(createLibSwampContext(), deps),
+    ),
+  );
+
+  assertEquals(data.findings.length, 0);
+  assertEquals(data.unresolved.length, 1);
+  assertEquals(data.unresolved[0].type, "missing/extension");
+});
+
+Deno.test("doctorSecrets: scans multiple definitions and counts them", async () => {
+  const deps = makeDeps(
+    [
+      {
+        definition: {
+          id: "def-1",
+          name: "leaky",
+          globalArguments: { apiKey: SECRET },
+        },
+        type: "acme/api",
+      },
+      {
+        definition: {
+          id: "def-2",
+          name: "clean",
+          globalArguments: { region: "us-east-1" },
+        },
+        type: "acme/api",
+      },
+    ],
+    () => ({ globalArguments: sensitiveSchema }),
+  );
+
+  const data = completedData(
+    await collect<DoctorSecretsEvent>(
+      doctorSecrets(createLibSwampContext(), deps),
+    ),
+  );
+
+  assertEquals(data.scanned, 2);
+  assertEquals(data.findings.length, 1);
+  assertEquals(data.findings[0].definitionName, "leaky");
+});

--- a/src/presentation/renderers/doctor_secrets.ts
+++ b/src/presentation/renderers/doctor_secrets.ts
@@ -1,0 +1,169 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import type {
+  DoctorSecretsData,
+  DoctorSecretsEvent,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { OutputMode } from "../output/output.ts";
+
+/**
+ * A clean scan passes; any cleartext leak fails so the command can gate CI.
+ * Unresolved definitions are advisory warnings — they do not fail the scan.
+ */
+export type DoctorSecretsStatus = "pass" | "fail";
+
+/**
+ * Renderer for `swamp doctor secrets`. Reports definitions holding cleartext
+ * sensitive global arguments with value-free remediation guidance. Never
+ * renders the offending secret value in any mode.
+ *
+ * Exposes `overallStatus` so the CLI can exit non-zero when a leak is found.
+ */
+export interface DoctorSecretsRenderer {
+  handlers(): EventHandlers<DoctorSecretsEvent>;
+  readonly overallStatus: DoctorSecretsStatus;
+}
+
+function renderUnresolvedLog(data: DoctorSecretsData): void {
+  if (data.unresolved.length === 0) {
+    return;
+  }
+  writeOutput(
+    `\n${yellow("⚠")} ${
+      bold(
+        `${data.unresolved.length} definition(s) could not be assessed`,
+      )
+    } ${dim("(type schema unavailable — install the extension to scan them)")}`,
+  );
+  for (const u of data.unresolved) {
+    writeOutput(`    ${yellow("•")} ${u.definitionName} ${dim(`[${u.type}]`)}`);
+  }
+}
+
+class LogDoctorSecretsRenderer implements DoctorSecretsRenderer {
+  overallStatus: DoctorSecretsStatus = "pass";
+
+  handlers(): EventHandlers<DoctorSecretsEvent> {
+    return {
+      scanning: () => {
+        writeOutput(
+          dim("Scanning definitions for cleartext sensitive global arguments…"),
+        );
+      },
+      completed: (e) => {
+        const { data } = e;
+
+        if (data.findings.length === 0) {
+          writeOutput(
+            `\n${green("✓")} ${
+              bold("No cleartext sensitive global arguments found")
+            } ${dim(`(${data.scanned} definition(s) scanned)`)}`,
+          );
+          renderUnresolvedLog(data);
+          return;
+        }
+
+        this.overallStatus = "fail";
+        writeOutput(
+          `\n${red("✗")} ${
+            bold(
+              `${data.findings.length} definition(s) hold a cleartext sensitive global argument`,
+            )
+          } ${dim(`(${data.scanned} definition(s) scanned)`)}`,
+        );
+
+        for (const finding of data.findings) {
+          writeOutput(
+            `\n  ${bold(finding.definitionName)} ${dim(`[${finding.type}]`)}`,
+          );
+          for (const r of finding.remediations) {
+            writeOutput(`    ${red("•")} ${bold(r.path)}`);
+            writeOutput(
+              `        ${
+                dim("1. Store the secret:")
+              } swamp vault put ${r.vaultName} ${r.vaultKey} <value>`,
+            );
+            writeOutput(
+              `        ${dim("2. Reference it:")}     ${r.expression}`,
+            );
+          }
+        }
+
+        writeOutput(
+          dim(
+            "\n  Each secret above sits in cleartext in its definition YAML. " +
+              "Migrate it to a vault, then re-save the definition.",
+          ),
+        );
+
+        renderUnresolvedLog(data);
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDoctorSecretsRenderer implements DoctorSecretsRenderer {
+  overallStatus: DoctorSecretsStatus = "pass";
+
+  handlers(): EventHandlers<DoctorSecretsEvent> {
+    return {
+      scanning: () => {
+        // No-op — JSON consumers get a single final emit.
+      },
+      completed: (e) => {
+        const { data } = e;
+        this.overallStatus = data.findings.length > 0 ? "fail" : "pass";
+        console.log(
+          JSON.stringify(
+            {
+              overallStatus: this.overallStatus,
+              scanned: data.scanned,
+              findings: data.findings,
+              unresolved: data.unresolved,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDoctorSecretsRenderer(
+  mode: OutputMode,
+): DoctorSecretsRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDoctorSecretsRenderer();
+    case "log":
+      return new LogDoctorSecretsRenderer();
+  }
+}

--- a/src/presentation/renderers/doctor_secrets_test.ts
+++ b/src/presentation/renderers/doctor_secrets_test.ts
@@ -1,0 +1,148 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { DoctorSecretsData } from "../../libswamp/mod.ts";
+import { createDoctorSecretsRenderer } from "./doctor_secrets.ts";
+
+await initializeLogging({});
+
+const SECRET = "SUPERSECRET123";
+
+function captureStdout(fn: () => void | Promise<void>): Promise<string> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  return Promise.resolve(fn())
+    .finally(() => {
+      console.log = originalLog;
+    })
+    .then(() => lines.join("\n"));
+}
+
+const cleanData: DoctorSecretsData = {
+  scanned: 3,
+  findings: [],
+  unresolved: [],
+};
+
+const leakData: DoctorSecretsData = {
+  scanned: 2,
+  findings: [{
+    definitionId: "def-1",
+    definitionName: "my-creds",
+    type: "acme/api",
+    leakedPaths: ["apiKey"],
+    remediations: [{
+      path: "apiKey",
+      vaultName: "my-vault",
+      vaultKey: "apiKey",
+      expression: "${{ vault.get('my-vault', 'apiKey') }}",
+    }],
+  }],
+  unresolved: [{
+    definitionId: "def-2",
+    definitionName: "orphan",
+    type: "missing/extension",
+  }],
+};
+
+Deno.test("doctor_secrets log renderer: passes on a clean scan", async () => {
+  const r = createDoctorSecretsRenderer("log");
+  const out = await captureStdout(() => {
+    r.handlers().completed?.({ kind: "completed", data: cleanData });
+  });
+
+  assertEquals(r.overallStatus, "pass");
+  assertStringIncludes(out, "No cleartext sensitive global arguments found");
+});
+
+Deno.test("doctor_secrets log renderer: fails and emits remediation on a leak", async () => {
+  const r = createDoctorSecretsRenderer("log");
+  const out = await captureStdout(() => {
+    r.handlers().completed?.({ kind: "completed", data: leakData });
+  });
+
+  assertEquals(r.overallStatus, "fail");
+  assertStringIncludes(out, "my-creds");
+  assertStringIncludes(out, "apiKey");
+  assertStringIncludes(out, "swamp vault put my-vault apiKey");
+  assertStringIncludes(out, "vault.get('my-vault', 'apiKey')");
+  // Unresolved definitions are surfaced as advisory warnings.
+  assertStringIncludes(out, "could not be assessed");
+  assertStringIncludes(out, "orphan");
+});
+
+Deno.test("doctor_secrets json renderer: emits structured payload and sets status", async () => {
+  const r = createDoctorSecretsRenderer("json");
+  const out = await captureStdout(() => {
+    r.handlers().completed?.({ kind: "completed", data: leakData });
+  });
+
+  assertEquals(r.overallStatus, "fail");
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.overallStatus, "fail");
+  assertEquals(parsed.scanned, 2);
+  assertEquals(parsed.findings.length, 1);
+  assertEquals(parsed.unresolved.length, 1);
+});
+
+Deno.test("doctor_secrets json renderer: passes on a clean scan", async () => {
+  const r = createDoctorSecretsRenderer("json");
+  const out = await captureStdout(() => {
+    r.handlers().completed?.({ kind: "completed", data: cleanData });
+  });
+
+  assertEquals(r.overallStatus, "pass");
+  assertEquals(JSON.parse(out).overallStatus, "pass");
+});
+
+Deno.test("doctor_secrets renderers: never print the secret value", async () => {
+  // The data the renderer receives is already value-free, but assert the
+  // contract holds end-to-end: nothing the renderer emits can carry a secret.
+  const dataWithSecretName: DoctorSecretsData = {
+    scanned: 1,
+    findings: [{
+      definitionId: "def-1",
+      definitionName: "my-creds",
+      type: "acme/api",
+      leakedPaths: ["apiKey"],
+      remediations: [{
+        path: "apiKey",
+        vaultName: "my-vault",
+        vaultKey: "apiKey",
+        expression: "${{ vault.get('my-vault', 'apiKey') }}",
+      }],
+    }],
+    unresolved: [],
+  };
+
+  for (const mode of ["log", "json"] as const) {
+    const r = createDoctorSecretsRenderer(mode);
+    const out = await captureStdout(() => {
+      r.handlers().completed?.({ kind: "completed", data: dataWithSecretName });
+    });
+    assertEquals(out.includes(SECRET), false);
+  }
+});


### PR DESCRIPTION
## Summary

Adds `swamp doctor secrets`, a read-only diagnostic that reports model definitions whose `sensitive: true` global arguments hold a **cleartext literal** value instead of a `vault.get(...)` expression, with value-free vault remediation guidance, and a non-zero exit when any are found (CI-gateable).

Follow-up to the at-rest write guard (swamp-club#480 / #1469). That guard only protects **new** writes at the `YamlDefinitionRepository.save()` chokepoint — it leaves two gaps a write-time guard cannot close:

1. **Legacy definitions** authored before the guard still hold the secret in cleartext until re-saved.
2. **Datastore sync / migration** copies definition YAML byte-for-byte, so a cleartext literal authored elsewhere lands on disk without passing through `save()`.

This PR is the **detection** half: it scans what is already on disk and points the user at the fix.

## What it does

- **Reuses the existing `findLiteralSensitiveGlobalArgs` domain rule** (from #480), so what the scan surfaces is exactly what a re-save would now refuse — no parallel detection logic.
- Scans both the source-of-truth `models/` tree (where datastore-synced definitions land after a pull) **and** `.swamp/auto-definitions`.
- **Read-only and value-free:** never calls `save()`, never echoes the secret value in any output mode or the JSON payload.
- **Best-effort residual:** definitions whose extension type cannot be resolved are reported as advisory "could not be assessed" warnings, not silently skipped.
- Both `log` and `--json` output modes (json shape: `{ overallStatus, scanned, findings, unresolved }`).
- **Scoped to model definitions.** Workflow-definition global args and a sync-time guard are intentionally out of scope.

## Files

- `src/domain/models/sensitive_field_extractor.ts` — `buildSensitiveArgRemediations` (value-free, structured sibling of the guard's message builder)
- `src/libswamp/models/doctor_secrets.ts` — the scan service + `createDoctorSecretsDeps`
- `src/presentation/renderers/doctor_secrets.ts` — log + json renderers
- `src/cli/commands/doctor_secrets.ts` + `doctor.ts` + `mod.ts` — command wiring/exports
- `design/doctor-secrets.md` — design doc

## Test Plan

- Unit tests: domain remediation builder (incl. value-free assertions), service (leak / clean / vault-expr / unresolved-type / multi-def), renderer (log + json, pass/fail, value-free), CLI wiring.
- Integration test (`integration/doctor_secrets_test.ts`): real `YamlDefinitionRepository` + real registry, planting a cleartext leak on disk in **both** the `models/` and `.swamp/auto-definitions` trees.
- End-to-end through the **compiled binary** in a scratch repo: clean scan (exit 0) and a planted-leak scan (exit 1) in both `log` and `--json`, confirming the secret never appears in output.
- `deno check`, `deno lint`, `deno fmt`, full `deno run test` (6491 passed) all green.

## Follow-ups

- UAT: systeminit/swamp-uat#243
- Docs: swamp-club Lab #490 (document the command in the manual reference `doctor.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)