### PR TITLE
feat(expressions): CEL cross-namespace queries (swamp-club#516)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -49,6 +49,29 @@ key, or history access beyond a single version.
 Results from any shortcut are structurally identical to the equivalent
 `data.query()` call — same `DataRecord[]` type, same fields, same semantics.
 
+### Cross-namespace queries (giga-swamp Phase 4)
+
+Point-lookup helpers (`data.latest`, `data.version`, `data.findBySpec`,
+`data.findByTag`, `data.listVersions`) support namespace-prefixed model names:
+
+| Syntax | Scope |
+| --- | --- |
+| `data.latest("model", "name")` | Own namespace only (default) |
+| `data.latest("infra:model", "name")` | Target namespace `infra` |
+| `data.latest("*:model", "name")` | All namespaces (errors if ambiguous) |
+
+`data.query()` spans all namespaces by default — no implicit namespace filter
+is injected. Use the `ns` field to filter explicitly:
+
+| Query | Scope |
+| --- | --- |
+| `data.query('modelType == "aws/ec2/vpc"')` | All namespaces |
+| `data.query('ns == "security"')` | Security namespace only |
+| `data.query('ns == ""')` | Solo-mode data only |
+
+The `ns` field name (not `namespace`) is used because `namespace` is a reserved
+identifier in CEL.
+
 ## DataRecord
 
 `data.query()` returns `DataRecord[]` — the same type returned by
@@ -128,6 +151,7 @@ filterable fields:
 | `jobName` | string | Job name (`""` outside workflows) |
 | `stepName` | string | Step name (`""` outside workflows) |
 | `source` | string | Provenance source (e.g. `"step-output"`, `""`) |
+| `ns` | string | Namespace slug (`""` in solo mode). Alias for `DataRecord.namespace` — CEL reserves `namespace` as an identifier |
 
 All fields except `attributes` and `content` are metadata stored in the
 catalog. `attributes` and `content` are loaded from disk on demand when the

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -238,6 +238,39 @@ inputs:
 
 The 2-argument forms continue to work for data stored without vary dimensions.
 
+### Cross-Namespace Queries
+
+Point-lookup helpers support namespace-prefixed model names for cross-namespace
+data access. The syntax uses a colon separator: `namespace:model-name`.
+
+```yaml
+attributes:
+  # Own namespace (default — same as today):
+  result: ${{ data.latest('scanner', 'result').attributes.value }}
+
+  # Specific namespace:
+  infraResult: ${{ data.latest('infra:scanner', 'result').attributes.value }}
+
+  # All namespaces (errors if model exists in multiple):
+  anyResult: ${{ data.latest('*:scanner', 'result').attributes.value }}
+```
+
+`data.findByTag()` does not take a model name, so it always queries the own
+namespace. `data.query()` spans all namespaces by default — use the `ns` field
+to filter:
+
+```yaml
+attributes:
+  # All namespaces:
+  allVpcs: ${{ data.query('modelType == "aws/ec2/vpc"') }}
+
+  # Specific namespace:
+  secVpcs: ${{ data.query('ns == "security" && modelType == "aws/ec2/vpc"') }}
+```
+
+The `ns` field name (not `namespace`) is used because `namespace` is a reserved
+identifier in the CEL language.
+
 ### Combined Example
 
 ```yaml

--- a/integration/giga_swamp_cel_namespace_test.ts
+++ b/integration/giga_swamp_cel_namespace_test.ts
@@ -1,0 +1,505 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for giga-swamp Phase 4: CEL cross-namespace queries.
+ *
+ * Verifies namespace routing in point-lookup helpers, wildcard ambiguity
+ * checks, data.query() namespace predicates, and the solo-mode byte-identical
+ * invariant.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { Data } from "../src/domain/data/data.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import {
+  type CatalogRow,
+  CatalogStore,
+} from "../src/infrastructure/persistence/catalog_store.ts";
+import { DataQueryService } from "../src/domain/data/data_query_service.ts";
+import { ModelResolver } from "../src/domain/expressions/model_resolver.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlOutputRepository } from "../src/infrastructure/persistence/yaml_output_repository.ts";
+import type { DataRecord } from "../src/domain/data/data_record.ts";
+import { SOLO_NAMESPACE } from "../src/domain/data/namespace.ts";
+import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/default_datastore_path_resolver.ts";
+import {
+  catalogDbPath,
+  namespaceFromResolver,
+} from "../src/infrastructure/persistence/repository_factory.ts";
+import type { DatastoreConfig } from "../src/domain/datastore/datastore_config.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-giga-cel-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+const modelType = ModelType.create("test/model");
+
+function makeData(
+  name: string,
+  modelName: string,
+  specName = "result",
+): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", modelName, specName },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: `test/model:${modelName}`,
+    },
+  });
+}
+
+interface SetupResult {
+  catalog: CatalogStore;
+  queryService: DataQueryService;
+  dataRepo: FileSystemUnifiedDataRepository;
+  repoDir: string;
+}
+
+function setupRepo(
+  repoDir: string,
+  dsDir: string,
+  namespace?: string,
+): SetupResult {
+  const config: DatastoreConfig = namespace
+    ? { type: "filesystem", path: dsDir, namespace }
+    : { type: "filesystem", path: dsDir };
+  const resolver = new DefaultDatastorePathResolver(repoDir, config);
+  const dataBaseDir = resolver.resolvePath("data");
+  const catalogPath = catalogDbPath(repoDir, resolver);
+  const ns = namespaceFromResolver(resolver);
+  const catalog = new CatalogStore(catalogPath);
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dataBaseDir,
+    catalog,
+    undefined,
+    undefined,
+    ns,
+  );
+  const queryService = new DataQueryService(catalog, dataRepo);
+  return { catalog, queryService, dataRepo, repoDir };
+}
+
+function makeCrossNamespaceRow(
+  namespace: string,
+  modelName: string,
+  dataName: string,
+): CatalogRow {
+  return {
+    namespace,
+    type_normalized: modelType.normalized,
+    model_id: crypto.randomUUID(),
+    data_name: dataName,
+    id: crypto.randomUUID(),
+    version: 1,
+    is_latest: 1,
+    model_name: modelName,
+    spec_name: "result",
+    data_type: "resource",
+    content_type: "application/json",
+    lifetime: "infinite",
+    owner_type: "model-method",
+    streaming: 0,
+    size: 2,
+    created_at: new Date().toISOString(),
+    tags: JSON.stringify({
+      type: "resource",
+      modelName,
+      specName: "result",
+    }),
+    owner_ref: "",
+    workflow_run_id: "",
+    workflow_name: "",
+    job_name: "",
+    step_name: "",
+    source: "",
+  };
+}
+
+async function buildDataContext(
+  setup: SetupResult,
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  const defRepo = new YamlDefinitionRepository(
+    join(setup.repoDir, ".swamp", "models"),
+  );
+  const outputRepo = new YamlOutputRepository(
+    join(setup.repoDir, ".swamp", "outputs"),
+  );
+  const resolver = new ModelResolver(defRepo, {
+    outputRepo,
+    repoDir: setup.repoDir,
+    dataRepo: setup.dataRepo,
+    dataQueryService: setup.queryService,
+  });
+  const context = await resolver.buildContext();
+  return context.data as unknown as Record<
+    string,
+    (...args: unknown[]) => unknown
+  >;
+}
+
+// --- Test 1: Solo mode byte-identical gate ---
+
+Deno.test("giga-swamp CEL Phase 4: solo mode produces byte-identical results", async () => {
+  await withTempDir(async (root) => {
+    const repoDir = join(root, "solo-repo");
+    const dsDir = join(root, "datastore");
+    const setup = setupRepo(repoDir, dsDir);
+    const modelId = crypto.randomUUID();
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        modelId,
+        makeData("output", "scanner"),
+        new TextEncoder().encode('{"found":42}'),
+      );
+
+      assertEquals(setup.dataRepo.namespace, SOLO_NAMESPACE);
+
+      const rawResults = await setup.queryService.query(
+        'modelName == "scanner" && name == "output"',
+      ) as DataRecord[];
+      assertEquals(rawResults.length, 1);
+      assertEquals(rawResults[0].namespace, "");
+
+      const data = await buildDataContext(setup);
+      const latest = await (data as {
+        latest: (m: string, n: string) => Promise<DataRecord | null>;
+      })
+        .latest("scanner", "output");
+      assertEquals(latest !== null, true);
+      assertEquals(latest!.name, "output");
+      assertEquals(latest!.namespace, "");
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 2: Cross-namespace point lookup ---
+// Uses a single repo/catalog with rows from multiple namespaces inserted
+// directly. In production, multi-namespace catalogs are built via datastore
+// sync; here we simulate by upserting rows for the "security" namespace.
+
+Deno.test("giga-swamp CEL Phase 4: cross-namespace point lookup with ns:model syntax", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo-infra");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "scanner"),
+        new TextEncoder().encode('{"source":"infra"}'),
+      );
+
+      // Mark populated before inserting cross-namespace rows to prevent
+      // backfill from overwriting them with disk-only (own-namespace) data.
+      setup.catalog.markPopulated();
+
+      setup.catalog.upsert(makeCrossNamespaceRow(
+        "security",
+        "scanner",
+        "output",
+      ));
+
+      const data = await buildDataContext(setup);
+      const latestFn = data.latest as (
+        m: string,
+        n: string,
+      ) => Promise<DataRecord | null>;
+
+      // Default: own namespace only
+      const ownResult = await latestFn("scanner", "output");
+      assertEquals(ownResult !== null, true);
+      assertEquals(ownResult!.namespace, "infra");
+
+      // Explicit cross-namespace
+      const crossResult = await latestFn("security:scanner", "output");
+      assertEquals(crossResult !== null, true);
+      assertEquals(crossResult!.namespace, "security");
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 3: Wildcard ambiguity check ---
+
+Deno.test("giga-swamp CEL Phase 4: wildcard ambiguity errors when model exists in multiple namespaces", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo-all");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "scanner"),
+        new TextEncoder().encode('{"ns":"infra"}'),
+      );
+
+      setup.catalog.markPopulated();
+
+      setup.catalog.upsert(makeCrossNamespaceRow(
+        "security",
+        "scanner",
+        "output",
+      ));
+
+      const data = await buildDataContext(setup);
+      const latestFn = data.latest as (
+        m: string,
+        n: string,
+      ) => Promise<DataRecord | null>;
+
+      // Wildcard with ambiguity should throw
+      await assertRejects(
+        async () => await latestFn("*:scanner", "output"),
+        Error,
+        "Ambiguous",
+      );
+
+      // Specific namespace should NOT throw
+      const specific = await latestFn("infra:scanner", "output");
+      assertEquals(specific !== null, true);
+      assertEquals(specific!.namespace, "infra");
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 4: data.query() namespace predicate filtering ---
+
+Deno.test("giga-swamp CEL Phase 4: data.query() with ns predicate filters by namespace", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "infra-model"),
+        new TextEncoder().encode("{}"),
+      );
+
+      setup.catalog.markPopulated();
+
+      setup.catalog.upsert(makeCrossNamespaceRow(
+        "security",
+        "sec-model",
+        "output",
+      ));
+
+      const data = await buildDataContext(setup);
+      const queryFn = data.query as (p: string) => Promise<DataRecord[]>;
+
+      const secResults = await queryFn('ns == "security"');
+      assertEquals(secResults.length, 1);
+      assertEquals(secResults[0].namespace, "security");
+
+      const infraResults = await queryFn('ns == "infra"');
+      assertEquals(infraResults.length, 1);
+      assertEquals(infraResults[0].namespace, "infra");
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 5: data.query() without namespace predicate spans all namespaces ---
+
+Deno.test("giga-swamp CEL Phase 4: data.query() without ns predicate spans all namespaces", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "infra-model"),
+        new TextEncoder().encode("{}"),
+      );
+
+      setup.catalog.markPopulated();
+
+      setup.catalog.upsert(makeCrossNamespaceRow(
+        "security",
+        "sec-model",
+        "output",
+      ));
+
+      const data = await buildDataContext(setup);
+      const queryFn = data.query as (p: string) => Promise<DataRecord[]>;
+
+      // No namespace predicate — should return data from ALL namespaces
+      const allResults = await queryFn('dataType == "resource"');
+      assertEquals(allResults.length, 2);
+      const namespaces = allResults.map((r) => r.namespace).sort();
+      assertEquals(namespaces, ["infra", "security"]);
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 6: Solo mode namespace predicate ---
+
+Deno.test("giga-swamp CEL Phase 4: data.query('ns == \"\"') in solo mode returns all data", async () => {
+  await withTempDir(async (root) => {
+    const repoDir = join(root, "solo-repo");
+    const dsDir = join(root, "datastore");
+    const setup = setupRepo(repoDir, dsDir);
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("out-a", "model-a"),
+        new TextEncoder().encode("{}"),
+      );
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("out-b", "model-b"),
+        new TextEncoder().encode("{}"),
+      );
+
+      const data = await buildDataContext(setup);
+      const queryFn = data.query as (p: string) => Promise<DataRecord[]>;
+
+      // Explicit empty-namespace predicate should match all solo-mode data
+      const soloResults = await queryFn('ns == ""');
+      assertEquals(soloResults.length, 2);
+      for (const r of soloResults) {
+        assertEquals(r.namespace, "");
+      }
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 7: Wildcard with unambiguous result succeeds ---
+
+Deno.test("giga-swamp CEL Phase 4: wildcard returns result when model exists in one namespace only", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "unique-scanner"),
+        new TextEncoder().encode('{"val":1}'),
+      );
+
+      const data = await buildDataContext(setup);
+      const latestFn = data.latest as (
+        m: string,
+        n: string,
+      ) => Promise<DataRecord | null>;
+
+      // Wildcard with only one namespace should succeed
+      const result = await latestFn("*:unique-scanner", "output");
+      assertEquals(result !== null, true);
+      assertEquals(result!.namespace, "infra");
+      assertEquals(result!.modelName, "unique-scanner");
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});
+
+// --- Test 8: listVersions wildcard ambiguity ---
+
+Deno.test("giga-swamp CEL Phase 4: listVersions wildcard errors when ambiguous", async () => {
+  await withTempDir(async (root) => {
+    const dsDir = join(root, "shared-ds");
+    const repoDir = join(root, "repo");
+    const setup = setupRepo(repoDir, dsDir, "infra");
+
+    try {
+      await setup.dataRepo.save(
+        modelType,
+        crypto.randomUUID(),
+        makeData("output", "scanner"),
+        new TextEncoder().encode("{}"),
+      );
+
+      setup.catalog.markPopulated();
+
+      setup.catalog.upsert(makeCrossNamespaceRow(
+        "security",
+        "scanner",
+        "output",
+      ));
+
+      const data = await buildDataContext(setup);
+      const listVersionsFn = data.listVersions as (
+        m: string,
+        n: string,
+      ) => number[];
+
+      // Wildcard with ambiguity should throw synchronously
+      let threw = false;
+      try {
+        listVersionsFn("*:scanner", "output");
+      } catch (e) {
+        threw = true;
+        assertEquals((e as Error).message.includes("Ambiguous"), true);
+      }
+      assertEquals(threw, true);
+
+      // Specific namespace should work fine
+      const versions = listVersionsFn("infra:scanner", "output");
+      assertEquals(versions.length, 1);
+      assertEquals(versions[0], 1);
+    } finally {
+      setup.catalog.close();
+    }
+  });
+});

--- a/src/domain/data/data_access_service.ts
+++ b/src/domain/data/data_access_service.ts
@@ -26,6 +26,8 @@ import type { Data } from "./data.ts";
 import type { DataRecord } from "./data_record.ts";
 import type { DataQueryService } from "./data_query_service.ts";
 import { fromData } from "./data_record_mapper.ts";
+import { parseNamespacedModelName } from "./namespace.ts";
+import { getLogger } from "@logtape/logtape";
 
 /**
  * A data item with its origin model coordinates, used to track
@@ -106,19 +108,34 @@ export class DataAccessService {
     modelName: string,
     specName?: string,
   ): Promise<DataRecord[]> {
+    const parsed = parseNamespacedModelName(modelName);
+
     if (this.dataQueryService) {
-      // Delegate to catalog-backed query — vault resolution handled there
       const escape = (s: string) =>
         s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-      let predicate = `modelName == "${escape(modelName)}"`;
+      let predicate = `modelName == "${escape(parsed.modelName)}"`;
       if (specName) {
         predicate += ` && specName == "${escape(specName)}"`;
+      }
+      if (parsed.namespace === undefined) {
+        const ownNs = this.dataRepo.namespace;
+        predicate += ` && ns == "${escape(ownNs)}"`;
+      } else if (parsed.namespace !== "*") {
+        predicate += ` && ns == "${escape(parsed.namespace)}"`;
       }
       return await this.dataQueryService.query(predicate) as DataRecord[];
     }
 
+    if (parsed.namespace !== undefined && parsed.namespace !== "*") {
+      getLogger(["data", "access"]).warn(
+        "Cross-namespace read {ns}:{model} falling back to own-namespace " +
+          "(filesystem path does not support cross-namespace resolution)",
+        { ns: parsed.namespace, model: parsed.modelName },
+      );
+    }
+
     // Fallback: file-system-based access (no catalog available)
-    const resolved = await this.resolveModel(modelName);
+    const resolved = await this.resolveModel(parsed.modelName);
     if (!resolved) {
       return [];
     }

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -185,12 +185,18 @@ export class DataQueryService {
       if (!needsContent) needsContent = referencesContent(selectAst);
     }
 
-    // Iterate catalog rows and evaluate predicate
+    // Iterate catalog rows and evaluate predicate.
+    // CEL reserves "namespace" as an identifier, so we expose an "ns" alias
+    // via a prototype-chain overlay — the record itself is not mutated.
     const results: DataRecord[] = [];
     for (const row of this.catalogStore.iterate()) {
       const record = this.rowToRecord(row, needsAttributes, needsContent);
+      const ctx = Object.create(
+        record as unknown as Record<string, unknown>,
+      ) as Record<string, unknown>;
+      ctx["ns"] = record.namespace;
       try {
-        const match = parsed(record as unknown as Record<string, unknown>);
+        const match = parsed(ctx);
         if (match === true) {
           results.push(record);
           if (results.length >= limit) break;
@@ -206,10 +212,15 @@ export class DataQueryService {
     // Apply projection if select expression provided.
     // Per-record errors (e.g. missing attribute keys) produce null instead of
     // failing the entire query, so partial results are still useful.
+    // The ns alias must be available in select expressions too.
     if (selectParsed) {
       return results.map((r) => {
         try {
-          return selectParsed(r as unknown as Record<string, unknown>);
+          const selectCtx = Object.create(
+            r as unknown as Record<string, unknown>,
+          ) as Record<string, unknown>;
+          selectCtx["ns"] = r.namespace;
+          return selectParsed(selectCtx);
         } catch {
           return null;
         }

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -684,3 +684,51 @@ Deno.test("DataQueryService: catalog backfill works with metadata-only files (no
     }
   }
 });
+
+Deno.test("DataQueryService: ns field is queryable for namespace filtering", () => {
+  const { catalog, service } = setupTest();
+  catalog.upsert(makeRow({ namespace: "", model_name: "solo-model" }));
+  catalog.upsert(
+    makeRow({
+      namespace: "infra",
+      model_name: "infra-model",
+      data_name: "infra-data",
+      id: "uuid-infra",
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      namespace: "security",
+      model_name: "sec-model",
+      data_name: "sec-data",
+      id: "uuid-sec",
+    }),
+  );
+
+  const infraResults = service.querySync(
+    'ns == "infra"',
+  ) as DataRecord[];
+  assertEquals(infraResults.length, 1);
+  assertEquals(infraResults[0].namespace, "infra");
+  assertEquals(infraResults[0].modelName, "infra-model");
+
+  const soloResults = service.querySync('ns == ""') as DataRecord[];
+  assertEquals(soloResults.length, 1);
+  assertEquals(soloResults[0].namespace, "");
+  assertEquals(soloResults[0].modelName, "solo-model");
+
+  const allResults = service.querySync(
+    'modelName == "solo-model" || modelName == "infra-model" || modelName == "sec-model"',
+  ) as DataRecord[];
+  assertEquals(allResults.length, 3);
+
+  // ns must also work in select projections
+  const projected = service.querySync(
+    'ns == "infra"',
+    { select: "ns" },
+  ) as string[];
+  assertEquals(projected.length, 1);
+  assertEquals(projected[0], "infra");
+
+  catalog.close();
+});

--- a/src/domain/data/query_predicate.ts
+++ b/src/domain/data/query_predicate.ts
@@ -44,6 +44,7 @@ export const QUERY_FIELDS = new Set([
   "jobName",
   "stepName",
   "source",
+  "ns",
 ]);
 
 /**

--- a/src/domain/expressions/dependency_extractor.ts
+++ b/src/domain/expressions/dependency_extractor.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { parseNamespacedModelName } from "../data/namespace.ts";
+
 /**
  * Type of model reference in an expression.
  */
@@ -112,9 +114,11 @@ export function extractModelRefs(expression: string): string[] {
   }
 
   // Extract from data.version('model', ...), data.latest('model', ...), etc.
+  // Strip namespace prefix ("ns:model" → "model", "*:model" → "model")
   const dataMatches = expression.matchAll(DATA_FUNCTION_PATTERN);
   for (const match of dataMatches) {
-    refs.add(match[2]);
+    const parsed = parseNamespacedModelName(match[2]);
+    refs.add(parsed.modelName);
   }
 
   // Extract from file.contents('model', ...)
@@ -177,9 +181,11 @@ export function extractArtifactDependencies(
   }
 
   // Extract from data function calls (all data functions create data dependencies)
+  // Strip namespace prefix ("ns:model" → "model")
   const dataMatches = expression.matchAll(DATA_FUNCTION_PATTERN);
   for (const match of dataMatches) {
-    const modelRef = match[2];
+    const parsed = parseNamespacedModelName(match[2]);
+    const modelRef = parsed.modelName;
     const key = `${modelRef}:data`;
 
     if (!seen.has(key)) {
@@ -242,7 +248,8 @@ export function extractDataFunctionDependencies(expression: string): string[] {
 
   const dataMatches = expression.matchAll(DATA_FUNCTION_PATTERN);
   for (const match of dataMatches) {
-    refs.add(match[2]);
+    const parsed = parseNamespacedModelName(match[2]);
+    refs.add(parsed.modelName);
   }
 
   return [...refs];

--- a/src/domain/expressions/dependency_extractor_test.ts
+++ b/src/domain/expressions/dependency_extractor_test.ts
@@ -381,3 +381,41 @@ Deno.test("hasStepOutputDependency returns true for data.findBySpec calls", () =
     true,
   );
 });
+
+// Tests for namespace prefix stripping in data function extraction
+
+Deno.test("extractModelRefs strips namespace prefix from data.latest", () => {
+  const expr = "data.latest('security:scanner', 'result').attributes.value";
+  const refs = extractModelRefs(expr);
+  assertEquals(refs.length, 1);
+  assertEquals(refs.includes("scanner"), true);
+});
+
+Deno.test("extractModelRefs strips wildcard prefix from data.latest", () => {
+  const expr = "data.latest('*:scanner', 'result').attributes.value";
+  const refs = extractModelRefs(expr);
+  assertEquals(refs.length, 1);
+  assertEquals(refs.includes("scanner"), true);
+});
+
+Deno.test("extractModelRefs preserves bare model name from data.latest", () => {
+  const expr = "data.latest('scanner', 'result').attributes.value";
+  const refs = extractModelRefs(expr);
+  assertEquals(refs.length, 1);
+  assertEquals(refs.includes("scanner"), true);
+});
+
+Deno.test("extractDataFunctionDependencies strips namespace prefix", () => {
+  const expr = "data.version('infra:vpc-model', 'state', 1)";
+  const refs = extractDataFunctionDependencies(expr);
+  assertEquals(refs.length, 1);
+  assertEquals(refs.includes("vpc-model"), true);
+});
+
+Deno.test("extractArtifactDependencies strips namespace prefix from data calls", () => {
+  const expr = "data.latest('security:scanner', 'output').attributes.id";
+  const deps = extractArtifactDependencies(expr);
+  assertEquals(deps.length, 1);
+  assertEquals(deps[0].modelRef, "scanner");
+  assertEquals(deps[0].type, "data");
+});

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -28,6 +28,9 @@ import type { DataRecord } from "../data/data_record.ts";
 import type { DataQueryService } from "../data/data_query_service.ts";
 import { isTextContentType } from "../data/content_type.ts";
 import { ModelNotFoundError } from "./errors.ts";
+import { parseNamespacedModelName } from "../data/namespace.ts";
+import type { Namespace } from "../data/namespace.ts";
+import { UserError } from "../errors.ts";
 import { VaultService } from "../vaults/vault_service.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
 import type { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
@@ -58,6 +61,65 @@ export type { DataRecord, FileDataRecord } from "../data/data_record.ts";
 /** Escapes a string for safe embedding in a CEL string literal. */
 function escapeCelString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+interface NamespaceRouting {
+  modelName: string;
+  namespacePredicate: string;
+  isWildcard: boolean;
+}
+
+/**
+ * Parses a possibly-namespaced model name and returns the bare model name,
+ * the CEL predicate fragment for namespace scoping, and whether the lookup
+ * is a wildcard query.
+ *
+ * - No prefix ("model") → own-namespace only: `namespace == "{ownNs}"`
+ * - Specific prefix ("ns:model") → target namespace: `namespace == "ns"`
+ * - Wildcard ("*:model") → all namespaces, no filter (caller must check ambiguity)
+ */
+function routeNamespace(
+  rawModelName: string,
+  ownNamespace: Namespace,
+): NamespaceRouting {
+  const parsed = parseNamespacedModelName(rawModelName);
+  if (parsed.namespace === undefined) {
+    return {
+      modelName: parsed.modelName,
+      namespacePredicate: ` && ns == "${escapeCelString(ownNamespace)}"`,
+      isWildcard: false,
+    };
+  }
+  if (parsed.namespace === "*") {
+    return {
+      modelName: parsed.modelName,
+      namespacePredicate: "",
+      isWildcard: true,
+    };
+  }
+  return {
+    modelName: parsed.modelName,
+    namespacePredicate: ` && ns == "${escapeCelString(parsed.namespace)}"`,
+    isWildcard: false,
+  };
+}
+
+/**
+ * Throws if wildcard query results span multiple namespaces.
+ */
+function checkWildcardAmbiguity(
+  results: DataRecord[],
+  rawModelName: string,
+): void {
+  if (results.length === 0) return;
+  const namespaces = new Set(results.map((r) => r.namespace));
+  if (namespaces.size > 1) {
+    const sorted = [...namespaces].sort();
+    throw new UserError(
+      `Ambiguous: "${rawModelName.slice(2)}" exists in namespaces ` +
+        `[${sorted.join(", ")}], qualify with a namespace prefix`,
+    );
+  }
 }
 
 /**
@@ -545,47 +607,73 @@ export class ModelResolver {
     // The query service owns the implicit `isLatest == true` injection, so
     // helpers compose predicates as if the catalog exposed history directly.
     //
+    // Point-lookup helpers (latest, version, findBySpec, findByTag,
+    // listVersions) default to own-namespace scoping. Cross-namespace access
+    // uses "ns:model" prefix syntax; wildcard "*:model" queries all namespaces
+    // with an ambiguity check. data.query() spans all namespaces by default.
+    //
     // Most helpers are async because the query path resolves vault
     // references in result attributes. Callers in sync CEL contexts (e.g.
     // `forEach.in`) must go through `CelEvaluator.evaluateAsync`, which
     // cel-js natively propagates Promises through.
+    const ownNamespace = this.dataRepo?.namespace ?? ("" as Namespace);
     context.data = {
       version: async (
-        modelName: string,
+        rawModelName: string,
         dataName: string,
         version: number,
       ): Promise<DataRecord | null> => {
         if (!this.dataQueryService) return null;
-        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
-          `&& name == "${escapeCelString(dataName)}" && version == ${version}`;
+        const ns = routeNamespace(rawModelName, ownNamespace);
+        const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}" && version == ${version}` +
+          ns.namespacePredicate;
         const results = await this.dataQueryService.query(predicate, {
-          limit: 1,
+          limit: ns.isWildcard ? undefined : 1,
           loadAttributes: true,
         }) as DataRecord[];
+        if (ns.isWildcard) {
+          checkWildcardAmbiguity(results, rawModelName);
+        }
         return results.length > 0 ? results[0] : null;
       },
       latest: async (
-        modelName: string,
+        rawModelName: string,
         dataName: string,
       ): Promise<DataRecord | null> => {
         if (!this.dataQueryService) return null;
-        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
-          `&& name == "${escapeCelString(dataName)}"`;
+        const ns = routeNamespace(rawModelName, ownNamespace);
+        const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}"` +
+          ns.namespacePredicate;
         const results = await this.dataQueryService.query(predicate, {
-          limit: 1,
+          limit: ns.isWildcard ? undefined : 1,
           loadAttributes: true,
         }) as DataRecord[];
