### PR TITLE
chore: update copyright and branding to Elder Swamp Club

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -86,7 +86,7 @@ where you decide whether to thank the issue author:
 Check collaborator status with:
 
 ```
-gh api /repos/systeminit/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
+gh api /repos/swamp-club/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
 ```
 
 If the author is NOT in the collaborator list, they are external — call

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -134,7 +134,7 @@ After `ship` or `complete`, the phase is `notify`. Check whether the issue
 author is an external contributor:
 
 ```
-gh api /repos/systeminit/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
+gh api /repos/swamp-club/swamp/collaborators --jq '.[].login' | grep -qx '<author>'
 ```
 
 - **External** (not a collaborator): call `notify` to post a thank-you ripple:

--- a/.claude/skills/swamp-issue/SKILL.md
+++ b/.claude/skills/swamp-issue/SKILL.md
@@ -105,7 +105,7 @@ With `--close`: adds `"statusChanged": "closed"`. With `--reopen`: adds
 1. **Logged in** → submits to Lab API → returns issue number and URL
 2. **Not logged in** → prompts: log in now, or send via email
 3. **`--email` flag** → opens email client with pre-filled subject/body to
-   `support@systeminit.com`
+   `support@swamp-club.com`
 
 **Output shape** (Lab submission with `--json`):
 

--- a/.claude/skills/swamp-issue/references/output_shapes.md
+++ b/.claude/skills/swamp-issue/references/output_shapes.md
@@ -38,7 +38,7 @@ to assert on results programmatically.
 ```json
 {
   "method": "email",
-  "to": "support@systeminit.com",
+  "to": "support@swamp-club.com",
   "subject": "...",
   "body": "..."
 }

--- a/.claude/skills/swamp-issue/references/sanitization.md
+++ b/.claude/skills/swamp-issue/references/sanitization.md
@@ -31,7 +31,7 @@ context is needed for diagnosis. Sanitize the final draft.
   `acme-corp/internal-tools`)
 - Internal hostnames and domains (e.g. `jenkins.internal.acme.com`)
 - Private IP addresses (RFC 1918: `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`)
-- Email addresses (except generic ones like `support@systeminit.com`)
+- Email addresses (except generic ones like `support@swamp-club.com`)
 - Usernames that identify real people
 
 **Placeholders:** `<ORG>`, `<INTERNAL_HOST>`, `<PRIVATE_IP>`, `<EMAIL>`,
@@ -63,7 +63,7 @@ distinct paths appear)
 
 - **Generic system paths** (`/usr/local/bin/swamp`, `/tmp/repro/`) are safe — do
   not redact.
-- **Public repository names** (`systeminit/swamp`, well-known open-source
+- **Public repository names** (`swamp-club/swamp`, well-known open-source
   projects) are safe.
 - **Quoted error output** often contains paths or identifiers from the user's
   environment. Redact the identifying parts while preserving the error structure

--- a/.github/actions/adversarial-review/README.md
+++ b/.github/actions/adversarial-review/README.md
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: systeminit/swamp/.github/actions/adversarial-review@COMMIT_SHA
+      - uses: swamp-club/swamp/.github/actions/adversarial-review@COMMIT_SHA
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -74,7 +74,7 @@ Add project-specific dimensions with the `extra_dimensions` input.
 ## Adding Custom Dimensions
 
 ```yaml
-- uses: systeminit/swamp/.github/actions/adversarial-review@COMMIT_SHA
+- uses: swamp-club/swamp/.github/actions/adversarial-review@COMMIT_SHA
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/BUG_BOUNTY.md
+++ b/BUG_BOUNTY.md
@@ -128,9 +128,9 @@ finding a vulnerability.
 - Swamp Club will reward valid reports of leaked credentials unknown to the
   program or monitoring tools. Hackers must include the leak's source and avoid
   testing beyond authenticating and deauthenticating.
-- A bypass of a resolved vulnerability will be treated as a new report. System
-  Initiative will consider awarding bonuses for reports providing additional
-  bypass information
+- A bypass of a resolved vulnerability will be treated as a new report. Swamp
+  Club will consider awarding bonuses for reports providing additional bypass
+  information
 - Reporters must not have:
   - Conducted phishing, vishing, smashing, or any other active user misleading.
   - Accessed data not owned by the reporter.
@@ -181,7 +181,7 @@ report and the potential impact
 
 5. **Informational Issues**
    - These are not eligible for rewards but may receive a goodwill $50 USD
-     gesture or a piece of highly sought after System Initiatve swag.
+     gesture or a piece of highly sought after Swamp Club swag.
 
 # Core Ineligible Findings
 
@@ -265,5 +265,5 @@ Examples include:
 | ------------------------ | ---------- | ----------- | ------------------- | ----------------------- | ------------------------ | --------------------------- | --------------------- | ------------ | ----------- | ----------------------- | ----------------------- |
 | telemetry.swamp-club.com | API        |             | true                | true                    |                          |                             |                       | critical     | production  | 2026-11-02 13:45:00 UTC | 2026-11-02 13:45:00 UTC |
 | swamp-club.com           | WEB APP    |             | true                | true                    |                          |                             |                       | critical     | production  | 2026-11-02 13:45:00 UTC | 2026-11-02 13:45:00 UTC |
-| swamp-club.com           | WEB APP    |             | true                | true                    |                          |                             |                       | medium       | production  | 2024-11-28 13:45:00 UTC | 2024-11-28 13:45:00 UTC |
+| systeminit.com           | WEB APP    |             | true                | true                    |                          |                             |                       | medium       | production  | 2024-11-28 13:45:00 UTC | 2024-11-28 13:45:00 UTC |
 | swamp CLI (stable)       | OTHER      |             | true                | true                    |                          |                             |                       | high         | production  | 2026-02-12 00:00:00 UTC | 2026-02-12 00:00:00 UTC |

--- a/BUG_BOUNTY.md
+++ b/BUG_BOUNTY.md
@@ -1,12 +1,12 @@
-# Bug Bounty at System Initiative
+# Bug Bounty at Swamp Club
 
 **Launch Date:** 27th November, 2024 | **Last updated:** 11th February, 2026
 
-Welcome to the **System Initiative Bug Bounty** guidelines. This document serves
-as a comprehensive reference for security researchers and stakeholders
-participating in our bug bounty program. It outlines our commitment to security,
-the rules of engagement, reward structures, and the scope of eligible and
-ineligible vulnerabilities.
+Welcome to the **Swamp Club Bug Bounty** guidelines. This document serves as a
+comprehensive reference for security researchers and stakeholders participating
+in our bug bounty program. It outlines our commitment to security, the rules of
+engagement, reward structures, and the scope of eligible and ineligible
+vulnerabilities.
 
 Our goal is to foster collaboration with the security community to identify and
 resolve potential vulnerabilities in our systems. By following this guide, you
@@ -28,19 +28,19 @@ considered final.
 - **Ineligible Findings**: Specific exclusions from the policy.
 - **Scope**: Details about what assets are in and out of scope.
 
