### PR TITLE
fix(catalog): prune stale cross-mount bundle_types rows before I-Repo-1 (swamp-club#574)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1139,6 +1139,16 @@ extracts + returns metadata, but **does not write to the catalog**. The
 lifecycle service is the catalog-write owner — keeping it that way is
 what lets I-Repo-1 fire on every install consistently.
 
+### Unreachable-path pre-flight prune
+
+Before I-Repo-1 evaluates, `saveAll` prunes non-Tombstoned rows whose
+`source_path` is not under the canonical repo root. This handles stale
+rows left by container sessions that bind-mounted the repo at a
+different path (e.g. `/workspace/...` vs `/Users/...`). Without the
+prune, these phantom rows form cross-aggregate `(kind, typeNormalized)`
+collisions that block *every* catalog write — including `rm` of
+unrelated extensions.
+
 ### Atomic upgrade pattern
 
 For every new aggregate the install service is about to save, it

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1097,7 +1097,7 @@ export class ExtensionCatalogStore {
     const pruned: string[] = [];
     for (const row of rows) {
       if ((row.state ?? "Indexed") === "Tombstoned") continue;
-      if (!row.source_path.startsWith(prefix)) {
+      if (!canonicalizePath(row.source_path).startsWith(prefix)) {
         this.removeBySourcePath(row.source_path);
         pruned.push(row.source_path);
       }

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1083,6 +1083,29 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Deletes non-Tombstoned rows whose source_path is not under the
+   * given canonical repo root. Returns the paths that were pruned.
+   * Designed to run inside a transaction before I-Repo-1 so stale rows
+   * from prior container sessions (bind-mounted at a different path)
+   * don't block catalog writes.
+   */
+  pruneUnreachableSources(canonicalRepoRoot: string): string[] {
+    const prefix = canonicalRepoRoot.endsWith("/")
+      ? canonicalRepoRoot
+      : canonicalRepoRoot + "/";
+    const rows = this.findAll();
+    const pruned: string[] = [];
+    for (const row of rows) {
+      if ((row.state ?? "Indexed") === "Tombstoned") continue;
+      if (!row.source_path.startsWith(prefix)) {
+        this.removeBySourcePath(row.source_path);
+        pruned.push(row.source_path);
+      }
+    }
+    return pruned;
+  }
+
+  /**
    * Returns every row in `bundle_types`, ordered by source_path so the
    * output is stable across runs. Used by ExtensionRepository.loadAll
    * (which groups by extension identity) and by I-Repo-1 verification

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -1797,3 +1797,87 @@ Deno.test("ExtensionCatalogStore: runInTransaction throws non-lock errors immedi
     store.close();
   }
 });
+
+Deno.test("pruneUnreachableSources: removes rows outside the repo root", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = canonicalizePath(dirname(dirname(dbPath)));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(
+    makeRow({
+      source_path: join(repoRoot, ".swamp", "pulled-extensions", "echo.ts"),
+      type_normalized: "@test/local",
+      kind: "model",
+    }),
+  );
+  store.upsert(
+    makeRow({
+      source_path:
+        "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts",
+      type_normalized: "@swamp/echo",
+      kind: "model",
+    }),
+  );
+
+  const pruned = store.pruneUnreachableSources(repoRoot);
+
+  assertEquals(pruned.length, 1);
+  assertEquals(
+    pruned[0],
+    "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts",
+  );
+  assertEquals(store.findAll().length, 1);
+  assertEquals(store.findAll()[0].type_normalized, "@test/local");
+
+  store.close();
+});
+
+Deno.test("pruneUnreachableSources: skips Tombstoned rows even if outside repo root", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = canonicalizePath(dirname(dirname(dbPath)));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(
+    makeRow({
+      source_path: "/workspace/tombstoned.ts",
+      type_normalized: "@test/tombstoned",
+      kind: "model",
+      state: "Tombstoned",
+    }),
+  );
+
+  const pruned = store.pruneUnreachableSources(repoRoot);
+
+  assertEquals(pruned.length, 0);
+  assertEquals(store.findAll().length, 1);
+
+  store.close();
+});
+
+Deno.test("pruneUnreachableSources: preserves all rows under the repo root", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = canonicalizePath(dirname(dirname(dbPath)));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(
+    makeRow({
+      source_path: join(repoRoot, "extensions", "models", "a.ts"),
+      type_normalized: "@test/a",
+      kind: "model",
+    }),
+  );
+  store.upsert(
+    makeRow({
+      source_path: join(repoRoot, ".swamp", "pulled-extensions", "b.ts"),
+      type_normalized: "@test/b",
+      kind: "datastore",
+    }),
+  );
+
+  const pruned = store.pruneUnreachableSources(repoRoot);
+
+  assertEquals(pruned.length, 0);
+  assertEquals(store.findAll().length, 2);
+
+  store.close();
+});

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -223,6 +223,11 @@ export class ExtensionRepository {
       for (const ext of extensions) {
         this.applyDiffForExtension(ext);
       }
+      const pruned = this.catalog.pruneUnreachableSources(this.repoRoot);
+      if (pruned.length > 0) {
+        logger
+          .info`Pruned ${pruned.length} catalog row(s) with unreachable source path(s)`;
+      }
       this.assertIRepo1();
     });
   }

--- a/src/libswamp/extensions/doctor_repair.ts
+++ b/src/libswamp/extensions/doctor_repair.ts
@@ -24,6 +24,7 @@ const logger = getLogger(["swamp", "doctor", "repair"]);
 
 export type RepairOperationKind =
   | "catalog-row-pruned"
+  | "unreachable-row-pruned"
   | "bundle-file-evicted"
   | "pulled-extension-repulled";
 
@@ -53,14 +54,15 @@ export interface RepairDeps {
  * aggregate state report. Handles three categories:
  *
  * - Catalog rows in Tombstoned state (no transitions out; safe to prune).
+ * - Catalog rows whose source_path doesn't exist on disk (stale rows
+ *   from prior container sessions with a different mount path).
  * - Bundle files not referenced by any catalog row.
  * - Pulled extensions with BundleBuildFailed or ValidationFailed sources
  *   (re-pulled from registry to restore pre-built bundles).
  *
- * NEVER touches Indexed, Bundled, or OrphanedBundleOnly rows.
- * OrphanedBundleOnly is excluded because those rows still reference a
- * live bundle file — pruning the row would strand the file as an orphan
- * on the next run, breaking idempotence.
+ * OrphanedBundleOnly rows are excluded from state-based pruning because
+ * they still reference a live bundle file — pruning the row would strand
+ * the file as an orphan on the next run, breaking idempotence.
  */
 export async function repairExtensions(
   deps: RepairDeps,
@@ -84,6 +86,20 @@ export async function repairExtensions(
         reason: `Tombstoned row — no longer active`,
       });
     }
+  }
+
+  // Phase 1b: Identify non-Tombstoned rows whose source_path doesn't
+  // exist on disk. These accumulate when the same repo is used from a
+  // container with a different mount path (e.g. /workspace vs /Users).
+  const unreachableRows: string[] = [];
+  for (const orphan of report.catalogOrphans) {
+    unreachableRows.push(orphan.sourcePath);
+    operations.push({
+      kind: "unreachable-row-pruned",
+      path: orphan.sourcePath,
+      reason:
+        `Source path does not exist on disk — stale row from a prior session`,
+    });
   }
 
   // Phase 2: Identify orphaned bundle files.
@@ -114,13 +130,14 @@ export async function repairExtensions(
     }
   }
 
-  let actualPruned = rowsToPrune.length;
+  let actualPruned = rowsToPrune.length + unreachableRows.length;
   let actualEvicted = filesToEvict.length;
   let actualRepulled = extensionsToRepull.size;
 
   if (deps.apply) {
-    if (rowsToPrune.length > 0) {
-      actualPruned = deps.deleteBySourcePaths(rowsToPrune);
+    const allRowsToPrune = [...rowsToPrune, ...unreachableRows];
+    if (allRowsToPrune.length > 0) {
+      actualPruned = deps.deleteBySourcePaths(allRowsToPrune);
       logger.info`Pruned ${actualPruned} catalog row(s)`;
     }
     actualEvicted = 0;

--- a/src/libswamp/extensions/doctor_repair_test.ts
+++ b/src/libswamp/extensions/doctor_repair_test.ts
@@ -453,3 +453,72 @@ Deno.test("repairExtensions: works without repullExtension callback", async () =
     true,
   );
 });
+
+Deno.test("repairExtensions: prunes catalog orphans with unreachable source paths", async () => {
+  const deleted: string[] = [];
+  const report = makeEmptyReport({
+    catalogOrphans: [
+      {
+        sourcePath:
+          "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts",
+        extensionName: "@swamp/echo",
+        stateTag: "Indexed",
+        bundlePath: "/workspace/.swamp/bundles/echo.js",
+      },
+    ],
+    orphanRowCount: 1,
+  });
+
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: (paths) => {
+      deleted.push(...paths);
+      return paths.length;
+    },
+    apply: true,
+  });
+
+  assertEquals(result.prunedRowCount, 1);
+  assertEquals(deleted.length, 1);
+  assertEquals(
+    deleted[0],
+    "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts",
+  );
+  assertEquals(
+    result.operations.some((op) => op.kind === "unreachable-row-pruned"),
+    true,
+  );
+});
+
+Deno.test("repairExtensions: dry-run reports but does not prune unreachable rows", async () => {
+  let deleteCalled = false;
+  const report = makeEmptyReport({
+    catalogOrphans: [
+      {
+        sourcePath:
+          "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts",
+        extensionName: "@swamp/echo",
+        stateTag: "Indexed",
+        bundlePath: "/workspace/.swamp/bundles/echo.js",
+      },
+    ],
+    orphanRowCount: 1,
+  });
+
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: () => {
+      deleteCalled = true;
+      return 0;
+    },
+    apply: false,
+  });
+
+  assertEquals(result.mode, "dry-run");
+  assertEquals(result.prunedRowCount, 1);
+  assertFalse(deleteCalled);
+  assertEquals(
+    result.operations.some((op) => op.kind === "unreachable-row-pruned"),
+    true,
+  );
+});

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects } from "@std/assert";
-import { join } from "@std/path";
+import { join, relative } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { RemoveExtensionService } from "./remove_extension_service.ts";
 import { InstallExtensionService } from "./install_extension_service.ts";
