### PR TITLE
fix(datastore): scope sync and register manifest when namespace in setup config (swamp-club#559)

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -163,7 +163,7 @@ const datastoreSetupExtensionCommand = new Command()
       );
     }
 
-    // Parse config JSON
+    // Parse config JSON and extract namespace before provider validation
     let config: Record<string, unknown>;
     try {
       config = JSON.parse(options.config) as Record<string, unknown>;
@@ -172,6 +172,8 @@ const datastoreSetupExtensionCommand = new Command()
         `Invalid JSON in --config: ${options.config}`,
       );
     }
+
+    const { namespace: configNamespace, ...providerConfig } = config;
 
     const { repoDir, marker } = await resolveDatastoreForRepo(
       resolveRepoDir(options.repoDir),
@@ -194,15 +196,19 @@ const datastoreSetupExtensionCommand = new Command()
       );
     }
 
+    const namespace = typeof configNamespace === "string"
+      ? configNamespace
+      : marker?.datastore?.namespace;
+
     await consumeStream(
       datastoreSetupExtension(ctx, deps, {
         type: resolvedType,
-        config,
+        config: providerConfig,
         repoDir,
         repoId: marker?.repoId,
         skipMigration: !!options.skipMigration,
         hydrationStrategy,
-        namespace: marker?.datastore?.namespace,
+        namespace,
       }),
       renderer.handlers(),
     );

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -59,6 +59,7 @@ export interface DatastoreSetupData {
   directoriesMigrated: string[];
   errors: string[];
   retryHint?: string;
+  namespace?: string;
 }
 
 export type DatastoreSetupEvent =
