### PR TITLE
fix(http): honor OS/system CA trust store by default (swamp-club#503)

### DIFF
--- a/integration/tls_trust_test.ts
+++ b/integration/tls_trust_test.ts
@@ -1,0 +1,260 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+
+/**
+ * Integration coverage for the TLS trust-store shim (issue #503).
+ *
+ * These tests drive the REAL `configureTlsTrust` code path in fresh
+ * subprocesses — Deno reads its TLS CA environment lazily and caches the rustls
+ * root store on first use, so each scenario must run in its own process. Using
+ * the actual module (rather than a hand-rolled fetch client) guards the wiring:
+ * if `configureTlsTrust` stopped mapping SSL_CERT_FILE, these would fail.
+ *
+ * Coverage boundary: the `system` trust-store branch cannot be exercised
+ * without mutating the operating-system trust store, so these tests use the
+ * SSL_CERT_FILE -> DENO_CERT mapping as the testable proxy for the lazy-env
+ * mechanism. The public-TLS assertion is offline-tolerant.
+ */
+
+const TLS_TRUST_MODULE = toFileUrl(
+  join(
+    import.meta.dirname!,
+    "..",
+    "src",
+    "infrastructure",
+    "runtime",
+    "tls_trust.ts",
+  ),
+).href;
+
+/** Returns true if `openssl` is available on PATH. */
+async function hasOpenssl(): Promise<boolean> {
+  try {
+    const { success } = await new Deno.Command("openssl", {
+      args: ["version"],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    return success;
+  } catch {
+    return false;
+  }
+}
+
+/** Generates a private CA and a localhost leaf cert signed by it. */
+async function generateCertChain(dir: string): Promise<{
+  caPath: string;
+  fullchainPath: string;
+  leafKeyPath: string;
+}> {
+  const run = async (args: string[]) => {
+    const { success, stderr } = await new Deno.Command("openssl", {
+      args,
+      stdout: "null",
+      stderr: "piped",
+    }).output();
+    if (!success) {
+      throw new Error(
+        `openssl ${args.join(" ")} failed: ${new TextDecoder().decode(stderr)}`,
+      );
+    }
+  };
+
+  const caKey = join(dir, "ca.key");
+  const caPath = join(dir, "ca.pem");
+  const leafKeyPath = join(dir, "leaf.key");
+  const leafCsr = join(dir, "leaf.csr");
+  const leafPath = join(dir, "leaf.pem");
+  const fullchainPath = join(dir, "fullchain.pem");
+  const extPath = join(dir, "leaf.ext");
+
+  await run([
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    caKey,
+    "-out",
+    caPath,
+    "-days",
+    "1",
+    "-subj",
+    "/CN=Test Private Root CA",
+  ]);
+  await run([
+    "req",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    leafKeyPath,
+    "-out",
+    leafCsr,
+    "-subj",
+    "/CN=localhost",
+  ]);
+  await Deno.writeTextFile(extPath, "subjectAltName=DNS:localhost\n");
+  await run([
+    "x509",
+    "-req",
+    "-in",
+    leafCsr,
+    "-CA",
+    caPath,
+    "-CAkey",
+    caKey,
+    "-CAcreateserial",
+    "-out",
+    leafPath,
+    "-days",
+    "1",
+    "-extfile",
+    extPath,
+  ]);
+
+  const leaf = await Deno.readTextFile(leafPath);
+  const ca = await Deno.readTextFile(caPath);
+  await Deno.writeTextFile(fullchainPath, leaf + ca);
+
+  return { caPath, fullchainPath, leafKeyPath };
+}
+
+/**
+ * Runs a small client in a subprocess. The client optionally calls the real
+ * `configureTlsTrust`, then fetches `url`. Returns the captured RESULT line.
+ * The subprocess env is fully controlled (clearEnv) so the test is
+ * deterministic regardless of the developer's shell.
+ */
+async function runClient(opts: {
+  url: string;
+  callShim: boolean;
+  env: Record<string, string>;
+}): Promise<string> {
+  const script = `
+import { configureTlsTrust } from ${JSON.stringify(TLS_TRUST_MODULE)};
+if (${opts.callShim}) configureTlsTrust();
+try {
+  const r = await fetch(${JSON.stringify(opts.url)});
+  console.log("RESULT:OK:" + r.status);
+} catch (e) {
+  console.log("RESULT:ERR:" + (e instanceof Error ? e.message : String(e)));
+}
+`;
+  // Preserve PATH/HOME/DENO_DIR so deno can resolve its cache, but drop any
+  // ambient TLS vars unless the scenario sets them explicitly.
+  const baseEnv: Record<string, string> = {};
+  for (const key of ["PATH", "HOME", "DENO_DIR", "TMPDIR", "SystemRoot"]) {
+    const v = Deno.env.get(key);
+    if (v) baseEnv[key] = v;
+  }
+  const { stdout } = await spawnWithStdin(script, { ...baseEnv, ...opts.env });
+  const out = new TextDecoder().decode(stdout);
+  const line = out.split("\n").find((l) => l.startsWith("RESULT:")) ??
+    out.trim();
+  return line;
+}
+
+/** Spawns `deno run -` feeding the script via stdin. */
+async function spawnWithStdin(
+  script: string,
+  env: Record<string, string>,
+): Promise<{ stdout: Uint8Array }> {
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-net", "--allow-read", "--allow-env", "-"],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "null",
+    clearEnv: true,
+    env,
+  }).spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(script));
+  await writer.close();
+  const { stdout } = await child.output();
+  return { stdout };
+}
+
+Deno.test("tls_trust integration: shim resolves a private-CA chain via SSL_CERT_FILE", async () => {
+  if (!(await hasOpenssl())) {
+    console.warn("skipping: openssl not available");
+    return;
+  }
+
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tls-trust-" });
+  try {
+    const { caPath, fullchainPath, leafKeyPath } = await generateCertChain(dir);
+    const cert = await Deno.readTextFile(fullchainPath);
+    const key = await Deno.readTextFile(leafKeyPath);
+
+    const ac = new AbortController();
+    const server = Deno.serve(
+      { port: 0, cert, key, signal: ac.signal, onListen: () => {} },
+      () => new Response("ok"),
+    );
+    const port = (server.addr as Deno.NetAddr).port;
+    const url = `https://localhost:${port}/`;
+
+    try {
+      // (a) Default behavior with no extra trust: the private CA is unknown.
+      const noTrust = await runClient({ url, callShim: false, env: {} });
+      assertStringIncludes(noTrust, "RESULT:ERR:");
+      assertStringIncludes(noTrust, "UnknownIssuer");
+
+      // (b) The real shim maps SSL_CERT_FILE -> DENO_CERT and the call succeeds.
+      const withShim = await runClient({
+        url,
+        callShim: true,
+        env: { SSL_CERT_FILE: caPath },
+      });
+      assertStringIncludes(withShim, "RESULT:OK:200");
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("tls_trust integration: public TLS still works under the merged store", async () => {
+  // The shim defaults DENO_TLS_CA_STORE to system,mozilla; mozilla roots must
+  // still validate public endpoints. Offline-tolerant: a connection/DNS error
+  // is skipped, but a certificate error is a real failure.
+  const result = await runClient({
+    url: "https://example.com/",
+    callShim: true,
+    env: {},
+  });
+  if (result.includes("RESULT:OK:")) {
+    assert(true);
+    return;
+  }
+  // Tolerate offline CI; fail only on certificate-trust regressions.
+  assert(
+    !result.includes("UnknownIssuer") &&
+      !result.includes("invalid peer certificate"),
+    `public TLS failed with a certificate error under the merged store: ${result}`,
+  );
+  console.warn(`skipping public-TLS assertion (offline?): ${result}`);
+});

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { runCli } from "./src/cli/mod.ts";
+import { configureTlsTrust } from "./src/infrastructure/runtime/tls_trust.ts";
 import { initializeLogging } from "./src/infrastructure/logging/logger.ts";
 import { renderError } from "./src/presentation/output/error_output.ts";
 import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_sync_coordinator.ts";
@@ -29,6 +30,10 @@ import {
 } from "./src/infrastructure/tracing/mod.ts";
 
 if (import.meta.main) {
+  // Configure TLS trust before any network I/O so Deno honors the OS trust
+  // store (and SSL_CERT_FILE) when it first builds its TLS root store.
+  configureTlsTrust();
+
   const parentCtx = await initTracing();
   try {
     await runWithParentTrace(parentCtx, () => runCli(Deno.args));

--- a/src/infrastructure/runtime/tls_trust.ts
+++ b/src/infrastructure/runtime/tls_trust.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * TLS trust-store configuration for the compiled swamp binary.
+ *
+ * swamp ships as a `deno compile` artifact, so every fetch-based TLS call
+ * (registry, model HTTP APIs, source download, update check, telemetry)
+ * validates against Deno's bundled Mozilla roots and, by default, ignores the
+ * operating-system trust store. Behind a TLS-inspecting middlebox or a
+ * privately-rooted CA installed in the OS store, every HTTPS call fails with
+ * `invalid peer certificate: UnknownIssuer`.
+ *
+ * Deno reads its TLS CA environment variables lazily (when the rustls root
+ * store is first built for a connection), so setting them in-process before the
+ * first network call is honored — no re-exec is required. Child processes
+ * spawned via `Deno.Command` inherit this environment, so the embedded-deno
+ * subprocesses (registry push/bundle) are covered too.
+ *
+ * Note: the OpenSSL `SSL_CERT_DIR` directory convention is intentionally NOT
+ * handled. Deno's `DENO_CERT` accepts a single PEM file only and has no
+ * directory equivalent; users relying on a cert directory are covered by the
+ * `system` trust-store default instead.
+ */
+
+/** Environment variable names this module consults and may set. */
+const DENO_TLS_CA_STORE = "DENO_TLS_CA_STORE";
+const DENO_CERT = "DENO_CERT";
+const SSL_CERT_FILE = "SSL_CERT_FILE";
+
+/**
+ * The default trust store. `system` adds the OS trust store; `mozilla` keeps
+ * Deno's bundled roots so public TLS still works even when the OS store is
+ * empty or misconfigured.
+ */
+const DEFAULT_CA_STORE = "system,mozilla";
+
+/** A snapshot of the environment variables relevant to TLS trust. */
+export interface TlsTrustEnv {
+  DENO_TLS_CA_STORE?: string;
+  DENO_CERT?: string;
+  SSL_CERT_FILE?: string;
+}
+
+/**
+ * Pure decision function: given a snapshot of the relevant environment
+ * variables, return the mutations to apply. Never overrides a value the user
+ * has already set. Empty strings are treated as unset.
+ */
+export function computeTlsTrustEnv(
+  env: TlsTrustEnv,
+): Record<string, string> {
+  const mutations: Record<string, string> = {};
+
+  // Default to merging the OS trust store with Deno's bundled roots, unless the
+  // user has explicitly chosen a store.
+  if (!env.DENO_TLS_CA_STORE) {
+    mutations[DENO_TLS_CA_STORE] = DEFAULT_CA_STORE;
+  }
+
+  // Honor the conventional OpenSSL `SSL_CERT_FILE` by mapping it to the variable
+  // Deno actually reads (`DENO_CERT`), unless the user already set `DENO_CERT`.
+  if (env.SSL_CERT_FILE && !env.DENO_CERT) {
+    mutations[DENO_CERT] = env.SSL_CERT_FILE;
+  }
+
+  return mutations;
+}
+
+/**
+ * Apply the TLS trust configuration to the current process environment. Must be
+ * called before any network I/O so Deno picks up the values when it first
+ * builds its TLS root store.
+ */
+export function configureTlsTrust(): void {
+  const mutations = computeTlsTrustEnv({
+    DENO_TLS_CA_STORE: Deno.env.get(DENO_TLS_CA_STORE),
+    DENO_CERT: Deno.env.get(DENO_CERT),
+    SSL_CERT_FILE: Deno.env.get(SSL_CERT_FILE),
+  });
+
+  for (const [key, value] of Object.entries(mutations)) {
+    Deno.env.set(key, value);
+  }
+}

--- a/src/infrastructure/runtime/tls_trust_test.ts
+++ b/src/infrastructure/runtime/tls_trust_test.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { computeTlsTrustEnv } from "./tls_trust.ts";
+
+Deno.test("computeTlsTrustEnv: defaults DENO_TLS_CA_STORE to system,mozilla when unset", () => {
+  const mutations = computeTlsTrustEnv({});
+  assertEquals(mutations["DENO_TLS_CA_STORE"], "system,mozilla");
+});
+
+Deno.test("computeTlsTrustEnv: respects an explicitly set DENO_TLS_CA_STORE", () => {
+  const mutations = computeTlsTrustEnv({ DENO_TLS_CA_STORE: "mozilla" });
+  assertEquals(mutations["DENO_TLS_CA_STORE"], undefined);
+});
+
+Deno.test("computeTlsTrustEnv: respects DENO_TLS_CA_STORE set to system", () => {
+  const mutations = computeTlsTrustEnv({ DENO_TLS_CA_STORE: "system" });
+  assertEquals(mutations["DENO_TLS_CA_STORE"], undefined);
+});
+
+Deno.test("computeTlsTrustEnv: treats empty-string DENO_TLS_CA_STORE as unset", () => {
+  const mutations = computeTlsTrustEnv({ DENO_TLS_CA_STORE: "" });
+  assertEquals(mutations["DENO_TLS_CA_STORE"], "system,mozilla");
+});
+
+Deno.test("computeTlsTrustEnv: maps SSL_CERT_FILE to DENO_CERT when DENO_CERT unset", () => {
+  const mutations = computeTlsTrustEnv({ SSL_CERT_FILE: "/etc/ca-bundle.pem" });
+  assertEquals(mutations["DENO_CERT"], "/etc/ca-bundle.pem");
+});
+
+Deno.test("computeTlsTrustEnv: does not override an explicitly set DENO_CERT", () => {
+  const mutations = computeTlsTrustEnv({
+    SSL_CERT_FILE: "/etc/ca-bundle.pem",
+    DENO_CERT: "/etc/explicit.pem",
+  });
+  assertEquals(mutations["DENO_CERT"], undefined);
+});
+
+Deno.test("computeTlsTrustEnv: treats empty-string SSL_CERT_FILE as unset", () => {
+  const mutations = computeTlsTrustEnv({ SSL_CERT_FILE: "" });
+  assertEquals(mutations["DENO_CERT"], undefined);
+});
+
+Deno.test("computeTlsTrustEnv: ignores SSL_CERT_DIR (no DENO_CERT directory equivalent)", () => {
+  // SSL_CERT_DIR is intentionally unsupported — it is not part of the snapshot
+  // and must never produce a mutation. Only the CA-store default is applied.
+  const mutations = computeTlsTrustEnv(
+    { SSL_CERT_FILE: undefined } as Record<string, string | undefined>,
+  );
+  assertEquals(mutations["DENO_CERT"], undefined);
+  assertEquals(mutations["DENO_TLS_CA_STORE"], "system,mozilla");
+});
+
+Deno.test("computeTlsTrustEnv: applies both mutations together", () => {
+  const mutations = computeTlsTrustEnv({ SSL_CERT_FILE: "/etc/ca-bundle.pem" });
+  assertEquals(mutations, {
+    DENO_TLS_CA_STORE: "system,mozilla",
+    DENO_CERT: "/etc/ca-bundle.pem",
+  });
+});
+
+Deno.test("computeTlsTrustEnv: no mutations when user has set everything", () => {
+  const mutations = computeTlsTrustEnv({
+    DENO_TLS_CA_STORE: "system",
+    DENO_CERT: "/etc/explicit.pem",
+    SSL_CERT_FILE: "/etc/ca-bundle.pem",
+  });
+  assertEquals(mutations, {});
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#503. swamp ships as a `deno compile` artifact, so all fetch-based TLS (registry, model HTTP APIs, source download, update check, telemetry) validated only against Deno's bundled Mozilla roots and ignored the OS trust store. Behind a TLS-inspecting middlebox or a privately-rooted CA installed in the OS store, every HTTPS call failed with `invalid peer certificate: UnknownIssuer`.

This adds a startup shim (`configureTlsTrust`) called as the **first statement** in `main.ts`, before any network I/O:

- Defaults `DENO_TLS_CA_STORE` → `system,mozilla` when unset — merges the OS trust store with Deno's bundled roots, so public TLS keeps working even if the OS store is empty/misconfigured.
- Maps `SSL_CERT_FILE` → `DENO_CERT` when `DENO_CERT` is unset — Deno honors `DENO_CERT`, not the conventional OpenSSL `SSL_CERT_FILE`.
- Always respects user-set `DENO_TLS_CA_STORE` / `DENO_CERT`.
- `SSL_CERT_DIR` is intentionally unsupported (`DENO_CERT` takes a single PEM file only; the `system` store default covers that case).

Deno reads these TLS CA env vars **lazily**, so setting them in-process before the first fetch is honored with no re-exec — and child processes inherit the env, so the embedded-deno subprocesses (registry push/bundle) are covered too.

### Changes

- `src/infrastructure/runtime/tls_trust.ts` (new) — pure `computeTlsTrustEnv` + impure `configureTlsTrust`.
- `main.ts` — call `configureTlsTrust()` first, before `initTracing()`.
- `src/infrastructure/runtime/tls_trust_test.ts` (new) — 10 unit tests.
- `integration/tls_trust_test.ts` (new) — drives the real shim in subprocesses against a private-CA HTTPS server.

## Test Plan

- `deno check`, `deno lint`, `deno fmt --check` — clean.
- `deno run test` — full suite, 6536 passed / 0 failed.
- Unit tests cover the decision matrix (default store, user override, `SSL_CERT_FILE` mapping, `SSL_CERT_DIR` ignored, empty-as-unset).
- Integration test reproduces the bug end-to-end: a private-CA → `localhost` leaf chain over local HTTPS fails with `UnknownIssuer` by default, succeeds via `SSL_CERT_FILE` through the real `configureTlsTrust`, and confirms public TLS still works under the merged store.
- Verified the compiled binary (`deno run compile`) makes real registry HTTPS calls cleanly with the shim in place.

## Follow-ups

- swamp-club Lab #509 — docs page on TLS behind proxies / private CAs.
- swamp-uat #248 — adversarial UAT for TLS-trust behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)