### PR TITLE
fix(extensions): honor paths.base: manifest for workflow resolution (swamp-club#540)

### DIFF
--- a/.claude/skills/swamp-extension-publish/references/publishing.md
+++ b/.claude/skills/swamp-extension-publish/references/publishing.md
@@ -57,7 +57,7 @@ dependencies:
 | `repository`      | No       | HTTPS URL of the upstream repository. Required for users to file issues via `swamp issue --extension` — `swamp extension push` warns when absent.             |
 | `paths.base`      | No       | Path resolution mode for typed keys + `additionalFiles`. `typedDir` (default) or `manifest`. See "Path resolution".                                           |
 | `models`          | No*      | Model file paths. Resolved via `paths.base`.                                                                                                                  |
-| `workflows`       | No*      | Workflow file paths. Workflows use a multi-base lookup and ignore `paths.base`.                                                                               |
+| `workflows`       | No*      | Workflow file paths. Resolved via `paths.base`. Under `manifest`, resolves from manifest dir first, then repo-root fallbacks.                                 |
 | `vaults`          | No*      | Vault file paths. Resolved via `paths.base`.                                                                                                                  |
 | `drivers`         | No*      | Driver file paths. Resolved via `paths.base`.                                                                                                                 |
 | `datastores`      | No*      | Datastore file paths. Resolved via `paths.base`.                                                                                                              |
@@ -198,8 +198,9 @@ additionalFiles:
 - The archive layout under each typed dir mirrors your manifest entries
   verbatim: `models: [echo.ts]` lands at `extension/models/echo.ts` in the
   archive (not at `extension/models/my-ext/echo.ts`).
-- Workflows keep their own multi-base lookup. `paths.base` does not apply to
-  workflows.
+- Workflows honour `paths.base: manifest` — the manifest's own directory is
+  searched first, falling back to repo-root `workflows/` and
+  `extensions/workflows/`.
 - Skills honour `paths.base: manifest` — manifest-relative directories are
   searched first, then project-local, then global. All enrolled tools are
   searched at each level.

--- a/design/extension.md
+++ b/design/extension.md
@@ -205,9 +205,10 @@ containing `..` or starting with `/`.
   and LICENSE all sit alongside each other. See "Path resolution" below.
 - `models`: Array of relative paths to TypeScript model files (e.g.,
   `["aws/ec2/instance.ts"]`). Resolved via `paths.base`.
-- `workflows`: Array of relative paths to YAML workflow files. Workflows
-  use a multi-base lookup (indexer dir then extension workflows dir) and
-  are not affected by `paths.base`.
+- `workflows`: Array of relative paths to YAML workflow files. Resolved
+  via `paths.base`. Under `paths.base: manifest`, workflows resolve
+  relative to the manifest's own directory first, falling back to the
+  repo-root `workflows/` and `extensions/workflows/` directories.
 - `vaults`: Array of relative paths to TypeScript vault files. Resolved
   via `paths.base`.
 - `drivers`: Array of relative paths to TypeScript driver files. Resolved
@@ -281,9 +282,11 @@ The `paths.base` field selects the directory typed-key entries
   `extensions/models/myext/manifest.yaml` next to `myext/echo.ts` and
   `myext/README.md`).
 
