### PR TITLE
fix(ci): update UAT dispatch target to swamp-club org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.UAT_TRIGGER_TOKEN }}
-          repository: systeminit/swamp-uat
+          repository: swamp-club/swamp-uat
           event-type: run-uat
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 


### PR DESCRIPTION
## Summary
- Update the `repository-dispatch` target in `release.yml` from `systeminit/swamp-uat` to `swamp-club/swamp-uat` to match the org migration.
- Docker Hub image references are left unchanged for now (separate migration).

## Test plan
- [ ] Verify next release triggers UAT in the correct `swamp-club/swamp-uat` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)