### PR TITLE
fix(workflow): load extension registries before resuming suspended runs

### DIFF
--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -50,6 +50,10 @@ import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { GIT_SHA } from "./version.ts";
 import { deepMerge, parseInputs, parseStdinContent } from "../input_parser.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { driverTypeRegistry } from "../../domain/drivers/driver_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -153,6 +157,13 @@ export const workflowResumeCommand = new Command()
             `Run "swamp workflow approve ${workflowName} ${waiting.stepName}" first.`,
         );
       }
+
+      await Promise.all([
+        modelRegistry.ensureLoaded(),
+        vaultTypeRegistry.ensureLoaded(),
+        driverTypeRegistry.ensureLoaded(),
+        reportRegistry.ensureLoaded(),
+      ]);
 
       // Surface what the resume inputs do to the run's inputs. Key names only —
       // values may be secrets and are never logged. Overrides (a resume key


### PR DESCRIPTION
## Summary

Fixes swamp-club#585.

`workflow resume` skipped the `ensureLoaded()` calls on the four extension
registries (`modelRegistry`, `vaultTypeRegistry`, `driverTypeRegistry`,
`reportRegistry`) that `workflow run` performs at startup. This left the lazy
type registry empty, so any step after a `manual_approval` gate whose model is
backed by an extension type — pulled or local — failed with
`"Unknown model type: <type>"`.

The fix adds the same `Promise.all([...ensureLoaded()])` block that
`workflow_run.ts` already has.

## Test Plan

- Reproduced the bug in a scratch repo (`/tmp/swamp-repro-issue-585`) with a
  local extension model and a `before-gate → manual_approval → after-gate`
  workflow
- Confirmed `after-gate` fails with "Unknown model type" before the fix
- Compiled the fixed binary and re-ran the scenario — workflow now succeeds
- Full test suite passes (6743 tests, 0 failures)
- `deno check`, `deno lint`, `deno fmt` all pass