-Workflows keep their bespoke multi-base lookup (fall back from the
-indexer dir to the extension workflows dir). `paths.base` does not
-apply to workflows.
+Workflows honour `paths.base: manifest` — when set, the manifest's own
+directory is searched first, falling back to the repo-root `workflows/`
+and `extensions/workflows/` directories. Under the default
+`paths.base: typedDir`, workflows resolve only from the repo-root
+locations.
 
 Skills honour `paths.base: manifest` — when set, the manifest's own
 directory is searched first (e.g. `sub/.claude/skills/<name>/`), then

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -229,33 +229,35 @@ export async function resolveExtensionFiles(
   // 5. Resolve workflow dependencies if workflows present
   const workflowFiles: Array<{ sourcePath: string; archiveName: string }> = [];
   if (manifest.workflows.length > 0) {
-    const indexerWorkflowsDir = resolve(repoDir, "workflows");
-    const extensionWorkflowsDir = resolve(
-      repoDir,
-      resolveWorkflowsDir(marker),
-    );
+    const wfCandidateDirs: string[] = [];
+    const seenWfDir = new Set<string>();
+    const addWfCandidate = (dir: string) => {
+      if (!seenWfDir.has(dir)) {
+        seenWfDir.add(dir);
+        wfCandidateDirs.push(dir);
+      }
+    };
+    if (useManifestBase) addWfCandidate(manifestDir);
+    addWfCandidate(resolve(repoDir, "workflows"));
+    addWfCandidate(resolve(repoDir, resolveWorkflowsDir(marker)));
+
     // Validate workflow files exist and resolve symlinks
     const wfNames: string[] = [];
     for (const wfRef of manifest.workflows) {
       let realPath: string | null = null;
 
-      // Try indexer symlinks first (workflows/)
-      try {
-        realPath = await Deno.realPath(resolve(indexerWorkflowsDir, wfRef));
-      } catch { /* not found here */ }
-
-      // Fall back to extension workflows dir
-      if (!realPath) {
+      for (const candidateDir of wfCandidateDirs) {
         try {
-          realPath = await Deno.realPath(
-            resolve(extensionWorkflowsDir, wfRef),
-          );
-        } catch { /* not found here either */ }
+          realPath = await Deno.realPath(resolve(candidateDir, wfRef));
+          break;
+        } catch { /* not found here */ }
       }
 
       if (!realPath) {
         throw new UserError(
-          `Workflow file not found: ${wfRef} (looked in ${indexerWorkflowsDir} and ${extensionWorkflowsDir})`,
+          `Workflow file not found: ${wfRef} (looked in ${
+            wfCandidateDirs.join(", ")
+          })`,
         );
       }
       // Derive a unique archive name from the manifest reference directory

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -1158,3 +1158,102 @@ Deno.test("resolveExtensionFiles multi-tool deduplicates shared SKILL_DIRS paths
     );
   });
 });
