### PR TITLE
fix(extensions): improve push error for disallowed file types to suggest binaries (swamp-club#589)

### DIFF
--- a/.claude/skills/swamp/references/extension-publish/references/publishing.md
+++ b/.claude/skills/swamp/references/extension-publish/references/publishing.md
@@ -447,15 +447,15 @@ The safety analyzer scans all files before push. Issues are classified as
 
 ### Errors (block push)
 
-| Rule                        | Detail                                                                  |
-| --------------------------- | ----------------------------------------------------------------------- |
-| `eval()` / `new Function()` | Dynamic code execution not allowed in `.ts` files                       |
-| Symlinks                    | Symlinked files are not allowed                                         |
-| Hidden files                | Files starting with `.` are not allowed                                 |
-| Disallowed extensions       | Only `.ts`, `.json`, `.md`, `.yaml`, `.yml`, `.txt` (`binaries` exempt) |
-| File too large              | Individual files must be under 1 MB                                     |
-| Total size exceeded         | All files combined must be under 10 MB                                  |
-| Too many files              | Maximum 150 files per extension                                         |
+| Rule                        | Detail                                                                                                                                                                                        |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eval()` / `new Function()` | Dynamic code execution not allowed in `.ts` files                                                                                                                                             |
+| Symlinks                    | Symlinked files are not allowed                                                                                                                                                               |
+| Hidden files                | Files starting with `.` are not allowed                                                                                                                                                       |
+| Disallowed extensions       | Only `.ts`, `.json`, `.md`, `.yaml`, `.yml`, `.txt` in `additionalFiles`. Files in the `binaries` manifest field are exempt — use `binaries` for executables and files with other extensions. |
+| File too large              | Individual files must be under 1 MB                                                                                                                                                           |
+| Total size exceeded         | All files combined must be under 10 MB                                                                                                                                                        |
+| Too many files              | Maximum 150 files per extension                                                                                                                                                               |
 
 ### Warnings (prompted)
 

--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -411,6 +411,30 @@ behavior is unchanged — omit it and paths resolve relative to the configured
 per-extension-subdir layouts. See
 [extension-publish references/publishing.md](../extension-publish/references/publishing.md#path-resolution--pathsbase).
 
+## Binaries
+
+Extensions can include executable host helpers (CLI tools, compiled binaries)
+via the `binaries` manifest field. Files listed in `binaries` are:
+
+- **Exempt from the file-extension allowlist** — unlike `additionalFiles` (which
+  only allows `.ts`, `.json`, `.md`, `.yaml`, `.yml`, `.txt`), binaries can have
+  any extension or no extension at all.
+- **Mode-bit preserved** — executable permissions survive the publish/pull cycle
+  on POSIX systems.
+- **Warned at pull time** — `swamp extension pull` alerts users to inspect
+  binaries before use.
+
+```yaml
+# manifest.yaml
+binaries:
+  - bin/my-helper
+  - bin/another-tool
+```
+
+Paths resolve the same way as `additionalFiles` (relative to the manifest
+directory, or following `paths.base`). Use `binaries` for executables and
+`additionalFiles` for non-code text files (README, LICENSE, config templates).
+
 ## CalVer Versioning
 
 Use `swamp extension version --manifest manifest.yaml --json` to get the correct

--- a/src/domain/extensions/extension_safety_analyzer.ts
+++ b/src/domain/extensions/extension_safety_analyzer.ts
@@ -102,7 +102,7 @@ export const DEFAULT_CONTENT_RULES: ContentRule[] = [
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const ALLOWED_EXTENSIONS = new Set([
+export const ALLOWED_EXTENSIONS = new Set([
   ".ts",
   ".json",
   ".md",

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { dirname, join, relative } from "@std/path";
+import { dirname, extname, join, relative } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { createTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -26,9 +26,10 @@ import type {
   ExtensionContentMetadata,
   ExtractedArgument,
 } from "../../domain/extensions/extension_content.ts";
-import type {
-  SafetyCheckResult,
-  SafetyIssue,
+import {
+  ALLOWED_EXTENSIONS,
+  type SafetyCheckResult,
+  type SafetyIssue,
 } from "../../domain/extensions/extension_safety_analyzer.ts";
 import type { QualityCheckResult } from "../../domain/extensions/extension_quality_checker.ts";
 import type { DependencySpecifier } from "../../domain/extensions/extension_dependency_extractor.ts";
@@ -579,7 +580,23 @@ export async function extensionPushPrepare(
   // 5. Build resolved data
   const resolvedData = buildResolvedData(input, contentMetadata);
 
-  // 6. Safety analysis
+  // 6a. Pre-check additionalFiles against the extension allowlist so the
+  // error can name the manifest field and suggest `binaries`.
+  for (const file of input.additionalFilePaths) {
+    const ext = extname(file).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      const rel = relative(input.repoDir, file);
+      throw validationFailed(
+        `File "${rel}" in additionalFiles has extension "${ext}" which is not allowed. ` +
+          `Allowed extensions for additionalFiles: ${
+            [...ALLOWED_EXTENSIONS].join(", ")
+          }. ` +
+          `If this is an executable or binary file, move it to the \`binaries\` field in manifest.yaml instead.`,
+      );
+    }
+  }
+
+  // 6b. Safety analysis
   // Include files are safety-checked but excluded from quality checks
   // (they may have their own tooling and conventions).
   const qualityFiles = [

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -200,6 +200,22 @@ Deno.test("extensionPushPrepare: invalid collective throws SwampError", async ()
   assertEquals(error.code, "validation_failed");
 });
 
