### PR TITLE
feat(skill): add sanitization gate to swamp-issue skill (swamp-club#530)

### DIFF
--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -81,6 +81,10 @@ Ripples (described in the intro) have these submission rules:
 - `--close` and `--reopen` are mutually exclusive. The ripple is posted first;
   the status change is a separate operation. If the status change fails, the
   ripple is still posted (partial success).
+- Before posting, sanitize the body for secrets, identifiers, and paths per
+  [references/sanitization.md](references/sanitization.md). Ripple bodies often
+  contain quoted error output from working sessions — redact identifying parts
+  while preserving diagnostic structure.
 
 **Output shape** (with `--json`):
 
@@ -139,7 +143,7 @@ A state machine. Each state gates the next — do not advance until the current
 state's **Verify** passes. If Verify fails, run **On Failure** and re-verify.
 
 ```
-gather_details → version_check → submit → verify
+gather_details → sanitize → version_check → submit → verify
 ```
 
 ### State 1: gather_details
@@ -157,9 +161,26 @@ are relevant to the bug (for the version check in the next state).
 
 **On Failure:** Ask the user for more details.
 
-### State 2: version_check
+### State 2: sanitize
 
-**Gate:** State 1 passed (title, body, and diagnosed file paths are known).
+**Gate:** State 1 passed (title and body are drafted).
+
+**Action:** Scan the drafted title and body for secrets, org-specific
+identifiers, and local paths. See
+[references/sanitization.md](references/sanitization.md) for the full pattern
+list, placeholders, and judgment calls.
+
+**Verify:** One of two outcomes:
+
+- **No findings** — content is clean. Advance silently.
+- **Findings exist** — present the redactions to the user and get confirmation
+  before advancing.
+
+**On Failure:** If the user rejects a redaction, adjust and re-verify.
+
+### State 3: version_check
+
+**Gate:** State 2 passed (title, body, and diagnosed file paths are known).
 
 **Action:** Check if the bug was already fixed in a newer version. Read
 [references/version_check.md](references/version_check.md) for the full
@@ -177,9 +198,9 @@ procedure.
 **On Failure:** If `swamp update --check` or `swamp source fetch` fails, treat
 as inconclusive and advance.
 
-### State 3: submit
+### State 4: submit
 
-**Gate:** State 2 passed with `bug_present` or `inconclusive`.
+**Gate:** State 3 passed with `bug_present` or `inconclusive`.
 
 **Action:** Verify syntax with `swamp help issue bug`. Run the command.
 
@@ -187,9 +208,9 @@ as inconclusive and advance.
 
 **On Failure:** See Error Recovery table below.
 
-### State 4: verify
+### State 5: verify
 
-**Gate:** State 3 passed.
+**Gate:** State 4 passed.
 
 **Action:** Confirm the returned issue number / URL with the user (or relay
 refusal guidance).
@@ -201,10 +222,13 @@ refusal guidance).
 Feature requests and security reports use a linear flow (no version check):
 
 1. Gather details from the user.
-2. For extension-scoped reports, confirm the extension is pulled locally.
-3. Verify syntax with `swamp help issue`.
-4. Run the appropriate command.
-5. Verify with the returned issue number / URL.
+2. Sanitize the drafted title and body — scan for secrets, identifiers, and
+   paths per [references/sanitization.md](references/sanitization.md). Present
+   any findings to the user for confirmation before proceeding.
+3. For extension-scoped reports, confirm the extension is pulled locally.
+4. Verify syntax with `swamp help issue`.
+5. Run the appropriate command.
+6. Verify with the returned issue number / URL.
 
 ## Error Recovery
 

--- a/.claude/skills/swamp-issue/references/formatting.md
+++ b/.claude/skills/swamp-issue/references/formatting.md
@@ -1,5 +1,10 @@
 # Formatting Issue Content
 
+Format the content first, then sanitize. Do not pre-sanitize during gathering —
+the original context (paths, error messages, identifiers) is needed for
+diagnosis and formatting. Once the draft is ready, run the sanitization step
+from [sanitization.md](sanitization.md) before submission.
+
 ## Bug Reports
 
 Provide a summary of the work involved to fix the bug:

--- a/.claude/skills/swamp-issue/references/sanitization.md
+++ b/.claude/skills/swamp-issue/references/sanitization.md
@@ -1,0 +1,74 @@
+# Content Sanitization
+
+Scan the drafted title and body for sensitive content before submission. This
+applies to all submission paths: bug reports, feature requests, security
+reports, extension-scoped reports, and ripples.
+
+## When to Sanitize
+
+After gathering all content (title, body, reproduction steps) and before running
+any `swamp issue` command. Do not sanitize during gathering — the original
+context is needed for diagnosis. Sanitize the final draft.
+
+## What to Scan For
+
+### Secrets
+
+- API keys, tokens, and passwords (e.g. `sk-...`, `ghp_...`, `AKIA...`,
+  `Bearer ...`, `token: ...`)
+- JWTs (three dot-separated base64 segments)
+- Private keys (`-----BEGIN ... PRIVATE KEY-----`)
+- `Authorization` headers and `Cookie` values
+- Connection strings with embedded credentials
+- Vault expressions: `vault.<name>.<key>` in CEL, `${{ vault.<name>.<key> }}` in
+  YAML — replace the key name and vault name
+
+**Placeholder:** `<REDACTED_SECRET>`
+
+### Identifiers
+
+- Organization and repository names that identify the user's employer (e.g.
+  `acme-corp/internal-tools`)
+- Internal hostnames and domains (e.g. `jenkins.internal.acme.com`)
+- Private IP addresses (RFC 1918: `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`)
+- Email addresses (except generic ones like `support@systeminit.com`)
+- Usernames that identify real people
+
+**Placeholders:** `<ORG>`, `<INTERNAL_HOST>`, `<PRIVATE_IP>`, `<EMAIL>`,
+`<USERNAME>`
+
+### Paths
+
+- Absolute paths under `/Users/<name>/`, `/home/<name>/`, `C:\Users\<name>\` —
+  these reveal the user's OS username and directory structure
+- Paths are safe when they use generic prefixes like `/tmp/`, `/usr/local/bin/`,
+  or relative paths like `./models/`
+- Preserve the path structure but replace the identifying segment:
+  `/Users/jdoe/code/acme/project` becomes `/path/to/repo`
+
+**Placeholder:** `/path/to/repo` (or `/path/to/<component>` when multiple
+distinct paths appear)
+
+## How to Sanitize
+
+1. Draft the title and body as normal during `gather_details`.
+2. Before submission, scan the final content against the categories above.
+3. If findings exist:
+   - List each finding with the original value and proposed replacement.
+   - Ask the user to confirm the redactions.
+   - Apply confirmed redactions to the title and body.
+4. If no findings, proceed to submission without interruption.
+
+## Judgment Calls
+
+- **Generic system paths** (`/usr/local/bin/swamp`, `/tmp/repro/`) are safe — do
+  not redact.
+- **Public repository names** (`systeminit/swamp`, well-known open-source
+  projects) are safe.
+- **Quoted error output** often contains paths or identifiers from the user's
+  environment. Redact the identifying parts while preserving the error structure
+  — the error message itself is diagnostic value.
+- **swamp-club and swamp.club references** are safe — these are the project's
+  own public infrastructure.
+- **When uncertain**, flag it to the user rather than silently redacting or
+  silently passing through.


### PR DESCRIPTION
## Summary

- Add a content sanitization step to the `swamp-issue` skill that scans drafted issue content for secrets (tokens, API keys, JWTs, vault expressions, private keys), org-specific identifiers (hostnames, IPs, emails), and local paths (`/Users/`, `/home/`) before submission
- New `references/sanitization.md` with detailed patterns, placeholder conventions, and judgment calls for edge cases
- Sanitization gate integrated into all submission paths: bug report state machine (new State 2), feature/security linear workflow (step 2), and ripple constraints

Closes https://github.com/systeminit/swamp/issues/530

## Test Plan

- [x] `deno fmt --check` passes on all skill files
- [x] `tessl skill review` scores 94% with no errors or warnings
- [ ] Manual: invoke `swamp-issue` skill with content containing test secrets, local paths, and org names — verify the agent catches and redacts them before submission

🤖 Generated with [Claude Code](https://claude.ai/claude-code)