### PR TITLE
fix(http): validate ripple submission response and fix commentCount (swamp-club#577)

### DIFF
--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -287,6 +287,11 @@ export class SwampClubClient {
     }
 
     const data = await res.json();
+    if (typeof data.id !== "string" || data.id.length === 0) {
+      throw new UserError(
+        `Server accepted the ripple on issue #${issueNumber} but did not return a comment ID. The ripple may not have been saved.`,
+      );
+    }
     return { id: data.id };
   }
 
@@ -421,7 +426,7 @@ export class SwampClubClient {
           (a: Record<string, unknown>) => typeof a.username === "string",
         )
         .map((a: Record<string, string>) => a.username),
-      commentCount: (issue.comments ?? []).length,
+      commentCount: (data.comments ?? []).length,
     };
   }
 

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -520,3 +520,102 @@ Deno.test("SwampClubClient lets caller-supplied Authorization win over construct
     await mock.shutdown();
   }
 });
+
+// ── submitComment response validation ────────────────────────────────
+
+Deno.test("submitComment: returns id on valid response", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({ id: "comment-abc-123" })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.submitComment("key", 42, "hello");
+    assertEquals(result.id, "comment-abc-123");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("submitComment: throws when id is missing from response", async () => {
+  const mock = startMockServer((_req) => Response.json({}));
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.submitComment("key", 42, "hello"),
+      UserError,
+      "did not return a comment ID",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("submitComment: throws when id is null", async () => {
+  const mock = startMockServer((_req) => Response.json({ id: null }));
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.submitComment("key", 42, "hello"),
+      UserError,
+      "did not return a comment ID",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("submitComment: throws when id is empty string", async () => {
+  const mock = startMockServer((_req) => Response.json({ id: "" }));
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () => client.submitComment("key", 42, "hello"),
+      UserError,
+      "did not return a comment ID",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── fetchIssue commentCount ──────────────────────────────────────────
+
+Deno.test("fetchIssue: reads commentCount from top-level comments array", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({
+      issue: {
+        number: 42,
+        title: "Test issue",
+        type: "bug",
+        status: "open",
+        authorUsername: "alice",
+      },
+      comments: [
+        { id: "c1", body: "first" },
+        { id: "c2", body: "second" },
+      ],
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.fetchIssue(undefined, 42);
+    assertEquals(result.commentCount, 2);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("fetchIssue: commentCount is 0 when no comments array in response", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({
+      issue: { number: 1, title: "x", type: "bug", status: "open" },
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.fetchIssue(undefined, 1);
+    assertEquals(result.commentCount, 0);
+  } finally {
+    await mock.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- `submitComment` now validates the API response contains a non-empty comment ID before reporting success — prevents false "Posted ripple" logs when the server didn't confirm the comment was persisted
- `fetchIssue` now reads `commentCount` from the top-level `data.comments` array instead of `data.issue.comments` (which doesn't exist in the API response), fixing the always-zero commentCount bug

Fixes swamp-club#577

## Test Plan

- Added 4 unit tests for `submitComment` response validation (valid id, missing id, null id, empty id)
- Added 2 unit tests for `fetchIssue` commentCount (top-level comments array, no comments)
- Verified manually: `swamp issue get 514` now returns `commentCount: 5` (was 0)
- All 6733 existing tests pass