+
+const stubWorkflowRepoContext = {
+  workflowRepo: { findByName: () => Promise.resolve(null) },
+  definitionRepo: { findByNameGlobal: () => Promise.resolve(null) },
+} as unknown as RepositoryContext;
+
+Deno.test("resolveExtensionFiles paths.base=manifest resolves workflows from manifest dir", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "sub");
+    await Deno.mkdir(join(subdir, "extensions", "workflows"), {
+      recursive: true,
+    });
+    await Deno.mkdir(join(subdir, "extensions", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "extensions", "models", "dummy.ts"),
+      'export const name = "dummy";',
+    );
+    await Deno.writeTextFile(
+      join(subdir, "extensions", "workflows", "test-wf.yaml"),
+      "name: test-wf\njobs: {}",
+    );
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/wf-manifest-base",
+        version: "2026.06.03.1",
+        paths: { base: "manifest" },
+        models: ["extensions/models/dummy.ts"],
+        workflows: ["extensions/workflows/test-wf.yaml"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubWorkflowRepoContext,
+      logger,
+    });
+
+    assertEquals(result.workflowFiles.length, 1);
+    const wfRealPath = await Deno.realPath(
+      join(subdir, "extensions", "workflows", "test-wf.yaml"),
+    );
+    assertEquals(result.workflowFiles[0].sourcePath, wfRealPath);
+  });
+});
+
+Deno.test("resolveExtensionFiles paths.base=manifest prefers manifest-relative for workflows", async () => {
+  await withTempRepo(async (dir) => {
+    const subdir = join(dir, "sub");
+    await Deno.mkdir(join(subdir, "extensions", "models"), { recursive: true });
+    await Deno.writeTextFile(
+      join(subdir, "extensions", "models", "dummy.ts"),
+      'export const name = "dummy";',
+    );
+    // Workflow in manifest-relative location
+    await Deno.mkdir(join(subdir, "extensions", "workflows"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      join(subdir, "extensions", "workflows", "shared.yaml"),
+      "name: manifest-relative\njobs: {}",
+    );
+    // Workflow with same name at repo root
+    await Deno.mkdir(join(dir, "extensions", "workflows"), { recursive: true });
+    await Deno.writeTextFile(
+      join(dir, "extensions", "workflows", "shared.yaml"),
+      "name: repo-root\njobs: {}",
+    );
+
+    const manifestPath = join(subdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/wf-priority",
+        version: "2026.06.03.1",
+        paths: { base: "manifest" },
+        models: ["extensions/models/dummy.ts"],
+        workflows: ["extensions/workflows/shared.yaml"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubWorkflowRepoContext,
+      logger,
+    });
+
+    assertEquals(result.workflowFiles.length, 1);
+    const manifestRelativePath = await Deno.realPath(
+      join(subdir, "extensions", "workflows", "shared.yaml"),
+    );
+    assertEquals(result.workflowFiles[0].sourcePath, manifestRelativePath);
+  });
+});

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -57,9 +57,9 @@ const safePathString = z.string().refine(isSafeRelativePath, {
  *   per-extension-subdir layouts where manifest, source, README, and
  *   LICENSE all live alongside each other.
  *
- * Workflows keep their own multi-base resolution (fall back from the
- * indexer dir to the extension workflows dir). `paths.base` does not
- * apply to workflows.
+ * Workflows honour `paths.base: manifest` — when set, the manifest's
+ * own directory is searched first, falling back to the repo-root
+ * `workflows/` and `extensions/workflows/` directories.
  *
  * Skills honour `paths.base: manifest` — when set, the manifest's own
  * directory is searched first (e.g. `<manifestDir>/.claude/skills/`),

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -487,3 +487,84 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "round-trip: paths.base=manifest bundles workflows from manifest-relative dir",
+  async () => {
+    const { parse: parseYaml } = await import("@std/yaml");
+    const src = await Deno.makeTempDir({ prefix: "rt-wf-src-" });
+    const dst = await Deno.makeTempDir({ prefix: "rt-wf-dst-" });
+    try {
+      const extDir = join(src, "sub");
+      await Deno.mkdir(extDir, { recursive: true });
+      await Deno.writeTextFile(
+        join(extDir, "echo.ts"),
+        'export const model = { type: "@t/wf-rt", version: "1.0.0" };',
+      );
+
+      await Deno.mkdir(join(extDir, "extensions", "workflows"), {
+        recursive: true,
+      });
+      const wfPath = join(extDir, "extensions", "workflows", "deploy.yaml");
+      await Deno.writeTextFile(wfPath, "name: deploy\njobs: {}");
+
+      const wfRealPath = await Deno.realPath(wfPath);
+
+      const manifest = makeManifest({
+        paths: { base: "manifest" },
+        models: ["echo.ts"],
+        workflows: ["extensions/workflows/deploy.yaml"],
+      });
+
+      const input: ExtensionPushPrepareInput = {
+        manifest,
+        repoDir: src,
+        modelsDir: extDir,
+        allModelFiles: [join(extDir, "echo.ts")],
+        modelEntryPoints: [join(extDir, "echo.ts")],
+        vaultsDir: extDir,
+        allVaultFiles: [],
+        vaultEntryPoints: [],
+        driversDir: extDir,
+        allDriverFiles: [],
+        driverEntryPoints: [],
+        datastoresDir: extDir,
+        allDatastoreFiles: [],
+        datastoreEntryPoints: [],
+        reportsDir: extDir,
+        allReportFiles: [],
+        reportEntryPoints: [],
+        workflowFiles: [{ sourcePath: wfRealPath, archiveName: "deploy.yaml" }],
+        skillDirs: [],
+        allSkillFiles: [],
+        includeFilePaths: [],
+        additionalFilePaths: [],
+        binaryFilePaths: [],
+        dryRun: true,
+      };
+
+      const ctx = createLibSwampContext();
+      const prepared = await extensionPushPrepare(
+        ctx,
+        makePrepareDeps(),
+        input,
+      );
+
+      await untarArchiveTo(prepared.archiveBytes, dst);
+
+      // Workflow file lands under extension/workflows/ in the archive
+      await Deno.stat(join(dst, "extension", "workflows", "deploy.yaml"));
+
+      const onWire = parseYaml(
+        await Deno.readTextFile(join(dst, "extension", "manifest.yaml")),
+      ) as Record<string, unknown>;
+      assertEquals(
+        onWire.workflows,
+        ["extensions/workflows/deploy.yaml"],
+      );
+    } finally {
+      await Deno.remove(src, { recursive: true }).catch(() => {});
+      await Deno.remove(dst, { recursive: true }).catch(() => {});
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Workflow entries in extension manifests now resolve relative to the manifest
  directory when `paths.base: manifest` is set, consistent with how models,
  vaults, drivers, datastores, reports, and skills already resolve.
- Previously workflows always resolved from repo-root `workflows/` and
  `extensions/workflows/` only, blocking self-contained subdir layouts for
  workflow-bundling extensions.
- Updated documentation across manifest schema JSDoc, `design/extension.md`,
  and the publishing skill reference to reflect the new behavior.

Closes swamp-club#540

## Test Plan

- Added unit test: `paths.base=manifest resolves workflows from manifest dir`
- Added unit test: `paths.base=manifest prefers manifest-relative for workflows`
- Added integration test: round-trip push/pull with manifest-relative workflow
- Reproduced the original bug in a scratch repo, verified the fix resolves the
  workflow from the manifest-relative directory
- Full test suite passes (6655 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)