### PR TITLE
fix(catalog): recover from read-only extension catalog during schema migration (swamp-club#518)

### DIFF
--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -143,7 +143,7 @@ export interface ExtensionTypeRow {
  * populated flag is not set.
  */
 export class ExtensionCatalogStore {
-  private readonly db: DatabaseSync;
+  private db: DatabaseSync;
   private readonly dbPath: string;
 
   constructor(dbPath: string) {
@@ -151,7 +151,21 @@ export class ExtensionCatalogStore {
     this.dbPath = dbPath;
     this.db = new DatabaseSync(dbPath);
     this.db.exec("PRAGMA busy_timeout=5000");
-    this.initializeWithRetry();
+    try {
+      this.initializeWithRetry();
+    } catch (error: unknown) {
+      if (isReadOnlyError(error)) {
+        logger
+          .warn`Catalog DB is read-only during schema migration; recreating from scratch`;
+        this.db.close();
+        removeCatalogFiles(dbPath);
+        this.db = new DatabaseSync(dbPath);
+        this.db.exec("PRAGMA busy_timeout=5000");
+        this.initializeWithRetry();
+      } else {
+        throw error;
+      }
+    }
   }
 
   /**
@@ -1179,4 +1193,21 @@ export function sourceDirsFingerprint(
  */
 function inferRepoRootFromDbPath(dbPath: string): string {
   return dirname(dirname(dbPath));
+}
+
+function isReadOnlyError(error: unknown): boolean {
+  return error instanceof Error &&
+    /attempt to write a readonly database/i.test(error.message);
+}
+
+function removeCatalogFiles(dbPath: string): void {
+  const sidecars = [`${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`];
+  try {
+    Deno.removeSync(dbPath);
+  } catch { /* file may already be gone */ }
+  for (const sidecar of sidecars) {
+    try {
+      Deno.removeSync(sidecar);
+    } catch { /* ok */ }
+  }
 }

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -1668,3 +1668,62 @@ Deno.test("ExtensionCatalogStore: W1b drop-validation_failed migration ROLLBACKs
 
   store.close();
 });
+
+Deno.test({
+  name:
+    "ExtensionCatalogStore: recovers from read-only catalog by deleting and recreating",
+  ignore: Deno.build.os === "windows",
+  fn() {
+    const dbPath = makeTempDbPath();
+
+    // Seed an old-schema catalog missing the 'last_error' column.
+    const seed = new DatabaseSync(dbPath);
+    seed.exec("PRAGMA journal_mode=WAL");
+    seed.exec(`
+      CREATE TABLE bundle_types (
+        source_path        TEXT NOT NULL PRIMARY KEY,
+        type_normalized    TEXT NOT NULL,
+        kind               TEXT NOT NULL DEFAULT 'model',
+        bundle_path        TEXT NOT NULL,
+        version            TEXT NOT NULL DEFAULT '',
+        description        TEXT NOT NULL DEFAULT '',
+        extends_type       TEXT NOT NULL DEFAULT '',
+        source_mtime       TEXT NOT NULL DEFAULT '',
+        source_fingerprint TEXT NOT NULL DEFAULT '',
+        state              TEXT NOT NULL DEFAULT 'Indexed',
+        extension_name     TEXT NOT NULL DEFAULT '',
+        extension_version  TEXT NOT NULL DEFAULT ''
+      );
+      CREATE TABLE bundle_meta (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+    seed.exec(
+      "INSERT INTO bundle_meta (key, value) VALUES ('migration_applied:per-extension-aggregate-v3', 'true')",
+    );
+    seed.exec(
+      "INSERT INTO bundle_meta (key, value) VALUES ('migration_applied:validation-failed-dropped-v1', 'true')",
+    );
+    seed.close();
+
+    // Make the file read-only so schema migration fails.
+    Deno.chmodSync(dbPath, 0o444);
+
+    // Construction should recover: delete the stale file, recreate.
+    const store = new ExtensionCatalogStore(dbPath);
+
+    // The recovered store should be fully functional.
+    store.upsert(makeRow({ source_path: "/test/echo.ts" }));
+    const rows = store.findByKind("model");
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].source_path, "/test/echo.ts");
+
+    store.close();
+
+    // Restore permissions for cleanup.
+    try {
+      Deno.removeSync(dbPath);
+    } catch { /* withTempDir handles cleanup */ }
+  },
+});


### PR DESCRIPTION
## Summary

- When `ExtensionCatalogStore` opens a stale catalog DB that is unwritable (read-only permissions from an older swamp version, corrupt WAL sidecar, or filesystem restrictions), schema migration fails with `ERR_SQLITE_ERROR: attempt to write a readonly database`
- The constructor now catches this error, deletes the stale `.db` file plus its `-wal`/`-shm`/`-journal` sidecars, and recreates the catalog from scratch — loaders repopulate from disk on next access
- Adds a unit test that seeds an old-schema catalog, makes it read-only, and verifies the constructor auto-recovers

Fixes: swamp-club#518

## Test Plan

- [x] Reproduced in scratch repo: `swamp repo init`, trigger catalog creation, `chmod 0444` the `.db` file → crash confirmed
- [x] Verified fix against reproduction: both `swamp repo upgrade` and `swamp model type search` succeed after the fix
- [x] New unit test: seeds old-schema DB, chmod 0444, asserts recovery + functional catalog (skipped on Windows)
- [x] Full test suite: 6602 passed, 0 failed
- [x] `deno check`, `deno lint`, `deno fmt` all clean