### PR TITLE
fix(workflow): disambiguate "workflow" to mean a swamp workflow

### DIFF
--- a/.claude/skills/swamp-workflow/SKILL.md
+++ b/.claude/skills/swamp-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-workflow
-description: Work with swamp workflows for AI-native automation — define jobs and steps in YAML, wire models together with dependencies, validate DAGs, and inspect run history. Use when searching for workflows, creating new workflows, validating workflow definitions, running workflows, or viewing run history. Triggers on "swamp workflow", "run workflow", "create workflow", "automate", "automation", "orchestrate", "run history", "execute workflow", "workflow logs", "workflow failure", "debug workflow".
+description: Work with swamp workflows for AI-native automation — define jobs and steps in YAML, wire models together with dependencies, validate DAGs, and inspect run history. Use when searching for workflows, creating new workflows, validating workflow definitions, running workflows, or viewing run history. Triggers on "swamp workflow", "swamp workflow create", "swamp workflow run", "swamp workflow validate", "workflow YAML", "workflow DAG", "wire models together", "model_method step", "workflows/*.yaml", "swamp run history", "swamp workflow logs", "debug swamp workflow". Use ONLY for swamp's declarative YAML workflow artifacts created via swamp workflow create — NOT for the Claude Code Workflow tool, multi-step agent task lists, worktrees, or cron/scheduled agent runs.
 ---
 
 # Swamp Workflow Skill
@@ -21,6 +21,15 @@ machine-readable output.
 
 Correct flow: `swamp workflow create <name> --json` → edit the YAML → validate →
 run.
+
+## Skill boundary
+
+This skill produces a durable swamp workflow YAML under `workflows/` via
+`swamp workflow create`. It is unrelated to the Claude Code Workflow tool /
+dynamic workflows, to agent task lists (`TaskCreate`), to worktrees
+(`EnterWorktree`), or to cron/remote-agent scheduling
+(`CronCreate`/`RemoteTrigger`). If the user wants any of those, do not use this
+skill.
 
 ## Quick Reference
 

--- a/.claude/skills/swamp-workflow/evals/trigger_evals.json
+++ b/.claude/skills/swamp-workflow/evals/trigger_evals.json
@@ -16,7 +16,7 @@
     "should_trigger": true
   },
   {
-    "query": "Create an automated job that runs the data sync every night",
+    "query": "Create a swamp workflow that runs the data-sync model every night.",
     "should_trigger": true
   },
   {
@@ -69,5 +69,20 @@
     "query": "How do I install swamp in CI to run workflows on every PR?",
     "should_trigger": false,
     "note": "CI installation → swamp-repo"
+  },
+  {
+    "query": "create a workflow to run these three steps for me",
+    "should_trigger": false,
+    "note": "Generic agent task plan, not a swamp workflow → Claude Code Workflow tool / TaskCreate"
+  },
+  {
+    "query": "schedule a recurring agent to run nightly",
+    "should_trigger": false,
+    "note": "Cron/remote-agent scheduling, not a swamp workflow → CronCreate"
+  },
+  {
+    "query": "set up a worktree workflow",
+    "should_trigger": false,
+    "note": "Worktree-based agent task, not a swamp workflow → EnterWorktree"
   }
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,21 @@ Deno based CLI for doing AI Native Automation.
 When planning new features, always use the `ddd` skill to inform the
 architecture.
 
