### PR TITLE
feat(report): add --type filter to report search (swamp-club#498)

### DIFF
--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -31,6 +31,8 @@ up-to-date CLI schema.
 
 | Task                     | Command                                                           |
 | ------------------------ | ----------------------------------------------------------------- |
+| Browse stored reports    | `swamp report search`                                             |
+| Search reports by type   | `swamp report search --type <report-name>`                        |
 | Get a stored report      | `swamp report get <report-name> --model <model>`                  |
 | Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
 | Get report as JSON       | `swamp report get <report-name> --model <model> --json`           |
@@ -166,6 +168,25 @@ allowing a push.
 | `--skip-report-label <label>` | Skip reports with this label (repeatable)     |
 | `--report <name>`             | Only run this report (repeatable, inclusion)  |
 | `--report-label <label>`      | Only run reports with this label (repeatable) |
+
+### report search
+
+Browse stored report results across all models and workflows. An optional
+positional `[query]` does a case-insensitive substring match across report name,
+data name, and forEach variant suffix. The flags below narrow the results
+further (each is an exact match):
+
+| Flag                | Description                                                 |
+| ------------------- | ----------------------------------------------------------- |
+| `--model <name>`    | Filter to a specific model                                  |
+| `--workflow <name>` | Filter to a specific workflow                               |
+| `--scope <scope>`   | Filter by report scope (`method`, `model`, `workflow`)      |
+| `--type <name>`     | Filter by exact report type name (e.g. `@myorg/cost-audit`) |
+| `--label <label>`   | Filter by report label (repeatable)                         |
+
+`--type` is exact-match on the report type name, unlike the positional `[query]`
+which matches substrings. Use `--type` when you know the precise report name and
+want only that type across every model and workflow.
 
 ### report get
 

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -31,8 +31,6 @@ up-to-date CLI schema.
 
 | Task                     | Command                                                           |
 | ------------------------ | ----------------------------------------------------------------- |
-| Browse stored reports    | `swamp report search`                                             |
-| Search reports by type   | `swamp report search --type <report-name>`                        |
 | Get a stored report      | `swamp report get <report-name> --model <model>`                  |
 | Get report as markdown   | `swamp report get <report-name> --model <model> --markdown`       |
 | Get report as JSON       | `swamp report get <report-name> --model <model> --json`           |
@@ -171,22 +169,18 @@ allowing a push.
 
 ### report search
 
-Browse stored report results across all models and workflows. An optional
-positional `[query]` does a case-insensitive substring match across report name,
-data name, and forEach variant suffix. The flags below narrow the results
-further (each is an exact match):
+Browse stored report results across all models and workflows. Pass an optional
+`[query]` argument for a case-insensitive substring match; the flags below are
+exact matches.
 
-| Flag                | Description                                                 |
-| ------------------- | ----------------------------------------------------------- |
-| `--model <name>`    | Filter to a specific model                                  |
-| `--workflow <name>` | Filter to a specific workflow                               |
-| `--scope <scope>`   | Filter by report scope (`method`, `model`, `workflow`)      |
-| `--type <name>`     | Filter by exact report type name (e.g. `@myorg/cost-audit`) |
-| `--label <label>`   | Filter by report label (repeatable)                         |
-
-`--type` is exact-match on the report type name, unlike the positional `[query]`
-which matches substrings. Use `--type` when you know the precise report name and
-want only that type across every model and workflow.
+| Flag                | Description                                            |
+| ------------------- | ------------------------------------------------------ |
+| `[query]`           | Substring match on report name, data name, or variant  |
+| `--model <name>`    | Filter to a specific model                             |
+| `--workflow <name>` | Filter to a specific workflow                          |
+| `--scope <scope>`   | Filter by report scope (`method`, `model`, `workflow`) |
+| `--type <name>`     | Filter by exact report type name (e.g. `@myorg/cost`)  |
+| `--label <label>`   | Filter by report label (repeatable)                    |
 
 ### report get
 

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -191,6 +191,7 @@ export async function reportSearchAction(
       model: options.model as string | undefined,
       workflow: options.workflow as string | undefined,
       scope: options.scope as string | undefined,
+      type: options.type as string | undefined,
       labels: options.label as string[] | undefined,
     }),
     searchRenderer.handlers(),
