### PR TITLE
fix(skills): replace stale per-area skill references with consolidated swamp skill (swamp-club#575)

### DIFF
--- a/.claude/skills/swamp-getting-started/SKILL.md
+++ b/.claude/skills/swamp-getting-started/SKILL.md
@@ -32,8 +32,8 @@ onboarding — say so and stop:
 > You already have models set up. You're past the getting-started stage — just
 > tell me what you'd like to work on and I'll use the right skill.
 
-If the command fails, surface the error and suggest `swamp repo init` (delegate
-to `swamp-repo` if needed), then return here. If no models exist, present the
+If the command fails, surface the error and suggest `swamp repo init` (use the
+`swamp` skill for guidance), then return here. If no models exist, present the
 5-step checklist (Goals → Create → Run → Inspect → Graduate) and begin State 1.
 
 ## State 1: goals_understood
@@ -45,7 +45,7 @@ implementation type). Tell them they can skip if they already know swamp.
 
 **Early exit:** If they describe a task with swamp terminology (e.g., "create a
 model for X", "set up a workflow"), skip ahead and delegate directly to the
-matching skill (`swamp-model`, `swamp-workflow`, `swamp-vault`, etc.).
+`swamp` skill — its routing table will load the right guide.
 
 **Verify:** The user described a goal. Then find a model type:
 
@@ -54,8 +54,8 @@ matching skill (`swamp-model`, `swamp-workflow`, `swamp-vault`, etc.).
 2. If an extension matches: `swamp extension pull <package>`
 3. `swamp model type search <keywords> --json` — check local/installed types
 4. Extend an existing type if it covers the domain but lacks the method you need
-5. If nothing exists, offer a custom extension via `swamp-extension`. Use
-   `command/shell` only for genuine one-off ad-hoc commands.
+5. If nothing exists, offer a custom extension via the `swamp` skill (extension
+   guide). Use `command/shell` only for genuine one-off ad-hoc commands.
 
 Store the goal — use it to name the model and tailor later examples.
 

--- a/.claude/skills/swamp-getting-started/references/tracks.md
+++ b/.claude/skills/swamp-getting-started/references/tracks.md
@@ -35,8 +35,8 @@ schema and available methods.
 ## Step 3: Build a Custom Extension
 
 If nothing matches locally or in the registry, offer to build a custom extension
-model using the `swamp-extension` skill. This creates a typed model with proper
-Zod schemas for the service the user wants to automate.
+model using the `swamp` skill (extension guide). This creates a typed model with
+proper Zod schemas for the service the user wants to automate.
 
 Only use `command/shell` if the user's goal is genuinely a one-off ad-hoc
 command (e.g., "check my disk space right now") — never for wrapping CLI tools
@@ -47,7 +47,7 @@ wrapping CLI tools or building integrations."_
 ## Credential Setup
 
 If the chosen model type requires credentials (cloud services, APIs, etc.), set
-up a vault before configuring the model. Use the `swamp-vault` skill:
+up a vault before configuring the model. Use the `swamp` skill (vault guide):
 
 1. Create a vault: `swamp vault create local_encryption my-secrets --json`
 2. Store credentials: `swamp vault put my-secrets KEY=VALUE --json`
@@ -89,12 +89,12 @@ Read the validation errors. Common fixes:
   `swamp model type describe <type> --json`
 - File not found → verify path from `swamp model get <name> --json`
 
-For detailed model guidance, see the `swamp-model` skill.
+For detailed model guidance, see the `swamp` skill (model guide).
 
 ### State 3 (method_run) — method failed
 
 - **Command failed**: Read the error output and suggest specific fixes
-- **Missing secrets**: Guide toward vault setup (delegate to `swamp-vault`)
+- **Missing secrets**: Guide toward vault setup (use the `swamp` skill)
 - **Permission denied**: Check the command exists and is executable
 - **Timeout**: Suggest a simpler command for the first run
 
@@ -113,12 +113,12 @@ scope), delegate to the appropriate skill with context about what they built.
 Always pass along the user's original goal and what they built so the next skill
 doesn't start from zero.
 
-| User intent                             | Delegate to               |
-| --------------------------------------- | ------------------------- |
-| Another model or edit the one they made | `swamp-model`             |
-| Chain models together                   | `swamp-workflow`          |
-| Secure credentials                      | `swamp-vault`             |
-| Inspect or query their data             | `swamp-data`              |
-| Build a typed model from scratch        | `swamp-extension`         |
-| Share their work                        | `swamp-extension-publish` |
-| Something is broken                     | `swamp-troubleshooting`   |
+| User intent                             | Delegate to                 |
+| --------------------------------------- | --------------------------- |
+| Another model or edit the one they made | `swamp` (model guide)       |
+| Chain models together                   | `swamp` (workflow guide)    |
+| Secure credentials                      | `swamp` (vault guide)       |
+| Inspect or query their data             | `swamp` (data guide)        |
+| Build a typed model from scratch        | `swamp` (extension guide)   |
+| Share their work                        | `swamp` (extension-publish) |
+| Something is broken                     | `swamp` (troubleshooting)   |

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -23,7 +23,7 @@ Swamp has two distinct CEL surfaces:
    already holds (e.g. selector predicates over a fleet of hosts).
    Extensions register their own functions, types, and operators on the
    returned Environment — registrations on one instance do not affect any
-   other. See `.claude/skills/swamp-extension/references/model/api.md` for
+   other. See `.claude/skills/swamp/references/extension/references/model/api.md` for
    the extension-author guide.
 
 The two surfaces share the same arithmetic-overload registrations

--- a/design/extension.md
+++ b/design/extension.md
@@ -371,7 +371,7 @@ externalization rules for zod). No per-specifier-kind configuration is required.
 reproducibility. An unpinned specifier resolves to the registry's current
 "latest" at push time, which means the published bundle silently changes
 whenever the upstream package publishes a new version. See
-`.claude/skills/swamp-extension-publish/references/publishing.md` for
+`.claude/skills/swamp/references/extension-publish/references/publishing.md` for
 author-facing guidance.
 
 #### Project-aware bundling

--- a/design/skills.md
+++ b/design/skills.md
@@ -89,7 +89,7 @@ correct skill. They live at
   {
     "query": "List all the data I have stored",
     "should_trigger": false,
-    "note": "Listing stored data routes to swamp-data, not this skill"
+    "note": "Listing stored data routes to the swamp skill (data guide), not this skill"
   }
 ]
 ```


### PR DESCRIPTION
## Summary

- Replace 14 stale per-area skill name references (`swamp-model`, `swamp-workflow`, `swamp-vault`, `swamp-extension`, `swamp-repo`, `swamp-data`, `swamp-extension-publish`, `swamp-troubleshooting`) in `swamp-getting-started` SKILL.md and `references/tracks.md` with references to the consolidated `swamp` skill
- Fix 3 stale skill path references in `design/skills.md`, `design/expressions.md`, and `design/extension.md`
- These references broke when the 10 per-area skills were consolidated into the gateway skill in #1512

Closes swamp-club#575

## Test Plan

- [x] `deno fmt --check` — formatting clean
- [x] `deno lint` — linting clean
- [x] `deno check` — type checking clean
- [x] `deno run test` — 6727 tests pass, 0 failures
- [x] `deno run compile` — binary recompiled
- [x] `tessl skill review` — 97% score, 0 errors, 0 warnings
- [x] Verified: `swamp repo init` in scratch repo produces SKILL.md with no stale references
- [x] `grep -nE 'swamp-(model|workflow|vault|extension|repo)' .claude/skills/swamp-getting-started/**/*.md` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)