### PR TITLE
feat(http): send User-Agent header on swamp-club requests

### DIFF
--- a/src/cli/load_identity.ts
+++ b/src/cli/load_identity.ts
@@ -20,6 +20,10 @@
 import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
+import { VERSION } from "./commands/version.ts";
+
+/** `User-Agent` sent on every swamp-club request, e.g. `swamp-cli/<version>`. */
+export const USER_AGENT = `swamp-cli/${VERSION}`;
 
 /**
  * Resolve the device/user identity to attach to outbound swamp-club
@@ -31,6 +35,10 @@ import { UserIdentityRepository } from "../infrastructure/persistence/user_ident
  * login, only distinctId) and rare "no identity at all" flows
  * (UserIdentityRepository read failed and no auth) are both supported
  * by the downstream `ClientIdentity` shape.
+ *
+ * Always sets `userAgent` (`swamp-cli/<version>`) regardless of whether
+ * the auth/device identity resolves — version attribution is independent
+ * of the file system and must survive the best-effort failure paths.
  *
  * This helper is the composition root for identity. libswamp and the
  * HTTP clients themselves never touch the file system to discover it.
@@ -54,5 +62,6 @@ export async function loadIdentity(): Promise<ClientIdentity> {
   return {
     bearerToken,
     distinctId: distinctId ?? undefined,
+    userAgent: USER_AGENT,
   };
 }

--- a/src/cli/load_identity_test.ts
+++ b/src/cli/load_identity_test.ts
@@ -17,8 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { loadIdentity } from "./load_identity.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { loadIdentity, USER_AGENT } from "./load_identity.ts";
+
+Deno.test("USER_AGENT identifies the CLI and carries the version", () => {
+  assertStringIncludes(USER_AGENT, "swamp-cli/");
+});
 
 Deno.test("loadIdentity returns empty identity when config dir is unresolvable", async () => {
   // Reproduces the Windows test-env scenario where HOME is not set
@@ -35,6 +39,9 @@ Deno.test("loadIdentity returns empty identity when config dir is unresolvable",
     const identity = await loadIdentity();
     assertEquals(identity.bearerToken, undefined);
     assertEquals(identity.distinctId, undefined);
+    // User-Agent is independent of the file system and must always be set,
+    // even when device/auth identity resolution fails.
+    assertEquals(identity.userAgent, USER_AGENT);
   } finally {
     if (homeBefore !== undefined) Deno.env.set("HOME", homeBefore);
     if (userProfileBefore !== undefined) {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -99,7 +99,7 @@ import { SKILL_DIRS } from "../domain/repo/skill_dirs.ts";
 import { ExtensionAutoResolver } from "../domain/extensions/extension_auto_resolver.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
-import { loadIdentity } from "./load_identity.ts";
+import { loadIdentity, USER_AGENT } from "./load_identity.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../domain/auth/auth_credentials.ts";
 import { setAutoResolver } from "./auto_resolver_context.ts";
 import {
@@ -1342,7 +1342,10 @@ export async function runCli(args: string[]): Promise<void> {
         // Flush telemetry to remote endpoint with a 2-second cancellation
         // timeout. If the endpoint is slow or unreachable, data stays local
         // and will be flushed on the next invocation.
-        const sender = new HttpTelemetrySender(telemetryCtx.telemetryEndpoint);
+        const sender = new HttpTelemetrySender(
+          telemetryCtx.telemetryEndpoint,
+          USER_AGENT,
+        );
         await telemetryCtx.service.flushTelemetry({
           sender,
           distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
@@ -1470,7 +1473,10 @@ export async function runCli(args: string[]): Promise<void> {
     if (telemetryCtx && error instanceof Error) {
       await telemetryCtx.service.recordError(commandInfo, startTime, error);
 
-      const sender = new HttpTelemetrySender(telemetryCtx.telemetryEndpoint);
+      const sender = new HttpTelemetrySender(
+        telemetryCtx.telemetryEndpoint,
+        USER_AGENT,
+      );
       await telemetryCtx.service.flushTelemetry({
         sender,
         distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,

--- a/src/infrastructure/http/client_identity.ts
+++ b/src/infrastructure/http/client_identity.ts
@@ -29,10 +29,15 @@
  *   per-device UUID lazily created by `UserIdentityRepository.getUserId()`
  *   and stored at `~/.config/swamp/identity.json`. The header name is
  *   vendor-prefixed per RFC 6648 (no `X-` prefix).
+ * - `userAgent` adds `User-Agent: <value>`. The value is
+ *   `swamp-cli/<version>`, built at the composition root from the CLI
+ *   `VERSION` constant so swamp-club can attribute traffic by client
+ *   version.
  */
 export interface ClientIdentity {
   bearerToken?: string;
   distinctId?: string;
+  userAgent?: string;
 }
 
 /**
@@ -59,6 +64,9 @@ export function mergeIdentityHeaders(
   }
   if (identity.distinctId) {
     merged.set("Swamp-Distinct-Id", identity.distinctId);
+  }
+  if (identity.userAgent) {
+    merged.set("User-Agent", identity.userAgent);
   }
   if (callerHeaders) {
     new Headers(callerHeaders).forEach((value, key) => {

--- a/src/infrastructure/http/client_identity_test.ts
+++ b/src/infrastructure/http/client_identity_test.ts
@@ -1,0 +1,56 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { mergeIdentityHeaders } from "./client_identity.ts";
+
+Deno.test("mergeIdentityHeaders: sets User-Agent from identity.userAgent", () => {
+  const headers = mergeIdentityHeaders(
+    { userAgent: "swamp-cli/1.2.3" },
+    undefined,
+  );
+  assertEquals(headers.get("User-Agent"), "swamp-cli/1.2.3");
+});
+
+Deno.test("mergeIdentityHeaders: omits User-Agent when not in identity", () => {
+  const headers = mergeIdentityHeaders({ bearerToken: "tok" }, undefined);
+  assertEquals(headers.get("User-Agent"), null);
+});
+
+Deno.test("mergeIdentityHeaders: sets all identity headers together", () => {
+  const headers = mergeIdentityHeaders(
+    {
+      bearerToken: "tok",
+      distinctId: "device-uuid",
+      userAgent: "swamp-cli/1.2.3",
+    },
+    undefined,
+  );
+  assertEquals(headers.get("Authorization"), "Bearer tok");
+  assertEquals(headers.get("Swamp-Distinct-Id"), "device-uuid");
+  assertEquals(headers.get("User-Agent"), "swamp-cli/1.2.3");
+});
+
+Deno.test("mergeIdentityHeaders: caller headers override identity User-Agent", () => {
+  const headers = mergeIdentityHeaders(
+    { userAgent: "swamp-cli/1.2.3" },
+    { "User-Agent": "custom/agent" },
+  );
+  assertEquals(headers.get("User-Agent"), "custom/agent");
+});

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -23,9 +23,17 @@ import type { TelemetryEntry } from "../../domain/telemetry/telemetry_entry.ts";
 /**
  * HTTP adapter implementing TelemetrySender.
  * Sends telemetry events to a remote /ingest endpoint.
+ *
+ * `userAgent` (e.g. `swamp-cli/<version>`) is optional so unit tests can
+ * construct the sender without it; the composition root passes it so the
+ * telemetry endpoint can attribute traffic by client version, matching
+ * the swamp-club API clients.
  */
 export class HttpTelemetrySender implements TelemetrySender {
-  constructor(private readonly endpointUrl: string) {}
+  constructor(
+    private readonly endpointUrl: string,
+    private readonly userAgent?: string,
+  ) {}
 
   async sendBatch(
     entries: TelemetryEntry[],
@@ -51,6 +59,7 @@ export class HttpTelemetrySender implements TelemetrySender {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         ...(authToken ? { "x-api-key": authToken } : {}),
+        ...(this.userAgent ? { "User-Agent": this.userAgent } : {}),
       };
 
       // Combine caller's signal with a hard 5-second ceiling

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -231,6 +231,33 @@ Deno.test("HttpTelemetrySender.sendBatch omits x-api-key header when authToken n
   await server.shutdown();
 });
 
+Deno.test("HttpTelemetrySender.sendBatch includes User-Agent header when provided", async () => {
+  let capturedUserAgent: string | null = null;
+
+  const server = Deno.serve({ port: 0 }, async (req: Request) => {
+    capturedUserAgent = req.headers.get("user-agent");
+    await req.body?.cancel();
+    return new Response(JSON.stringify({ accepted: 1 }), { status: 202 });
+  });
+
+  const port = server.addr.port;
+  const sender = new HttpTelemetrySender(
+    `http://localhost:${port}`,
+    "swamp-cli/1.2.3",
+  );
+  const entry = createTestEntry(
+    "test-uuid-1",
+    new Date("2024-03-10T10:00:00Z"),
+  );
+
+  const result = await sender.sendBatch([entry], "user-uuid-123");
+
+  assertEquals(result, true);
+  assertEquals(capturedUserAgent, "swamp-cli/1.2.3");
+
+  await server.shutdown();
+});
+
 Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.invocationContext", async () => {
   // Wire-shape contract: TelemetryEntry.toData() is splatted into properties
   // verbatim, so the swamp-club consumer side queries


### PR DESCRIPTION
## Summary

Adds a `User-Agent: swamp-cli/<version>` header to outbound requests to swamp-club so the server can attribute traffic by client version.

The header is injected at the identity composition root rather than at each call site:
- `loadIdentity()` now sets a `userAgent` field on `ClientIdentity`, built from the CLI `VERSION` constant and exported as `USER_AGENT`.
- `mergeIdentityHeaders()` emits it, so **both** swamp-club API clients (`SwampClubClient` and `ExtensionApiClient`) are covered by one change. Caller-supplied headers still take precedence on conflict.
- The telemetry sender (`telemetry.swamp-club.com/ingest`) builds requests outside the `ClientIdentity` path, so it gains an optional `userAgent` constructor arg wired from `USER_AGENT` at its construction sites in `mod.ts`.

The version comes from the `VERSION` constant that `scripts/compile.ts` stamps at release-build time, so released binaries report a real version (dev builds report the source default, `swamp-cli/<date>.<time>.0-sha.`).

### Deliberately out of scope
- **Update checker** (`artifacts.swamp-club.com`) — anonymous static CDN downloads, no identity path.
- **Source downloader** — fetches from GitHub, not swamp-club.

## Test Plan

- New `client_identity_test.ts`: header set / omitted / combined with other identity headers / caller override.
- Updated `load_identity_test.ts`: `USER_AGENT` format and that it's always present even on the no-config-dir fallback path.
- New `http_telemetry_sender_test.ts` case: `User-Agent` sent when provided.
- Verified Deno honors a custom `User-Agent` override on `fetch` (it does).
- `deno fmt --check`, `deno lint`, `deno run test` (6517 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)