### PR TITLE
feat(extensions): support SWAMP_EXTENSION_REVIEW_DIR for CI-friendly review artifacts

### DIFF
--- a/.claude/skills/swamp/references/extension/references/adversarial-review.md
+++ b/.claude/skills/swamp/references/extension/references/adversarial-review.md
@@ -32,7 +32,9 @@ Workflow:
 2. Run `swamp extension push manifest.yaml --dry-run`. When no report exists,
    the push prints the exact report path (a content-hash-bound JSON file under
    the system temp directory) and a fill-in skeleton listing every applicable
-   dimension with `"verdict": "pending"`.
+   dimension with `"verdict": "pending"`. Set `SWAMP_EXTENSION_REVIEW_DIR` to
+   override the base directory (useful for CI — store reports in the repo so
+   they survive across runners).
 3. Write the skeleton to the printed path, setting each dimension's `verdict`:
    - `pass` — the dimension is satisfied.
    - `issue` — a problem was found; add a `note`. (Surfaces as a push warning,

--- a/design/extension.md
+++ b/design/extension.md
@@ -592,6 +592,32 @@ The CLI rejects `--extensions-dir` values that point inside `.swamp/` to
 prevent accidental reads of data-plane files as extension sources. The
 directory must exist and must be a real directory (not a file).
 
+## Adversarial Review Directory (`SWAMP_EXTENSION_REVIEW_DIR`)
+
+The adversarial review gate in `swamp extension push` looks for a
+content-hash-bound report at
+`<base>/swamp-extension-review/<name>-<hash>.json`. By default `<base>` is
+the OS temp directory (`TMPDIR` / `TMP` / `TEMP` / `/tmp`), which works for
+local development but is ephemeral on CI runners.
+
+Set `SWAMP_EXTENSION_REVIEW_DIR` to override the base directory. This lets CI
+workflows store review reports in a durable, repo-local path that survives
+across runners:
+
+```yaml
+# GitHub Actions example
+env:
+  SWAMP_EXTENSION_REVIEW_DIR: ${{ github.workspace }}/.swamp-reviews
+
+steps:
+  - uses: actions/checkout@v4
+  - run: swamp extension push extensions/my-ext/manifest.yaml --yes
+```
+
+Precedence: `SWAMP_EXTENSION_REVIEW_DIR` > `TMPDIR` > `TMP` > `TEMP` >
+`/tmp`. The explicit `baseTmpDir` parameter on `reviewReportPath()` (used by
+tests) overrides all env vars.
+
 ## Dependencies
 
 Extensions can declare dependencies on other extensions. During a pull,

--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -428,8 +428,9 @@ export function parseReviewReport(raw: string): ExtensionReviewReport | null {
   }
 }
 
