### PR TITLE
fix(vault): preserve trailing newline for multiline stdin in vault put (swamp-club#531)

### DIFF
--- a/.claude/skills/swamp-vault/SKILL.md
+++ b/.claude/skills/swamp-vault/SKILL.md
@@ -153,8 +153,9 @@ swamp vault put dev-secrets API_KEY
 ```
 
 Interactive mode (TTY, no `=`, no pipe) prompts with echo suppressed; piped
-stdin reads the value and strips one trailing newline. Not available in `--json`
-mode.
+stdin reads the value and strips a trailing newline for single-line values (the
+`echo` artifact). Multiline content (PEM keys, certificates) is preserved
+exactly. Not available in `--json` mode.
 
 **IMPORTANT — agent security:** Never ask the user to paste or type a secret
 value into conversation. Instead, instruct them to run `vault put` directly in

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -82,7 +82,11 @@ export function resolveKeyValue(
   }
 
   if (stdinContent !== null) {
-    const value = stdinContent.replace(/\n$/, "");
+    const hasInternalNewlines = stdinContent.indexOf("\n") <
+      stdinContent.length - 1;
+    const value = hasInternalNewlines
+      ? stdinContent
+      : stdinContent.replace(/\n$/, "");
     return { key, value };
   }
 

--- a/src/cli/commands/vault_put_test.ts
+++ b/src/cli/commands/vault_put_test.ts
@@ -82,14 +82,21 @@ Deno.test("resolveKeyValue - strips trailing newline from stdin", () => {
   assertEquals(result, { key: "API_KEY", value: "piped-secret" });
 });
 
-Deno.test("resolveKeyValue - strips only one trailing newline", () => {
+Deno.test("resolveKeyValue - preserves multiline content exactly (PEM keys, certificates)", () => {
   const result = resolveKeyValue("API_KEY", "line1\nline2\n");
-  assertEquals(result, { key: "API_KEY", value: "line1\nline2" });
+  assertEquals(result, { key: "API_KEY", value: "line1\nline2\n" });
 });
 
 Deno.test("resolveKeyValue - preserves value with no trailing newline", () => {
   const result = resolveKeyValue("API_KEY", "exact-value");
   assertEquals(result, { key: "API_KEY", value: "exact-value" });
+});
+
+Deno.test("resolveKeyValue - preserves PEM key with trailing newline", () => {
+  const pem =
+    "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXk=\n-----END OPENSSH PRIVATE KEY-----\n";
+  const result = resolveKeyValue("SSH_KEY", pem);
+  assertEquals(result, { key: "SSH_KEY", value: pem });
 });
 
 Deno.test("resolveKeyValue - error when no = and no stdin", () => {


### PR DESCRIPTION
## Summary

- `vault put` unconditionally stripped the trailing newline from piped stdin, breaking PEM private keys and certificates that OpenSSH requires to end with a newline
- Only strip the trailing newline for single-line values (the `echo` artifact); multiline content is now preserved exactly
- Updated vault skill docs to reflect the new behavior

## Root Cause

`resolveKeyValue()` in `vault_put.ts` applied `stdinContent.replace(/\n$/, "")` unconditionally. For `echo "api-key" | swamp vault put`, this correctly removes the echo artifact. But for `cat key.pem | swamp vault put`, it strips the trailing newline that OpenSSH requires in PEM format, causing "Load key: invalid format" errors.

## Fix

Heuristic: if the stdin content has newlines before the final position, it's multiline content — preserve it exactly. If the only newline is the last character, it's an `echo` artifact — strip it.

## Test Plan

- [x] Updated existing multiline test to expect preserved trailing newline
- [x] Added PEM key preservation test
- [x] Verified single-line stripping behavior unchanged
- [x] Full test suite passes (6631 tests, 0 failures)
- [x] End-to-end verification: `cat key.pem | swamp vault put` → `vault.get()` in @swamp/ssh → SSH connection succeeds

Fixes swamp-club#531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)