### PR TITLE
fix(datastore): thread namespace into explicit CLI sync path (swamp-club#534)

### DIFF
--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -112,6 +112,7 @@ export async function createDatastoreSyncDeps(
       options.syncTimeoutMsOverride,
     );
     const label = config.type;
+    const ns = config.namespace;
     return {
       validateSyncSupport: () =>
         Promise.resolve({ supported: true, type: config.type }),
@@ -120,7 +121,11 @@ export async function createDatastoreSyncDeps(
           label,
           "push",
           timeoutMs,
-          (signal) => syncService.pushChanged({ signal }),
+          (signal) =>
+            syncService.pushChanged({
+              signal,
+              ...(ns ? { namespace: ns } : {}),
+            }),
         );
         return { filesPushed: typeof count === "number" ? count : 0 };
       },
@@ -129,7 +134,11 @@ export async function createDatastoreSyncDeps(
           label,
           "pull",
           timeoutMs,
-          (signal) => syncService.pullChanged({ signal }),
+          (signal) =>
+            syncService.pullChanged({
+              signal,
+              ...(ns ? { namespace: ns } : {}),
+            }),
         );
         return { filesPulled: typeof count === "number" ? count : 0 };
       },
@@ -138,13 +147,21 @@ export async function createDatastoreSyncDeps(
           label,
           "pull",
           timeoutMs,
-          (signal) => syncService.pullChanged({ signal }),
+          (signal) =>
+            syncService.pullChanged({
+              signal,
+              ...(ns ? { namespace: ns } : {}),
+            }),
         );
         const pushed = await runBoundedSync(
           label,
           "push",
           timeoutMs,
-          (signal) => syncService.pushChanged({ signal }),
+          (signal) =>
+            syncService.pushChanged({
+              signal,
+              ...(ns ? { namespace: ns } : {}),
+            }),
         );
         return {
           filesPulled: typeof pulled === "number" ? pulled : 0,

--- a/src/libswamp/datastores/sync_test.ts
+++ b/src/libswamp/datastores/sync_test.ts
@@ -21,10 +21,15 @@ import { assertEquals } from "@std/assert";
 import { assertErrors, collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createDatastoreSyncDeps,
   datastoreSync,
   type DatastoreSyncDeps,
   type DatastoreSyncEvent,
 } from "./sync.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { CustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import type { DatastoreSyncOptions } from "../../domain/datastore/datastore_sync_service.ts";
 
 function makeDeps(
   overrides: Partial<DatastoreSyncDeps> = {},
@@ -96,6 +101,125 @@ Deno.test("datastoreSync: full sync success", async () => {
   assertEquals(completed.data.filesPulled, 3);
   assertEquals(completed.data.filesPushed, 5);
   assertEquals(completed.data.errors, []);
+});
+
+// ============================================================================
+// createDatastoreSyncDeps: namespace threading
+// ============================================================================
+
+const syncSpyCalls: {
+  method: string;
+  options: DatastoreSyncOptions | undefined;
+}[] = [];
+
+const SYNC_TEST_TYPE = "test-sync-ns-threading";
+
+if (!datastoreTypeRegistry.has(SYNC_TEST_TYPE)) {
+  datastoreTypeRegistry.register({
+    type: SYNC_TEST_TYPE,
+    name: "Sync NS Test",
+    description: "Test datastore for namespace threading",
+    isBuiltIn: false,
+    createProvider: () => ({
+      createLock: () => ({
+        acquire: () => Promise.resolve(),
+        release: () => Promise.resolve(),
+        withLock: <T>(fn: () => Promise<T>) => fn(),
+        inspect: () => Promise.resolve(null),
+        forceRelease: () => Promise.resolve(true),
+      }),
+      createVerifier: () => ({
+        verify: () =>
+          Promise.resolve({
+            healthy: true,
+            message: "ok",
+            latencyMs: 1,
+            datastoreType: SYNC_TEST_TYPE,
+          }),
+      }),
+      resolveDatastorePath: (repoDir: string) => `${repoDir}/.store`,
+      createSyncService: () => ({
+        pullChanged: (opts?: DatastoreSyncOptions) => {
+          syncSpyCalls.push({ method: "pullChanged", options: opts });
+          return Promise.resolve(1);
+        },
+        pushChanged: (opts?: DatastoreSyncOptions) => {
+          syncSpyCalls.push({ method: "pushChanged", options: opts });
+          return Promise.resolve(2);
+        },
+        markDirty: () => Promise.resolve(),
+      }),
+    }),
+  });
+}
+
+function makeResolver(namespace?: string): DatastorePathResolver {
+  const config: CustomDatastoreConfig = {
+    type: SYNC_TEST_TYPE,
+    config: {},
+    datastorePath: "s3://bucket/path",
+    cachePath: "/tmp/cache",
+    ...(namespace ? { namespace } : {}),
+  };
+  return {
+    localPath: (...segs: string[]) => `/tmp/local/${segs.join("/")}`,
+    datastorePath: (...segs: string[]) => `/tmp/ds/${segs.join("/")}`,
+    isDatastoreSubdir: () => true,
+    isExcluded: () => false,
+    resolvePath: (subdir: string, ...rest: string[]) =>
+      `/tmp/ds/${subdir}/${rest.join("/")}`,
+    config: () => config,
+  };
+}
+
+Deno.test("createDatastoreSyncDeps: pushSync threads namespace from config", async () => {
+  syncSpyCalls.length = 0;
+  const deps = await createDatastoreSyncDeps(
+    "/tmp/repo",
+    makeResolver("my-ns"),
+  );
+  await deps.pushSync();
+
+  const push = syncSpyCalls.find((c) => c.method === "pushChanged");
+  assertEquals(push?.options?.namespace, "my-ns");
+});
+
+Deno.test("createDatastoreSyncDeps: pullSync threads namespace from config", async () => {
+  syncSpyCalls.length = 0;
+  const deps = await createDatastoreSyncDeps(
+    "/tmp/repo",
+    makeResolver("my-ns"),
+  );
+  await deps.pullSync();
+
+  const pull = syncSpyCalls.find((c) => c.method === "pullChanged");
+  assertEquals(pull?.options?.namespace, "my-ns");
+});
+
+Deno.test("createDatastoreSyncDeps: fullSync threads namespace to both push and pull", async () => {
+  syncSpyCalls.length = 0;
+  const deps = await createDatastoreSyncDeps(
+    "/tmp/repo",
+    makeResolver("my-ns"),
+  );
+  await deps.fullSync();
+
+  const pull = syncSpyCalls.find((c) => c.method === "pullChanged");
+  const push = syncSpyCalls.find((c) => c.method === "pushChanged");
+  assertEquals(pull?.options?.namespace, "my-ns");
+  assertEquals(push?.options?.namespace, "my-ns");
+});
+
+Deno.test("createDatastoreSyncDeps: omits namespace when config has none", async () => {
+  syncSpyCalls.length = 0;
+  const deps = await createDatastoreSyncDeps(
+    "/tmp/repo",
+    makeResolver(),
+  );
+  await deps.pushSync();
+
+  const push = syncSpyCalls.find((c) => c.method === "pushChanged");
+  assertEquals(push?.options?.namespace, undefined);
 });
 
 Deno.test("datastoreSync: unsupported datastore type yields error", async () => {


### PR DESCRIPTION
## Summary

- `swamp datastore sync --push` was creating a global `.datastore-index.json` ignoring the namespace config in `.swamp.yaml`
- Root cause: `createDatastoreSyncDeps()` in `src/libswamp/datastores/sync.ts` was not passing `config.namespace` to `syncService.pushChanged()`/`pullChanged()` — the auto-sync path in `repo_context.ts` already threaded it correctly
- Now passes `namespace` from config to all sync service calls (push, pull, full sync), matching the auto-sync path

## Test Plan

- Added 4 unit tests verifying namespace threading through `createDatastoreSyncDeps`:
  - pushSync threads namespace from config
  - pullSync threads namespace from config
  - fullSync threads namespace to both push and pull
  - omits namespace when config has none
- All 6648 existing tests pass with 0 failures
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)