### PR TITLE
feat(extension): check for an adversarial review at extension push (swamp-club#500)

### DIFF
--- a/.claude/skills/swamp-extension-publish/SKILL.md
+++ b/.claude/skills/swamp-extension-publish/SKILL.md
@@ -176,7 +176,10 @@ swamp extension push manifest.yaml --dry-run --json
 
 **Verify:** Exit code 0. Confirm any warnings with the user.
 
-**On Failure:** See
+**On Failure:** If the dry-run reports a missing or incomplete adversarial
+review report, the review gate is unsatisfied. Complete the **Adversarial Review
+Gate** in the `swamp-extension` skill (write the content-hash-bound review
+report at the path the dry-run prints), then re-run. For other failures see
 [references/publishing.md](references/publishing.md#safety-rules).
 
 ## State 8: pushed

--- a/.claude/skills/swamp-extension/SKILL.md
+++ b/.claude/skills/swamp-extension/SKILL.md
@@ -279,15 +279,28 @@ All extension types follow the same lifecycle:
 
 ### Adversarial Review Gate
 
-> **STOP — do not skip.**
+> **`swamp extension push` checks for this.**
+>
+> `swamp extension push` warns and prompts for confirmation unless a complete,
+> content-hash-bound review report exists for the exact code being pushed. The
+> prompt is the gate — do not answer it blindly or pass `--yes` to dodge the
+> review. Editing any source (or bumping the version) changes the content hash
+> and asks for a fresh report.
 >
 > After authoring or **significantly modifying** extension code, and BEFORE
 > running smoke tests or unit tests:
 >
 > 1. Read [references/adversarial-review.md](references/adversarial-review.md)
->    and self-review against every applicable dimension.
-> 2. Produce the structured findings report described in that file.
-> 3. Present the report to the user and wait for acknowledgement.
+>    and review against every applicable dimension.
+> 2. Run `swamp extension push manifest.yaml --dry-run`. When no report exists,
+>    it prints the exact report path (a content-hash-bound file under the temp
+>    directory) and a JSON skeleton listing every applicable dimension.
+> 3. Write that skeleton to the printed path, setting each dimension's `verdict`
+>    to `pass`, `issue`, or `na` (with a `note` for anything not `pass`). Set
+>    `reviewedAt` to the current ISO-8601 timestamp.
+> 4. Present the findings to the user, then re-run the push. A missing, stale,
+>    or incomplete report (or any `issue` verdict) surfaces as a warning to
+>    confirm.
 
 ## Key Rules (All Types)
 

--- a/.claude/skills/swamp-extension/references/adversarial-review.md
+++ b/.claude/skills/swamp-extension/references/adversarial-review.md
@@ -18,6 +18,55 @@ and 6 (unit tests).
   dimensions)
 - Before publishing with `swamp extension push`
 
+## Recording the Review (checked at push)
+
+`swamp extension push` checks for this review. A missing, stale, or incomplete
+report surfaces as a warning the user must confirm before the push proceeds (it
+is not a hard block — a benign version bump should not brick a push). The report
+is bound to a content hash: any source change (or version bump) moves the report
+path, so a prior review no longer matches and a fresh one is requested.
+
+Workflow:
+
+1. Review the code against every applicable dimension below.
+2. Run `swamp extension push manifest.yaml --dry-run`. When no report exists,
+   the push prints the exact report path (a content-hash-bound JSON file under
+   the system temp directory) and a fill-in skeleton listing every applicable
+   dimension with `"verdict": "pending"`.
+3. Write the skeleton to the printed path, setting each dimension's `verdict`:
+   - `pass` — the dimension is satisfied.
+   - `issue` — a problem was found; add a `note`. (Surfaces as a push warning,
+     does not block.)
+   - `na` — the dimension does not apply (e.g. `api-contracts` for an extension
+     making no HTTP calls).
+   - Leave none as `pending` — a `pending` or missing verdict surfaces as a push
+     warning to confirm.
+   - Set `reviewedAt` to the current ISO-8601 timestamp.
+4. Present the findings to the user, then run `swamp extension push`.
+
+Report schema (the skeleton already has the right shape):
+
+```json
+{
+  "extension": "@collective/name",
+  "version": "2026.05.31.1",
+  "reviewedAt": "2026-05-31T21:00:00Z",
+  "dimensions": [
+    { "id": "credentials-secrets", "verdict": "pass" },
+    {
+      "id": "error-handling",
+      "verdict": "issue",
+      "note": "delete swallows 404"
+    }
+  ]
+}
+```
+
+The applicable dimension `id`s are the universal set plus the type-specific set
+for the content kinds present (the skeleton lists exactly these). The push gate
+checks that the report matches the extension name/version, covers every
+applicable dimension, and has no `pending` verdicts.
+
 ## Output Format
 
 Produce a structured findings report with one line per applicable dimension.

--- a/.claude/skills/swamp-report/SKILL.md
+++ b/.claude/skills/swamp-report/SKILL.md
@@ -15,17 +15,9 @@ description: >
 
 Create and run reports that analyze model and workflow executions. Reports
 produce markdown (human-readable) and JSON (machine-readable) output. All
-commands support `--json` for machine-readable output.
-
-## When to Create a Report
-
-Create a report extension when you need a **repeatable pipeline** to transform,
-aggregate, or analyze model output. If the analysis will be run more than once
-or should be stored alongside model data, a report is the right choice.
-
-**Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp report --help` or `swamp model method run --help` for the complete,
-up-to-date CLI schema.
+commands support `--json`. If unsure about exact flags or subcommands, run
+`swamp report --help` or `swamp model method run --help` for the up-to-date
+schema.
 
 ## Quick Reference
 
@@ -67,73 +59,19 @@ To create a new report extension, use the `swamp-extension` skill. It covers the
 TypeScript authoring workflow, export contract, scopes, reading execution data,
 and testing.
 
-## Three-Level Report Control Model
+## Report Control (Three Levels)
 
-Reports are controlled at three levels, from most general to most specific:
+Reports are selected at three levels, most general to most specific:
 
-### 1. Model Type Defaults (TypeScript `ModelDefinition`)
+1. **Model-type defaults** — `reports: [...]` on the model definition.
+2. **Definition YAML** — `reports.require` adds, `reports.skip` removes.
+3. **Workflow YAML** — workflow-scope reports plus per-run overrides.
 
-The `reports` field on model definitions lists standalone report names that are
-defaults for any model of this type:
-
-```typescript
-// extensions/models/my_model.ts
-export const model = {
-  type: "@myorg/ec2",
-  version: "2026.03.01.1",
-  reports: ["@myorg/cost-report", "@myorg/drift-report"],
-  // ... methods, resources, etc.
-};
-```
-
-### 2. Definition YAML Overrides (`reportSelection`)
-
-The `reports:` field in definition YAML provides per-definition overrides.
-`require` adds reports beyond model-type defaults. `skip` removes reports from
-the defaults.
-
-```yaml
-# definitions/my-vpc.yaml
-id: 550e8400-e29b-41d4-a716-446655440000
-name: my-vpc
-version: 1
-tags: {}
-reports:
-  require:
-    - "@myorg/compliance-report" # adds to model-type defaults
-    - name: security-audit # only run for these methods
-      methods: ["create", "delete"]
-  skip:
-    - "@myorg/drift-report" # removes from model-type defaults
-globalArguments:
-  cidrBlock: "10.0.0.0/16"
-methods:
-  create:
-    arguments: {}
-```
-
-### 3. Workflow YAML Overrides
-
-The `reports:` field in workflow YAML controls workflow-scope reports and can
-also override model-level reports for the workflow run.
-
-```yaml
-# workflows/deploy.yaml
-name: deploy
-reports:
-  require:
-    - "@myorg/workflow-summary" # workflow-scope report
-  skip:
-    - "@myorg/cost-report" # skip for all models in this workflow
-```
-
-### Filtering Semantics and Precedence
-
-The candidate set is built from model-type defaults plus `require`, minus
-`skip`, with CLI flags applied last. `skip` always wins over `require`, and
-`require` makes a report immune to CLI skip flags. See
-[references/filtering.md](references/filtering.md) for the full set composition
-and precedence rules.
+CLI flags apply last. `skip` always wins over `require`, and `require` makes a
+report immune to CLI skip flags. See
+[references/control-model.md](references/control-model.md) for the configuration
+examples at each level, and [references/filtering.md](references/filtering.md)
+for the full set composition and precedence rules.
 
 ## Publishing Reports
 
@@ -238,6 +176,9 @@ combine. Env vars: `SWAMP_REPORT_MAX_WIDTH`, `SWAMP_REPORT_MAX_COL_WIDTH`.
 - **Report API**: See [references/report-types.md](references/report-types.md)
   for full `ReportDefinition`, `ReportContext`, `ReportRegistry`, and
   `ReportSelection` type definitions
+- **Control model**: See
+  [references/control-model.md](references/control-model.md) for the
+  configuration examples at each of the three control levels
 - **Filtering**: See [references/filtering.md](references/filtering.md) for the
   full filtering semantics and precedence rules
 - **Testing**: See [references/testing.md](references/testing.md) for unit

--- a/.claude/skills/swamp-report/references/control-model.md
+++ b/.claude/skills/swamp-report/references/control-model.md
@@ -1,0 +1,66 @@
+# Three-Level Report Control Model
+
+Reports are controlled at three levels, from most general to most specific.
+
+## 1. Model Type Defaults (TypeScript `ModelDefinition`)
+
+The `reports` field on model definitions lists standalone report names that are
+defaults for any model of this type:
+
+```typescript
+// extensions/models/my_model.ts
+export const model = {
+  type: "@myorg/ec2",
+  version: "2026.03.01.1",
+  reports: ["@myorg/cost-report", "@myorg/drift-report"],
+  // ... methods, resources, etc.
+};
+```
+
+## 2. Definition YAML Overrides (`reportSelection`)
+
+The `reports:` field in definition YAML provides per-definition overrides.
+`require` adds reports beyond model-type defaults. `skip` removes reports from
+the defaults.
+
+```yaml
+# definitions/my-vpc.yaml
+id: 550e8400-e29b-41d4-a716-446655440000
+name: my-vpc
+version: 1
+tags: {}
+reports:
+  require:
+    - "@myorg/compliance-report" # adds to model-type defaults
+    - name: security-audit # only run for these methods
+      methods: ["create", "delete"]
+  skip:
+    - "@myorg/drift-report" # removes from model-type defaults
+globalArguments:
+  cidrBlock: "10.0.0.0/16"
+methods:
+  create:
+    arguments: {}
+```
+
+## 3. Workflow YAML Overrides
+
+The `reports:` field in workflow YAML controls workflow-scope reports and can
+also override model-level reports for the workflow run.
+
+```yaml
+# workflows/deploy.yaml
+name: deploy
+reports:
+  require:
+    - "@myorg/workflow-summary" # workflow-scope report
+  skip:
+    - "@myorg/cost-report" # skip for all models in this workflow
+```
+
+## Filtering Semantics and Precedence
+
+The candidate set is built from model-type defaults plus `require`, minus
+`skip`, with CLI flags applied last. `skip` always wins over `require`, and
+`require` makes a report immune to CLI skip flags. See
+[filtering.md](filtering.md) for the full set composition and precedence rules.

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -52,6 +52,7 @@ import {
   type QualityIssue,
 } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import type { ReviewFinding } from "../../domain/extensions/extension_review_rules.ts";
 import type {
   CollectiveMismatch,
 } from "../../domain/extensions/extension_collective_validator.ts";
@@ -346,6 +347,7 @@ export const extensionPushCommand = new Command()
         releaseNotes: options.releaseNotes,
         denoConfigPath,
         packageJsonDir,
+        contentHash: cacheHash,
         cachedArchive: cached?.archiveBytes,
       });
     } catch (error) {
@@ -355,6 +357,10 @@ export const extensionPushCommand = new Command()
         if (details?.dependencyTrustErrors) {
           renderer.renderDependencyTrustErrors(
             details.dependencyTrustErrors as DependencyTrustIssue[],
+          );
+        } else if (details?.reviewRuleErrors) {
+          renderer.renderReviewRuleErrors(
+            details.reviewRuleErrors as ReviewFinding[],
           );
         } else if (details?.safetyErrors) {
           renderer.renderSafetyErrors(
@@ -383,6 +389,9 @@ export const extensionPushCommand = new Command()
             );
             if (confirmed) {
               manifest.version = bumped.value;
+              // The version is part of the content hash, so bumping it
+              // changes the hash and therefore the review-report path.
+              const bumpedHash = await computePackageCacheHash(cacheHashInput);
               // Re-run prepare with bumped version
               try {
                 prepared = await extensionPushPrepare(ctx, prepareDeps, {
@@ -414,6 +423,7 @@ export const extensionPushCommand = new Command()
                   releaseNotes: options.releaseNotes,
                   denoConfigPath,
                   packageJsonDir,
+                  contentHash: bumpedHash,
                 });
               } catch (retryError) {
                 if (isSwampError(retryError)) {
@@ -466,17 +476,33 @@ export const extensionPushCommand = new Command()
       );
     }
 
+    // 6a. Handle review-rule warnings
+    if (prepared.reviewRulesResult.warnings.length > 0) {
+      renderer.renderReviewRuleWarnings(
+        prepared.reviewRulesResult.warnings,
+      );
+    }
+
     // 6b. Handle safety warnings
     if (prepared.safetyWarnings.length > 0) {
       renderer.renderSafetyWarnings(prepared.safetyWarnings);
-      if (!options.yes && cliCtx.outputMode === "log") {
-        const confirmed = await promptConfirmation(
-          "Continue with push despite warnings?",
-        );
-        if (!confirmed) {
-          renderExtensionPushCancelled(cliCtx.outputMode);
-          return;
-        }
+    }
+
+    // 6c. A single consolidated confirmation covers safety and review-rule
+    // warnings, so the user isn't prompted twice. Skipped on --dry-run, which
+    // performs no push and so has nothing to confirm.
+    const hasBlockableWarnings = prepared.safetyWarnings.length > 0 ||
+      prepared.reviewRulesResult.warnings.length > 0;
+    if (
+      hasBlockableWarnings && !prepared.isDryRun && !options.yes &&
+      cliCtx.outputMode === "log"
+    ) {
+      const confirmed = await promptConfirmation(
+        "Continue with push despite warnings?",
+      );
+      if (!confirmed) {
+        renderExtensionPushCancelled(cliCtx.outputMode);
+        return;
       }
     }
 

--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -80,6 +80,12 @@ export interface ReviewFinding {
   file: string;
   /** Actionable description of the issue. */
   message: string;
+  /**
+   * Optional fill-in report skeleton (JSON). Set only on the missing-report
+   * finding so JSON consumers get it as a discrete field rather than parsing
+   * it out of `message`.
+   */
+  skeleton?: string;
 }
 
 /**
@@ -509,12 +515,15 @@ export function evaluateReviewReport(
       dimension: REVIEW_REPORT_DIMENSION,
       severity: gate,
       file: ctx.reportPath,
-      // First line is self-sufficient (the path is the finding's `file`); the
-      // bulky skeleton follows for --json consumers. Log mode shows line one.
+      // Single-line, self-sufficient message (the path is the finding's
+      // `file`); the skeleton rides on its own field for JSON consumers.
+      // `--dry-run --json` is the safe incantation — `--json` alone would
+      // bypass the confirmation prompt and push without the review.
       message:
         "No adversarial review recorded for the current code — perform the " +
-        "review and write the report here (run with --json, or see the " +
-        `swamp-extension skill, for the fill-in skeleton).\n\nSkeleton:\n${ctx.skeleton}`,
+        "review and write the report here (run with --dry-run --json for the " +
+        "fill-in skeleton, or see the swamp-extension skill).",
+      skeleton: ctx.skeleton,
     });
     return findings;
   }

--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -1,0 +1,693 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { extname, join } from "@std/path";
+import { z } from "zod";
+
+/**
+ * Deterministic, push-time static rules for extensions.
+ *
+ * IMPORTANT: this is NOT the adversarial review. The adversarial review is a
+ * judgment pass performed by an AI agent (and by the CI
+ * `claude-adversarial-review` action) that reasons about intent across all
+ * dimensions — idempotency, API contracts, error-before-write, resource
+ * cleanup, and so on. Those cannot be decided by a static scan.
+ *
+ * This ruleset only enforces the small, mechanically-decidable floor (e.g.
+ * an empty-object `.passthrough()`, a missing sibling test, an unmarked
+ * sensitive field). It runs at push time exactly like the dependency-trust
+ * audit: findings carry a severity and the result partitions by it —
+ * `critical`/`high` block the push, `medium`/`low` only warn. It complements
+ * the adversarial review; it does not replace it.
+ *
+ * New checks are added as {@link ReviewRule} entries in
+ * {@link DEFAULT_REVIEW_RULES}. Each rule is self-contained: it declares the
+ * adversarial-review dimension it relates to (see
+ * `.claude/skills/swamp-extension/references/adversarial-review.md`), the
+ * content kinds it inspects, its severity, and a pure detector.
+ */
+
+/** Severity of a review-rule finding. Mirrors the CI review scale. */
+export type ReviewSeverity = "critical" | "high" | "medium" | "low";
+
+/** The extension content kinds a rule can inspect. */
+export type ExtensionContentKind =
+  | "model"
+  | "vault"
+  | "driver"
+  | "datastore"
+  | "report";
+
+/** A single source file presented to the ruleset. */
+export interface ReviewSource {
+  /** Absolute path of the source file. */
+  path: string;
+  /** Which content kind this file belongs to. */
+  kind: ExtensionContentKind;
+  /** File contents. */
+  content: string;
+  /** Whether this file is an entry point (the main implementation file). */
+  isEntryPoint: boolean;
+  /** Whether a sibling `<base>_test.ts` exists for this file. */
+  hasSiblingTest: boolean;
+}
+
+/** A finding emitted by a rule against a single source file. */
+export interface ReviewFinding {
+  /** The id of the rule that produced this finding. */
+  ruleId: string;
+  /** The adversarial-review dimension this rule relates to. */
+  dimension: string;
+  /** Severity — determines whether the finding blocks or only warns. */
+  severity: ReviewSeverity;
+  /** Absolute path of the offending file. */
+  file: string;
+  /** Actionable description of the issue. */
+  message: string;
+}
+
+/**
+ * A single review rule. Add new rules to {@link DEFAULT_REVIEW_RULES} to grow
+ * the enforced set.
+ */
+export interface ReviewRule {
+  /** Stable identifier, e.g. `schema-strictness`. */
+  id: string;
+  /** The adversarial-review dimension this rule relates to. */
+  dimension: string;
+  /** Severity assigned to every finding this rule emits. */
+  severity: ReviewSeverity;
+  /** Content kinds this rule inspects. */
+  appliesTo: ExtensionContentKind[];
+  /**
+   * Pure detector. Returns one message per issue found in `source`; an
+   * empty array means the file passes this rule. The framework attaches the
+   * rule's id, dimension, and severity.
+   */
+  detect: (source: ReviewSource) => string[];
+}
+
+/** Result of running the ruleset over a set of sources. */
+export interface ReviewRulesResult {
+  /** Findings whose severity is `critical` or `high` — these block the push. */
+  errors: ReviewFinding[];
+  /** Findings whose severity is `medium` or `low` — these only warn. */
+  warnings: ReviewFinding[];
+  /** True when there are no blocking (error) findings. */
+  passed: boolean;
+}
+
+/** Returns true when a severity blocks the push. */
+export function isBlockingSeverity(severity: ReviewSeverity): boolean {
+  return severity === "critical" || severity === "high";
+}
+
+// ── Detection helpers ─────────────────────────────────────────────────
+
+/**
+ * Strips `//` line comments from a single source line so detectors don't
+ * fire on commented-out code. Not a full tokenizer — block comments and
+ * string-literal occurrences are out of scope for this first cut.
+ */
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("//");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+/**
+ * Substrings that, in a field name, strongly suggest a secret value. Matched
+ * without word boundaries so camelCase fields like `apiToken` are caught.
+ */
+const SENSITIVE_FIELD_PATTERN =
+  /password|passwd|secret|token|api[_-]?key|access[_-]?key|credential|private[_-]?key/i;
+
+/** Matches `z.object({}).passthrough()` — an empty-object passthrough. */
+const EMPTY_OBJECT_PASSTHROUGH =
+  /z\s*\.\s*object\s*\(\s*\{\s*\}\s*\)\s*\.\s*passthrough\s*\(/;
+
+// ── Default ruleset ───────────────────────────────────────────────────
+
+/**
+ * The default review ruleset. All starter rules are non-blocking
+ * (`medium`/`low`) — none of the mechanical patterns is an unambiguous hard
+ * rule (the skill phrases every dimension as "should", and even
+ * `.passthrough()` is legitimate when properties are declared). The severity
+ * machinery still routes any future `critical`/`high` rule to the blocking
+ * path. Append new rules here.
+ */
+export const DEFAULT_REVIEW_RULES: ReviewRule[] = [
+  {
+    id: "schema-strictness",
+    dimension: "Schema strictness",
+    severity: "medium",
+    appliesTo: ["model"],
+    detect: (source) => {
+      const messages: string[] = [];
+      const lines = source.content.split("\n");
+      for (const line of lines) {
+        if (EMPTY_OBJECT_PASSTHROUGH.test(stripLineComment(line))) {
+          messages.push(
+            "Uses `z.object({}).passthrough()` with no declared properties — " +
+              "CEL expressions cannot validate against an empty schema. Declare " +
+              "the referenced properties explicitly.",
+          );
+        }
+      }
+      return messages;
+    },
+  },
+  {
+    id: "testing-completeness",
+    dimension: "Testing Completeness",
+    severity: "medium",
+    appliesTo: ["model", "vault", "driver", "datastore", "report"],
+    detect: (source) => {
+      if (!source.isEntryPoint) return [];
+      if (source.path.endsWith("_test.ts")) return [];
+      if (source.hasSiblingTest) return [];
+      return [
+        "No sibling `_test.ts` found — cover both success and failure paths " +
+        "with unit tests before publishing.",
+      ];
+    },
+  },
+  {
+    id: "credentials-sensitive-field",
+    dimension: "Credentials & Secrets",
+    severity: "medium",
+    appliesTo: ["model", "vault"],
+    detect: (source) => {
+      const messages: string[] = [];
+      const lines = source.content.split("\n");
+      for (const raw of lines) {
+        const line = stripLineComment(raw);
+        // Heuristic: a schema field whose name suggests a secret, declared
+        // with a zod type, but not marked sensitive on the same line.
+        if (
+          SENSITIVE_FIELD_PATTERN.test(line) &&
+          /z\s*\./.test(line) &&
+          !/sensitive/i.test(line)
+        ) {
+          messages.push(
+            `Field on line "${line.trim()}" looks like a secret but is not ` +
+              "marked `.meta({ sensitive: true })`. Sensitive values must be " +
+              "vaulted.",
+          );
+        }
+      }
+      return messages;
+    },
+  },
+  {
+    id: "driver-log-forwarding",
+    dimension: "Logging Quality",
+    severity: "low",
+    appliesTo: ["driver"],
+    detect: (source) => {
+      if (!source.isEntryPoint) return [];
+      if (source.content.includes("onLog")) return [];
+      return [
+        "Driver does not forward logs to the host via `callbacks.onLog()` — " +
+        "host-side observability of driver execution will be limited.",
+      ];
+    },
+  },
+];
+
+// ── Pure evaluator ────────────────────────────────────────────────────
+
+/**
+ * Runs `rules` over `sources` and partitions findings by severity.
+ * Pure and synchronous — all I/O is the caller's responsibility.
+ */
+export function evaluateReviewRules(
+  sources: ReviewSource[],
+  rules: ReviewRule[] = DEFAULT_REVIEW_RULES,
+): ReviewRulesResult {
+  const errors: ReviewFinding[] = [];
+  const warnings: ReviewFinding[] = [];
+
+  for (const source of sources) {
+    for (const rule of rules) {
+      if (!rule.appliesTo.includes(source.kind)) continue;
+      for (const message of rule.detect(source)) {
+        const finding: ReviewFinding = {
+          ruleId: rule.id,
+          dimension: rule.dimension,
+          severity: rule.severity,
+          file: source.path,
+          message,
+        };
+        if (isBlockingSeverity(rule.severity)) {
+          errors.push(finding);
+        } else {
+          warnings.push(finding);
+        }
+      }
+    }
+  }
+
+  return { errors, warnings, passed: errors.length === 0 };
+}
+
+// ── Adversarial-review report ─────────────────────────────────────────
+
+/**
+ * The adversarial review itself (the agent/CI judgment pass) records its
+ * verdicts to a report at a content-hash-bound tmp path. The push gate
+ * verifies that report exists, matches the current code, and is complete —
+ * making the review a non-optional step. Editing any source changes the
+ * content hash, which changes the report path, so a stale review is simply
+ * "not found" and re-blocks the push.
+ */
+
+/** A review dimension from the adversarial-review skill reference. */
+export interface ReviewDimension {
+  /** Stable identifier, e.g. `credentials-secrets`. */
+  id: string;
+  /** Human label matching the skill reference. */
+  label: string;
+  /** Content kinds this dimension applies to, or "all" for universal. */
+  appliesTo: ExtensionContentKind[] | "all";
+}
+
+/**
+ * The catalog of adversarial-review dimensions. Single source of truth,
+ * mirroring `.claude/skills/swamp-extension/references/adversarial-review.md`.
+ */
+export const REVIEW_DIMENSIONS: ReviewDimension[] = [
+  // Universal
+  {
+    id: "credentials-secrets",
+    label: "Credentials & Secrets",
+    appliesTo: "all",
+  },
+  { id: "logging-quality", label: "Logging Quality", appliesTo: "all" },
+  { id: "error-handling", label: "Error Handling", appliesTo: "all" },
+  {
+    id: "testing-completeness",
+    label: "Testing Completeness",
+    appliesTo: "all",
+  },
+  {
+    id: "idempotency-resilience",
+    label: "Idempotency & Resilience",
+    appliesTo: "all",
+  },
+  { id: "api-contracts", label: "API Contracts", appliesTo: "all" },
+  { id: "resource-management", label: "Resource Management", appliesTo: "all" },
+  // Models
+  { id: "schema-strictness", label: "Schema strictness", appliesTo: ["model"] },
+  { id: "lifetime-gc", label: "Lifetime & GC", appliesTo: ["model"] },
+  { id: "crud-completeness", label: "CRUD completeness", appliesTo: ["model"] },
+  { id: "preflight-checks", label: "Pre-flight checks", appliesTo: ["model"] },
+  { id: "instance-names", label: "Instance names", appliesTo: ["model"] },
+  { id: "data-access", label: "Data access", appliesTo: ["model"] },
+  { id: "version-upgrades", label: "Version upgrades", appliesTo: ["model"] },
+  // Drivers
+  {
+    id: "driver-output-kind",
+    label: "Driver output kind",
+    appliesTo: ["driver"],
+  },
+  { id: "driver-duration", label: "Driver durationMs", appliesTo: ["driver"] },
+  {
+    id: "driver-log-forwarding",
+    label: "Driver log forwarding",
+    appliesTo: ["driver"],
+  },
+  { id: "driver-lifecycle", label: "Driver lifecycle", appliesTo: ["driver"] },
+  {
+    id: "driver-error-status",
+    label: "Driver error status",
+    appliesTo: ["driver"],
+  },
+  // Vaults
+  { id: "vault-get-throws", label: "Vault get throws", appliesTo: ["vault"] },
+  {
+    id: "vault-put-idempotent",
+    label: "Vault put idempotent",
+    appliesTo: ["vault"],
+  },
+  {
+    id: "vault-list-keys-only",
+    label: "Vault list keys only",
+    appliesTo: ["vault"],
+  },
+  { id: "vault-getname", label: "Vault getName", appliesTo: ["vault"] },
+  // Datastores
+  {
+    id: "datastore-createlock",
+    label: "Datastore createLock",
+    appliesTo: ["datastore"],
+  },
+  {
+    id: "datastore-withlock-release",
+    label: "Datastore withLock release",
+    appliesTo: ["datastore"],
+  },
+  {
+    id: "datastore-verifier",
+    label: "Datastore verifier",
+    appliesTo: ["datastore"],
+  },
+  {
+    id: "datastore-path-deterministic",
+    label: "Datastore path deterministic",
+    appliesTo: ["datastore"],
+  },
+  {
+    id: "datastore-cachepath",
+    label: "Datastore cachePath",
+    appliesTo: ["datastore"],
+  },
+];
+
+/** Returns the dimensions applicable to the content kinds present. */
+export function applicableDimensions(
+  kinds: ExtensionContentKind[],
+): ReviewDimension[] {
+  const present = new Set(kinds);
+  return REVIEW_DIMENSIONS.filter((d) =>
+    d.appliesTo === "all" || d.appliesTo.some((k) => present.has(k))
+  );
+}
+
+/** A per-dimension verdict recorded by the reviewer. */
+const ReviewVerdictSchema = z.enum(["pass", "issue", "na", "pending"]);
+
+/** Schema for the on-disk adversarial-review report. */
+const ExtensionReviewReportSchema = z.object({
+  extension: z.string(),
+  version: z.string(),
+  reviewedAt: z.string(),
+  dimensions: z.array(z.object({
+    id: z.string(),
+    verdict: ReviewVerdictSchema,
+    note: z.string().optional(),
+  })),
+});
+
+/** The on-disk adversarial-review report. */
+export type ExtensionReviewReport = z.infer<typeof ExtensionReviewReportSchema>;
+
+/** Parses report JSON, returning null when missing or malformed. */
+export function parseReviewReport(raw: string): ExtensionReviewReport | null {
+  try {
+    const result = ExtensionReviewReportSchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function osTempDir(): string {
+  return Deno.env.get("TMPDIR") ?? Deno.env.get("TMP") ??
+    Deno.env.get("TEMP") ??
+    "/tmp";
+}
+
+function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+/**
+ * Content-hash-bound path of the adversarial-review report. The full content
+ * hash in the filename binds the report to the exact code and is the real
+ * uniqueness key — the content hash already encodes the manifest name, so even
+ * if the human-readable name prefix collides under `sanitizeName` (e.g. `@a/b`
+ * vs `@a_b`), the hashes differ and the files do not clash. Any source change
+ * yields a different path, so a prior review no longer satisfies the gate.
+ */
+export function reviewReportPath(
+  extensionName: string,
+  contentHash: string,
+  baseTmpDir: string = osTempDir(),
+): string {
+  return join(
+    baseTmpDir,
+    "swamp-extension-review",
+    `${sanitizeName(extensionName)}-${contentHash}.json`,
+  );
+}
+
+/** Builds a fill-in-the-blanks report skeleton for the given dimensions. */
+export function buildReviewReportSkeleton(
+  extensionName: string,
+  extensionVersion: string,
+  dimensions: ReviewDimension[],
+): string {
+  return JSON.stringify(
+    {
+      extension: extensionName,
+      version: extensionVersion,
+      reviewedAt: "<ISO-8601 timestamp>",
+      dimensions: dimensions.map((d) => ({
+        id: d.id,
+        verdict: "pending",
+        note: "",
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+/** Context for evaluating the adversarial-review report at push time. */
+export interface ReviewReportContext {
+  /** Parsed report, or null when missing/malformed. */
+  report: ExtensionReviewReport | null;
+  /** The content-hash-bound path the report was looked up at. */
+  reportPath: string;
+  /** Expected extension name (from the manifest). */
+  extensionName: string;
+  /** Expected extension version (from the manifest). */
+  extensionVersion: string;
+  /** Dimensions that must each carry a non-pending verdict. */
+  applicableDimensions: ReviewDimension[];
+  /** Skeleton to show the reviewer when the report is missing. */
+  skeleton: string;
+}
+
+const REVIEW_REPORT_RULE = "adversarial-review-report";
+const REVIEW_REPORT_DIMENSION = "Adversarial review";
+
+/**
+ * Validates the adversarial-review report against the current code. All
+ * report findings are `medium` warnings: at push time they surface a
+ * "continue despite warnings?" prompt (bypassable with `--yes`) rather than a
+ * hard block — so a manual version bump or other benign hash change nudges the
+ * reviewer without bricking the push. A hard block here would punish the common
+ * "bumped the version, didn't touch the code" case, since the version is part
+ * of the content hash.
+ */
+export function evaluateReviewReport(
+  ctx: ReviewReportContext,
+): ReviewFinding[] {
+  const findings: ReviewFinding[] = [];
+  const gate: ReviewSeverity = "medium";
+
+  if (!ctx.report) {
+    findings.push({
+      ruleId: REVIEW_REPORT_RULE,
+      dimension: REVIEW_REPORT_DIMENSION,
+      severity: gate,
+      file: ctx.reportPath,
+      // First line is self-sufficient (the path is the finding's `file`); the
+      // bulky skeleton follows for --json consumers. Log mode shows line one.
+      message:
+        "No adversarial review recorded for the current code — perform the " +
+        "review and write the report here (run with --json, or see the " +
+        `swamp-extension skill, for the fill-in skeleton).\n\nSkeleton:\n${ctx.skeleton}`,
+    });
+    return findings;
+  }
+
+  if (
+    ctx.report.extension !== ctx.extensionName ||
+    ctx.report.version !== ctx.extensionVersion
+  ) {
+    findings.push({
+      ruleId: REVIEW_REPORT_RULE,
+      dimension: REVIEW_REPORT_DIMENSION,
+      severity: gate,
+      file: ctx.reportPath,
+      message:
+        `Review report is for ${ctx.report.extension}@${ctx.report.version}, ` +
+        `but this push is ${ctx.extensionName}@${ctx.extensionVersion}.`,
+    });
+  }
+
+  const byId = new Map(ctx.report.dimensions.map((d) => [d.id, d]));
+  const missing: string[] = [];
+  const pending: string[] = [];
+  for (const d of ctx.applicableDimensions) {
+    const entry = byId.get(d.id);
+    if (!entry) {
+      missing.push(d.id);
+    } else if (entry.verdict === "pending") {
+      pending.push(d.id);
+    }
+  }
+  if (missing.length > 0) {
+    findings.push({
+      ruleId: REVIEW_REPORT_RULE,
+      dimension: REVIEW_REPORT_DIMENSION,
+      severity: gate,
+      file: ctx.reportPath,
+      message: `Review report is missing verdicts for: ${missing.join(", ")}.`,
+    });
+  }
+  if (pending.length > 0) {
+    findings.push({
+      ruleId: REVIEW_REPORT_RULE,
+      dimension: REVIEW_REPORT_DIMENSION,
+      severity: gate,
+      file: ctx.reportPath,
+      message: `Review report still has pending verdicts for: ${
+        pending.join(", ")
+      }.`,
+    });
+  }
+
+  for (const entry of ctx.report.dimensions) {
+    if (entry.verdict === "issue") {
+      findings.push({
+        ruleId: REVIEW_REPORT_RULE,
+        dimension: REVIEW_REPORT_DIMENSION,
+        severity: "medium",
+        file: ctx.reportPath,
+        message: `Dimension ${entry.id} flagged ISSUE${
+          entry.note ? `: ${entry.note}` : ""
+        }.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ── Async wrapper (reads source from disk) ────────────────────────────
+
+/** A source file to review, before its content has been read. */
+export interface ReviewFileRef {
+  path: string;
+  kind: ExtensionContentKind;
+  isEntryPoint: boolean;
+}
+
+/**
+ * The report lookup request push hands to {@link checkReviewRules}. The
+ * parsed report is filled in by the checker after reading from disk.
+ */
+export type ReviewReportRequest = Omit<ReviewReportContext, "report">;
+
+/** Input to {@link checkReviewRules}: source files plus optional report. */
+export interface ExtensionReviewInput {
+  /** Source files to run the static file rules over. */
+  files: ReviewFileRef[];
+  /**
+   * When present, the adversarial-review report is also validated. Omitted
+   * by non-push callers (e.g. quality packaging) that only need file rules.
+   */
+  report?: ReviewReportRequest;
+}
+
+/** Injectable I/O for {@link checkReviewRules}. */
+export interface ReviewRulesIo {
+  readTextFile: (path: string) => Promise<string>;
+  fileExists: (path: string) => Promise<boolean>;
+}
+
+const DEFAULT_IO: ReviewRulesIo = {
+  readTextFile: (path) => Deno.readTextFile(path),
+  fileExists: async (path) => {
+    try {
+      const info = await Deno.stat(path);
+      return info.isFile;
+    } catch {
+      return false;
+    }
+  },
+};
+
+/** Computes the sibling test path for a `.ts` source file. */
+function siblingTestPath(path: string): string {
+  const ext = extname(path);
+  const base = path.slice(0, path.length - ext.length);
+  return `${base}_test${ext}`;
+}
+
+/**
+ * Reads each referenced file, runs the static file rules, and — when a report
+ * request is supplied — reads and validates the adversarial-review report.
+ * Findings from both are re-partitioned by severity. Files that cannot be read
+ * are skipped (they are surfaced by the safety analyzer's read check).
+ * Modelled on `checkDependencyTrust`.
+ */
+export async function checkReviewRules(
+  input: ExtensionReviewInput,
+  rules: ReviewRule[] = DEFAULT_REVIEW_RULES,
+  io: ReviewRulesIo = DEFAULT_IO,
+): Promise<ReviewRulesResult> {
+  const sources: ReviewSource[] = [];
+
+  for (const ref of input.files) {
+    if (extname(ref.path) !== ".ts") continue;
+    if (ref.path.endsWith("_test.ts")) continue;
+
+    let content: string;
+    try {
+      content = await io.readTextFile(ref.path);
+    } catch {
+      continue;
+    }
+
+    const hasSiblingTest = await io.fileExists(siblingTestPath(ref.path));
+
+    sources.push({
+      path: ref.path,
+      kind: ref.kind,
+      content,
+      isEntryPoint: ref.isEntryPoint,
+      hasSiblingTest,
+    });
+  }
+
+  const fileResult = evaluateReviewRules(sources, rules);
+  const findings: ReviewFinding[] = [
+    ...fileResult.errors,
+    ...fileResult.warnings,
+  ];
+
+  if (input.report) {
+    let raw: string | null = null;
+    try {
+      raw = await io.readTextFile(input.report.reportPath);
+    } catch {
+      raw = null;
+    }
+    const report = raw === null ? null : parseReviewReport(raw);
+    findings.push(...evaluateReviewReport({ ...input.report, report }));
+  }
+
+  const errors = findings.filter((f) => isBlockingSeverity(f.severity));
+  const warnings = findings.filter((f) => !isBlockingSeverity(f.severity));
+  return { errors, warnings, passed: errors.length === 0 };
+}

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -1,0 +1,399 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  applicableDimensions,
+  buildReviewReportSkeleton,
+  checkReviewRules,
+  DEFAULT_REVIEW_RULES,
+  evaluateReviewReport,
+  evaluateReviewRules,
+  type ExtensionReviewReport,
+  isBlockingSeverity,
+  parseReviewReport,
+  type ReviewDimension,
+  reviewReportPath,
+  type ReviewRule,
+  type ReviewRulesIo,
+  type ReviewSource,
+} from "./extension_review_rules.ts";
+
+function source(overrides: Partial<ReviewSource>): ReviewSource {
+  return {
+    path: "/ext/models/thing.ts",
+    kind: "model",
+    content: "",
+    isEntryPoint: true,
+    hasSiblingTest: true,
+    ...overrides,
+  };
+}
+
+Deno.test("isBlockingSeverity: critical and high block, others do not", () => {
+  assertEquals(isBlockingSeverity("critical"), true);
+  assertEquals(isBlockingSeverity("high"), true);
+  assertEquals(isBlockingSeverity("medium"), false);
+  assertEquals(isBlockingSeverity("low"), false);
+});
+
+Deno.test("evaluateReviewRules: clean source produces no findings", () => {
+  const result = evaluateReviewRules([
+    source({
+      content: "export const model = z.object({ id: z.string() });",
+    }),
+  ]);
+  assertEquals(result.errors, []);
+  assertEquals(result.warnings, []);
+  assertEquals(result.passed, true);
+});
+
+Deno.test("evaluateReviewRules: partitions critical/high into errors, medium/low into warnings", () => {
+  const rules: ReviewRule[] = [
+    {
+      id: "always-high",
+      dimension: "Test",
+      severity: "high",
+      appliesTo: ["model"],
+      detect: () => ["boom"],
+    },
+    {
+      id: "always-low",
+      dimension: "Test",
+      severity: "low",
+      appliesTo: ["model"],
+      detect: () => ["meh"],
+    },
+  ];
+  const result = evaluateReviewRules([source({})], rules);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.errors[0].ruleId, "always-high");
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].ruleId, "always-low");
+  assertEquals(result.passed, false);
+});
+
+Deno.test("evaluateReviewRules: rule only runs against its declared kinds", () => {
+  const rules: ReviewRule[] = [
+    {
+      id: "vault-only",
+      dimension: "Test",
+      severity: "low",
+      appliesTo: ["vault"],
+      detect: () => ["fired"],
+    },
+  ];
+  const onModel = evaluateReviewRules([source({ kind: "model" })], rules);
+  assertEquals(onModel.warnings.length, 0);
+  const onVault = evaluateReviewRules([source({ kind: "vault" })], rules);
+  assertEquals(onVault.warnings.length, 1);
+});
+
+Deno.test("schema-strictness: flags empty-object passthrough as a warning, not an error", () => {
+  const result = evaluateReviewRules([
+    source({ content: "schema: z.object({}).passthrough()," }),
+  ]);
+  assertEquals(result.errors, []);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].ruleId, "schema-strictness");
+  assertEquals(result.passed, true);
+});
+
+Deno.test("schema-strictness: does not flag passthrough with declared properties", () => {
+  const result = evaluateReviewRules([
+    source({
+      content: "schema: z.object({ VpcId: z.string() }).passthrough(),",
+    }),
+  ]);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("schema-strictness: ignores commented-out passthrough", () => {
+  const result = evaluateReviewRules([
+    source({ content: "// schema: z.object({}).passthrough()," }),
+  ]);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("credentials-sensitive-field: warns on unmarked secret field", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "vault",
+      content: "  apiToken: z.string(),",
+    }),
+  ]);
+  assertEquals(result.warnings.length, 1);
+  assertEquals(result.warnings[0].ruleId, "credentials-sensitive-field");
+});
+
+Deno.test("credentials-sensitive-field: no warning when marked sensitive", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "vault",
+      content: "  apiToken: z.string().meta({ sensitive: true }),",
+    }),
+  ]);
+  assertEquals(result.warnings.length, 0);
+});
+
+Deno.test("testing-completeness: warns when entry point lacks a sibling test", () => {
+  const result = evaluateReviewRules([
+    source({ isEntryPoint: true, hasSiblingTest: false, content: "" }),
+  ]);
+  const ids = result.warnings.map((w) => w.ruleId);
+  assert(ids.includes("testing-completeness"));
+});
+
+Deno.test("testing-completeness: no warning for non-entry-point files", () => {
+  const result = evaluateReviewRules([
+    source({ isEntryPoint: false, hasSiblingTest: false, content: "" }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "testing-completeness").length,
+    0,
+  );
+});
+
+Deno.test("driver-log-forwarding: warns when a driver never forwards logs", () => {
+  const result = evaluateReviewRules([
+    source({ kind: "driver", content: "export const driver = {};" }),
+  ]);
+  const ids = result.warnings.map((w) => w.ruleId);
+  assert(ids.includes("driver-log-forwarding"));
+});
+
+Deno.test("driver-log-forwarding: no warning when onLog is used", () => {
+  const result = evaluateReviewRules([
+    source({ kind: "driver", content: "callbacks?.onLog?.(line);" }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "driver-log-forwarding").length,
+    0,
+  );
+});
+
+Deno.test("checkReviewRules: reads content, computes sibling test, skips test files", async () => {
+  const fileContents: Record<string, string> = {
+    "/ext/models/thing.ts": "schema: z.object({}).passthrough(),",
+    "/ext/models/thing_test.ts": "Deno.test(...)",
+  };
+  const io: ReviewRulesIo = {
+    readTextFile: (path) => Promise.resolve(fileContents[path] ?? ""),
+    fileExists: (path) => Promise.resolve(path in fileContents),
+  };
+  const result = await checkReviewRules(
+    {
+      files: [
+        { path: "/ext/models/thing.ts", kind: "model", isEntryPoint: true },
+        {
+          path: "/ext/models/thing_test.ts",
+          kind: "model",
+          isEntryPoint: false,
+        },
+      ],
+    },
+    DEFAULT_REVIEW_RULES,
+    io,
+  );
+  // schema-strictness warns; testing-completeness does NOT (sibling test exists).
+  const ids = result.warnings.map((w) => w.ruleId);
+  assert(ids.includes("schema-strictness"));
+  assertEquals(ids.includes("testing-completeness"), false);
+});
+
+Deno.test("checkReviewRules: skips non-ts files and unreadable files", async () => {
+  const io: ReviewRulesIo = {
+    readTextFile: (path) => {
+      if (path.endsWith("missing.ts")) return Promise.reject(new Error("nope"));
+      return Promise.resolve("");
+    },
+    fileExists: () => Promise.resolve(false),
+  };
+  const result = await checkReviewRules(
+    {
+      files: [
+        {
+          path: "/ext/reports/report.yaml",
+          kind: "report",
+          isEntryPoint: true,
+        },
+        { path: "/ext/models/missing.ts", kind: "model", isEntryPoint: true },
+      ],
+    },
+    DEFAULT_REVIEW_RULES,
+    io,
+  );
+  // yaml skipped; unreadable ts skipped — no crash, no findings from them.
+  assertEquals(result.errors, []);
+});
+
+Deno.test("checkReviewRules: entry point without sibling test warns", async () => {
+  const io: ReviewRulesIo = {
+    readTextFile: () => Promise.resolve("export const x = 1;"),
+    fileExists: () => Promise.resolve(false),
+  };
+  const result = await checkReviewRules(
+    {
+      files: [{ path: "/ext/vaults/v.ts", kind: "vault", isEntryPoint: true }],
+    },
+    DEFAULT_REVIEW_RULES,
+    io,
+  );
+  const ids = result.warnings.map((w) => w.ruleId);
+  assert(ids.includes("testing-completeness"));
+});
+
+// ── Report machinery ──────────────────────────────────────────────────
+
+Deno.test("applicableDimensions: universal always present; type-specific gated by kind", () => {
+  const modelOnly = applicableDimensions(["model"]).map((d) => d.id);
+  assert(modelOnly.includes("credentials-secrets")); // universal
+  assert(modelOnly.includes("schema-strictness")); // model-specific
+  assertEquals(modelOnly.includes("vault-getname"), false); // vault-specific
+  const vaultOnly = applicableDimensions(["vault"]).map((d) => d.id);
+  assert(vaultOnly.includes("vault-getname"));
+  assertEquals(vaultOnly.includes("schema-strictness"), false);
+});
+
+Deno.test("reviewReportPath: deterministic and hash-bound", () => {
+  const a = reviewReportPath("@acme/thing", "abcdef0123456789aa", "/tmp");
+  const b = reviewReportPath("@acme/thing", "abcdef0123456789aa", "/tmp");
+  assertEquals(a, b);
+  const c = reviewReportPath("@acme/thing", "ffffffffffffffffbb", "/tmp");
+  assert(a !== c); // different hash → different path
+});
+
+Deno.test("parseReviewReport: returns null on malformed JSON or bad shape", () => {
+  assertEquals(parseReviewReport("not json"), null);
+  assertEquals(parseReviewReport('{"extension":"x"}'), null);
+  const ok = parseReviewReport(
+    JSON.stringify({
+      extension: "@a/b",
+      version: "1",
+      reviewedAt: "now",
+      dimensions: [{ id: "credentials-secrets", verdict: "pass" }],
+    }),
+  );
+  assert(ok !== null);
+});
+
+function reportCtx(
+  report: ExtensionReviewReport | null,
+  dims: ReviewDimension[],
+) {
+  return {
+    report,
+    reportPath: "/tmp/review.json",
+    extensionName: "@a/b",
+    extensionVersion: "1",
+    applicableDimensions: dims,
+    skeleton: "{}",
+  };
+}
+
+Deno.test("evaluateReviewReport: missing report is a warning (prompt), never a hard block", () => {
+  const findings = evaluateReviewReport(
+    reportCtx(null, applicableDimensions(["model"])),
+  );
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].severity, "medium");
+  // The report path must be carried on the finding (rendered in log mode).
+  assertEquals(findings[0].file, "/tmp/review.json");
+  // The first message line is self-sufficient; the skeleton follows.
+  assert(!findings[0].message.split("\n")[0].includes("{"));
+});
+
+Deno.test("evaluateReviewReport: name/version mismatch warns (e.g. manual version bump)", () => {
+  const report: ExtensionReviewReport = {
+    extension: "@a/b",
+    version: "9", // report from a different version
+    reviewedAt: "now",
+    dimensions: [],
+  };
+  const findings = evaluateReviewReport(reportCtx(report, []));
+  assert(findings.length > 0);
+  assertEquals(findings.every((f) => f.severity === "medium"), true);
+});
+
+Deno.test("evaluateReviewReport: pending verdicts warn, issue warns, all-pass is clean", () => {
+  const dims = applicableDimensions(["vault"]);
+  // One pending, the rest pass.
+  const pendingReport: ExtensionReviewReport = {
+    extension: "@a/b",
+    version: "1",
+    reviewedAt: "now",
+    dimensions: dims.map((d, i) => ({
+      id: d.id,
+      verdict: i === 0 ? ("pending" as const) : ("pass" as const),
+    })),
+  };
+  const pendingFindings = evaluateReviewReport(reportCtx(pendingReport, dims));
+  assert(pendingFindings.length > 0);
+  assertEquals(pendingFindings.every((f) => f.severity === "medium"), true);
+
+  // All pass except one issue → exactly one warning.
+  const passReport: ExtensionReviewReport = {
+    extension: "@a/b",
+    version: "1",
+    reviewedAt: "now",
+    dimensions: dims.map((d, i) => ({
+      id: d.id,
+      verdict: i === 0 ? ("issue" as const) : ("pass" as const),
+      note: i === 0 ? "needs work" : undefined,
+    })),
+  };
+  const passFindings = evaluateReviewReport(reportCtx(passReport, dims));
+  assertEquals(passFindings.length, 1);
+  assertEquals(passFindings[0].severity, "medium");
+
+  // Fully clean report → no findings.
+  const cleanReport: ExtensionReviewReport = {
+    extension: "@a/b",
+    version: "1",
+    reviewedAt: "now",
+    dimensions: dims.map((d) => ({ id: d.id, verdict: "pass" as const })),
+  };
+  assertEquals(evaluateReviewReport(reportCtx(cleanReport, dims)).length, 0);
+});
+
+Deno.test("checkReviewRules: validates report when a report request is supplied", async () => {
+  const dims = applicableDimensions(["model"]);
+  const skeleton = buildReviewReportSkeleton("@a/b", "1", dims);
+  const io: ReviewRulesIo = {
+    readTextFile: () => Promise.reject(new Error("missing")),
+    fileExists: () => Promise.resolve(true),
+  };
+  const result = await checkReviewRules(
+    {
+      files: [],
+      report: {
+        reportPath: "/tmp/review.json",
+        extensionName: "@a/b",
+        extensionVersion: "1",
+        applicableDimensions: dims,
+        skeleton,
+      },
+    },
+    DEFAULT_REVIEW_RULES,
+    io,
+  );
+  // Missing report → non-blocking warning (prompt), not a hard error.
+  assertEquals(result.passed, true);
+  assert(result.warnings.some((w) => w.ruleId === "adversarial-review-report"));
+});

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -315,8 +315,11 @@ Deno.test("evaluateReviewReport: missing report is a warning (prompt), never a h
   assertEquals(findings[0].severity, "medium");
   // The report path must be carried on the finding (rendered in log mode).
   assertEquals(findings[0].file, "/tmp/review.json");
-  // The first message line is self-sufficient; the skeleton follows.
-  assert(!findings[0].message.split("\n")[0].includes("{"));
+  // The message is a single, self-sufficient line (no embedded skeleton).
+  assertEquals(findings[0].message.includes("\n"), false);
+  assert(!findings[0].message.includes("{"));
+  // The skeleton rides on its own field for JSON consumers.
+  assertEquals(findings[0].skeleton, "{}");
 });
 
 Deno.test("evaluateReviewReport: name/version mismatch warns (e.g. manual version bump)", () => {

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -33,6 +33,17 @@ import type {
 import type { QualityCheckResult } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencySpecifier } from "../../domain/extensions/extension_dependency_extractor.ts";
 import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import type {
+  ExtensionContentKind,
+  ExtensionReviewInput,
+  ReviewFileRef,
+  ReviewRulesResult,
+} from "../../domain/extensions/extension_review_rules.ts";
+import {
+  applicableDimensions,
+  buildReviewReportSkeleton,
+  reviewReportPath,
+} from "../../domain/extensions/extension_review_rules.ts";
 import type { ExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -159,6 +170,12 @@ export interface ExtensionPushPrepareInput {
   denoConfigPath?: string;
   packageJsonDir?: string;
   /**
+   * Content hash of the resolved source tree (the package cache hash). When
+   * provided, push verifies a content-hash-bound adversarial-review report.
+   * Omitted by non-push callers (e.g. quality packaging).
+   */
+  contentHash?: string;
+  /**
    * If provided, reuse these archive bytes instead of bundling and
    * tarring from source. Callers supply this when a prior
    * `swamp extension quality` run left a cached tarball whose source
@@ -174,6 +191,7 @@ export interface ExtensionPushPrepared {
   resolvedData: ExtensionPushResolvedData;
   safetyWarnings: SafetyIssue[];
   dependencyTrustResult: DependencyTrustResult;
+  reviewRulesResult: ReviewRulesResult;
   archiveBytes: Uint8Array;
   manifest: ExtensionManifest;
   contentMetadata: ExtensionContentMetadata | undefined;
@@ -253,6 +271,9 @@ export interface ExtensionPushPrepareDeps {
   checkDependencyTrust: (
     specifiers: DependencySpecifier[],
   ) => Promise<DependencyTrustResult>;
+  checkReviewRules: (
+    input: ExtensionReviewInput,
+  ) => Promise<ReviewRulesResult>;
   ensureDenoPath: () => Promise<string>;
   getLatestVersion: (
     serverUrl: string,
@@ -309,6 +330,7 @@ import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety
 import { checkExtensionQuality } from "../../domain/extensions/extension_quality_checker.ts";
 import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
 import { checkDependencyTrust } from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import { checkReviewRules as checkReviewRulesImpl } from "../../domain/extensions/extension_review_rules.ts";
 import { bundleExtension } from "../../domain/models/bundle.ts";
 import { extractContentMetadata } from "../../domain/extensions/extension_content_extractor.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
@@ -345,6 +367,7 @@ export function createExtensionPushPrepareDeps(
     checkExtensionQuality,
     extractDependencySpecifiers,
     checkDependencyTrust,
+    checkReviewRules: checkReviewRulesImpl,
     bundleEntryPoint: bundleExtension,
     ensureDenoPath: () => denoRuntime.ensureDeno(),
     getLatestVersion: async (serverUrl, name, apiKey) => {
@@ -392,6 +415,58 @@ export function createExtensionPushExecuteDeps(
 }
 
 // ── Prepare function ──────────────────────────────────────────────────
+
+/**
+ * Builds the flat list of source files for the adversarial review, tagging
+ * each with its content kind and whether it is an entry point. Entry points
+ * are the main implementation files; the remaining `all*Files` are helpers.
+ */
+function buildReviewFileRefs(
+  input: ExtensionPushPrepareInput,
+): ReviewFileRef[] {
+  const refs: ReviewFileRef[] = [];
+  const groups: Array<
+    { kind: ReviewFileRef["kind"]; all: string[]; entry: string[] }
+  > = [
+    { kind: "model", all: input.allModelFiles, entry: input.modelEntryPoints },
+    { kind: "vault", all: input.allVaultFiles, entry: input.vaultEntryPoints },
+    {
+      kind: "driver",
+      all: input.allDriverFiles,
+      entry: input.driverEntryPoints,
+    },
+    {
+      kind: "datastore",
+      all: input.allDatastoreFiles,
+      entry: input.datastoreEntryPoints,
+    },
+    {
+      kind: "report",
+      all: input.allReportFiles,
+      entry: input.reportEntryPoints,
+    },
+  ];
+  for (const group of groups) {
+    const entrySet = new Set(group.entry);
+    for (const path of group.all) {
+      refs.push({ path, kind: group.kind, isEntryPoint: entrySet.has(path) });
+    }
+  }
+  return refs;
+}
+
+/** The reviewable content kinds present in the extension. */
+function contentKindsPresent(
+  input: ExtensionPushPrepareInput,
+): ExtensionContentKind[] {
+  const kinds: ExtensionContentKind[] = [];
+  if (input.allModelFiles.length > 0) kinds.push("model");
+  if (input.allVaultFiles.length > 0) kinds.push("vault");
+  if (input.allDriverFiles.length > 0) kinds.push("driver");
+  if (input.allDatastoreFiles.length > 0) kinds.push("datastore");
+  if (input.allReportFiles.length > 0) kinds.push("report");
+  return kinds;
+}
 
 /**
  * Performs the extension push prepare phase: validates auth & collectives,
@@ -615,6 +690,39 @@ export async function extensionPushPrepare(
     }
   }
 
+  // 10b. Review — runs after the mechanical gates (safety/deps/fmt) so those
+  // fire first. Two parts: deterministic static file rules (NOT the adversarial
+  // review — those only warn), and validation of the adversarial-review report
+  // (the agent/CI judgment pass). Report findings are warnings: a missing or
+  // stale report surfaces the "continue despite warnings?" prompt rather than a
+  // hard block, so a benign version bump nudges the reviewer instead of bricking
+  // the push.
+  const reviewInput: ExtensionReviewInput = {
+    files: buildReviewFileRefs(input),
+  };
+  const reviewKinds = contentKindsPresent(input);
+  if (input.contentHash && reviewKinds.length > 0) {
+    const dims = applicableDimensions(reviewKinds);
+    reviewInput.report = {
+      reportPath: reviewReportPath(input.manifest.name, input.contentHash),
+      extensionName: input.manifest.name,
+      extensionVersion: input.manifest.version,
+      applicableDimensions: dims,
+      skeleton: buildReviewReportSkeleton(
+        input.manifest.name,
+        input.manifest.version,
+        dims,
+      ),
+    };
+  }
+  const reviewRulesResult = await deps.checkReviewRules(reviewInput);
+  if (reviewRulesResult.errors.length > 0) {
+    throw validationFailed(
+      "Extension review found issues that must be resolved before pushing.",
+      { reviewRuleErrors: reviewRulesResult.errors },
+    );
+  }
+
   // 11. Bundle entry points + build archive — skip on cache hit
   let totalBundles: number;
   let archiveBytes: Uint8Array;
@@ -648,6 +756,7 @@ export async function extensionPushPrepare(
     resolvedData,
     safetyWarnings: safetyResult.warnings,
     dependencyTrustResult,
+    reviewRulesResult,
     archiveBytes,
     manifest: input.manifest,
     contentMetadata,

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -88,6 +88,8 @@ function makePrepareDeps(
     extractDependencySpecifiers: () => Promise.resolve([]),
     checkDependencyTrust: () =>
       Promise.resolve({ errors: [], warnings: [], audited: [], passed: true }),
+    checkReviewRules: () =>
+      Promise.resolve({ errors: [], warnings: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -118,6 +118,8 @@ function makePrepareDeps(
     extractDependencySpecifiers: () => Promise.resolve([]),
     checkDependencyTrust: () =>
       Promise.resolve({ errors: [], warnings: [], audited: [], passed: true }),
+    checkReviewRules: () =>
+      Promise.resolve({ errors: [], warnings: [], passed: true }),
     bundleEntryPoint: () => Promise.resolve("/* bundled */"),
     ensureDenoPath: () => Promise.resolve("/usr/bin/deno"),
     getLatestVersion: () => Promise.resolve(null),
@@ -253,6 +255,60 @@ Deno.test("extensionPushPrepare: safety warnings are returned in result", async 
   const result = await extensionPushPrepare(ctx, deps, input);
   assertEquals(result.safetyWarnings.length, 1);
   assertEquals(result.safetyWarnings[0].file, "cmd.ts");
+});
+
+Deno.test("extensionPushPrepare: review-rule errors throw SwampError", async () => {
+  const deps = makePrepareDeps({
+    checkReviewRules: () =>
+      Promise.resolve({
+        errors: [{
+          ruleId: "always-high",
+          dimension: "Schema strictness",
+          severity: "high" as const,
+          file: "model.ts",
+          message: "blocking issue",
+        }],
+        warnings: [],
+        passed: false,
+      }),
+  });
+  const input = makePrepareInput();
+
+  const error = await assertRejects(
+    () => extensionPushPrepare(ctx, deps, input),
+  ) as SwampError;
+  assertEquals(error.code, "validation_failed");
+  assertEquals(
+    Array.isArray(
+      (error.details as Record<string, unknown>).reviewRuleErrors,
+    ),
+    true,
+  );
+});
+
+Deno.test("extensionPushPrepare: review-rule warnings are returned in result", async () => {
+  const deps = makePrepareDeps({
+    checkReviewRules: () =>
+      Promise.resolve({
+        errors: [],
+        warnings: [{
+          ruleId: "testing-completeness",
+          dimension: "Testing Completeness",
+          severity: "medium" as const,
+          file: "model.ts",
+          message: "no sibling test",
+        }],
+        passed: true,
+      }),
+  });
+  const input = makePrepareInput();
+
+  const result = await extensionPushPrepare(ctx, deps, input);
+  assertEquals(result.reviewRulesResult.warnings.length, 1);
+  assertEquals(
+    result.reviewRulesResult.warnings[0].ruleId,
+    "testing-completeness",
+  );
 });
 
 Deno.test("extensionPushPrepare: skips auth for dry run", async () => {

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -185,7 +185,9 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
   }
 
   renderReviewRuleWarnings(warnings: ReviewFinding[]): void {
-    this.logger.warn`Extension review rule warnings (non-blocking):`;
+    // No "(non-blocking)" qualifier — these warnings do trigger the push
+    // confirmation prompt, matching the `Safety warnings:` style.
+    this.logger.warn`Extension review warnings:`;
     for (const w of warnings) {
       // Render the first line only; multi-line detail (e.g. the report
       // skeleton) stays in the JSON output.

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -32,6 +32,7 @@ import {
   type QualityIssue,
 } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencyTrustIssue } from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import type { ReviewFinding } from "../../domain/extensions/extension_review_rules.ts";
 import type { CollectiveMismatch } from "../../domain/extensions/extension_collective_validator.ts";
 import type { CompilationError } from "../../libswamp/mod.ts";
 
@@ -40,6 +41,8 @@ export interface ExtensionPushRenderer extends Renderer<ExtensionPushEvent> {
   renderResolved(data: ExtensionPushResolvedData): void;
   renderDependencyTrustWarnings(warnings: DependencyTrustIssue[]): void;
   renderDependencyTrustErrors(errors: DependencyTrustIssue[]): void;
+  renderReviewRuleWarnings(warnings: ReviewFinding[]): void;
+  renderReviewRuleErrors(errors: ReviewFinding[]): void;
   renderSafetyWarnings(warnings: SafetyIssue[]): void;
   renderSafetyErrors(errors: SafetyIssue[]): void;
   renderCollectiveErrors(
@@ -181,6 +184,26 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
     }
   }
 
+  renderReviewRuleWarnings(warnings: ReviewFinding[]): void {
+    this.logger.warn`Extension review rule warnings (non-blocking):`;
+    for (const w of warnings) {
+      // Render the first line only; multi-line detail (e.g. the report
+      // skeleton) stays in the JSON output.
+      const summary = w.message.split("\n")[0];
+      this.logger
+        .warn`  [${w.severity}] ${w.dimension} — ${w.file}: ${summary}`;
+    }
+  }
+
+  renderReviewRuleErrors(errors: ReviewFinding[]): void {
+    this.logger.error`Extension review rule errors (push blocked):`;
+    for (const e of errors) {
+      const summary = e.message.split("\n")[0];
+      this.logger
+        .error`  [${e.severity}] ${e.dimension} — ${e.file}: ${summary}`;
+    }
+  }
+
   renderSafetyWarnings(warnings: SafetyIssue[]): void {
     this.logger.warn`Safety warnings:`;
     for (const w of warnings) {
@@ -290,6 +313,16 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
 
   renderDependencyTrustErrors(errors: DependencyTrustIssue[]): void {
     console.log(JSON.stringify({ dependencyTrustErrors: errors }, null, 2));
+  }
+
+  renderReviewRuleWarnings(warnings: ReviewFinding[]): void {
+    console.log(
+      JSON.stringify({ reviewRuleWarnings: warnings }, null, 2),
+    );
+  }
+
+  renderReviewRuleErrors(errors: ReviewFinding[]): void {
+    console.log(JSON.stringify({ reviewRuleErrors: errors }, null, 2));
   }
 
   renderSafetyWarnings(warnings: SafetyIssue[]): void {


### PR DESCRIPTION
## Summary

Closes swamp-club#500. Adds a push-time review step to `swamp extension push`, modelled on the existing dependency-trust audit and run **after** the mechanical gates (safety / deps / fmt / lint). Two parts:

1. **Static review rules** (`src/domain/extensions/extension_review_rules.ts`) — an extensible ruleset flagging empty-object `.passthrough()`, missing sibling `_test.ts`, unmarked sensitive vault fields, and drivers that never call `callbacks.onLog()`. Each finding carries a severity; **critical/high block, medium/low warn**. All starter rules warn — the severity machinery is ready for future blocking rules. This is **not** the adversarial review; it's a deterministic mechanical floor.

2. **Adversarial-review report check** — the agent/CI judgment review records per-dimension verdicts (`pass`/`issue`/`na`) to a temp file **keyed by the full content hash** (`<tmp>/swamp-extension-review/<name>-<hash>.json`). The hash binds the report to the exact code, so any source change (or version bump) requests a fresh review. A missing, stale, or incomplete report — or any `issue` verdict — surfaces as a **warning + confirmation prompt, never a hard block**, so a benign version bump doesn't brick a push. On `--dry-run` it is advisory and prints the report path plus a fill-in skeleton.

Skills (`swamp-extension`, `swamp-extension-publish`) updated to document the push-checked review and the report workflow.

### Design notes
- **Why warn, not block:** the version is part of the content hash, so a hard block would punish the common "bumped the version, didn't touch the code" case. The prompt is the gate; `--yes`/`--json` bypass it the same way they bypass safety and dependency-trust warnings.
- **Positioning:** the static rules are deliberately distinct from the agent/CI adversarial review — the code and docs say so explicitly to avoid conflating a mechanical scan with judgment.

## Test Plan

- Unit tests for the ruleset, severity partitioning, dimension catalog, report parsing/validation, and the content-hash-bound path (`extension_review_rules_test.ts`).
- Push-wiring tests (`push_test.ts`): review errors block, warnings are returned; mocked deps updated.
- Integration: existing `integration/extension_push_test.ts` (13) pass — dry-run reaches the review gate after fmt, and the report check is advisory.
- Manually ran `swamp extension push --dry-run` against a scratch extension and observed: fmt gate fires first; review gate prints the content-hash-bound report path + skeleton; clean single-line log rendering; `--json` carries the full skeleton; "Dry run complete" (exit 0).
- `deno check`, `deno lint`, `deno fmt --check`, full `deno run test` (6546) all green.

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)