### PR TITLE
feat(datastore): namespace migration commands (swamp-club#548)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -227,6 +227,18 @@ datastore-tier subdir uniformly. Solo mode (empty namespace) produces
 byte-identical paths to a non-namespaced repo — no prefix, no stray separator.
 The local tier (`localPath`, `.swamp/`) is never namespaced.
 
+#### Migration
+
+`swamp datastore namespace migrate` re-keys data from the solo layout to the
+namespaced layout. For each directory in `DEFAULT_DATASTORE_SUBDIRS` that exists
+at the un-namespaced path `{base}/{subdir}/`, it moves it to
+`{base}/{namespace}/{subdir}/` via `Deno.rename()`. The catalog is invalidated
+after migration so backfill rebuilds from the new paths.
+
+The reverse (`--reverse`) flattens namespaced paths back to solo layout, with
+conflict detection — it refuses if the un-namespaced path already contains data.
+`swamp datastore namespace unset --migrate` combines unset + reverse migration.
+
 Two things are deliberately **not** namespaced:
 
 - **The `_catalog.db` catalog** is repo-local at `{repoDir}/.swamp/data/`,

--- a/integration/giga_swamp_namespace_migrate_test.ts
+++ b/integration/giga_swamp_namespace_migrate_test.ts
@@ -1,0 +1,383 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration test for giga-swamp Phase 7 — namespace migration.
+ *
+ * Tests the full round-trip: solo repo with data → namespace set → migrate →
+ * verify namespaced layout → namespace unset --migrate → verify solo layout.
+ * Verifies data integrity (file count + content) at every step.
+ */
+
+import { assertEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import {
+  createLibSwampContext,
+  datastoreNamespaceMigrate,
+  type NamespaceMigrateEvent,
+} from "../src/libswamp/mod.ts";
+import { collect } from "../src/libswamp/testing.ts";
+import { DEFAULT_DATASTORE_SUBDIRS } from "../src/domain/datastore/datastore_config.ts";
+import {
+  removeNamespaceManifest,
+  writeNamespaceManifest,
+} from "../src/infrastructure/persistence/namespace_manifest.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import {
+  catalogDbPath,
+} from "../src/infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-migrate-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function countFiles(dir: string): Promise<number> {
+  let count = 0;
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      if (entry.isFile) count++;
+      if (entry.isDirectory) count += await countFiles(join(dir, entry.name));
+    }
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return 0;
+    throw e;
+  }
+  return count;
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const stat = await Deno.stat(path);
+    return stat.isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+async function dirSize(
+  path: string,
+): Promise<{ fileCount: number; totalBytes: number }> {
+  let fileCount = 0;
+  let totalBytes = 0;
+  try {
+    for await (const entry of Deno.readDir(path)) {
+      if (entry.isFile) {
+        fileCount++;
+        const stat = await Deno.stat(join(path, entry.name));
+        totalBytes += stat.size;
+      }
+      if (entry.isDirectory) {
+        const sub = await dirSize(join(path, entry.name));
+        fileCount += sub.fileCount;
+        totalBytes += sub.totalBytes;
+      }
+    }
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      return { fileCount: 0, totalBytes: 0 };
+    }
+    throw e;
+  }
+  return { fileCount, totalBytes };
+}
+
+function buildDeps(
+  dsPath: string,
+  namespace: string,
+  catalogStore: CatalogStore,
+) {
+  return {
+    getDatastorePath: () => dsPath,
+    getNamespace: () => namespace,
+    dirExists,
+    dirSize,
+    renameDir: (source: string, destination: string) =>
+      Deno.rename(source, destination),
+    ensureDir: (path: string) => ensureDir(path),
+    invalidateCatalog: () => catalogStore.invalidate(),
+    markDirtyBulk: () => Promise.resolve(),
+    removeNamespaceManifest: (ns: string) =>
+      removeNamespaceManifest(dsPath, ns),
+    isExtensionDatastore: false,
+  };
+}
+
+Deno.test("namespace migrate: full round-trip solo → namespaced → solo", async () => {
+  await withTempDir(async (root) => {
+    const repoDir = join(root, "repo");
+    const dsPath = join(root, "ds");
+    const namespace = "infra";
+
+    await ensureDir(join(repoDir, ".swamp"));
+    await ensureDir(dsPath);
+
+    // Create solo-mode data in a few subdirs
+    const testContent = '{"test": true}';
+    for (const subdir of ["data", "outputs", "audit"]) {
+      const dir = join(dsPath, subdir, "test-model", "v1");
+      await ensureDir(dir);
+      await Deno.writeTextFile(join(dir, "raw"), testContent);
+    }
+
+    // Write a namespace manifest (simulates namespace set)
+    await writeNamespaceManifest(dsPath, namespace, "repo-1");
+
+    const soloFileCount = await countFiles(dsPath);
+    // 3 data files + 1 manifest file
+    assertEquals(soloFileCount, 4);
+
+    // Create catalog
+    const catalogPath = catalogDbPath(repoDir);
+    const catalogStore = new CatalogStore(catalogPath);
+
+    try {
+      const ctx = createLibSwampContext({});
+
+      // --- Forward migration: solo → namespaced ---
+      const fwdDeps = buildDeps(dsPath, namespace, catalogStore);
+      const fwdEvents = await collect<NamespaceMigrateEvent>(
+        datastoreNamespaceMigrate(ctx, fwdDeps, {
+          confirm: true,
+          reverse: false,
+        }),
+      );
+
+      const fwdPreview = fwdEvents.find((e) => e.kind === "preview");
+      assertEquals(fwdPreview?.kind, "preview");
+      if (fwdPreview?.kind === "preview") {
+        assertEquals(fwdPreview.data.directories.length, 3);
+        assertEquals(fwdPreview.data.totalFiles, 3);
+      }
+
+      const fwdCompleted = fwdEvents.find((e) => e.kind === "completed");
+      assertEquals(fwdCompleted?.kind, "completed");
+      if (fwdCompleted?.kind === "completed") {
+        assertEquals(fwdCompleted.data.migratedDirectories.length, 3);
+      }
+
+      // Verify data moved to namespaced paths
+      for (const subdir of ["data", "outputs", "audit"]) {
+        assertEquals(
+          await dirExists(join(dsPath, namespace, subdir)),
+          true,
+          `${subdir} should exist at namespaced path`,
+        );
+        assertEquals(
+          await dirExists(join(dsPath, subdir)),
+          false,
+          `${subdir} should NOT exist at solo path`,
+        );
+        // Verify content integrity
+        const content = await Deno.readTextFile(
+          join(dsPath, namespace, subdir, "test-model", "v1", "raw"),
+        );
+        assertEquals(content, testContent);
+      }
+
+      // --- Dry-run reverse: should NOT move anything ---
+      const dryDeps = buildDeps(dsPath, namespace, catalogStore);
+      const dryEvents = await collect<NamespaceMigrateEvent>(
+        datastoreNamespaceMigrate(ctx, dryDeps, {
+          confirm: false,
+          reverse: true,
+        }),
+      );
+
+      const dryPreview = dryEvents.find((e) => e.kind === "preview");
+      assertEquals(dryPreview?.kind, "preview");
+      if (dryPreview?.kind === "preview") {
+        assertEquals(dryPreview.data.reverse, true);
+        assertEquals(dryPreview.data.directories.length, 3);
+      }
+
+      // Verify nothing actually moved
+      for (const subdir of ["data", "outputs", "audit"]) {
+        assertEquals(
+          await dirExists(join(dsPath, namespace, subdir)),
+          true,
+          `${subdir} should still be at namespaced path after dry-run`,
+        );
+      }
+
+      // --- Reverse migration: namespaced → solo ---
+      const revDeps = buildDeps(dsPath, namespace, catalogStore);
+      const revEvents = await collect<NamespaceMigrateEvent>(
+        datastoreNamespaceMigrate(ctx, revDeps, {
+          confirm: true,
+          reverse: true,
+        }),
+      );
+
+      const revCompleted = revEvents.find((e) => e.kind === "completed");
+      assertEquals(revCompleted?.kind, "completed");
+      if (revCompleted?.kind === "completed") {
+        assertEquals(revCompleted.data.migratedDirectories.length, 3);
+        assertEquals(revCompleted.data.reverse, true);
+      }
+
+      // Verify data moved back to solo paths
+      for (const subdir of ["data", "outputs", "audit"]) {
+        assertEquals(
+          await dirExists(join(dsPath, subdir)),
+          true,
+          `${subdir} should be back at solo path`,
+        );
+        assertEquals(
+          await dirExists(join(dsPath, namespace, subdir)),
+          false,
+          `${subdir} should NOT exist at namespaced path`,
+        );
+        // Verify content integrity
+        const content = await Deno.readTextFile(
+          join(dsPath, subdir, "test-model", "v1", "raw"),
+        );
+        assertEquals(content, testContent);
+      }
+
+      // Verify manifest was removed on reverse migration
+      const manifestPath = join(dsPath, namespace, ".namespace.json");
+      let manifestExists = false;
+      try {
+        await Deno.stat(manifestPath);
+        manifestExists = true;
+      } catch {
+        manifestExists = false;
+      }
+      assertEquals(
+        manifestExists,
+        false,
+        "Manifest should be removed after reverse migration",
+      );
+    } finally {
+      catalogStore.close();
+    }
+  });
+});
+
+Deno.test("namespace migrate: conflict detection on reverse", async () => {
+  await withTempDir(async (root) => {
+    const dsPath = join(root, "ds");
+    const repoDir = join(root, "repo");
+    const namespace = "infra";
+
+    await ensureDir(join(repoDir, ".swamp"));
+
+    // Create data at both namespaced AND solo paths (conflict scenario)
+    await ensureDir(join(dsPath, namespace, "data", "model-a"));
+    await Deno.writeTextFile(
+      join(dsPath, namespace, "data", "model-a", "raw"),
+      "namespaced",
+    );
+    await ensureDir(join(dsPath, "data", "model-b"));
+    await Deno.writeTextFile(
+      join(dsPath, "data", "model-b", "raw"),
+      "solo",
+    );
+
+    const catalogPath = catalogDbPath(repoDir);
+    const catalogStore = new CatalogStore(catalogPath);
+
+    try {
+      const ctx = createLibSwampContext({});
+      const deps = buildDeps(dsPath, namespace, catalogStore);
+      const events = await collect<NamespaceMigrateEvent>(
+        datastoreNamespaceMigrate(ctx, deps, {
+          confirm: false,
+          reverse: true,
+        }),
+      );
+
+      assertEquals(events.length, 1);
+      assertEquals(events[0].kind, "error");
+      if (events[0].kind === "error") {
+        assertEquals(events[0].error.code, "validation_failed");
+      }
+    } finally {
+      catalogStore.close();
+    }
+  });
+});
+
+Deno.test("namespace migrate: skips subdirs that don't exist in source", async () => {
+  await withTempDir(async (root) => {
+    const dsPath = join(root, "ds");
+    const repoDir = join(root, "repo");
+    const namespace = "infra";
+
+    await ensureDir(join(repoDir, ".swamp"));
+
+    // Only create "data" — the other 15 subdirs don't exist
+    await ensureDir(join(dsPath, "data"));
+    await Deno.writeTextFile(join(dsPath, "data", "test.json"), "{}");
+
+    const catalogPath = catalogDbPath(repoDir);
+    const catalogStore = new CatalogStore(catalogPath);
+
+    try {
+      const ctx = createLibSwampContext({});
+      const deps = buildDeps(dsPath, namespace, catalogStore);
+      const events = await collect<NamespaceMigrateEvent>(
+        datastoreNamespaceMigrate(ctx, deps, {
+          confirm: true,
+          reverse: false,
+        }),
+      );
+
+      const preview = events.find((e) => e.kind === "preview");
+      if (preview?.kind === "preview") {
+        assertEquals(preview.data.directories.length, 1);
+        assertEquals(preview.data.directories[0].subdir, "data");
+      }
+
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind === "completed") {
+        assertEquals(completed.data.migratedDirectories, ["data"]);
+      }
+
+      // Only "data" should have moved
+      assertEquals(await dirExists(join(dsPath, namespace, "data")), true);
+      assertEquals(await dirExists(join(dsPath, "data")), false);
+
+      // All other subdirs should not exist at either path
+      for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
+        if (subdir === "data") continue;
+        assertEquals(
+          await dirExists(join(dsPath, subdir)),
+          false,
+        );
+        assertEquals(
+          await dirExists(join(dsPath, namespace, subdir)),
+          false,
+        );
+      }
+    } finally {
+      catalogStore.close();
+    }
+  });
+});

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -26,6 +26,7 @@ import { datastoreLockCommand } from "./datastore_lock.ts";
 import { datastoreCompactCommand } from "./datastore_compact.ts";
 import { datastoreCatalogPullCommand } from "./datastore_catalog_pull.ts";
 import {
+  datastoreNamespaceMigrateCommand,
   datastoreNamespaceSetCommand,
   datastoreNamespaceUnsetCommand,
 } from "./datastore_namespace.ts";