-function osTempDir(): string {
-  return Deno.env.get("TMPDIR") ?? Deno.env.get("TMP") ??
+function reviewBaseDir(): string {
+  return Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR") ??
+    Deno.env.get("TMPDIR") ?? Deno.env.get("TMP") ??
     Deno.env.get("TEMP") ??
     "/tmp";
 }
@@ -449,7 +450,7 @@ function sanitizeName(name: string): string {
 export function reviewReportPath(
   extensionName: string,
   contentHash: string,
-  baseTmpDir: string = osTempDir(),
+  baseTmpDir: string = reviewBaseDir(),
 ): string {
   return join(
     baseTmpDir,

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -281,6 +281,49 @@ Deno.test("reviewReportPath: deterministic and hash-bound", () => {
   assert(a !== c); // different hash → different path
 });
 
+Deno.test("reviewReportPath: explicit baseTmpDir takes precedence over env var", () => {
+  const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", "/ci/reviews");
+    const p = reviewReportPath("@acme/thing", "abc123", "/explicit");
+    assert(p.startsWith("/explicit/"));
+  } finally {
+    if (prev !== undefined) {
+      Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);
+    } else {
+      Deno.env.delete("SWAMP_EXTENSION_REVIEW_DIR");
+    }
+  }
+});
+
+Deno.test("reviewReportPath: SWAMP_EXTENSION_REVIEW_DIR used when no explicit baseTmpDir", () => {
+  const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
+  try {
+    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", "/ci/reviews");
+    const p = reviewReportPath("@acme/thing", "abc123");
+    assert(p.startsWith("/ci/reviews/"));
+  } finally {
+    if (prev !== undefined) {
+      Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);
+    } else {
+      Deno.env.delete("SWAMP_EXTENSION_REVIEW_DIR");
+    }
+  }
+});
+
+Deno.test("reviewReportPath: falls back to OS temp when env var is unset", () => {
+  const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
+  try {
+    Deno.env.delete("SWAMP_EXTENSION_REVIEW_DIR");
+    const p = reviewReportPath("@acme/thing", "abc123");
+    assert(!p.startsWith("/ci/"));
+  } finally {
+    if (prev !== undefined) {
+      Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);
+    }
+  }
+});
+
 Deno.test("parseReviewReport: returns null on malformed JSON or bad shape", () => {
   assertEquals(parseReviewReport("not json"), null);
   assertEquals(parseReviewReport('{"extension":"x"}'), null);

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assert, assertEquals } from "@std/assert";
+import { join, SEPARATOR } from "@std/path";
 import {
   applicableDimensions,
   buildReviewReportSkeleton,
@@ -284,9 +285,10 @@ Deno.test("reviewReportPath: deterministic and hash-bound", () => {
 Deno.test("reviewReportPath: explicit baseTmpDir takes precedence over env var", () => {
   const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
   try {
-    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", "/ci/reviews");
-    const p = reviewReportPath("@acme/thing", "abc123", "/explicit");
-    assert(p.startsWith("/explicit/"));
+    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", join(SEPARATOR, "ci", "reviews"));
+    const p = reviewReportPath("@acme/thing", "abc123", join(SEPARATOR, "explicit"));
+    const expected = join(SEPARATOR, "explicit", "swamp-extension-review");
+    assert(p.startsWith(expected));
   } finally {
     if (prev !== undefined) {
       Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);
@@ -298,10 +300,12 @@ Deno.test("reviewReportPath: explicit baseTmpDir takes precedence over env var",
 
 Deno.test("reviewReportPath: SWAMP_EXTENSION_REVIEW_DIR used when no explicit baseTmpDir", () => {
   const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
+  const reviewDir = join(SEPARATOR, "ci", "reviews");
   try {
-    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", "/ci/reviews");
+    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", reviewDir);
     const p = reviewReportPath("@acme/thing", "abc123");
-    assert(p.startsWith("/ci/reviews/"));
+    const expected = join(reviewDir, "swamp-extension-review");
+    assert(p.startsWith(expected));
   } finally {
     if (prev !== undefined) {
       Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);
@@ -313,10 +317,11 @@ Deno.test("reviewReportPath: SWAMP_EXTENSION_REVIEW_DIR used when no explicit ba
 
 Deno.test("reviewReportPath: falls back to OS temp when env var is unset", () => {
   const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
+  const ciDir = join(SEPARATOR, "ci");
   try {
     Deno.env.delete("SWAMP_EXTENSION_REVIEW_DIR");
     const p = reviewReportPath("@acme/thing", "abc123");
-    assert(!p.startsWith("/ci/"));
+    assert(!p.startsWith(ciDir));
   } finally {
     if (prev !== undefined) {
       Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", prev);

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -285,8 +285,15 @@ Deno.test("reviewReportPath: deterministic and hash-bound", () => {
 Deno.test("reviewReportPath: explicit baseTmpDir takes precedence over env var", () => {
   const prev = Deno.env.get("SWAMP_EXTENSION_REVIEW_DIR");
   try {
-    Deno.env.set("SWAMP_EXTENSION_REVIEW_DIR", join(SEPARATOR, "ci", "reviews"));
-    const p = reviewReportPath("@acme/thing", "abc123", join(SEPARATOR, "explicit"));
+    Deno.env.set(
+      "SWAMP_EXTENSION_REVIEW_DIR",
+      join(SEPARATOR, "ci", "reviews"),
+    );
+    const p = reviewReportPath(
+      "@acme/thing",
+      "abc123",
+      join(SEPARATOR, "explicit"),
+    );
     const expected = join(SEPARATOR, "explicit", "swamp-extension-review");
     assert(p.startsWith(expected));
   } finally {


### PR DESCRIPTION
## Summary

- Add `SWAMP_EXTENSION_REVIEW_DIR` env var to `reviewReportPath()` so CI runners can store adversarial review reports in a durable, repo-local directory instead of the ephemeral OS temp dir
- Precedence: `SWAMP_EXTENSION_REVIEW_DIR` > `TMPDIR` > `TMP` > `TEMP` > `/tmp`; explicit `baseTmpDir` parameter (used by tests) still overrides all env vars
- Document the env var in `design/extension.md` with a GitHub Actions example and in the adversarial review skill reference

Closes swamp-club#596

## Test plan

- [x] 3 new unit tests covering env var precedence, override by explicit param, and fallback when unset
- [x] All 26 existing review rules tests pass
- [x] Manual verification of all 3 scenarios via `deno eval`
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)