### PR TITLE
feat(issue-lifecycle): add platform type to IssueType Zod schema

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -94,11 +94,12 @@ If the author is NOT in the collaborator list, they are external — call
 
 ## Classification Types
 
-The `triage` method classifies issues into one of three types (matching
+The `triage` method classifies issues into one of four types (matching
 swamp-club):
 
 - `bug` — something is broken or behaving incorrectly
 - `feature` — a request for new functionality or enhancement
+- `platform` — admin-only platform infrastructure work
 - `security` — security vulnerability or hardening work
 
 Two additional classification details are captured in the classification record

--- a/.claude/skills/issue-lifecycle/references/triage.md
+++ b/.claude/skills/issue-lifecycle/references/triage.md
@@ -69,7 +69,7 @@ on affected files to see if they were recently changed.
 
 ```
 swamp model @swamp/issue-lifecycle method run triage issue-<N> \
-  --input type=<bug|feature|security> \
+  --input type=<bug|feature|platform|security> \
   --input confidence=<high|medium|low> \
   --input reasoning="<your analysis>"
 ```
@@ -78,6 +78,7 @@ swamp model @swamp/issue-lifecycle method run triage issue-<N> \
 
 - `bug` — something is broken or behaving incorrectly
 - `feature` — a request for new functionality or enhancement
+- `platform` — admin-only platform infrastructure work
 - `security` — security vulnerability, hardening, or compliance work
 
 Add `--input isRegression=true` when the bug previously worked. Look for signals

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -90,7 +90,7 @@ export const TRANSITIONS: Record<string, Phase[]> = {
 // ---------------------------------------------------------------------------
 
 /** Issue types supported by swamp-club. */
-export const IssueType = z.enum(["bug", "feature", "security"]);
+export const IssueType = z.enum(["bug", "feature", "platform", "security"]);
 export type IssueType = z.infer<typeof IssueType>;
 
 // ---------------------------------------------------------------------------

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -556,7 +556,7 @@ export const model = {
       }),
       execute: async (
         args: {
-          type: "bug" | "feature" | "security";
+          type: "bug" | "feature" | "platform" | "security";
           confidence: "high" | "medium" | "low";
           reasoning: string;
           isRegression?: boolean;


### PR DESCRIPTION
## Summary

- Add `"platform"` to the `IssueType` Zod enum in `extensions/models/_lib/schemas.ts` so the issue-lifecycle model accepts swamp-club's new admin-only platform issue type at runtime
- Update the corresponding type annotation in `extensions/models/issue_lifecycle.ts`
- Update issue-lifecycle skill docs to document platform as a fourth classification type

Closes swamp-club#537

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 6649 passed, 3 failed (pre-existing extension_pull/rm_test network flakes, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)