### PR TITLE
fix(datastore): reclaim catalog space via manual rebuild instead of VACUUM (swamp-club#494)

### DIFF
--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -83,14 +83,35 @@ export interface CatalogCheckpointStats {
  */
 export const CATALOG_SCHEMA_VERSION = "4";
 
+/**
+ * A value SQLite can round-trip when copying rows generically during
+ * compaction. Mirrors node:sqlite's supported bind/output value union.
+ */
+type SqlValue = null | number | bigint | string | Uint8Array;
+
 export class CatalogStore {
-  private readonly db: DatabaseSync;
+  private db: DatabaseSync;
+  private readonly dbPath: string;
+  private closed = false;
 
   constructor(dbPath: string) {
-    ensureDirSync(dirname(dbPath));
-    this.db = new DatabaseSync(dbPath);
-    this.db.exec("PRAGMA busy_timeout=5000");
+    this.dbPath = dbPath;
+    this.db = this.openConnection(dbPath);
     this.initializeWithRetry();
+  }
+
+  /**
+   * Opens a SQLite connection at `path` and applies the baseline pragma shared
+   * by initial construction and the post-compaction reopen. WAL mode is
+   * established separately — with retry by {@link initializeWithRetry} on the
+   * constructor path, and explicitly on the reopen path in {@link vacuum} — so
+   * this helper only sets `busy_timeout`.
+   */
+  private openConnection(path: string): DatabaseSync {
+    ensureDirSync(dirname(path));
+    const db = new DatabaseSync(path);
+    db.exec("PRAGMA busy_timeout=5000");
+    return db;
   }
 
   /**
@@ -569,30 +590,162 @@ export class CatalogStore {
   }
 
   /**
-   * Runs VACUUM to rebuild the database file and reclaim freed pages.
+   * Rebuilds the database file to reclaim freed pages — a manual VACUUM.
    *
-   * Must be called outside any open transaction. Acquires an exclusive lock
-   * and rewrites the entire database file — on a large catalog this may take
-   * several seconds. Safe to call only when no other connections are active.
+   * SQLite's native `VACUUM` (and `VACUUM INTO`) cannot run under Deno's
+   * node:sqlite binding: both ATTACH a temporary database internally, but the
+   * binding hardcodes `SQLITE_LIMIT_ATTACHED` to 0, so the attach is rejected
+   * with "too many attached databases - max 0". Instead we rebuild manually:
+   * copy the schema and stream every row into a fresh single-file database via
+   * a second connection (no ATTACH), then atomically swap it into place.
    *
-   * Returns `true` if VACUUM succeeded, `false` if it was skipped due to a
-   * runtime limitation (e.g. SQLITE_LIMIT_ATTACHED=0 in the canary Deno
-   * runtime).
+   * The rows are paged by rowid in {@link ITERATE_PAGE_SIZE} batches so a large
+   * catalog is never loaded into memory at once. The rebuild transiently needs
+   * roughly twice the catalog size in free disk (old file plus the temp file)
+   * — the same requirement as native VACUUM.
+   *
+   * Must be called outside any open transaction and only when no other
+   * connection is writing the catalog — the compact command holds the
+   * datastore-global lock for this reason. Returns `true` on success, or
+   * `false` (after logging a warning) if the rebuild failed, preserving the
+   * graceful-degradation contract: the WAL checkpoint already reclaimed space.
    */
   vacuum(): boolean {
+    const tmpPath = `${this.dbPath}.compact`;
     try {
-      this.db.exec("VACUUM");
-      return true;
+      this.rebuildInto(tmpPath);
     } catch (error) {
       logger.warn`VACUUM skipped: ${error}`;
+      this.removeDbFiles(tmpPath);
       return false;
+    }
+
+    // Swap the rebuilt file into place. Close first so Windows releases the
+    // handle, then drop the stale WAL/SHM sidecars of the old file before the
+    // rename so they cannot shadow the new database.
+    this.db.close();
+    this.removeDbFiles(this.dbPath, { keepMain: true });
+    try {
+      // POSIX renameSync atomically replaces the destination.
+      Deno.renameSync(tmpPath, this.dbPath);
+    } catch {
+      // Windows rejects rename onto an existing file — remove then rename.
+      try {
+        Deno.removeSync(this.dbPath);
+      } catch {
+        // Already gone — nothing to remove.
+      }
+      Deno.renameSync(tmpPath, this.dbPath);
+    }
+
+    // Reopen so the store stays valid for the caller, restoring WAL mode. No
+    // other process can be opening concurrently (compact holds the global
+    // lock), so WAL can be set eagerly without the constructor's retry.
+    this.db = this.openConnection(this.dbPath);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    return true;
+  }
+
+  /**
+   * Rebuilds the catalog into a fresh database at `targetPath`. Copies all DDL
+   * (tables before indexes/triggers/views) then streams every row of every
+   * user table inside a single transaction. Throws on any failure; the caller
+   * cleans up `targetPath`.
+   */
+  private rebuildInto(targetPath: string): void {
+    // Clear any stale temp artifacts from a previous interrupted run.
+    this.removeDbFiles(targetPath);
+
+    // Default rollback-journal mode keeps the rebuilt DB to a single file (no
+    // -wal/-shm to orphan), which the swap then moves atomically.
+    const dst = new DatabaseSync(targetPath);
+    try {
+      const ddl = this.db.prepare(
+        `SELECT sql FROM sqlite_master
+         WHERE sql IS NOT NULL AND type IN ('table', 'index', 'trigger', 'view')
+         ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END`,
+      ).all() as { sql: string }[];
+      for (const { sql } of ddl) dst.exec(sql);
+
+      const tables = this.db.prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`,
+      ).all() as { name: string }[];
+
+      dst.exec("BEGIN IMMEDIATE");
+      try {
+        for (const { name } of tables) {
+          this.copyTableRows(dst, name);
+        }
+        dst.exec("COMMIT");
+      } catch (error) {
+        dst.exec("ROLLBACK");
+        throw error;
+      }
+    } finally {
+      dst.close();
     }
   }
 
   /**
-   * Closes the database connection.
+   * Streams every row of `table` from this database into `dst`, paging by
+   * rowid in {@link ITERATE_PAGE_SIZE} batches so the full table is never
+   * materialized in memory. Assumes a rowid table — both `catalog` and
+   * `catalog_meta` are ordinary rowid tables; a WITHOUT ROWID table would
+   * break this cursor.
+   */
+  private copyTableRows(dst: DatabaseSync, table: string): void {
+    const columns = (this.db.prepare(`PRAGMA table_info("${table}")`)
+      .all() as { name: string }[]).map((c) => c.name);
+    const colList = columns.map((c) => `"${c}"`).join(", ");
+    const placeholders = columns.map(() => "?").join(", ");
+    const insert = dst.prepare(
+      `INSERT INTO "${table}" (${colList}) VALUES (${placeholders})`,
+    );
+    const page = this.db.prepare(
+      `SELECT rowid AS __rowid, ${colList} FROM "${table}"
+       WHERE rowid > ? ORDER BY rowid LIMIT ?`,
+    );
+
+    let lastRowid = 0;
+    for (;;) {
+      const rows = page.all(lastRowid, ITERATE_PAGE_SIZE) as Record<
+        string,
+        SqlValue
+      >[];
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        insert.run(...columns.map((c) => row[c]));
+        lastRowid = Number(row.__rowid);
+      }
+      if (rows.length < ITERATE_PAGE_SIZE) break;
+    }
+  }
+
+  /**
+   * Removes a SQLite database file and its WAL/SHM sidecars, ignoring any that
+   * are already absent. Pass `keepMain` to drop only the sidecars.
+   */
+  private removeDbFiles(path: string, opts: { keepMain?: boolean } = {}): void {
+    const targets = opts.keepMain ? [] : [path];
+    targets.push(`${path}-wal`, `${path}-shm`);
+    for (const target of targets) {
+      try {
+        Deno.removeSync(target);
+      } catch {
+        // Missing file — nothing to remove.
+      }
+    }
+  }
+
+  /**
+   * Closes the database connection. Idempotent — a second call is a no-op, so
+   * a `finally { close() }` cannot mask an earlier reopen failure (node:sqlite
+   * throws "database is not open" on double-close).
    */
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.db.close();
   }
 }

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals, assertLess } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { DatabaseSync } from "node:sqlite";
 import {
@@ -591,6 +591,73 @@ Deno.test("CatalogStore: vacuum returns boolean and does not throw", () => {
   const result = store.vacuum();
   assertEquals(typeof result, "boolean");
 
+  store.close();
+});
+
+Deno.test("CatalogStore: vacuum reclaims space and preserves rows", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  // Insert enough fragmentation that the rebuild measurably shrinks the file,
+  // and enough rows to span multiple ITERATE_PAGE_SIZE batches.
+  const bloat = "x".repeat(400);
+  const total = ITERATE_PAGE_SIZE * 3 + 7;
+  for (let version = 1; version <= total; version++) {
+    store.upsert(makeRow({ version, id: `id-${version}`, tags: bloat }));
+  }
+  // Delete the even versions to free pages and fragment the file.
+  for (let version = 2; version <= total; version += 2) {
+    store.removeVersion("", "test-model", "model-001", "my-data", version);
+  }
+  store.checkpoint();
+
+  const before = Deno.statSync(dbPath).size;
+  const survivors = store.count();
+
+  assertEquals(store.vacuum(), true);
+
+  const after = Deno.statSync(dbPath).size;
+  assertLess(after, before);
+  // No data lost: the same rows remain and are still queryable.
+  assertEquals(store.count(), survivors);
+  store.close();
+
+  // The swapped-in file is intact: a fresh store sees identical data.
+  const reopened = new CatalogStore(dbPath);
+  assertEquals(reopened.count(), survivors);
+  const versions = [...reopened.iterate()].map((r) => r.version).sort((a, b) =>
+    a - b
+  );
+  assertEquals(versions[0], 1);
+  assert(versions.every((v) => v % 2 === 1));
+  reopened.close();
+});
+
+Deno.test("CatalogStore: vacuum on an empty catalog returns true and keeps schema", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  assertEquals(store.vacuum(), true);
+
+  // Schema survived the rebuild — the store is still writable and readable.
+  store.upsert(makeRow());
+  assertEquals(store.count(), 1);
+  store.close();
+});
+
+Deno.test("CatalogStore: store is usable after vacuum and close is idempotent", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+  store.upsert(makeRow({ version: 1 }));
+
+  assertEquals(store.vacuum(), true);
+
+  // The reopened connection accepts further writes and reads.
+  store.upsert(makeRow({ version: 2 }));
+  assertEquals(store.count(), 2);
+
+  store.close();
+  // A second close must not throw (node:sqlite errors on double-close).
   store.close();
 });
 

--- a/src/presentation/renderers/datastore_compact.ts
+++ b/src/presentation/renderers/datastore_compact.ts
@@ -49,7 +49,7 @@ class LogDatastoreCompactRenderer implements Renderer<DatastoreCompactEvent> {
         }
         if (e.data.vacuumSkipped) {
           logger
-            .warn`VACUUM skipped (runtime limitation) — WAL checkpoint still reclaimed space`;
+            .warn`Catalog rebuild skipped — WAL checkpoint still reclaimed space`;
         } else if (e.data.dbBytesReclaimed > 0) {
           logger
             .info`Catalog compacted: reclaimed ${e.data.dbBytesReclaimed} bytes`;


### PR DESCRIPTION
## Summary

`swamp datastore compact` always failed its VACUUM step with `VACUUM skipped: too many attached databases - max 0` (`ERR_SQLITE_ERROR`), so it never reclaimed fragmented pages — only the WAL checkpoint freed any space.

**Root cause:** SQLite's native `VACUUM` (and `VACUUM INTO`) cannot run under Deno's `node:sqlite` binding. Both ATTACH a temporary database internally, but the binding hardcodes `SQLITE_LIMIT_ATTACHED` to `0`, so the attach is rejected. Confirmed reproducible under both `deno run` and the compiled binary — VACUUM has never functioned in this runtime (PR #1340 only made the failure skip gracefully). Reproduced end-to-end on a fresh repo with no datastore configured, confirming the fault is purely in the local catalog.

**Fix:** Replace the `VACUUM` call in `CatalogStore.vacuum()` with a manual rebuild that never uses ATTACH:

- Copy all DDL from `sqlite_master` (tables before indexes/triggers/views) into a fresh single-file database via a second connection.
- Stream every row of every user table by **rowid in `ITERATE_PAGE_SIZE` (1000) batches** inside one transaction, so a large (giga-swamp) catalog is never materialized in memory.
- Atomically swap the rebuilt file into place (POSIX rename-replace, with a remove-then-rename fallback for Windows), dropping the old WAL/SHM sidecars, then reopen and restore WAL mode.
- `close()` is now idempotent so the CLI's `finally { close() }` cannot mask a reopen failure (`node:sqlite` throws on double-close).

`catalog_meta` (`schema_version`, `populated`) is copied by the generic table pass, so reopening does not trigger a destructive re-migration or needless backfill. The `vacuum()` `(): boolean` contract and the `DatastoreCompactDeps` boundary are unchanged, so the libswamp compact operation and CLI command are untouched. The renderer's skip wording is softened (JSON shape unchanged).

## Test Plan

- New unit tests in `catalog_store_test.ts`:
  - reclaims space and preserves rows (3000+ rows, deletes half, crosses the page boundary, asserts file size strictly decreases and a reopened store sees identical data)
  - vacuum on an empty catalog returns true and keeps the schema
  - store is usable after vacuum, and a second `close()` is a no-op
- `deno check`, `deno lint`, `deno fmt --check` all clean.
- Full suite: **6524 passed, 0 failed**.
- Compiled-binary end-to-end against a scratch repo: the `VACUUM skipped` warning is gone and `swamp datastore compact --json` reports `"vacuumSkipped": false` (previously `true`).

Fixes swamp-club#494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)