### PR TITLE
fix(extensions): resolve bare specifiers in quality scorer (swamp-club#505)

### DIFF
--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -536,12 +536,6 @@ export function createRubricScoreDeps(
   };
 }
 
-const CONTROLLED_DENO_JSON = JSON.stringify(
-  { nodeModulesDir: "auto" },
-  null,
-  2,
-) + "\n";
-
 const STRIPPED_CONFIG_FILES = [
   "deno.json",
   "deno.jsonc",
@@ -584,6 +578,7 @@ export async function scoreExtensionTarball(
   options?: {
     dependencyTrustPassed?: boolean;
     dependencyTrustBlockerCount?: number;
+    importMap?: Record<string, string>;
   },
 ): Promise<RubricScore> {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_quality_" });
@@ -618,9 +613,16 @@ export async function scoreExtensionTarball(
     }
     await Deno.remove(join(logicalRoot, "node_modules"), { recursive: true })
       .catch(() => {});
+
+    const controlledConfig: Record<string, unknown> = {
+      nodeModulesDir: "auto",
+    };
+    if (options?.importMap && Object.keys(options.importMap).length > 0) {
+      controlledConfig.imports = options.importMap;
+    }
     await Deno.writeTextFile(
       join(logicalRoot, "deno.json"),
-      CONTROLLED_DENO_JSON,
+      JSON.stringify(controlledConfig, null, 2) + "\n",
     );
 
     const rootAbs = resolve(logicalRoot);

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
 import {
   composeScore,
@@ -30,6 +31,8 @@ import {
   hasModuleDoc,
   repositoryLikelyVerifiable,
   RUBRIC_VERSION,
+  type RubricScoreDeps,
+  scoreExtensionTarball,
   SLOW_TYPE_CODES,
   stripAnsi,
 } from "./extension_rubric_scorer.ts";
@@ -925,4 +928,96 @@ Deno.test("composeScore: dependency-trust fails with blockers", () => {
   assertEquals(factor.earnedPoints, 0);
   assertEquals(factor.status, "missing");
   assertStringIncludes(factor.remediation ?? "", "3 dependency blocker(s)");
+});
+
+// ── scoreExtensionTarball: import map merging ────────────────────────
+
+function fakeExtractTarball(
+  files: Record<string, string>,
+): RubricScoreDeps["extractTarball"] {
+  return async (_source: ReadableStream<Uint8Array>, destDir: string) => {
+    const extDir = join(destDir, "extension");
+    await Deno.mkdir(join(extDir, "models"), { recursive: true });
+    for (const [name, content] of Object.entries(files)) {
+      await Deno.writeTextFile(join(extDir, name), content);
+    }
+  };
+}
+
+const MINIMAL_DOC_OUTPUT: DocOutput = { version: 1, nodes: {} };
+
+function fakeScoreDeps(
+  files: Record<string, string>,
+  onRunDeno?: (args: string[], cwd: string) => void,
+): RubricScoreDeps {
+  return {
+    extractTarball: fakeExtractTarball(files),
+    runDeno: (args: string[], cwd: string) => {
+      onRunDeno?.(args, cwd);
+      if (args[0] === "doc" && args[1] === "--json") {
+        return Promise.resolve({
+          success: true,
+          stdout: JSON.stringify(MINIMAL_DOC_OUTPUT),
+          stderr: "",
+        });
+      }
+      return Promise.resolve({ success: true, stdout: "", stderr: "" });
+    },
+  };
+}
+
+Deno.test("scoreExtensionTarball: merges importMap into controlled deno.json", async () => {
+  let capturedConfig: Record<string, unknown> | undefined;
+  const deps = fakeScoreDeps(
+    {
+      "manifest.yaml": "manifestVersion: 1\nname: '@test/bare'\n",
+      "models/mod.ts": 'import { z } from "zod";\nexport const s = z.string();',
+      "README.md": "# Test",
+      "LICENSE": "MIT",
+    },
+    (_args, cwd) => {
+      const raw = Deno.readTextFileSync(join(cwd, "deno.json"));
+      capturedConfig = JSON.parse(raw);
+    },
+  );
+
+  const tarball = new Uint8Array(0);
+  const manifest = makeManifest({
+    models: ["mod.ts"],
+  });
+  const importMap = { "zod": "npm:zod@4" };
+
+  const score = await scoreExtensionTarball(tarball, manifest, deps, {
+    importMap,
+  });
+
+  assert(capturedConfig !== undefined, "runDeno should have been called");
+  assertEquals(capturedConfig!.nodeModulesDir, "auto");
+  assertEquals(capturedConfig!.imports, { "zod": "npm:zod@4" });
+  assert(score.earnedPoints >= 0);
+});
+
+Deno.test("scoreExtensionTarball: omits imports when importMap is undefined", async () => {
+  let capturedConfig: Record<string, unknown> | undefined;
+  const deps = fakeScoreDeps(
+    {
+      "manifest.yaml": "manifestVersion: 1\nname: '@test/no-map'\n",
+      "models/mod.ts": "export const x = 1;",
+      "README.md": "# Test",
+      "LICENSE": "MIT",
+    },
+    (_args, cwd) => {
+      const raw = Deno.readTextFileSync(join(cwd, "deno.json"));
+      capturedConfig = JSON.parse(raw);
+    },
+  );
+
+  const tarball = new Uint8Array(0);
+  const manifest = makeManifest({ models: ["mod.ts"] });
+
+  await scoreExtensionTarball(tarball, manifest, deps);
+
+  assert(capturedConfig !== undefined, "runDeno should have been called");
+  assertEquals(capturedConfig!.nodeModulesDir, "auto");
+  assertEquals(capturedConfig!.imports, undefined);
 });

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -73,6 +73,25 @@ export interface ExtensionQualityDeps {
   makeScoreDeps: (denoPath: string) => RubricScoreDeps;
 }
 
+async function readImportMap(
+  denoConfigPath: string | undefined,
+): Promise<Record<string, string> | undefined> {
+  if (!denoConfigPath) return undefined;
+  try {
+    const raw = await Deno.readTextFile(denoConfigPath);
+    const config = JSON.parse(raw);
+    if (
+      config.imports && typeof config.imports === "object" &&
+      !Array.isArray(config.imports)
+    ) {
+      return config.imports as Record<string, string>;
+    }
+  } catch {
+    // Missing or unparseable config — fall back to no import map.
+  }
+  return undefined;
+}
+
 /** Wires real infrastructure into ExtensionQualityDeps. */
 export function createExtensionQualityDeps(
   pushPrepareDeps: ExtensionPushPrepareDeps,
@@ -166,16 +185,18 @@ export async function* extensionQuality(
       yield { kind: "scoring" };
       const denoPath = await deps.ensureDenoPath();
       const scoreDeps = deps.makeScoreDeps(denoPath);
+      const importMap = await readImportMap(
+        input.prepareInput.denoConfigPath,
+      );
       const score = await scoreExtensionTarball(
         archiveBytes,
         input.prepareInput.manifest,
         scoreDeps,
-        dependencyTrustResult
-          ? {
-            dependencyTrustPassed: dependencyTrustResult.passed,
-            dependencyTrustBlockerCount: dependencyTrustResult.errors.length,
-          }
-          : undefined,
+        {
+          dependencyTrustPassed: dependencyTrustResult?.passed,
+          dependencyTrustBlockerCount: dependencyTrustResult?.errors.length,
+          importMap,
+        },
       );
 
       yield {


### PR DESCRIPTION
## Summary

- Fix `swamp extension quality` crashing on bare specifiers (e.g., `import { z } from "zod"`) by reading the repo's `deno.json` imports and merging them into the controlled config written to the quality scorer's temp extraction directory
- The scorer previously stripped all config files and wrote `{ "nodeModulesDir": "auto" }` with no `imports` map, so `deno doc` could not resolve bare specifiers — contradicting `fmt` and `push` which require them via the `no-import-prefix` lint rule
- Filed #594 for the server-side scorer parity fix (the registry's `DenoDocExtensionTarballAnalyzer` has the same issue)

## Test Plan

- [x] Added 2 unit tests for `scoreExtensionTarball`: verifies import map is merged into controlled deno.json, and omitted when undefined
- [x] Full test suite passes (6764 tests, 0 failures)
- [x] Reproduced bug in scratch repo (`/tmp/swamp-repro-issue-505`) — confirmed `quality` now scores 13/14 instead of crashing with `Failed resolving 'zod'`
- [x] Verified both cached and non-cached code paths work
- [x] `deno check`, `deno lint`, `deno fmt --check` all pass

Closes swamp-club#505