### PR TITLE
fix(http): run TLS trust config before the first handshake (swamp-club#477, swamp-club#503)

### DIFF
--- a/integration/tls_trust_test.ts
+++ b/integration/tls_trust_test.ts
@@ -21,30 +21,36 @@ import { assert, assertStringIncludes } from "@std/assert";
 import { join, toFileUrl } from "@std/path";
 
 /**
- * Integration coverage for the TLS trust-store shim (issue #503).
+ * Integration coverage for the TLS trust-store shim (issues #503 and #477).
  *
- * These tests drive the REAL `configureTlsTrust` code path in fresh
- * subprocesses — Deno reads its TLS CA environment lazily and caches the rustls
- * root store on first use, so each scenario must run in its own process. Using
- * the actual module (rather than a hand-rolled fetch client) guards the wiring:
- * if `configureTlsTrust` stopped mapping SSL_CERT_FILE, these would fail.
+ * These tests drive the REAL trust-configuration code path in fresh subprocesses
+ * (Deno caches its rustls root store on the first TLS handshake in a process, so
+ * each scenario must run in its own process). Using the actual modules — rather
+ * than a hand-rolled fetch client — guards the wiring: if `configureTlsTrust`
+ * stopped mapping SSL_CERT_FILE, or the bootstrap stopped running first, these
+ * would fail.
  *
- * Coverage boundary: the `system` trust-store branch cannot be exercised
- * without mutating the operating-system trust store, so these tests use the
- * SSL_CERT_FILE -> DENO_CERT mapping as the testable proxy for the lazy-env
- * mechanism. The public-TLS assertion is offline-tolerant.
+ * The `ordering` tests below encode the regression the first #503 fix missed:
+ * trust configured AFTER an import-time handshake is too late, so the bootstrap
+ * must run as the first import side effect.
+ *
+ * Coverage boundary: the `system` trust-store branch cannot be exercised without
+ * mutating the operating-system trust store, so these tests use the
+ * SSL_CERT_FILE -> DENO_CERT mapping as the testable proxy. The public-TLS
+ * assertion is offline-tolerant.
  */
 
-const TLS_TRUST_MODULE = toFileUrl(
-  join(
-    import.meta.dirname!,
-    "..",
-    "src",
-    "infrastructure",
-    "runtime",
-    "tls_trust.ts",
-  ),
-).href;
+const RUNTIME_DIR = join(
+  import.meta.dirname!,
+  "..",
+  "src",
+  "infrastructure",
+  "runtime",
+);
+const TLS_TRUST_MODULE = toFileUrl(join(RUNTIME_DIR, "tls_trust.ts")).href;
+const TLS_TRUST_BOOTSTRAP_MODULE =
+  toFileUrl(join(RUNTIME_DIR, "tls_trust_bootstrap.ts")).href;
+const MAIN_MODULE = join(import.meta.dirname!, "..", "main.ts");
 
 /** Returns true if `openssl` is available on PATH. */
 async function hasOpenssl(): Promise<boolean> {
@@ -257,4 +263,131 @@ Deno.test("tls_trust integration: public TLS still works under the merged store"
     `public TLS failed with a certificate error under the merged store: ${result}`,
   );
   console.warn(`skipping public-TLS assertion (offline?): ${result}`);
+});
+
+/** Runs an arbitrary entry script in a subprocess and returns its RESULT line. */
+async function runScript(
+  script: string,
+  env: Record<string, string>,
+): Promise<string> {
+  const baseEnv: Record<string, string> = {};
+  for (const key of ["PATH", "HOME", "DENO_DIR", "TMPDIR", "SystemRoot"]) {
+    const v = Deno.env.get(key);
+    if (v) baseEnv[key] = v;
+  }
+  const { stdout } = await spawnWithStdin(script, { ...baseEnv, ...env });
+  const out = new TextDecoder().decode(stdout);
+  return out.split("\n").find((l) => l.startsWith("RESULT:")) ?? out.trim();
+}
+
+// These two tests encode the regression that the first tls_trust fix missed:
+// Deno caches its TLS root store on the FIRST handshake in the process, so
+// trust configured *after* an import-time handshake (e.g. by a heavy dependency
+// evaluated before main()'s body) has no effect. The bootstrap module must run
+// as the first import side effect to win that race.
+Deno.test("tls_trust ordering: trust configured AFTER an import-time handshake is too late", async () => {
+  if (!(await hasOpenssl())) {
+    console.warn("skipping: openssl not available");
+    return;
+  }
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tls-order-" });
+  try {
+    const { caPath, fullchainPath, leafKeyPath } = await generateCertChain(dir);
+    const cert = await Deno.readTextFile(fullchainPath);
+    const key = await Deno.readTextFile(leafKeyPath);
+    const ac = new AbortController();
+    const server = Deno.serve(
+      { port: 0, cert, key, signal: ac.signal, onListen: () => {} },
+      () => new Response("ok"),
+    );
+    const port = (server.addr as Deno.NetAddr).port;
+    const url = `https://localhost:${port}/`;
+    // A module that performs a TLS handshake at evaluation time (a stand-in for
+    // a heavy dependency). Imported first, it caches the untrusted root store.
+    const offender = join(dir, "offender.ts");
+    await Deno.writeTextFile(
+      offender,
+      `try { await fetch(${
+        JSON.stringify(url)
+      }); } catch (_e) { /* untrusted */ }\n`,
+    );
+    try {
+      const script = `
+import ${JSON.stringify(toFileUrl(offender).href)};
+Deno.env.set("DENO_CERT", ${JSON.stringify(caPath)});
+try { const r = await fetch(${
+        JSON.stringify(url)
+      }); console.log("RESULT:OK:" + r.status); }
+catch (e) { console.log("RESULT:ERR:" + (e instanceof Error ? e.message : String(e))); }
+`;
+      const result = await runScript(script, {});
+      assertStringIncludes(result, "RESULT:ERR:");
+      assertStringIncludes(result, "UnknownIssuer");
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("tls_trust ordering: the bootstrap import wins the race against a later import-time handshake", async () => {
+  if (!(await hasOpenssl())) {
+    console.warn("skipping: openssl not available");
+    return;
+  }
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tls-order-" });
+  try {
+    const { caPath, fullchainPath, leafKeyPath } = await generateCertChain(dir);
+    const cert = await Deno.readTextFile(fullchainPath);
+    const key = await Deno.readTextFile(leafKeyPath);
+    const ac = new AbortController();
+    const server = Deno.serve(
+      { port: 0, cert, key, signal: ac.signal, onListen: () => {} },
+      () => new Response("ok"),
+    );
+    const port = (server.addr as Deno.NetAddr).port;
+    const url = `https://localhost:${port}/`;
+    const offender = join(dir, "offender.ts");
+    await Deno.writeTextFile(
+      offender,
+      `try { await fetch(${
+        JSON.stringify(url)
+      }); } catch (_e) { /* untrusted */ }\n`,
+    );
+    try {
+      // The real bootstrap module is imported FIRST (as in main.ts); the
+      // import-time handshake then sees the trust and the store is built with it.
+      const script = `
+import ${JSON.stringify(TLS_TRUST_BOOTSTRAP_MODULE)};
+import ${JSON.stringify(toFileUrl(offender).href)};
+try { const r = await fetch(${
+        JSON.stringify(url)
+      }); console.log("RESULT:OK:" + r.status); }
+catch (e) { console.log("RESULT:ERR:" + (e instanceof Error ? e.message : String(e))); }
+`;
+      const result = await runScript(script, { SSL_CERT_FILE: caPath });
+      assertStringIncludes(result, "RESULT:OK:200");
+    } finally {
+      ac.abort();
+      await server.finished;
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("tls_trust ordering: main.ts imports the bootstrap before any other module", async () => {
+  // Structural guard: the trust bootstrap must be the first import in main.ts.
+  // If it is reordered after a module that opens a TLS connection at evaluation
+  // time, the root store is cached before trust is configured.
+  const source = await Deno.readTextFile(MAIN_MODULE);
+  const firstImport = source.match(/^import\s+["']([^"']+)["']/m) ??
+    source.match(/^import\s.*?from\s+["']([^"']+)["']/ms);
+  assert(firstImport, "no import statement found in main.ts");
+  assertStringIncludes(
+    firstImport[1],
+    "runtime/tls_trust_bootstrap.ts",
+  );
 });

--- a/main.ts
+++ b/main.ts
@@ -17,8 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+// MUST be first: configures the TLS trust store before any other module is
+// evaluated. Deno caches its root store on the first TLS handshake, which a
+// heavy dependency (AWS SDK, OpenTelemetry, …) can trigger at import time —
+// before main()'s body runs. See tls_trust_bootstrap.ts for the full rationale.
+import "./src/infrastructure/runtime/tls_trust_bootstrap.ts";
 import { runCli } from "./src/cli/mod.ts";
-import { configureTlsTrust } from "./src/infrastructure/runtime/tls_trust.ts";
 import { initializeLogging } from "./src/infrastructure/logging/logger.ts";
 import { renderError } from "./src/presentation/output/error_output.ts";
 import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_sync_coordinator.ts";
@@ -30,10 +34,6 @@ import {
 } from "./src/infrastructure/tracing/mod.ts";
 
 if (import.meta.main) {
-  // Configure TLS trust before any network I/O so Deno honors the OS trust
-  // store (and SSL_CERT_FILE) when it first builds its TLS root store.
-  configureTlsTrust();
-
   const parentCtx = await initTracing();
   try {
     await runWithParentTrace(parentCtx, () => runCli(Deno.args));

--- a/src/infrastructure/runtime/tls_trust_bootstrap.ts
+++ b/src/infrastructure/runtime/tls_trust_bootstrap.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * TLS trust bootstrap — runs `configureTlsTrust` as an import side effect.
+ *
+ * This module MUST be the first import in `main.ts`. Deno builds and caches its
+ * rustls root store on the first TLS handshake in the process, after which
+ * changes to `DENO_TLS_CA_STORE` / `DENO_CERT` have no effect. ES modules
+ * evaluate depth-first in source order, so the first import is fully evaluated
+ * before any later import's module body. Heavy dependencies pulled in by other
+ * imports (the AWS SDK, OpenTelemetry, etc.) can trigger that first handshake at
+ * module-evaluation time — i.e. before any statement in `main.ts`'s body. A
+ * function call in the body therefore runs too late.
+ *
+ * Performing the configuration here, as the side effect of the first-evaluated
+ * import, guarantees the trust environment is in place before any other module
+ * is evaluated and before the first TLS connection is made.
+ *
+ * Keep this module's import graph minimal — it must not transitively import
+ * anything that opens a TLS connection at evaluation time.
+ */
+
+import { configureTlsTrust } from "./tls_trust.ts";
+
+configureTlsTrust();


### PR DESCRIPTION
## Summary

Fixes swamp-club#477 (and completes the swamp-club#503 fix). Users behind a TLS-inspecting proxy or a private CA still hit `invalid peer certificate: UnknownIssuer` on `swamp update` / `swamp extension search` unless they set `DENO_TLS_CA_STORE=system` manually — i.e. the #503 fix wasn't actually taking effect.

**Root cause:** Deno caches its rustls root store on the **first TLS handshake in the process**, after which `DENO_TLS_CA_STORE` / `DENO_CERT` changes have no effect. The #503 fix called `configureTlsTrust()` in `main.ts`'s body — but ES module imports all evaluate *before* the body, and a heavy dependency (AWS SDK, OpenTelemetry, …) triggers that first handshake at module-evaluation time. So the in-process env-set was always too late. The unit/integration tests passed only because they never had a prior handshake.

**Fix:** move the configuration into a side-effecting bootstrap module (`tls_trust_bootstrap.ts`) imported **first** in `main.ts`, so it runs before any other module evaluates and before the first TLS connection. This honors the OS/system CA store by default and maps `SSL_CERT_FILE` → `DENO_CERT`, satisfying #477's request for system + custom CA support.

### Changes

- `src/infrastructure/runtime/tls_trust_bootstrap.ts` (new) — runs `configureTlsTrust()` as the first import side effect.
- `main.ts` — bootstrap is now the first import; removed the late body call.
- `integration/tls_trust_test.ts` — added ordering regression tests (trust-after-handshake fails; bootstrap-first wins) and a structural guard that `main.ts`'s first import is the bootstrap.
- `tls_trust.ts` and its unit tests are unchanged — the decision logic was correct; only the execution timing was wrong.

## Test Plan

- `deno check`, `deno lint`, `deno fmt --check` — clean.
- `deno run test` — full suite, **6742 passed / 0 failed**.
- **Compiled-binary verification** (the check that the original fix lacked): with `SWAMP_CLUB_URL` pointed at a local private-CA HTTPS server, `SSL_CERT_FILE=<ca>` now resolves where it previously failed with `UnknownIssuer`; `DENO_CERT` at launch still works; public TLS against the real registry is unaffected.
- New ordering tests encode the regression: trust configured after an import-time handshake fails (the trap), and the real bootstrap imported first wins the race.

## Follow-ups (already filed)

- swamp-uat #248 — adversarial UAT for TLS trust against the compiled binary (the right home for end-to-end CI coverage).
- swamp-club Lab #509 — TLS/proxy/private-CA docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)