### PR TITLE
fix(extensions): dry-run preview only shows manifest-declared entry points (swamp-club#583)

### DIFF
--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -778,13 +778,13 @@ export async function extensionPushPrepare(
     manifest: input.manifest,
     contentMetadata,
     counts: {
-      models: input.allModelFiles.length,
+      models: input.modelEntryPoints.length,
       workflows: input.workflowFiles.length,
       bundles: totalBundles,
-      vaults: input.allVaultFiles.length,
-      drivers: input.allDriverFiles.length,
-      datastores: input.allDatastoreFiles.length,
-      reports: input.allReportFiles.length,
+      vaults: input.vaultEntryPoints.length,
+      drivers: input.driverEntryPoints.length,
+      datastores: input.datastoreEntryPoints.length,
+      reports: input.reportEntryPoints.length,
       skills: input.skillDirs.length,
     },
     isDryRun: input.dryRun,
@@ -938,7 +938,7 @@ function buildResolvedData(
     (contentMetadata?.reports ?? []).map((r) => [r.fileName, r]),
   );
 
-  const resolvedModels = input.allModelFiles.map((f) => {
+  const resolvedModels = input.modelEntryPoints.map((f) => {
     const relPath = relative(input.repoDir, f);
     const extracted = extractedModelsByFile.get(
       relative(input.modelsDir, f),
@@ -950,7 +950,7 @@ function buildResolvedData(
     };
   });
 
-  const resolvedVaults = input.allVaultFiles.map((f) => {
+  const resolvedVaults = input.vaultEntryPoints.map((f) => {
     const relPath = relative(input.repoDir, f);
     const extracted = extractedVaultsByFile.get(
       relative(input.vaultsDir, f),
@@ -964,7 +964,7 @@ function buildResolvedData(
     };
   });
 
-  const resolvedDrivers = input.allDriverFiles.map((f) => {
+  const resolvedDrivers = input.driverEntryPoints.map((f) => {
     const relPath = relative(input.repoDir, f);
     const extracted = extractedDriversByFile.get(
       relative(input.driversDir, f),
@@ -978,7 +978,7 @@ function buildResolvedData(
     };
   });
 
-  const resolvedDatastores = input.allDatastoreFiles.map((f) => {
+  const resolvedDatastores = input.datastoreEntryPoints.map((f) => {
     const relPath = relative(input.repoDir, f);
     const extracted = extractedDatastoresByFile.get(
       relative(input.datastoresDir, f),
@@ -992,7 +992,7 @@ function buildResolvedData(
     };
   });
 
-  const resolvedReports = input.allReportFiles.map((f) => {
+  const resolvedReports = input.reportEntryPoints.map((f) => {
     const relPath = relative(input.repoDir, f);
     const extracted = extractedReportsByFile.get(
       relative(input.reportsDir, f),

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import type { Logger } from "@logtape/logtape";
@@ -501,7 +502,7 @@ Deno.test("extensionPushPrepare: resolvedData excludes helper files that are not
 
   const result = await extensionPushPrepare(ctx, deps, input);
   assertEquals(result.resolvedData.models.length, 1);
-  assertEquals(result.resolvedData.models[0].fileName, "models/echo.ts");
+  assertPathEquals(result.resolvedData.models[0].fileName, "models/echo.ts");
   assertEquals(result.counts.models, 1);
   await Deno.remove(tempDir, { recursive: true }).catch(() => {});
 });

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -479,3 +479,29 @@ Deno.test("extensionPush: yields pushing events for each phase", async () => {
     assertEquals(pushingEvents[2].phase, "confirm");
   }
 });
+
+Deno.test("extensionPushPrepare: resolvedData excludes helper files that are not entry points", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const modelsDir = `${tempDir}/models`;
+  await Deno.mkdir(`${modelsDir}/_lib`, { recursive: true });
+  await Deno.writeTextFile(`${modelsDir}/echo.ts`, "export default {};");
+  await Deno.writeTextFile(`${modelsDir}/_lib/retry.ts`, "export {};");
+
+  const deps = makePrepareDeps();
+  const input = makePrepareInput({
+    repoDir: tempDir,
+    modelsDir,
+    allModelFiles: [
+      `${modelsDir}/echo.ts`,
+      `${modelsDir}/_lib/retry.ts`,
+    ],
+    modelEntryPoints: [`${modelsDir}/echo.ts`],
+    dryRun: true,
+  });
+
+  const result = await extensionPushPrepare(ctx, deps, input);
+  assertEquals(result.resolvedData.models.length, 1);
+  assertEquals(result.resolvedData.models[0].fileName, "models/echo.ts");
+  assertEquals(result.counts.models, 1);
+  await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+});


### PR DESCRIPTION
## Summary

- `buildResolvedData()` was iterating over `allModelFiles` (which includes transitive local imports like `_lib/retry.ts`) instead of `modelEntryPoints` when building the dry-run resolved preview
- Fixed the same bug for vaults, drivers, datastores, and reports
- Corrected the `counts` object to report entry-point counts rather than total file counts

Fixes swamp-club#583

## Test Plan

- Added unit test verifying helper files in `allModelFiles` but not in `modelEntryPoints` are excluded from resolved output
- Verified with a local reproduction: created an extension with a `_lib/helper.ts` import, confirmed `--dry-run --json` no longer lists it as a model
- All 6762 existing tests pass