+## Workflows
+
+In this repository the word "workflow" — including "create/run/execute/validate/
+debug workflow", "automate", "orchestrate", and "automated/nightly job" — refers
+to a swamp workflow: a declarative YAML DAG of model-method steps authored via
+`swamp workflow create`. This is swamp's own first-class concept, implemented in
+this codebase, and it is the default meaning here. Load and follow the
+`swamp-workflow` skill for these requests. Do NOT interpret them as a request to
+build a Claude Code agent task list, spin up worktrees, or schedule a
+cron/remote agent. Only reach for the harness orchestration tools
+(TaskCreate/TaskList, EnterWorktree, CronCreate, RemoteTrigger) when the user
+explicitly names that mechanism (e.g. "task list", "subagent", "worktree",
+"cron", "remote agent") or explicitly asks you to do the work yourself step by
+step rather than author a swamp workflow.
+
 ## Skills
 
 Skills live in `.claude/skills/<skill-name>/`.

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -814,6 +814,9 @@ This repository is managed with [swamp](https://github.com/systeminit/swamp).
 8. **Reports for reusable data pipelines.** When the task involves building a repeatable pipeline to transform, aggregate, or analyze model output (security reports, cost analysis, compliance checks, summaries), create a report extension. ${
       skillAction("swamp-report", "Use")
     } for guidance.
+9. **"Workflow" means a swamp workflow.** In this repository the word "workflow" (and "create/run/execute/validate/debug workflow", "automate", "orchestrate", "automated/nightly job") refers to a swamp workflow — a declarative YAML DAG of model-method steps authored via \`swamp workflow create\`. ${
+      skillAction("swamp-workflow", "Load and follow")
+    } for these requests. Do NOT interpret these as a request to build an agent task list, spin up worktrees, or schedule a cron/remote agent. Only use those orchestration mechanisms when the user explicitly names one (e.g. "task list", "subagent", "worktree", "cron", "remote agent") or explicitly asks you to do the work yourself step by step rather than author a swamp workflow.
 
 ## Skills
 
@@ -834,7 +837,7 @@ ${
 ${
       skillListEntry(
         "swamp-workflow",
-        "Work with workflows (creating, editing, running)",
+        'Work with swamp workflows — the default meaning of "workflow" here (see Rule 9)',
       )
     }
 ${skillListEntry("swamp-vault", "Manage secrets and credentials")}

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -449,6 +449,22 @@ Deno.test("RepoService.init generates CLAUDE.md with extension search guidance",
   });
 });
 
+Deno.test("RepoService.init generates CLAUDE.md disambiguating workflow to swamp workflow", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const content = await Deno.readTextFile(claudeMdPath);
+
+    assertStringIncludes(content, '"Workflow" means a swamp workflow');
+    assertStringIncludes(content, "swamp workflow create");
+    assertStringIncludes(content, "do the work yourself step by step");
+  });
+});
+
 Deno.test("RepoService.init always creates .gitignore with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");


### PR DESCRIPTION
## Summary

Claude Code ships a built-in **Workflow tool** that auto-triggers on the bare keyword "workflow" at the harness input layer — before any skill is evaluated. The swamp repo has its own first-class **workflow** concept (a declarative YAML DAG of model-method steps, authored via `swamp workflow create`). These collide: when a user says "create a workflow that runs model X then Y" (dropping "swamp"), the harness can win and spin up agent task lists / worktrees / cron scheduling instead of producing a durable `workflows/*.yaml` DAG.

This PR closes the gap with two layers of pure-documentation/guidance, no behavior change to the CLI:

**1. Generated CLAUDE.md rule (`repo_service.ts`)** — the user-facing CLAUDE.md written during `repo_init` / `repo_update` gains a rule pinning "workflow" / "automate" / "orchestrate" / "automated job" to the swamp meaning, gating agent-orchestration mechanisms behind explicit opt-in vocabulary. Phrasing is tool-agnostic since the same template serves Cursor, opencode, codex, and kiro alongside Claude. Existing repos pick it up via the managed-section migration on `swamp repo update`. The swamp-dev `CLAUDE.md` mirrors the guidance (Claude-Code-only, so it names the literal harness tools).

**2. swamp-workflow skill hardening** — the skill's trigger list previously listed the same bare verbs the harness cues on (`automate`, `orchestrate`, `create/run/execute workflow`), actively contributing to the ambiguity. Those are removed and every trigger namespaced to the swamp concept, with an explicit NOT-clause in the description and a `## Skill boundary` section in the body. Adversarial `should_trigger: false` eval seeds lock the boundary in.

The two layers are intentionally paired: namespacing the skill triggers trades "false-positives-to-harness" for "false-negatives-to-nothing", and the CLAUDE.md rule gives the model in-context authority to still route un-namespaced phrasings to the skill.

### Caveat

This is soft model guidance. The harness `workflow` keyword fires *above* the instruction/skill tier, so on a borderline prompt the model can still be pulled toward the orchestration reading. A hard guarantee would require `disableWorkflows` / `permissions.deny: ["Workflow"]`, which is deliberately out of scope here.

## Test Plan

- `deno fmt --check`, `deno lint` — clean
- `deno run test` — **6512 passed, 0 failed** (includes a new `repo_service_test.ts` case asserting the workflow-disambiguation rule lands in the generated CLAUDE.md)
- tessl skill review on `swamp-workflow` — 0.925 avg, both judges above the 0.90 threshold
- promptfoo trigger evals (`deno run eval-skill-triggers --model sonnet`) — all `swamp-workflow` seeds pass, including the 3 new adversarial negatives ("create a workflow to run these three steps", "schedule a recurring agent to run nightly", "set up a worktree workflow"). The 3 unrelated suite failures (swamp-data, swamp-vault) are pre-existing on `main` and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)