@@ -229,6 +230,10 @@ export const reportSearchCommand = new Command()
   .option(
     "--scope <scope:string>",
     "Filter by report scope (method, model, workflow)",
+  )
+  .option(
+    "--type <name:string>",
+    "Filter by exact report type name (e.g. @webframp/cost-audit-report)",
   )
   .option(
     "--label <label:string>",

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -48,6 +48,7 @@ export interface ReportSearchInput {
   model?: string;
   workflow?: string;
   scope?: string;
+  type?: string;
   labels?: string[];
 }
 
@@ -190,6 +191,17 @@ export async function* reportSearch(
       if (input.scope) {
         candidates = candidates.filter(
           (c) => c.data.tags.reportScope === input.scope,
+        );
+      }
+
+      // Apply report type filter — exact match on the report type name. Runs
+      // before the label filter to shrink the candidate set ahead of the
+      // per-candidate definition lookups the label filter performs. Compares
+      // against the reportName tag directly (no fallback to data.name), so
+      // entries missing the tag are excluded.
+      if (input.type) {
+        candidates = candidates.filter(
+          (c) => c.data.tags.reportName === input.type,
         );
       }
 

--- a/src/libswamp/reports/search_test.ts
+++ b/src/libswamp/reports/search_test.ts
@@ -133,6 +133,99 @@ Deno.test("reportSearch - filters by scope", async () => {
   }
 });
 
+Deno.test("reportSearch - filters by exact report type", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const costReport = makeReportData(
+    "report-cost",
+    "@webframp/cost-audit-report",
+    "model",
+  );
+  const secReport = makeReportData(
+    "report-security",
+    "@webframp/security-report",
+    "model",
+  );
+
+  const deps = makeDeps([
+    { data: costReport, modelType, modelId: "test-id" },
+    { data: secReport, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportSearch(ctx, deps, { type: "@webframp/cost-audit-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(
+      last.data.reports[0].reportName,
+      "@webframp/cost-audit-report",
+    );
+  }
+});
+
+Deno.test("reportSearch - type filter is exact, not substring", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const costReport = makeReportData(
+    "report-cost",
+    "@webframp/cost-audit-report",
+    "model",
+  );
+
+  const deps = makeDeps([
+    { data: costReport, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  // A substring of the type name must not match — exact matching only.
+  const events = await collect(
+    reportSearch(ctx, deps, { type: "cost-audit-report" }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 0);
+  }
+});
+
+Deno.test("reportSearch - type filter composes with scope filter", async () => {
+  const modelType = ModelType.create("aws/ec2");
+  const costModel = makeReportData(
+    "report-cost-model",
+    "@webframp/cost-audit-report",
+    "model",
+  );
+  const costMethod = makeReportData(
+    "report-cost-method",
+    "@webframp/cost-audit-report",
+    "method",
+  );
+
+  const deps = makeDeps([
+    { data: costModel, modelType, modelId: "test-id" },
+    { data: costMethod, modelType, modelId: "test-id" },
+  ]);
+
+  const ctx = createLibSwampContext();
+  const events = await collect(
+    reportSearch(ctx, deps, {
+      type: "@webframp/cost-audit-report",
+      scope: "method",
+    }),
+  );
+  const last = events[events.length - 1];
+
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.reports.length, 1);
+    assertEquals(last.data.reports[0].reportScope, "method");
+  }
+});
+
 Deno.test("reportSearch - filters by query", async () => {
   const modelType = ModelType.create("aws/ec2");
   const costReport = makeReportData("report-cost", "cost-report", "model");


### PR DESCRIPTION
## Summary

Adds a `--type <report-name>` filter to `swamp report search` so users can
narrow stored reports to an exact report type name across all models and
workflows (e.g. `swamp report search --type @webframp/cost-audit-report`).

The report type name is already stored on every report artifact as the
`reportName` tag and is already shown in search results, so this is a pure
filter addition — **no schema or data-model changes**.

`--type` is an **exact match**, deliberately distinct from the positional
`[query]` substring match. This provides the precise type matching that the
existing `--label` workaround cannot. The filter runs after `--scope` and
before the `--label` filter so it shrinks the candidate set ahead of the
per-candidate definition lookups the label filter performs.

Also documents the previously-undocumented `report search` browse command and
all its flags in the `swamp-report` skill.

Resolves swamp-club#498.

## Changes

- `src/libswamp/reports/search.ts` — `type?: string` on `ReportSearchInput`; exact-match filter block
- `src/cli/commands/report_search.ts` — `--type <name>` CLI option, passed into the search input
- `src/libswamp/reports/search_test.ts` — 3 tests: exact match, exact-not-substring, composes with `--scope`
- `.claude/skills/swamp-report/SKILL.md` — documents the `report search` browse command and flags

## Test Plan

- `deno fmt --check`, `deno check`, `deno lint` — all pass
- `deno run test src/libswamp/reports/search_test.ts` — 12 passed
- End-to-end against a compiled binary: `--type "@swamp/method-summary"` returns the report; `--type "method-summary"` (substring) returns nothing, confirming exact matching through the full stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)