@@ -1039,7 +1039,7 @@ Deno.test(
           "model.ts",
           MINIMAL_MODEL_CODE(targetType),
         );
-        const relTargetPath = targetPath.replace(repoDir + "/", "");
+        const relTargetPath = relative(repoDir, targetPath);
         const installSvc = new InstallExtensionService({
           denoRuntime: testDenoRuntime,
           repository,

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -1010,3 +1010,116 @@ Deno.test(
     );
   },
 );
+
+// =============================================================
+// swamp-club#574 cross-mount stale rows reproducer
+// =============================================================
+//
+// When the same repo is used from both a host shell and a container
+// that bind-mounts the repo at a different path, stale catalog rows
+// accumulate with container-path source_paths. These cause I-Repo-1
+// violations that block ALL catalog writes, including rm of unrelated
+// extensions.
+
+Deno.test(
+  "swamp-club#574: rm succeeds when unrelated extension has stale cross-mount rows",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, catalog, lockfileRepository }) => {
+        const ts = Date.now();
+        const targetExt = `@test/target-${ts}`;
+        const targetType = `@test/target-model-${ts}`;
+        const staleExt = `@test/stale-${ts}`;
+        const staleType = `@test/stale-datastore-${ts}`;
+
+        // Install the extension we'll remove.
+        const targetPath = await stageModel(
+          repoDir,
+          targetExt,
+          "model.ts",
+          MINIMAL_MODEL_CODE(targetType),
+        );
+        const relTargetPath = targetPath.replace(repoDir + "/", "");
+        const installSvc = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: async (ref, ctx) => {
+            await ctx.lockfileRepository.writeEntry(
+              ref.name,
+              "2026.01.01.1",
+              [relTargetPath],
+            );
+            return makeStubInstallResult(ref.name, "2026.01.01.1", [
+              relTargetPath,
+            ]);
+          },
+        });
+        await installSvc.execute(
+          { name: targetExt, version: "2026.01.01.1" },
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+
+        // Inject a stale row from a container session — source_path
+        // points at /workspace/... which doesn't exist on this host.
+        // Also inject the "real" host row for the same extension so
+        // they form an I-Repo-1 violation pair.
+        const hostSourcePath = join(
+          repoDir,
+          ".swamp",
+          "pulled-extensions",
+          staleExt,
+          "datastores",
+          "ds.ts",
+        );
+        await ensureDir(
+          join(repoDir, ".swamp", "pulled-extensions", staleExt, "datastores"),
+        );
+        await Deno.writeTextFile(hostSourcePath, "// host source");
+        catalog.upsert({
+          source_path: hostSourcePath,
+          type_normalized: staleType,
+          kind: "datastore",
+          bundle_path: join(repoDir, ".swamp", "datastore-bundles", "ds.js"),
+          version: "2026.01.01.1",
+          description: "",
+          extends_type: "",
+          source_mtime: "",
+          extension_name: staleExt,
+          extension_version: "2026.01.01.1",
+        });
+        catalog.upsert({
+          source_path: "/workspace/.swamp/pulled-extensions/" + staleExt +
+            "/datastores/ds.ts",
+          type_normalized: staleType,
+          kind: "datastore",
+          bundle_path: "/workspace/.swamp/datastore-bundles/ds.js",
+          version: "2026.01.01.1",
+          description: "",
+          extends_type: "",
+          source_mtime: "",
+          extension_name: staleExt,
+          extension_version: "2025.12.01.1",
+        });
+
+        // Before the fix, this would throw DuplicateTypeError wrapped
+        // in a UserError because the stale /workspace row and the host
+        // row form an I-Repo-1 violation. After the fix, the stale row
+        // is pruned before I-Repo-1 fires.
+        const rmSvc = new RemoveExtensionService({
+          repository,
+          lockfileRepository,
+          repoDir,
+        });
+        const result = await rmSvc.execute(targetExt);
+        assertEquals(result.filesDeleted > 0 || result.filesSkipped > 0, true);
+
+        // The stale /workspace row should have been pruned.
+        const remaining = catalog.findAll();
+        const stalePaths = remaining.filter((r) =>
+          r.source_path.startsWith("/workspace")
+        );
+        assertEquals(stalePaths.length, 0);
+      },
+    );
+  },
+);

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -209,16 +209,18 @@ function renderRepairLog(report: RepairReport): void {
   writeOutput("");
 
   for (const op of report.operations) {
-    const icon = op.kind === "catalog-row-pruned"
-      ? "x"
-      : op.kind === "pulled-extension-repulled"
-      ? "+"
-      : "-";
-    const label = op.kind === "catalog-row-pruned"
-      ? dim("[row]")
-      : op.kind === "pulled-extension-repulled"
-      ? dim("[pull]")
-      : dim("[file]");
+    const icon =
+      op.kind === "catalog-row-pruned" || op.kind === "unreachable-row-pruned"
+        ? "x"
+        : op.kind === "pulled-extension-repulled"
+        ? "+"
+        : "-";
+    const label =
+      op.kind === "catalog-row-pruned" || op.kind === "unreachable-row-pruned"
+        ? dim("[row]")
+        : op.kind === "pulled-extension-repulled"
+        ? dim("[pull]")
+        : dim("[file]");
     writeOutput(`  ${icon} ${label} ${op.path}`);
     writeOutput(`     ${dim(op.reason)}`);
   }


### PR DESCRIPTION
## Summary

- When the same repo is used from both a host shell and a container with a different bind-mount path, stale `bundle_types` rows accumulate with container-path `source_path` values (e.g. `/workspace/...` vs `/Users/...`)
- These phantom rows cause `I-Repo-1` violations that block **all** catalog writes — including `extension rm` on completely unrelated extensions
- Add a pre-flight prune in `ExtensionRepository.saveAll()` that deletes non-Tombstoned rows whose `source_path` is not under the canonical repo root, before `assertIRepo1()` fires
- Extend `swamp doctor extensions` repair to also detect and prune unreachable catalog orphans

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 6733 tests pass (0 failed)
- [x] 3 new unit tests for `pruneUnreachableSources()` (prunes outside root, preserves inside root, skips Tombstoned)
- [x] 2 new doctor repair tests (prunes unreachable rows on apply, dry-run reports without pruning)
- [x] 1 new integration test reproducing the exact swamp-club#574 scenario end-to-end
- [x] Manual verification: compiled binary, injected stale `/workspace/` row, confirmed `extension rm` on unrelated extension now succeeds (previously failed with I-Repo-1 violation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>