### PR TITLE
feat(datastore): namespace management commands and NAMESPACE column (swamp-club#542)

### DIFF
--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -71,13 +71,15 @@ export const dataListCommand = new Command()
       );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const namespace = datastoreResolver.config().namespace;
     const deps = createDataListDeps(
       repoDir,
       datastoreResolver,
       repoContext.unifiedDataRepo,
+      namespace,
     );
 
-    const renderer = createDataListRenderer(cliCtx.outputMode);
+    const renderer = createDataListRenderer(cliCtx.outputMode, !!namespace);
     await consumeStream(
       dataList(ctx, deps, {
         modelIdOrName,

--- a/src/cli/commands/data_query.ts
+++ b/src/cli/commands/data_query.ts
@@ -71,10 +71,12 @@ export const dataQueryCommand = new Command()
   .action(async function (options: AnyOptions, predicate?: string) {
     const ctx = createContext(options as GlobalOptions, ["data", "query"]);
 
-    const { repoContext } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: ctx.outputMode,
-    });
+    const { repoContext, datastoreResolver } =
+      await requireInitializedRepoReadOnly({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: ctx.outputMode,
+      });
+    const showNamespace = !!datastoreResolver.config().namespace;
 
     if (!repoContext.catalogStore) {
       throw new UserError(
@@ -114,7 +116,7 @@ export const dataQueryCommand = new Command()
 
     const libCtx = createLibSwampContext();
 
-    const renderer = createDataQueryRenderer(ctx.outputMode);
+    const renderer = createDataQueryRenderer(ctx.outputMode, showNamespace);
     await consumeStream(
       dataQuery(libCtx, deps, {
         predicate,

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -61,7 +61,8 @@ const datastoreNamespaceCommand = new Command()
   .description("Manage datastore namespace")
   .action(groupCommandAction)
   .command("set", datastoreNamespaceSetCommand)
-  .command("unset", datastoreNamespaceUnsetCommand);
+  .command("unset", datastoreNamespaceUnsetCommand)
+  .command("list", datastoreNamespacesCommand);
 
 export const datastoreCommand = new Command()
   .description("Manage datastore configuration")
@@ -74,5 +75,4 @@ export const datastoreCommand = new Command()
   .command("lock", datastoreLockCommand)
   .command("compact", datastoreCompactCommand)
   .command("catalog", datastoreCatalogCommand)
-  .command("namespace", datastoreNamespaceCommand)
-  .command("namespaces", datastoreNamespacesCommand);
+  .command("namespace", datastoreNamespaceCommand);

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -26,6 +26,11 @@ import { datastoreLockCommand } from "./datastore_lock.ts";
 import { datastoreCompactCommand } from "./datastore_compact.ts";
 import { datastoreCatalogPullCommand } from "./datastore_catalog_pull.ts";
 import {
+  datastoreNamespaceSetCommand,
+  datastoreNamespaceUnsetCommand,
+} from "./datastore_namespace.ts";
+import { datastoreNamespacesCommand } from "./datastore_namespaces.ts";
+import {
   datastoreTypeSearchAction,
   datastoreTypeSearchCommand,
 } from "./datastore_type_search.ts";
@@ -51,6 +56,13 @@ const datastoreCatalogCommand = new Command()
   .action(groupCommandAction)
   .command("pull", datastoreCatalogPullCommand);
 
+const datastoreNamespaceCommand = new Command()
+  .name("namespace")
+  .description("Manage datastore namespace")
+  .action(groupCommandAction)
+  .command("set", datastoreNamespaceSetCommand)
+  .command("unset", datastoreNamespaceUnsetCommand);
+
 export const datastoreCommand = new Command()
   .description("Manage datastore configuration")
   .error(unknownCommandErrorHandler)
@@ -61,4 +73,6 @@ export const datastoreCommand = new Command()
   .command("sync", datastoreSyncCommand)
   .command("lock", datastoreLockCommand)
   .command("compact", datastoreCompactCommand)
-  .command("catalog", datastoreCatalogCommand);
+  .command("catalog", datastoreCatalogCommand)
+  .command("namespace", datastoreNamespaceCommand)
+  .command("namespaces", datastoreNamespacesCommand);

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -36,6 +36,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { resolveDatastoreForRepo } from "../repo_context.ts";
+import { datastoreBasePath } from "../resolve_datastore.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -46,15 +47,11 @@ import {
 } from "../../infrastructure/persistence/namespace_manifest.ts";
 import {
   type CustomDatastoreConfig,
-  type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
-
-function datastoreBasePath(config: DatastoreConfig): string {
-  return isCustomDatastoreConfig(config) ? config.datastorePath : config.path;
-}
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -99,12 +96,16 @@ export const datastoreNamespaceSetCommand = new Command()
       supportsRegistration,
       listNamespaces: async () => {
         if (resolvedProvider?.listNamespaces) {
-          return await resolvedProvider.listNamespaces(
+          const slugs = await resolvedProvider.listNamespaces(
             (datastoreConfig as CustomDatastoreConfig).datastorePath,
           );
+          return slugs.map((ns) => ({ namespace: ns, repoId: "" }));
         }
         const manifests = await listNamespaceManifests(dsBasePath);
-        return manifests.map((m) => m.namespace);
+        return manifests.map((m) => ({
+          namespace: m.namespace,
+          repoId: m.repoId,
+        }));
       },
       registerNamespace: async (namespace: string, rId: string) => {
         if (resolvedProvider?.registerNamespace) {
@@ -119,11 +120,14 @@ export const datastoreNamespaceSetCommand = new Command()
       },
       updateMarkerNamespace: async (namespace: string) => {
         const current = await markerRepo.read(repoPath);
-        if (current) {
-          current.datastore = current.datastore ?? { type: "filesystem" };
-          current.datastore.namespace = namespace;
-          await markerRepo.write(repoPath, current);
+        if (!current) {
+          throw new UserError(
+            "Cannot update namespace: .swamp.yaml marker not found.",
+          );
         }
+        current.datastore = current.datastore ?? { type: "filesystem" };
+        current.datastore.namespace = namespace;
+        await markerRepo.write(repoPath, current);
       },
       getRepoId: () => repoId,
     };

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -1,0 +1,193 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  datastoreNamespaceSet,
+  datastoreNamespaceUnset,
+} from "../../libswamp/mod.ts";
+import {
+  createNamespaceSetRenderer,
+} from "../../presentation/renderers/datastore_namespace_set.ts";
+import {
+  createNamespaceUnsetRenderer,
+} from "../../presentation/renderers/datastore_namespace_unset.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+import {
+  RepoMarkerRepository,
+} from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import {
+  listNamespaceManifests,
+  writeNamespaceManifest,
+} from "../../infrastructure/persistence/namespace_manifest.ts";
+import {
+  type CustomDatastoreConfig,
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+
+function datastoreBasePath(config: DatastoreConfig): string {
+  return isCustomDatastoreConfig(config) ? config.datastorePath : config.path;
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const datastoreNamespaceSetCommand = new Command()
+  .description("Assign a namespace to this repository")
+  .example("Set namespace", "swamp datastore namespace set infra")
+  .arguments("<slug:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions, slug: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "namespace",
+      "set",
+    ]);
+    cliCtx.logger.debug("Executing datastore namespace set command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    const { datastoreConfig, marker } = await resolveDatastoreForRepo(repoDir);
+    const dsBasePath = datastoreBasePath(datastoreConfig);
+    const markerRepo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(repoDir);
+    const repoId = marker?.repoId ?? crypto.randomUUID();
+
+    let supportsRegistration = true;
+    let resolvedProvider: DatastoreProvider | undefined;
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      await datastoreTypeRegistry.ensureLoaded();
+      await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
+      const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
+      resolvedProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+      supportsRegistration = !!resolvedProvider?.registerNamespace;
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = {
+      getDatastorePath: () => dsBasePath,
+      getCurrentNamespace: () => datastoreConfig.namespace,
+      supportsRegistration,
+      listNamespaces: async () => {
+        if (resolvedProvider?.listNamespaces) {
+          return await resolvedProvider.listNamespaces(
+            (datastoreConfig as CustomDatastoreConfig).datastorePath,
+          );
+        }
+        const manifests = await listNamespaceManifests(dsBasePath);
+        return manifests.map((m) => m.namespace);
+      },
+      registerNamespace: async (namespace: string, rId: string) => {
+        if (resolvedProvider?.registerNamespace) {
+          await resolvedProvider.registerNamespace(
+            (datastoreConfig as CustomDatastoreConfig).datastorePath,
+            namespace,
+            rId,
+          );
+          return;
+        }
+        await writeNamespaceManifest(dsBasePath, namespace, rId);
+      },
+      updateMarkerNamespace: async (namespace: string) => {
+        const current = await markerRepo.read(repoPath);
+        if (current) {
+          current.datastore = current.datastore ?? { type: "filesystem" };
+          current.datastore.namespace = namespace;
+          await markerRepo.write(repoPath, current);
+        }
+      },
+      getRepoId: () => repoId,
+    };
+
+    const renderer = createNamespaceSetRenderer(cliCtx.outputMode);
+    await consumeStream(
+      datastoreNamespaceSet(ctx, deps, { slug }),
+      renderer.handlers(),
+    );
+  });
+
+export const datastoreNamespaceUnsetCommand = new Command()
+  .description("Remove namespace from this repository")
+  .example("Unset namespace", "swamp datastore namespace unset")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "namespace",
+      "unset",
+    ]);
+    cliCtx.logger.debug("Executing datastore namespace unset command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+    const dsBasePath = datastoreBasePath(datastoreConfig);
+    const markerRepo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(repoDir);
+
+    let unsetProvider: DatastoreProvider | undefined;
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      await datastoreTypeRegistry.ensureLoaded();
+      await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
+      const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
+      unsetProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = {
+      getCurrentNamespace: () => datastoreConfig.namespace,
+      listNamespaces: async () => {
+        if (unsetProvider?.listNamespaces) {
+          return await unsetProvider.listNamespaces(
+            (datastoreConfig as CustomDatastoreConfig).datastorePath,
+          );
+        }
+        const manifests = await listNamespaceManifests(dsBasePath);
+        return manifests.map((m) => m.namespace);
+      },
+      removeMarkerNamespace: async () => {
+        const current = await markerRepo.read(repoPath);
+        if (current?.datastore) {
+          delete current.datastore.namespace;
+          await markerRepo.write(repoPath, current);
+        }
+      },
+    };
+
+    const renderer = createNamespaceUnsetRenderer(cliCtx.outputMode);
+    await consumeStream(
+      datastoreNamespaceUnset(ctx, deps),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/datastore_namespaces.ts
+++ b/src/cli/commands/datastore_namespaces.ts
@@ -48,7 +48,7 @@ type AnyOptions = any;
 
 export const datastoreNamespacesCommand = new Command()
   .description("List all namespaces in the datastore")
-  .example("List namespaces", "swamp datastore namespaces")
+  .example("List namespaces", "swamp datastore namespace list")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",

--- a/src/cli/commands/datastore_namespaces.ts
+++ b/src/cli/commands/datastore_namespaces.ts
@@ -1,0 +1,102 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  datastoreNamespaceList,
+} from "../../libswamp/mod.ts";
+import {
+  createNamespaceListRenderer,
+} from "../../presentation/renderers/datastore_namespace_list.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+import {
+  listNamespaceManifests,
+} from "../../infrastructure/persistence/namespace_manifest.ts";
+import {
+  type CustomDatastoreConfig,
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+
+function datastoreBasePath(config: DatastoreConfig): string {
+  return isCustomDatastoreConfig(config) ? config.datastorePath : config.path;
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const datastoreNamespacesCommand = new Command()
+  .description("List all namespaces in the datastore")
+  .example("List namespaces", "swamp datastore namespaces")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "namespaces",
+    ]);
+    cliCtx.logger.debug("Executing datastore namespaces command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+    const dsBasePath = datastoreBasePath(datastoreConfig);
+
+    let listProvider: DatastoreProvider | undefined;
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      await datastoreTypeRegistry.ensureLoaded();
+      await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
+      const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
+      listProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = {
+      getCurrentNamespace: () => datastoreConfig.namespace,
+      listNamespaces: async () => {
+        if (listProvider?.listNamespaces) {
+          const slugs = await listProvider.listNamespaces(
+            (datastoreConfig as CustomDatastoreConfig).datastorePath,
+          );
+          return slugs.map((ns) => ({
+            namespace: ns,
+            repoId: "",
+            registeredAt: "",
+          }));
+        }
+        return await listNamespaceManifests(dsBasePath);
+      },
+    };
+
+    const renderer = createNamespaceListRenderer(cliCtx.outputMode);
+    await consumeStream(
+      datastoreNamespaceList(ctx, deps),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/datastore_namespaces.ts
+++ b/src/cli/commands/datastore_namespaces.ts
@@ -32,20 +32,16 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { resolveDatastoreForRepo } from "../repo_context.ts";
+import { datastoreBasePath } from "../resolve_datastore.ts";
 import {
   listNamespaceManifests,
 } from "../../infrastructure/persistence/namespace_manifest.ts";
 import {
   type CustomDatastoreConfig,
-  type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
-
-function datastoreBasePath(config: DatastoreConfig): string {
-  return isCustomDatastoreConfig(config) ? config.datastorePath : config.path;
-}
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -34,7 +34,10 @@
 import { join } from "@std/path";
 import { getLogger } from "@logtape/logtape";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
-import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import {
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../domain/datastore/datastore_config.ts";
 import { getSwampDataDir } from "../infrastructure/persistence/paths.ts";
 import { expandEnvVars } from "../infrastructure/persistence/env_path.ts";
 import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_registry.ts";
@@ -43,6 +46,10 @@ import { resolveDatastoreType } from "../domain/extensions/extension_auto_resolv
 import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 
 const logger = getLogger(["swamp", "datastore", "resolve"]);
+
+export function datastoreBasePath(config: DatastoreConfig): string {
+  return isCustomDatastoreConfig(config) ? config.datastorePath : config.path;
+}
 
 /**
  * Maps old built-in datastore type names to their extension replacements.

--- a/src/domain/data/namespace.ts
+++ b/src/domain/data/namespace.ts
@@ -77,3 +77,11 @@ export function parseNamespacedModelName(input: string): NamespacedModelName {
 
   return { namespace, modelName };
 }
+
+export function formatNamespacedModelName(
+  namespace: string | undefined,
+  modelName: string,
+): string {
+  if (namespace === undefined || namespace === "") return modelName;
+  return `${namespace}:${modelName}`;
+}

--- a/src/domain/data/namespace_test.ts
+++ b/src/domain/data/namespace_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   createNamespace,
+  formatNamespacedModelName,
   isEmptyNamespace,
   parseNamespacedModelName,
   SOLO_NAMESPACE,
@@ -221,4 +222,27 @@ Deno.test("parseNamespacedModelName: handles model name with slashes", () => {
 Deno.test("parseNamespacedModelName: plain model name with no special chars", () => {
   const result = parseNamespacedModelName("my-model");
   assertEquals(result, { namespace: undefined, modelName: "my-model" });
+});
+
+// --- formatNamespacedModelName ---
+
+Deno.test("formatNamespacedModelName: returns bare name when namespace undefined", () => {
+  assertEquals(formatNamespacedModelName(undefined, "scanner"), "scanner");
+});
+
+Deno.test("formatNamespacedModelName: returns bare name when namespace empty", () => {
+  assertEquals(formatNamespacedModelName("", "scanner"), "scanner");
+});
+
+Deno.test("formatNamespacedModelName: prefixes namespace with colon", () => {
+  assertEquals(
+    formatNamespacedModelName("security", "scanner"),
+    "security:scanner",
+  );
+});
+
+Deno.test("formatNamespacedModelName: round-trips with parseNamespacedModelName", () => {
+  const formatted = formatNamespacedModelName("infra", "@swamp/echo");
+  const parsed = parseNamespacedModelName(formatted);
+  assertEquals(parsed, { namespace: "infra", modelName: "@swamp/echo" });
 });

--- a/src/domain/datastore/datastore_provider.ts
+++ b/src/domain/datastore/datastore_provider.ts
@@ -51,4 +51,28 @@ export interface DatastoreProvider {
    * inferred from a missing property.
    */
   resolveCachePath?(repoDir: string): string | undefined;
+
+  /**
+   * Register a namespace in the datastore.
+   *
+   * Writes a namespace manifest so the namespace is discoverable by
+   * `listNamespaces`. Fails if the slug is already claimed.
+   *
+   * Optional — solo-mode backends that don't support namespaces omit this.
+   */
+  registerNamespace?(
+    datastorePath: string,
+    namespace: string,
+    repoId: string,
+  ): Promise<void>;
+
+  /**
+   * List all registered namespaces in the datastore.
+   *
+   * Returns the namespace slugs discovered from namespace manifests.
+   * An empty array means solo mode (no namespaces registered).
+   *
+   * Optional — solo-mode backends that don't support namespaces omit this.
+   */
+  listNamespaces?(datastorePath: string): Promise<string[]>;
 }

--- a/src/infrastructure/persistence/namespace_manifest.ts
+++ b/src/infrastructure/persistence/namespace_manifest.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+
+const MANIFEST_FILENAME = ".namespace.json";
+
+export interface NamespaceManifest {
+  namespace: string;
+  repoId: string;
+  registeredAt: string;
+}
+
+export function namespaceManifestPath(
+  datastorePath: string,
+  namespace: string,
+): string {
+  return join(datastorePath, namespace, MANIFEST_FILENAME);
+}
+
+export async function writeNamespaceManifest(
+  datastorePath: string,
+  namespace: string,
+  repoId: string,
+): Promise<void> {
+  const dir = join(datastorePath, namespace);
+  await ensureDir(dir);
+  const manifest: NamespaceManifest = {
+    namespace,
+    repoId,
+    registeredAt: new Date().toISOString(),
+  };
+  await Deno.writeTextFile(
+    join(dir, MANIFEST_FILENAME),
+    JSON.stringify(manifest, null, 2) + "\n",
+  );
+}
+
+export async function readNamespaceManifest(
+  datastorePath: string,
+  namespace: string,
+): Promise<NamespaceManifest | null> {
+  const path = namespaceManifestPath(datastorePath, namespace);
+  try {
+    const content = await Deno.readTextFile(path);
+    return JSON.parse(content) as NamespaceManifest;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+}
+
+export async function listNamespaceManifests(
+  datastorePath: string,
+): Promise<NamespaceManifest[]> {
+  const manifests: NamespaceManifest[] = [];
+  try {
+    for await (const entry of Deno.readDir(datastorePath)) {
+      if (!entry.isDirectory) continue;
+      if (entry.name.startsWith(".")) continue;
+      const manifest = await readNamespaceManifest(datastorePath, entry.name);
+      if (manifest) manifests.push(manifest);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return [];
+    throw error;
+  }
+  return manifests.sort((a, b) => a.namespace.localeCompare(b.namespace));
+}

--- a/src/infrastructure/persistence/namespace_manifest_test.ts
+++ b/src/infrastructure/persistence/namespace_manifest_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertNotEquals } from "@std/assert";
+import { join } from "@std/path";
 import {
   listNamespaceManifests,
   readNamespaceManifest,
@@ -75,7 +76,7 @@ Deno.test("listNamespaceManifests: returns empty for nonexistent directory", asy
 Deno.test("listNamespaceManifests: skips directories without manifests", async () => {
   await withTempDir(async (dir) => {
     await writeNamespaceManifest(dir, "infra", "repo-1");
-    await Deno.mkdir(dir + "/data", { recursive: true });
+    await Deno.mkdir(join(dir, "data"), { recursive: true });
 
     const manifests = await listNamespaceManifests(dir);
     assertEquals(manifests.length, 1);
@@ -86,7 +87,7 @@ Deno.test("listNamespaceManifests: skips directories without manifests", async (
 Deno.test("listNamespaceManifests: skips dot-prefixed directories", async () => {
   await withTempDir(async (dir) => {
     await writeNamespaceManifest(dir, "infra", "repo-1");
-    await Deno.mkdir(dir + "/.locks", { recursive: true });
+    await Deno.mkdir(join(dir, ".locks"), { recursive: true });
 
     const manifests = await listNamespaceManifests(dir);
     assertEquals(manifests.length, 1);

--- a/src/infrastructure/persistence/namespace_manifest_test.ts
+++ b/src/infrastructure/persistence/namespace_manifest_test.ts
@@ -1,0 +1,94 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  listNamespaceManifests,
+  readNamespaceManifest,
+  writeNamespaceManifest,
+} from "./namespace_manifest.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-ns-manifest-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("writeNamespaceManifest: creates manifest file", async () => {
+  await withTempDir(async (dir) => {
+    await writeNamespaceManifest(dir, "infra", "repo-123");
+    const manifest = await readNamespaceManifest(dir, "infra");
+    assertNotEquals(manifest, null);
+    assertEquals(manifest!.namespace, "infra");
+    assertEquals(manifest!.repoId, "repo-123");
+    assertNotEquals(manifest!.registeredAt, undefined);
+  });
+});
+
+Deno.test("readNamespaceManifest: returns null for missing namespace", async () => {
+  await withTempDir(async (dir) => {
+    const manifest = await readNamespaceManifest(dir, "nonexistent");
+    assertEquals(manifest, null);
+  });
+});
+
+Deno.test("listNamespaceManifests: lists registered namespaces", async () => {
+  await withTempDir(async (dir) => {
+    await writeNamespaceManifest(dir, "infra", "repo-1");
+    await writeNamespaceManifest(dir, "security", "repo-2");
+
+    const manifests = await listNamespaceManifests(dir);
+    assertEquals(manifests.length, 2);
+    assertEquals(manifests[0].namespace, "infra");
+    assertEquals(manifests[1].namespace, "security");
+  });
+});
+
+Deno.test("listNamespaceManifests: returns empty for nonexistent directory", async () => {
+  const manifests = await listNamespaceManifests(
+    "/tmp/swamp-ns-test-nonexistent-" + crypto.randomUUID(),
+  );
+  assertEquals(manifests, []);
+});
+
+Deno.test("listNamespaceManifests: skips directories without manifests", async () => {
+  await withTempDir(async (dir) => {
+    await writeNamespaceManifest(dir, "infra", "repo-1");
+    await Deno.mkdir(dir + "/data", { recursive: true });
+
+    const manifests = await listNamespaceManifests(dir);
+    assertEquals(manifests.length, 1);
+    assertEquals(manifests[0].namespace, "infra");
+  });
+});
+
+Deno.test("listNamespaceManifests: skips dot-prefixed directories", async () => {
+  await withTempDir(async (dir) => {
+    await writeNamespaceManifest(dir, "infra", "repo-1");
+    await Deno.mkdir(dir + "/.locks", { recursive: true });
+
+    const manifests = await listNamespaceManifests(dir);
+    assertEquals(manifests.length, 1);
+  });
+});

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -59,6 +59,7 @@ export interface DataListData {
   modelId: string;
   modelName: string;
   modelType: string;
+  namespace: string;
   groups: DataGroupedByType[];
   total: number;
 }
@@ -158,6 +159,7 @@ export interface DataListDeps {
     workflowId: string,
     runId: string,
   ) => Promise<WorkflowDataEntry[]>;
+  namespace?: string;
 }
 
 /** Wires real infrastructure into DataListDeps. */
@@ -165,6 +167,7 @@ export function createDataListDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
+  namespace?: string,
 ): DataListDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -188,6 +191,7 @@ export function createDataListDeps(
     dataRepo,
   );
   return {
+    namespace,
     lookupDefinition: (idOrName) =>
       findDefinitionByIdOrName(definitionRepo, idOrName),
     findAllForModel: (type, definitionId) =>
@@ -386,6 +390,7 @@ async function* modelScopedList(
       modelId: definition.id,
       modelName: definition.name,
       modelType: modelType.normalized,
+      namespace: deps.namespace ?? "",
       groups,
       total: filteredData.length,
     },

--- a/src/libswamp/datastores/namespace_list.ts
+++ b/src/libswamp/datastores/namespace_list.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface NamespaceInfo {
+  namespace: string;
+  repoId: string;
+  registeredAt: string;
+  isCurrent: boolean;
+}
+
+export interface NamespaceListData {
+  namespaces: NamespaceInfo[];
+  currentNamespace: string | undefined;
+}
+
+export type NamespaceListEvent =
+  | { kind: "completed"; data: NamespaceListData }
+  | { kind: "error"; error: SwampError };
+
+export interface NamespaceListDeps {
+  getCurrentNamespace: () => string | undefined;
+  listNamespaces: () => Promise<
+    Array<{ namespace: string; repoId: string; registeredAt: string }>
+  >;
+}
+
+export async function* datastoreNamespaceList(
+  _ctx: LibSwampContext,
+  deps: NamespaceListDeps,
+): AsyncIterable<NamespaceListEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.namespace.list",
+    {},
+    (async function* () {
+      const current = deps.getCurrentNamespace();
+      const manifests = await deps.listNamespaces();
+
+      const namespaces: NamespaceInfo[] = manifests.map((m) => ({
+        namespace: m.namespace,
+        repoId: m.repoId,
+        registeredAt: m.registeredAt,
+        isCurrent: m.namespace === current,
+      }));
+
+      yield {
+        kind: "completed",
+        data: { namespaces, currentNamespace: current },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/namespace_list_test.ts
+++ b/src/libswamp/datastores/namespace_list_test.ts
@@ -1,0 +1,121 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertCompletes } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreNamespaceList,
+  type NamespaceListDeps,
+  type NamespaceListEvent,
+} from "./namespace_list.ts";
+
+function makeDeps(
+  overrides: Partial<NamespaceListDeps> = {},
+): NamespaceListDeps {
+  return {
+    getCurrentNamespace: () => undefined,
+    listNamespaces: () => Promise.resolve([]),
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreNamespaceList: empty datastore returns empty list", async () => {
+  const deps = makeDeps();
+  await assertCompletes<NamespaceListEvent>(
+    datastoreNamespaceList(createLibSwampContext(), deps),
+    {
+      kind: "completed",
+      data: { namespaces: [], currentNamespace: undefined },
+    },
+  );
+});
+
+Deno.test("datastoreNamespaceList: lists namespaces with current marker", async () => {
+  const deps = makeDeps({
+    getCurrentNamespace: () => "infra",
+    listNamespaces: () =>
+      Promise.resolve([
+        {
+          namespace: "infra",
+          repoId: "repo-1",
+          registeredAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          namespace: "security",
+          repoId: "repo-2",
+          registeredAt: "2026-01-02T00:00:00Z",
+        },
+      ]),
+  });
+
+  await assertCompletes<NamespaceListEvent>(
+    datastoreNamespaceList(createLibSwampContext(), deps),
+    {
+      kind: "completed",
+      data: {
+        namespaces: [
+          {
+            namespace: "infra",
+            repoId: "repo-1",
+            registeredAt: "2026-01-01T00:00:00Z",
+            isCurrent: true,
+          },
+          {
+            namespace: "security",
+            repoId: "repo-2",
+            registeredAt: "2026-01-02T00:00:00Z",
+            isCurrent: false,
+          },
+        ],
+        currentNamespace: "infra",
+      },
+    },
+  );
+});
+
+Deno.test("datastoreNamespaceList: no current namespace marks none as current", async () => {
+  const deps = makeDeps({
+    listNamespaces: () =>
+      Promise.resolve([
+        {
+          namespace: "infra",
+          repoId: "repo-1",
+          registeredAt: "2026-01-01T00:00:00Z",
+        },
+      ]),
+  });
+
+  await assertCompletes<NamespaceListEvent>(
+    datastoreNamespaceList(createLibSwampContext(), deps),
+    {
+      kind: "completed",
+      data: {
+        namespaces: [
+          {
+            namespace: "infra",
+            repoId: "repo-1",
+            registeredAt: "2026-01-01T00:00:00Z",
+            isCurrent: false,
+          },
+        ],
+        currentNamespace: undefined,
+      },
+    },
+  );
+});

--- a/src/libswamp/datastores/namespace_set.ts
+++ b/src/libswamp/datastores/namespace_set.ts
@@ -38,10 +38,15 @@ export interface NamespaceSetInput {
   slug: string;
 }
 
+export interface NamespaceRegistration {
+  namespace: string;
+  repoId: string;
+}
+
 export interface NamespaceSetDeps {
   getDatastorePath: () => string;
   getCurrentNamespace: () => string | undefined;
-  listNamespaces: () => Promise<string[]>;
+  listNamespaces: () => Promise<NamespaceRegistration[]>;
   registerNamespace: (namespace: string, repoId: string) => Promise<void>;
   updateMarkerNamespace: (namespace: string) => Promise<void>;
   getRepoId: () => string;
@@ -70,15 +75,23 @@ export async function* datastoreNamespaceSet(
         return;
       }
 
+      const slug: string = ns as string;
       const current = deps.getCurrentNamespace();
-      if (current === (ns as string)) {
+      if (current === slug) {
         yield {
           kind: "error",
           error: validationFailed(
-            `Namespace is already set to "${ns}".`,
+            `Namespace is already set to "${slug}".`,
           ),
         };
         return;
+      }
+
+      if (current) {
+        ctx.logger.info(
+          "Changing namespace from {old} to {new}",
+          { old: current, new: slug },
+        );
       }
 
       const datastorePath = deps.getDatastorePath();
@@ -87,16 +100,16 @@ export async function* datastoreNamespaceSet(
 
       if (deps.supportsRegistration) {
         const existing = await deps.listNamespaces();
-        if (existing.includes(ns as string)) {
+        const conflict = existing.find((r) => r.namespace === slug);
+        if (conflict && conflict.repoId !== repoId) {
           yield {
             kind: "error",
             error: validationFailed(
-              `Namespace "${ns}" is already registered in this datastore by another repo.`,
+              `Namespace "${slug}" is already registered in this datastore by repo ${conflict.repoId}.`,
             ),
           };
           return;
         }
-        await deps.registerNamespace(ns as string, repoId);
       } else {
         registrationSkipped = true;
         ctx.logger.warn(
@@ -104,25 +117,27 @@ export async function* datastoreNamespaceSet(
         );
       }
 
-      await deps.updateMarkerNamespace(ns as string);
+      await deps.updateMarkerNamespace(slug);
 
-      ctx.logger.info("Namespace set to {namespace}", {
-        namespace: ns as string,
-      });
+      if (deps.supportsRegistration) {
+        await deps.registerNamespace(slug, repoId);
+      }
+
+      ctx.logger.info("Namespace set to {namespace}", { namespace: slug });
 
       let warning =
-        "Existing data will remain at the old path and won't be visible. " +
-        "Use `swamp datastore namespace migrate` (coming in a future version) to move it.";
+        "Existing data will remain at the old path and won't be visible until " +
+        "migration tooling is available in a future version.";
       if (registrationSkipped) {
         warning +=
           "\n\nThis datastore backend does not support namespace registration. " +
-          `Conflict detection is unavailable — ensure no other repo uses the namespace "${ns}" in this datastore.`;
+          `Conflict detection is unavailable — ensure no other repo uses the namespace "${slug}" in this datastore.`;
       }
 
       yield {
         kind: "completed",
         data: {
-          namespace: ns as string,
+          namespace: slug,
           datastorePath,
           warning,
           registrationSkipped,

--- a/src/libswamp/datastores/namespace_set.ts
+++ b/src/libswamp/datastores/namespace_set.ts
@@ -1,0 +1,133 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { validationFailed } from "../errors.ts";
+import { createNamespace } from "../../domain/data/namespace.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface NamespaceSetData {
+  namespace: string;
+  datastorePath: string;
+  warning: string;
+  registrationSkipped?: boolean;
+}
+
+export type NamespaceSetEvent =
+  | { kind: "completed"; data: NamespaceSetData }
+  | { kind: "error"; error: SwampError };
+
+export interface NamespaceSetInput {
+  slug: string;
+}
+
+export interface NamespaceSetDeps {
+  getDatastorePath: () => string;
+  getCurrentNamespace: () => string | undefined;
+  listNamespaces: () => Promise<string[]>;
+  registerNamespace: (namespace: string, repoId: string) => Promise<void>;
+  updateMarkerNamespace: (namespace: string) => Promise<void>;
+  getRepoId: () => string;
+  supportsRegistration: boolean;
+}
+
+export async function* datastoreNamespaceSet(
+  ctx: LibSwampContext,
+  deps: NamespaceSetDeps,
+  input: NamespaceSetInput,
+): AsyncIterable<NamespaceSetEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.namespace.set",
+    { "namespace.slug": input.slug },
+    (async function* () {
+      let ns;
+      try {
+        ns = createNamespace(input.slug);
+      } catch (error) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
+
+      const current = deps.getCurrentNamespace();
+      if (current === (ns as string)) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Namespace is already set to "${ns}".`,
+          ),
+        };
+        return;
+      }
+
+      const datastorePath = deps.getDatastorePath();
+      const repoId = deps.getRepoId();
+      let registrationSkipped = false;
+
+      if (deps.supportsRegistration) {
+        const existing = await deps.listNamespaces();
+        if (existing.includes(ns as string)) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Namespace "${ns}" is already registered in this datastore by another repo.`,
+            ),
+          };
+          return;
+        }
+        await deps.registerNamespace(ns as string, repoId);
+      } else {
+        registrationSkipped = true;
+        ctx.logger.warn(
+          "Datastore backend does not support namespace registration — conflict detection is unavailable",
+        );
+      }
+
+      await deps.updateMarkerNamespace(ns as string);
+
+      ctx.logger.info("Namespace set to {namespace}", {
+        namespace: ns as string,
+      });
+
+      let warning =
+        "Existing data will remain at the old path and won't be visible. " +
+        "Use `swamp datastore namespace migrate` (coming in a future version) to move it.";
+      if (registrationSkipped) {
+        warning +=
+          "\n\nThis datastore backend does not support namespace registration. " +
+          `Conflict detection is unavailable — ensure no other repo uses the namespace "${ns}" in this datastore.`;
+      }
+
+      yield {
+        kind: "completed",
+        data: {
+          namespace: ns as string,
+          datastorePath,
+          warning,
+          registrationSkipped,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/namespace_set_test.ts
+++ b/src/libswamp/datastores/namespace_set_test.ts
@@ -1,0 +1,162 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertCompletes, assertErrors, collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreNamespaceSet,
+  type NamespaceSetDeps,
+  type NamespaceSetEvent,
+} from "./namespace_set.ts";
+
+function makeDeps(
+  overrides: Partial<NamespaceSetDeps> = {},
+): NamespaceSetDeps {
+  return {
+    getDatastorePath: () => "/tmp/ds",
+    getCurrentNamespace: () => undefined,
+    listNamespaces: () => Promise.resolve([]),
+    registerNamespace: () => Promise.resolve(),
+    updateMarkerNamespace: () => Promise.resolve(),
+    getRepoId: () => "repo-1",
+    supportsRegistration: true,
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreNamespaceSet: valid slug succeeds", async () => {
+  let registered = "";
+  let markerUpdated = "";
+  const deps = makeDeps({
+    registerNamespace: (ns) => {
+      registered = ns;
+      return Promise.resolve();
+    },
+    updateMarkerNamespace: (ns) => {
+      markerUpdated = ns;
+      return Promise.resolve();
+    },
+  });
+
+  const completed = await assertCompletes<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+    {
+      kind: "completed",
+      data: {
+        namespace: "infra",
+        datastorePath: "/tmp/ds",
+        warning:
+          "Existing data will remain at the old path and won't be visible until " +
+          "migration tooling is available in a future version.",
+        registrationSkipped: false,
+      },
+    },
+  );
+  assertEquals(completed.kind, "completed");
+  assertEquals(registered, "infra");
+  assertEquals(markerUpdated, "infra");
+});
+
+Deno.test("datastoreNamespaceSet: invalid slug yields error", async () => {
+  const deps = makeDeps();
+  await assertErrors<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "INVALID" }),
+    "validation_failed",
+  );
+});
+
+Deno.test("datastoreNamespaceSet: already-set namespace yields error", async () => {
+  const deps = makeDeps({
+    getCurrentNamespace: () => "infra",
+  });
+  const error = await assertErrors<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+    "validation_failed",
+  );
+  assertEquals(error.message, 'Namespace is already set to "infra".');
+});
+
+Deno.test("datastoreNamespaceSet: conflict with different repoId yields error", async () => {
+  const deps = makeDeps({
+    listNamespaces: () =>
+      Promise.resolve([{ namespace: "infra", repoId: "other-repo" }]),
+  });
+  const error = await assertErrors<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+    "validation_failed",
+  );
+  assertEquals(
+    error.message,
+    'Namespace "infra" is already registered in this datastore by repo other-repo.',
+  );
+});
+
+Deno.test("datastoreNamespaceSet: re-registration with same repoId succeeds", async () => {
+  const deps = makeDeps({
+    listNamespaces: () =>
+      Promise.resolve([{ namespace: "infra", repoId: "repo-1" }]),
+  });
+  const events = await collect<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+  );
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+});
+
+Deno.test("datastoreNamespaceSet: registration skipped when unsupported", async () => {
+  let registerCalled = false;
+  const deps = makeDeps({
+    supportsRegistration: false,
+    registerNamespace: () => {
+      registerCalled = true;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+  );
+  const last = events[events.length - 1] as Extract<
+    NamespaceSetEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(last.kind, "completed");
+  assertEquals(last.data.registrationSkipped, true);
+  assertEquals(registerCalled, false);
+});
+
+Deno.test("datastoreNamespaceSet: marker updated before registration", async () => {
+  const callOrder: string[] = [];
+  const deps = makeDeps({
+    updateMarkerNamespace: () => {
+      callOrder.push("marker");
+      return Promise.resolve();
+    },
+    registerNamespace: () => {
+      callOrder.push("register");
+      return Promise.resolve();
+    },
+  });
+
+  await collect<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+  );
+  assertEquals(callOrder, ["marker", "register"]);
+});

--- a/src/libswamp/datastores/namespace_unset.ts
+++ b/src/libswamp/datastores/namespace_unset.ts
@@ -1,0 +1,84 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { validationFailed } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface NamespaceUnsetData {
+  previousNamespace: string;
+}
+
+export type NamespaceUnsetEvent =
+  | { kind: "completed"; data: NamespaceUnsetData }
+  | { kind: "error"; error: SwampError };
+
+export interface NamespaceUnsetDeps {
+  getCurrentNamespace: () => string | undefined;
+  listNamespaces: () => Promise<string[]>;
+  removeMarkerNamespace: () => Promise<void>;
+}
+
+export async function* datastoreNamespaceUnset(
+  ctx: LibSwampContext,
+  deps: NamespaceUnsetDeps,
+): AsyncIterable<NamespaceUnsetEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.namespace.unset",
+    {},
+    (async function* () {
+      const current = deps.getCurrentNamespace();
+      if (!current) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "No namespace is currently configured. Nothing to unset.",
+          ),
+        };
+        return;
+      }
+
+      const namespaces = await deps.listNamespaces();
+      if (namespaces.length > 1) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Cannot unset namespace: datastore contains ${namespaces.length} namespaces ` +
+              `(${
+                namespaces.join(", ")
+              }). Unsetting is only allowed when a single namespace exists.`,
+          ),
+        };
+        return;
+      }
+
+      await deps.removeMarkerNamespace();
+
+      ctx.logger.info("Namespace unset (was {namespace})", {
+        namespace: current,
+      });
+
+      yield {
+        kind: "completed",
+        data: { previousNamespace: current },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/namespace_unset_test.ts
+++ b/src/libswamp/datastores/namespace_unset_test.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertCompletes, assertErrors } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreNamespaceUnset,
+  type NamespaceUnsetDeps,
+  type NamespaceUnsetEvent,
+} from "./namespace_unset.ts";
+
+function makeDeps(
+  overrides: Partial<NamespaceUnsetDeps> = {},
+): NamespaceUnsetDeps {
+  return {
+    getCurrentNamespace: () => "infra",
+    listNamespaces: () => Promise.resolve(["infra"]),
+    removeMarkerNamespace: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreNamespaceUnset: unset with single namespace succeeds", async () => {
+  let removed = false;
+  const deps = makeDeps({
+    removeMarkerNamespace: () => {
+      removed = true;
+      return Promise.resolve();
+    },
+  });
+
+  await assertCompletes<NamespaceUnsetEvent>(
+    datastoreNamespaceUnset(createLibSwampContext(), deps),
+    {
+      kind: "completed",
+      data: { previousNamespace: "infra" },
+    },
+  );
+  assertEquals(removed, true);
+});
+
+Deno.test("datastoreNamespaceUnset: no namespace configured yields error", async () => {
+  const deps = makeDeps({
+    getCurrentNamespace: () => undefined,
+  });
+  const error = await assertErrors<NamespaceUnsetEvent>(
+    datastoreNamespaceUnset(createLibSwampContext(), deps),
+    "validation_failed",
+  );
+  assertEquals(
+    error.message,
+    "No namespace is currently configured. Nothing to unset.",
+  );
+});
+
+Deno.test("datastoreNamespaceUnset: blocked with multiple namespaces", async () => {
+  const deps = makeDeps({
+    listNamespaces: () => Promise.resolve(["infra", "security"]),
+  });
+  const error = await assertErrors<NamespaceUnsetEvent>(
+    datastoreNamespaceUnset(createLibSwampContext(), deps),
+    "validation_failed",
+  );
+  assertEquals(
+    error.message,
+    "Cannot unset namespace: datastore contains 2 namespaces " +
+      "(infra, security). Unsetting is only allowed when a single namespace exists.",
+  );
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -318,6 +318,7 @@ export {
 export type { DataRecord } from "../domain/data/data_record.ts";
 export {
   createNamespace,
+  formatNamespacedModelName,
   isEmptyNamespace,
   type Namespace,
   type NamespacedModelName,
@@ -1234,3 +1235,23 @@ export {
   type DatastoreCompactDeps,
   type DatastoreCompactEvent,
 } from "./datastores/compact.ts";
+export {
+  datastoreNamespaceSet,
+  type NamespaceSetData,
+  type NamespaceSetDeps,
+  type NamespaceSetEvent,
+  type NamespaceSetInput,
+} from "./datastores/namespace_set.ts";
+export {
+  datastoreNamespaceUnset,
+  type NamespaceUnsetData,
+  type NamespaceUnsetDeps,
+  type NamespaceUnsetEvent,
+} from "./datastores/namespace_unset.ts";
+export {
+  datastoreNamespaceList,
+  type NamespaceInfo,
+  type NamespaceListData,
+  type NamespaceListDeps,
+  type NamespaceListEvent,
+} from "./datastores/namespace_list.ts";

--- a/src/presentation/renderers/data_list.ts
+++ b/src/presentation/renderers/data_list.ts
@@ -78,11 +78,8 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
       for (const item of group.items) {
         const size = formatSize(item.size);
         const date = item.createdAt.slice(0, 10);
-        const nsPrefix = this.showNamespace && data.namespace
-          ? `[${data.namespace}]  `
-          : "";
         let line =
-          `  ${nsPrefix}${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`;
+          `  ${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`;
         if (line.length > cols) {
           line = line.substring(0, cols - 1) + "…";
         }

--- a/src/presentation/renderers/data_list.ts
+++ b/src/presentation/renderers/data_list.ts
@@ -44,6 +44,8 @@ function isWorkflowData(
 }
 
 class LogDataListRenderer implements Renderer<DataListEvent> {
+  constructor(private showNamespace: boolean) {}
+
   handlers(): EventHandlers<DataListEvent> {
     return {
       resolving: () => {},
@@ -62,7 +64,10 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
 
   private renderModel(data: DataListData): void {
     const cols = getTerminalColumns();
-    console.log(`Data for ${data.modelName} (${data.modelType})`);
+    const header = this.showNamespace && data.namespace
+      ? `Data for ${data.namespace}:${data.modelName} (${data.modelType})`
+      : `Data for ${data.modelName} (${data.modelType})`;
+    console.log(header);
     console.log();
 
     for (const group of data.groups) {
@@ -73,8 +78,11 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
       for (const item of group.items) {
         const size = formatSize(item.size);
         const date = item.createdAt.slice(0, 10);
+        const nsPrefix = this.showNamespace && data.namespace
+          ? `[${data.namespace}]  `
+          : "";
         let line =
-          `  ${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`;
+          `  ${nsPrefix}${item.name}  v${item.version}  ${item.contentType}  ${size}  ${date}`;
         if (line.length > cols) {
           line = line.substring(0, cols - 1) + "…";
         }
@@ -114,11 +122,18 @@ class LogDataListRenderer implements Renderer<DataListEvent> {
 }
 
 class JsonDataListRenderer implements Renderer<DataListEvent> {
+  constructor(private showNamespace: boolean) {}
+
   handlers(): EventHandlers<DataListEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        console.log(JSON.stringify(e.data, null, 2));
+        if (!this.showNamespace && !isWorkflowData(e.data)) {
+          const { namespace: _ns, ...rest } = e.data;
+          console.log(JSON.stringify(rest, null, 2));
+        } else {
+          console.log(JSON.stringify(e.data, null, 2));
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -129,11 +144,12 @@ class JsonDataListRenderer implements Renderer<DataListEvent> {
 
 export function createDataListRenderer(
   mode: OutputMode,
+  showNamespace = false,
 ): Renderer<DataListEvent> {
   switch (mode) {
     case "json":
-      return new JsonDataListRenderer();
+      return new JsonDataListRenderer(showNamespace);
     case "log":
-      return new LogDataListRenderer();
+      return new LogDataListRenderer(showNamespace);
   }
 }

--- a/src/presentation/renderers/data_list_test.ts
+++ b/src/presentation/renderers/data_list_test.ts
@@ -47,6 +47,7 @@ Deno.test("JsonDataListRenderer - completed outputs JSON", async () => {
             modelId: "def-1",
             modelName: "my-model",
             modelType: "aws/ec2",
+            namespace: "",
             groups: [],
             total: 0,
           },

--- a/src/presentation/renderers/data_query.ts
+++ b/src/presentation/renderers/data_query.ts
@@ -73,27 +73,40 @@ function markdownTable(
  * scaled at ~3ms per row — fine for the TUI's bounded result set, fatal
  * for `--limit 100000` on a real catalog.
  */
-function renderDefaultTable(data: DataQueryData): string {
+function renderDefaultTable(
+  data: DataQueryData,
+  showNamespace = false,
+): string {
   if (data.results.length === 0) {
     return "No matching data found.";
   }
 
-  const headers = [
-    "name",
-    "modelName",
-    "specName",
-    "dataType",
-    "version",
-    "size",
-  ];
-  const rows = data.results.map((r) => [
-    r.name,
-    r.modelName,
-    r.specName,
-    r.dataType,
-    String(r.version),
-    formatSize(r.size),
-  ]);
+  const hasNamespace = showNamespace &&
+    data.results.some((r) => r.namespace !== "");
+
+  const headers = hasNamespace
+    ? [
+      "namespace",
+      "name",
+      "modelName",
+      "specName",
+      "dataType",
+      "version",
+      "size",
+    ]
+    : ["name", "modelName", "specName", "dataType", "version", "size"];
+
+  const rows = data.results.map((r) => {
+    const base = [
+      r.name,
+      r.modelName,
+      r.specName,
+      r.dataType,
+      String(r.version),
+      formatSize(r.size),
+    ];
+    return hasNamespace ? [r.namespace, ...base] : base;
+  });
 
   const table = new Table()
     .header(headers.map((h) => bold(h)))
@@ -213,8 +226,13 @@ function renderJson(data: DataQueryData): void {
  * (`--select`) path; the default table path bypasses markdown entirely and
  * builds ANSI output directly via {@link renderQueryResultsTerminal}.
  */
-export function renderQueryResultsMarkdown(data: DataQueryData): string {
-  return data.projected ? renderProjected(data) : renderDefaultTable(data);
+export function renderQueryResultsMarkdown(
+  data: DataQueryData,
+  showNamespace = false,
+): string {
+  return data.projected
+    ? renderProjected(data)
+    : renderDefaultTable(data, showNamespace);
 }
 
 /**
@@ -228,15 +246,21 @@ export function renderQueryResultsMarkdown(data: DataQueryData): string {
  * branch is bounded by the markdown parser and should only be used for
  * small result sets.
  */
-export function renderQueryResultsTerminal(data: DataQueryData): string {
+export function renderQueryResultsTerminal(
+  data: DataQueryData,
+  showNamespace = false,
+): string {
   if (data.projected) {
-    return renderMarkdownToTerminal(renderQueryResultsMarkdown(data));
+    return renderMarkdownToTerminal(
+      renderQueryResultsMarkdown(data, showNamespace),
+    );
   }
-  return renderDefaultTable(data);
+  return renderDefaultTable(data, showNamespace);
 }
 
 export function createDataQueryRenderer(
   outputMode: OutputMode,
+  showNamespace = false,
 ): { handlers: () => EventHandlers<DataQueryEvent> } {
   return {
     handlers: () => ({
@@ -248,7 +272,7 @@ export function createDataQueryRenderer(
           renderJson(event.data);
           return;
         }
-        writeOutput(renderQueryResultsTerminal(event.data));
+        writeOutput(renderQueryResultsTerminal(event.data, showNamespace));
       },
       error: (event: DataQueryEvent & { kind: "error" }) => {
         throw new UserError(event.error.message);

--- a/src/presentation/renderers/datastore_namespace_list.ts
+++ b/src/presentation/renderers/datastore_namespace_list.ts
@@ -1,0 +1,90 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, green } from "@std/fmt/colors";
+import type { EventHandlers, NamespaceListEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { Table } from "@cliffy/table";
+
+class LogNamespaceListRenderer implements Renderer<NamespaceListEvent> {
+  handlers(): EventHandlers<NamespaceListEvent> {
+    return {
+      completed: (e) => {
+        const { namespaces } = e.data;
+
+        if (namespaces.length === 0) {
+          writeOutput("No namespaces registered in this datastore.");
+          return;
+        }
+
+        const table = new Table()
+          .header(
+            [
+              "namespace",
+              "repoId",
+              "registeredAt",
+              "current",
+            ].map((h) => bold(h)),
+          )
+          .body(
+            namespaces.map((ns) => [
+              ns.namespace,
+              ns.repoId || "-",
+              ns.registeredAt ? ns.registeredAt.slice(0, 10) : "-",
+              ns.isCurrent ? green("*") : "",
+            ]),
+          )
+          .border(true)
+          .padding(1);
+
+        writeOutput(table.toString());
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonNamespaceListRenderer implements Renderer<NamespaceListEvent> {
+  handlers(): EventHandlers<NamespaceListEvent> {
+    return {
+      completed: (e) => {
+        writeOutput(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createNamespaceListRenderer(
+  mode: OutputMode,
+): Renderer<NamespaceListEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonNamespaceListRenderer();
+    case "log":
+      return new LogNamespaceListRenderer();
+  }
+}

--- a/src/presentation/renderers/datastore_namespace_set.ts
+++ b/src/presentation/renderers/datastore_namespace_set.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, yellow } from "@std/fmt/colors";
+import type { EventHandlers, NamespaceSetEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+class LogNamespaceSetRenderer implements Renderer<NamespaceSetEvent> {
+  handlers(): EventHandlers<NamespaceSetEvent> {
+    return {
+      completed: (e) => {
+        const lines = [
+          bold(`Namespace set to "${e.data.namespace}"`),
+          `  Datastore: ${e.data.datastorePath}`,
+          "",
+          yellow("Warning: " + e.data.warning),
+        ];
+        writeOutput(lines.join("\n"));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonNamespaceSetRenderer implements Renderer<NamespaceSetEvent> {
+  handlers(): EventHandlers<NamespaceSetEvent> {
+    return {
+      completed: (e) => {
+        writeOutput(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createNamespaceSetRenderer(
+  mode: OutputMode,
+): Renderer<NamespaceSetEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonNamespaceSetRenderer();
+    case "log":
+      return new LogNamespaceSetRenderer();
+  }
+}

--- a/src/presentation/renderers/datastore_namespace_unset.ts
+++ b/src/presentation/renderers/datastore_namespace_unset.ts
@@ -1,0 +1,65 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 System Initiative, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold } from "@std/fmt/colors";
+import type { EventHandlers, NamespaceUnsetEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+class LogNamespaceUnsetRenderer implements Renderer<NamespaceUnsetEvent> {
+  handlers(): EventHandlers<NamespaceUnsetEvent> {
+    return {
+      completed: (e) => {
+        writeOutput(
+          bold("Namespace unset") +
+            ` (was "${e.data.previousNamespace}")`,
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonNamespaceUnsetRenderer implements Renderer<NamespaceUnsetEvent> {
+  handlers(): EventHandlers<NamespaceUnsetEvent> {
+    return {
+      completed: (e) => {
+        writeOutput(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createNamespaceUnsetRenderer(
+  mode: OutputMode,
+): Renderer<NamespaceUnsetEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonNamespaceUnsetRenderer();
+    case "log":
+      return new LogNamespaceUnsetRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

Giga-swamp Phase 5: adds CLI surface for namespace management and conditional NAMESPACE column in output renderers.

- Add optional `registerNamespace()`/`listNamespaces()` methods to `DatastoreProvider` interface
- Add `formatNamespacedModelName()` utility (inverse of `parseNamespacedModelName`)
- Add `swamp datastore namespace set <slug>` / `unset` commands with filesystem manifest-based conflict detection
- Add `swamp datastore namespaces` list command
- Add conditional NAMESPACE column to `data list` and `data query` renderers (config-based detection — column absent in solo mode)
- Thread namespace from datastore config through libswamp generators to renderer interfaces
- Filesystem backends write `.namespace.json` manifests for conflict detection
- Extension backends (S3/GCS) that don't implement registration get a clear warning: "Conflict detection is unavailable — ensure no other repo uses the namespace"
- Solo mode output is byte-identical to released binary (verified via `diff` on JSON and log modes for both `data list` and `data query`)

## Verification

Tested against compiled binary with real repos:

**Solo mode regression** — `data list` and `data query` output (JSON + log) diffed against released binary on same repo: byte-identical in all four comparisons.

**Filesystem namespace commands:**
- `namespace set infra` → updates `.swamp.yaml`, writes manifest at `{ds}/infra/.namespace.json`
- `namespaces` → lists registered namespaces with current marker
- Conflict detection → second repo blocked from claiming same namespace
- `namespace unset` guard → blocked when multiple namespaces exist

**S3 extension compatibility (MinIO):**
- `datastore setup extension @swamp/s3-datastore` → succeeds
- Model run + `datastore sync` → 14 files pushed to bucket under `infra/` prefix
- Cache wipe + pull → 14 files recovered, `data list` and `data query` show NAMESPACE column
- `datastore lock status` → works
- `namespace set infra` → warns about unsupported registration, proceeds, no local manifest written

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 6662 passed, 0 failed
- [x] `deno run compile` — binary compiled
- [x] Solo mode regression: output byte-identical to released binary
- [x] Namespaced filesystem repo: NAMESPACE column appears in data list + data query
- [x] S3 round-trip: NAMESPACE column correct after push/wipe/pull
- [x] Extension compat: published @swamp/s3-datastore works with Phase 5 binary

Closes swamp-club#542

🤖 Generated with [Claude Code](https://claude.com/claude-code)