### PR TITLE
feat(issue): add `swamp issue edit` command (swamp-club#513)

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-issue
-description: Fetch issue details and submit issues to the swamp Lab or route them to the publisher's repository — fetch issue details, file bug reports, feature requests, and security vulnerability reports against swamp itself or against a specific extension, and post follow-up ripples (comments) on existing Lab issues with optional close/reopen. Use when the user wants to view an issue, report a bug, request a feature, disclose a vulnerability, comment on an existing issue, close or reopen an issue, or provide feedback about swamp. Triggers on "bug report", "feature request", "security report", "vulnerability", "report bug", "request feature", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "report against extension", "extension bug", "ripple", "comment on issue", "reply to issue", "follow up on issue", "add comment to issue", "close issue", "reopen issue", "get issue", "view issue", "fetch issue", "issue details", "show issue".
+description: Fetch, edit, and submit issues to swamp Lab — view details, edit title/body, file bugs/features/security reports, post ripples (comments) with close/reopen, route to extension publishers. Triggers on "bug report", "feature request", "security report", "report bug", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "extension bug", "ripple", "comment on issue", "close issue", "reopen issue", "get issue", "view issue", "fetch issue", "show issue", "edit issue", "update issue", "change issue title".
 ---
 
 # Swamp Issue Skill
@@ -14,6 +14,10 @@ flag skips straight to a pre-filled email.
 To view an existing issue, use `swamp issue get <number>` — this fetches and
 displays the issue's title, type, status, author, body, assignees, and comment
 count.
+
+To edit an existing issue's title or body, use `swamp issue edit <number>`. This
+opens `$EDITOR` pre-filled with the current title and body. Use `--title` and/or
+`--body` flags to skip the editor. Only the issue author (or admins) can edit.
 
 With `--extension <name>`, reports are routed to the extension's publisher
 instead — either as a tagged swamp.club Lab issue (for `@swamp/*` extensions) or
@@ -38,6 +42,7 @@ directly.
 | Command                       | Purpose                                                                                       |
 | ----------------------------- | --------------------------------------------------------------------------------------------- |
 | `swamp issue get <number>`    | Fetch and display issue details (title, type, status, author, body, assignees, comment count) |
+| `swamp issue edit <number>`   | Edit title and/or body of an existing issue (author or admin only)                            |
 | `swamp issue bug`             | Title, description, steps to reproduce, environment                                           |
 | `swamp issue feature`         | Title, problem statement, proposed solution, alternatives                                     |
 | `swamp issue security`        | Title, description, reproduction, affected components, impact                                 |
@@ -48,6 +53,9 @@ directly.
 ```bash
 swamp issue get 42
 swamp issue get 42 --json
+swamp issue edit 42
+swamp issue edit 42 --title "Updated title"
+swamp issue edit 42 --title "Updated title" --body "Updated body" --json
 swamp issue bug --title "CLI crashes on empty input" --body "When running..." --json
 swamp issue feature --title "Add dark mode" --body "I'd like..." --json
 swamp issue security --title "..." --body "..." --json

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import { issueBugCommand } from "./issue_bug.ts";
+import { issueEditCommand } from "./issue_edit.ts";
 import { issueFeatureCommand } from "./issue_feature.ts";
 import { issueGetCommand } from "./issue_get.ts";
 import { issueRippleCommand } from "./issue_ripple.ts";
@@ -32,6 +33,7 @@ export const issueCommand = new Command()
   )
   .action(groupCommandAction)
   .command("get", issueGetCommand)
+  .command("edit", issueEditCommand)
   .command("bug", issueBugCommand)
   .command("feature", issueFeatureCommand)
   .command("security", issueSecurityCommand)

--- a/src/cli/commands/issue_edit.ts
+++ b/src/cli/commands/issue_edit.ts
@@ -1,0 +1,191 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  issueEdit,
+  type IssueEditDeps,
+} from "../../libswamp/mod.ts";
+import {
+  renderIssueCancelled,
+} from "../../presentation/renderers/issue_create.ts";
+import { createIssueEditRenderer } from "../../presentation/renderers/issue_edit.ts";
+import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import { UserError } from "../../domain/errors.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import { loadIdentity } from "../load_identity.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const EDIT_TEMPLATE_HEADER =
+  `<!-- Edit the title and body below. Lines starting with '<!--' are stripped. Save and close to submit; leave unchanged to cancel. -->
+
+`;
+
+export function buildEditTemplate(title: string, body: string): string {
+  return `${EDIT_TEMPLATE_HEADER}## Title
+${title}
+
+## Body
+${body}
+`;
+}
+
+export function parseEditContent(
+  content: string,
+): { title: string; body: string } | null {
+  const cleaned = content
+    .split("\n")
+    .filter((line) => !line.match(/^\s*<!--.*-->\s*$/))
+    .join("\n");
+
+  const titleMatch = cleaned.match(/## Title\s*\n([^\n#][^\n]*)/);
+  const title = titleMatch?.[1]?.trim();
+
+  if (!title) {
+    return null;
+  }
+
+  const bodyIndex = cleaned.indexOf("## Body");
+  if (bodyIndex === -1) {
+    return { title, body: "" };
+  }
+
+  const body = cleaned.substring(bodyIndex + "## Body".length).trim();
+  return { title, body };
+}
+
+export const issueEditCommand = new Command()
+  .name("edit")
+  .description("Edit the title or body of an existing swamp-club Lab issue")
+  .example("Open the editor to edit an issue", "swamp issue edit 42")
+  .example("Update just the title", 'swamp issue edit 42 --title "New title"')
+  .example(
+    "Update title and body",
+    'swamp issue edit 42 --title "New title" --body "New body"',
+  )
+  .arguments("<number:integer>")
+  .option("-t, --title <title:string>", "New title (skips editor for title)")
+  .option(
+    "-b, --body <body:string>",
+    "New body (requires --title, skips editor entirely)",
+  )
+  .action(async function (options: AnyOptions, issueNumber: number) {
+    const ctx = createContext(options as GlobalOptions, ["issue", "edit"]);
+
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new UserError("Issue number must be a positive integer.");
+    }
+
+    const credentials = await new AuthRepository().load();
+    if (!credentials) {
+      throw new UserError(
+        'Not logged in. Run "swamp auth login" first to edit issues.',
+      );
+    }
+
+    const identity = await loadIdentity();
+    const client = new SwampClubClient(credentials.serverUrl, identity);
+
+    const current = await client.fetchIssue(
+      credentials.apiKey,
+      issueNumber,
+    );
+
+    let title: string;
+    let body: string;
+
+    if (options.title && options.body) {
+      title = options.title;
+      body = options.body;
+    } else if (options.body && !options.title) {
+      throw new UserError("--body requires --title to be specified.");
+    } else if (options.title && !options.body) {
+      title = options.title;
+      body = current.body;
+    } else {
+      if (ctx.outputMode === "json") {
+        throw new UserError(
+          "Interactive mode is not available with --json. Use --title and --body options.",
+        );
+      }
+
+      const tempFile = await Deno.makeTempFile({
+        prefix: "swamp-issue-edit-",
+        suffix: ".md",
+      });
+
+      try {
+        await Deno.writeTextFile(
+          tempFile,
+          buildEditTemplate(current.title, current.body),
+        );
+        ctx.logger.debug`Opening editor to edit issue #${issueNumber}`;
+        await new EditorService().openFile(tempFile, { wait: true });
+
+        const content = await Deno.readTextFile(tempFile);
+        const parsed = parseEditContent(content);
+        if (!parsed) {
+          renderIssueCancelled(
+            { type: "edit", reason: "empty" },
+            ctx.outputMode,
+          );
+          return;
+        }
+
+        title = parsed.title;
+        body = parsed.body;
+      } finally {
+        try {
+          await Deno.remove(tempFile);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+    const renderer = createIssueEditRenderer(ctx.outputMode);
+    const deps: IssueEditDeps = {
+      updateIssue: async (input) => {
+        const result = await client.updateIssue(
+          credentials.apiKey,
+          input.issueNumber,
+          input.fields,
+        );
+        return { ...result, serverUrl: credentials.serverUrl };
+      },
+    };
+
+    await consumeStream(
+      issueEdit(libCtx, deps, {
+        issueNumber,
+        title,
+        body,
+        originalTitle: current.title,
+        originalBody: current.body,
+      }),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/issue_edit_test.ts
+++ b/src/cli/commands/issue_edit_test.ts
@@ -1,0 +1,91 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { buildEditTemplate, parseEditContent } from "./issue_edit.ts";
+
+Deno.test("parseEditContent: extracts title and body", () => {
+  const content = `## Title
+My Issue Title
+
+## Body
+This is the body content.
+
+Multiple paragraphs.
+`;
+  const result = parseEditContent(content);
+  assertEquals(result?.title, "My Issue Title");
+  assertEquals(
+    result?.body,
+    "This is the body content.\n\nMultiple paragraphs.",
+  );
+});
+
+Deno.test("parseEditContent: strips HTML comment lines", () => {
+  const content = `<!-- This is a comment -->
+
+## Title
+My Title
+
+## Body
+Some body text.
+`;
+  const result = parseEditContent(content);
+  assertEquals(result?.title, "My Title");
+  assertEquals(result?.body, "Some body text.");
+});
+
+Deno.test("parseEditContent: returns null when title is missing", () => {
+  const content = `## Title
+
+## Body
+Some body text.
+`;
+  const result = parseEditContent(content);
+  assertEquals(result, null);
+});
+
+Deno.test("parseEditContent: returns empty body when body section is missing", () => {
+  const content = `## Title
+My Title
+`;
+  const result = parseEditContent(content);
+  assertEquals(result?.title, "My Title");
+  assertEquals(result?.body, "");
+});
+
+Deno.test("parseEditContent: returns null for completely empty content", () => {
+  const result = parseEditContent("");
+  assertEquals(result, null);
+});
+
+Deno.test("buildEditTemplate: round-trips through parseEditContent", () => {
+  const template = buildEditTemplate("Original Title", "Original body content");
+  const parsed = parseEditContent(template);
+  assertEquals(parsed?.title, "Original Title");
+  assertEquals(parsed?.body, "Original body content");
+});
+
+Deno.test("buildEditTemplate: round-trips multiline body", () => {
+  const body = "First paragraph.\n\nSecond paragraph.\n\n- list item";
+  const template = buildEditTemplate("Title", body);
+  const parsed = parseEditContent(template);
+  assertEquals(parsed?.title, "Title");
+  assertEquals(parsed?.body, body);
+});

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -310,6 +310,61 @@ export class SwampClubClient {
   }
 
   /**
+   * Update the title and/or body of an existing Lab issue.
+   * Authenticates using the x-api-key header.
+   */
+  async updateIssue(
+    apiKey: string,
+    issueNumber: number,
+    fields: { title?: string; body?: string },
+  ): Promise<{ title: string; body: string }> {
+    const res = await this.fetch(
+      `/api/v1/lab/issues/${issueNumber}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify(fields),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 404) {
+        throw new UserError(`Issue #${issueNumber} not found.`);
+      }
+      if (res.status === 403) {
+        throw new UserError(
+          `You do not have permission to edit issue #${issueNumber}.`,
+        );
+      }
+      if (res.status === 422) {
+        try {
+          const parsed = JSON.parse(text);
+          if (
+            parsed?.error && Array.isArray(parsed.flagged) &&
+            parsed.flagged.length > 0
+          ) {
+            throw new UserError(
+              `${parsed.error}: ${parsed.flagged.join(", ")}`,
+            );
+          }
+        } catch (err) {
+          if (err instanceof UserError) throw err;
+        }
+      }
+      throw new UserError(
+        `Failed to update issue #${issueNumber} (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    const data = await res.json();
+    return { title: data.issue.title, body: data.issue.body };
+  }
+
+  /**
    * Fetch an existing Lab issue by number.
    * When an API key is provided, authenticates using the x-api-key header.
    */

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -270,6 +270,104 @@ Deno.test("SwampClubClient - updateIssueStatus throws on failure", async () => {
   }
 });
 
+Deno.test("SwampClubClient - updateIssue sends PATCH with title and body", async () => {
+  let capturedMethod = "";
+  let capturedBody: Record<string, unknown> = {};
+  let capturedApiKey = "";
+  const mock = startMockServer(async (req) => {
+    capturedMethod = req.method;
+    capturedApiKey = req.headers.get("x-api-key") ?? "";
+    capturedBody = await req.json();
+    return Response.json({
+      issue: { number: 42, title: "New title", body: "New body" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.updateIssue("my-key", 42, {
+      title: "New title",
+      body: "New body",
+    });
+    assertEquals(capturedMethod, "PATCH");
+    assertEquals(capturedApiKey, "my-key");
+    assertEquals(capturedBody.title, "New title");
+    assertEquals(capturedBody.body, "New body");
+    assertEquals(result.title, "New title");
+    assertEquals(result.body, "New body");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssue sends only provided fields", async () => {
+  let capturedBody: Record<string, unknown> = {};
+  const mock = startMockServer(async (req) => {
+    capturedBody = await req.json();
+    return Response.json({
+      issue: { number: 1, title: "Updated title", body: "Same body" },
+    });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await client.updateIssue("key", 1, { title: "Updated title" });
+    assertEquals(capturedBody.title, "Updated title");
+    assertEquals(capturedBody.body, undefined);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssue throws on 404", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("Not found", { status: 404 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.updateIssue("key", 999, { title: "x" }),
+      UserError,
+      "Issue #999 not found",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssue throws on 403", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("Forbidden", { status: 403 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.updateIssue("key", 42, { title: "x" }),
+      UserError,
+      "do not have permission",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("SwampClubClient - updateIssue surfaces profanity on 422", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json(
+      { error: "Profanity detected", flagged: ["badword"] },
+      { status: 422 },
+    )
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.updateIssue("key", 42, { title: "badword" }),
+      UserError,
+      "badword",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
 Deno.test("SwampClubClient - 429 surfaces Retry-After in UserError", async () => {
   const mock = startMockServer((_req) =>
     new Response("rate limited", {

--- a/src/libswamp/issues/edit.ts
+++ b/src/libswamp/issues/edit.ts
@@ -1,0 +1,99 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { UserError } from "../../domain/errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface IssueEditData {
+  issueNumber: number;
+  title: string;
+  body: string;
+  serverUrl: string;
+}
+
+export type IssueEditEvent =
+  | { kind: "completed"; data: IssueEditData }
+  | { kind: "noop"; issueNumber: number }
+  | { kind: "error"; error: SwampError };
+
+export interface IssueEditInput {
+  issueNumber: number;
+  title?: string;
+  body?: string;
+  originalTitle: string;
+  originalBody: string;
+}
+
+export interface IssueEditDeps {
+  updateIssue: (input: {
+    issueNumber: number;
+    fields: { title?: string; body?: string };
+  }) => Promise<{ title: string; body: string; serverUrl: string }>;
+}
+
+export async function* issueEdit(
+  ctx: LibSwampContext,
+  deps: IssueEditDeps,
+  input: IssueEditInput,
+): AsyncIterable<IssueEditEvent> {
+  yield* withGeneratorSpan(
+    "swamp.issue.edit",
+    {},
+    (async function* () {
+      ctx.logger.debug`Editing issue #${input.issueNumber}`;
+
+      const fields: { title?: string; body?: string } = {};
+
+      if (
+        input.title !== undefined && input.title !== input.originalTitle
+      ) {
+        fields.title = input.title;
+      }
+      if (input.body !== undefined && input.body !== input.originalBody) {
+        fields.body = input.body;
+      }
+
+      if (Object.keys(fields).length === 0) {
+        yield { kind: "noop", issueNumber: input.issueNumber };
+        return;
+      }
+
+      if (fields.title !== undefined && fields.title.trim().length === 0) {
+        throw new UserError("Title must not be empty.");
+      }
+
+      const result = await deps.updateIssue({
+        issueNumber: input.issueNumber,
+        fields,
+      });
+
+      yield {
+        kind: "completed",
+        data: {
+          issueNumber: input.issueNumber,
+          title: result.title,
+          body: result.body,
+          serverUrl: result.serverUrl,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/issues/edit_test.ts
+++ b/src/libswamp/issues/edit_test.ts
@@ -1,0 +1,168 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { issueEdit, type IssueEditDeps, type IssueEditEvent } from "./edit.ts";
+
+function makeDeps(overrides: Partial<IssueEditDeps> = {}): IssueEditDeps {
+  return {
+    updateIssue: () =>
+      Promise.resolve({
+        title: "Updated title",
+        body: "Updated body",
+        serverUrl: "https://swamp-club.com",
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("issueEdit: yields completed when title changes", async () => {
+  const events = await collect<IssueEditEvent>(
+    issueEdit(createLibSwampContext(), makeDeps(), {
+      issueNumber: 42,
+      title: "New title",
+      body: "Same body",
+      originalTitle: "Old title",
+      originalBody: "Same body",
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+  const completed = events[0] as Extract<IssueEditEvent, { kind: "completed" }>;
+  assertEquals(completed.data.issueNumber, 42);
+  assertEquals(completed.data.serverUrl, "https://swamp-club.com");
+});
+
+Deno.test("issueEdit: yields completed when body changes", async () => {
+  const events = await collect<IssueEditEvent>(
+    issueEdit(createLibSwampContext(), makeDeps(), {
+      issueNumber: 10,
+      title: "Same title",
+      body: "New body",
+      originalTitle: "Same title",
+      originalBody: "Old body",
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+});
+
+Deno.test("issueEdit: yields noop when nothing changes", async () => {
+  let updateCalled = false;
+  const deps = makeDeps({
+    updateIssue: () => {
+      updateCalled = true;
+      return Promise.resolve({
+        title: "Same",
+        body: "Same",
+        serverUrl: "https://swamp-club.com",
+      });
+    },
+  });
+
+  const events = await collect<IssueEditEvent>(
+    issueEdit(createLibSwampContext(), deps, {
+      issueNumber: 5,
+      title: "Same",
+      body: "Same",
+      originalTitle: "Same",
+      originalBody: "Same",
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "noop");
+  assertEquals(updateCalled, false);
+});
+
+Deno.test("issueEdit: sends only changed fields to updateIssue", async () => {
+  let capturedFields: { title?: string; body?: string } = {};
+  const deps = makeDeps({
+    updateIssue: (input) => {
+      capturedFields = input.fields;
+      return Promise.resolve({
+        title: input.fields.title ?? "Original",
+        body: input.fields.body ?? "Original",
+        serverUrl: "https://swamp-club.com",
+      });
+    },
+  });
+
+  await collect(
+    issueEdit(createLibSwampContext(), deps, {
+      issueNumber: 1,
+      title: "Changed title",
+      body: "Same body",
+      originalTitle: "Old title",
+      originalBody: "Same body",
+    }),
+  );
+
+  assertEquals(capturedFields.title, "Changed title");
+  assertEquals(capturedFields.body, undefined);
+});
+
+Deno.test("issueEdit: rejects empty title", async () => {
+  await assertRejects(
+    () =>
+      collect(
+        issueEdit(createLibSwampContext(), makeDeps(), {
+          issueNumber: 1,
+          title: "  ",
+          body: "body",
+          originalTitle: "Old title",
+          originalBody: "body",
+        }),
+      ),
+    UserError,
+    "Title must not be empty",
+  );
+});
+
+Deno.test("issueEdit: sends both fields when both change", async () => {
+  let capturedFields: { title?: string; body?: string } = {};
+  const deps = makeDeps({
+    updateIssue: (input) => {
+      capturedFields = input.fields;
+      return Promise.resolve({
+        title: "New title",
+        body: "New body",
+        serverUrl: "https://swamp-club.com",
+      });
+    },
+  });
+
+  await collect(
+    issueEdit(createLibSwampContext(), deps, {
+      issueNumber: 1,
+      title: "New title",
+      body: "New body",
+      originalTitle: "Old title",
+      originalBody: "Old body",
+    }),
+  );
+
+  assertEquals(capturedFields.title, "New title");
+  assertEquals(capturedFields.body, "New body");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1118,6 +1118,13 @@ export {
   type IssueGetEvent,
   type IssueGetInput,
 } from "./issues/get.ts";
+export {
+  issueEdit,
+  type IssueEditData,
+  type IssueEditDeps,
+  type IssueEditEvent,
+  type IssueEditInput,
+} from "./issues/edit.ts";
 
 // Audit operations
 export {

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -111,8 +111,19 @@ export function createIssueCreateRenderer(
 
 /** Data structure for issue editor cancelled output. */
 export interface IssueCancelledData {
-  type: "bug" | "feature" | "security" | "ripple";
+  type: "bug" | "feature" | "security" | "ripple" | "edit";
   reason: "empty" | "cancelled";
+}
+
+function cancelledAction(type: IssueCancelledData["type"]): string {
+  switch (type) {
+    case "ripple":
+      return "Ripple";
+    case "edit":
+      return "Issue edit";
+    default:
+      return "Issue creation";
+  }
 }
 
 export function renderIssueCancelled(
@@ -123,7 +134,7 @@ export function renderIssueCancelled(
     console.log(JSON.stringify({ status: "cancelled", ...data }, null, 2));
   } else {
     const logger = getSwampLogger(["issue", "create"]);
-    const action = data.type === "ripple" ? "Ripple" : "Issue creation";
+    const action = cancelledAction(data.type);
     if (data.reason === "empty") {
       logger.info(`${action} cancelled: no content provided`);
     } else {

--- a/src/presentation/renderers/issue_edit.ts
+++ b/src/presentation/renderers/issue_edit.ts
@@ -1,0 +1,76 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, IssueEditEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+import { bold, cyan, dim } from "@std/fmt/colors";
+
+class LogIssueEditRenderer implements Renderer<IssueEditEvent> {
+  handlers(): EventHandlers<IssueEditEvent> {
+    return {
+      completed: (e) => {
+        const d = e.data;
+        writeOutput(`Updated issue ${bold(cyan(`#${d.issueNumber}`))}`);
+        writeOutput(dim(`View at: ${d.serverUrl}/lab/${d.issueNumber}`));
+      },
+      noop: (e) => {
+        writeOutput(`No changes to issue ${bold(cyan(`#${e.issueNumber}`))}`);
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonIssueEditRenderer implements Renderer<IssueEditEvent> {
+  handlers(): EventHandlers<IssueEditEvent> {
+    return {
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      noop: (e) => {
+        console.log(
+          JSON.stringify(
+            { status: "noop", issueNumber: e.issueNumber },
+            null,
+            2,
+          ),
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createIssueEditRenderer(
+  mode: OutputMode,
+): Renderer<IssueEditEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonIssueEditRenderer();
+    case "log":
+      return new LogIssueEditRenderer();
+  }
+}

--- a/src/presentation/renderers/issue_edit_test.ts
+++ b/src/presentation/renderers/issue_edit_test.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { createIssueEditRenderer } from "./issue_edit.ts";
+
+await initializeLogging({});
+
+function captureStdout(fn: () => void): string {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join("\n");
+}
+
+Deno.test("createIssueEditRenderer: json completed handler outputs structured data", () => {
+  const renderer = createIssueEditRenderer("json");
+  const handlers = renderer.handlers();
+  const out = captureStdout(() =>
+    handlers.completed({
+      kind: "completed",
+      data: {
+        issueNumber: 42,
+        title: "Updated title",
+        body: "Updated body",
+        serverUrl: "https://swamp-club.com",
+      },
+    })
+  );
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.issueNumber, 42);
+  assertEquals(parsed.title, "Updated title");
+  assertEquals(parsed.body, "Updated body");
+  assertEquals(parsed.serverUrl, "https://swamp-club.com");
+});
+
+Deno.test("createIssueEditRenderer: json noop handler outputs status", () => {
+  const renderer = createIssueEditRenderer("json");
+  const handlers = renderer.handlers();
+  const out = captureStdout(() =>
+    handlers.noop({
+      kind: "noop",
+      issueNumber: 7,
+    })
+  );
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.status, "noop");
+  assertEquals(parsed.issueNumber, 7);
+});
+
+Deno.test("createIssueEditRenderer: log completed handler does not throw", () => {
+  const renderer = createIssueEditRenderer("log");
+  const handlers = renderer.handlers();
+  handlers.completed({
+    kind: "completed",
+    data: {
+      issueNumber: 42,
+      title: "Updated",
+      body: "Body",
+      serverUrl: "https://swamp-club.com",
+    },
+  });
+});
+
+Deno.test("createIssueEditRenderer: log noop handler does not throw", () => {
+  const renderer = createIssueEditRenderer("log");
+  const handlers = renderer.handlers();
+  handlers.noop({
+    kind: "noop",
+    issueNumber: 5,
+  });
+});
+
+Deno.test("createIssueEditRenderer: json completed output is valid JSON with serverUrl", () => {
+  const renderer = createIssueEditRenderer("json");
+  const handlers = renderer.handlers();
+  const out = captureStdout(() =>
+    handlers.completed({
+      kind: "completed",
+      data: {
+        issueNumber: 100,
+        title: "T",
+        body: "B",
+        serverUrl: "https://example.com",
+      },
+    })
+  );
+  JSON.parse(out);
+  assertStringIncludes(out, "https://example.com");
+});


### PR DESCRIPTION
## Summary

Adds `swamp issue edit <number>` to edit the title and body of an existing swamp-club Lab issue after submission, as requested in swamp-club#513 by @bixu.

- **`src/infrastructure/http/swamp_club_client.ts`** — new `updateIssue()` method: PATCH `/api/v1/lab/issues/{number}` with optional title/body fields. Handles 404, 403, and 422 (profanity) errors.
- **`src/libswamp/issues/edit.ts`** — new `issueEdit` generator function following the established Input/Deps/Event pattern. Compares against original values to detect no-op edits (skips API call), validates non-empty title, and sends only changed fields.
- **`src/cli/commands/issue_edit.ts`** — new CLI command with `--title` and `--body` flags. Opens `$EDITOR` pre-filled with the current issue content when flags are omitted. Requires auth (`swamp auth login`).
- **`src/presentation/renderers/issue_edit.ts`** — renderer for edit events in both log and json modes, using `writeOutput` with styled output matching the `issue_get` pattern.
- **`src/presentation/renderers/issue_create.ts`** — extended `IssueCancelledData` type with `"edit"` variant so the cancellation message correctly says "Issue edit cancelled".
- **`.claude/skills/swamp-issue/SKILL.md`** — documented the new `edit` command, trimmed description to pass tessl validation (94% score).

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 6,580 tests pass, 0 failures
- [x] `deno run compile` — binary compiles
- [x] `tessl skill review` — 94% score, all validation passed
- [x] 5 new HTTP client tests (PATCH success, partial fields, 404, 403, 422 profanity)
- [x] 6 new generator tests (title change, body change, noop, partial fields, empty title rejection, both fields)
- [x] 7 new CLI parser tests (round-trip, comment stripping, empty content, missing sections)
- [x] 5 new renderer tests (json completed/noop, log completed/noop, valid JSON output)