### PR TITLE
fix(skills): resolve broken reference-doc links in managed skills

### DIFF
--- a/.claude/skills/swamp/references/data/references/expressions.md
+++ b/.claude/skills/swamp/references/data/references/expressions.md
@@ -109,6 +109,6 @@ manifest: ${{ data.query('tags.role == "manifest"', '{"name": name, "version": v
   workflow start.
 - Use `data.version()` function for specific versions
 - Use `data.findByTag()` to query across models
-- See the `swamp-workflow` skill's
-  [data-chaining reference](../../swamp-workflow/references/data-chaining.md)
-  for detailed guidance on expression choice in workflows.
+- See the workflow skill's
+  [data-chaining reference](../../workflow/references/data-chaining.md) for
+  detailed guidance on expression choice in workflows.

--- a/.claude/skills/swamp/references/extension-publish/references/publishing.md
+++ b/.claude/skills/swamp/references/extension-publish/references/publishing.md
@@ -262,8 +262,8 @@ anything that needs to score: prefer the inline form in entrypoint files.
 - Use `include` in the manifest for helper scripts executed via `Deno.Command`
   that shouldn't be bundled
 
-See [examples.md](examples.md#import-styles) for import style examples and
-[examples.md](examples.md#helper-scripts) for helper script details.
+See the extension model [examples](../../extension/references/model/examples.md)
+for import style examples and helper script details.
 
 ### How Content Maps to Manifest
 

--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -409,13 +409,13 @@ All extension types support the optional `paths.base` manifest field. Default
 behavior is unchanged — omit it and paths resolve relative to the configured
 `extensions/<type>/` directory. Set `paths.base: manifest` for
 per-extension-subdir layouts. See
-[swamp-extension-publish references/publishing.md](../swamp-extension-publish/references/publishing.md#path-resolution--pathsbase).
+[extension-publish references/publishing.md](../extension-publish/references/publishing.md#path-resolution--pathsbase).
 
 ## CalVer Versioning
 
 Use `swamp extension version --manifest manifest.yaml --json` to get the correct
 next version. See
-[publishing reference](../swamp-extension-publish/references/publishing.md#calver-versioning).
+[publishing reference](../extension-publish/references/publishing.md#calver-versioning).
 
 ## When to Use Other Skills
 

--- a/.claude/skills/swamp/references/extension/references/adversarial-review.md
+++ b/.claude/skills/swamp/references/extension/references/adversarial-review.md
@@ -6,14 +6,14 @@ dimension below **before running smoke tests or unit tests**. Present findings
 to the user before proceeding.
 
 This is step 4 of the Development Workflow in
-[../SKILL.md](../SKILL.md#development-workflow) and gates steps 5 (smoke test)
-and 6 (unit tests).
+[../guide.md](../guide.md#shared-development-workflow) and gates steps 5 (smoke
+test) and 6 (unit tests).
 
 ## When to Run
 
 - After writing new extension code, **before** smoke tests or unit tests
   (workflow step 4 — see the
-  [Adversarial Review Gate](../SKILL.md#adversarial-review-gate))
+  [Adversarial Review Gate](../guide.md#adversarial-review-gate))
 - After revising code in response to smoke test failures (review only changed
   dimensions)
 - Before publishing with `swamp extension push`

--- a/.claude/skills/swamp/references/extension/references/model/docker-execution.md
+++ b/.claude/skills/swamp/references/extension/references/model/docker-execution.md
@@ -62,4 +62,4 @@ All context methods work identically in Docker:
 ## Design Reference
 
 For the full architecture, bundle execution flow, and output parity details, see
-[design/execution-drivers.md](design/execution-drivers.md).
+`design/execution-drivers.md` in the swamp source repo.

--- a/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
+++ b/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
@@ -232,7 +232,7 @@ directory. Only manifests that explicitly opt in with `paths.base: manifest`
 skip the table entirely and resolve typed keys (`models`, `vaults`, `drivers`,
 `datastores`, `reports`, `include`) relative to the manifest's own directory.
 Default behavior is unchanged. See
-[swamp-extension-publish references/publishing.md](../../../swamp-extension-publish/references/publishing.md#path-resolution--pathsbase)
+[extension-publish references/publishing.md](../../../extension-publish/references/publishing.md#path-resolution--pathsbase)
 for the canonical reference.
 
 ## Auto-Resolution Failures

--- a/.claude/skills/swamp/references/extension/references/model/typing.md
+++ b/.claude/skills/swamp/references/extension/references/model/typing.md
@@ -3,7 +3,7 @@
 This reference applies **only when your `_test.ts` file imports the model source
 directly.** If your tests do not import the model source, you do not need this
 page — the default unannotated form in the
-[Quick Start](../SKILL.md#quick-start) works without any changes.
+[Quick Start](../../guide.md#quick-starts) works without any changes.
 
 ## The problem
 

--- a/.claude/skills/swamp/references/extension/references/quality/templates.md
+++ b/.claude/skills/swamp/references/extension/references/quality/templates.md
@@ -61,7 +61,7 @@ other), opt in with `paths.base: manifest`. The default is unchanged in the code
 (a single ternary picks between the configured typed dir and the manifest's own
 directory), so omitting the field is the same as writing `paths.base: typedDir`
 — historical behavior. See
-[swamp-extension-publish references/publishing.md](../../../swamp-extension-publish/references/publishing.md#path-resolution--pathsbase)
+[extension-publish references/publishing.md](../../../extension-publish/references/publishing.md#path-resolution--pathsbase)
 for the canonical reference.
 
 ```yaml

--- a/.claude/skills/swamp/references/model/references/execution-drivers.md
+++ b/.claude/skills/swamp/references/model/references/execution-drivers.md
@@ -86,4 +86,4 @@ container execution. See the `swamp-extension` skill for details.
 ## Design Reference
 
 For architecture details, execution flow diagrams, and implementation files, see
-[design/execution-drivers.md](design/execution-drivers.md).
+`design/execution-drivers.md` in the swamp source repo.

--- a/.claude/skills/swamp/references/repo/guide.md
+++ b/.claude/skills/swamp/references/repo/guide.md
@@ -382,6 +382,6 @@ pointing at your local development copy — your local version loads instead.
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md) for config
   problems and recovery procedures
-- **Repository design**: See [design/repo.md](design/repo.md)
-- **Model structure**: See [design/models.md](design/models.md)
-- **Datastore design**: See [design/datastores.md](design/datastores.md)
+- **Repository design**: See `design/repo.md` in the swamp source repo
+- **Model structure**: See `design/models.md` in the swamp source repo
+- **Datastore design**: See `design/datastores.md` in the swamp source repo

--- a/.claude/skills/swamp/references/report/references/report-types.md
+++ b/.claude/skills/swamp/references/report/references/report-types.md
@@ -196,7 +196,7 @@ actual data bytes, then parse as needed (e.g.
 
 The `dataHandles` array contains handles returned by `writeResource` /
 `createFileWriter` during method execution. See the
-[extension model API reference](../swamp-extension-model/references/api.md#datahandle-structure)
+[extension model API reference](../../extension/references/model/api.md#datahandle-structure)
 for the full structure.
 
 **`metadata` sub-fields:**

--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -624,8 +624,8 @@ End-to-end workflow creation:
 
 ## References
 
-- **CI/CD integration**: See `swamp-repo` skill's
-  [references/ci-integration.md](../swamp-repo/references/ci-integration.md) for
+- **CI/CD integration**: See the repo skill's
+  [references/ci-integration.md](../repo/references/ci-integration.md) for
   installing swamp in CI and GitHub Actions examples
 - **Nested workflows**: See
   [references/nested-workflows.md](references/nested-workflows.md) for when to

--- a/.claude/skills/swamp/references/workflow/references/data-chaining.md
+++ b/.claude/skills/swamp/references/workflow/references/data-chaining.md
@@ -433,7 +433,7 @@ named instances. Instead of maintaining 4 separate subnet model definitions, you
 define one `prod-subnet` model and call it 4 times with different inputs.
 
 For a complete walkthrough, see the
-[swamp-model scenarios](../../swamp-model/references/scenarios.md#scenario-5-factory-pattern-for-model-reuse).
+[model scenarios](../../model/references/scenarios.md#scenario-5-factory-pattern-for-model-reuse).
 
 ### Calling One Model Multiple Times
 

--- a/.claude/skills/swamp/references/workflow/references/execution-drivers.md
+++ b/.claude/skills/swamp/references/workflow/references/execution-drivers.md
@@ -75,4 +75,4 @@ interfere with each other's file system or processes.
 ## Design Reference
 
 For architecture details, Docker driver configuration schema, and implementation
-files, see [design/execution-drivers.md](design/execution-drivers.md).
+files, see `design/execution-drivers.md` in the swamp source repo.


### PR DESCRIPTION
## Summary

- Fixes 18 broken markdown links across 14 managed skill reference docs caused by the skill consolidation into the gateway `swamp` skill (#1512)
- Updates stale paths referencing old standalone skill directories (`swamp-extension-publish`, `swamp-repo`, `swamp-model`, `swamp-workflow`, `swamp-extension-model`) to post-consolidation paths
- Converts `../SKILL.md` references to `../guide.md` (new structure)
- Converts `design/` doc links to plain-text references (design docs don't ship to user repos)
- Fixes dangling `examples.md` reference in extension-publish

Closes swamp-club#565

## Test plan

- [x] Automated link checker confirms zero broken markdown links across all 87 bundled skill files
- [x] Verified all 87 `BUNDLED_SKILLS` entries match filesystem — no missing or extra files
- [x] `copySkillsTo` overwrites unconditionally, so users get the fixed files on next `repo upgrade`
- [x] `deno fmt` applied to all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)