### PR TITLE
fix(datastore): include default path when materializing namespace config (swamp-club#557)

### DIFF
--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -134,7 +134,8 @@ export const datastoreNamespaceSetCommand = new Command()
             "Cannot update namespace: .swamp.yaml marker not found.",
           );
         }
-        current.datastore = current.datastore ?? { type: "filesystem" };
+        current.datastore = current.datastore ??
+          { type: "filesystem", path: ".swamp" };
         current.datastore.namespace = namespace;
         await markerRepo.write(repoPath, current);
       },


### PR DESCRIPTION
## Summary

- Fix `namespace set` on repos with no explicit datastore config writing an incomplete `.swamp.yaml` block (missing `path` field), which caused all subsequent namespace commands to crash with "Filesystem datastore config in .swamp.yaml requires a 'path' field."
- One-line fix: the `updateMarkerNamespace` fallback now includes `path: ".swamp"` alongside the type when materializing a new datastore config block.

Fixes swamp-club#557

## Test Plan

- [x] Existing namespace set tests pass (7/7)
- [x] Full test suite passes (6706/6706)
- [x] Reproduced the bug in a scratch repo: `repo init` → `namespace set infra` → `namespace list` crashed
- [x] Verified the fix: same scenario now produces `datastore: { type: filesystem, path: .swamp, namespace: infra }` and all namespace commands work