### PR TITLE
fix(registry): await pending type-load promise in ensureTypeLoaded (swamp-club#521)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1443,7 +1443,11 @@ the model registry is wired up initially.
    type.
 
 4. Concurrent callers requesting the same type share a single load promise
-   (per-type memoization).
+   (per-type memoization). Additionally, `ensureTypeLoaded` awaits any
+   pending load promise even when the type is already in the registry —
+   `loadSingleType` registers the base type via `promoteFromLazy` before
+   attaching extensions, so a concurrent caller arriving between those two
+   steps must wait for extensions to be merged (swamp-club#521).
 
 ### Self-Healing
 

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -810,8 +810,16 @@ export class ModelRegistry {
     const modelType = typeof type === "string" ? ModelType.create(type) : type;
     const key = modelType.normalized;
 
-    // Already fully loaded
-    if (this.models.has(key)) return;
+    // Already fully loaded — but only if no concurrent load is still in
+    // progress. loadSingleType registers the base type (promoteFromLazy)
+    // before attaching extensions; a pending promise means extensions may
+    // not yet be merged. Await the pending promise to avoid returning a
+    // base-only definition. (swamp-club#521)
+    if (this.models.has(key)) {
+      const pending = this.typeLoadPromises.get(key);
+      if (pending) await pending;
+      return;
+    }
 
     // Not known at all — nothing to load
     if (!this.lazyTypes.has(key)) return;

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -973,6 +973,42 @@ Deno.test("ModelRegistry.ensureTypeLoaded: concurrent callers share same promise
   assertEquals(registry.get("@myorg/echo")?.version, "2026.02.09.1");
 });
 
+Deno.test("ModelRegistry.ensureTypeLoaded: concurrent caller waits for extensions during load", async () => {
+  const registry = new ModelRegistry();
+  registry.registerLazy(createLazyEntry("@myorg/echo"));
+
+  // Simulate loadSingleType: register base type, yield, then extend.
+  // A concurrent caller arriving between promoteFromLazy and extend
+  // must wait for the full load to complete (swamp-club#521).
+  registry.setTypeLoader(async (type) => {
+    registry.promoteFromLazy(createTestModel(type));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    registry.extend(type, {
+      extension_method: {
+        description: "Extension method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    });
+  });
+
+  // Caller 1: starts loading (triggers the type loader)
+  const promise1 = registry.ensureTypeLoaded("@myorg/echo");
+
+  // Wait for promoteFromLazy but NOT extend
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  // Caller 2: must see extensions after awaiting
+  await registry.ensureTypeLoaded("@myorg/echo");
+
+  const modelDef = registry.get("@myorg/echo");
+  assertEquals(modelDef !== undefined, true);
+  assertEquals("extension_method" in modelDef!.methods, true);
+  assertEquals("write" in modelDef!.methods, true);
+
+  await promise1;
+});
+
 Deno.test("ModelRegistry.ensureTypeLoaded: retries after transient failure", async () => {
   const registry = new ModelRegistry();
   registry.registerLazy(createLazyEntry("@myorg/echo"));


### PR DESCRIPTION
## Summary

- Fix race condition in `ModelRegistry.ensureTypeLoaded()` where concurrent callers see a partially-loaded type (base only, no extensions)
- `loadSingleType` registers the base type via `promoteFromLazy` before attaching extensions; between these two async steps, concurrent callers saw `models.has(key) === true` and returned the base-only definition
- Now awaits any pending `typeLoadPromise` even when the type is already in `this.models`, ensuring concurrent callers wait for extensions to be merged

## Test plan

- [x] New unit test exercises the race window: type loader registers base, yields, then extends — concurrent `ensureTypeLoaded` call correctly waits for extensions
- [x] Existing `ensureTypeLoaded` tests still pass (concurrent callers share promise, retry after failure, no-op for loaded/unknown types)
- [x] Full test suite: 6602 passed, 0 failed
- [x] `deno check` / `deno lint` / `deno fmt`: clean
- [x] `deno run compile`: clean
- [x] Updated `design/extension.md` concurrency documentation

Fixes swamp-club#521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)