@@ -62,6 +63,7 @@ const datastoreNamespaceCommand = new Command()
   .action(groupCommandAction)
   .command("set", datastoreNamespaceSetCommand)
   .command("unset", datastoreNamespaceUnsetCommand)
+  .command("migrate", datastoreNamespaceMigrateCommand)
   .command("list", datastoreNamespacesCommand);
 
 export const datastoreCommand = new Command()

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -348,7 +348,7 @@ function buildMigrateDeps(
 }
 
 export const datastoreNamespaceMigrateCommand = new Command()
-  .description("Migrate data between solo and namespaced layouts")
+  .description("Migrate data to namespaced layout (use --reverse to undo)")
   .example(
     "Preview migration",
     "swamp datastore namespace migrate",

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -197,6 +197,21 @@ export const datastoreNamespaceUnsetCommand = new Command()
         );
       }
 
+      const namespaces = unsetProvider?.listNamespaces
+        ? await unsetProvider.listNamespaces(
+          (datastoreConfig as CustomDatastoreConfig).datastorePath,
+        )
+        : (await listNamespaceManifests(dsBasePath)).map((m) => m.namespace);
+
+      if (namespaces.length > 1) {
+        throw new UserError(
+          `Cannot unset namespace: datastore contains ${namespaces.length} namespaces ` +
+            `(${
+              namespaces.join(", ")
+            }). Unsetting is only allowed when a single namespace exists.`,
+        );
+      }
+
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const migrateDeps = buildMigrateDeps(
         repoDir,
@@ -311,8 +326,11 @@ function buildMigrateDeps(
     ensureDir: (path: string) => ensureDir(path),
     invalidateCatalog: () => {
       catalogStore = createCatalogStore(repoDir);
-      catalogStore.invalidate();
-      catalogStore.close();
+      try {
+        catalogStore.invalidate();
+      } finally {
+        catalogStore.close();
+      }
     },
     markDirtyBulk: async () => {
       if (!provider?.createSyncService) return;

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -18,12 +18,17 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
+import { ensureDir, walk } from "@std/fs";
 import {
   consumeStream,
   createLibSwampContext,
+  datastoreNamespaceMigrate,
   datastoreNamespaceSet,
   datastoreNamespaceUnset,
 } from "../../libswamp/mod.ts";
+import {
+  createNamespaceMigrateRenderer,
+} from "../../presentation/renderers/datastore_namespace_migrate.ts";
 import {
   createNamespaceSetRenderer,
 } from "../../presentation/renderers/datastore_namespace_set.ts";
@@ -42,7 +47,11 @@ import {
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import {
+  createCatalogStore,
+} from "../../infrastructure/persistence/repository_factory.ts";
+import {
   listNamespaceManifests,
+  removeNamespaceManifest,
   writeNamespaceManifest,
 } from "../../infrastructure/persistence/namespace_manifest.ts";
 import {
@@ -142,9 +151,21 @@ export const datastoreNamespaceSetCommand = new Command()
 export const datastoreNamespaceUnsetCommand = new Command()
   .description("Remove namespace from this repository")
   .example("Unset namespace", "swamp datastore namespace unset")
+  .example(
+    "Unset and reverse-migrate data",
+    "swamp datastore namespace unset --migrate --confirm",
+  )
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--migrate",
+    "Also reverse-migrate data back to un-namespaced layout",
+  )
+  .option(
+    "--confirm",
+    "Execute the migration (required with --migrate, ignored otherwise)",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -166,6 +187,45 @@ export const datastoreNamespaceUnsetCommand = new Command()
       await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
       const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
       unsetProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+    }
+
+    if (options.migrate) {
+      const savedNamespace = datastoreConfig.namespace;
+      if (!savedNamespace) {
+        throw new UserError(
+          "No namespace is configured. Nothing to unset or migrate.",
+        );
+      }
+
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const migrateDeps = buildMigrateDeps(
+        repoDir,
+        dsBasePath,
+        datastoreConfig,
+        savedNamespace,
+        unsetProvider,
+      );
+
+      const migrateRenderer = createNamespaceMigrateRenderer(
+        cliCtx.outputMode,
+      );
+      await consumeStream(
+        datastoreNamespaceMigrate(ctx, migrateDeps, {
+          confirm: !!options.confirm,
+          reverse: true,
+        }),
+        migrateRenderer.handlers(),
+      );
+
+      if (options.confirm) {
+        const current = await markerRepo.read(repoPath);
+        if (current?.datastore) {
+          delete current.datastore.namespace;
+          await markerRepo.write(repoPath, current);
+        }
+      }
+
+      return;
     }
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
@@ -192,6 +252,143 @@ export const datastoreNamespaceUnsetCommand = new Command()
     const renderer = createNamespaceUnsetRenderer(cliCtx.outputMode);
     await consumeStream(
       datastoreNamespaceUnset(ctx, deps),
+      renderer.handlers(),
+    );
+  });
+
+async function dirSize(
+  path: string,
+): Promise<{ fileCount: number; totalBytes: number }> {
+  let fileCount = 0;
+  let totalBytes = 0;
+  for await (
+    const entry of walk(path, { includeFiles: true, includeDirs: false })
+  ) {
+    fileCount++;
+    try {
+      const stat = await Deno.stat(entry.path);
+      totalBytes += stat.size;
+    } catch {
+      // Skip files that can't be stat'd
+    }
+  }
+  return { fileCount, totalBytes };
+}
+
+function buildMigrateDeps(
+  repoDir: string,
+  dsBasePath: string,
+  datastoreConfig: { namespace?: string; type: string },
+  namespace: string,
+  provider: DatastoreProvider | undefined,
+): Parameters<typeof datastoreNamespaceMigrate>[1] {
+  const isExtension = isCustomDatastoreConfig(
+    datastoreConfig as Parameters<typeof isCustomDatastoreConfig>[0],
+  );
+  const catalogStore = createCatalogStore(repoDir);
+
+  return {
+    getDatastorePath: () => dsBasePath,
+    getNamespace: () => namespace,
+    dirExists: async (path: string) => {
+      try {
+        const stat = await Deno.stat(path);
+        return stat.isDirectory;
+      } catch {
+        return false;
+      }
+    },
+    dirSize,
+    renameDir: (source: string, destination: string) =>
+      Deno.rename(source, destination),
+    ensureDir: (path: string) => ensureDir(path),
+    invalidateCatalog: () => {
+      catalogStore.invalidate();
+      catalogStore.close();
+    },
+    markDirtyBulk: async () => {
+      if (!provider?.createSyncService) return;
+      const customConfig = datastoreConfig as CustomDatastoreConfig;
+      const syncService = provider.createSyncService(
+        repoDir,
+        customConfig.cachePath ?? customConfig.datastorePath,
+      );
+      await syncService.markDirty();
+    },
+    removeNamespaceManifest: (ns: string) =>
+      removeNamespaceManifest(dsBasePath, ns),
+    isExtensionDatastore: isExtension,
+  };
+}
+
+export const datastoreNamespaceMigrateCommand = new Command()
+  .description("Migrate data between solo and namespaced layouts")
+  .example(
+    "Preview migration",
+    "swamp datastore namespace migrate",
+  )
+  .example(
+    "Execute migration",
+    "swamp datastore namespace migrate --confirm",
+  )
+  .example(
+    "Reverse migration (namespaced → solo)",
+    "swamp datastore namespace migrate --reverse --confirm",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--confirm",
+    "Execute the migration (without this flag, only a preview is shown)",
+  )
+  .option(
+    "--reverse",
+    "Reverse-migrate from namespaced layout back to solo layout",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "namespace",
+      "migrate",
+    ]);
+    cliCtx.logger.debug("Executing datastore namespace migrate command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+    const dsBasePath = datastoreBasePath(datastoreConfig);
+    const namespace = datastoreConfig.namespace;
+
+    if (!namespace) {
+      throw new UserError(
+        "No namespace is configured. Run 'swamp datastore namespace set <slug>' first.",
+      );
+    }
+
+    let migrateProvider: DatastoreProvider | undefined;
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      await datastoreTypeRegistry.ensureLoaded();
+      await datastoreTypeRegistry.ensureTypeLoaded(datastoreConfig.type);
+      const typeInfo = datastoreTypeRegistry.get(datastoreConfig.type);
+      migrateProvider = typeInfo?.createProvider?.(datastoreConfig.config);
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = buildMigrateDeps(
+      repoDir,
+      dsBasePath,
+      datastoreConfig,
+      namespace,
+      migrateProvider,
+    );
+
+    const renderer = createNamespaceMigrateRenderer(cliCtx.outputMode);
+    await consumeStream(
+      datastoreNamespaceMigrate(ctx, deps, {
+        confirm: !!options.confirm,
+        reverse: !!options.reverse,
+      }),
       renderer.handlers(),
     );
   });

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -261,16 +261,23 @@ async function dirSize(
 ): Promise<{ fileCount: number; totalBytes: number }> {
   let fileCount = 0;
   let totalBytes = 0;
-  for await (
-    const entry of walk(path, { includeFiles: true, includeDirs: false })
-  ) {
-    fileCount++;
-    try {
-      const stat = await Deno.stat(entry.path);
-      totalBytes += stat.size;
-    } catch {
-      // Skip files that can't be stat'd
+  try {
+    for await (
+      const entry of walk(path, { includeFiles: true, includeDirs: false })
+    ) {
+      fileCount++;
+      try {
+        const stat = await Deno.stat(entry.path);
+        totalBytes += stat.size;
+      } catch {
+        // Skip files that can't be stat'd
+      }
     }
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      return { fileCount: 0, totalBytes: 0 };
+    }
+    throw e;
   }
   return { fileCount, totalBytes };
 }
@@ -285,7 +292,7 @@ function buildMigrateDeps(
   const isExtension = isCustomDatastoreConfig(
     datastoreConfig as Parameters<typeof isCustomDatastoreConfig>[0],
   );
-  const catalogStore = createCatalogStore(repoDir);
+  let catalogStore: ReturnType<typeof createCatalogStore> | null = null;
 
   return {
     getDatastorePath: () => dsBasePath,
@@ -303,6 +310,7 @@ function buildMigrateDeps(
       Deno.rename(source, destination),
     ensureDir: (path: string) => ensureDir(path),
     invalidateCatalog: () => {
+      catalogStore = createCatalogStore(repoDir);
       catalogStore.invalidate();
       catalogStore.close();
     },

--- a/src/infrastructure/persistence/namespace_manifest.ts
+++ b/src/infrastructure/persistence/namespace_manifest.ts
@@ -67,6 +67,19 @@ export async function readNamespaceManifest(
   }
 }
 
+export async function removeNamespaceManifest(
+  datastorePath: string,
+  namespace: string,
+): Promise<void> {
+  const path = namespaceManifestPath(datastorePath, namespace);
+  try {
+    await Deno.remove(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+}
+
 export async function listNamespaceManifests(
   datastorePath: string,
 ): Promise<NamespaceManifest[]> {

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -129,18 +129,17 @@ export async function* datastoreNamespaceMigrate(
           continue;
         }
 
-        if (input.reverse) {
-          if (await deps.dirExists(destination)) {
-            yield {
-              kind: "error",
-              error: validationFailed(
-                `Cannot reverse-migrate: "${subdir}" already exists at the ` +
-                  `un-namespaced path "${destination}". Remove or rename it first.`,
-              ),
-              succeededDirectories: [],
-            };
-            return;
-          }
+        if (await deps.dirExists(destination)) {
+          const direction = input.reverse ? "reverse-migrate" : "migrate";
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Cannot ${direction}: "${subdir}" already exists at ` +
+                `"${destination}". Remove or rename it first.`,
+            ),
+            succeededDirectories: [],
+          };
+          return;
         }
 
         const size = await deps.dirSize(source);

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -36,6 +36,7 @@ export interface NamespaceMigratePreviewData {
   namespace: string;
   datastorePath: string;
   reverse: boolean;
+  confirm: boolean;
   directories: SubdirPreview[];
   totalFiles: number;
   totalBytes: number;
@@ -178,6 +179,7 @@ export async function* datastoreNamespaceMigrate(
           namespace,
           datastorePath,
           reverse: input.reverse,
+          confirm: input.confirm,
           directories,
           totalFiles,
           totalBytes,
@@ -221,6 +223,9 @@ export async function* datastoreNamespaceMigrate(
           ctx.logger
             .info`Migrated ${dir.subdir}: ${dir.source} → ${dir.destination}`;
         } catch (err) {
+          if (succeeded.length > 0) {
+            deps.invalidateCatalog();
+          }
           yield {
             kind: "error",
             error: validationFailed(

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -1,0 +1,274 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { validationFailed } from "../errors.ts";
+import { DEFAULT_DATASTORE_SUBDIRS } from "../../domain/datastore/datastore_config.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface SubdirPreview {
+  subdir: string;
+  source: string;
+  destination: string;
+  fileCount: number;
+  totalBytes: number;
+}
+
+export interface NamespaceMigratePreviewData {
+  namespace: string;
+  datastorePath: string;
+  reverse: boolean;
+  directories: SubdirPreview[];
+  totalFiles: number;
+  totalBytes: number;
+  isExtensionDatastore: boolean;
+}
+
+export interface NamespaceMigrateProgressData {
+  subdir: string;
+  source: string;
+  destination: string;
+}
+
+export interface NamespaceMigrateCompletedData {
+  namespace: string;
+  datastorePath: string;
+  reverse: boolean;
+  migratedDirectories: string[];
+  totalFiles: number;
+  totalBytes: number;
+  isExtensionDatastore: boolean;
+}
+
+export type NamespaceMigrateEvent =
+  | { kind: "preview"; data: NamespaceMigratePreviewData }
+  | { kind: "progress"; data: NamespaceMigrateProgressData }
+  | { kind: "completed"; data: NamespaceMigrateCompletedData }
+  | {
+    kind: "error";
+    error: SwampError;
+    succeededDirectories: string[];
+    failedDirectory?: string;
+  };
+
+export interface NamespaceMigrateInput {
+  confirm: boolean;
+  reverse: boolean;
+}
+
+export interface DirSize {
+  fileCount: number;
+  totalBytes: number;
+}
+
+export interface NamespaceMigrateDeps {
+  getDatastorePath: () => string;
+  getNamespace: () => string | undefined;
+  dirExists: (path: string) => Promise<boolean>;
+  dirSize: (path: string) => Promise<DirSize>;
+  renameDir: (source: string, destination: string) => Promise<void>;
+  ensureDir: (path: string) => Promise<void>;
+  invalidateCatalog: () => void;
+  markDirtyBulk: () => Promise<void>;
+  removeNamespaceManifest: (namespace: string) => Promise<void>;
+  isExtensionDatastore: boolean;
+}
+
+export async function* datastoreNamespaceMigrate(
+  ctx: LibSwampContext,
+  deps: NamespaceMigrateDeps,
+  input: NamespaceMigrateInput,
+): AsyncIterable<NamespaceMigrateEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.namespace.migrate",
+    { "namespace.reverse": input.reverse },
+    (async function* () {
+      const namespace = deps.getNamespace();
+      if (!namespace) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "No namespace is configured. Run 'swamp datastore namespace set <slug>' first.",
+          ),
+          succeededDirectories: [],
+        };
+        return;
+      }
+
+      const datastorePath = deps.getDatastorePath();
+      const directories: SubdirPreview[] = [];
+
+      for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
+        const source = input.reverse
+          ? join(datastorePath, namespace, subdir)
+          : join(datastorePath, subdir);
+        const destination = input.reverse
+          ? join(datastorePath, subdir)
+          : join(datastorePath, namespace, subdir);
+
+        if (!(await deps.dirExists(source))) {
+          ctx.logger.debug`Skipping ${subdir}: source does not exist`;
+          continue;
+        }
+
+        if (input.reverse) {
+          if (await deps.dirExists(destination)) {
+            yield {
+              kind: "error",
+              error: validationFailed(
+                `Cannot reverse-migrate: "${subdir}" already exists at the ` +
+                  `un-namespaced path "${destination}". Remove or rename it first.`,
+              ),
+              succeededDirectories: [],
+            };
+            return;
+          }
+        }
+
+        const size = await deps.dirSize(source);
+        directories.push({
+          subdir,
+          source,
+          destination,
+          fileCount: size.fileCount,
+          totalBytes: size.totalBytes,
+        });
+      }
+
+      if (directories.length === 0) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            "No data directories found to migrate.",
+          ),
+          succeededDirectories: [],
+        };
+        return;
+      }
+
+      const totalFiles = directories.reduce(
+        (sum, d) => sum + d.fileCount,
+        0,
+      );
+      const totalBytes = directories.reduce(
+        (sum, d) => sum + d.totalBytes,
+        0,
+      );
+
+      yield {
+        kind: "preview",
+        data: {
+          namespace,
+          datastorePath,
+          reverse: input.reverse,
+          directories,
+          totalFiles,
+          totalBytes,
+          isExtensionDatastore: deps.isExtensionDatastore,
+        },
+      };
+
+      if (!input.confirm) {
+        yield {
+          kind: "completed",
+          data: {
+            namespace,
+            datastorePath,
+            reverse: input.reverse,
+            migratedDirectories: [],
+            totalFiles: 0,
+            totalBytes: 0,
+            isExtensionDatastore: deps.isExtensionDatastore,
+          },
+        };
+        return;
+      }
+
+      const succeeded: string[] = [];
+
+      for (const dir of directories) {
+        try {
+          await deps.ensureDir(dirname(dir.destination));
+          await deps.renameDir(dir.source, dir.destination);
+          succeeded.push(dir.subdir);
+
+          yield {
+            kind: "progress",
+            data: {
+              subdir: dir.subdir,
+              source: dir.source,
+              destination: dir.destination,
+            },
+          };
+
+          ctx.logger
+            .info`Migrated ${dir.subdir}: ${dir.source} → ${dir.destination}`;
+        } catch (err) {
+          yield {
+            kind: "error",
+            error: validationFailed(
+              `Failed to migrate "${dir.subdir}": ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            ),
+            succeededDirectories: succeeded,
+            failedDirectory: dir.subdir,
+          };
+          return;
+        }
+      }
+
+      deps.invalidateCatalog();
+      ctx.logger.info("Catalog invalidated — will rebuild on next access");
+
+      if (deps.isExtensionDatastore) {
+        await deps.markDirtyBulk();
+        ctx.logger.info(
+          "Extension datastore marked dirty — run 'swamp datastore sync --push' to sync",
+        );
+      }
+
+      if (input.reverse) {
+        try {
+          await deps.removeNamespaceManifest(namespace);
+          ctx.logger.info`Removed namespace manifest for ${namespace}`;
+        } catch (err) {
+          ctx.logger.warn`Failed to remove namespace manifest: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: {
+          namespace,
+          datastorePath,
+          reverse: input.reverse,
+          migratedDirectories: succeeded,
+          totalFiles,
+          totalBytes,
+          isExtensionDatastore: deps.isExtensionDatastore,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -1,0 +1,288 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreNamespaceMigrate,
+  type NamespaceMigrateDeps,
+  type NamespaceMigrateEvent,
+} from "./namespace_migrate.ts";
+
+const DS_PATH = "/tmp/ds";
+const NAMESPACE = "infra";
+
+function makeDeps(
+  overrides: Partial<NamespaceMigrateDeps> = {},
+): NamespaceMigrateDeps {
+  return {
+    getDatastorePath: () => DS_PATH,
+    getNamespace: () => NAMESPACE,
+    dirExists: () => Promise.resolve(false),
+    dirSize: () => Promise.resolve({ fileCount: 0, totalBytes: 0 }),
+    renameDir: () => Promise.resolve(),
+    ensureDir: () => Promise.resolve(),
+    invalidateCatalog: () => {},
+    markDirtyBulk: () => Promise.resolve(),
+    removeNamespaceManifest: () => Promise.resolve(),
+    isExtensionDatastore: false,
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreNamespaceMigrate: errors when no namespace configured", async () => {
+  const ctx = createLibSwampContext({});
+  const deps = makeDeps({ getNamespace: () => undefined });
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
+  );
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "error");
+  if (events[0].kind === "error") {
+    assertStringIncludes(events[0].error.message, "No namespace is configured");
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: errors when no data directories exist", async () => {
+  const ctx = createLibSwampContext({});
+  const deps = makeDeps();
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
+  );
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "error");
+  if (events[0].kind === "error") {
+    assertStringIncludes(events[0].error.message, "No data directories found");
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: dry-run yields preview and completed with no migrations", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set(["data", "outputs"]);
+  const deps = makeDeps({
+    dirExists: (path) =>
+      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirSize: () => Promise.resolve({ fileCount: 10, totalBytes: 5000 }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "preview");
+  if (events[0].kind === "preview") {
+    assertEquals(events[0].data.namespace, NAMESPACE);
+    assertEquals(events[0].data.reverse, false);
+    assertEquals(events[0].data.directories.length, 2);
+    assertEquals(events[0].data.totalFiles, 20);
+    assertEquals(events[0].data.totalBytes, 10000);
+
+    const dataDir = events[0].data.directories.find((d) => d.subdir === "data");
+    assertEquals(dataDir?.source, join(DS_PATH, "data"));
+    assertEquals(dataDir?.destination, join(DS_PATH, NAMESPACE, "data"));
+  }
+
+  assertEquals(events[1].kind, "completed");
+  if (events[1].kind === "completed") {
+    assertEquals(events[1].data.migratedDirectories.length, 0);
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: confirm executes forward migration", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set(["data", "outputs"]);
+  const renamed: Array<{ source: string; destination: string }> = [];
+  const ensured: string[] = [];
+  let catalogInvalidated = false;
+
+  const deps = makeDeps({
+    dirExists: (path) =>
+      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+    renameDir: (source, destination) => {
+      renamed.push({ source, destination });
+      return Promise.resolve();
+    },
+    ensureDir: (path) => {
+      ensured.push(path);
+      return Promise.resolve();
+    },
+    invalidateCatalog: () => {
+      catalogInvalidated = true;
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const preview = events.find((e) => e.kind === "preview");
+  assertEquals(preview?.kind, "preview");
+
+  const progressEvents = events.filter((e) => e.kind === "progress");
+  assertEquals(progressEvents.length, 2);
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.migratedDirectories, ["data", "outputs"]);
+  }
+
+  assertEquals(renamed.length, 2);
+  assertEquals(renamed[0].source, join(DS_PATH, "data"));
+  assertEquals(renamed[0].destination, join(DS_PATH, NAMESPACE, "data"));
+  assertEquals(catalogInvalidated, true);
+});
+
+Deno.test("datastoreNamespaceMigrate: confirm executes reverse migration with manifest cleanup", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set([
+    join(DS_PATH, NAMESPACE, "data"),
+  ]);
+  const renamed: Array<{ source: string; destination: string }> = [];
+  let manifestRemoved = "";
+
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(existingDirs.has(path)),
+    dirSize: () => Promise.resolve({ fileCount: 3, totalBytes: 1000 }),
+    renameDir: (source, destination) => {
+      renamed.push({ source, destination });
+      return Promise.resolve();
+    },
+    removeNamespaceManifest: (ns) => {
+      manifestRemoved = ns;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: true }),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.reverse, true);
+    assertEquals(completed.data.migratedDirectories, ["data"]);
+  }
+
+  assertEquals(renamed.length, 1);
+  assertEquals(renamed[0].source, join(DS_PATH, NAMESPACE, "data"));
+  assertEquals(renamed[0].destination, join(DS_PATH, "data"));
+  assertEquals(manifestRemoved, NAMESPACE);
+});
+
+Deno.test("datastoreNamespaceMigrate: reverse refuses when un-namespaced path has content", async () => {
+  const ctx = createLibSwampContext({});
+  const deps = makeDeps({
+    dirExists: () => Promise.resolve(true),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: true }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "error");
+  if (events[0].kind === "error") {
+    assertStringIncludes(events[0].error.message, "Cannot reverse-migrate");
+    assertStringIncludes(events[0].error.message, "already exists");
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: partial failure reports succeeded and failed directories", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set(["data", "outputs"]);
+  let callCount = 0;
+
+  const deps = makeDeps({
+    dirExists: (path) =>
+      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+    renameDir: () => {
+      callCount++;
+      if (callCount === 2) {
+        return Promise.reject(new Error("Permission denied"));
+      }
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const errorEvent = events.find((e) => e.kind === "error");
+  assertEquals(errorEvent?.kind, "error");
+  if (errorEvent?.kind === "error") {
+    assertStringIncludes(errorEvent.error.message, "Permission denied");
+    assertEquals(errorEvent.succeededDirectories, ["data"]);
+    assertEquals(errorEvent.failedDirectory, "outputs");
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: extension datastore calls markDirtyBulk", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set(["data"]);
+  let markedDirty = false;
+
+  const deps = makeDeps({
+    dirExists: (path) =>
+      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirSize: () => Promise.resolve({ fileCount: 1, totalBytes: 100 }),
+    isExtensionDatastore: true,
+    markDirtyBulk: () => {
+      markedDirty = true;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.isExtensionDatastore, true);
+  }
+  assertEquals(markedDirty, true);
+});
+
+Deno.test("datastoreNamespaceMigrate: skips nonexistent subdirs", async () => {
+  const ctx = createLibSwampContext({});
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(path.endsWith("data")),
+    dirSize: () => Promise.resolve({ fileCount: 1, totalBytes: 100 }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
+  );
+
+  assertEquals(events[0].kind, "preview");
+  if (events[0].kind === "preview") {
+    assertEquals(events[0].data.directories.length, 1);
+    assertEquals(events[0].data.directories[0].subdir, "data");
+  }
+});

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { basename, join } from "@std/path";
+import { join } from "@std/path";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -76,9 +76,12 @@ Deno.test("datastoreNamespaceMigrate: errors when no data directories exist", as
 
 Deno.test("datastoreNamespaceMigrate: dry-run yields preview and completed with no migrations", async () => {
   const ctx = createLibSwampContext({});
-  const existingDirs = new Set(["data", "outputs"]);
+  const sourcePaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, "outputs"),
+  ]);
   const deps = makeDeps({
-    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
+    dirExists: (path) => Promise.resolve(sourcePaths.has(path)),
     dirSize: () => Promise.resolve({ fileCount: 10, totalBytes: 5000 }),
   });
 
@@ -108,13 +111,16 @@ Deno.test("datastoreNamespaceMigrate: dry-run yields preview and completed with 
 
 Deno.test("datastoreNamespaceMigrate: confirm executes forward migration", async () => {
   const ctx = createLibSwampContext({});
-  const existingDirs = new Set(["data", "outputs"]);
+  const sourcePaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, "outputs"),
+  ]);
   const renamed: Array<{ source: string; destination: string }> = [];
   const ensured: string[] = [];
   let catalogInvalidated = false;
 
   const deps = makeDeps({
-    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
+    dirExists: (path) => Promise.resolve(sourcePaths.has(path)),
     dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
     renameDir: (source, destination) => {
       renamed.push({ source, destination });
@@ -210,11 +216,14 @@ Deno.test("datastoreNamespaceMigrate: reverse refuses when un-namespaced path ha
 
 Deno.test("datastoreNamespaceMigrate: partial failure reports succeeded and failed directories", async () => {
   const ctx = createLibSwampContext({});
-  const existingDirs = new Set(["data", "outputs"]);
+  const sourcePaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, "outputs"),
+  ]);
   let callCount = 0;
 
   const deps = makeDeps({
-    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
+    dirExists: (path) => Promise.resolve(sourcePaths.has(path)),
     dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
     renameDir: () => {
       callCount++;
@@ -240,11 +249,11 @@ Deno.test("datastoreNamespaceMigrate: partial failure reports succeeded and fail
 
 Deno.test("datastoreNamespaceMigrate: extension datastore calls markDirtyBulk", async () => {
   const ctx = createLibSwampContext({});
-  const existingDirs = new Set(["data"]);
+  const sourcePaths = new Set([join(DS_PATH, "data")]);
   let markedDirty = false;
 
   const deps = makeDeps({
-    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
+    dirExists: (path) => Promise.resolve(sourcePaths.has(path)),
     dirSize: () => Promise.resolve({ fileCount: 1, totalBytes: 100 }),
     isExtensionDatastore: true,
     markDirtyBulk: () => {
@@ -267,8 +276,9 @@ Deno.test("datastoreNamespaceMigrate: extension datastore calls markDirtyBulk", 
 
 Deno.test("datastoreNamespaceMigrate: skips nonexistent subdirs", async () => {
   const ctx = createLibSwampContext({});
+  const sourcePaths = new Set([join(DS_PATH, "data")]);
   const deps = makeDeps({
-    dirExists: (path) => Promise.resolve(path.endsWith("data")),
+    dirExists: (path) => Promise.resolve(sourcePaths.has(path)),
     dirSize: () => Promise.resolve({ fileCount: 1, totalBytes: 100 }),
   });
 

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -78,8 +78,7 @@ Deno.test("datastoreNamespaceMigrate: dry-run yields preview and completed with 
   const ctx = createLibSwampContext({});
   const existingDirs = new Set(["data", "outputs"]);
   const deps = makeDeps({
-    dirExists: (path) =>
-      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
     dirSize: () => Promise.resolve({ fileCount: 10, totalBytes: 5000 }),
   });
 
@@ -115,8 +114,7 @@ Deno.test("datastoreNamespaceMigrate: confirm executes forward migration", async
   let catalogInvalidated = false;
 
   const deps = makeDeps({
-    dirExists: (path) =>
-      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
     dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
     renameDir: (source, destination) => {
       renamed.push({ source, destination });
@@ -216,8 +214,7 @@ Deno.test("datastoreNamespaceMigrate: partial failure reports succeeded and fail
   let callCount = 0;
 
   const deps = makeDeps({
-    dirExists: (path) =>
-      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
     dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
     renameDir: () => {
       callCount++;
@@ -247,8 +244,7 @@ Deno.test("datastoreNamespaceMigrate: extension datastore calls markDirtyBulk", 
   let markedDirty = false;
 
   const deps = makeDeps({
-    dirExists: (path) =>
-      Promise.resolve(existingDirs.has(path.split("/").pop()!)),
+    dirExists: (path) => Promise.resolve(existingDirs.has(basename(path))),
     dirSize: () => Promise.resolve({ fileCount: 1, totalBytes: 100 }),
     isExtensionDatastore: true,
     markDirtyBulk: () => {

--- a/src/libswamp/datastores/namespace_set.ts
+++ b/src/libswamp/datastores/namespace_set.ts
@@ -125,9 +125,8 @@ export async function* datastoreNamespaceSet(
 
       ctx.logger.info("Namespace set to {namespace}", { namespace: slug });
 
-      let warning =
-        "Existing data will remain at the old path and won't be visible until " +
-        "migration tooling is available in a future version.";
+      let warning = "Existing data remains at the old un-namespaced path. " +
+        "Run 'swamp datastore namespace migrate --confirm' to move it to the namespaced layout.";
       if (registrationSkipped) {
         warning +=
           "\n\nThis datastore backend does not support namespace registration. " +

--- a/src/libswamp/datastores/namespace_set_test.ts
+++ b/src/libswamp/datastores/namespace_set_test.ts
@@ -62,9 +62,8 @@ Deno.test("datastoreNamespaceSet: valid slug succeeds", async () => {
       data: {
         namespace: "infra",
         datastorePath: "/tmp/ds",
-        warning:
-          "Existing data will remain at the old path and won't be visible until " +
-          "migration tooling is available in a future version.",
+        warning: "Existing data remains at the old un-namespaced path. " +
+          "Run 'swamp datastore namespace migrate --confirm' to move it to the namespaced layout.",
         registrationSkipped: false,
       },
     },

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1257,6 +1257,7 @@ export {
 } from "./datastores/namespace_list.ts";
 export {
   datastoreNamespaceMigrate,
+  type DirSize,
   type NamespaceMigrateCompletedData,
   type NamespaceMigrateDeps,
   type NamespaceMigrateEvent,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1255,3 +1255,13 @@ export {
   type NamespaceListDeps,
   type NamespaceListEvent,
 } from "./datastores/namespace_list.ts";
+export {
+  datastoreNamespaceMigrate,
+  type NamespaceMigrateCompletedData,
+  type NamespaceMigrateDeps,
+  type NamespaceMigrateEvent,
+  type NamespaceMigrateInput,
+  type NamespaceMigratePreviewData,
+  type NamespaceMigrateProgressData,
+  type SubdirPreview,
+} from "./datastores/namespace_migrate.ts";

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -60,9 +60,11 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
           `Total: ${e.data.totalFiles} file(s), ${
             formatBytes(e.data.totalBytes)
           }`,
-          "",
-          yellow("Add --confirm to execute this migration."),
         );
+
+        if (!e.data.confirm) {
+          lines.push("", yellow("Add --confirm to execute this migration."));
+        }
 
         writeOutput(lines.join("\n"));
       },
@@ -131,6 +133,17 @@ class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
         }
       },
       error: (e) => {
+        if (e.succeededDirectories.length > 0 || e.failedDirectory) {
+          writeOutput(JSON.stringify(
+            {
+              error: e.error.message,
+              succeededDirectories: e.succeededDirectories,
+              failedDirectory: e.failedDirectory ?? null,
+            },
+            null,
+            2,
+          ));
+        }
         throw new UserError(e.error.message);
       },
     };

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -21,6 +21,7 @@ import { bold, dim, green, yellow } from "@std/fmt/colors";
 import type {
   EventHandlers,
   NamespaceMigrateEvent,
+  NamespaceMigratePreviewData,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
@@ -60,7 +61,7 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
             formatBytes(e.data.totalBytes)
           }`,
           "",
-          yellow("Run with --confirm to execute this migration."),
+          yellow("Add --confirm to execute this migration."),
         );
 
         writeOutput(lines.join("\n"));
@@ -114,15 +115,19 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
 }
 
 class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
+  #previewData: NamespaceMigratePreviewData | null = null;
+
   handlers(): EventHandlers<NamespaceMigrateEvent> {
     return {
       preview: (e) => {
-        writeOutput(JSON.stringify(e.data, null, 2));
+        this.#previewData = e.data;
       },
       progress: () => {},
       completed: (e) => {
         if (e.data.migratedDirectories.length > 0) {
           writeOutput(JSON.stringify(e.data, null, 2));
+        } else {
+          writeOutput(JSON.stringify(this.#previewData, null, 2));
         }
       },
       error: (e) => {

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -1,0 +1,144 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, yellow } from "@std/fmt/colors";
+import type {
+  EventHandlers,
+  NamespaceMigrateEvent,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
+  handlers(): EventHandlers<NamespaceMigrateEvent> {
+    return {
+      preview: (e) => {
+        const direction = e.data.reverse ? "Reverse migration" : "Migration";
+        const lines = [
+          bold(`${direction} preview (namespace: "${e.data.namespace}")`),
+          "",
+        ];
+
+        for (const dir of e.data.directories) {
+          lines.push(
+            `  ${dir.subdir}`,
+            `    ${dim(dir.source)}`,
+            `    → ${dir.destination}`,
+            `    ${
+              dim(`${dir.fileCount} file(s), ${formatBytes(dir.totalBytes)}`)
+            }`,
+          );
+        }
+
+        lines.push(
+          "",
+          `Total: ${e.data.totalFiles} file(s), ${
+            formatBytes(e.data.totalBytes)
+          }`,
+          "",
+          yellow("Run with --confirm to execute this migration."),
+        );
+
+        writeOutput(lines.join("\n"));
+      },
+      progress: (e) => {
+        writeOutput(green(`  ✓ ${e.data.subdir}`));
+      },
+      completed: (e) => {
+        if (e.data.migratedDirectories.length === 0) return;
+
+        const direction = e.data.reverse ? "Reverse migration" : "Migration";
+        const lines = [
+          "",
+          bold(
+            `${direction} complete: ${e.data.migratedDirectories.length} directory(s) moved`,
+          ),
+          `  Total: ${e.data.totalFiles} file(s), ${
+            formatBytes(e.data.totalBytes)
+          }`,
+        ];
+
+        if (e.data.isExtensionDatastore) {
+          lines.push(
+            "",
+            yellow(
+              "This is an extension datastore. Run 'swamp datastore sync --push' to sync the new layout to the remote.",
+            ),
+          );
+        }
+
+        writeOutput(lines.join("\n"));
+      },
+      error: (e) => {
+        if (e.succeededDirectories.length > 0) {
+          const lines = [
+            "",
+            yellow(
+              `Partially migrated: ${e.succeededDirectories.length} directory(s) moved before failure.`,
+            ),
+            `  Succeeded: ${e.succeededDirectories.join(", ")}`,
+          ];
+          if (e.failedDirectory) {
+            lines.push(`  Failed: ${e.failedDirectory}`);
+          }
+          writeOutput(lines.join("\n"));
+        }
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
+  handlers(): EventHandlers<NamespaceMigrateEvent> {
+    return {
+      preview: (e) => {
+        writeOutput(JSON.stringify(e.data, null, 2));
+      },
+      progress: () => {},
+      completed: (e) => {
+        if (e.data.migratedDirectories.length > 0) {
+          writeOutput(JSON.stringify(e.data, null, 2));
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createNamespaceMigrateRenderer(
+  mode: OutputMode,
+): Renderer<NamespaceMigrateEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonNamespaceMigrateRenderer();
+    case "log":
+      return new LogNamespaceMigrateRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

Adds `swamp datastore namespace migrate` to re-key data between solo and namespaced layouts, completing giga-swamp phase 7. Also adds `--migrate` flag on `namespace unset` for combined unset + reverse migration.

- **Forward migration** (`namespace migrate --confirm`): moves each `DEFAULT_DATASTORE_SUBDIRS` entry from `{ds}/{subdir}/` to `{ds}/{namespace}/{subdir}/` via atomic `Deno.rename()`. Dry-run preview by default.
- **Reverse migration** (`namespace migrate --reverse --confirm` or `namespace unset --migrate --confirm`): flattens namespaced paths back to solo with conflict detection.
- Catalog invalidated after migration for automatic backfill. Extension datastores get bulk `markDirty()` for re-index on next push.
- Namespace manifest cleaned up on reverse migration.
- Updated `namespace set` warning to reference the new migrate command.

## Test Plan

- 8 unit tests in `namespace_migrate_test.ts` (dry-run, forward, reverse, conflict detection, partial failure, manifest cleanup, extension datastore markDirty, skip nonexistent subdirs)
- 3 integration tests in `giga_swamp_namespace_migrate_test.ts` (full round-trip with data integrity, conflict detection, skip nonexistent)
- Full 10-step manual verification against a real repo with `@command/shell` models — transcript at `/tmp/phase7-verification-transcript.md`
- `deno check` ✓ | `deno lint` ✓ | `deno fmt` ✓ | `deno run test` 6690 passed ✓ | `deno run compile` ✓

Closes swamp-club#548

🤖 Generated with [Claude Code](https://claude.com/claude-code)