### PR TITLE
feat(issue): add `swamp issue search` command (swamp-club#523)

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swamp-issue
-description: Fetch, edit, and submit issues to swamp Lab — view details, edit title/body, file bugs/features/security reports, post ripples (comments) with close/reopen, route to extension publishers. Triggers on "bug report", "feature request", "security report", "report bug", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "extension bug", "ripple", "comment on issue", "close issue", "reopen issue", "get issue", "view issue", "fetch issue", "show issue", "edit issue", "update issue", "change issue title".
+description: Fetch, edit, search, and submit issues to swamp Lab — view details, edit title/body, search/list issues, file bugs/features/security reports, post ripples (comments) with close/reopen, route to extension publishers. Triggers on "bug report", "feature request", "security report", "report bug", "file bug", "submit bug", "swamp bug", "swamp feature", "feedback", "report issue", "file issue", "extension bug", "ripple", "comment on issue", "close issue", "reopen issue", "get issue", "view issue", "fetch issue", "show issue", "edit issue", "update issue", "change issue title", "search issues", "list issues", "find issue", "issue search".
 ---
 
 # Swamp Issue Skill
@@ -41,6 +41,7 @@ directly.
 
 | Command                       | Purpose                                                                                       |
 | ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `swamp issue search [query]`  | Search or list issues by keyword, with optional `--type`, `--status`, `--source`, `--limit`   |
 | `swamp issue get <number>`    | Fetch and display issue details (title, type, status, author, body, assignees, comment count) |
 | `swamp issue edit <number>`   | Edit title and/or body of an existing issue (author or admin only)                            |
 | `swamp issue bug`             | Title, description, steps to reproduce, environment                                           |
@@ -51,6 +52,9 @@ directly.
 **Basic non-interactive examples:**
 
 ```bash
+swamp issue search vault
+swamp issue search --type bug --status open
+swamp issue search --source swamp --limit 10 --json
 swamp issue get 42
 swamp issue get 42 --json
 swamp issue edit 42

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -24,14 +24,16 @@ import { issueEditCommand } from "./issue_edit.ts";
 import { issueFeatureCommand } from "./issue_feature.ts";
 import { issueGetCommand } from "./issue_get.ts";
 import { issueRippleCommand } from "./issue_ripple.ts";
+import { issueSearchCommand } from "./issue_search.ts";
 import { issueSecurityCommand } from "./issue_security.ts";
 
 export const issueCommand = new Command()
   .name("issue")
   .description(
-    "Fetch issue details, submit bug reports, feature requests, security reports, and ripples (comments)",
+    "Search, fetch, submit, and comment on swamp-club Lab issues",
   )
   .action(groupCommandAction)
+  .command("search", issueSearchCommand)
   .command("get", issueGetCommand)
   .command("edit", issueEditCommand)
   .command("bug", issueBugCommand)

--- a/src/cli/commands/issue_search.ts
+++ b/src/cli/commands/issue_search.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  issueSearch,
+  type IssueSearchDeps,
+} from "../../libswamp/mod.ts";
+import { createIssueSearchRenderer } from "../../presentation/renderers/issue_search.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import { loadIdentity } from "../load_identity.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const issueSearchCommand = new Command()
+  .name("search")
+  .description("Search or list swamp-club Lab issues")
+  .example("Search by keyword", "swamp issue search vault")
+  .example("List all open bugs", "swamp issue search --type bug --status open")
+  .example("List all issues as JSON", "swamp issue search --json")
+  .example("Limit results", "swamp issue search --limit 10")
+  .arguments("[query:string]")
+  .option(
+    "--type <type:string>",
+    "Filter by issue type (bug, feature, security)",
+  )
+  .option(
+    "--status <status:string>",
+    "Filter by status (open, triaged, in_progress, shipped, closed)",
+  )
+  .option("--source <source:string>", "Filter by source tag")
+  .option("--limit <limit:integer>", "Maximum number of results to return")
+  .action(async function (options: AnyOptions, query?: string) {
+    const ctx = createContext(options as GlobalOptions, ["issue", "search"]);
+
+    const credentials = await new AuthRepository().load();
+    const identity = await loadIdentity();
+    const serverUrl = credentials?.serverUrl ??
+      Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
+
+    const client = new SwampClubClient(serverUrl, identity);
+    const deps: IssueSearchDeps = {
+      searchIssues: async (input) => {
+        const result = await client.searchIssues(credentials?.apiKey, {
+          q: input.q,
+          type: input.type,
+          status: input.status,
+          source: input.source,
+          limit: input.limit,
+        });
+        return {
+          issues: result.issues.map((issue) => ({
+            number: issue.number,
+            title: issue.title,
+            type: issue.type,
+            status: issue.status,
+            author: issue.author,
+          })),
+          total: result.total,
+          serverUrl,
+        };
+      },
+    };
+
+    const libCtx = createLibSwampContext({ logger: ctx.logger });
+    const renderer = createIssueSearchRenderer(ctx.outputMode);
+
+    await consumeStream(
+      issueSearch(libCtx, deps, {
+        q: query,
+        type: options.type,
+        status: options.status,
+        source: options.source,
+        limit: options.limit,
+      }),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/issue_search_test.ts
+++ b/src/cli/commands/issue_search_test.ts
@@ -1,0 +1,29 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { issueSearchCommand } from "./issue_search.ts";
+
+Deno.test("issueSearchCommand: has correct name and description", () => {
+  assertEquals(issueSearchCommand.getName(), "search");
+  assertEquals(
+    issueSearchCommand.getDescription(),
+    "Search or list swamp-club Lab issues",
+  );
+});

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -84,6 +84,22 @@ export interface FetchIssueResponse {
   commentCount: number;
 }
 
+/** Filters for the issue search endpoint. */
+export interface SearchIssuesFilter {
+  q?: string;
+  type?: string;
+  status?: string;
+  source?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Response from the issue search/list endpoint. */
+export interface SearchIssuesResponse {
+  issues: FetchIssueResponse[];
+  total: number;
+}
+
 /**
  * HTTP client for swamp-club API interactions.
  * Used by auth commands to sign in, create API keys, and verify identity.
@@ -407,6 +423,63 @@ export class SwampClubClient {
         .map((a: Record<string, string>) => a.username),
       commentCount: (issue.comments ?? []).length,
     };
+  }
+
+  /**
+   * Search or list Lab issues with optional filters.
+   * When an API key is provided, authenticates using the x-api-key header.
+   */
+  async searchIssues(
+    apiKey: string | undefined,
+    filter?: SearchIssuesFilter,
+  ): Promise<SearchIssuesResponse> {
+    const params = new URLSearchParams();
+    if (filter?.q) params.set("q", filter.q);
+    if (filter?.type) params.set("type", filter.type);
+    if (filter?.status) params.set("status", filter.status);
+    if (filter?.source) params.set("source", filter.source);
+    if (filter?.limit !== undefined) {
+      params.set("limit", String(filter.limit));
+    }
+    if (filter?.offset !== undefined) {
+      params.set("offset", String(filter.offset));
+    }
+    const qs = params.toString();
+    const path = `/api/v1/lab/issues${qs ? `?${qs}` : ""}`;
+
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["x-api-key"] = apiKey;
+    }
+    const res = await this.fetch(path, { method: "GET", headers });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new UserError(
+        `Failed to search issues (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    const data = await res.json();
+    const issues: FetchIssueResponse[] = (data.issues ?? []).map(
+      // deno-lint-ignore no-explicit-any
+      (issue: any) => ({
+        number: issue.number,
+        title: issue.title ?? "",
+        type: issue.type ?? "feature",
+        status: issue.status ?? "open",
+        author: issue.authorUsername ?? "unknown",
+        body: issue.body ?? "",
+        assignees: (issue.assignees ?? [])
+          .filter(
+            (a: Record<string, unknown>) => typeof a.username === "string",
+          )
+          .map((a: Record<string, string>) => a.username),
+        commentCount: (issue.comments ?? []).length,
+      }),
+    );
+
+    return { issues, total: data.total ?? issues.length };
   }
 
   private async fetch(

--- a/src/infrastructure/http/swamp_club_client_search_test.ts
+++ b/src/infrastructure/http/swamp_club_client_search_test.ts
@@ -1,0 +1,176 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { SwampClubClient } from "./swamp_club_client.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function startMockServer(
+  handler: (req: Request) => Response | Promise<Response>,
+): { port: number; shutdown: () => Promise<void> } {
+  const ac = new AbortController();
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal, onListen() {} },
+    handler,
+  );
+  return {
+    port: (server.addr as Deno.NetAddr).port,
+    async shutdown() {
+      ac.abort();
+      await server.finished;
+    },
+  };
+}
+
+Deno.test("searchIssues: returns issues and total", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({
+      issues: [
+        {
+          number: 1,
+          title: "First issue",
+          type: "bug",
+          status: "open",
+          authorUsername: "alice",
+          body: "Body text",
+          assignees: [{ userId: "u1", username: "bob" }],
+          comments: [{ id: "c1" }],
+        },
+      ],
+      total: 42,
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.searchIssues("key-123");
+    assertEquals(result.total, 42);
+    assertEquals(result.issues.length, 1);
+    assertEquals(result.issues[0].number, 1);
+    assertEquals(result.issues[0].title, "First issue");
+    assertEquals(result.issues[0].type, "bug");
+    assertEquals(result.issues[0].status, "open");
+    assertEquals(result.issues[0].author, "alice");
+    assertEquals(result.issues[0].assignees, ["bob"]);
+    assertEquals(result.issues[0].commentCount, 1);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("searchIssues: sends query params", async () => {
+  let capturedUrl = "";
+  const mock = startMockServer((req) => {
+    capturedUrl = req.url;
+    return Response.json({ issues: [], total: 0 });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await client.searchIssues("key-123", {
+      q: "vault",
+      type: "bug",
+      status: "open",
+      source: "swamp",
+      limit: 10,
+      offset: 20,
+    });
+    const url = new URL(capturedUrl);
+    assertEquals(url.searchParams.get("q"), "vault");
+    assertEquals(url.searchParams.get("type"), "bug");
+    assertEquals(url.searchParams.get("status"), "open");
+    assertEquals(url.searchParams.get("source"), "swamp");
+    assertEquals(url.searchParams.get("limit"), "10");
+    assertEquals(url.searchParams.get("offset"), "20");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("searchIssues: omits empty params", async () => {
+  let capturedUrl = "";
+  const mock = startMockServer((req) => {
+    capturedUrl = req.url;
+    return Response.json({ issues: [], total: 0 });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await client.searchIssues(undefined);
+    const url = new URL(capturedUrl);
+    assertEquals(url.search, "");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("searchIssues: sends api key header", async () => {
+  let capturedApiKey: string | null = null;
+  const mock = startMockServer((req) => {
+    capturedApiKey = req.headers.get("x-api-key");
+    return Response.json({ issues: [], total: 0 });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await client.searchIssues("my-secret-key");
+    assertEquals(capturedApiKey, "my-secret-key");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("searchIssues: throws UserError on failure", async () => {
+  const mock = startMockServer((_req) =>
+    new Response("Bad request", { status: 400 })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.searchIssues("key"),
+      UserError,
+      "Failed to search issues",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("searchIssues: handles missing total gracefully", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({
+      issues: [
+        {
+          number: 5,
+          title: "No total",
+          type: "feature",
+          status: "open",
+          authorUsername: "eve",
+          body: "",
+          assignees: [],
+          comments: [],
+        },
+      ],
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.searchIssues(undefined);
+    assertEquals(result.total, 1);
+    assertEquals(result.issues.length, 1);
+  } finally {
+    await mock.shutdown();
+  }
+});

--- a/src/libswamp/issues/search.ts
+++ b/src/libswamp/issues/search.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface IssueSearchItem {
+  number: number;
+  title: string;
+  type: string;
+  status: string;
+  author: string;
+}
+
+export interface IssueSearchData {
+  issues: IssueSearchItem[];
+  total: number;
+  serverUrl: string;
+}
+
+export type IssueSearchEvent =
+  | { kind: "completed"; data: IssueSearchData }
+  | { kind: "error"; error: SwampError };
+
+export interface IssueSearchInput {
+  q?: string;
+  type?: string;
+  status?: string;
+  source?: string;
+  limit?: number;
+}
+
+export interface IssueSearchDeps {
+  searchIssues: (input: IssueSearchInput) => Promise<IssueSearchData>;
+}
+
+export async function* issueSearch(
+  ctx: LibSwampContext,
+  deps: IssueSearchDeps,
+  input: IssueSearchInput,
+): AsyncIterable<IssueSearchEvent> {
+  yield* withGeneratorSpan(
+    "swamp.issue.search",
+    {},
+    (async function* () {
+      ctx.logger.debug`Searching issues${input.q ? ` for ${input.q}` : ""}`;
+
+      const result = await deps.searchIssues(input);
+
+      yield {
+        kind: "completed",
+        data: result,
+      };
+    })(),
+  );
+}

--- a/src/libswamp/issues/search_test.ts
+++ b/src/libswamp/issues/search_test.ts
@@ -1,0 +1,120 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  issueSearch,
+  type IssueSearchData,
+  type IssueSearchDeps,
+  type IssueSearchEvent,
+  type IssueSearchInput,
+} from "./search.ts";
+import { createLibSwampContext } from "../context.ts";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+function collectEvents(
+  gen: AsyncIterable<IssueSearchEvent>,
+): Promise<IssueSearchEvent[]> {
+  return Array.fromAsync(gen);
+}
+
+Deno.test("issueSearch: returns completed event with search results", async () => {
+  const mockData: IssueSearchData = {
+    issues: [
+      {
+        number: 42,
+        title: "Test issue",
+        type: "bug",
+        status: "open",
+        author: "alice",
+      },
+    ],
+    total: 1,
+    serverUrl: "https://swamp-club.com",
+  };
+
+  const deps: IssueSearchDeps = {
+    searchIssues: (_input: IssueSearchInput) => Promise.resolve(mockData),
+  };
+
+  const ctx = createLibSwampContext({});
+  const events = await collectEvents(
+    issueSearch(ctx, deps, { q: "test" }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+  if (events[0].kind === "completed") {
+    assertEquals(events[0].data.issues.length, 1);
+    assertEquals(events[0].data.issues[0].number, 42);
+    assertEquals(events[0].data.total, 1);
+    assertEquals(events[0].data.serverUrl, "https://swamp-club.com");
+  }
+});
+
+Deno.test("issueSearch: passes input filters to deps", async () => {
+  let capturedInput: IssueSearchInput | undefined;
+  const deps: IssueSearchDeps = {
+    searchIssues: (input: IssueSearchInput) => {
+      capturedInput = input;
+      return Promise.resolve({
+        issues: [],
+        total: 0,
+        serverUrl: "https://swamp-club.com",
+      });
+    },
+  };
+
+  const ctx = createLibSwampContext({});
+  const input: IssueSearchInput = {
+    q: "vault",
+    type: "feature",
+    status: "open",
+    source: "swamp",
+    limit: 25,
+  };
+  await collectEvents(issueSearch(ctx, deps, input));
+
+  assertEquals(capturedInput, input);
+});
+
+Deno.test("issueSearch: returns empty results", async () => {
+  const deps: IssueSearchDeps = {
+    searchIssues: () =>
+      Promise.resolve({
+        issues: [],
+        total: 0,
+        serverUrl: "https://swamp-club.com",
+      }),
+  };
+
+  const ctx = createLibSwampContext({});
+  const events = await collectEvents(
+    issueSearch(ctx, deps, {}),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "completed");
+  if (events[0].kind === "completed") {
+    assertEquals(events[0].data.issues.length, 0);
+    assertEquals(events[0].data.total, 0);
+  }
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1125,6 +1125,14 @@ export {
   type IssueEditEvent,
   type IssueEditInput,
 } from "./issues/edit.ts";
+export {
+  issueSearch,
+  type IssueSearchData,
+  type IssueSearchDeps,
+  type IssueSearchEvent,
+  type IssueSearchInput,
+  type IssueSearchItem,
+} from "./issues/search.ts";
 
 // Audit operations
 export {

--- a/src/presentation/renderers/issue_search.ts
+++ b/src/presentation/renderers/issue_search.ts
@@ -1,0 +1,99 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, IssueSearchEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+import { bold, cyan, dim } from "@std/fmt/colors";
+
+const MAX_TITLE_WIDTH = 60;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
+}
+
+function padEnd(text: string, width: number): string {
+  if (text.length >= width) return text;
+  return text + " ".repeat(width - text.length);
+}
+
+class LogIssueSearchRenderer implements Renderer<IssueSearchEvent> {
+  handlers(): EventHandlers<IssueSearchEvent> {
+    return {
+      completed: (e) => {
+        const d = e.data;
+        if (d.issues.length === 0) {
+          writeOutput("No issues found.");
+          return;
+        }
+
+        for (const issue of d.issues) {
+          const num = cyan(`#${issue.number}`);
+          const title = truncate(issue.title, MAX_TITLE_WIDTH);
+          const meta = dim(
+            `${padEnd(issue.type, 8)} ${
+              padEnd(issue.status, 12)
+            } ${issue.author}`,
+          );
+          writeOutput(
+            `${bold(num)}  ${padEnd(title, MAX_TITLE_WIDTH)}  ${meta}`,
+          );
+        }
+
+        writeOutput("");
+        const showing = d.issues.length;
+        if (d.total > showing) {
+          writeOutput(dim(`Showing ${showing} of ${d.total} issues`));
+        } else {
+          writeOutput(dim(`${d.total} issue${d.total === 1 ? "" : "s"}`));
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonIssueSearchRenderer implements Renderer<IssueSearchEvent> {
+  handlers(): EventHandlers<IssueSearchEvent> {
+    return {
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createIssueSearchRenderer(
+  mode: OutputMode,
+): Renderer<IssueSearchEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonIssueSearchRenderer();
+    case "log":
+      return new LogIssueSearchRenderer();
+  }
+}

--- a/src/presentation/renderers/issue_search_test.ts
+++ b/src/presentation/renderers/issue_search_test.ts
@@ -1,0 +1,148 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertThrows } from "@std/assert/throws";
+import { createIssueSearchRenderer } from "./issue_search.ts";
+import { UserError } from "../../domain/errors.ts";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+Deno.test("issue search renderer: json mode outputs JSON", () => {
+  const renderer = createIssueSearchRenderer("json");
+  const handlers = renderer.handlers();
+
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(String(args[0]));
+  try {
+    const event = {
+      kind: "completed" as const,
+      data: {
+        issues: [
+          {
+            number: 1,
+            title: "Test",
+            type: "bug",
+            status: "open",
+            author: "alice",
+          },
+        ],
+        total: 1,
+        serverUrl: "https://swamp-club.com",
+      },
+    };
+    handlers.completed(event);
+    const parsed = JSON.parse(output.join(""));
+    assertEquals(parsed.total, 1);
+    assertEquals(parsed.issues.length, 1);
+    assertEquals(parsed.issues[0].number, 1);
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("issue search renderer: json error throws UserError", () => {
+  const renderer = createIssueSearchRenderer("json");
+  const handlers = renderer.handlers();
+
+  const event = {
+    kind: "error" as const,
+    error: { code: "search_failed", message: "something went wrong" },
+  };
+  assertThrows(
+    () => handlers.error(event),
+    UserError,
+    "something went wrong",
+  );
+});
+
+Deno.test("issue search renderer: log error throws UserError", () => {
+  const renderer = createIssueSearchRenderer("log");
+  const handlers = renderer.handlers();
+
+  const event = {
+    kind: "error" as const,
+    error: { code: "search_failed", message: "search failed" },
+  };
+  assertThrows(
+    () => handlers.error(event),
+    UserError,
+    "search failed",
+  );
+});
+
+Deno.test("issue search renderer: log mode renders without throwing", () => {
+  const renderer = createIssueSearchRenderer("log");
+  const handlers = renderer.handlers();
+
+  handlers.completed({
+    kind: "completed",
+    data: {
+      issues: [
+        {
+          number: 42,
+          title: "Fix the thing",
+          type: "bug",
+          status: "open",
+          author: "bob",
+        },
+      ],
+      total: 1,
+      serverUrl: "https://swamp-club.com",
+    },
+  });
+});
+
+Deno.test("issue search renderer: log mode handles empty results", () => {
+  const renderer = createIssueSearchRenderer("log");
+  const handlers = renderer.handlers();
+
+  handlers.completed({
+    kind: "completed",
+    data: {
+      issues: [],
+      total: 0,
+      serverUrl: "https://swamp-club.com",
+    },
+  });
+});
+
+Deno.test("issue search renderer: log mode handles partial results", () => {
+  const renderer = createIssueSearchRenderer("log");
+  const handlers = renderer.handlers();
+
+  handlers.completed({
+    kind: "completed",
+    data: {
+      issues: [
+        {
+          number: 1,
+          title: "First",
+          type: "bug",
+          status: "open",
+          author: "alice",
+        },
+      ],
+      total: 50,
+      serverUrl: "https://swamp-club.com",
+    },
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `swamp issue search [query]` subcommand to search/list swamp-club Lab issues from the CLI
- Supports `--type`, `--status`, `--source`, and `--limit` filters; optional query argument for keyword search
- Calls `GET /api/v1/lab/issues` with server-side filtering (enabled by swamp-club PR #621)
- Log mode renders a compact table (#number, title, type, status, author); JSON mode returns full array with total count
- 16 new tests across HTTP client, application service, CLI command, and renderer layers

Closes swamp-club#523

## Test Plan

- [x] `deno check` — full type check passes
- [x] `deno lint` — no issues
- [x] `deno fmt --check` — formatted
- [x] `deno run test` — 6617 tests pass, 0 failures
- [x] `deno run compile` — binary compiles
- [x] `tessl skill review` — skill passes at 94%
- [ ] Manual: `swamp issue search vault --json` returns filtered results
- [ ] Manual: `swamp issue search --type bug --status open` lists open bugs
- [ ] Manual: `swamp issue search` with no args lists all issues