### PR TITLE
docs(extensions): type execute callbacks in skill guidance (swamp-club#587)

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -72,6 +72,8 @@ const GlobalArgsSchema = z.object({
   message: z.string(),
 });
 
+type GlobalArgs = z.infer<typeof GlobalArgsSchema>;
+
 const OutputSchema = z.object({
   id: z.uuid(),
   message: z.string(),
@@ -95,7 +97,17 @@ export const model = {
     run: {
       description: "Process the input message",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: GlobalArgs;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const handle = await context.writeResource("result", "main", {
           id: crypto.randomUUID(),
           message: context.globalArgs.message.toUpperCase(),

--- a/.claude/skills/swamp/references/extension/references/model/api.md
+++ b/.claude/skills/swamp/references/extension/references/model/api.md
@@ -111,11 +111,14 @@ additionalFiles:
 Read them at runtime via `ctx.extensionFile()`:
 
 ```ts
-execute: (async (_args, ctx) => {
+execute: async (
+  _args: Record<string, never>,
+  ctx: { extensionFile: (path: string) => string },
+) => {
   const promptPath = ctx.extensionFile("prompts/review.md");
   const prompt = await Deno.readTextFile(promptPath);
   // ...
-});
+},
 ```
 
 Do **not** hardcode `.swamp/pulled-extensions/<name>/files/...` — that layout
@@ -369,7 +372,16 @@ executions should not persist incorrect or misleading data.
 **Pattern: check for failure first, only write data on success.**
 
 ```typescript
-execute: (async (args, context) => {
+execute: async (
+  args: z.infer<typeof RequestArgsSchema>,
+  context: {
+    writeResource: (
+      specName: string,
+      name: string,
+      data: Record<string, unknown>,
+    ) => Promise<{ name: string }>;
+  },
+) => {
   const result = await callExternalApi(args);
 
   // Throw BEFORE writing data — don't persist failure data
@@ -384,7 +396,7 @@ execute: (async (args, context) => {
   });
 
   return { dataHandles: [handle] };
-});
+},
 ```
 
 **Workflow integration:** When a model method throws, the workflow engine
@@ -404,7 +416,13 @@ arithmetic-overload registrations.
 ### Basic usage
 
 ```typescript
-execute: (async (args, ctx) => {
+execute: async (
+  args: z.infer<typeof SelectorArgsSchema>,
+  ctx: {
+    globalArgs: GlobalArgs;
+    createCelEnvironment: () => Environment;
+  },
+) => {
   const env = ctx.createCelEnvironment();
 
   // Compile once, evaluate many.
@@ -415,7 +433,7 @@ execute: (async (args, ctx) => {
   );
 
   // ... write resource with matched ...
-});
+},
 ```
 
 The example above takes a selector like
@@ -448,14 +466,17 @@ If a helper signature inside the extension needs the named type, use
 `ReturnType<typeof ctx.createCelEnvironment>` — no external import is required:
 
 ```typescript
-execute: (async (args, ctx) => {
+execute: async (
+  args: z.infer<typeof SelectorArgsSchema>,
+  ctx: { createCelEnvironment: () => Environment },
+) => {
   type CelEnv = ReturnType<typeof ctx.createCelEnvironment>;
   return runPredicate(ctx.createCelEnvironment(), args.selector);
 
   function runPredicate(env: CelEnv, selector: string) {
     return env.parse(selector)({/* ... */});
   }
-});
+},
 ```
 
 Do NOT import `Environment` from `@systeminit/swamp-testing` in production
@@ -472,6 +493,38 @@ class identifiers are different objects. Method calls dispatch correctly via
 prototypes, but `instanceof Environment` will return `false` across that
 boundary. Don't write identity checks against the class — duck-type against the
 methods you call.
+
+---
+
+## Method execute Signature
+
+```typescript
+execute: (async (
+  args: z.infer<typeof MethodArgsSchema>,
+  context: {/* only the fields you use */},
+) => Promise<{ dataHandles?: Array<{ name: string }> }>);
+```
+
+### Context Fields Available in Methods
+
+| Field                          | Type                                                                                           | Description                                      |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `context.signal`               | `AbortSignal`                                                                                  | Cancellation signal for async operations         |
+| `context.repoDir`              | `string`                                                                                       | Repository root path                             |
+| `context.globalArgs`           | `z.infer<typeof GlobalArgsSchema>`                                                             | Validated global arguments from the definition   |
+| `context.definition`           | `{ id: string; name: string; version: string; tags: Record<string, string> }`                  | Model instance metadata                          |
+| `context.methodName`           | `string`                                                                                       | Name of the method being invoked                 |
+| `context.logger`               | LogTape Logger (trace/debug/info/warning/error/fatal)                                          | Structured logging                               |
+| `context.writeResource`        | `(specName: string, name: string, data: Record<string, unknown>) => Promise<{ name: string }>` | Write structured JSON data                       |
+| `context.readResource`         | `(instanceName: string, version?: number) => Promise<Record<string, unknown> \| null>`         | Read previously stored data                      |
+| `context.createFileWriter`     | `(specName: string, name: string) => DataWriter`                                               | Create binary/streaming file writer              |
+| `context.createCelEnvironment` | `() => Environment`                                                                            | Fresh CEL environment for expression evaluation  |
+| `context.dataRepository`       | Low-level data API                                                                             | For reading non-JSON content or cross-model data |
+| `context.modelType`            | `string`                                                                                       | The model type string (e.g. `@myorg/my-model`)   |
+| `context.modelId`              | `string`                                                                                       | The model instance ID                            |
+
+Type only the fields your method body actually uses — don't declare the full
+interface. See [typing.md](typing.md) for the complete typing guide.
 
 ---
 

--- a/.claude/skills/swamp/references/extension/references/model/examples.md
+++ b/.claude/skills/swamp/references/extension/references/model/examples.md
@@ -119,7 +119,17 @@ export const model = {
       arguments: z.object({
         topN: z.number().default(5),
       }),
-      execute: async (args, context) => {
+      execute: async (
+        args: { topN: number },
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const allWords = words(context.globalArgs.text.toLowerCase());
         const counts = countBy(allWords);
         const sorted = sortBy(
@@ -211,7 +221,17 @@ export const model = {
     create: {
       description: "Create a VPC",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { cidrBlock, region } = context.globalArgs;
 
         const cmd = new Deno.Command("aws", {
@@ -238,7 +258,20 @@ export const model = {
     update: {
       description: "Update VPC attributes (e.g., enable DNS support)",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (
+            name: string,
+          ) => Promise<Record<string, unknown> | null>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const region = context.globalArgs.region;
 
         // 1. Read stored data to get the resource ID
@@ -297,7 +330,15 @@ export const model = {
     delete: {
       description: "Delete the VPC",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (
+            name: string,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
         const region = context.globalArgs.region;
 
         // Read back stored data to get the VPC ID
@@ -330,7 +371,20 @@ export const model = {
     sync: {
       description: "Refresh stored VPC state from live AWS API",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (
+            name: string,
+          ) => Promise<Record<string, unknown> | null>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const region = context.globalArgs.region;
 
         // 1. Read stored data to get the VPC ID
@@ -566,7 +620,17 @@ export const model = {
     create: {
       description: "Create a load balancer and wait until active",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { name, region, apiToken } = context.globalArgs;
 
         // 1. Call the create API
@@ -711,7 +775,20 @@ export const model = {
     create: {
       description: "Create a droplet (idempotent — skips if already exists)",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (
+            name: string,
+          ) => Promise<Record<string, unknown> | null>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { name, region, size, image, apiToken } = context.globalArgs;
         const instanceName = "main";
 
@@ -804,7 +881,19 @@ marker. The purpose is detection, not failure.
 sync: {
   description: "Refresh stored state from live API",
   arguments: z.object({}),
-  execute: async (_args, context) => {
+  execute: async (
+    _args: Record<string, never>,
+    context: {
+      readResource: (
+        name: string,
+      ) => Promise<Record<string, unknown> | null>;
+      writeResource: (
+        specName: string,
+        name: string,
+        data: Record<string, unknown>,
+      ) => Promise<{ name: string }>;
+    },
+  ) => {
     const instanceName = "main";
 
     // 1. Read stored state to get the resource ID
@@ -931,7 +1020,17 @@ export const model = {
     check: {
       description: "Check endpoint health",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { url, expectedStatus } = context.globalArgs;
         const start = Date.now();
 
@@ -999,7 +1098,16 @@ export const model = {
     process: {
       description: "Process text according to the specified operation",
       arguments: InputSchema,
-      execute: async (args, context) => {
+      execute: async (
+        args: z.infer<typeof InputSchema>,
+        context: {
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { text, operation } = args;
 
         let processedText: string;
@@ -1067,7 +1175,17 @@ export const model = {
     deploy: {
       description: "Deploy the application",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof InputSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const attrs = context.globalArgs;
         const deploymentId = `deploy-${attrs.appName}-${Date.now()}`;
 
@@ -1086,7 +1204,17 @@ export const model = {
     scale: {
       description: "Scale the deployment replicas",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof InputSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const attrs = context.globalArgs;
 
         const handle = await context.writeResource("state", "state", {
@@ -1134,7 +1262,17 @@ export const model = {
     run: {
       description: "Echo the message with timestamp",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof InputSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const handle = await context.writeResource("data", "data", {
           message: context.globalArgs.message,
           timestamp: new Date().toISOString(),
@@ -1185,7 +1323,17 @@ export const model = {
     generate: {
       description: "Generate service configuration based on environment",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof InputSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { environment, serviceName } = context.globalArgs;
 
         // Generate environment-specific configuration
@@ -1268,7 +1416,18 @@ export const model = {
     run: {
       description: "Run a system command with streamed output",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof InputSchema>;
+          logger: { info(msg: string, ...args: unknown[]): void };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const attrs = context.globalArgs;
 
         // executeProcess streams stdout (info) and stderr (warn) through
@@ -1381,7 +1540,17 @@ export const model = {
     create: {
       description: "Create a VPC",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { cidrBlock, region, awsProfile } = context.globalArgs;
 
         await validateCredentials({ region, awsProfile });
@@ -1429,7 +1598,22 @@ export const extension = {
     audit: {
       description: "Audit the shell command execution",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          definition: {
+            id: string;
+            name: string;
+            version: string;
+            tags: Record<string, string>;
+          };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         // Extensions use the target model's resources/files
         const handle = await context.writeResource("result", "result", {
           exitCode: 0,
@@ -1455,7 +1639,22 @@ export const extension = {
     audit: {
       description: "Audit the shell command execution",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          definition: {
+            id: string;
+            name: string;
+            version: string;
+            tags: Record<string, string>;
+          };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
@@ -1467,7 +1666,17 @@ export const extension = {
     validate: {
       description: "Validate the shell command format",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: Record<string, unknown>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `valid: ${context.globalArgs.run?.length > 0}`,
@@ -1531,7 +1740,10 @@ export const model = {
         type: "resource",
         description: "Discovered devices",
       }],
-      execute: async (_args: unknown, context: { repoDir: string }) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: { repoDir: string },
+      ) => {
         const scriptPath =
           `${context.repoDir}/extensions/models/homekit_discover.ts`;
         const cmd = new Deno.Command("deno", {
@@ -1618,7 +1830,17 @@ export const model = {
     send: {
       description: "Send a notification",
       arguments: z.object({}),
-      execute: async (args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { content: string; priority: "low" | "medium" | "high" };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const globalArgs = context.globalArgs;
         const handle = await context.writeResource("result", "main", {
           sent: true,

--- a/.claude/skills/swamp/references/extension/references/model/scenarios.md
+++ b/.claude/skills/swamp/references/extension/references/model/scenarios.md
@@ -77,7 +77,17 @@ export const model = {
     create: {
       description: "Create a new Stripe customer",
       arguments: CreateArgsSchema,
-      execute: async (args, context) => {
+      execute: async (
+        args: z.infer<typeof CreateArgsSchema>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const response = await fetch("https://api.stripe.com/v1/customers", {
           method: "POST",
           headers: {
@@ -109,9 +119,20 @@ export const model = {
     get: {
       description: "Get customer details",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (name: string) => Promise<unknown>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         // Read stored customer ID
-        const stored = await context.readResource!("primary") as
+        const stored = await context.readResource("primary") as
           | CustomerData
           | null;
 
@@ -250,7 +271,17 @@ export const model = {
     create: {
       description: "Create an S3 bucket",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { bucketName, region } = context.globalArgs;
 
         const cmd = new Deno.Command("aws", {
@@ -297,11 +328,22 @@ export const model = {
     update: {
       description: "Update bucket settings (enable versioning)",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          readResource: (name: string) => Promise<unknown>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { bucketName, versioning } = context.globalArgs;
 
         // Read existing data
-        const existingData = await context.readResource!("main") as
+        const existingData = await context.readResource("main") as
           | BucketData
           | null;
 
@@ -343,9 +385,15 @@ export const model = {
     delete: {
       description: "Delete the S3 bucket",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          readResource: (name: string) => Promise<unknown>;
+          logger: { info: (msg: string, ...args: unknown[]) => void };
+        },
+      ) => {
         // Read stored data to get bucket name
-        const bucketData = await context.readResource!("main") as
+        const bucketData = await context.readResource("main") as
           | BucketData
           | null;
 
@@ -381,9 +429,19 @@ export const model = {
     sync: {
       description: "Refresh stored bucket state from live AWS API",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          readResource: (name: string) => Promise<unknown>;
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         // Read stored data to get bucket name
-        const bucketData = await context.readResource!("main") as
+        const bucketData = await context.readResource("main") as
           | BucketData
           | null;
 
@@ -560,7 +618,18 @@ export const model = {
     scan: {
       description: "Scan and discover all VPCs in the region",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: z.infer<typeof GlobalArgsSchema>;
+          logger: { info: (msg: string, ...args: unknown[]) => void };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const { region } = context.globalArgs;
 
         const cmd = new Deno.Command("aws", {
@@ -693,7 +762,19 @@ export const extension = {
       arguments: z.object({
         auditTag: z.string().optional(),
       }),
-      execute: async (args, context) => {
+      execute: async (
+        args: { auditTag?: string },
+        context: {
+          definition: { name: string };
+          globalArgs: { run: string };
+          logger: { info: (msg: string, ...args: unknown[]) => void };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const auditEntry = {
           modelName: context.definition.name,
           command: context.globalArgs.run,
@@ -717,7 +798,18 @@ export const extension = {
     dryRun: {
       description: "Show what would be executed without running",
       arguments: z.object({}),
-      execute: async (_args, context) => {
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          globalArgs: { run: string };
+          logger: { info: (msg: string, ...args: unknown[]) => void };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
         const command = context.globalArgs.run;
 
         context.logger.info("Would execute: {command}", { command });

--- a/.claude/skills/swamp/references/extension/references/model/testing.md
+++ b/.claude/skills/swamp/references/extension/references/model/testing.md
@@ -58,7 +58,10 @@ a stub instead of the live SDK:
 
 ```typescript
 // In the model execute function
-execute: (async (args, context) => {
+execute: (async (
+  args: z.infer<typeof ArgsSchema> & { _s3Client?: S3Client },
+  context: { globalArgs: { region: string; bucket: string } },
+) => {
   const s3 = args._s3Client ??
     new S3Client({ region: context.globalArgs.region });
   await s3.send(new CreateBucketCommand({ Bucket: context.globalArgs.bucket }));

--- a/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
+++ b/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
@@ -56,7 +56,16 @@ export const model = {
     run: {
       description: "Run the model",
       arguments: InputSchema,
-      execute: async (args, context) => { ... },
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => { ... },
     },
   },
 };

--- a/.claude/skills/swamp/references/extension/references/model/typing.md
+++ b/.claude/skills/swamp/references/extension/references/model/typing.md
@@ -1,70 +1,39 @@
-# Execute function typing — the `satisfies` escape hatch
+# Execute function typing
 
-This reference applies **only when your `_test.ts` file imports the model source
-directly.** If your tests do not import the model source, you do not need this
-page — the default unannotated form in the
-[Quick Start](../../guide.md#quick-starts) works without any changes.
+Extension model `execute` callbacks receive `args` and `context` from the swamp
+runtime. Under Deno's strict TypeScript mode, unannotated parameters produce
+TS7006 when a sibling `_test.ts` file imports the model source. This page
+documents the recommended typing patterns.
 
 ## The problem
 
 The default extension-model shape uses unannotated execute parameters:
 
 ```typescript
-import { z } from "npm:zod@4";
-
-export const model = {
-  type: "@myorg/my-model",
-  version: "2026.04.21.1",
-  globalArguments: z.object({ region: z.string() }),
-  methods: {
-    run: {
-      description: "Run the model",
-      arguments: z.object({ bucket: z.string() }),
-      execute: async (args, context) => {
-        // args and context are contextually typed from the
-        // inferred shape of `model` — works fine in isolation.
-        return { dataHandles: [] };
-      },
-    },
-  },
-};
+execute: (async (args, context) => {/* ... */});
 ```
 
-This is valid TypeScript. Swamp loads the model at runtime, validates it against
-the canonical shape, and everything works.
-
-**Where it breaks:** when a sibling `_test.ts` file imports the source:
-
-```typescript
-// my_model_test.ts
-import { model } from "./my_model.ts";
-// ...
-```
-
-Deno type-checks the imported source under the repo's `strict: true` compiler
-options. Without an anchor type, TS cannot infer the parameters of inline method
-`execute` functions and reports:
+This is valid TypeScript in isolation. But when a sibling `_test.ts` file
+imports the source, Deno type-checks it under strict mode and reports:
 
 ```
 TS7006 [ERROR]: Parameter 'args' implicitly has an 'any' type.
 TS7006 [ERROR]: Parameter 'context' implicitly has an 'any' type.
 ```
 
-Models whose tests do not import the source (for example because the test stubs
-the CLI rather than the model literal) silently escape the problem, producing an
-inconsistent experience across the ecosystem.
+## Recommended pattern: inline type annotations
 
-## The escape hatch
-
-Wrap the model literal with
-`satisfies ModelDefinition<typeof YourGlobalArgsSchema>` from
-`@systeminit/swamp-testing`:
+Type `args` using `z.infer<typeof YourSchema>` and type `context` inline with
+only the fields the method uses. This requires no external imports beyond `zod`
+(already present in every extension):
 
 ```typescript
 import { z } from "npm:zod@4";
-import type { ModelDefinition } from "jsr:@systeminit/swamp-testing";
 
 const GlobalArgsSchema = z.object({ region: z.string() });
+type GlobalArgs = z.infer<typeof GlobalArgsSchema>;
+
+const RunArgsSchema = z.object({ bucket: z.string() });
 
 export const model = {
   type: "@myorg/my-model",
@@ -73,11 +42,84 @@ export const model = {
   methods: {
     run: {
       description: "Run the model",
-      arguments: z.object({ bucket: z.string() }),
+      arguments: RunArgsSchema,
+      execute: async (
+        args: z.infer<typeof RunArgsSchema>,
+        context: {
+          globalArgs: GlobalArgs;
+          logger: { info(msg: string, ...args: unknown[]): void };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        context.logger.info("Processing bucket {bucket}", args.bucket);
+        const handle = await context.writeResource("result", "main", {
+          region: context.globalArgs.region,
+          bucket: args.bucket,
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};
+```
+
+### Key conventions
+
+- **Type only the context fields you use.** Don't declare all 12 fields — just
+  the ones the method body references. This keeps signatures readable.
+- **Use `z.infer<typeof Schema>` for args.** This gives you the exact shape
+  validated by the runtime, with zero duplication.
+- **Use `_args: Record<string, never>` for methods with no arguments.** This is
+  clearer than `_args: unknown` or `_args: z.infer<typeof z.object({})>`.
+- **Define a `type GlobalArgs = z.infer<typeof GlobalArgsSchema>` alias** at the
+  top of the file for reuse across methods.
+
+### Available context fields
+
+Every `execute` callback receives these fields on `context`. Type only what you
+use:
+
+| Field                  | Type signature                                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `signal`               | `AbortSignal`                                                                                  |
+| `repoDir`              | `string`                                                                                       |
+| `globalArgs`           | `z.infer<typeof YourGlobalArgsSchema>`                                                         |
+| `definition`           | `{ id: string; name: string; version: string; tags: Record<string, string> }`                  |
+| `methodName`           | `string`                                                                                       |
+| `logger`               | `{ info(msg: string, ...args: unknown[]): void; ... }` (trace/debug/info/warning/error/fatal)  |
+| `writeResource`        | `(specName: string, name: string, data: Record<string, unknown>) => Promise<{ name: string }>` |
+| `readResource`         | `(instanceName: string, version?: number) => Promise<Record<string, unknown> \| null>`         |
+| `createFileWriter`     | `(specName: string, name: string) => DataWriter`                                               |
+| `createCelEnvironment` | `() => Environment`                                                                            |
+| `dataRepository`       | Low-level data API (for reading non-JSON content)                                              |
+| `modelType`            | `string`                                                                                       |
+| `modelId`              | `string`                                                                                       |
+
+## Alternative: `satisfies ModelDefinition`
+
+If you prefer not to annotate each method individually, you can wrap the model
+literal with `satisfies ModelDefinition<typeof GlobalArgsSchema>` from
+`@systeminit/swamp-testing`:
+
+```typescript
+import type { ModelDefinition } from "jsr:@systeminit/swamp-testing";
+
+export const model = {
+  type: "@myorg/my-model",
+  version: "2026.04.21.1",
+  globalArguments: GlobalArgsSchema,
+  methods: {
+    run: {
+      description: "Run the model",
+      arguments: RunArgsSchema,
       execute: async (args, context) => {
-        // context.globalArgs narrows to { region: string } — you get
-        // type safety on the typed parts of the execution context
-        // without any annotation on the execute parameters.
+        // context.globalArgs narrows to { region: string }
+        // args is z.infer<z.ZodTypeAny> — effectively `any`
+        const { bucket } = RunArgsSchema.parse(args);
         return { dataHandles: [] };
       },
     },
@@ -85,96 +127,31 @@ export const model = {
 } satisfies ModelDefinition<typeof GlobalArgsSchema>;
 ```
 
-Nothing inside `execute` changes. The only addition is the trailing
-`satisfies ModelDefinition<typeof GlobalArgsSchema>` and the type-only import.
+This resolves TS7006 and narrows `context.globalArgs`, but `args` remains
+untyped — you need `.parse(args)` at the top of each execute body to recover the
+specific shape. The inline annotation pattern (above) is preferred because it
+gives full type safety on both `args` and `context` without additional imports.
 
-## What changes, concretely
+### `defineModel` function form
 
-Before (with `// deno-lint-ignore no-explicit-any` and `: any`):
-
-```typescript
-// deno-lint-ignore no-explicit-any
-execute: async (_args: any, context: any) => {
-  context.globalArgs.region // hover: any
-  context.writeResource(...) // no autocomplete
-}
-```
-
-After (`satisfies ModelDefinition<typeof GlobalArgsSchema>`):
-
-```typescript
-execute: async (_args, context) => {
-  context.globalArgs.region // hover: string — narrowed from the schema
-  context.writeResource(...) // full autocomplete and argument checking
-}
-```
-
-## Narrowing `args` per method
-
-`args` inside each execute body is typed via `z.infer<z.ZodTypeAny>` —
-effectively `any`. This resolves TS7006 but does not give you the specific shape
-of the method's `arguments` schema. To narrow `args` at the top of an execute
-body, parse it with the method's schema:
-
-```typescript
-const RunArgsSchema = z.object({ bucket: z.string() });
-
-methods: {
-  run: {
-    description: "Run the model",
-    arguments: RunArgsSchema,
-    execute: async (args, context) => {
-      const { bucket } = RunArgsSchema.parse(args);
-      // bucket: string — fully typed from here on
-      return { dataHandles: [] };
-    },
-  },
-},
-```
-
-Swamp already validates `args` against the schema before calling `execute`, so
-the `.parse()` call is a compile-time helper, not a runtime safety net — feel
-free to use `as z.infer<typeof RunArgsSchema>` if you prefer an assertion over a
-parse call.
-
-## When not to use this
-
-- **Your tests do not import the model source.** The unannotated default form
-  works — don't add the import or the `satisfies` clause.
-- **You want the simplest possible model file.** The default unannotated form is
-  still the recommended Quick Start for new extensions.
-- **You are comfortable with inline context shapes.** If your model already
-  declares `context: { globalArgs: ..., logger: ..., ... }` inline, that
-  continues to work and does not conflict with the escape hatch.
-
-## `defineModel` alternative
-
-If you prefer a function-form wrapper to `satisfies`, the testing package also
-exports `defineModel`:
+The testing package also exports `defineModel` — identical behaviour to
+`satisfies`, different call-site syntax:
 
 ```typescript
 import { defineModel } from "jsr:@systeminit/swamp-testing";
 
 export const model = defineModel({
   type: "@myorg/my-model",
-  version: "2026.04.21.1",
-  globalArguments: GlobalArgsSchema,
-  methods: {/* ... */},
+  // ...
 });
 ```
 
-Contract is identical to `satisfies ModelDefinition<...>` — same narrowing
-behavior, just different call-site syntax. Runtime cost is zero (`defineModel`
-returns its input unchanged).
+Same trade-off: `context.globalArgs` narrows, `args` remains `any`.
 
-## References
+## When not to use any of this
 
-- Swamp Club issue [#141](https://swamp.club/lab/issues/141) — the original DX
-  gap that motivated this escape hatch.
-- `src/domain/models/testing_package_compat_test.ts` — CI test that keeps the
-  testing-package `ModelDefinition` structurally aligned with the canonical
-  `ModelDefinition` in `src/domain/models/model.ts`. If the two drift, this test
-  fails.
-- [`references/testing.md`](testing.md) — unit-testing patterns for extension
-  models; read this if you are writing the tests that originally triggered
-  TS7006.
+- **Your tests do not import the model source.** The unannotated form works fine
+  — don't add annotations you don't need.
+- **You are comfortable with `: any`.** The workaround
+  `execute: async (args: any, context: any) =>` continues to work and push. It
+  sacrifices type safety but is not a blocker.


### PR DESCRIPTION
## Summary

Updates the extension model skill to generate properly typed `execute` callbacks by default, resolving the TS7006 errors reported in swamp-club#587.

**What changed:**
- Quick Start template in `guide.md` now uses typed parameters
- `typing.md` rewritten: inline annotation is the primary pattern, `satisfies`/`defineModel` demoted to alternatives
- `api.md` gains a "Method execute Signature" section with full context fields table
- All execute callbacks across `examples.md`, `scenarios.md`, `testing.md`, and `troubleshooting.md` now have typed args and context

**Why this approach:**
- No new packages or libraries — existing extensions continue working unchanged
- `swamp extension push` doesn't run `deno check`, so untyped extensions aren't blocked from publishing
- The fix is purely additive DX: newly generated extensions get type safety from day one, existing ones can adopt at their own pace
- Uses only `z.infer<typeof Schema>` (already available from zod) and inline TypeScript interfaces — zero new imports required

**Convention established:**
- Type `args` with `z.infer<typeof MethodArgsSchema>` (or `Record<string, never>` for empty args)
- Type `context` inline with only the fields the method body uses
- Define `type GlobalArgs = z.infer<typeof GlobalArgsSchema>` once at the top for reuse

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — 6743 tests pass
- [x] No remaining untyped execute callbacks outside the intentional "before" examples in typing.md
- [x] Verified the typed Quick Start pattern resolves TS7006 when imported by a test file

Closes swamp-club#587