### PR TITLE
fix(data): resolve extension-delivered workflows in data and history commands (swamp-club#571)

### DIFF
--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -86,6 +86,7 @@ export const dataGetCommand = new Command()
         repoDir,
         datastoreResolver,
         repoContext.unifiedDataRepo,
+        repoContext.workflowRepo,
       );
 
       const renderer = createDataGetRenderer(cliCtx.outputMode);

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -77,6 +77,7 @@ export const dataListCommand = new Command()
       datastoreResolver,
       repoContext.unifiedDataRepo,
       namespace,
+      repoContext.workflowRepo,
     );
 
     const renderer = createDataListRenderer(cliCtx.outputMode, !!namespace);

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -53,15 +53,20 @@ export const workflowHistoryGetCommand = new Command()
     ]);
     cliCtx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
 
-    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
-      {
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      },
-    );
+    const { repoDir, repoContext, datastoreResolver } =
+      await requireInitializedRepoReadOnly(
+        {
+          repoDir: resolveRepoDir(options.repoDir),
+          outputMode: cliCtx.outputMode,
+        },
+      );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowHistoryGetDeps(repoDir, datastoreResolver);
+    const deps = createWorkflowHistoryGetDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.workflowRepo,
+    );
 
     const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/workflow_history_logs.ts
+++ b/src/cli/commands/workflow_history_logs.ts
@@ -56,15 +56,20 @@ export const workflowHistoryLogsCommand = new Command()
     );
     cliCtx.logger.debug`Getting logs for workflow run: ${runIdOrWorkflow}`;
 
-    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
-      {
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      },
-    );
+    const { repoDir, repoContext, datastoreResolver } =
+      await requireInitializedRepoReadOnly(
+        {
+          repoDir: resolveRepoDir(options.repoDir),
+          outputMode: cliCtx.outputMode,
+        },
+      );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowHistoryLogsDeps(repoDir, datastoreResolver);
+    const deps = createWorkflowHistoryLogsDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.workflowRepo,
+    );
 
     const renderer = createWorkflowHistoryLogsRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/libswamp/data/get.ts
+++ b/src/libswamp/data/get.ts
@@ -22,6 +22,7 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { WorkflowDataService } from "../../domain/data/workflow_data_service.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
@@ -175,6 +176,7 @@ export function createDataGetDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): DataGetDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -193,7 +195,8 @@ export function createDataGetDeps(
     undefined,
     namespaceFromResolver(datastoreResolver),
   );
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflowRepo: WorkflowRepository = injectedWorkflowRepo ??
+    new YamlWorkflowRepository(repoDir);
   const runRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,

--- a/src/libswamp/data/list.ts
+++ b/src/libswamp/data/list.ts
@@ -22,6 +22,7 @@ import { WorkflowDataService } from "../../domain/data/workflow_data_service.ts"
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
@@ -168,6 +169,7 @@ export function createDataListDeps(
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
   namespace?: string,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): DataListDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -186,7 +188,8 @@ export function createDataListDeps(
     undefined,
     namespaceFromResolver(datastoreResolver),
   );
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflowRepo: WorkflowRepository = injectedWorkflowRepo ??
+    new YamlWorkflowRepository(repoDir);
   const runRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,

--- a/src/libswamp/workflows/history_get.ts
+++ b/src/libswamp/workflows/history_get.ts
@@ -24,6 +24,7 @@ import {
   createWorkflowRunId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
@@ -51,10 +52,12 @@ export interface WorkflowHistoryGetDeps {
 export function createWorkflowHistoryGetDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): WorkflowHistoryGetDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflowRepo: WorkflowRepository = injectedWorkflowRepo ??
+    new YamlWorkflowRepository(repoDir);
   const runRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,

--- a/src/libswamp/workflows/history_logs.ts
+++ b/src/libswamp/workflows/history_logs.ts
@@ -20,6 +20,7 @@
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import {
   isPartialId,
   matchByPartialId,
@@ -95,6 +96,7 @@ export interface WorkflowHistoryLogsDeps {
 export function createWorkflowHistoryLogsDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): WorkflowHistoryLogsDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -103,7 +105,8 @@ export function createWorkflowHistoryLogsDeps(
     undefined,
     dsPath(SWAMP_SUBDIRS.workflowRuns),
   );
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflowRepo: WorkflowRepository = injectedWorkflowRepo ??
+    new YamlWorkflowRepository(repoDir);
   return {
     isPartialId,
     matchRunByPartialId: async (idPrefix: string) => {


### PR DESCRIPTION
## Summary

- Four deps factories (`createDataGetDeps`, `createDataListDeps`, `createWorkflowHistoryGetDeps`, `createWorkflowHistoryLogsDeps`) constructed bare `YamlWorkflowRepository` instances that only scan repo-local workflows, causing "Workflow not found" errors for extension-delivered workflows
- Added an optional `WorkflowRepository` parameter to each factory and wired the composite repo (which includes extension workflows) from the CLI layer
- All four affected commands (`data get --workflow`, `data list --workflow`, `workflow history get`, `workflow history logs`) now resolve extension workflows correctly

## Test Plan

- [x] Reproduced the bug in a scratch repo with `@swamp/kubernetes/cluster-summary`
- [x] Verified all four commands now succeed for extension-delivered workflows after the fix
- [x] Verified repo-local workflows continue to work (no regression)
- [x] All 6727 unit/integration tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Fixes swamp-club#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)