### PR TITLE
fix(models): copy explicitGlobalArgs before mutation in resolveOrCreateDefinition (swamp-club#532)

### DIFF
--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -160,15 +160,16 @@ export async function resolveOrCreateDefinition(
         },
       };
     }
+    const globalArgs = { ...explicitGlobalArgs };
     if (modelDef.globalArguments) {
       const coerced = coerceMethodArgs(
-        explicitGlobalArgs,
+        globalArgs,
         modelDef.globalArguments,
       );
-      Object.assign(explicitGlobalArgs, coerced);
+      Object.assign(globalArgs, coerced);
     }
     routed = {
-      globalArguments: explicitGlobalArgs,
+      globalArguments: globalArgs,
       methodArguments: inputs,
     };
   } else {

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -640,3 +640,34 @@ Deno.test("resolveOrCreateDefinition: accepts a vault.get expression for a sensi
   assertEquals(result.ok, true);
   assertEquals(saved, true);
 });
+
+Deno.test("resolveOrCreateDefinition: explicit globalArgs object is not mutated by coercion", async () => {
+  const modelDef = createTestModelDef(
+    z.object({ port: z.number() }),
+    { run: z.object({ id: z.string() }) },
+  );
+  const resolvedType = ModelType.create("test/repro");
+  const callerGlobalArgs: Record<string, unknown> = { port: "42" };
+
+  await resolveOrCreateDefinition(
+    {
+      lookupDefinition: () => Promise.resolve(null),
+      getModelDef: () => modelDef,
+      saveDefinition: () => Promise.resolve(),
+      getDefinitionPath: (_type, id) => `/tmp/models/test/repro/${id}.yaml`,
+    },
+    "test/repro",
+    "repro-model",
+    "run",
+    { id: "abc" },
+    resolvedType,
+    modelDef,
+    callerGlobalArgs,
+  );
+
+  assertEquals(
+    callerGlobalArgs.port,
+    "42",
+    "caller's explicitGlobalArgs must not be mutated by coercion",
+  );
+});


### PR DESCRIPTION
## Summary

- Spread-copy `explicitGlobalArgs` into a local variable before mutating with
  `Object.assign`, matching the ownership pattern already used by
  `routeInputsBySchema` on its implicit routing path.
- Add a unit test that passes a string value where the schema expects a number,
  then asserts the caller's original object is not mutated by coercion.

Fixes swamp-club#532.

## Test Plan

- [x] New unit test: `resolveOrCreateDefinition: explicit globalArgs object is not mutated by coercion`
- [x] All 19 `direct_execution_test.ts` tests pass
- [x] Full test suite passes (6631 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all clean