+Deno.test("extensionPushPrepare: additionalFiles with disallowed extension suggests binaries", async () => {
+  const deps = makePrepareDeps();
+  const input = makePrepareInput({
+    additionalFilePaths: ["/tmp/test-repo/helper.bin"],
+    manifest: makeManifest({ additionalFiles: ["helper.bin"] }),
+  });
+
+  const error = await assertRejects(
+    () => extensionPushPrepare(ctx, deps, input),
+  ) as SwampError;
+  assertEquals(error.code, "validation_failed");
+  assertStringIncludes(error.message, "additionalFiles");
+  assertStringIncludes(error.message, "binaries");
+  assertStringIncludes(error.message, ".bin");
+});
+
 Deno.test("extensionPushPrepare: safety errors throw SwampError", async () => {
   const deps = makePrepareDeps({
     analyzeExtensionSafety: () =>


### PR DESCRIPTION
## Summary

- Pre-checks `additionalFilePaths` against the extension allowlist in `extensionPushPrepare` before the safety analyzer runs, producing a targeted error that names the file, identifies it came from `additionalFiles`, and suggests moving it to the `binaries` manifest field
- Exports `ALLOWED_EXTENSIONS` from the safety analyzer so the push prepare function can reference it without duplication
- Documents the `binaries` manifest field in the extension guide skill doc (previously zero mentions) and expands the parenthetical in the publishing skill doc

**Before:**
```
File extension ".bin" is not allowed. Allowed: .ts, .json, .md, .yaml, .yml, .txt
```

**After:**
```
File "helper.bin" in additionalFiles has extension ".bin" which is not allowed.
Allowed extensions for additionalFiles: .ts, .json, .md, .yaml, .yml, .txt.
If this is an executable or binary file, move it to the `binaries` field in manifest.yaml instead.
```

Closes swamp-club#589

## Test Plan

- Added unit test asserting the pre-check error mentions `additionalFiles` and `binaries`
- Reproduced the original bug in `/tmp/swamp-repro-issue-589`, verified fix produces the improved error
- All 45 existing push + safety analyzer tests pass
- `deno check`, `deno lint`, `deno fmt` all pass
- `tessl skill review` on swamp skill: 94/100, all checks pass