### PR TITLE
fix(skills): lead vault guide with safe secret-storage patterns

### DIFF
--- a/.claude/skills/swamp-getting-started/references/tracks.md
+++ b/.claude/skills/swamp-getting-started/references/tracks.md
@@ -50,7 +50,7 @@ If the chosen model type requires credentials (cloud services, APIs, etc.), set
 up a vault before configuring the model. Use the `swamp` skill (vault guide):
 
 1. Create a vault: `swamp vault create local_encryption my-secrets --json`
-2. Store credentials: `swamp vault put my-secrets KEY=VALUE --json`
+2. Store credentials: `swamp vault put my-secrets API_KEY` (prompts securely)
 3. Reference in model YAML: `${{ vault.get("my-secrets", "KEY") }}`
 
 ## Method Selection

--- a/.claude/skills/swamp-getting-started/references/tracks.md
+++ b/.claude/skills/swamp-getting-started/references/tracks.md
@@ -51,7 +51,7 @@ up a vault before configuring the model. Use the `swamp` skill (vault guide):
 
 1. Create a vault: `swamp vault create local_encryption my-secrets --json`
 2. Store credentials: `swamp vault put my-secrets API_KEY` (prompts securely)
-3. Reference in model YAML: `${{ vault.get("my-secrets", "KEY") }}`
+3. Reference in model YAML: `${{ vault.get("my-secrets", "API_KEY") }}`
 
 ## Method Selection
 

--- a/.claude/skills/swamp/references/vault/guide.md
+++ b/.claude/skills/swamp/references/vault/guide.md
@@ -26,9 +26,9 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 | Search vaults      | `swamp vault search [query] --json`                     |
 | Get vault details  | `swamp vault get <name_or_id> --json`                   |
 | Edit vault config  | `swamp vault edit <name_or_id>`                         |
-| Store a secret     | `swamp vault put <vault> KEY=VALUE --json`              |
-| Store from stdin   | `echo "val" \| swamp vault put <vault> KEY --json`      |
-| Store interactive  | `swamp vault put <vault> KEY` (prompts for value)       |
+| Store a secret     | `swamp vault put <vault> KEY` (prompts for value)       |
+| Store from stdin   | `echo "$VAL" \| swamp vault put <vault> KEY --json`     |
+| Store inline       | `swamp vault put <vault> KEY=VALUE --json` (insecure)   |
 | Read a secret      | `swamp vault read-secret <vault> <key> --force --json`  |
 | List secret keys   | `swamp vault list-keys <vault> --json`                  |
 | Annotate a secret  | `swamp vault annotate <vault> <key> --url <u>`          |
@@ -115,11 +115,11 @@ swamp vault edit dev-secrets
 
 ## Store Secrets
 
-**Inline value (appears in shell history):**
+**Interactive prompt (recommended for humans — value is hidden):**
 
 ```bash
-swamp vault put dev-secrets API_KEY=sk-1234567890 --json
-swamp vault put prod-secrets DB_PASSWORD=secret123 -f --json  # Skip confirmation
+swamp vault put dev-secrets API_KEY
+# Enter value for API_KEY: ********
 ```
 
 **Piped value (recommended for scripts/CI — keeps secrets out of shell
@@ -131,11 +131,11 @@ cat ~/secrets/token.txt | swamp vault put dev-secrets TOKEN --json
 op read "op://vault/item/field" | swamp vault put dev-secrets SECRET --json
 ```
 
-**Interactive prompt (recommended for humans — value is hidden):**
+**Inline value (insecure — exposes secrets in shell history, process tables, and
+logs; use only for non-sensitive test data):**
 
 ```bash
-swamp vault put dev-secrets API_KEY
-# Enter value for API_KEY: ********
+swamp vault put dev-secrets API_KEY=test-placeholder --json
 ```
 
 Interactive mode (TTY, no `=`, no pipe) prompts with echo suppressed; piped

--- a/.claude/skills/swamp/references/vault/references/examples.md
+++ b/.claude/skills/swamp/references/vault/references/examples.md
@@ -57,32 +57,33 @@ swamp vault create local_encryption backend-secrets --json
 There are three ways to provide a secret value:
 
 ```bash
-# 1. Inline KEY=VALUE
-swamp vault put dev-secrets API_KEY=dev-key-12345 --json
-
-# 2. Piped from stdin (useful in scripts/CI)
-echo "dev-db-pass" | swamp vault put dev-secrets DB_PASSWORD --json
-cat secret.txt | swamp vault put dev-secrets CERT --json
-
-# 3. Interactive prompt (TTY only, value is hidden)
+# 1. Interactive prompt (recommended — value is hidden)
 #    Just provide the key without a value — you'll be prompted:
 #    $ swamp vault put dev-secrets API_KEY
 #    Enter value for API_KEY: ********
 swamp vault put dev-secrets API_KEY
+
+# 2. Piped from stdin (recommended for scripts/CI)
+echo "$DB_PASSWORD" | swamp vault put dev-secrets DB_PASSWORD --json
+cat secret.txt | swamp vault put dev-secrets CERT --json
+
+# 3. Inline KEY=VALUE (insecure — exposes value in shell history/process tables;
+#    use only for non-sensitive test data)
+swamp vault put dev-secrets TEST_MODE=enabled --json
 ```
 
 ```bash
-# Dev environment
-swamp vault put dev-secrets API_KEY=dev-key-12345 --json
-swamp vault put dev-secrets DB_PASSWORD=dev-db-pass --json
+# Dev environment (piped from env vars)
+echo "$API_KEY" | swamp vault put dev-secrets API_KEY --json
+echo "$DB_PASSWORD" | swamp vault put dev-secrets DB_PASSWORD --json
 
-# Staging environment
-swamp vault put staging-secrets API_KEY=staging-key-67890 --json
-swamp vault put staging-secrets DB_PASSWORD=staging-db-pass --json
+# Staging environment (piped from env vars)
+echo "$API_KEY" | swamp vault put staging-secrets API_KEY --json
+echo "$DB_PASSWORD" | swamp vault put staging-secrets DB_PASSWORD --json
 
-# Production environment (via AWS)
-swamp vault put prod-secrets API_KEY=prod-key-secure --json
-swamp vault put prod-secrets DB_PASSWORD=prod-db-secure --json
+# Production environment (piped from a secrets manager)
+op read "op://prod/api-key/credential" | swamp vault put prod-secrets API_KEY --json
+op read "op://prod/db-password/credential" | swamp vault put prod-secrets DB_PASSWORD --json
 ```
 
 ## Using Vaults in Models


### PR DESCRIPTION
## Summary

- Reorder vault documentation to present interactive prompt and piped stdin as the primary methods for storing secrets
- Demote inline `KEY=VALUE` to an explicitly-warned anti-pattern (exposes values in shell history, process tables, and logs)
- Update quick reference table, examples, and getting-started track to match

Closes swamp-club#576

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] Verified all three affected files present safe patterns first
- [x] Inline form is still documented (valid for non-sensitive test data) but clearly labelled as insecure