### PR TITLE
fix(models): fail fast when sensitive output requires vault (swamp-club#562)

### DIFF
--- a/design/doctor-vaults.md
+++ b/design/doctor-vaults.md
@@ -1,0 +1,64 @@
+# Doctor Vaults — sensitive-output vault availability scan
+
+`swamp doctor vaults` is a read-only diagnostic that reports model definitions
+whose resource output schemas contain sensitive fields (`{ sensitive: true }`
+metadata or `sensitiveOutput: true` on the spec) when no vault is configured in
+the repository. It exits non-zero when any finding is present, so CI can gate
+on it.
+
+## Why it exists
+
+Models that produce sensitive data in their resource outputs (credentials, API
+keys, private key material) rely on a configured vault to store those values
+securely. Without a vault, the method execution fails at persist time — but only
+after the method has already run, potentially creating cloud resources that
+cannot be recorded.
+
+swamp-club#562 added two runtime guards:
+
+1. **Pre-flight check** in `MethodExecutionService.executeWorkflow()` — before
+   method execution begins, if the model's resource output specs contain
+   sensitive fields and no vault is configured, the method fails immediately
+   with a `UserError`. No API calls are made, no cloud resources are created.
+
+2. **Defense-in-depth** in `createResourceWriter()` — if a resource write is
+   attempted for a spec with sensitive fields and no `vaultService` is
+   available, it throws an explicit error instead of silently writing plaintext.
+
+`doctor vaults` is the validation-time counterpart: it scans all model
+definitions proactively so users discover the mismatch before they even attempt
+a `method run`.
+
+## What it scans
+
+It enumerates the same two definition trees as `doctor secrets`:
+
+- Source-of-truth definitions under `models/`.
+- Auto-created definitions under `.swamp/auto-definitions`.
+
+For each definition, it resolves the model type from the registry and checks
+whether any `ResourceOutputSpec` requires a vault (via `modelRequiresVault()`
+in `data_writer.ts`). A spec requires a vault when:
+
+- Any field in the spec's Zod schema has `.meta({ sensitive: true })`, or
+- The spec has `sensitiveOutput: true` (all fields treated as sensitive).
+
+If any spec requires a vault and no vault is configured in the repository, the
+definition is reported as a finding.
+
+## Vault availability
+
+Vault availability is checked by instantiating a `VaultService` from the
+repository and verifying at least one vault provider is registered. This is the
+same check the runtime pre-flight uses.
+
+## Best-effort residual
+
+Like `doctor secrets`, definitions whose type cannot be resolved are reported
+as unresolved — advisory, not silent.
+
+## Out of scope
+
+This scan does not check whether the configured vault is _functional_ (e.g.
+encryption keys present, provider reachable). That is a runtime concern handled
+by the vault provider itself.

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -23,6 +23,7 @@ import { doctorAuditCommand } from "./doctor_audit.ts";
 import { doctorExtensionsCommand } from "./doctor_extensions.ts";
 import { doctorInstallCommand } from "./doctor_install.ts";
 import { doctorSecretsCommand } from "./doctor_secrets.ts";
+import { doctorVaultsCommand } from "./doctor_vaults.ts";
 import { doctorWorkflowsCommand } from "./doctor_workflows.ts";
 
 export const doctorCommand = new Command()
@@ -53,6 +54,10 @@ export const doctorCommand = new Command()
     "Scan for cleartext sensitive global arguments",
     "swamp doctor secrets",
   )
+  .example(
+    "Check models with sensitive outputs have a vault configured",
+    "swamp doctor vaults",
+  )
   // `--repo-dir` is accepted on the top-level command for consistency
   // with subcommands and other repo-scoped commands. The top-level
   // action only shows help; subcommands consume the option.
@@ -65,4 +70,5 @@ export const doctorCommand = new Command()
   .command("extensions", doctorExtensionsCommand)
   .command("install", doctorInstallCommand)
   .command("secrets", doctorSecretsCommand)
+  .command("vaults", doctorVaultsCommand)
   .command("workflows", doctorWorkflowsCommand);

