### PR TITLE
fix(workflow): resolve pulled extension types in validate (swamp-club#506)

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -178,6 +178,25 @@ top-level `workflows/` directory of the repository, as
 at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
 `.swamp/workflow-runs/`).
 
+## Validation
+
+`swamp workflow validate` checks structure (schema, unique names, dependency
+references, cycles) and validates each step's inputs against the resolved
+method's required arguments. To resolve a step's model type, the command first
+hot-loads pulled and local extensions (`modelRegistry.ensureLoaded()`), matching
+the resolution available to `swamp model type describe` and
+`swamp model validate`.
+
+Step-input checks fail when the resolved method does not exist
+(`method_not_found`) or when a required argument is missing. A step whose model
+**type cannot be resolved** also fails: an unresolvable type is reported as a
+validation failure (non-zero exit), never silently skipped as a pass — a silent
+skip would mask real contract bugs such as non-existent method names or wrong
+argument keys. Dynamic CEL references (`${{ ... }}`) in model/type names are
+skipped, since they can only be resolved at run time. A step that references a
+model **instance** which does not exist locally (`model_not_found`) is also
+skipped, because the instance may be created by an upstream step during the run.
+
 ## Workflow Definition
 
 Workflows are specified in `workflows/workflow-{uuid}.yaml`. They have a unique

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -31,6 +31,7 @@ import {
   workflowValidate,
 } from "../../libswamp/mod.ts";
 import { createWorkflowValidateRenderer } from "../../presentation/renderers/workflow_validate.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -54,6 +55,12 @@ export const workflowValidateCommand = new Command()
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
+
+    // Hot-load pulled/local extensions so step-input validation can resolve
+    // their model types. Without this, pulled extension types are skipped as
+    // "not resolved" and the step silently passes (parity with `type describe`
+    // and `model validate`, which both call ensureLoaded before resolving).
+    await modelRegistry.ensureLoaded();
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = createWorkflowValidateDeps(

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -435,6 +435,10 @@ export class DefaultWorkflowValidationService
 
     switch (resolution.status) {
       case "model_not_found":
+        // A step may reference a model created at run time (by an upstream
+        // direct-execution step or out-of-band), so a missing model instance
+        // is skipped rather than failed. This differs from an unresolvable
+        // model *type* below, which is always a real authoring error.
         return [
           WorkflowValidationResult.pass(
             checkName +
@@ -443,9 +447,11 @@ export class DefaultWorkflowValidationService
         ];
       case "type_unresolvable":
         return [
-          WorkflowValidationResult.pass(
-            checkName +
-              ` (model type '${resolution.modelType}' not resolved, skipped)`,
+          WorkflowValidationResult.fail(
+            checkName,
+            `Model type '${resolution.modelType}' could not be resolved — ` +
+              `ensure the extension is pulled and available so its step ` +
+              `inputs can be validated`,
           ),
         ];
       case "method_not_found":

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -720,6 +720,8 @@ Deno.test("validateStepInputs: model not found produces passing result with skip
 
   const results = await svc.validate(workflow);
   const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  // A missing model *instance* is skipped (it may be created at run time),
+  // unlike an unresolvable model *type*, which fails. See swamp-club#506.
   assertEquals(inputResult?.passed, true);
   assertEquals(inputResult?.name.includes("skipped"), true);
 });
@@ -1198,7 +1200,7 @@ Deno.test("validateStepInputs: direct-execution step with missing required args 
   assertEquals(inputResult?.error?.includes("version"), true);
 });
 
-Deno.test("validateStepInputs: direct-execution step with unresolvable type produces descriptive skip", async () => {
+Deno.test("validateStepInputs: direct-execution step with unresolvable type fails validation", async () => {
   const resolver = mockResolverWithType({
     "type:@swamp/nonexistent/type.deploy": {
       status: "type_unresolvable",
@@ -1228,9 +1230,41 @@ Deno.test("validateStepInputs: direct-execution step with unresolvable type prod
 
   const results = await svc.validate(workflow);
   const inputResult = results.find((r) => r.name.includes("Step inputs"));
-  assertEquals(inputResult?.passed, true);
-  assertEquals(inputResult?.name.includes("not resolved"), true);
-  assertEquals(inputResult?.name.includes("model not found"), false);
+  // An unresolvable type must NOT silently pass — it hides real contract bugs
+  // (non-existent methods, wrong arg keys). See swamp-club#506.
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("could not be resolved"), true);
+  assertEquals(inputResult?.error?.includes("@swamp/nonexistent/type"), true);
+});
+
+Deno.test("validateStepInputs: name-referenced step with unresolvable type fails validation", async () => {
+  const resolver = mockResolver({
+    "http-poll.pollUrl": {
+      status: "type_unresolvable",
+      modelType: "@hivemq/http-poll",
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("http-poll", "pollUrl"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const inputResult = results.find((r) => r.name.includes("Step inputs"));
+  assertEquals(inputResult?.passed, false);
+  assertEquals(inputResult?.error?.includes("could not be resolved"), true);
 });
 
 Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips validation", async () => {

--- a/src/libswamp/workflows/validate_test.ts
+++ b/src/libswamp/workflows/validate_test.ts
@@ -70,6 +70,34 @@ Deno.test("workflowValidate single workflow yields completed", async () => {
   assertEquals(data.passed, true);
 });
 
+Deno.test("workflowValidate single workflow with a failing validation reports passed=false", async () => {
+  // Guards the exit-code path: a failing validation result (e.g. an
+  // unresolvable step-input type, see swamp-club#506) must surface as
+  // passed=false so the CLI exits non-zero rather than reporting PASSED.
+  const deps = makeDeps({
+    validate: () =>
+      Promise.resolve([
+        WorkflowValidationResult.pass("schema"),
+        WorkflowValidationResult.fail(
+          "step inputs",
+          "type could not be resolved",
+        ),
+      ]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {
+      workflowIdOrName: "my-workflow",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowValidateEvent,
+    { kind: "completed" }
+  >;
+  const data = completed.data as WorkflowValidateData;
+  assertEquals(data.passed, false);
+});
+
 Deno.test("workflowValidate all workflows yields aggregate", async () => {
   const deps = makeDeps();
   const events = await collect<WorkflowValidateEvent>(


### PR DESCRIPTION
## Summary

`swamp workflow validate` did not hot-load **pulled** extensions before validating step inputs, so a pulled, version-matched model type resolved to `type_unresolvable` and the step-input check was logged as `... not resolved, skipped` — then **counted as a pass**. A step calling a non-existent method (e.g. `pollUrl` on `@hivemq/http-poll`) or passing wrong argument keys reported `Result: PASSED` and exited 0, silently masking real workflow contract bugs. (`swamp model type describe` resolved the same type fine, because it calls `ensureLoaded()`.)

This fixes the reporter's two asks with two coordinated changes:

1. **Resolve pulled types.** Call `modelRegistry.ensureLoaded()` in the validate command before resolving — parity with `model type describe` and `model validate`. Pulled and local extension types now resolve, so a bad method is correctly caught as `method_not_found`.
2. **Never pass an unresolvable type.** Map the `type_unresolvable` status to a validation **failure** instead of a pass, so a genuinely unresolvable model *type* fails loudly (non-zero exit) rather than being silently skipped.

### Behavior change (intentional)
A workflow step whose model **type** cannot be resolved now **fails** validation where it previously silently passed. This is the point of the fix, but it can surface in offline/CI validation of workflows that reference a type which isn't pulled/available — call out in release notes if relevant.

### Deliberate scope boundary
A missing model **instance** (`model_not_found`) is **still skipped**, not failed — an instance may legitimately be created at run time by an upstream step, and swamp's own integration tests rely on validating a workflow's structure before its models exist. Flipping that to a failure (to catch typo'd `modelIdOrName`) is a separate product decision and will be filed as its own issue.

## Test Plan

- New/updated unit tests in `validation_service_test.ts`: `type_unresolvable` (both name-referenced and direct-execution) now asserts **fail**; the `model_not_found` skip test is retained.
- New guard in `validate_test.ts`: a failing validation result propagates to `passed: false` (exit-code path).
- `design/workflow.md`: documents the resolution + fail-on-unresolvable-type policy.
- `deno check` / `deno lint` / `deno fmt --check`: clean.
- Full suite: **6527 passed, 0 failed**.
- Clean-room repro (compiled binary):
  - Bad method on pulled type → `Method 'pollUrl' not found` → **FAILED, exit 1**
  - Valid workflow (required `url` provided) → **PASSED, exit 0**
  - Missing required input on a now-resolved type → **FAILED** (previously masked)

Fixes swamp-club#506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)