@@ -484,8 +485,13 @@ export async function* datastoreSetupExtension(
       if (errors.length === 0 && ns && input.repoId) {
         const datastorePath = provider.resolveDatastorePath(input.repoDir);
         if (provider.registerNamespace) {
-          await provider.registerNamespace(datastorePath, ns, input.repoId);
-          ctx.logger.info`Registered namespace ${ns} in datastore`;
+          try {
+            await provider.registerNamespace(datastorePath, ns, input.repoId);
+            ctx.logger.info`Registered namespace ${ns} in datastore`;
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            errors.push(`Namespace registration failed: ${msg}`);
+          }
         } else {
           ctx.logger
             .warn`Datastore backend does not support namespace registration — conflict detection is unavailable`;
@@ -501,6 +507,7 @@ export async function* datastoreSetupExtension(
           bytesCopied: 0,
           directoriesMigrated: [],
           errors,
+          ...(ns ? { namespace: ns } : {}),
           ...(errors.length > 0
             ? {
               retryHint:

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -30,6 +30,7 @@ import {
   verifyMigration,
 } from "../../domain/datastore/datastore_migration_service.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import { createNamespace } from "../../domain/data/namespace.ts";
 import { UserError } from "../../domain/errors.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { collapseEnvVars } from "../../infrastructure/persistence/env_path.ts";
@@ -341,6 +342,23 @@ export async function* datastoreSetupExtension(
       );
       const ns = input.namespace;
 
+      if (ns) {
+        try {
+          createNamespace(ns);
+        } catch (error) {
+          yield {
+            kind: "error",
+            error: {
+              code: "validation_failed",
+              message: `Invalid namespace: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            },
+          };
+          return;
+        }
+      }
+
       let migrationResult:
         | {
           filesCopied: number;
@@ -457,7 +475,21 @@ export async function* datastoreSetupExtension(
           ...(input.hydrationStrategy
             ? { hydrationStrategy: input.hydrationStrategy }
             : {}),
+          ...(ns ? { namespace: ns } : {}),
         });
+      }
+
+      // Register namespace manifest after config is persisted.
+      // provider.registerNamespace handles conflict detection internally.
+      if (errors.length === 0 && ns && input.repoId) {
+        const datastorePath = provider.resolveDatastorePath(input.repoDir);
+        if (provider.registerNamespace) {
+          await provider.registerNamespace(datastorePath, ns, input.repoId);
+          ctx.logger.info`Registered namespace ${ns} in datastore`;
+        } else {
+          ctx.logger
+            .warn`Datastore backend does not support namespace registration — conflict detection is unavailable`;
+        }
       }
 
       yield {

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -812,3 +812,176 @@ Deno.test("datastoreSetupExtension: threads namespace on skip-migration pull-onl
   assertEquals(push, undefined, "skip-migration should not push");
   assertEquals(pull?.options?.namespace, "staging");
 });
+
+// ============================================================================
+// Namespace config persistence and registration tests (issue #559)
+// ============================================================================
+
+Deno.test("datastoreSetupExtension: includes namespace in updateRepoConfig", async () => {
+  ensureTestExtensionType("test-ext-ns-persist");
+  let savedConfig: Record<string, unknown> | undefined;
+  const deps = makeDeps({
+    updateRepoConfig: (_dir: string, config: Record<string, unknown>) => {
+      savedConfig = config;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-ns-persist",
+    namespace: "infra",
+    skipMigration: true,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(savedConfig?.namespace, "infra");
+  assertEquals(savedConfig?.type, "test-ext-ns-persist");
+});
+
+Deno.test("datastoreSetupExtension: omits namespace from config when not set", async () => {
+  ensureTestExtensionType("test-ext-ns-persist-none");
+  let savedConfig: Record<string, unknown> | undefined;
+  const deps = makeDeps({
+    updateRepoConfig: (_dir: string, config: Record<string, unknown>) => {
+      savedConfig = config;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-ns-persist-none",
+    skipMigration: true,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(savedConfig?.namespace, undefined);
+});
+
+Deno.test("datastoreSetupExtension: calls registerNamespace when provider supports it", async () => {
+  let registered:
+    | { datastorePath: string; namespace: string; repoId: string }
+    | undefined;
+  const NS_REG_TYPE = "test-ext-ns-register";
+  if (!datastoreTypeRegistry.has(NS_REG_TYPE)) {
+    datastoreTypeRegistry.register({
+      type: NS_REG_TYPE,
+      name: "NS Register Test",
+      description: "Test namespace registration",
+      isBuiltIn: false,
+      createProvider: () => ({
+        ...createStubProvider(),
+        registerNamespace: (
+          datastorePath: string,
+          namespace: string,
+          repoId: string,
+        ) => {
+          registered = { datastorePath, namespace, repoId };
+          return Promise.resolve();
+        },
+        listNamespaces: () => Promise.resolve([]),
+      }),
+    });
+  }
+
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: NS_REG_TYPE,
+    namespace: "infra",
+    repoId: "repo-123",
+    skipMigration: true,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(registered?.namespace, "infra");
+  assertEquals(registered?.repoId, "repo-123");
+  assertEquals(registered?.datastorePath, "/tmp/repo/.custom-store");
+});
+
+Deno.test("datastoreSetupExtension: skips registerNamespace when provider lacks it", async () => {
+  ensureTestExtensionType("test-ext-ns-no-reg");
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-ns-no-reg",
+    namespace: "infra",
+    repoId: "repo-123",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors, []);
+});
+
+Deno.test("datastoreSetupExtension: skips registerNamespace when repoId is missing", async () => {
+  let registerCalled = false;
+  const NS_NO_REPO_TYPE = "test-ext-ns-no-repoid";
+  if (!datastoreTypeRegistry.has(NS_NO_REPO_TYPE)) {
+    datastoreTypeRegistry.register({
+      type: NS_NO_REPO_TYPE,
+      name: "NS No RepoId Test",
+      description: "Test namespace registration without repoId",
+      isBuiltIn: false,
+      createProvider: () => ({
+        ...createStubProvider(),
+        registerNamespace: () => {
+          registerCalled = true;
+          return Promise.resolve();
+        },
+      }),
+    });
+  }
+
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: NS_NO_REPO_TYPE,
+    namespace: "infra",
+    repoId: undefined,
+    skipMigration: true,
+  });
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(
+    registerCalled,
+    false,
+    "registerNamespace must not be called when repoId is missing",
+  );
+});
+
+Deno.test("datastoreSetupExtension: rejects invalid namespace slug", async () => {
+  ensureTestExtensionType("test-ext-ns-invalid");
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-ns-invalid",
+    namespace: "INVALID NAMESPACE!",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const error = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "validation_failed");
+  assertStringIncludes(error.error.message, "Invalid namespace");
+});

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -964,6 +964,89 @@ Deno.test("datastoreSetupExtension: skips registerNamespace when repoId is missi
   );
 });
 
+Deno.test("datastoreSetupExtension: includes namespace in completed data", async () => {
+  ensureTestExtensionType("test-ext-ns-completed");
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-ns-completed",
+    namespace: "infra",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.namespace, "infra");
+});
+
+Deno.test("datastoreSetupExtension: omits namespace from completed data when not set", async () => {
+  ensureTestExtensionType("test-ext-ns-completed-none");
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-ns-completed-none",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.namespace, undefined);
+});
+
+Deno.test("datastoreSetupExtension: registerNamespace failure surfaces in errors", async () => {
+  const NS_REG_FAIL_TYPE = "test-ext-ns-reg-fail";
+  if (!datastoreTypeRegistry.has(NS_REG_FAIL_TYPE)) {
+    datastoreTypeRegistry.register({
+      type: NS_REG_FAIL_TYPE,
+      name: "NS Register Fail Test",
+      description: "Test namespace registration failure",
+      isBuiltIn: false,
+      createProvider: () => ({
+        ...createStubProvider(),
+        registerNamespace: () => {
+          return Promise.reject(new Error("permission denied"));
+        },
+      }),
+    });
+  }
+
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: NS_REG_FAIL_TYPE,
+    namespace: "infra",
+    repoId: "repo-123",
+    skipMigration: true,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(
+    completed.data.errors[0],
+    "Namespace registration failed",
+  );
+  assertStringIncludes(completed.data.errors[0], "permission denied");
+});
+
 Deno.test("datastoreSetupExtension: rejects invalid namespace slug", async () => {
   ensureTestExtensionType("test-ext-ns-invalid");
   const deps = makeDeps();

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -51,6 +51,9 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
         if (data.path) {
           lines.push(`  Path:     ${data.path}`);
         }
+        if (data.namespace) {
+          lines.push(`  Namespace: ${data.namespace}`);
+        }
         lines.push(
           `  Files:    ${data.filesCopied} copied (${
             formatBytes(data.bytesCopied)


### PR DESCRIPTION
## Summary

Fixes the `datastore setup extension` command when namespace is passed via `--config` JSON:

- **Extract namespace from config JSON** before provider schema validation — prevents the namespace key from reaching the provider's `configSchema.safeParse()` which would reject it
- **Persist namespace to `.swamp.yaml`** — includes namespace in the `updateRepoConfig()` call so the `DatastorePathResolver` picks it up for scoped paths
- **Register namespace manifest** — calls `provider.registerNamespace()` after successful setup so `swamp datastore namespaces` reports the namespace and conflict detection works
- **Validate namespace slug** early in the setup flow using `createNamespace()`

Previously, the setup-with-namespace path was broken: data went to the root prefix instead of under the namespace, and no manifest was written. The workaround was to run setup without namespace then `swamp datastore namespace set` separately.

Closes swamp-club#559

## Test Plan

- 6 new unit tests covering namespace config persistence, registration when supported, skip when unsupported, skip when repoId missing, and invalid namespace rejection
- All 6712 existing tests pass with no regressions
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)