--- a/src/cli/commands/doctor_vaults.ts
+++ b/src/cli/commands/doctor_vaults.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createDoctorVaultsDeps,
+  createLibSwampContext,
+  doctorVaults,
+} from "../../libswamp/mod.ts";
+import { createDoctorVaultsRenderer } from "../../presentation/renderers/doctor_vaults.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const doctorVaultsCommand = new Command()
+  .description(
+    "Scan model definitions for sensitive resource outputs and verify " +
+      "a vault is configured to store them.",
+  )
+  .example("Scan this repo's definitions", "swamp doctor vaults")
+  .example("Machine-readable output for CI", "swamp doctor vaults --json")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "doctor",
+      "vaults",
+    ]);
+    cliCtx.logger.debug("Executing doctor vaults command");
+
+    const repoDir = resolveRepoDir(options.repoDir);
+    await resolveDatastoreForRepo(repoDir);
+
+    const libCtx = createLibSwampContext();
+    const deps = await createDoctorVaultsDeps(repoDir);
+    const renderer = createDoctorVaultsRenderer(cliCtx.outputMode);
+
+    await consumeStream(
+      doctorVaults(libCtx, deps),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("doctor vaults command completed");
+
+    if (renderer.overallStatus === "fail") {
+      Deno.exit(1);
+    }
+  });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -299,6 +299,21 @@ export function sanitizeVaultKey(key: string): string {
 }
 
 /**
+ * Returns true if any resource output spec in the model requires a vault
+ * (has fields marked `{ sensitive: true }` or `sensitiveOutput: true`).
+ */
+export function modelRequiresVault(
+  resources: Record<string, ResourceOutputSpec> | undefined,
+): boolean {
+  if (!resources) return false;
+  for (const spec of Object.values(resources)) {
+    if (spec.sensitiveOutput) return true;
+    if (extractSensitiveFields(spec.schema).length > 0) return true;
+  }
+  return false;
+}
+
+/**
  * Processes sensitive fields in resource data before persistence.
  *
  * For each field marked with `{ sensitive: true }` metadata in the schema
@@ -556,7 +571,20 @@ export function createResourceWriter(
     }
 
     // Process sensitive fields before serialization
-    if (vaultService && methodName) {
+    const hasSensitiveFields = spec.sensitiveOutput ||
+      extractSensitiveFields(spec.schema).length > 0;
+    if (hasSensitiveFields && !vaultService) {
+      const fields = extractSensitiveFields(spec.schema)
+        .map((f) => `'${f.path}'`).join(", ");
+      const detail = spec.sensitiveOutput
+        ? `resource '${specName}' is marked sensitiveOutput`
+        : `fields ${fields} in resource '${specName}' are marked as sensitive`;
+      throw new Error(
+        `Cannot persist data: ${detail} but no vault is configured. ` +
+          `Create a vault using: swamp vault create <type> <name>`,
+      );
+    }
+    if (vaultService && methodName && hasSensitiveFields) {
       await processSensitiveResourceData(
         data,
         spec,

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -23,6 +23,7 @@ import {
   createFileWriterFactory,
   createResourceReader,
   createResourceWriter,
+  modelRequiresVault,
   processSensitiveResourceData,
   resolveVaultRefsInData,
   sanitizeVaultKey,
@@ -1280,4 +1281,124 @@ Deno.test("processSensitiveResourceData: handles namespaced model types (#447)",
 
   const stored = await vaultService.get("test-vault", expectedKey);
   assertEquals(stored, "-----BEGIN RSA PRIVATE KEY-----");
+});
+
+// --- modelRequiresVault tests ---
+
+Deno.test("modelRequiresVault: returns false for undefined resources", () => {
+  assertEquals(modelRequiresVault(undefined), false);
+});
+
+Deno.test("modelRequiresVault: returns false for resources without sensitive fields", () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    output: {
+      schema: z.object({ name: z.string(), count: z.number() }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  };
+  assertEquals(modelRequiresVault(resources), false);
+});
+
+Deno.test("modelRequiresVault: returns true for schema with sensitive metadata", () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    creds: {
+      schema: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        endpoint: z.string(),
+      }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  };
+  assertEquals(modelRequiresVault(resources), true);
+});
+
+Deno.test("modelRequiresVault: returns true for sensitiveOutput flag", () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    secret: {
+      schema: z.object({ data: z.string() }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+      sensitiveOutput: true,
+    },
+  };
+  assertEquals(modelRequiresVault(resources), true);
+});
+
+Deno.test("modelRequiresVault: returns false when no spec is sensitive", () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    a: {
+      schema: z.object({ x: z.string() }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+    b: {
+      schema: z.object({ y: z.number() }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  };
+  assertEquals(modelRequiresVault(resources), false);
+});
+
+// --- createResourceWriter defense-in-depth tests ---
+
+Deno.test("createResourceWriter: throws when sensitive fields present but no vaultService", async () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    creds: {
+      schema: z.object({
+        apiKey: z.string().meta({ sensitive: true }),
+        endpoint: z.string(),
+      }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  };
+
+  const { writeResource } = createResourceWriter(
+    createMockRepo(),
+    modelType,
+    modelId,
+    resources,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined, // no vaultService
+    "create",
+  );
+
+  await assertRejects(
+    () =>
+      writeResource("creds", "main", {
+        apiKey: "secret-value",
+        endpoint: "https://example.com",
+      }),
+    Error,
+    "no vault is configured",
+  );
+});
+
+Deno.test("createResourceWriter: succeeds for non-sensitive resources without vaultService", async () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    output: {
+      schema: z.object({ name: z.string() }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  };
+
+  const { writeResource } = createResourceWriter(
+    createMockRepo(),
+    modelType,
+    modelId,
+    resources,
+  );
+
+  const handle = await writeResource("output", "main", {
+    name: "test",
+  });
+  assertEquals(handle.name, "main");
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -39,6 +39,7 @@ import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
 import {
   createFileWriterFactory,
   createResourceWriter,
+  modelRequiresVault,
 } from "./data_writer.ts";
 import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
 import { valueContainsExpression } from "../expressions/expression_parser.ts";
@@ -599,6 +600,21 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             }
             throw new UserError(lines.join("\n"));
           }
+        }
+      }
+
+      // Fast-fail: reject methods that write sensitive output without a vault.
+      if (
+        isMutatingKind(methodKind) && modelRequiresVault(modelDef.resources)
+      ) {
+        const hasVault = context.vaultService &&
+          context.vaultService.getVaultNames().length > 0;
+        if (!hasVault) {
+          throw new UserError(
+            `Model "${currentDefinition.name}" has sensitive resource output ` +
+              `fields but no vault is configured. Create a vault before ` +
+              `running this method: swamp vault create <type> <name>`,
+          );
         }
       }
 

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -203,6 +203,15 @@ export {
   type UnresolvedDefinition,
 } from "./models/doctor_secrets.ts";
 export {
+  createDoctorVaultsDeps,
+  doctorVaults,
+  type DoctorVaultsData,
+  type DoctorVaultsDeps,
+  type DoctorVaultsEvent,
+  type UnresolvedVaultDefinition,
+  type VaultRequiredFinding,
+} from "./models/doctor_vaults.ts";
+export {
   modelOutputSearch,
   type ModelOutputSearchData,
   type ModelOutputSearchDeps,

--- a/src/libswamp/models/doctor_vaults.ts
+++ b/src/libswamp/models/doctor_vaults.ts
@@ -1,0 +1,159 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ModelDefinition } from "../../domain/models/model.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { modelRequiresVault } from "../../domain/models/data_writer.ts";
+import type { Definition } from "../../domain/definitions/definition.ts";
+
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/**
+ * A model definition whose registered type has sensitive resource output
+ * fields but no vault is configured in the repository.
+ */
+export interface VaultRequiredFinding {
+  definitionId: string;
+  definitionName: string;
+  type: string;
+}
+
+/**
+ * A definition whose type schema could not be resolved.
+ */
+export interface UnresolvedVaultDefinition {
+  definitionId: string;
+  definitionName: string;
+  type: string;
+}
+
+/** Outcome of a `doctor vaults` scan. */
+export interface DoctorVaultsData {
+  scanned: number;
+  hasVault: boolean;
+  findings: VaultRequiredFinding[];
+  unresolved: UnresolvedVaultDefinition[];
+}
+
+export type DoctorVaultsEvent =
+  | { kind: "scanning" }
+  | { kind: "completed"; data: DoctorVaultsData }
+  | { kind: "error"; error: SwampError };
+
+/** Dependencies for the `doctor vaults` scan. */
+export interface DoctorVaultsDeps {
+  findAllDefinitions: () => Promise<
+    { definition: Definition; type: ModelType }[]
+  >;
+  getModelDef: (
+    type: ModelType,
+  ) => ModelDefinition | undefined | Promise<ModelDefinition | undefined>;
+  hasVault: () => Promise<boolean>;
+}
+
+/**
+ * Wires real infrastructure into {@link DoctorVaultsDeps}.
+ */
+export async function createDoctorVaultsDeps(
+  repoDir: string,
+): Promise<DoctorVaultsDeps> {
+  await modelRegistry.ensureLoaded();
+  const primaryRepo = new YamlDefinitionRepository(repoDir);
+  const autoRepo = new YamlDefinitionRepository(
+    repoDir,
+    undefined,
+    swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+    false,
+  );
+  return {
+    findAllDefinitions: async () => {
+      const [primary, auto] = await Promise.all([
+        primaryRepo.findAllGlobal(),
+        autoRepo.findAllGlobal(),
+      ]);
+      return [...primary, ...auto];
+    },
+    getModelDef: async (type) => {
+      await modelRegistry.ensureTypeLoaded(type);
+      return modelRegistry.get(type);
+    },
+    hasVault: async () => {
+      const vs = await VaultService.fromRepository(repoDir);
+      return vs.getVaultNames().length > 0;
+    },
+  };
+}
+
+/**
+ * Read-only scan that reports model definitions with sensitive resource
+ * outputs when no vault is configured. These models will fail at runtime
+ * when they try to write sensitive data.
+ */
+export async function* doctorVaults(
+  _ctx: LibSwampContext,
+  deps: DoctorVaultsDeps,
+): AsyncGenerator<DoctorVaultsEvent> {
+  yield* withGeneratorSpan(
+    "swamp.doctor.vaults",
+    {},
+    (async function* () {
+      yield { kind: "scanning" };
+
+      const hasVault = await deps.hasVault();
+      const all = await deps.findAllDefinitions();
+      const findings: VaultRequiredFinding[] = [];
+      const unresolved: UnresolvedVaultDefinition[] = [];
+
+      for (const { definition, type } of all) {
+        const modelDef = await deps.getModelDef(type);
+        if (!modelDef) {
+          unresolved.push({
+            definitionId: definition.id,
+            definitionName: definition.name,
+            type: type.normalized,
+          });
+          continue;
+        }
+
+        if (modelRequiresVault(modelDef.resources) && !hasVault) {
+          findings.push({
+            definitionId: definition.id,
+            definitionName: definition.name,
+            type: type.normalized,
+          });
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: { scanned: all.length, hasVault, findings, unresolved },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/models/doctor_vaults_test.ts
+++ b/src/libswamp/models/doctor_vaults_test.ts
@@ -1,0 +1,198 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  doctorVaults,
+  type DoctorVaultsDeps,
+  type DoctorVaultsEvent,
+} from "./doctor_vaults.ts";
+
+type DefStub = {
+  id: string;
+  name: string;
+  globalArguments: Record<string, unknown>;
+};
+
+function makeDeps(
+  definitions: { definition: DefStub; type: string }[],
+  modelDefForType: (type: string) => object | undefined,
+  hasVault: boolean,
+): DoctorVaultsDeps {
+  return {
+    findAllDefinitions: () =>
+      Promise.resolve(
+        definitions.map(({ definition, type }) => ({
+          definition,
+          type: { normalized: type },
+        })) as Awaited<ReturnType<DoctorVaultsDeps["findAllDefinitions"]>>,
+      ),
+    getModelDef:
+      ((type: { normalized: string }) =>
+        modelDefForType(type.normalized)) as DoctorVaultsDeps["getModelDef"],
+    hasVault: () => Promise.resolve(hasVault),
+  };
+}
+
+Deno.test("doctorVaults: no findings when vault is configured", async () => {
+  const deps = makeDeps(
+    [{
+      definition: { id: "d1", name: "my-model", globalArguments: {} },
+      type: "test/sensitive",
+    }],
+    () => ({
+      resources: {
+        creds: {
+          schema: z.object({
+            apiKey: z.string().meta({ sensitive: true }),
+          }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+        },
+      },
+    }),
+    true,
+  );
+
+  const events = await collect<DoctorVaultsEvent>(
+    doctorVaults(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.findings.length, 0);
+    assertEquals(completed.data.hasVault, true);
+    assertEquals(completed.data.scanned, 1);
+  }
+});
+
+Deno.test("doctorVaults: finding when sensitive output and no vault", async () => {
+  const deps = makeDeps(
+    [{
+      definition: { id: "d1", name: "my-model", globalArguments: {} },
+      type: "test/sensitive",
+    }],
+    () => ({
+      resources: {
+        creds: {
+          schema: z.object({
+            apiKey: z.string().meta({ sensitive: true }),
+          }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+        },
+      },
+    }),
+    false,
+  );
+
+  const events = await collect<DoctorVaultsEvent>(
+    doctorVaults(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.findings.length, 1);
+    assertEquals(completed.data.findings[0].definitionName, "my-model");
+    assertEquals(completed.data.hasVault, false);
+  }
+});
+
+Deno.test("doctorVaults: no findings for non-sensitive models without vault", async () => {
+  const deps = makeDeps(
+    [{
+      definition: { id: "d1", name: "plain-model", globalArguments: {} },
+      type: "test/plain",
+    }],
+    () => ({
+      resources: {
+        output: {
+          schema: z.object({ name: z.string() }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+        },
+      },
+    }),
+    false,
+  );
+
+  const events = await collect<DoctorVaultsEvent>(
+    doctorVaults(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.findings.length, 0);
+  }
+});
+
+Deno.test("doctorVaults: unresolved when model def not found", async () => {
+  const deps = makeDeps(
+    [{
+      definition: { id: "d1", name: "unknown-model", globalArguments: {} },
+      type: "test/unknown",
+    }],
+    () => undefined,
+    false,
+  );
+
+  const events = await collect<DoctorVaultsEvent>(
+    doctorVaults(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.findings.length, 0);
+    assertEquals(completed.data.unresolved.length, 1);
+    assertEquals(completed.data.unresolved[0].definitionName, "unknown-model");
+  }
+});
+
+Deno.test("doctorVaults: sensitiveOutput flag triggers finding without vault", async () => {
+  const deps = makeDeps(
+    [{
+      definition: { id: "d1", name: "all-sensitive", globalArguments: {} },
+      type: "test/sensitive-output",
+    }],
+    () => ({
+      resources: {
+        secret: {
+          schema: z.object({ data: z.string() }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+          sensitiveOutput: true,
+        },
+      },
+    }),
+    false,
+  );
+
+  const events = await collect<DoctorVaultsEvent>(
+    doctorVaults(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.findings.length, 1);
+    assertEquals(completed.data.findings[0].definitionName, "all-sensitive");
+  }
+});

--- a/src/presentation/renderers/doctor_vaults.ts
+++ b/src/presentation/renderers/doctor_vaults.ts
@@ -1,0 +1,150 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import type {
+  DoctorVaultsData,
+  DoctorVaultsEvent,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { OutputMode } from "../output/output.ts";
+
+export type DoctorVaultsStatus = "pass" | "fail";
+
+export interface DoctorVaultsRenderer {
+  handlers(): EventHandlers<DoctorVaultsEvent>;
+  readonly overallStatus: DoctorVaultsStatus;
+}
+
+function renderUnresolvedLog(data: DoctorVaultsData): void {
+  if (data.unresolved.length === 0) {
+    return;
+  }
+  writeOutput(
+    `\n${yellow("⚠")} ${
+      bold(
+        `${data.unresolved.length} definition(s) could not be assessed`,
+      )
+    } ${dim("(type schema unavailable — install the extension to scan them)")}`,
+  );
+  for (const u of data.unresolved) {
+    writeOutput(`    ${yellow("•")} ${u.definitionName} ${dim(`[${u.type}]`)}`);
+  }
+}
+
+class LogDoctorVaultsRenderer implements DoctorVaultsRenderer {
+  overallStatus: DoctorVaultsStatus = "pass";
+
+  handlers(): EventHandlers<DoctorVaultsEvent> {
+    return {
+      scanning: () => {
+        writeOutput(
+          dim(
+            "Scanning definitions for sensitive resource outputs without a vault…",
+          ),
+        );
+      },
+      completed: (e) => {
+        const { data } = e;
+
+        if (data.findings.length === 0) {
+          writeOutput(
+            `\n${green("✓")} ${
+              bold("All models with sensitive outputs have a vault configured")
+            } ${dim(`(${data.scanned} definition(s) scanned)`)}`,
+          );
+          renderUnresolvedLog(data);
+          return;
+        }
+
+        this.overallStatus = "fail";
+        writeOutput(
+          `\n${red("✗")} ${
+            bold(
+              `${data.findings.length} definition(s) have sensitive resource outputs but no vault is configured`,
+            )
+          } ${dim(`(${data.scanned} definition(s) scanned)`)}`,
+        );
+
+        for (const finding of data.findings) {
+          writeOutput(
+            `    ${red("•")} ${bold(finding.definitionName)} ${
+              dim(`[${finding.type}]`)
+            }`,
+          );
+        }
+
+        writeOutput(
+          dim(
+            "\n  These models will fail at runtime when writing sensitive data. " +
+              "Create a vault: swamp vault create <type> <name>",
+          ),
+        );
+
+        renderUnresolvedLog(data);
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDoctorVaultsRenderer implements DoctorVaultsRenderer {
+  overallStatus: DoctorVaultsStatus = "pass";
+
+  handlers(): EventHandlers<DoctorVaultsEvent> {
+    return {
+      scanning: () => {},
+      completed: (e) => {
+        const { data } = e;
+        this.overallStatus = data.findings.length > 0 ? "fail" : "pass";
+        console.log(
+          JSON.stringify(
+            {
+              overallStatus: this.overallStatus,
+              scanned: data.scanned,
+              hasVault: data.hasVault,
+              findings: data.findings,
+              unresolved: data.unresolved,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDoctorVaultsRenderer(
+  mode: OutputMode,
+): DoctorVaultsRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDoctorVaultsRenderer();
+    case "log":
+      return new LogDoctorVaultsRenderer();
+  }
+}


### PR DESCRIPTION
## Summary

Models with sensitive resource output fields now fail **before** method execution when no vault is configured, instead of running the method and failing at persist time. This prevents wasteful cloud resource creation that cannot be recorded.

Three layers of validation:
- **Pre-flight check** in `MethodExecutionService` rejects mutating methods before execution begins
- **Defense-in-depth** in `createResourceWriter` throws instead of silently writing plaintext when `vaultService` is absent
- **`swamp doctor vaults`** subcommand scans definitions proactively so users discover the mismatch at validation time

Closes swamp-club#562

### Follow-up issues
- swamp-club#568 — Docs: add doctor vaults subcommand and pre-flight vault validation
- swamp-club#569 — UAT: sensitive resource output without vault produces clear pre-flight error

## Test Plan

- 7 new unit tests for `modelRequiresVault` and `createResourceWriter` defense-in-depth (`data_writer_test.ts`)
- 5 new unit tests for `doctorVaults` generator (`doctor_vaults_test.ts`)
- All 6724 existing tests pass with 0 failures
- Manual verification against reproduction repo: model with `apiKey: z.string().meta({ sensitive: true })` and no vault — method run now fails immediately with `"Model X has sensitive resource output fields but no vault is configured"`
- `swamp doctor vaults` correctly reports findings in both log and JSON modes