### PR TITLE
fix(extensions): deprecate "No slow types" rubric factor (swamp-club#572)

### DIFF
--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -337,11 +337,7 @@ export function composeScore(
     ),
     richReadmeRow(factors.readmeLength, factors.readmeCodeBlockCount),
     symbolsRow(factors.percentageDocumentedSymbols),
-    boolRow("fast-check", "No slow types", 1, factors.allFastCheck, {
-      remediation:
-        "Run `deno doc --lint <entrypoint>` — add explicit return types and " +
-        "avoid leaking private types in public exports.",
-    }),
+    boolRow("fast-check", "No slow types (deprecated)", 1, true, {}),
     boolRow(
       "description",
       "Has description",

--- a/src/domain/extensions/extension_rubric_scorer_test.ts
+++ b/src/domain/extensions/extension_rubric_scorer_test.ts
@@ -843,9 +843,9 @@ Deno.test("[parity] composeScore: empty everything earns universal-platform only
       platforms: [],
     }),
   );
-  // Universal platforms earns 2 points only; dependency-trust fails.
-  assertEquals(score.earnedPoints, 2);
-  assertEquals(score.percentage, Math.floor((2 * 100) / 14));
+  // Universal platforms earns 2 + fast-check always earns 1 (deprecated).
+  assertEquals(score.earnedPoints, 3);
+  assertEquals(score.percentage, Math.floor((3 * 100) / 14));
   assertEquals(score.rubricVersion, 3);
   assertEquals(score.factors.length, 10);
   const byId = new Map(score.factors.map((f) => [f.id, f]));
@@ -902,6 +902,17 @@ Deno.test("[parity] composeScore: platforms factor earns 2 for any count", () =>
   const m3 = new Map(s3.factors.map((f) => [f.id, f]));
   assertEquals(m3.get("platforms")?.status, "earned");
   assertEquals(m3.get("platforms")?.earnedPoints, 2);
+});
+
+Deno.test("composeScore: fast-check is always earned (deprecated)", () => {
+  const score = composeScore(
+    { ...factorsAllEarned(), allFastCheck: false },
+    makeManifest(),
+  );
+  const factor = score.factors.find((f) => f.id === "fast-check")!;
+  assertEquals(factor.status, "earned");
+  assertEquals(factor.earnedPoints, 1);
+  assertEquals(factor.label, "No slow types (deprecated)");
 });
 
 Deno.test("composeScore: dependency-trust is worth 2 points when passing", () => {

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -75,6 +75,10 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
           const mark = factor.status === "earned" ? "✓" : "✗";
           const pts = `${factor.earnedPoints}/${factor.maxPoints}`;
           logger.info`  ${mark} ${factor.id} [${pts}] — ${factor.label}`;
+          if (factor.id === "fast-check") {
+            logger
+              .info`      ℹ This factor is deprecated and will be removed in a future release.`;
+          }
           if (factor.status !== "earned" && factor.remediation) {
             logger.info`      → ${factor.remediation}`;
           }


### PR DESCRIPTION
## Summary

- Deprecate the `fast-check` ("No slow types") quality rubric factor by always awarding the 1 point regardless of `deno doc --lint` results
- Update the factor label to "No slow types (deprecated)" in the scorecard
- Log a deprecation notice in CLI output: "This factor is deprecated and will be removed in a future release"

The fast-check factor applied a JSR slow-types heuristic (penalizing exported Zod schemas and `z.infer<>` types) that doesn't apply to swamp extensions — they're consumed by the runtime via model+CEL, not TypeScript type imports. The check nudged authors to hide reusable schemas to earn a point, which is the opposite of good composability.

Server-side scorer update tracked in swamp-club#595.

Closes swamp-club#572

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 69 rubric scorer tests pass, including new test for always-earned behavior
- [x] Parity test updated for +1 earned point on empty-everything scenario