### PR TITLE
feat(workflow): allow explicit globalArgs in direct type execution steps (swamp-club#504)

### DIFF
--- a/.claude/skills/swamp-workflow/references/direct-execution.md
+++ b/.claude/skills/swamp-workflow/references/direct-execution.md
@@ -24,6 +24,30 @@ task:
 - Auto-created definitions are stored in `.swamp/auto-definitions/`.
 - Inputs are routed between global args and method args using the type's schemas
   (method args take precedence on ambiguous keys).
+- An optional `globalArgs` field passes global arguments explicitly, bypassing
+  the implicit routing. When present, `inputs` are treated as method arguments
+  only. `globalArgs` is only valid with direct type execution.
+
+## Explicit Global Arguments
+
+Use `globalArgs` when you want to separate global arguments from method inputs
+explicitly — especially useful for `forEach` fan-out where each iteration needs
+distinct configuration:
+
+```yaml
+- name: deploy-${{self.env.name}}
+  forEach: { item: env, in: "${{ inputs.environments }}" }
+  task:
+    type: model_method
+    modelType: "@myorg/deployer"
+    modelName: "deployer-${{ self.env.name }}"
+    methodName: deploy
+    globalArgs:
+      region: ${{ self.env.region }}
+      account: ${{ self.env.account }}
+    inputs:
+      version: ${{ inputs.version }}
+```
 
 ## forEach Support
 

--- a/design/inputs.md
+++ b/design/inputs.md
@@ -289,3 +289,30 @@ and handles both Zod v3 and v4.
 This routing happens at definition creation time. The routed global arguments
 are stored in the auto-created definition; the routed method arguments are
 passed to the method's execute function.
+
+### Explicit `globalArgs` in Workflow Steps
+
+Workflow step tasks using direct type execution can also pass global arguments
+explicitly via a `globalArgs` field, bypassing the implicit routing:
+
+```yaml
+task:
+  type: model_method
+  modelType: "@myorg/deployer"
+  modelName: "deployer-${{ self.env.name }}"
+  methodName: deploy
+  globalArgs:
+    region: ${{ self.env.region }}
+    account: ${{ self.env.account }}
+  inputs:
+    version: ${{ inputs.version }}
+```
+
+When `globalArgs` is present, `inputs` are treated as method arguments only — no
+schema-based routing is performed. The `globalArgs` values are passed directly to
+the auto-created definition's `globalArguments`. This is particularly useful for
+`forEach` fan-out, where each iteration needs distinct connection or
+configuration global args.
+
+`globalArgs` is only valid with direct type execution (`modelType` + `modelName`)
+and is rejected for existing definitions (`modelIdOrName`).

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -57,6 +57,25 @@ These variants are mutually exclusive — a step cannot have both `modelIdOrName
 and `modelType`. Auto-created definitions are stored in
 `.swamp/auto-definitions/`.
 
+An optional `globalArgs` field passes global arguments explicitly, bypassing
+schema-based input routing. When present, `inputs` are treated as method
+arguments only:
+
+```yaml
+task:
+  type: model_method
+  modelType: "@myorg/deployer"
+  modelName: my-deployer
+  methodName: deploy
+  globalArgs:
+    region: us-east-1
+  inputs:
+    version: "1.0"
+```
+
+`globalArgs` is only valid with direct type execution — the schema rejects it
+for `modelIdOrName` tasks.
+
 For `forEach` steps, `modelName` supports CEL template expressions:
 
 ```yaml

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -307,6 +307,7 @@ export const workflowRunCommand = new Command()
             defName,
             methodName,
             inputs,
+            globalArgs,
           ) => {
             const typeStr = typeArg;
             let resolvedType = ModelType.create(typeStr);
@@ -356,6 +357,7 @@ export const workflowRunCommand = new Command()
               inputs,
               resolvedType,
               modelDef,
+              globalArgs,
             );
             if (!result.ok) throw new Error(result.error.message);
             return {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -262,6 +262,7 @@ export type DirectTypeResolver = (
   definitionName: string,
   methodName: string,
   inputs: Record<string, unknown>,
+  globalArgs?: Record<string, unknown>,
 ) => Promise<DirectTypeResolveResult>;
 
 export interface StepExecutorDeps {
@@ -397,6 +398,7 @@ export class DefaultStepExecutor implements StepExecutor {
       modelName?: string;
       methodName: string;
       inputs?: Record<string, unknown>;
+      globalArgs?: Record<string, unknown>;
     },
     ctx: StepExecutionContext,
   ): Promise<unknown> {
@@ -458,6 +460,7 @@ export class DefaultStepExecutor implements StepExecutor {
         task.modelName,
         task.methodName,
         task.inputs ?? {},
+        task.globalArgs,
       );
 
       originalDefinition = result.definition;

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -34,6 +34,7 @@ const StepTaskRawSchema = z.discriminatedUnion("type", [
     modelName: z.string().min(1).optional(),
     methodName: z.string().min(1),
     inputs: z.record(z.string(), z.unknown()).optional(),
+    globalArgs: z.record(z.string(), z.unknown()).optional(),
   }),
   z.object({
     type: z.literal("workflow"),
@@ -99,6 +100,12 @@ export const StepTaskSchema = z.preprocess((data) => {
           `modelType requires modelName to name the auto-created definition.`,
         );
       }
+      if ("globalArgs" in d && d.globalArgs && !hasDirect) {
+        throw new Error(
+          `globalArgs is only valid with direct type execution (modelType + modelName). ` +
+            `For existing definitions, set global arguments in the definition YAML instead.`,
+        );
+      }
     }
   }
   return data;
@@ -160,6 +167,7 @@ export class StepTask {
     modelName: string,
     methodName: string,
     inputs?: Record<string, unknown>,
+    globalArgs?: Record<string, unknown>,
   ): StepTask {
     return new StepTask({
       type: "model_method",
@@ -167,6 +175,7 @@ export class StepTask {
       modelName,
       methodName,
       inputs,
+      globalArgs,
     });
   }
 

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -284,6 +284,73 @@ Deno.test("StepTaskSchema rejects neither modelIdOrName nor modelType", () => {
   );
 });
 
+// globalArgs tests for direct type execution
+
+Deno.test("StepTaskSchema parses globalArgs with modelType + modelName", () => {
+  const result = StepTaskSchema.parse({
+    type: "model_method",
+    modelType: "@test/deployer",
+    modelName: "my-deployer",
+    methodName: "deploy",
+    globalArgs: { region: "us-east-1", account: "123456" },
+    inputs: { target: "prod" },
+  });
+  assertEquals(result.type, "model_method");
+  if (result.type === "model_method") {
+    assertEquals(result.globalArgs, {
+      region: "us-east-1",
+      account: "123456",
+    });
+    assertEquals(result.inputs, { target: "prod" });
+  }
+});
+
+Deno.test("StepTaskSchema rejects globalArgs with modelIdOrName", () => {
+  assertThrows(
+    () => {
+      StepTaskSchema.parse({
+        type: "model_method",
+        modelIdOrName: "my-model",
+        methodName: "run",
+        globalArgs: { region: "us-east-1" },
+      });
+    },
+    Error,
+    "globalArgs",
+  );
+});
+
+Deno.test("StepTask.directExecution creates task with globalArgs", () => {
+  const task = StepTask.directExecution(
+    "@test/deployer",
+    "my-deployer",
+    "deploy",
+    { target: "prod" },
+    { region: "us-east-1" },
+  );
+  assertEquals(task.data.type, "model_method");
+  assertEquals(task.isDirectExecution(), true);
+  if (task.data.type === "model_method") {
+    assertEquals(task.data.globalArgs, { region: "us-east-1" });
+    assertEquals(task.data.inputs, { target: "prod" });
+  }
+});
+
+Deno.test("StepTaskSchema parses globalArgs without inputs", () => {
+  const result = StepTaskSchema.parse({
+    type: "model_method",
+    modelType: "@test/deployer",
+    modelName: "my-deployer",
+    methodName: "deploy",
+    globalArgs: { region: "us-east-1" },
+  });
+  assertEquals(result.type, "model_method");
+  if (result.type === "model_method") {
+    assertEquals(result.globalArgs, { region: "us-east-1" });
+    assertEquals(result.inputs, undefined);
+  }
+});
+
 // Manual approval tests
 
 Deno.test("StepTask.manualApproval creates manual approval task", () => {

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -142,11 +142,41 @@ export async function resolveOrCreateDefinition(
   inputs: Record<string, unknown>,
   resolvedType: ModelType,
   modelDef: ModelDefinition,
+  explicitGlobalArgs?: Record<string, unknown>,
 ): Promise<DirectExecutionResult> {
-  // Route inputs
-  const routed = routeInputsBySchema(inputs, methodName, modelDef);
-  if ("error" in routed) {
-    return { ok: false, error: routed.error };
+  // When explicit globalArgs are provided, skip routing — treat inputs as
+  // method args only and use the explicit values as global args.
+  let routed: RoutedInputs;
+  if (explicitGlobalArgs) {
+    const method = modelDef.methods[methodName];
+    if (!method) {
+      return {
+        ok: false,
+        error: {
+          code: "unknown_method",
+          message: `Unknown method '${methodName}'. Available methods: ${
+            Object.keys(modelDef.methods).join(", ") || "none"
+          }`,
+        },
+      };
+    }
+    if (modelDef.globalArguments) {
+      const coerced = coerceMethodArgs(
+        explicitGlobalArgs,
+        modelDef.globalArguments,
+      );
+      Object.assign(explicitGlobalArgs, coerced);
+    }
+    routed = {
+      globalArguments: explicitGlobalArgs,
+      methodArguments: inputs,
+    };
+  } else {
+    const routeResult = routeInputsBySchema(inputs, methodName, modelDef);
+    if ("error" in routeResult) {
+      return { ok: false, error: routeResult.error };
+    }
+    routed = routeResult;
   }
 
   // Look up existing definition

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -519,6 +519,95 @@ Deno.test("resolveOrCreateDefinition: refuses a literal sensitive global arg on 
   assertEquals(saved, false);
 });
 
+Deno.test("resolveOrCreateDefinition: uses explicit globalArgs and treats inputs as method-only", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string(), account: z.string() }),
+    { deploy: z.object({ target: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/deploy");
+  let savedDefinition: Definition | null = null;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: (_type, def) => {
+        savedDefinition = def;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/deploy/${id}.yaml`,
+    },
+    "test/deploy",
+    "my-deployer",
+    "deploy",
+    { target: "prod" },
+    resolvedType,
+    modelDef,
+    { region: "us-east-1", account: "123456" },
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, true);
+    assertEquals(result.routedInputs.globalArguments, {
+      region: "us-east-1",
+      account: "123456",
+    });
+    assertEquals(result.routedInputs.methodArguments, { target: "prod" });
+    assertEquals(savedDefinition !== null, true);
+    assertEquals(
+      savedDefinition!.globalArguments as Record<string, unknown>,
+      { region: "us-east-1", account: "123456" },
+    );
+  }
+});
+
+Deno.test("resolveOrCreateDefinition: explicit globalArgs updates existing definition", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ region: z.string() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/model");
+  const existingDef = Definition.create({
+    name: "existing-model",
+    type: "test/model",
+    typeVersion: "2026.01.01.1",
+    globalArguments: { region: "us-west-2" },
+  });
+  let saved = false;
+
+  const result = await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () =>
+        Promise.resolve({ definition: existingDef, type: resolvedType }),
+      getModelDef: () => modelDef,
+      saveDefinition: () => {
+        saved = true;
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type, id) => `/tmp/models/test/model/${id}.yaml`,
+    },
+    "test/model",
+    "existing-model",
+    "run",
+    { id: "abc" },
+    resolvedType,
+    modelDef,
+    { region: "us-east-1" },
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.created, false);
+    assertEquals(result.globalArgsUpdated, true);
+    assertEquals(
+      result.definition.globalArguments as Record<string, unknown>,
+      { region: "us-east-1" },
+    );
+    assertEquals(saved, true);
+  }
+});
+
 Deno.test("resolveOrCreateDefinition: accepts a vault.get expression for a sensitive global arg", async () => {
   const modelDef = createTestModelDef(
     z.object({


### PR DESCRIPTION
## Summary

- Add a `globalArgs` field to `model_method` step tasks for direct type execution (`modelType` + `modelName`)
- When present, `globalArgs` values are passed directly as global arguments to the auto-created definition, and `inputs` are treated as method arguments only (no schema-based routing)
- When absent, existing implicit routing via `routeInputsBySchema` is preserved (fully backward compatible)
- Reject `globalArgs` on `modelIdOrName` tasks with a clear error message

This enables `forEach` fan-out workflows to pass per-item connection/config global args cleanly:

```yaml
- name: deploy-${{ self.env.name }}
  forEach: { item: env, in: "${{ inputs.environments }}" }
  task:
    type: model_method
    modelType: "@myorg/deployer"
    modelName: "deployer-${{ self.env.name }}"
    methodName: deploy
    globalArgs:
      region: ${{ self.env.region }}
    inputs:
      version: ${{ inputs.version }}
```

## Test Plan

- 4 new unit tests for `StepTaskSchema` (globalArgs parsing, rejection with modelIdOrName, factory, globalArgs without inputs)
- 2 new unit tests for `resolveOrCreateDefinition` (explicit globalArgs on create, explicit globalArgs updating existing definition)
- All 6625 existing tests pass
- Compiled binary and verified end-to-end in scratch repo:
  - `swamp workflow validate` passes (8/8 checks) for workflow with `globalArgs` + `forEach`
  - `swamp workflow run` correctly expands forEach steps and passes globalArgs to the resolver
  - Invalid workflow with `globalArgs` + `modelIdOrName` rejected with clear error

Closes swamp-club#504