### PR TITLE
fix(datastore): thread namespace into datastoreSetupExtension push/pull (swamp-club#536)

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -202,6 +202,7 @@ const datastoreSetupExtensionCommand = new Command()
         repoId: marker?.repoId,
         skipMigration: !!options.skipMigration,
         hydrationStrategy,
+        namespace: marker?.datastore?.namespace,
       }),
       renderer.handlers(),
     );

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -241,6 +241,7 @@ export interface DatastoreSetupExtensionInput {
   repoId?: string;
   skipMigration: boolean;
   hydrationStrategy?: "full" | "lazy";
+  namespace?: string;
 }
 
 /** Sets up an extension-provided datastore. */
@@ -338,6 +339,7 @@ export async function* datastoreSetupExtension(
         input.repoDir,
         cachePath,
       );
+      const ns = input.namespace;
 
       let migrationResult:
         | {
@@ -370,7 +372,11 @@ export async function* datastoreSetupExtension(
               input.type,
               "push",
               timeoutMs,
-              (signal) => syncService.pushChanged({ signal }),
+              (signal) =>
+                syncService.pushChanged({
+                  signal,
+                  ...(ns ? { namespace: ns } : {}),
+                }),
             );
             ctx.logger.debug`Push complete`;
           } catch (error) {
@@ -408,6 +414,7 @@ export async function* datastoreSetupExtension(
             (signal) =>
               syncService.pullChanged({
                 signal,
+                ...(ns ? { namespace: ns } : {}),
                 ...(input.hydrationStrategy === "lazy"
                   ? { metadataOnly: true }
                   : {}),

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -31,6 +31,7 @@ import {
 } from "./setup.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
+import type { DatastoreSyncOptions } from "../../domain/datastore/datastore_sync_service.ts";
 
 function makeDeps(
   overrides: Partial<DatastoreSetupDeps> = {},
@@ -705,4 +706,109 @@ Deno.test("datastoreSetupExtension: ensures cachePath exists before hydration pu
       JSON.stringify(ensureDirCalls)
     }`,
   );
+});
+
+// ============================================================================
+// Namespace threading tests (issue #536)
+// ============================================================================
+
+const setupSyncSpyCalls: {
+  method: string;
+  options: DatastoreSyncOptions | undefined;
+}[] = [];
+
+const SETUP_NS_TYPE = "test-ext-ns-threading";
+
+if (!datastoreTypeRegistry.has(SETUP_NS_TYPE)) {
+  datastoreTypeRegistry.register({
+    type: SETUP_NS_TYPE,
+    name: "Setup NS Test",
+    description: "Test datastore for setup namespace threading",
+    isBuiltIn: false,
+    createProvider: () => ({
+      createLock: () => ({
+        acquire: () => Promise.resolve(),
+        release: () => Promise.resolve(),
+        withLock: <T>(fn: () => Promise<T>) => fn(),
+        inspect: () => Promise.resolve(null),
+        forceRelease: () => Promise.resolve(true),
+      }),
+      createVerifier: () => ({
+        verify: () =>
+          Promise.resolve({
+            healthy: true,
+            message: "ok",
+            latencyMs: 1,
+            datastoreType: SETUP_NS_TYPE,
+          }),
+      }),
+      resolveDatastorePath: (repoDir: string) => `${repoDir}/.store`,
+      resolveCachePath: (repoDir: string) => `${repoDir}/.cache`,
+      createSyncService: () => ({
+        pullChanged: (opts?: DatastoreSyncOptions) => {
+          setupSyncSpyCalls.push({ method: "pullChanged", options: opts });
+          return Promise.resolve(1);
+        },
+        pushChanged: (opts?: DatastoreSyncOptions) => {
+          setupSyncSpyCalls.push({ method: "pushChanged", options: opts });
+          return Promise.resolve(2);
+        },
+        markDirty: () => Promise.resolve(),
+      }),
+    }),
+  });
+}
+
+Deno.test("datastoreSetupExtension: threads namespace into push and pull", async () => {
+  setupSyncSpyCalls.length = 0;
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: SETUP_NS_TYPE,
+    namespace: "infra",
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const push = setupSyncSpyCalls.find((c) => c.method === "pushChanged");
+  const pull = setupSyncSpyCalls.find((c) => c.method === "pullChanged");
+  assertEquals(push?.options?.namespace, "infra");
+  assertEquals(pull?.options?.namespace, "infra");
+});
+
+Deno.test("datastoreSetupExtension: omits namespace when not configured", async () => {
+  setupSyncSpyCalls.length = 0;
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: SETUP_NS_TYPE,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const push = setupSyncSpyCalls.find((c) => c.method === "pushChanged");
+  const pull = setupSyncSpyCalls.find((c) => c.method === "pullChanged");
+  assertEquals(push?.options?.namespace, undefined);
+  assertEquals(pull?.options?.namespace, undefined);
+});
+
+Deno.test("datastoreSetupExtension: threads namespace on skip-migration pull-only path", async () => {
+  setupSyncSpyCalls.length = 0;
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: SETUP_NS_TYPE,
+    skipMigration: true,
+    namespace: "staging",
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const push = setupSyncSpyCalls.find((c) => c.method === "pushChanged");
+  const pull = setupSyncSpyCalls.find((c) => c.method === "pullChanged");
+  assertEquals(push, undefined, "skip-migration should not push");
+  assertEquals(pull?.options?.namespace, "staging");
 });


### PR DESCRIPTION
## Summary

- `datastoreSetupExtension()` in `src/libswamp/datastores/setup.ts` was ignoring the `namespace` config field when calling `syncService.pushChanged()` and `pullChanged()` during the initial migration push/pull
- Root cause: same pattern as swamp-club#534 (fixed in PR #1497 for the explicit CLI sync path) — the setup path was missed
- Now adds `namespace?: string` to `DatastoreSetupExtensionInput` and threads it into both push and pull calls using the conditional spread pattern
- CLI caller in `src/cli/commands/datastore_setup.ts` passes `marker.datastore?.namespace`

## Test Plan

- Added 3 unit tests verifying namespace threading through `datastoreSetupExtension`:
  - threads namespace into push and pull when configured
  - omits namespace when not configured
  - threads namespace on skip-migration pull-only path
- All 6652 existing tests pass with 0 failures
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)