### PR TITLE
fix(extensions): include repository fields in extension search results (swamp-club#573)

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -124,6 +124,9 @@ export interface ExtensionSearchEntry {
   id: string;
   name: string;
   description: string;
+  repository?: string | null;
+  repositoryVerified?: boolean | null;
+  repositoryVerifiedUrl?: string | null;
   platforms: string[];
   labels: string[];
   contentTypes?: string[];

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -25,6 +25,9 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 export interface ExtensionSearchItem {
   name: string;
   description: string;
+  repository: string | null;
+  repositoryVerified: boolean | null;
+  repositoryVerifiedUrl: string | null;
   latestVersion: string;
   platforms: string[];
   labels: string[];
@@ -77,6 +80,9 @@ export interface ExtensionSearchDeps {
     extensions: Array<{
       name: string;
       description: string;
+      repository?: string | null;
+      repositoryVerified?: boolean | null;
+      repositoryVerifiedUrl?: string | null;
       latestVersion: string;
       platforms: string[];
       labels: string[];
@@ -123,6 +129,9 @@ export async function* extensionSearch(
           results: response.extensions.map((ext) => ({
             name: ext.name,
             description: ext.description,
+            repository: ext.repository ?? null,
+            repositoryVerified: ext.repositoryVerified ?? null,
+            repositoryVerifiedUrl: ext.repositoryVerifiedUrl ?? null,
             latestVersion: ext.latestVersion,
             platforms: ext.platforms,
             labels: ext.labels,

--- a/src/libswamp/extensions/search_test.ts
+++ b/src/libswamp/extensions/search_test.ts
@@ -36,6 +36,9 @@ function makeDeps(
           {
             name: "@ns/aws-ec2",
             description: "AWS EC2 model",
+            repository: "https://github.com/ns/aws-ec2",
+            repositoryVerified: true,
+            repositoryVerifiedUrl: "https://github.com/ns/aws-ec2",
             latestVersion: "1.0.0",
             platforms: ["aws"],
             labels: ["compute"],
@@ -76,7 +79,19 @@ Deno.test("extensionSearch: returns results from API", async () => {
   assertEquals(completed.data.query, "aws");
   assertEquals(completed.data.results.length, 2);
   assertEquals(completed.data.results[0].name, "@ns/aws-ec2");
+  assertEquals(
+    completed.data.results[0].repository,
+    "https://github.com/ns/aws-ec2",
+  );
+  assertEquals(completed.data.results[0].repositoryVerified, true);
+  assertEquals(
+    completed.data.results[0].repositoryVerifiedUrl,
+    "https://github.com/ns/aws-ec2",
+  );
   assertEquals(completed.data.results[1].name, "@ns/aws-s3");
+  assertEquals(completed.data.results[1].repository, null);
+  assertEquals(completed.data.results[1].repositoryVerified, null);
+  assertEquals(completed.data.results[1].repositoryVerifiedUrl, null);
   assertEquals(completed.data.meta.total, 2);
   assertEquals(completed.data.meta.page, 1);
   assertEquals(completed.data.meta.perPage, 20);

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -198,6 +198,16 @@ function renderExtensionPreview(
     );
   }
 
+  if (item.repository) {
+    lines.push(<Text key="repo-gap" />);
+    lines.push(
+      <Text key="repo" wrap="truncate-end">
+        <Text bold>Repository:</Text> {item.repository}
+        {item.repositoryVerified && <Text color="green">(verified)</Text>}
+      </Text>,
+    );
+  }
+
   if (item.deprecatedAt != null) {
     lines.push(<Text key="dep-gap" />);
     lines.push(
@@ -256,6 +266,11 @@ function renderExtensionScrollback(
 
   if (item.contentTypes.length > 0) {
     lines.push(`Content Types: ${item.contentTypes.join(", ")}`);
+  }
+
+  if (item.repository) {
+    const verified = item.repositoryVerified ? " (verified)" : "";
+    lines.push(`Repository: ${item.repository}${verified}`);
   }
 
   if (item.deprecatedAt != null) {


### PR DESCRIPTION
## Summary

- `extension search --json` returned `null` for `repository`, `repositoryVerified`, and `repositoryVerifiedUrl` while `extension info --json` returned the correct values for the same extension
- Added the three missing fields to `ExtensionSearchEntry` (API client), `ExtensionSearchItem` (domain), `ExtensionSearchDeps` (port), and the mapping in `extensionSearch()`  
- Uses `?? null` normalization so the fields always appear in JSON output even if the API omits them
- Updated the Ink preview renderer to show repository info with a verified badge
- Added test coverage for both populated and null repository field cases

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — all 6727 tests pass
- [x] Compiled binary and verified `swamp extension search 'mongodb' --json` now returns correct `repository`, `repositoryVerified`, and `repositoryVerifiedUrl` matching `swamp extension info @keeb/mongodb --json`

Closes swamp-club/lab#573