+        if (ns.isWildcard) {
+          checkWildcardAmbiguity(results, rawModelName);
+        }
         return results.length > 0 ? results[0] : null;
       },
-      listVersions: (modelName: string, dataName: string): number[] => {
+      listVersions: (rawModelName: string, dataName: string): number[] => {
         if (!this.dataQueryService) return [];
+        const ns = routeNamespace(rawModelName, ownNamespace);
         // `version >= 0` is the history opt-in: it suppresses the implicit
         // `isLatest == true` injection so every version of this data item
         // is returned. The select projection extracts just the version
         // numbers. querySync is used so this helper can be called from
         // synchronous CEL contexts.
-        const predicate = `modelName == "${escapeCelString(modelName)}" ` +
-          `&& name == "${escapeCelString(dataName)}" && version >= 0`;
+        const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
+          `&& name == "${escapeCelString(dataName)}" && version >= 0` +
+          ns.namespacePredicate;
+        if (ns.isWildcard) {
+          // Can't check ambiguity on projected number[], so query records first.
+          const records = this.dataQueryService.querySync(
+            predicate,
+          ) as DataRecord[];
+          checkWildcardAmbiguity(records, rawModelName);
+          return records.map((r) => r.version).sort((a, b) => a - b);
+        }
         const results = this.dataQueryService.querySync(predicate, {
           select: "version",
         }) as number[];
@@ -596,24 +684,30 @@ export class ModelResolver {
         tagValue: string,
       ): Promise<DataRecord[]> => {
         if (!this.dataQueryService) return [];
-        const predicate = `tags.${escapeCelString(tagKey)} == "${
-          escapeCelString(tagValue)
-        }"`;
+        const nsPredicate = ` && ns == "${escapeCelString(ownNamespace)}"`;
+        const predicate =
+          `tags.${escapeCelString(tagKey)} == "${escapeCelString(tagValue)}"` +
+          nsPredicate;
         const results = await this.dataQueryService.query(predicate, {
           loadAttributes: true,
         }) as DataRecord[];
         return deduplicateByName(results);
       },
       findBySpec: async (
-        specModelName: string,
+        rawSpecModelName: string,
         specName: string,
       ): Promise<DataRecord[]> => {
         if (!this.dataQueryService) return [];
-        const predicate = `modelName == "${escapeCelString(specModelName)}" ` +
-          `&& specName == "${escapeCelString(specName)}"`;
+        const ns = routeNamespace(rawSpecModelName, ownNamespace);
+        const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
+          `&& specName == "${escapeCelString(specName)}"` +
+          ns.namespacePredicate;
         const results = await this.dataQueryService.query(predicate, {
           loadAttributes: true,
         }) as DataRecord[];
+        if (ns.isWildcard) {
+          checkWildcardAmbiguity(results, rawSpecModelName);
+        }
         return deduplicateByName(results);
       },
       query: async (


### PR DESCRIPTION
## Summary

- Add namespace routing to all CEL point-lookup helpers (`data.latest`, `data.version`, `data.findBySpec`, `data.findByTag`, `data.listVersions`) — default to own-namespace, support `ns:model` prefix for cross-namespace and `*:model` wildcard with ambiguity check
- Add `ns` as a queryable field in `data.query()` predicates for namespace filtering (`namespace` is a CEL reserved identifier, so `ns` is the alias)
- Update `data_access_service.ts` `readModelData()` with namespace:model parsing
- Update dependency extractor to strip namespace prefixes for workflow DAG correctness
- 8 integration tests covering solo-mode byte-identical gate, cross-namespace lookup, wildcard ambiguity, namespace predicates, and select projection

This is giga-swamp Phase 4 of 7. Solo-mode expressions produce byte-identical results — verified by 15 existing unit tests passing unchanged plus dedicated integration tests.

Fixes swamp-club#516

## Test Plan

- [x] `deno check` — all files pass
- [x] `deno lint` — clean
- [x] `deno fmt` — formatted
- [x] `deno run test` — 6575 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Solo-mode byte-identical gate: existing model_resolver_test.ts tests pass unchanged
- [x] Integration tests: 8 scenarios covering cross-namespace lookup, wildcard ambiguity, namespace predicates, select projection, and listVersions ambiguity
- [ ] Manual: smoke-test compiled binary against a real repo with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)