### PR TITLE
feat(workflow): trim stale 'skipped' suffix from model_not_found warning (swamp-club#529)

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -440,7 +440,7 @@ export class DefaultWorkflowValidationService
         return [
           WorkflowValidationResult.warning(
             checkName +
-              " (model not found, skipped)",
+              " (model not found)",
             "Model instance not found — may be created at runtime, " +
               "or could be a typo",
           ),

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -700,7 +700,7 @@ Deno.test("validateStepInputs: skipped when no resolver provided", async () => {
   assertEquals(inputResults.length, 0);
 });
 
-Deno.test("validateStepInputs: model not found produces warning with skip note", async () => {
+Deno.test("validateStepInputs: model not found produces warning", async () => {
   const resolver = mockResolver({});
   const svc = new DefaultWorkflowValidationService(resolver);
 
@@ -725,7 +725,8 @@ Deno.test("validateStepInputs: model not found produces warning with skip note",
   // unlike an unresolvable model *type*, which fails. See swamp-club#506/#517.
   assertEquals(inputResult?.passed, true);
   assertEquals(inputResult?.warning, true);
-  assertEquals(inputResult?.name.includes("skipped"), true);
+  assertEquals(inputResult?.name.includes("skipped"), false);
+  assertEquals(inputResult?.name.includes("model not found"), true);
   assertEquals(inputResult?.error?.includes("not found"), true);
 });
 

--- a/src/libswamp/workflows/validate_test.ts
+++ b/src/libswamp/workflows/validate_test.ts
@@ -136,7 +136,7 @@ Deno.test("workflowValidate: warning does not affect passed aggregation", async 
       Promise.resolve([
         WorkflowValidationResult.pass("schema"),
         WorkflowValidationResult.warning(
-          "step inputs (model not found, skipped)",
+          "step inputs (model not found)",
           "Model instance not found",
         ),
       ]),


### PR DESCRIPTION
## Summary

- Removes the contradictory `(model not found, skipped)` suffix from the
  model_not_found warning in `workflow validate`, replacing it with
  `(model not found)`. The "skipped" label was a leftover from when this check
  was a silent pass — now that it's surfaced as a warning (PR #1490), the label
  is misleading.
- Updates the domain test assertion and the libswamp integration test mock to
  match the new suffix.

Closes swamp-club#529

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 41 domain validation service tests pass
- [x] All 6 libswamp workflow validate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)