-System Initiative's Bounty Standards set expectations for both System Initiative
-and hackers when assessing the reward for a report. The standards begin with a
-relevant rating system such as [CVSS](https://nvd.nist.gov/vuln-metrics/cvss)
-for report assessments and then additionally consider additional adjustments
-("bumps") for discrepancies between associated rating scores and actual business
-impact. This ensures more accurate correlations between vulnerability impact
-evaluations to reward bounties.
+Swamp Club's Bounty Standards set expectations for both Swamp Club and hackers
+when assessing the reward for a report. The standards begin with a relevant
+rating system such as [CVSS](https://nvd.nist.gov/vuln-metrics/cvss) for report
+assessments and then additionally consider additional adjustments ("bumps") for
+discrepancies between associated rating scores and actual business impact. This
+ensures more accurate correlations between vulnerability impact evaluations to
+reward bounties.
 
 These Platform Standards aim to ensure consistency, fairness, and the best
 results for all program participants.
 
-We value your expertise and collaboration in helping make System Initiative more
-secure for everyone.
+We value your expertise and collaboration in helping make Swamp Club more secure
+for everyone.
 
 ---
 
@@ -93,7 +93,7 @@ Vulnerabilities are classified by **risk level** and **impact**:
 **Do not pivot further** into the network or alternative account/workspace after
 finding a vulnerability.
 
-- Avoid testing third-party service providers or non-System Initiative assets.
+- Avoid testing third-party service providers or non-Swamp Club assets.
 
 **If you encounter Personally Identifiable Information (PII):**
 
@@ -109,25 +109,25 @@ finding a vulnerability.
 - Aggressive testing causing service degradation or unnecessarily deep service
   penetration will result in permanent ineligibility from the program.
 - Multiple reports of the same vulnerability class on similar endpoints will pay
-  for the value received. However, reports that alert System Initiative to a
-  systemic issue across its assets will be considered for a discretionary bonus.
+  for the value received. However, reports that alert Swamp Club to a systemic
+  issue across its assets will be considered for a discretionary bonus.
 - Reports demonstrating significant security issues through chained
-  vulnerabilities will be evaluated based on overall impact. System Initiative
-  will issue bonuses for distinct reports that comprise a serious vulnerability
+  vulnerabilities will be evaluated based on overall impact. Swamp Club will
+  issue bonuses for distinct reports that comprise a serious vulnerability
   chain.
 - Vulnerabilities allowing attackers to bypass encryption in client applications
   (e.g., Adversary In The Middle attacks) will be prioritized. Vulnerabilities
   requiring attackers to disable certificate pinning are not valid.
 - Hackers must report vulnerabilities in third-party components to the component
-  owner before disclosing them to System Initiative. System Initiative will
-  reward valid reports for vulnerabilities in third-party components that lead
-  to urgent fixes or drive value outside regular patching schedules or SLA's.
+  owner before disclosing them to Swamp Club. Swamp Club will reward valid
+  reports for vulnerabilities in third-party components that lead to urgent
+  fixes or drive value outside regular patching schedules or SLA's.
 - Reports exposing sensitive PII for multiple users will be rated Critical.
   Sensitive PII includes Social Security numbers, passport numbers, driver’s
   license numbers, hashed passwords, and credit card numbers.
-- System Initiative will reward valid reports of leaked credentials unknown to
-  the program or monitoring tools. Hackers must include the leak's source and
-  avoid testing beyond authenticating and deauthenticating.
+- Swamp Club will reward valid reports of leaked credentials unknown to the
+  program or monitoring tools. Hackers must include the leak's source and avoid
+  testing beyond authenticating and deauthenticating.
 - A bypass of a resolved vulnerability will be treated as a new report. System
   Initiative will consider awarding bonuses for reports providing additional
   bypass information
@@ -146,20 +146,20 @@ finding a vulnerability.
 Reports for vulnerabilities that were either recently disclosed to the public or
 where a patch was recently released may not be eligible for a reward. "Recently"
 can be assumed to be 90 calendar days before the current point in time. This is
-because **System Initiative** already tracks many of these announcements and
-needs an appropriate amount of time to test and implement patches and safeguards
-before a report with the same information can provide value. However, each
-submission is evaluated on a case-by-case basis, and those providing significant
-value or new information such as more simplistic mitigation steps may still be
-eligible for a reward.
+because **Swamp Club** already tracks many of these announcements and needs an
+appropriate amount of time to test and implement patches and safeguards before a
+report with the same information can provide value. However, each submission is
+evaluated on a case-by-case basis, and those providing significant value or new
+information such as more simplistic mitigation steps may still be eligible for a
+reward.
 
 ---
 
 # Rewards
 
-**System Initiative** rewards findings based on **security impact** and **CVSS
-3.0 base score**. These values are guidelines only and depend on both the
-quality of the report and the potential impact
+**Swamp Club** rewards findings based on **security impact** and **CVSS 3.0 base
+score**. These values are guidelines only and depend on both the quality of the
+report and the potential impact
 
 ### Severity Levels
 

--- a/BUG_BOUNTY.md
+++ b/BUG_BOUNTY.md
@@ -17,7 +17,7 @@ All contributions endeavoring to maintain the safety of our platform are
 appreciated but not at all are eligble for reward.
 
 The associated rules, qualifications, and rewards for this program may be
-revised at any time and any decisions made by security@systeminit.com will be
+revised at any time and any decisions made by security@swamp-club.com will be
 considered final.
 
 # Contained within this document:
@@ -72,7 +72,7 @@ news articles are less likely to be rewarded.
 ### Key Points
 
 Please submit all reports to
-[security@systeminit.com](mailto:security@systeminit.com) with the following
+[security@swamp-club.com](mailto:security@swamp-club.com) with the following
 headings:
 
 - Executive Summary
@@ -98,7 +98,7 @@ finding a vulnerability.
 **If you encounter Personally Identifiable Information (PII):**
 
 - Contact us immediately at
-  [security@systeminit.com](mailto:security@systeminit.com).
+  [security@swamp-club.com](mailto:security@swamp-club.com).
 - Do not proceed with accessing or retaining local copies.
 
 **Limits/Additional Considerations:**
@@ -265,5 +265,5 @@ Examples include:
 | ------------------------ | ---------- | ----------- | ------------------- | ----------------------- | ------------------------ | --------------------------- | --------------------- | ------------ | ----------- | ----------------------- | ----------------------- |
 | telemetry.swamp-club.com | API        |             | true                | true                    |                          |                             |                       | critical     | production  | 2026-11-02 13:45:00 UTC | 2026-11-02 13:45:00 UTC |
 | swamp-club.com           | WEB APP    |             | true                | true                    |                          |                             |                       | critical     | production  | 2026-11-02 13:45:00 UTC | 2026-11-02 13:45:00 UTC |
-| systeminit.com           | WEB APP    |             | true                | true                    |                          |                             |                       | medium       | production  | 2024-11-28 13:45:00 UTC | 2024-11-28 13:45:00 UTC |
+| swamp-club.com           | WEB APP    |             | true                | true                    |                          |                             |                       | medium       | production  | 2024-11-28 13:45:00 UTC | 2024-11-28 13:45:00 UTC |
 | swamp CLI (stable)       | OTHER      |             | true                | true                    |                          |                             |                       | high         | production  | 2026-02-12 00:00:00 UTC | 2026-02-12 00:00:00 UTC |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Use `deno run` to get a complete list of custom tasks.
   to recompile swamp.
 - When a PR fixes a GitHub issue filed by an external contributor (not a repo
   collaborator), add them as a co-author to the commit. Check with
-  `gh api /repos/systeminit/swamp/collaborators --jq '.[].login'` to determine
+  `gh api /repos/swamp-club/swamp/collaborators --jq '.[].login'` to determine
   if the issue author is a team member. If they are not, add
   `Co-authored-by: Name <email>` to the commit. Use `gh api /users/<username>`
   to look up their name, and use `<username>@users.noreply.github.com` as the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@
 These are the policies for upholding our community’s standards of conduct. If
 you feel that a thread needs moderation, please inform an admin on
 [Discord](https://discord.com/invite/swamp-club) or email
-<code_of_conduct@systeminit.com>.
+<code_of_conduct@swamp-club.com>.
 
 The team at System Initiative is repsonsible for community moderation.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -39,12 +39,11 @@ you feel that a thread needs moderation, please inform an admin on
 [Discord](https://discord.com/invite/swamp-club) or email
 <code_of_conduct@swamp-club.com>.
 
-The team at System Initiative is repsonsible for community moderation.
+The team at Swamp Club is repsonsible for community moderation.
 
-- Remarks that violate the System Initiative standards of conduct, including
-  hateful, hurtful, oppressive, or exclusionary remarks, are not allowed.
-  (Cursing is allowed, but never targeting another user, and never in a hateful
-  manner.)
+- Remarks that violate the Swamp Club standards of conduct, including hateful,
+  hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is
+  allowed, but never targeting another user, and never in a hateful manner.)
 - Remarks that moderators find inappropriate, whether listed in the code of
   conduct or not, are also not allowed.
 - Moderators will first respond to such remarks with a warning.
@@ -61,12 +60,12 @@ The team at System Initiative is repsonsible for community moderation.
   moderator creates an inappropriate situation, they should expect less leeway
   than others.
 
-In the System Initiative community, we strive to go the extra step to look out
-for each other. Don’t just aim to be technically unimpeachable, try to be your
-best self. In particular, avoid flirting with offensive or sensitive issues,
-particularly if they’re off-topic; this all too often leads to unnecessary
-fights, hurt feelings, and damaged trust; worse, it can drive people away from
-the community entirely.
+In the Swamp Club community, we strive to go the extra step to look out for each
+other. Don’t just aim to be technically unimpeachable, try to be your best self.
+In particular, avoid flirting with offensive or sensitive issues, particularly
+if they’re off-topic; this all too often leads to unnecessary fights, hurt
+feelings, and damaged trust; worse, it can drive people away from the community
+entirely.
 
 And if someone takes issue with something you said or did, resist the urge to be
 defensive. Just stop doing what it was they complained about and apologize. Even
@@ -77,8 +76,8 @@ to get along and we are all here first and foremost because we want to talk
 about cool technology. You will find that people will be eager to assume good
 intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official System Initiative
-venues; including [Discord channels](https://discord.com/invite/swamp-club), all
+The enforcement policies listed above apply to all official Swamp Club venues;
+including [Discord channels](https://discord.com/invite/swamp-club), all
 repositories owned by this GitHub organization, and all other public mediums.
 
 _Adapted from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing Code to Swamp
 
-Only employees of System Initiative, Inc. are allowed to contribute code to
+Only employees of Elder Swamp Club, Inc. are allowed to contribute code to
 Swamp.
 
 There are no exceptions. All pull requests to this repository not made by
-employees of System Initiative will be closed immediately.
+employees of Elder Swamp Club will be closed immediately.
 
 # Contributing Bug Reports and Feature Requests
 
 We are thrilled to receive your bug reports and feature requests, which we will
 implement for you (and maintain over time) at our discretion. By including any
 source code in a bug report or feature request, you grant a full copyright
-license to System Initiative, Inc.
+license to Elder Swamp Club, Inc.
 
 # Why?
 
@@ -34,7 +34,7 @@ co-author on the pull request we generate at your request.
 # Copyright
 
 This does _not_ imply that we share the copyright ownership of the work - the
-resulting software will be the exclusive copyright of System Initiative, Inc.
+resulting software will be the exclusive copyright of Elder Swamp Club, Inc.
 
 # No Exceptions
 

--- a/FILE-LICENSE-TEMPLATE.md
+++ b/FILE-LICENSE-TEMPLATE.md
@@ -1,4 +1,4 @@
-Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 
 This file is part of Swamp.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Swamp
-Copyright (C) 2026 System Initiative, Inc.
+Copyright (C) 2026 Elder Swamp Club, Inc.
 
 Swamp is licensed under the GNU Affero General Public License,
 version 3 only (AGPLv3).

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ development process.
    confirms bugs by tracing through the codebase, and generates a detailed
    implementation plan. Plans are revised interactively until the approach is
    solid.
-3. **We build it** — System Initiative engineers (with AI agents under our
-   direct control) implement the plan, with full test coverage and code review.
+3. **We build it** — Elder Swamp Club engineers (with AI agents under our direct
+   control) implement the plan, with full test coverage and code review.
 4. **You get credit** — We're happy to include you as a co-author on any PR
    generated from your request.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ so the community can track progress and discuss.
 
 If the vulnerability involves **secret or credential exposure, data
 exfiltration, or any issue where public disclosure could put users at risk**,
-please email [security@systeminit.com](mailto:security@systeminit.com) instead.
+please email [security@swamp-club.com](mailto:security@swamp-club.com) instead.
 
 ### What to Include
 
@@ -42,4 +42,4 @@ The following are examples of issues that should be reported privately:
 
 Everything else — general bugs, feature requests, and non-sensitive defects —
 should be filed as a
-[public issue](https://github.com/systeminit/swamp/issues/new).
+[public issue](https://github.com/swamp-club/swamp/issues/new).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -227,8 +227,8 @@ Also, if you are using our Marks in a way described in the sections "Uses for
 which we are granting a license," please put following notice at the foot of the
 page where you have used the Mark (or, if in a book, on the credits page), on
 any packaging or labeling, and on advertising or marketing materials: "System
-Initiative is trademark of System Initiative, Inc., registered in the United
-States and other countries. Used with permission from System Initiative, Inc."
+Initiative is trademark of Elder Swamp Club, Inc., registered in the United
+States and other countries. Used with permission from Elder Swamp Club, Inc."
 
 ### What to do when you see abuse
 
@@ -241,7 +241,7 @@ described below so that we can investigate it further.
 If you have any questions about this Policy, would like to speak with us about
 the use of our Marks in ways not described in the Policy, or see any abuse of
 our Marks, please email
-<a href="mailto:legal@systeminit.com">legal@systeminit.com</a>.
+<a href="mailto:legal@swamp-club.com">legal@swamp-club.com</a>.
 
 ### General considerations about trademarks and their use
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-This document, the "Policy," outlines the System Initiative project's (the
-"Project") policy for the use of our trademarks. While our software is available
-under a free and open source software license, the copyright license does not
-include any right, express or implied, to use our trademarks. These guidelines
-are where we describe how you may use our trademarks.
+This document, the "Policy," outlines the Swamp Club project's (the "Project")
+policy for the use of our trademarks. While our software is available under a
+free and open source software license, the copyright license does not include
+any right, express or implied, to use our trademarks. These guidelines are where
+we describe how you may use our trademarks.
 
 The role of trademarks is to provide assurance about the quality of the products
 or services with which the trademark is associated. But because an open source
@@ -47,15 +47,14 @@ This Policy covers:
 
 1. Our word trademarks and service marks (the "Marks"):
 
-| Mark              | Common descriptive name for the goods or services |
-| ----------------- | ------------------------------------------------- |
-| SYSTEM INITIATIVE | software platform                                 |
-| SI                | software platform                                 |
-| Swamp             | software platform                                 |
-| swamp             | software platform                                 |
-| Swamp Club        | software platform                                 |
-| swamp.club        | software platform                                 |
-| swamp-club.com    | software platform                                 |
+| Mark           | Common descriptive name for the goods or services |
+| -------------- | ------------------------------------------------- |
+| Swamp Club     | software platform                                 |
+| SWAMP CLUB     | software platform                                 |
+| Swamp          | software platform                                 |
+| swamp          | software platform                                 |
+| swamp.club     | software platform                                 |
+| swamp-club.com | software platform                                 |
 
 Some Marks may not be registered, but registration does not equal ownership of
 trademarks. This Policy covers our Marks whether they are registered or not.
@@ -77,15 +76,15 @@ mislead anyone, either directly or by omission, about exactly what they are
 getting and from whom. The law reflects this requirement in two major ways
 described in more detail below: it prohibits creating a "likelihood of
 confusion" but allows for "nominative use." For example, you cannot say you are
-distributing the System Initiative software when you're distributing a modified
-version of it, because people would be confused when they are not getting the
-same features and functionality they would get if they downloaded the software
+distributing the Swamp Club software when you're distributing a modified version
+of it, because people would be confused when they are not getting the same
+features and functionality they would get if they downloaded the software
 directly from us. You also cannot use our logo on your website in a way that
 suggests that your website is an official website or that we endorse your
-website. You can, though, say you like the System Initiative software, that you
-participate in the System Initiative community, that you are providing the
-binary of the ~Mark software obtained from the Project, or that you wrote a book
-describing how to use the System Initiative software.
+website. You can, though, say you like the Swamp Club software, that you
+participate in the Swamp Club community, that you are providing the binary of
+the ~Mark software obtained from the Project, or that you wrote a book
+describing how to use the Swamp Club software.
 
 This fundamental requirement, that it is always clear to people what they are
 getting and from whom, is reflected throughout this Policy. It should also serve
@@ -107,9 +106,8 @@ Marks or any phonetic equivalent, foreign language equivalent, takeoff, or
 abbreviation for a similar or compatible product or service. We would consider
 the following too similar to one of our Marks:
 
-- Network Initiative
-- NI
 - Swamp Team
+- SwampClub
 - [any logo similar to our own]
 
 You agree that you will not acquire any rights in the Marks and that any
@@ -136,17 +134,16 @@ changed in any way.
 You may use the Marks to truthfully describe the relationship between your
 software and ours. Our Mark should be used after a verb or preposition that
 describes the relationship between your software and ours. So you may say, for
-example, "Terry’s plugin for the System Initiative software" but may not say
-"Terry's System Initiative software." Some other examples that may work for you
-are:
+example, "Terry’s plugin for the Swamp Club software" but may not say "Terry’s
+Swamp Club software." Some other examples that may work for you are:
 
-- [Your software] works with System Initiative software
-- [Your software] uses System Initiative software
-- [Your software] is compatible with System Initiative software
-- [Your software] is for use with System Initiative software
-- [Your software] for System Initiative software
+- [Your software] works with Swamp Club software
+- [Your software] uses Swamp Club software
+- [Your software] is compatible with Swamp Club software
+- [Your software] is for use with Swamp Club software
+- [Your software] for Swamp Club software
 - [Your software] is compatible with Swamp software
-- [Your software] is compatible with for use with Swamp software
+- [Your software] is for use with Swamp software
 
 ## Uses for which we are granting a license
 
@@ -226,9 +223,9 @@ Trademark List for the correct symbol to use.
 Also, if you are using our Marks in a way described in the sections "Uses for
 which we are granting a license," please put following notice at the foot of the
 page where you have used the Mark (or, if in a book, on the credits page), on
-any packaging or labeling, and on advertising or marketing materials: "System
-Initiative is trademark of Elder Swamp Club, Inc., registered in the United
-States and other countries. Used with permission from Elder Swamp Club, Inc."
+any packaging or labeling, and on advertising or marketing materials: "Swamp
+Club is trademark of Elder Swamp Club, Inc., registered in the United States and
+other countries. Used with permission from Elder Swamp Club, Inc."
 
 ### What to do when you see abuse
 
@@ -311,44 +308,42 @@ Use of trademarks in text
 
 - Always distinguish trademarks from surrounding text with at least initial
   capital letters or in all capital letters.
-- Unacceptable: system initiative
-- Acceptable: System Initiative, SYSTEM INITIATIVE
+- Unacceptable: swamp club
+- Acceptable: Swamp Club, SWAMP CLUB
 
 Always use trademarks in their exact form with the correct spelling, neither
 abbreviated, hyphenated, or combined with any other word or words.
 
-- Unacceptable: SystemInitiative, Sys Int
-- Acceptable: System Initiative
+- Unacceptable: SwampClub, SC
+- Acceptable: Swamp Club
 
 Don't pluralize a trademark.
 
-- Unacceptable: I have seventeen System Initiatives running in my lab.
-- Acceptable: I have seventeen System Initiative installations running in my
-  lab.
+- Unacceptable: I have seventeen Swamp Clubs running in my lab.
+- Acceptable: I have seventeen Swamp Club installations running in my lab.
 
 Always use a trademark as an adjective modifying a noun.* You can see the nouns
 we prefer under "Our trademarks."
 
-- Unacceptable: This is a System Initiative. Anyone can install it.
-- Acceptable: This is a System Initiative instance. Anyone can install it.
+- Unacceptable: This is a Swamp Club. Anyone can install it.
+- Acceptable: This is a Swamp Club instance. Anyone can install it.
 
 Don't use a trademark as a verb. Trademarks are products or services, never
 actions.
 
-- Unacceptable: I System Initiated my computer today!
-- Acceptable: I installed System Initiative software on my computer today!
+- Unacceptable: I Swamp Clubbed my computer today!
+- Acceptable: I installed Swamp Club software on my computer today!
 
 Don't use a trademark as a possessive. Instead, the following noun should be
 used in possessive form or the sentence reworded so there is no possessive.
 
-- Unacceptable: System Initiative's desktop interface is very clean.
-- Acceptable: The System Initiative desktop's interface is very clean.
+- Unacceptable: Swamp Club's desktop interface is very clean.
+- Acceptable: The Swamp Club desktop's interface is very clean.
 
 Don't translate a trademark into another language.
 
-- Unacceptable: Quiero instalar el software Iniciativa del Sistema en mi
-  sistema.
-- Acceptable: Quiero instalar System Initiative software en mi sistema.
+- Unacceptable: Quiero instalar el software Club del Pantano en mi sistema.
+- Acceptable: Quiero instalar Swamp Club software en mi sistema.
 
 These guidelines are based on the Model Trademark Guidelines, available at
 http://www.modeltrademarkguidelines.org

--- a/agent-constraints/adversarial-dimensions.md
+++ b/agent-constraints/adversarial-dimensions.md
@@ -31,7 +31,7 @@ cleanup's own failure shadows the original error.
 Is the testing strategy sufficient? Are edge cases covered? Are there
 integration test gaps? Is there over-reliance on unit tests? Was the UAT
 assessment thorough — are there end-to-end CLI or adversarial test gaps that
-should be filed in `systeminit/swamp-uat`?
+should be filed in `swamp-club/swamp-uat`?
 
 ## Complexity
 

--- a/agent-constraints/planning-conventions.md
+++ b/agent-constraints/planning-conventions.md
@@ -16,7 +16,7 @@ renamed types or methods referenced in skill examples.
 ## User Acceptance Testing (UAT) Assessment
 
 Evaluate whether the change requires end-to-end UAT coverage in the
-`systeminit/swamp-uat` repo. That repo has two categories of tests:
+`swamp-club/swamp-uat` repo. That repo has two categories of tests:
 
 - **CLI UAT tests** (`tests/cli/`) — verify CLI commands, flags, and output from
   a user's perspective. File paths mirror CLI command paths (e.g.
@@ -28,7 +28,7 @@ Evaluate whether the change requires end-to-end UAT coverage in the
 First, check if existing UAT coverage exists:
 
 ```
-gh api repos/systeminit/swamp-uat/contents/tests/cli --jq '.[].name'
+gh api repos/swamp-club/swamp-uat/contents/tests/cli --jq '.[].name'
 ```
 
 Then assess:
@@ -43,7 +43,7 @@ Then assess:
   existing adversarial test covers it → flag this to the human.
 - If the human agrees a UAT gap exists, file an issue in `swamp-uat`:
   ```
-  gh issue create --repo systeminit/swamp-uat \
+  gh issue create --repo swamp-club/swamp-uat \
     --title "UAT: <describe the missing test scenario>" \
     --body "<reproduction steps, expected behavior, which CLI commands to test>"
   ```
@@ -54,7 +54,7 @@ Then assess:
 ## Manual Documentation Assessment
 
 Evaluate whether the change requires updates to the user-facing documentation in
-the `systeminit/swamp-club` repo under `content/manual/`. That directory follows
+the `swamp-club/swamp-club` repo under `content/manual/`. That directory follows
 the Diátaxis framework:
 
 - **How-to guides** (`content/manual/how-to/`) — task-oriented guides (e.g.
@@ -70,10 +70,10 @@ the Diátaxis framework:
 First, check what documentation exists:
 
 ```
-gh api repos/systeminit/swamp-club/contents/content/manual/reference --jq '.[].name'
-gh api repos/systeminit/swamp-club/contents/content/manual/how-to --jq '.[].name'
-gh api repos/systeminit/swamp-club/contents/content/manual/explanation --jq '.[].name'
-gh api repos/systeminit/swamp-club/contents/content/manual/tutorials --jq '.[].name'
+gh api repos/swamp-club/swamp-club/contents/content/manual/reference --jq '.[].name'
+gh api repos/swamp-club/swamp-club/contents/content/manual/how-to --jq '.[].name'
+gh api repos/swamp-club/swamp-club/contents/content/manual/explanation --jq '.[].name'
+gh api repos/swamp-club/swamp-club/contents/content/manual/tutorials --jq '.[].name'
 ```
 
 Then assess:
@@ -91,7 +91,7 @@ Then assess:
   flag the doc that needs updating or removal.
 - If the human agrees a documentation gap exists, file an issue in `swamp-club`:
   ```
-  gh issue create --repo systeminit/swamp-club \
+  gh issue create --repo swamp-club/swamp-club \
     --title "Docs: <describe the documentation gap>" \
     --body "<what changed, which manual page needs updating, suggested content>"
   ```

--- a/evals/promptfoo/generate_config.ts
+++ b/evals/promptfoo/generate_config.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -1,4 +1,4 @@
-// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -1,4 +1,4 @@
-// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -79,7 +79,7 @@ Deno.test("TRANSITIONS: link_pr is rejected from earlier lifecycle phases", () =
 Deno.test("PullRequestSchema: accepts any non-empty URL string", () => {
   // URLs are opaque to the model — GitHub, GitLab, Gitea, Forgejo, etc.
   const samples = [
-    "https://github.com/systeminit/swamp/pull/1141",
+    "https://github.com/swamp-club/swamp/pull/1141",
     "https://gitlab.com/group/project/-/merge_requests/42",
     "https://codeberg.org/user/repo/pulls/7",
     "https://git.internal/project/+/123",
@@ -105,7 +105,7 @@ Deno.test("PullRequestSchema: rejects empty url string", () => {
 
 Deno.test("PullRequestSchema: requires linkedAt", () => {
   const result = PullRequestSchema.safeParse({
-    url: "https://github.com/systeminit/swamp/pull/1",
+    url: "https://github.com/swamp-club/swamp/pull/1",
   });
   assertEquals(result.success, false);
 });

--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -1,4 +1,4 @@
-// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -1,4 +1,4 @@
-// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -1,4 +1,4 @@
-// Swamp, an Automation Framework Copyright (C) 2026 System Initiative, Inc.
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -106,7 +106,7 @@ Deno.test("link_pr: writes pullRequest-main resource with url, attempt, and link
   const { context, writes, restore } = await buildTestContext(42);
   try {
     await model.methods.link_pr.execute(
-      { url: "https://github.com/systeminit/swamp/pull/1141" },
+      { url: "https://github.com/swamp-club/swamp/pull/1141" },
       context,
     );
 
@@ -119,7 +119,7 @@ Deno.test("link_pr: writes pullRequest-main resource with url, attempt, and link
     );
     assertEquals(
       prWrite!.data.url,
-      "https://github.com/systeminit/swamp/pull/1141",
+      "https://github.com/swamp-club/swamp/pull/1141",
     );
     assertEquals(prWrite!.data.attempt, 1);
     assertEquals(typeof prWrite!.data.linkedAt, "string");
@@ -132,7 +132,7 @@ Deno.test("link_pr: transitions state to pr_open", async () => {
   const { context, writes, restore } = await buildTestContext(42);
   try {
     await model.methods.link_pr.execute(
-      { url: "https://github.com/systeminit/swamp/pull/1141" },
+      { url: "https://github.com/swamp-club/swamp/pull/1141" },
       context,
     );
 
@@ -150,11 +150,11 @@ Deno.test("link_pr: is idempotent — second call increments attempt", async () 
   const { context, writes, restore } = await buildTestContext(42);
   try {
     await model.methods.link_pr.execute(
-      { url: "https://github.com/systeminit/swamp/pull/1141" },
+      { url: "https://github.com/swamp-club/swamp/pull/1141" },
       context,
     );
     await model.methods.link_pr.execute(
-      { url: "https://github.com/systeminit/swamp/pull/1142" },
+      { url: "https://github.com/swamp-club/swamp/pull/1142" },
       context,
     );
 
@@ -167,7 +167,7 @@ Deno.test("link_pr: is idempotent — second call increments attempt", async () 
     );
     assertEquals(
       prWrites[1].data.url,
-      "https://github.com/systeminit/swamp/pull/1142",
+      "https://github.com/swamp-club/swamp/pull/1142",
     );
     assertEquals(prWrites[0].data.attempt, 1);
     assertEquals(prWrites[1].data.attempt, 2);
@@ -186,7 +186,7 @@ Deno.test("link_pr: from pr_failed clears failure fields and increments attempt"
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "pullRequest-main": {
-        url: "https://github.com/systeminit/swamp/pull/1141",
+        url: "https://github.com/swamp-club/swamp/pull/1141",
         attempt: 1,
         linkedAt: "2026-04-09T10:00:00.000Z",
         failedAt: "2026-04-09T10:05:00.000Z",
@@ -196,7 +196,7 @@ Deno.test("link_pr: from pr_failed clears failure fields and increments attempt"
   });
   try {
     await model.methods.link_pr.execute(
-      { url: "https://github.com/systeminit/swamp/pull/1142" },
+      { url: "https://github.com/swamp-club/swamp/pull/1142" },
       context,
     );
 
@@ -204,7 +204,7 @@ Deno.test("link_pr: from pr_failed clears failure fields and increments attempt"
     assertEquals(prWrite !== undefined, true);
     assertEquals(
       prWrite!.data.url,
-      "https://github.com/systeminit/swamp/pull/1142",
+      "https://github.com/swamp-club/swamp/pull/1142",
     );
     assertEquals(prWrite!.data.attempt, 2);
     // link_pr overwrites the entire resource — failure fields are absent
@@ -233,7 +233,7 @@ Deno.test("pr-cooldown: rejects when PR was linked too recently", async () => {
           return Promise.resolve(
             new TextEncoder().encode(
               JSON.stringify({
-                url: "https://github.com/systeminit/swamp/pull/1",
+                url: "https://github.com/swamp-club/swamp/pull/1",
                 linkedAt: recentLinkedAt,
               }),
             ),
@@ -267,7 +267,7 @@ Deno.test("pr-cooldown: passes when enough time has elapsed", async () => {
           return Promise.resolve(
             new TextEncoder().encode(
               JSON.stringify({
-                url: "https://github.com/systeminit/swamp/pull/1",
+                url: "https://github.com/swamp-club/swamp/pull/1",
                 linkedAt: oldLinkedAt,
               }),
             ),
@@ -331,7 +331,7 @@ Deno.test("pr_merged: transitions state to releasing and writes mergedAt with at
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "pullRequest-main": {
-        url: "https://github.com/systeminit/swamp/pull/1141",
+        url: "https://github.com/swamp-club/swamp/pull/1141",
         attempt: 2,
         linkedAt: "2026-04-09T10:00:00.000Z",
       },
@@ -349,7 +349,7 @@ Deno.test("pr_merged: transitions state to releasing and writes mergedAt with at
     assertEquals(prWrite !== undefined, true);
     assertEquals(
       prWrite!.data.url,
-      "https://github.com/systeminit/swamp/pull/1141",
+      "https://github.com/swamp-club/swamp/pull/1141",
     );
     assertEquals(prWrite!.data.attempt, 2);
     assertEquals(typeof prWrite!.data.mergedAt, "string");
@@ -362,7 +362,7 @@ Deno.test("pr_merged: uses provided mergedAt when given", async () => {
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "pullRequest-main": {
-        url: "https://github.com/systeminit/swamp/pull/1141",
+        url: "https://github.com/swamp-club/swamp/pull/1141",
         attempt: 1,
         linkedAt: "2026-04-09T10:00:00.000Z",
       },
@@ -402,7 +402,7 @@ Deno.test("pr_failed: transitions state to pr_failed and writes failure info wit
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "pullRequest-main": {
-        url: "https://github.com/systeminit/swamp/pull/1141",
+        url: "https://github.com/swamp-club/swamp/pull/1141",
         attempt: 1,
         linkedAt: "2026-04-09T10:00:00.000Z",
       },
@@ -476,7 +476,7 @@ Deno.test("ship: accepts optional releaseUrl and releaseNotes", async () => {
     // Should not throw
     await model.methods.ship.execute(
       {
-        releaseUrl: "https://github.com/systeminit/swamp/releases/tag/v1.0.0",
+        releaseUrl: "https://github.com/swamp-club/swamp/releases/tag/v1.0.0",
         releaseNotes: "Bug fix release",
       },
       context,

--- a/integration/architecture_boundary_test.ts
+++ b/integration/architecture_boundary_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/auto_resolver_no_clobber_test.ts
+++ b/integration/auto_resolver_no_clobber_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/auto_resolver_truncated_test.ts
+++ b/integration/auto_resolver_truncated_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/bundle_cache_freshness_test.ts
+++ b/integration/bundle_cache_freshness_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/catalog_namespace_upgrade_test.ts
+++ b/integration/catalog_namespace_upgrade_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/cel_data_access_test.ts
+++ b/integration/cel_data_access_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/cli_test.ts
+++ b/integration/cli_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/copyright_header_test.ts
+++ b/integration/copyright_header_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/cross_model_data_access_test.ts
+++ b/integration/cross_model_data_access_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_delete_test.ts
+++ b/integration/data_delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_expression_test.ts
+++ b/integration/data_expression_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_output_flow_test.ts
+++ b/integration/data_output_flow_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_output_specs_test.ts
+++ b/integration/data_output_specs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_ownership_test.ts
+++ b/integration/data_ownership_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_tagging_test.ts
+++ b/integration/data_tagging_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/data_versioning_test.ts
+++ b/integration/data_versioning_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/definition_lifecycle_test.ts
+++ b/integration/definition_lifecycle_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/definition_test.ts
+++ b/integration/definition_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/direct_type_execution_test.ts
+++ b/integration/direct_type_execution_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/doctor_audit_test.ts
+++ b/integration/doctor_audit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/doctor_secrets_test.ts
+++ b/integration/doctor_secrets_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/driver_resolution_test.ts
+++ b/integration/driver_resolution_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_fmt_test.ts
+++ b/integration/extension_fmt_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_kind_sync_test.ts
+++ b/integration/extension_kind_sync_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_list_test.ts
+++ b/integration/extension_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_pull_test.ts
+++ b/integration/extension_pull_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_push_test.ts
+++ b/integration/extension_push_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extension_rm_test.ts
+++ b/integration/extension_rm_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extensions/doctor_extensions_aggregate_test.ts
+++ b/integration/extensions/doctor_extensions_aggregate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extensions/doctor_extensions_failure_states_test.ts
+++ b/integration/extensions/doctor_extensions_failure_states_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extensions/doctor_extensions_test.ts
+++ b/integration/extensions/doctor_extensions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extensions/doctor_extensions_transitions_test.ts
+++ b/integration/extensions/doctor_extensions_transitions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/extensions/silent_load_failure_test.ts
+++ b/integration/extensions/silent_load_failure_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/foreach_test.ts
+++ b/integration/foreach_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/giga_swamp_cel_namespace_test.ts
+++ b/integration/giga_swamp_cel_namespace_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/giga_swamp_namespace_layout_test.ts
+++ b/integration/giga_swamp_namespace_layout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/input_override_validation_test.ts
+++ b/integration/input_override_validation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/inputs_test.ts
+++ b/integration/inputs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/issue_extension_test.ts
+++ b/integration/issue_extension_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/json_isolation_test.ts
+++ b/integration/json_isolation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/keeb_shell_model_test.ts
+++ b/integration/keeb_shell_model_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/lazy_registry_promotion_test.ts
+++ b/integration/lazy_registry_promotion_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/method_context_cel_env_test.ts
+++ b/integration/method_context_cel_env_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/model_create_sensitive_test.ts
+++ b/integration/model_create_sensitive_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/model_edit_sensitive_lazy_test.ts
+++ b/integration/model_edit_sensitive_lazy_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/model_evaluate_test.ts
+++ b/integration/model_evaluate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/model_get_sensitive_test.ts
+++ b/integration/model_get_sensitive_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/model_validate_test.ts
+++ b/integration/model_validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/sensitive_field_vault_test.ts
+++ b/integration/sensitive_field_vault_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/serve_shutdown_test.ts
+++ b/integration/serve_shutdown_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/simple_return_format_test.ts
+++ b/integration/simple_return_format_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/source_extension_rebundle_test.ts
+++ b/integration/source_extension_rebundle_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/source_fetch_test.ts
+++ b/integration/source_fetch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/summarise_perf_test.ts
+++ b/integration/summarise_perf_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/telemetry_invocation_context_test.ts
+++ b/integration/telemetry_invocation_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/telemetry_workflow_method_invocations_test.ts
+++ b/integration/telemetry_workflow_method_invocations_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/test_helpers.ts
+++ b/integration/test_helpers.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/tls_trust_test.ts
+++ b/integration/tls_trust_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/unified_data_test.ts
+++ b/integration/unified_data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/vary_test.ts
+++ b/integration/vary_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/vault_cel_integration_test.ts
+++ b/integration/vault_cel_integration_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_approval_datastore_test.ts
+++ b/integration/workflow_approval_datastore_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_approval_test.ts
+++ b/integration/workflow_approval_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_evaluate_test.ts
+++ b/integration/workflow_evaluate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_new_architecture_test.ts
+++ b/integration/workflow_new_architecture_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_partial_inputs_test.ts
+++ b/integration/workflow_partial_inputs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -22,7 +22,7 @@
  *
  * Verifies that globalArgument expressions referencing unprovided inputs
  * are skipped during workflow execution, matching the CLI path behavior.
- * See: https://github.com/systeminit/swamp/issues/653
+ * See: https://github.com/swamp-club/swamp/issues/653
  */
 
 import { assertEquals } from "@std/assert";

--- a/integration/workflow_query_data_context_test.ts
+++ b/integration/workflow_query_data_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_report_data_test.ts
+++ b/integration/workflow_report_data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_run_search_test.ts
+++ b/integration/workflow_run_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_subprocess_lock_test.ts
+++ b/integration/workflow_subprocess_lock_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/client_test.ts
+++ b/packages/client/client_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/stream.ts
+++ b/packages/client/stream.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/client/stream_test.ts
+++ b/packages/client/stream_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,6 +1,6 @@
 # @systeminit/swamp-testing
 
-Test utilities for [swamp](https://github.com/systeminit/swamp) extensions.
+Test utilities for [swamp](https://github.com/swamp-club/swamp) extensions.
 Provides test factories for all extension types — models, vaults, datastores,
 execution drivers, and reports — for unit testing without real infrastructure.
 
@@ -59,7 +59,7 @@ cel-js Environment seeded with the same baseline registrations as production.
 Extensions that use CEL evaluation in their `execute` methods can be unit-tested
 with no extra setup. See the
 [Custom CEL Evaluation section in the model API
-reference](https://github.com/systeminit/swamp/blob/main/.claude/skills/swamp-extension/references/model/api.md#custom-cel-evaluation)
+reference](https://github.com/swamp-club/swamp/blob/main/.claude/skills/swamp-extension/references/model/api.md#custom-cel-evaluation)
 for usage patterns.
 
 ## Inspection Helpers
@@ -255,11 +255,11 @@ export const model = {
 No change is required for models whose tests don't import the source — the
 unannotated default form in the swamp-extension-model skill still applies. See
 the
-[`references/typing.md`](https://github.com/systeminit/swamp/blob/main/.claude/skills/swamp-extension-model/references/typing.md)
+[`references/typing.md`](https://github.com/swamp-club/swamp/blob/main/.claude/skills/swamp-extension-model/references/typing.md)
 guide in the swamp-extension-model skill for the full rationale, worked example,
 and the `defineModel` function-form alternative.
 
 ## License
 
 AGPL-3.0-only — see
-[LICENSE](https://github.com/systeminit/swamp/blob/main/LICENSE).
+[LICENSE](https://github.com/swamp-club/swamp/blob/main/LICENSE).

--- a/packages/testing/_cel_environment.ts
+++ b/packages/testing/_cel_environment.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/datastore_conformance_test.ts
+++ b/packages/testing/datastore_conformance_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/datastore_test_context.ts
+++ b/packages/testing/datastore_test_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/datastore_test_context_test.ts
+++ b/packages/testing/datastore_test_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/driver_test_context.ts
+++ b/packages/testing/driver_test_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/driver_test_context_test.ts
+++ b/packages/testing/driver_test_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/driver_types.ts
+++ b/packages/testing/driver_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/mock_command.ts
+++ b/packages/testing/mock_command.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/mock_command_test.ts
+++ b/packages/testing/mock_command_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/mock_fetch.ts
+++ b/packages/testing/mock_fetch.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/mock_fetch_test.ts
+++ b/packages/testing/mock_fetch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/model_definition_types.ts
+++ b/packages/testing/model_definition_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/model_definition_types_test.ts
+++ b/packages/testing/model_definition_types_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/report_test_context.ts
+++ b/packages/testing/report_test_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/report_test_context_test.ts
+++ b/packages/testing/report_test_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/report_types.ts
+++ b/packages/testing/report_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/test_context_test.ts
+++ b/packages/testing/test_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/vault_conformance.ts
+++ b/packages/testing/vault_conformance.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/vault_conformance_test.ts
+++ b/packages/testing/vault_conformance_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/vault_test_context.ts
+++ b/packages/testing/vault_test_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/vault_test_context_test.ts
+++ b/packages/testing/vault_test_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/packages/testing/vault_types.ts
+++ b/packages/testing/vault_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/add_license_headers.ts
+++ b/scripts/add_license_headers.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -21,7 +21,7 @@ import { walk } from "@std/fs/walk";
 import { join } from "@std/path";
 
 const HEADER = `// Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/analyze_eval_results.ts
+++ b/scripts/analyze_eval_results.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/audit_actions.ts
+++ b/scripts/audit_actions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/audit_deps.ts
+++ b/scripts/audit_deps.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run -A
 
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/download_deno.ts
+++ b/scripts/download_deno.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run -A
 
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/download_deno_test.ts
+++ b/scripts/download_deno_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/eval_skill_triggers_promptfoo.ts
+++ b/scripts/eval_skill_triggers_promptfoo.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/review_skills.ts
+++ b/scripts/review_skills.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/scripts/seed_test_repo.ts
+++ b/scripts/seed_test_repo.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/ai_tool_parser.ts
+++ b/src/cli/ai_tool_parser.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/ai_tool_parser_test.ts
+++ b/src/cli/ai_tool_parser_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/arg_rewriter.ts
+++ b/src/cli/arg_rewriter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/arg_rewriter_test.ts
+++ b/src/cli/arg_rewriter_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/auto_resolver_context.ts
+++ b/src/cli/auto_resolver_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/cli_schema.ts
+++ b/src/cli/cli_schema.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/cli_schema_test.ts
+++ b/src/cli/cli_schema_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/auth_login.ts
+++ b/src/cli/commands/auth_login.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/auth_logout.ts
+++ b/src/cli/commands/auth_logout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/auth_whoami_test.ts
+++ b/src/cli/commands/auth_whoami_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/config_test.ts
+++ b/src/cli/commands/config_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data.ts
+++ b/src/cli/commands/data.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_delete_test.ts
+++ b/src/cli/commands/data_delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_gc_test.ts
+++ b/src/cli/commands/data_gc_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_get_test.ts
+++ b/src/cli/commands/data_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_list_test.ts
+++ b/src/cli/commands/data_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_query.ts
+++ b/src/cli/commands/data_query.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_rename_test.ts
+++ b/src/cli/commands/data_rename_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_search.ts
+++ b/src/cli/commands/data_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_search_test.ts
+++ b/src/cli/commands/data_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_test.ts
+++ b/src/cli/commands/data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/data_versions_test.ts
+++ b/src/cli/commands/data_versions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_catalog_pull.ts
+++ b/src/cli/commands/datastore_catalog_pull.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_compact.ts
+++ b/src/cli/commands/datastore_compact.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_lock.ts
+++ b/src/cli/commands/datastore_lock.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_namespaces.ts
+++ b/src/cli/commands/datastore_namespaces.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_status.ts
+++ b/src/cli/commands/datastore_status.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_sync.ts
+++ b/src/cli/commands/datastore_sync.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_sync_test.ts
+++ b/src/cli/commands/datastore_sync_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/datastore_type_search.ts
+++ b/src/cli/commands/datastore_type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_audit.ts
+++ b/src/cli/commands/doctor_audit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_audit_test.ts
+++ b/src/cli/commands/doctor_audit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_extensions_test.ts
+++ b/src/cli/commands/doctor_extensions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_install.ts
+++ b/src/cli/commands/doctor_install.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_install_test.ts
+++ b/src/cli/commands/doctor_install_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_secrets.ts
+++ b/src/cli/commands/doctor_secrets.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_secrets_test.ts
+++ b/src/cli/commands/doctor_secrets_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/doctor_workflows.ts
+++ b/src/cli/commands/doctor_workflows.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/driver.ts
+++ b/src/cli/commands/driver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/driver_type_search.ts
+++ b/src/cli/commands/driver_type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_deprecate.ts
+++ b/src/cli/commands/extension_deprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_fmt.ts
+++ b/src/cli/commands/extension_fmt.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_info.ts
+++ b/src/cli/commands/extension_info.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_install.ts
+++ b/src/cli/commands/extension_install.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_list_freshness.ts
+++ b/src/cli/commands/extension_list_freshness.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_list_freshness_test.ts
+++ b/src/cli/commands/extension_list_freshness_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_list_test.ts
+++ b/src/cli/commands/extension_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_outdated_test.ts
+++ b/src/cli/commands/extension_outdated_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_pull_test.ts
+++ b/src/cli/commands/extension_pull_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_report_dispatcher.ts
+++ b/src/cli/commands/extension_report_dispatcher.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_report_dispatcher_test.ts
+++ b/src/cli/commands/extension_report_dispatcher_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_rm_test.ts
+++ b/src/cli/commands/extension_rm_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_search_test.ts
+++ b/src/cli/commands/extension_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_source.ts
+++ b/src/cli/commands/extension_source.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_source_list.ts
+++ b/src/cli/commands/extension_source_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_source_rm.ts
+++ b/src/cli/commands/extension_source_rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_trust.ts
+++ b/src/cli/commands/extension_trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_trust_add.ts
+++ b/src/cli/commands/extension_trust_add.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_trust_auto_trust.ts
+++ b/src/cli/commands/extension_trust_auto_trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_trust_list.ts
+++ b/src/cli/commands/extension_trust_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_trust_rm.ts
+++ b/src/cli/commands/extension_trust_rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_undeprecate.ts
+++ b/src/cli/commands/extension_undeprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_update_test.ts
+++ b/src/cli/commands/extension_update_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_version.ts
+++ b/src/cli/commands/extension_version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/help_test.ts
+++ b/src/cli/commands/help_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_bug_test.ts
+++ b/src/cli/commands/issue_bug_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_edit.ts
+++ b/src/cli/commands/issue_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_edit_test.ts
+++ b/src/cli/commands/issue_edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_feature_test.ts
+++ b/src/cli/commands/issue_feature_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_get.ts
+++ b/src/cli/commands/issue_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_get_test.ts
+++ b/src/cli/commands/issue_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_ripple_test.ts
+++ b/src/cli/commands/issue_ripple_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_search.ts
+++ b/src/cli/commands/issue_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_search_test.ts
+++ b/src/cli/commands/issue_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_security.ts
+++ b/src/cli/commands/issue_security.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_security_test.ts
+++ b/src/cli/commands/issue_security_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -61,7 +61,7 @@ export type UsableExtensionTarget = Exclude<
   { kind: "refused" }
 >;
 
-const SUPPORT_EMAIL = "support@systeminit.com";
+const SUPPORT_EMAIL = "support@swamp-club.com";
 
 /** The resolved submission destination. */
 export type SubmitDestination =

--- a/src/cli/commands/issue_submit_test.ts
+++ b/src/cli/commands/issue_submit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -22,7 +22,7 @@ import { buildMailtoUrl } from "./issue_submit.ts";
 
 Deno.test("buildMailtoUrl: builds correct mailto URL for bug", () => {
   const url = buildMailtoUrl("bug", "CLI crash", "Steps to reproduce");
-  assertEquals(url.startsWith("mailto:support@systeminit.com?"), true);
+  assertEquals(url.startsWith("mailto:support@swamp-club.com?"), true);
   assertEquals(url.includes("subject=%5Bbug%5D%20CLI%20crash"), true);
   assertEquals(url.includes("body=Steps%20to%20reproduce"), true);
   // Verify no + encoding (RFC 6068 requires %20)

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_create_test.ts
+++ b/src/cli/commands/model_create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_delete_test.ts
+++ b/src/cli/commands/model_delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_edit_test.ts
+++ b/src/cli/commands/model_edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_evaluate.ts
+++ b/src/cli/commands/model_evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_get.ts
+++ b/src/cli/commands/model_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_get_test.ts
+++ b/src/cli/commands/model_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_describe.ts
+++ b/src/cli/commands/model_method_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_describe_test.ts
+++ b/src/cli/commands/model_method_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_history.ts
+++ b/src/cli/commands/model_method_history.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_history_get.ts
+++ b/src/cli/commands/model_method_history_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_history_logs.ts
+++ b/src/cli/commands/model_method_history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_history_search.ts
+++ b/src/cli/commands/model_method_history_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_method_run_test.ts
+++ b/src/cli/commands/model_method_run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output.ts
+++ b/src/cli/commands/model_output.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_data.ts
+++ b/src/cli/commands/model_output_data.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_data_test.ts
+++ b/src/cli/commands/model_output_data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_logs.ts
+++ b/src/cli/commands/model_output_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_logs_test.ts
+++ b/src/cli/commands/model_output_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_output_search.ts
+++ b/src/cli/commands/model_output_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_search_test.ts
+++ b/src/cli/commands/model_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_type.ts
+++ b/src/cli/commands/model_type.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_validate.ts
+++ b/src/cli/commands/model_validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/model_validate_test.ts
+++ b/src/cli/commands/model_validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/repo_init_test.ts
+++ b/src/cli/commands/repo_init_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/report_describe.ts
+++ b/src/cli/commands/report_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/report_get.ts
+++ b/src/cli/commands/report_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/report_type_search.ts
+++ b/src/cli/commands/report_type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/source.ts
+++ b/src/cli/commands/source.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/source_clean.ts
+++ b/src/cli/commands/source_clean.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/source_fetch.ts
+++ b/src/cli/commands/source_fetch.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/source_path.ts
+++ b/src/cli/commands/source_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/summarise.ts
+++ b/src/cli/commands/summarise.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/summarise_test.ts
+++ b/src/cli/commands/summarise_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/type_describe_test.ts
+++ b/src/cli/commands/type_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/type_search_test.ts
+++ b/src/cli/commands/type_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/update_test.ts
+++ b/src/cli/commands/update_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_annotate.ts
+++ b/src/cli/commands/vault_annotate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_annotate_test.ts
+++ b/src/cli/commands/vault_annotate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_describe.ts
+++ b/src/cli/commands/vault_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_edit.ts
+++ b/src/cli/commands/vault_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_get.ts
+++ b/src/cli/commands/vault_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_inspect.ts
+++ b/src/cli/commands/vault_inspect.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_put_test.ts
+++ b/src/cli/commands/vault_put_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_read_secret.ts
+++ b/src/cli/commands/vault_read_secret.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_search.ts
+++ b/src/cli/commands/vault_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/vault_type_search.ts
+++ b/src/cli/commands/vault_type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/version_test.ts
+++ b/src/cli/commands/version_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_delete_test.ts
+++ b/src/cli/commands/workflow_delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_edit_test.ts
+++ b/src/cli/commands/workflow_edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_evaluate_test.ts
+++ b/src/cli/commands/workflow_evaluate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_history_logs_test.ts
+++ b/src/cli/commands/workflow_history_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_run_search_test.ts
+++ b/src/cli/commands/workflow_run_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_run_test.ts
+++ b/src/cli/commands/workflow_run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_schema.ts
+++ b/src/cli/commands/workflow_schema.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_schema_test.ts
+++ b/src/cli/commands/workflow_schema_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/completion_types.ts
+++ b/src/cli/completion_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/completion_types_test.ts
+++ b/src/cli/completion_types_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/duration_parser.ts
+++ b/src/cli/duration_parser.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/duration_parser_test.ts
+++ b/src/cli/duration_parser_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/group_action.ts
+++ b/src/cli/group_action.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/group_action_test.ts
+++ b/src/cli/group_action_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/input_parser_test.ts
+++ b/src/cli/input_parser_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/load_identity.ts
+++ b/src/cli/load_identity.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/load_identity_test.ts
+++ b/src/cli/load_identity_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_datastores_dir.ts
+++ b/src/cli/resolve_datastores_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_datastores_dir_test.ts
+++ b/src/cli/resolve_datastores_dir_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_drivers_dir.ts
+++ b/src/cli/resolve_drivers_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_models_dir.ts
+++ b/src/cli/resolve_models_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_reports_dir.ts
+++ b/src/cli/resolve_reports_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_vaults_dir.ts
+++ b/src/cli/resolve_vaults_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_vaults_dir_test.ts
+++ b/src/cli/resolve_vaults_dir_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/resolve_workflows_dir.ts
+++ b/src/cli/resolve_workflows_dir.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/cli/unknown_command_handler_test.ts
+++ b/src/cli/unknown_command_handler_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_command_entry.ts
+++ b/src/domain/audit/audit_command_entry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_command_entry_test.ts
+++ b/src/domain/audit/audit_command_entry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_entry.ts
+++ b/src/domain/audit/audit_entry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_path.ts
+++ b/src/domain/audit/audit_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_path_test.ts
+++ b/src/domain/audit/audit_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_repository.ts
+++ b/src/domain/audit/audit_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_service.ts
+++ b/src/domain/audit/audit_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/audit_service_test.ts
+++ b/src/domain/audit/audit_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/check.ts
+++ b/src/domain/audit/doctor/check.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/check_test.ts
+++ b/src/domain/audit/doctor/check_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/agent_config_loadable.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/default_agent_set.ts
+++ b/src/domain/audit/doctor/checks/default_agent_set.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/default_agent_set_test.ts
+++ b/src/domain/audit/doctor/checks/default_agent_set_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/resolve_binary.ts
+++ b/src/domain/audit/doctor/checks/resolve_binary.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/doctor_service.ts
+++ b/src/domain/audit/doctor/doctor_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/doctor_service_test.ts
+++ b/src/domain/audit/doctor/doctor_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/doctor/synthetic_payloads_test.ts
+++ b/src/domain/audit/doctor/synthetic_payloads_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/audit/mod.ts
+++ b/src/domain/audit/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/auth/auth_credentials.ts
+++ b/src/domain/auth/auth_credentials.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/auth/device_code.ts
+++ b/src/domain/auth/device_code.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/auth/device_code_test.ts
+++ b/src/domain/auth/device_code_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/autocomplete_provider.ts
+++ b/src/domain/data/autocomplete_provider.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/autocomplete_provider_test.ts
+++ b/src/domain/data/autocomplete_provider_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/cel_cursor_context.ts
+++ b/src/domain/data/cel_cursor_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/cel_cursor_context_test.ts
+++ b/src/domain/data/cel_cursor_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/composite_name.ts
+++ b/src/domain/data/composite_name.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/composite_name_test.ts
+++ b/src/domain/data/composite_name_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/content_type.ts
+++ b/src/domain/data/content_type.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data.ts
+++ b/src/domain/data/data.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_access_service.ts
+++ b/src/domain/data/data_access_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_access_service_test.ts
+++ b/src/domain/data/data_access_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_contract_test.ts
+++ b/src/domain/data/data_contract_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_delete_service.ts
+++ b/src/domain/data/data_delete_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_delete_service_test.ts
+++ b/src/domain/data/data_delete_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_id.ts
+++ b/src/domain/data/data_id.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_lifecycle_service_test.ts
+++ b/src/domain/data/data_lifecycle_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_metadata.ts
+++ b/src/domain/data/data_metadata.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_metadata_property_test.ts
+++ b/src/domain/data/data_metadata_property_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_metadata_test.ts
+++ b/src/domain/data/data_metadata_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_property_test.ts
+++ b/src/domain/data/data_property_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_record.ts
+++ b/src/domain/data/data_record.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_record_mapper.ts
+++ b/src/domain/data/data_record_mapper.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_record_mapper_test.ts
+++ b/src/domain/data/data_record_mapper_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_rename_service.ts
+++ b/src/domain/data/data_rename_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/data_test.ts
+++ b/src/domain/data/data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/duration.ts
+++ b/src/domain/data/duration.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/duration_test.ts
+++ b/src/domain/data/duration_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/mod.ts
+++ b/src/domain/data/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/namespace.ts
+++ b/src/domain/data/namespace.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/namespace_test.ts
+++ b/src/domain/data/namespace_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/query_predicate.ts
+++ b/src/domain/data/query_predicate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/workflow_data_service.ts
+++ b/src/domain/data/workflow_data_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/data/workflow_data_service_test.ts
+++ b/src/domain/data/workflow_data_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_health.ts
+++ b/src/domain/datastore/datastore_health.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_migration_service.ts
+++ b/src/domain/datastore/datastore_migration_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_path_resolver.ts
+++ b/src/domain/datastore/datastore_path_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_pattern_matcher.ts
+++ b/src/domain/datastore/datastore_pattern_matcher.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_pattern_matcher_test.ts
+++ b/src/domain/datastore/datastore_pattern_matcher_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_provider.ts
+++ b/src/domain/datastore/datastore_provider.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_sync_service_test.ts
+++ b/src/domain/datastore/datastore_sync_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_type_registry.ts
+++ b/src/domain/datastore/datastore_type_registry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_type_registry_test.ts
+++ b/src/domain/datastore/datastore_type_registry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/datastore_types.ts
+++ b/src/domain/datastore/datastore_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/distributed_lock.ts
+++ b/src/domain/datastore/distributed_lock.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/distributed_lock_test.ts
+++ b/src/domain/datastore/distributed_lock_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/testing_package_compat_test.ts
+++ b/src/domain/datastore/testing_package_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/datastore/user_datastore_loader_test.ts
+++ b/src/domain/datastore/user_datastore_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/definitions/definition_contract_test.ts
+++ b/src/domain/definitions/definition_contract_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/definitions/definition_property_test.ts
+++ b/src/domain/definitions/definition_property_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/definitions/repositories.ts
+++ b/src/domain/definitions/repositories.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/console_guard.ts
+++ b/src/domain/drivers/console_guard.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/console_guard_test.ts
+++ b/src/domain/drivers/console_guard_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/docker_execution_driver.ts
+++ b/src/domain/drivers/docker_execution_driver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/docker_execution_driver_test.ts
+++ b/src/domain/drivers/docker_execution_driver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/docker_runner.ts
+++ b/src/domain/drivers/docker_runner.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_config.ts
+++ b/src/domain/drivers/driver_config.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_plan.ts
+++ b/src/domain/drivers/driver_plan.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_plan_test.ts
+++ b/src/domain/drivers/driver_plan_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_resolution.ts
+++ b/src/domain/drivers/driver_resolution.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_resolution_test.ts
+++ b/src/domain/drivers/driver_resolution_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_type_registry.ts
+++ b/src/domain/drivers/driver_type_registry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_type_registry_test.ts
+++ b/src/domain/drivers/driver_type_registry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/driver_types.ts
+++ b/src/domain/drivers/driver_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/execution_driver.ts
+++ b/src/domain/drivers/execution_driver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/execution_driver_test.ts
+++ b/src/domain/drivers/execution_driver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/mod.ts
+++ b/src/domain/drivers/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/raw_execution_driver.ts
+++ b/src/domain/drivers/raw_execution_driver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/raw_execution_driver_test.ts
+++ b/src/domain/drivers/raw_execution_driver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/testing_package_compat_test.ts
+++ b/src/domain/drivers/testing_package_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/drivers/user_driver_loader_test.ts
+++ b/src/domain/drivers/user_driver_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/events/event_bus.ts
+++ b/src/domain/events/event_bus.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/events/event_bus_contract_test.ts
+++ b/src/domain/events/event_bus_contract_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/events/event_bus_test.ts
+++ b/src/domain/events/event_bus_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/events/mod.ts
+++ b/src/domain/events/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/cel_runtime.ts
+++ b/src/domain/expressions/cel_runtime.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/dependency_extractor.ts
+++ b/src/domain/expressions/dependency_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/dependency_extractor_test.ts
+++ b/src/domain/expressions/dependency_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/errors.ts
+++ b/src/domain/expressions/errors.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/errors_test.ts
+++ b/src/domain/expressions/errors_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression.ts
+++ b/src/domain/expressions/expression.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_evaluation_service_test.ts
+++ b/src/domain/expressions/expression_evaluation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_path_extractor.ts
+++ b/src/domain/expressions/expression_path_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/expression_path_extractor_test.ts
+++ b/src/domain/expressions/expression_path_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/model_resolver_contract_test.ts
+++ b/src/domain/expressions/model_resolver_contract_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/schema_path_validator.ts
+++ b/src/domain/expressions/schema_path_validator.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/expressions/schema_path_validator_test.ts
+++ b/src/domain/expressions/schema_path_validator_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/auto_resolver_context.ts
+++ b/src/domain/extensions/auto_resolver_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/bundle_freshness.ts
+++ b/src/domain/extensions/bundle_freshness.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/bundle_freshness_test.ts
+++ b/src/domain/extensions/bundle_freshness_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/bundle_location.ts
+++ b/src/domain/extensions/bundle_location.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/bundle_location_test.ts
+++ b/src/domain/extensions/bundle_location_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/datastore_kind_adapter.ts
+++ b/src/domain/extensions/datastore_kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/driver_kind_adapter.ts
+++ b/src/domain/extensions/driver_kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/duplicate_type_user_error.ts
+++ b/src/domain/extensions/duplicate_type_user_error.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension.ts
+++ b/src/domain/extensions/extension.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_collective_validator.ts
+++ b/src/domain/extensions/extension_collective_validator.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_collective_validator_test.ts
+++ b/src/domain/extensions/extension_collective_validator_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_extractor.ts
+++ b/src/domain/extensions/extension_dependency_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_extractor_test.ts
+++ b/src/domain/extensions/extension_dependency_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_resolver.ts
+++ b/src/domain/extensions/extension_dependency_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_resolver_test.ts
+++ b/src/domain/extensions/extension_dependency_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_trust_checker.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_dependency_trust_checker_test.ts
+++ b/src/domain/extensions/extension_dependency_trust_checker_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_file_resolver.ts
+++ b/src/domain/extensions/extension_file_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_file_resolver_test.ts
+++ b/src/domain/extensions/extension_file_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_import_resolver.ts
+++ b/src/domain/extensions/extension_import_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_import_resolver_test.ts
+++ b/src/domain/extensions/extension_import_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_loader_subprocess_test.ts
+++ b/src/domain/extensions/extension_loader_subprocess_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_loader_test.ts
+++ b/src/domain/extensions/extension_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_package_cache.ts
+++ b/src/domain/extensions/extension_package_cache.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_package_cache_test.ts
+++ b/src/domain/extensions/extension_package_cache_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_safety_analyzer.ts
+++ b/src/domain/extensions/extension_safety_analyzer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_safety_analyzer_test.ts
+++ b/src/domain/extensions/extension_safety_analyzer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_skill_validator.ts
+++ b/src/domain/extensions/extension_skill_validator.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_skill_validator_test.ts
+++ b/src/domain/extensions/extension_skill_validator_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_test.ts
+++ b/src/domain/extensions/extension_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_update_check_cache.ts
+++ b/src/domain/extensions/extension_update_check_cache.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_update_check_cache_test.ts
+++ b/src/domain/extensions/extension_update_check_cache_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_update_service.ts
+++ b/src/domain/extensions/extension_update_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/extension_update_service_test.ts
+++ b/src/domain/extensions/extension_update_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/find_repo_root.ts
+++ b/src/domain/extensions/find_repo_root.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/find_repo_root_test.ts
+++ b/src/domain/extensions/find_repo_root_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/installed_extension_digest.ts
+++ b/src/domain/extensions/installed_extension_digest.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/installed_extension_digest_test.ts
+++ b/src/domain/extensions/installed_extension_digest_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/installed_extension_lookup.ts
+++ b/src/domain/extensions/installed_extension_lookup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/installed_extension_lookup_test.ts
+++ b/src/domain/extensions/installed_extension_lookup_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/kind_adapter.ts
+++ b/src/domain/extensions/kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/repo_root_not_found_error.ts
+++ b/src/domain/extensions/repo_root_not_found_error.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/report_kind_adapter.ts
+++ b/src/domain/extensions/report_kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/reporter_context.ts
+++ b/src/domain/extensions/reporter_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/reporter_context_test.ts
+++ b/src/domain/extensions/reporter_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/repository_url.ts
+++ b/src/domain/extensions/repository_url.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/repository_url_test.ts
+++ b/src/domain/extensions/repository_url_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/row_state.ts
+++ b/src/domain/extensions/row_state.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/row_state_test.ts
+++ b/src/domain/extensions/row_state_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source.ts
+++ b/src/domain/extensions/source.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_failure_recorder.ts
+++ b/src/domain/extensions/source_failure_recorder.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_failure_recorder_test.ts
+++ b/src/domain/extensions/source_failure_recorder_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_fingerprint.ts
+++ b/src/domain/extensions/source_fingerprint.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_location.ts
+++ b/src/domain/extensions/source_location.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_location_test.ts
+++ b/src/domain/extensions/source_location_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/source_test.ts
+++ b/src/domain/extensions/source_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/validation_error.ts
+++ b/src/domain/extensions/validation_error.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/validation_error_test.ts
+++ b/src/domain/extensions/validation_error_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/extensions/vault_kind_adapter.ts
+++ b/src/domain/extensions/vault_kind_adapter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/identity/user_identity.ts
+++ b/src/domain/identity/user_identity.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/identity/user_identity_test.ts
+++ b/src/domain/identity/user_identity_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_coercion.ts
+++ b/src/domain/inputs/input_coercion.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_coercion_test.ts
+++ b/src/domain/inputs/input_coercion_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_merge.ts
+++ b/src/domain/inputs/input_merge.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_merge_test.ts
+++ b/src/domain/inputs/input_merge_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_override_validation_service.ts
+++ b/src/domain/inputs/input_override_validation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_override_validation_service_test.ts
+++ b/src/domain/inputs/input_override_validation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_validation_service.ts
+++ b/src/domain/inputs/input_validation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/input_validation_service_test.ts
+++ b/src/domain/inputs/input_validation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/inputs/mod.ts
+++ b/src/domain/inputs/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/aws/aws_models.ts
+++ b/src/domain/models/aws/aws_models.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/checksum.ts
+++ b/src/domain/models/checksum.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/posix_shell_strategy.ts
+++ b/src/domain/models/command/shell/posix_shell_strategy.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/posix_shell_strategy_test.ts
+++ b/src/domain/models/command/shell/posix_shell_strategy_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/powershell_strategy.ts
+++ b/src/domain/models/command/shell/powershell_strategy.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/powershell_strategy_test.ts
+++ b/src/domain/models/command/shell/powershell_strategy_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/shell_strategy.ts
+++ b/src/domain/models/command/shell/shell_strategy.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/command/shell/shell_strategy_test.ts
+++ b/src/domain/models/command/shell/shell_strategy_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/data_output_override.ts
+++ b/src/domain/models/data_output_override.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/data_output_validation_service.ts
+++ b/src/domain/models/data_output_validation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/data_output_validation_service_test.ts
+++ b/src/domain/models/data_output_validation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/definition_upgrade_service.ts
+++ b/src/domain/models/definition_upgrade_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/definition_upgrade_service_test.ts
+++ b/src/domain/models/definition_upgrade_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/env_var_detector.ts
+++ b/src/domain/models/env_var_detector.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/env_var_detector_test.ts
+++ b/src/domain/models/env_var_detector_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/local_import_resolver.ts
+++ b/src/domain/models/local_import_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_context.ts
+++ b/src/domain/models/method_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_context_arch_test.ts
+++ b/src/domain/models/method_context_arch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_context_test.ts
+++ b/src/domain/models/method_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_events.ts
+++ b/src/domain/models/method_events.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_lookup.ts
+++ b/src/domain/models/model_lookup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_lookup_test.ts
+++ b/src/domain/models/model_lookup_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_type.ts
+++ b/src/domain/models/model_type.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_type_property_test.ts
+++ b/src/domain/models/model_type_property_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/model_type_test.ts
+++ b/src/domain/models/model_type_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/output_spec_builder.ts
+++ b/src/domain/models/output_spec_builder.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/output_spec_builder_test.ts
+++ b/src/domain/models/output_spec_builder_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/zod_type_coercion.ts
+++ b/src/domain/models/zod_type_coercion.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/models/zod_type_coercion_test.ts
+++ b/src/domain/models/zod_type_coercion_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/ai_tool.ts
+++ b/src/domain/repo/ai_tool.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/primary_tool.ts
+++ b/src/domain/repo/primary_tool.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/primary_tool_test.ts
+++ b/src/domain/repo/primary_tool_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/repo_index_service.ts
+++ b/src/domain/repo/repo_index_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/repo_path.ts
+++ b/src/domain/repo/repo_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/repo_path_test.ts
+++ b/src/domain/repo/repo_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -798,7 +798,7 @@ to work with swamp models.`;
 
     return `# Project
 
-This repository is managed with [swamp](https://github.com/systeminit/swamp).
+This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 
 ## Rules
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -1880,7 +1880,7 @@ Deno.test("RepoService.upgrade migrates legacy content (template-only) to marker
     const claudeMdPath = join(tempDir, "CLAUDE.md");
     const legacyContent = `# Project
 
-This repository is managed with [swamp](https://github.com/systeminit/swamp).
+This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 
 ## Rules
 
@@ -1928,7 +1928,7 @@ Deno.test("RepoService.upgrade migrates legacy content and preserves user additi
     const claudeMdPath = join(tempDir, "CLAUDE.md");
     const legacyWithUserContent = `# Project
 
-This repository is managed with [swamp](https://github.com/systeminit/swamp).
+This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 
 ## Commands
 
@@ -1971,7 +1971,7 @@ Run npm install first.
 
 # Project
 
-This repository is managed with [swamp](https://github.com/systeminit/swamp).
+This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 
 ## Commands
 
@@ -2139,7 +2139,7 @@ Deno.test("RepoService.upgrade legacy migration with partial template match pres
     const claudeMdPath = join(tempDir, "CLAUDE.md");
     const legacyWithEditedEnd = `# Project
 
-This repository is managed with [swamp](https://github.com/systeminit/swamp).
+This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 
 ## Commands
 

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/swamp_sources.ts
+++ b/src/domain/repo/swamp_sources.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/swamp_sources_test.ts
+++ b/src/domain/repo/swamp_sources_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/swamp_version.ts
+++ b/src/domain/repo/swamp_version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/swamp_version_test.ts
+++ b/src/domain/repo/swamp_version_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/tool_resolver.ts
+++ b/src/domain/repo/tool_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/repo/tool_resolver_test.ts
+++ b/src/domain/repo/tool_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/method_summary_report.ts
+++ b/src/domain/reports/builtin/method_summary_report.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/method_summary_report_test.ts
+++ b/src/domain/reports/builtin/method_summary_report_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/mod.ts
+++ b/src/domain/reports/builtin/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/report_error_report.ts
+++ b/src/domain/reports/builtin/report_error_report.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/report_error_report_test.ts
+++ b/src/domain/reports/builtin/report_error_report_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/workflow_summary_report.ts
+++ b/src/domain/reports/builtin/workflow_summary_report.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/builtin/workflow_summary_report_test.ts
+++ b/src/domain/reports/builtin/workflow_summary_report_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/mod.ts
+++ b/src/domain/reports/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report.ts
+++ b/src/domain/reports/report.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_context.ts
+++ b/src/domain/reports/report_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_context_arch_test.ts
+++ b/src/domain/reports/report_context_arch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_registry.ts
+++ b/src/domain/reports/report_registry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_registry_test.ts
+++ b/src/domain/reports/report_registry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_selection.ts
+++ b/src/domain/reports/report_selection.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/report_types.ts
+++ b/src/domain/reports/report_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/testing_package_compat_test.ts
+++ b/src/domain/reports/testing_package_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/reports/user_report_loader_test.ts
+++ b/src/domain/reports/user_report_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/runtime/deno_runtime.ts
+++ b/src/domain/runtime/deno_runtime.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/runtime/deno_version.ts
+++ b/src/domain/runtime/deno_version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/runtime/deno_version_test.ts
+++ b/src/domain/runtime/deno_version_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/secrets/mod.ts
+++ b/src/domain/secrets/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/secrets/secret_redactor.ts
+++ b/src/domain/secrets/secret_redactor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/secrets/secret_redactor_test.ts
+++ b/src/domain/secrets/secret_redactor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/source/mod.ts
+++ b/src/domain/source/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/source/source_metadata.ts
+++ b/src/domain/source/source_metadata.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/source/source_service.ts
+++ b/src/domain/source/source_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/source/source_service_test.ts
+++ b/src/domain/source/source_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/string_distance.ts
+++ b/src/domain/string_distance.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/string_distance_test.ts
+++ b/src/domain/string_distance_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/summary/summary_service.ts
+++ b/src/domain/summary/summary_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/summary/summary_service_test.ts
+++ b/src/domain/summary/summary_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/summary/summary_types.ts
+++ b/src/domain/summary/summary_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/agent_harness_detection.ts
+++ b/src/domain/telemetry/agent_harness_detection.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/agent_harness_detection_test.ts
+++ b/src/domain/telemetry/agent_harness_detection_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/command_invocation.ts
+++ b/src/domain/telemetry/command_invocation.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/invocation_context_test.ts
+++ b/src/domain/telemetry/invocation_context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/invocation_result.ts
+++ b/src/domain/telemetry/invocation_result.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/repositories.ts
+++ b/src/domain/telemetry/repositories.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_entry.ts
+++ b/src/domain/telemetry/telemetry_entry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_id.ts
+++ b/src/domain/telemetry/telemetry_id.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_sender.ts
+++ b/src/domain/telemetry/telemetry_sender.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/telemetry/workflow_context.ts
+++ b/src/domain/telemetry/workflow_context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/autoupdate_log.ts
+++ b/src/domain/update/autoupdate_log.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/autoupdate_scheduler.ts
+++ b/src/domain/update/autoupdate_scheduler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/install_health.ts
+++ b/src/domain/update/install_health.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/install_health_test.ts
+++ b/src/domain/update/install_health_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/integrity.ts
+++ b/src/domain/update/integrity.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/integrity_test.ts
+++ b/src/domain/update/integrity_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/platform.ts
+++ b/src/domain/update/platform.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/platform_test.ts
+++ b/src/domain/update/platform_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_check_cache.ts
+++ b/src/domain/update/update_check_cache.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_check_cache_test.ts
+++ b/src/domain/update/update_check_cache_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_notification_service.ts
+++ b/src/domain/update/update_notification_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_notification_service_test.ts
+++ b/src/domain/update/update_notification_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_preferences.ts
+++ b/src/domain/update/update_preferences.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_preferences_test.ts
+++ b/src/domain/update/update_preferences_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_service.ts
+++ b/src/domain/update/update_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/update_service_test.ts
+++ b/src/domain/update/update_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/version_staleness.ts
+++ b/src/domain/update/version_staleness.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/update/version_staleness_test.ts
+++ b/src/domain/update/version_staleness_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_annotation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/local_encryption_vault_provider_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/mock_vault_provider.ts
+++ b/src/domain/vaults/mock_vault_provider.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/mock_vault_provider_test.ts
+++ b/src/domain/vaults/mock_vault_provider_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/testing_package_compat_test.ts
+++ b/src/domain/vaults/testing_package_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_annotation.ts
+++ b/src/domain/vaults/vault_annotation.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_annotation_test.ts
+++ b/src/domain/vaults/vault_annotation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_config.ts
+++ b/src/domain/vaults/vault_config.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_config_test.ts
+++ b/src/domain/vaults/vault_config_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_expression_test.ts
+++ b/src/domain/vaults/vault_expression_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_provider.ts
+++ b/src/domain/vaults/vault_provider.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_provider_factory.ts
+++ b/src/domain/vaults/vault_provider_factory.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_provider_factory_test.ts
+++ b/src/domain/vaults/vault_provider_factory_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_secret_bag.ts
+++ b/src/domain/vaults/vault_secret_bag.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_secret_bag_test.ts
+++ b/src/domain/vaults/vault_secret_bag_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_service_annotation_test.ts
+++ b/src/domain/vaults/vault_service_annotation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_type_registry.ts
+++ b/src/domain/vaults/vault_type_registry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_type_registry_test.ts
+++ b/src/domain/vaults/vault_type_registry_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_types.ts
+++ b/src/domain/vaults/vault_types.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/vaults/vault_types_test.ts
+++ b/src/domain/vaults/vault_types_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/approval_timeout.ts
+++ b/src/domain/workflows/approval_timeout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/approval_timeout_test.ts
+++ b/src/domain/workflows/approval_timeout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/data_suffix.ts
+++ b/src/domain/workflows/data_suffix.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/data_suffix_test.ts
+++ b/src/domain/workflows/data_suffix_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/expression_evaluators_test.ts
+++ b/src/domain/workflows/expression_evaluators_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/for_each_expansion_service.ts
+++ b/src/domain/workflows/for_each_expansion_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/for_each_expansion_service_test.ts
+++ b/src/domain/workflows/for_each_expansion_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/method_report_runner.ts
+++ b/src/domain/workflows/method_report_runner.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/model_reference_extractor.ts
+++ b/src/domain/workflows/model_reference_extractor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/model_reference_extractor_test.ts
+++ b/src/domain/workflows/model_reference_extractor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/step_task_test.ts
+++ b/src/domain/workflows/step_task_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/suspended_run_resolver.ts
+++ b/src/domain/workflows/suspended_run_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/suspended_run_resolver_test.ts
+++ b/src/domain/workflows/suspended_run_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/topological_sort_service.ts
+++ b/src/domain/workflows/topological_sort_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/topological_sort_service_test.ts
+++ b/src/domain/workflows/topological_sort_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/trigger_condition.ts
+++ b/src/domain/workflows/trigger_condition.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/trigger_condition_test.ts
+++ b/src/domain/workflows/trigger_condition_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_contract_test.ts
+++ b/src/domain/workflows/workflow_contract_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_id.ts
+++ b/src/domain/workflows/workflow_id.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_id_test.ts
+++ b/src/domain/workflows/workflow_id_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_property_test.ts
+++ b/src/domain/workflows/workflow_property_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_report_runner.ts
+++ b/src/domain/workflows/workflow_report_runner.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_scheduler.ts
+++ b/src/domain/workflows/workflow_scheduler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_scheduler_test.ts
+++ b/src/domain/workflows/workflow_scheduler_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/zod_compat.ts
+++ b/src/domain/zod_compat.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/domain/zod_compat_test.ts
+++ b/src/domain/zod_compat_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/archive/tar_archive.ts
+++ b/src/infrastructure/archive/tar_archive.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/archive/tar_archive_test.ts
+++ b/src/infrastructure/archive/tar_archive_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/editor/editor_service.ts
+++ b/src/infrastructure/editor/editor_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/editor/editor_service_test.ts
+++ b/src/infrastructure/editor/editor_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/github/github_issue_service.ts
+++ b/src/infrastructure/github/github_issue_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -48,7 +48,7 @@ export interface CreateIssueOptions {
  * Service for interacting with GitHub issues via the gh CLI.
  */
 export class GitHubIssueService {
-  private readonly defaultRepo = "systeminit/swamp";
+  private readonly defaultRepo = "swamp-club/swamp";
 
   /**
    * Checks if the gh CLI is installed and authenticated.

--- a/src/infrastructure/github/github_issue_service_test.ts
+++ b/src/infrastructure/github/github_issue_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -21,7 +21,7 @@ import { assertEquals } from "@std/assert";
 import { GitHubIssueService } from "./github_issue_service.ts";
 
 Deno.test("issue URL parsing extracts issue number", () => {
-  const url = "https://github.com/systeminit/swamp/issues/123";
+  const url = "https://github.com/swamp-club/swamp/issues/123";
   const match = url.match(/\/issues\/(\d+)$/);
   const number = match ? parseInt(match[1], 10) : 0;
   assertEquals(number, 123);
@@ -46,7 +46,7 @@ Deno.test("getNewIssueUrl uses default repo with labels", () => {
   const url = service.getNewIssueUrl({ labels: ["bug", "needs-triage"] });
   assertEquals(
     url,
-    "https://github.com/systeminit/swamp/issues/new?labels=bug%2Cneeds-triage",
+    "https://github.com/swamp-club/swamp/issues/new?labels=bug%2Cneeds-triage",
   );
 });
 
@@ -65,5 +65,5 @@ Deno.test("getNewIssueUrl uses custom repo", () => {
 Deno.test("getNewIssueUrl with no labels omits query string", () => {
   const service = new GitHubIssueService();
   const url = service.getNewIssueUrl({ labels: [] });
-  assertEquals(url, "https://github.com/systeminit/swamp/issues/new");
+  assertEquals(url, "https://github.com/swamp-club/swamp/issues/new");
 });

--- a/src/infrastructure/http/callback_server.ts
+++ b/src/infrastructure/http/callback_server.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/callback_server_test.ts
+++ b/src/infrastructure/http/callback_server_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/client_identity.ts
+++ b/src/infrastructure/http/client_identity.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/client_identity_test.ts
+++ b/src/infrastructure/http/client_identity_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/rate_limit.ts
+++ b/src/infrastructure/http/rate_limit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/rate_limit_test.ts
+++ b/src/infrastructure/http/rate_limit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/swamp_club_client_search_test.ts
+++ b/src/infrastructure/http/swamp_club_client_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/io/stdin_reader.ts
+++ b/src/infrastructure/io/stdin_reader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/extension_load_warnings.ts
+++ b/src/infrastructure/logging/extension_load_warnings.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/extension_load_warnings_test.ts
+++ b/src/infrastructure/logging/extension_load_warnings_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/logger_test.ts
+++ b/src/infrastructure/logging/logger_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/logging/run_file_sink_test.ts
+++ b/src/infrastructure/logging/run_file_sink_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/atomic_write.ts
+++ b/src/infrastructure/persistence/atomic_write.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/atomic_write_test.ts
+++ b/src/infrastructure/persistence/atomic_write_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/canonicalize_path.ts
+++ b/src/infrastructure/persistence/canonicalize_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/canonicalize_path_test.ts
+++ b/src/infrastructure/persistence/canonicalize_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/composite_workflow_repository.ts
+++ b/src/infrastructure/persistence/composite_workflow_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/composite_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/composite_workflow_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/custom_tools_repository.ts
+++ b/src/infrastructure/persistence/custom_tools_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/custom_tools_repository_test.ts
+++ b/src/infrastructure/persistence/custom_tools_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/default_datastore_path_resolver.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/derive_extension_identity.ts
+++ b/src/infrastructure/persistence/derive_extension_identity.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/derive_extension_identity_test.ts
+++ b/src/infrastructure/persistence/derive_extension_identity_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/directory_cleanup.ts
+++ b/src/infrastructure/persistence/directory_cleanup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/directory_cleanup_test.ts
+++ b/src/infrastructure/persistence/directory_cleanup_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/duplicate_type_error.ts
+++ b/src/infrastructure/persistence/duplicate_type_error.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/env_path.ts
+++ b/src/infrastructure/persistence/env_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/env_path_test.ts
+++ b/src/infrastructure/persistence/env_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_update_check_repository.ts
+++ b/src/infrastructure/persistence/extension_update_check_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_update_check_repository_test.ts
+++ b/src/infrastructure/persistence/extension_update_check_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/extension_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/filesystem_datastore_verifier.ts
+++ b/src/infrastructure/persistence/filesystem_datastore_verifier.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/installed_extension_digest_reader.ts
+++ b/src/infrastructure/persistence/installed_extension_digest_reader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/installed_extension_digest_reader_test.ts
+++ b/src/infrastructure/persistence/installed_extension_digest_reader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/jsonl_audit_repository.ts
+++ b/src/infrastructure/persistence/jsonl_audit_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/jsonl_audit_repository_test.ts
+++ b/src/infrastructure/persistence/jsonl_audit_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -128,7 +128,7 @@ Deno.test("JsonlAuditRepository.findByTimeRange returns entries in range", async
 });
 
 Deno.test("JsonlAuditRepository.findByTimeRange reads correct UTC-dated file for same-day queries", async () => {
-  // Regression test for https://github.com/systeminit/swamp/issues/659
+  // Regression test for https://github.com/swamp-club/swamp/issues/659
   // Ensures date iteration uses UTC dates to match filenames written by append().
   // The bug: setHours(0,0,0,0) uses local time, so in UTC+ timezones,
   // toISOString() would produce the previous day's date, missing today's file.

--- a/src/infrastructure/persistence/local_manifest_reader.ts
+++ b/src/infrastructure/persistence/local_manifest_reader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/local_manifest_reader_test.ts
+++ b/src/infrastructure/persistence/local_manifest_reader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/lockfile_repository_test.ts
+++ b/src/infrastructure/persistence/lockfile_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/namespace_manifest.ts
+++ b/src/infrastructure/persistence/namespace_manifest.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/namespace_manifest_test.ts
+++ b/src/infrastructure/persistence/namespace_manifest_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/path_test_helpers.ts
+++ b/src/infrastructure/persistence/path_test_helpers.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/path_test_helpers_test.ts
+++ b/src/infrastructure/persistence/path_test_helpers_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repo_marker_loader.ts
+++ b/src/infrastructure/persistence/repo_marker_loader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repo_marker_loader_test.ts
+++ b/src/infrastructure/persistence/repo_marker_loader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/repository_factory_test.ts
+++ b/src/infrastructure/persistence/repository_factory_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/safe_path.ts
+++ b/src/infrastructure/persistence/safe_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/safe_path_test.ts
+++ b/src/infrastructure/persistence/safe_path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/swamp_sources_repository.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/swamp_sources_repository_test.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/sync_error_diagnostic.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/sync_error_diagnostic_test.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/test_helpers/faulting_stub_repository.ts
+++ b/src/infrastructure/persistence/test_helpers/faulting_stub_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/test_helpers/stub_extension_repository.ts
+++ b/src/infrastructure/persistence/test_helpers/stub_extension_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/unified_data_repository_re_export_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_re_export_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/upstream_extensions.ts
+++ b/src/infrastructure/persistence/upstream_extensions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/user_identity_repository.ts
+++ b/src/infrastructure/persistence/user_identity_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/user_identity_repository_test.ts
+++ b/src/infrastructure/persistence/user_identity_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_vault_config_repository.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_vault_config_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/browser.ts
+++ b/src/infrastructure/process/browser.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/browser_test.ts
+++ b/src/infrastructure/process/browser_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/gh_cli.ts
+++ b/src/infrastructure/process/gh_cli.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/gh_cli_test.ts
+++ b/src/infrastructure/process/gh_cli_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/process_executor.ts
+++ b/src/infrastructure/process/process_executor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/process_executor_test.ts
+++ b/src/infrastructure/process/process_executor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/reporter_context_collector.ts
+++ b/src/infrastructure/process/reporter_context_collector.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/reporter_context_collector_test.ts
+++ b/src/infrastructure/process/reporter_context_collector_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/resolve_command.ts
+++ b/src/infrastructure/process/resolve_command.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/resolve_command_test.ts
+++ b/src/infrastructure/process/resolve_command_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/shutdown_handlers.ts
+++ b/src/infrastructure/process/shutdown_handlers.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/process/shutdown_handlers_test.ts
+++ b/src/infrastructure/process/shutdown_handlers_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/repo/noop_repo_index_service.ts
+++ b/src/infrastructure/repo/noop_repo_index_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/runtime/embedded_deno_runtime_test.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/runtime/tls_trust.ts
+++ b/src/infrastructure/runtime/tls_trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/runtime/tls_trust_test.ts
+++ b/src/infrastructure/runtime/tls_trust_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/security/file_security_check.ts
+++ b/src/infrastructure/security/file_security_check.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/security/file_security_check_test.ts
+++ b/src/infrastructure/security/file_security_check_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/source/http_source_downloader.ts
+++ b/src/infrastructure/source/http_source_downloader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -28,7 +28,7 @@ import { extractTarGz } from "../archive/tar_archive.ts";
  */
 export class HttpSourceDownloader implements SourceDownloader {
   private static readonly GITHUB_BASE =
-    "https://github.com/systeminit/swamp/archive/refs";
+    "https://github.com/swamp-club/swamp/archive/refs";
 
   /**
    * Get the GitHub archive URL for a version.

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/source/json_source_metadata_repository.ts
+++ b/src/infrastructure/source/json_source_metadata_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/source/source_paths.ts
+++ b/src/infrastructure/source/source_paths.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/async_queue.ts
+++ b/src/infrastructure/stream/async_queue.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/async_queue_test.ts
+++ b/src/infrastructure/stream/async_queue_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/event_bridge.ts
+++ b/src/infrastructure/stream/event_bridge.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/event_bridge_test.ts
+++ b/src/infrastructure/stream/event_bridge_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/merge.ts
+++ b/src/infrastructure/stream/merge.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/merge_test.ts
+++ b/src/infrastructure/stream/merge_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/semaphore.ts
+++ b/src/infrastructure/stream/semaphore.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/stream/semaphore_test.ts
+++ b/src/infrastructure/stream/semaphore_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/testing/subprocess_entry.ts
+++ b/src/infrastructure/testing/subprocess_entry.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/testing/subprocess_harness.ts
+++ b/src/infrastructure/testing/subprocess_harness.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/testing/subprocess_harness_test.ts
+++ b/src/infrastructure/testing/subprocess_harness_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/fetch_otlp_exporter.ts
+++ b/src/infrastructure/tracing/fetch_otlp_exporter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/fetch_otlp_exporter_test.ts
+++ b/src/infrastructure/tracing/fetch_otlp_exporter_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/mod.ts
+++ b/src/infrastructure/tracing/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/otel_init_test.ts
+++ b/src/infrastructure/tracing/otel_init_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/parent_trace.ts
+++ b/src/infrastructure/tracing/parent_trace.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/parent_trace_test.ts
+++ b/src/infrastructure/tracing/parent_trace_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/propagation.ts
+++ b/src/infrastructure/tracing/propagation.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/propagation_test.ts
+++ b/src/infrastructure/tracing/propagation_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/tracer.ts
+++ b/src/infrastructure/tracing/tracer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/tracing/tracer_test.ts
+++ b/src/infrastructure/tracing/tracer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/autoupdate_log_file_repository.ts
+++ b/src/infrastructure/update/autoupdate_log_file_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/autoupdate_log_file_repository_test.ts
+++ b/src/infrastructure/update/autoupdate_log_file_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/http_update_checker_test.ts
+++ b/src/infrastructure/update/http_update_checker_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/scheduler_factory.ts
+++ b/src/infrastructure/update/scheduler_factory.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/update_check_cache_file_repository.ts
+++ b/src/infrastructure/update/update_check_cache_file_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/update_check_cache_file_repository_test.ts
+++ b/src/infrastructure/update/update_check_cache_file_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/update_preferences_file_repository.ts
+++ b/src/infrastructure/update/update_preferences_file_repository.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/infrastructure/update/update_preferences_file_repository_test.ts
+++ b/src/infrastructure/update/update_preferences_file_repository_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/audit/timeline.ts
+++ b/src/libswamp/audit/timeline.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/audit/timeline_test.ts
+++ b/src/libswamp/audit/timeline_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/login_test.ts
+++ b/src/libswamp/auth/login_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/logout.ts
+++ b/src/libswamp/auth/logout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/logout_test.ts
+++ b/src/libswamp/auth/logout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/auth/whoami_test.ts
+++ b/src/libswamp/auth/whoami_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -63,7 +63,7 @@ const testWhoamiResponse: WhoamiResponse = {
   email: "adam@example.com",
   name: "Adam",
   organizations: [
-    { slug: "si", name: "System Initiative", role: "admin", personal: false },
+    { slug: "si", name: "Swamp Club", role: "admin", personal: false },
   ],
 };
 

--- a/src/libswamp/context.ts
+++ b/src/libswamp/context.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/context_test.ts
+++ b/src/libswamp/context_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/delete.ts
+++ b/src/libswamp/data/delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/delete_test.ts
+++ b/src/libswamp/data/delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/gc_test.ts
+++ b/src/libswamp/data/gc_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/get.ts
+++ b/src/libswamp/data/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/get_test.ts
+++ b/src/libswamp/data/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/list_test.ts
+++ b/src/libswamp/data/list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/query.ts
+++ b/src/libswamp/data/query.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/rename.ts
+++ b/src/libswamp/data/rename.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/rename_test.ts
+++ b/src/libswamp/data/rename_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/search.ts
+++ b/src/libswamp/data/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/search_test.ts
+++ b/src/libswamp/data/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/versions.ts
+++ b/src/libswamp/data/versions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/data/versions_test.ts
+++ b/src/libswamp/data/versions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/compact.ts
+++ b/src/libswamp/datastores/compact.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/compact_test.ts
+++ b/src/libswamp/datastores/compact_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/lock.ts
+++ b/src/libswamp/datastores/lock.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/lock_test.ts
+++ b/src/libswamp/datastores/lock_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_list.ts
+++ b/src/libswamp/datastores/namespace_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_list_test.ts
+++ b/src/libswamp/datastores/namespace_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_set.ts
+++ b/src/libswamp/datastores/namespace_set.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_set_test.ts
+++ b/src/libswamp/datastores/namespace_set_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_unset.ts
+++ b/src/libswamp/datastores/namespace_unset.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/namespace_unset_test.ts
+++ b/src/libswamp/datastores/namespace_unset_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/status.ts
+++ b/src/libswamp/datastores/status.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/status_test.ts
+++ b/src/libswamp/datastores/status_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/sync_test.ts
+++ b/src/libswamp/datastores/sync_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/type_search.ts
+++ b/src/libswamp/datastores/type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/datastores/type_search_test.ts
+++ b/src/libswamp/datastores/type_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/drivers/type_search.ts
+++ b/src/libswamp/drivers/type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/drivers/type_search_test.ts
+++ b/src/libswamp/drivers/type_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/errors.ts
+++ b/src/libswamp/errors.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/errors_test.ts
+++ b/src/libswamp/errors_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/deprecate.ts
+++ b/src/libswamp/extensions/deprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/deprecate_test.ts
+++ b/src/libswamp/extensions/deprecate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor_aggregate.ts
+++ b/src/libswamp/extensions/doctor_aggregate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor_aggregate_test.ts
+++ b/src/libswamp/extensions/doctor_aggregate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor_repair.ts
+++ b/src/libswamp/extensions/doctor_repair.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor_repair_test.ts
+++ b/src/libswamp/extensions/doctor_repair_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/enumerate_pulled.ts
+++ b/src/libswamp/extensions/enumerate_pulled.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/enumerate_pulled_test.ts
+++ b/src/libswamp/extensions/enumerate_pulled_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/fmt.ts
+++ b/src/libswamp/extensions/fmt.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/fmt_test.ts
+++ b/src/libswamp/extensions/fmt_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/info_test.ts
+++ b/src/libswamp/extensions/info_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/install_extension_service.ts
+++ b/src/libswamp/extensions/install_extension_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/list.ts
+++ b/src/libswamp/extensions/list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/list_test.ts
+++ b/src/libswamp/extensions/list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/local_edits.ts
+++ b/src/libswamp/extensions/local_edits.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/local_edits_test.ts
+++ b/src/libswamp/extensions/local_edits_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/module_reload_bench.ts
+++ b/src/libswamp/extensions/module_reload_bench.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/reconcile_from_disk_bench.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_bench.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/reconcile_from_disk_service_test.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/remove_extension_service.ts
+++ b/src/libswamp/extensions/remove_extension_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/rm.ts
+++ b/src/libswamp/extensions/rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/rm_test.ts
+++ b/src/libswamp/extensions/rm_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/search_test.ts
+++ b/src/libswamp/extensions/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust.ts
+++ b/src/libswamp/extensions/trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_add.ts
+++ b/src/libswamp/extensions/trust_add.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_add_test.ts
+++ b/src/libswamp/extensions/trust_add_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_auto_trust.ts
+++ b/src/libswamp/extensions/trust_auto_trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_auto_trust_test.ts
+++ b/src/libswamp/extensions/trust_auto_trust_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_list.ts
+++ b/src/libswamp/extensions/trust_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_list_test.ts
+++ b/src/libswamp/extensions/trust_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_rm.ts
+++ b/src/libswamp/extensions/trust_rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_rm_test.ts
+++ b/src/libswamp/extensions/trust_rm_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/trust_test.ts
+++ b/src/libswamp/extensions/trust_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/undeprecate.ts
+++ b/src/libswamp/extensions/undeprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/undeprecate_test.ts
+++ b/src/libswamp/extensions/undeprecate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/unyank.ts
+++ b/src/libswamp/extensions/unyank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/unyank_test.ts
+++ b/src/libswamp/extensions/unyank_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/upgrade_extension_service.ts
+++ b/src/libswamp/extensions/upgrade_extension_service.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/upgrade_extension_service_test.ts
+++ b/src/libswamp/extensions/upgrade_extension_service_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/version_test.ts
+++ b/src/libswamp/extensions/version_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/yank.ts
+++ b/src/libswamp/extensions/yank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/extensions/yank_test.ts
+++ b/src/libswamp/extensions/yank_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/comment.ts
+++ b/src/libswamp/issues/comment.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/comment_test.ts
+++ b/src/libswamp/issues/comment_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/create.ts
+++ b/src/libswamp/issues/create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/create_test.ts
+++ b/src/libswamp/issues/create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -238,13 +238,13 @@ Deno.test("issueCreate: extension body contains Upstream repository line when se
     type: "bug",
     extensionName: "@swamp/aws",
     extensionVersion: "2026.04.22.1",
-    repositoryUrl: "https://github.com/systeminit/swamp-aws",
+    repositoryUrl: "https://github.com/swamp-club/swamp-aws",
     reporterContext: SAMPLE_CONTEXT,
   }));
 
   assertStringIncludes(
     captured?.body ?? "",
-    "Upstream repository: https://github.com/systeminit/swamp-aws",
+    "Upstream repository: https://github.com/swamp-club/swamp-aws",
   );
 });
 

--- a/src/libswamp/issues/edit.ts
+++ b/src/libswamp/issues/edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/edit_test.ts
+++ b/src/libswamp/issues/edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/get.ts
+++ b/src/libswamp/issues/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/get_test.ts
+++ b/src/libswamp/issues/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/search.ts
+++ b/src/libswamp/issues/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/issues/search_test.ts
+++ b/src/libswamp/issues/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/create_test.ts
+++ b/src/libswamp/models/create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/delete_test.ts
+++ b/src/libswamp/models/delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/doctor_secrets.ts
+++ b/src/libswamp/models/doctor_secrets.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/doctor_secrets_test.ts
+++ b/src/libswamp/models/doctor_secrets_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/edit.ts
+++ b/src/libswamp/models/edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/edit_test.ts
+++ b/src/libswamp/models/edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/evaluate_test.ts
+++ b/src/libswamp/models/evaluate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/get_test.ts
+++ b/src/libswamp/models/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/method_describe.ts
+++ b/src/libswamp/models/method_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/method_describe_test.ts
+++ b/src/libswamp/models/method_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/method_history_logs.ts
+++ b/src/libswamp/models/method_history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/method_history_logs_test.ts
+++ b/src/libswamp/models/method_history_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/model_method_run_view.ts
+++ b/src/libswamp/models/model_method_run_view.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_data_test.ts
+++ b/src/libswamp/models/output_data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_get.ts
+++ b/src/libswamp/models/output_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_get_test.ts
+++ b/src/libswamp/models/output_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_logs_test.ts
+++ b/src/libswamp/models/output_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_search.ts
+++ b/src/libswamp/models/output_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/output_search_test.ts
+++ b/src/libswamp/models/output_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/search.ts
+++ b/src/libswamp/models/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/search_test.ts
+++ b/src/libswamp/models/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/models/validate_test.ts
+++ b/src/libswamp/models/validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/repo/init_test.ts
+++ b/src/libswamp/repo/init_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/describe.ts
+++ b/src/libswamp/reports/describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/describe_test.ts
+++ b/src/libswamp/reports/describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/get.ts
+++ b/src/libswamp/reports/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/get_test.ts
+++ b/src/libswamp/reports/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/report_views.ts
+++ b/src/libswamp/reports/report_views.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/search.ts
+++ b/src/libswamp/reports/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/search_test.ts
+++ b/src/libswamp/reports/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/type_search.ts
+++ b/src/libswamp/reports/type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/reports/type_search_test.ts
+++ b/src/libswamp/reports/type_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/clean.ts
+++ b/src/libswamp/source/clean.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/clean_test.ts
+++ b/src/libswamp/source/clean_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/fetch.ts
+++ b/src/libswamp/source/fetch.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/fetch_test.ts
+++ b/src/libswamp/source/fetch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/path.ts
+++ b/src/libswamp/source/path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/source/path_test.ts
+++ b/src/libswamp/source/path_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/list.ts
+++ b/src/libswamp/sources/list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/list_test.ts
+++ b/src/libswamp/sources/list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/remove_test.ts
+++ b/src/libswamp/sources/remove_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/sources/source_events.ts
+++ b/src/libswamp/sources/source_events.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream.ts
+++ b/src/libswamp/stream.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream/async_queue.ts
+++ b/src/libswamp/stream/async_queue.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream/async_queue_test.ts
+++ b/src/libswamp/stream/async_queue_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream/merge.ts
+++ b/src/libswamp/stream/merge.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream/merge_test.ts
+++ b/src/libswamp/stream/merge_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/stream_test.ts
+++ b/src/libswamp/stream_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/summary/summarise.ts
+++ b/src/libswamp/summary/summarise.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/summary/summarise_test.ts
+++ b/src/libswamp/summary/summarise_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/telemetry/stats.ts
+++ b/src/libswamp/telemetry/stats.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/telemetry/stats_test.ts
+++ b/src/libswamp/telemetry/stats_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/testing.ts
+++ b/src/libswamp/testing.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/testing_test.ts
+++ b/src/libswamp/testing_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/describe.ts
+++ b/src/libswamp/types/describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/describe_test.ts
+++ b/src/libswamp/types/describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/schema_helpers_test.ts
+++ b/src/libswamp/types/schema_helpers_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/search.ts
+++ b/src/libswamp/types/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/types/search_test.ts
+++ b/src/libswamp/types/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/update/check.ts
+++ b/src/libswamp/update/check.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/update/check_test.ts
+++ b/src/libswamp/update/check_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/annotate.ts
+++ b/src/libswamp/vaults/annotate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/annotate_test.ts
+++ b/src/libswamp/vaults/annotate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/create.ts
+++ b/src/libswamp/vaults/create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/create_test.ts
+++ b/src/libswamp/vaults/create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/describe.ts
+++ b/src/libswamp/vaults/describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/describe_test.ts
+++ b/src/libswamp/vaults/describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/edit.ts
+++ b/src/libswamp/vaults/edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/edit_test.ts
+++ b/src/libswamp/vaults/edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/get.ts
+++ b/src/libswamp/vaults/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/get_test.ts
+++ b/src/libswamp/vaults/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/inspect_test.ts
+++ b/src/libswamp/vaults/inspect_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/list_keys.ts
+++ b/src/libswamp/vaults/list_keys.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/list_keys_test.ts
+++ b/src/libswamp/vaults/list_keys_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/migrate.ts
+++ b/src/libswamp/vaults/migrate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/migrate_test.ts
+++ b/src/libswamp/vaults/migrate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/put.ts
+++ b/src/libswamp/vaults/put.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/put_test.ts
+++ b/src/libswamp/vaults/put_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/read_secret.ts
+++ b/src/libswamp/vaults/read_secret.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/read_secret_test.ts
+++ b/src/libswamp/vaults/read_secret_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/search.ts
+++ b/src/libswamp/vaults/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/search_test.ts
+++ b/src/libswamp/vaults/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/type_search.ts
+++ b/src/libswamp/vaults/type_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/vaults/type_search_test.ts
+++ b/src/libswamp/vaults/type_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/version.ts
+++ b/src/libswamp/version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/version_test.ts
+++ b/src/libswamp/version_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/create.ts
+++ b/src/libswamp/workflows/create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/create_test.ts
+++ b/src/libswamp/workflows/create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/delete_test.ts
+++ b/src/libswamp/workflows/delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/doctor.ts
+++ b/src/libswamp/workflows/doctor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/doctor_test.ts
+++ b/src/libswamp/workflows/doctor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/edit_test.ts
+++ b/src/libswamp/workflows/edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/get_test.ts
+++ b/src/libswamp/workflows/get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_get.ts
+++ b/src/libswamp/workflows/history_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_get_test.ts
+++ b/src/libswamp/workflows/history_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_logs.ts
+++ b/src/libswamp/workflows/history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_logs_test.ts
+++ b/src/libswamp/workflows/history_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/run_search.ts
+++ b/src/libswamp/workflows/run_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/run_search_test.ts
+++ b/src/libswamp/workflows/run_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/schema.ts
+++ b/src/libswamp/workflows/schema.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/schema_test.ts
+++ b/src/libswamp/workflows/schema_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/search.ts
+++ b/src/libswamp/workflows/search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/search_test.ts
+++ b/src/libswamp/workflows/search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/telemetry_bridge.ts
+++ b/src/libswamp/workflows/telemetry_bridge.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/telemetry_bridge_test.ts
+++ b/src/libswamp/workflows/telemetry_bridge_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/validate_test.ts
+++ b/src/libswamp/workflows/validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/watcher.ts
+++ b/src/libswamp/workflows/watcher.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/watcher_test.ts
+++ b/src/libswamp/workflows/watcher_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/markdown_renderer.ts
+++ b/src/presentation/markdown_renderer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/markdown_renderer_test.ts
+++ b/src/presentation/markdown_renderer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/hooks/mod.ts
+++ b/src/presentation/output/hooks/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/hooks/useScrollableList.ts
+++ b/src/presentation/output/hooks/useScrollableList.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/hooks/useScrollableList_test.ts
+++ b/src/presentation/output/hooks/useScrollableList_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/hooks/useTerminalSize.ts
+++ b/src/presentation/output/hooks/useTerminalSize.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/ink_lifecycle.ts
+++ b/src/presentation/output/ink_lifecycle.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/log_file_reader.ts
+++ b/src/presentation/output/log_file_reader.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/log_file_reader_test.ts
+++ b/src/presentation/output/log_file_reader_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/model_get_output_test.ts
+++ b/src/presentation/output/model_get_output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/output.ts
+++ b/src/presentation/output/output.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/output_test.ts
+++ b/src/presentation/output/output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/terminal_size.ts
+++ b/src/presentation/output/terminal_size.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/terminal_size_test.ts
+++ b/src/presentation/output/terminal_size_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/type_describe_output_test.ts
+++ b/src/presentation/output/type_describe_output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/update_notification_output_test.ts
+++ b/src/presentation/output/update_notification_output_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/utils/duration_formatter.ts
+++ b/src/presentation/output/utils/duration_formatter.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/output/utils/duration_formatter_test.ts
+++ b/src/presentation/output/utils/duration_formatter_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderer.ts
+++ b/src/presentation/renderer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/audit_doctor.ts
+++ b/src/presentation/renderers/audit_doctor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/audit_timeline.ts
+++ b/src/presentation/renderers/audit_timeline.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/auth_login.ts
+++ b/src/presentation/renderers/auth_login.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/auth_logout.ts
+++ b/src/presentation/renderers/auth_logout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/auth_whoami.ts
+++ b/src/presentation/renderers/auth_whoami.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/auth_whoami_test.ts
+++ b/src/presentation/renderers/auth_whoami_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/help_bar.tsx
+++ b/src/presentation/renderers/components/help_bar.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/hooks/mod.ts
+++ b/src/presentation/renderers/components/hooks/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/hooks/use_preview_fetch.ts
+++ b/src/presentation/renderers/components/hooks/use_preview_fetch.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/hooks/use_preview_fetch_test.ts
+++ b/src/presentation/renderers/components/hooks/use_preview_fetch_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/hooks/use_preview_scroll.ts
+++ b/src/presentation/renderers/components/hooks/use_preview_scroll.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/picker_borders.tsx
+++ b/src/presentation/renderers/components/picker_borders.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/picker_layout.ts
+++ b/src/presentation/renderers/components/picker_layout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/picker_layout_test.ts
+++ b/src/presentation/renderers/components/picker_layout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/preview_pane.tsx
+++ b/src/presentation/renderers/components/preview_pane.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/results_list.tsx
+++ b/src/presentation/renderers/components/results_list.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/search_picker.tsx
+++ b/src/presentation/renderers/components/search_picker.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/components/search_tui.tsx
+++ b/src/presentation/renderers/components/search_tui.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_delete.ts
+++ b/src/presentation/renderers/data_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_delete_test.ts
+++ b/src/presentation/renderers/data_delete_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_gc.ts
+++ b/src/presentation/renderers/data_gc.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_gc_test.ts
+++ b/src/presentation/renderers/data_gc_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_get.ts
+++ b/src/presentation/renderers/data_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_get_test.ts
+++ b/src/presentation/renderers/data_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_list.ts
+++ b/src/presentation/renderers/data_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_list_test.ts
+++ b/src/presentation/renderers/data_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query.ts
+++ b/src/presentation/renderers/data_query.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui.tsx
+++ b/src/presentation/renderers/data_query_tui.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/autocomplete_dropdown.tsx
+++ b/src/presentation/renderers/data_query_tui/autocomplete_dropdown.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/cel_input.tsx
+++ b/src/presentation/renderers/data_query_tui/cel_input.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/cel_input_test.ts
+++ b/src/presentation/renderers/data_query_tui/cel_input_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/hooks/use_debounced_query.ts
+++ b/src/presentation/renderers/data_query_tui/hooks/use_debounced_query.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/layout.ts
+++ b/src/presentation/renderers/data_query_tui/layout.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_query_tui/layout_test.ts
+++ b/src/presentation/renderers/data_query_tui/layout_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_rename.ts
+++ b/src/presentation/renderers/data_rename.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_search.tsx
+++ b/src/presentation/renderers/data_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_versions.ts
+++ b/src/presentation/renderers/data_versions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/data_versions_test.ts
+++ b/src/presentation/renderers/data_versions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_compact.ts
+++ b/src/presentation/renderers/datastore_compact.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_lock.ts
+++ b/src/presentation/renderers/datastore_lock.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_namespace_list.ts
+++ b/src/presentation/renderers/datastore_namespace_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_namespace_set.ts
+++ b/src/presentation/renderers/datastore_namespace_set.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_namespace_unset.ts
+++ b/src/presentation/renderers/datastore_namespace_unset.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_status.ts
+++ b/src/presentation/renderers/datastore_status.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_sync.ts
+++ b/src/presentation/renderers/datastore_sync.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_sync_test.ts
+++ b/src/presentation/renderers/datastore_sync_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/datastore_type_search.tsx
+++ b/src/presentation/renderers/datastore_type_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_install.ts
+++ b/src/presentation/renderers/doctor_install.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_install_test.ts
+++ b/src/presentation/renderers/doctor_install_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_secrets.ts
+++ b/src/presentation/renderers/doctor_secrets.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/doctor_secrets_test.ts
+++ b/src/presentation/renderers/doctor_secrets_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/driver_type_search.tsx
+++ b/src/presentation/renderers/driver_type_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_deprecate.ts
+++ b/src/presentation/renderers/extension_deprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_fmt.ts
+++ b/src/presentation/renderers/extension_fmt.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_install.ts
+++ b/src/presentation/renderers/extension_install.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_list_test.ts
+++ b/src/presentation/renderers/extension_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_outdated.ts
+++ b/src/presentation/renderers/extension_outdated.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_outdated_test.ts
+++ b/src/presentation/renderers/extension_outdated_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_pull.ts
+++ b/src/presentation/renderers/extension_pull.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_rm.ts
+++ b/src/presentation/renderers/extension_rm.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_source_list.ts
+++ b/src/presentation/renderers/extension_source_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_source_list_test.ts
+++ b/src/presentation/renderers/extension_source_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_source_modify.ts
+++ b/src/presentation/renderers/extension_source_modify.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_undeprecate.ts
+++ b/src/presentation/renderers/extension_undeprecate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_unyank.ts
+++ b/src/presentation/renderers/extension_unyank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_update.ts
+++ b/src/presentation/renderers/extension_update.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_version.ts
+++ b/src/presentation/renderers/extension_version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/extension_yank.ts
+++ b/src/presentation/renderers/extension_yank.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/input_file_select.tsx
+++ b/src/presentation/renderers/input_file_select.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
@@ -74,7 +74,7 @@ class LogIssueCreateRenderer implements Renderer<IssueCreateEvent> {
           );
           logger.info(
             "If your email client did not open, send manually to {email}",
-            { email: "support@systeminit.com" },
+            { email: "support@swamp-club.com" },
           );
         }
       },

--- a/src/presentation/renderers/issue_create_test.ts
+++ b/src/presentation/renderers/issue_create_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_edit.ts
+++ b/src/presentation/renderers/issue_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_edit_test.ts
+++ b/src/presentation/renderers/issue_edit_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_get.ts
+++ b/src/presentation/renderers/issue_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_search.ts
+++ b/src/presentation/renderers/issue_search.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/issue_search_test.ts
+++ b/src/presentation/renderers/issue_search_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_create.ts
+++ b/src/presentation/renderers/model_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_delete.ts
+++ b/src/presentation/renderers/model_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_edit.ts
+++ b/src/presentation/renderers/model_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_evaluate.ts
+++ b/src/presentation/renderers/model_evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_get_test.ts
+++ b/src/presentation/renderers/model_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_describe.ts
+++ b/src/presentation/renderers/model_method_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_describe_test.ts
+++ b/src/presentation/renderers/model_method_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_history_logs.ts
+++ b/src/presentation/renderers/model_method_history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_history_logs_test.ts
+++ b/src/presentation/renderers/model_method_history_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_method_run_test.ts
+++ b/src/presentation/renderers/model_method_run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_data.ts
+++ b/src/presentation/renderers/model_output_data.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_data_test.ts
+++ b/src/presentation/renderers/model_output_data_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_get.ts
+++ b/src/presentation/renderers/model_output_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_get_test.ts
+++ b/src/presentation/renderers/model_output_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_logs.ts
+++ b/src/presentation/renderers/model_output_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_logs_test.ts
+++ b/src/presentation/renderers/model_output_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_output_search.tsx
+++ b/src/presentation/renderers/model_output_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_validate.ts
+++ b/src/presentation/renderers/model_validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/model_validate_test.ts
+++ b/src/presentation/renderers/model_validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_describe.ts
+++ b/src/presentation/renderers/report_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_describe_test.ts
+++ b/src/presentation/renderers/report_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_get.ts
+++ b/src/presentation/renderers/report_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_get_test.ts
+++ b/src/presentation/renderers/report_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_search.tsx
+++ b/src/presentation/renderers/report_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/report_type_search.tsx
+++ b/src/presentation/renderers/report_type_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/search_renderer.ts
+++ b/src/presentation/renderers/search_renderer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/source_clean.ts
+++ b/src/presentation/renderers/source_clean.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/source_fetch.ts
+++ b/src/presentation/renderers/source_fetch.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/source_path.ts
+++ b/src/presentation/renderers/source_path.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/summarise.ts
+++ b/src/presentation/renderers/summarise.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/summarise_test.ts
+++ b/src/presentation/renderers/summarise_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/telemetry_stats.ts
+++ b/src/presentation/renderers/telemetry_stats.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/telemetry_stats_test.ts
+++ b/src/presentation/renderers/telemetry_stats_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_auto_trust.ts
+++ b/src/presentation/renderers/trust_auto_trust.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_auto_trust_test.ts
+++ b/src/presentation/renderers/trust_auto_trust_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_list.ts
+++ b/src/presentation/renderers/trust_list.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_list_test.ts
+++ b/src/presentation/renderers/trust_list_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_modify.ts
+++ b/src/presentation/renderers/trust_modify.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/trust_modify_test.ts
+++ b/src/presentation/renderers/trust_modify_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/type_describe.ts
+++ b/src/presentation/renderers/type_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/type_describe_test.ts
+++ b/src/presentation/renderers/type_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/type_search.tsx
+++ b/src/presentation/renderers/type_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/update_check.ts
+++ b/src/presentation/renderers/update_check.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/update_notification.ts
+++ b/src/presentation/renderers/update_notification.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_annotate.ts
+++ b/src/presentation/renderers/vault_annotate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_create.ts
+++ b/src/presentation/renderers/vault_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_describe.ts
+++ b/src/presentation/renderers/vault_describe.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_describe_test.ts
+++ b/src/presentation/renderers/vault_describe_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_edit.ts
+++ b/src/presentation/renderers/vault_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_get.ts
+++ b/src/presentation/renderers/vault_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_get_test.ts
+++ b/src/presentation/renderers/vault_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_inspect.ts
+++ b/src/presentation/renderers/vault_inspect.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_list_keys.ts
+++ b/src/presentation/renderers/vault_list_keys.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_list_keys_test.ts
+++ b/src/presentation/renderers/vault_list_keys_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_migrate.ts
+++ b/src/presentation/renderers/vault_migrate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_put.ts
+++ b/src/presentation/renderers/vault_put.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_read_secret.ts
+++ b/src/presentation/renderers/vault_read_secret.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_search.tsx
+++ b/src/presentation/renderers/vault_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/vault_type_search.tsx
+++ b/src/presentation/renderers/vault_type_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/version.ts
+++ b/src/presentation/renderers/version.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_action_select.tsx
+++ b/src/presentation/renderers/workflow_action_select.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_create.ts
+++ b/src/presentation/renderers/workflow_create.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_delete.ts
+++ b/src/presentation/renderers/workflow_delete.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_doctor.ts
+++ b/src/presentation/renderers/workflow_doctor.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_doctor_test.ts
+++ b/src/presentation/renderers/workflow_doctor_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_edit.ts
+++ b/src/presentation/renderers/workflow_edit.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_evaluate.ts
+++ b/src/presentation/renderers/workflow_evaluate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_get.ts
+++ b/src/presentation/renderers/workflow_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_get_test.ts
+++ b/src/presentation/renderers/workflow_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_history_get.ts
+++ b/src/presentation/renderers/workflow_history_get.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_history_get_test.ts
+++ b/src/presentation/renderers/workflow_history_get_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_history_logs.ts
+++ b/src/presentation/renderers/workflow_history_logs.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_history_logs_test.ts
+++ b/src/presentation/renderers/workflow_history_logs_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_history_search.tsx
+++ b/src/presentation/renderers/workflow_history_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_search.tsx
+++ b/src/presentation/renderers/workflow_run_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_test.ts
+++ b/src/presentation/renderers/workflow_run_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/budget.ts
+++ b/src/presentation/renderers/workflow_run_tree/budget.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/budget_test.ts
+++ b/src/presentation/renderers/workflow_run_tree/budget_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/active_zone.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/active_zone.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/data_hints.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/data_hints.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/job_line.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/job_line.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/peek_lines.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/peek_lines.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/report_block.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/report_block.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/scrollback_item.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/scrollback_item.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/step_line.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/hooks.ts
+++ b/src/presentation/renderers/workflow_run_tree/hooks.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/mod.ts
+++ b/src/presentation/renderers/workflow_run_tree/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/renderer_test.ts
+++ b/src/presentation/renderers/workflow_run_tree/renderer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/state_test.ts
+++ b/src/presentation/renderers/workflow_run_tree/state_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/workflow_run_tree.tsx
+++ b/src/presentation/renderers/workflow_run_tree/workflow_run_tree.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_run_tree/workflow_run_tree_test.tsx
+++ b/src/presentation/renderers/workflow_run_tree/workflow_run_tree_test.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_schema.ts
+++ b/src/presentation/renderers/workflow_schema.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_schema_test.ts
+++ b/src/presentation/renderers/workflow_schema_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_search.tsx
+++ b/src/presentation/renderers/workflow_search.tsx
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_validate.ts
+++ b/src/presentation/renderers/workflow_validate.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/renderers/workflow_validate_test.ts
+++ b/src/presentation/renderers/workflow_validate_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/presentation/spinner.ts
+++ b/src/presentation/spinner.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/mod.ts
+++ b/src/serve/mod.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/open/favicon.ts
+++ b/src/serve/open/favicon.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/open/http.ts
+++ b/src/serve/open/http.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/open/http_test.ts
+++ b/src/serve/open/http_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/open/ui.ts
+++ b/src/serve/open/ui.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/protocol_test.ts
+++ b/src/serve/protocol_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/serializer.ts
+++ b/src/serve/serializer.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/serializer_test.ts
+++ b/src/serve/serializer_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -1,5 +1,5 @@
 // Swamp, an Automation Framework
-// Copyright (C) 2026 System Initiative, Inc.
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //


### PR DESCRIPTION
## Summary

Elder Swamp Club, Inc. has acquired the copyright from System Initiative, Inc. This PR updates all references across the codebase in two commits:

**Commit 1 — Corporate entity + infrastructure:**
- **Copyright headers**: `LICENSE`, `FILE-LICENSE-TEMPLATE.md`, and 5 extension source files
- **Legal docs**: `CONTRIBUTING.md` (employer/copyright holder), `TRADEMARKS.md` (trademark ownership attribution)
- **Contact emails**: `security@`, `legal@`, `code_of_conduct@`, `support@` moved from `@systeminit.com` → `@swamp-club.com`
- **GitHub org**: `systeminit/swamp` → `swamp-club/swamp` in source constants, tests, docs, skills, agent constraints, and CI action README
- **Website**: `systeminit.com` → `swamp-club.com` in Bug Bounty scope table
- **README**: "System Initiative engineers" → "Elder Swamp Club engineers"

**Commit 2 — Product/community branding (per legal: product and community are "Swamp Club"):**
- **TRADEMARKS.md**: Mark table updated (removed SYSTEM INITIATIVE/SI, kept Swamp Club marks), all usage examples, attribution notice
- **BUG_BOUNTY.md**: Program name, bounty standards, scope references
- **CODE_OF_CONDUCT.md**: Community name, moderation team, venues
- **whoami_test.ts**: Mock org name in test fixture

### Intentionally unchanged
- JSR package scopes (`@systeminit/swamp-testing`, `@systeminit/swamp-lib`) — requires registry migration
- Docker image tags (`systeminit/swamp:*`) — requires Docker Hub migration
- Local filesystem paths in test fixtures

## Test plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes
- [x] `deno run test` — 6678 passed, 0 failed
- [x] `deno run compile` — passes
- [x] `grep -rn "System Initiative"` returns zero hits (excluding worktrees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)