### PR TITLE
chore(packages): move JSR packages from @systeminit to @swamp-club scope (swamp-club#545)

### DIFF
--- a/.claude/skills/swamp/references/extension/references/datastore/testing.md
+++ b/.claude/skills/swamp/references/extension/references/datastore/testing.md
@@ -1,9 +1,9 @@
 # Testing Datastore Extensions
 
-The `@systeminit/swamp-testing` package provides conformance suites, mock
+The `@swamp-club/swamp-testing` package provides conformance suites, mock
 primitives, and test doubles for datastore extensions.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 ## Export Conformance
 
@@ -11,7 +11,7 @@ One call replaces all structural boilerplate tests (metadata, config schema,
 method existence on provider/lock/verifier):
 
 ```typescript
-import { assertDatastoreExportConformance } from "@systeminit/swamp-testing";
+import { assertDatastoreExportConformance } from "@swamp-club/swamp-testing";
 import { datastore } from "./s3.ts";
 
 Deno.test("datastore export conforms", () => {
@@ -32,7 +32,7 @@ methods, verifier has verify().
 Test the full DistributedLock contract against your implementation:
 
 ```typescript
-import { assertLockConformance } from "@systeminit/swamp-testing";
+import { assertLockConformance } from "@swamp-club/swamp-testing";
 
 Deno.test("lock contract", async () => {
   const lock = provider.createLock("/test/path");
@@ -49,7 +49,7 @@ Works with both real backends and mocked clients (e.g., `createMockS3Client`).
 ## Verifier Conformance
 
 ```typescript
-import { assertVerifierConformance } from "@systeminit/swamp-testing";
+import { assertVerifierConformance } from "@swamp-club/swamp-testing";
 
 Deno.test("verifier contract", async () => {
   const verifier = provider.createVerifier();
@@ -70,7 +70,7 @@ Datastores that accept an `endpoint` config can point at a local mock server to
 test verifier and sync behavior without real AWS credentials:
 
 ```typescript
-import { assertVerifierConformance } from "@systeminit/swamp-testing";
+import { assertVerifierConformance } from "@swamp-club/swamp-testing";
 import { datastore } from "./s3.ts";
 
 Deno.test({
@@ -110,7 +110,7 @@ For testing lock semantics, create an in-memory mock of your storage client and
 pass it to your lock implementation. The S3 datastore uses this pattern:
 
 ```typescript
-import { assertLockConformance } from "@systeminit/swamp-testing";
+import { assertLockConformance } from "@swamp-club/swamp-testing";
 import { S3Lock } from "./_lib/s3_lock.ts";
 
 function createMockS3Client() {
@@ -147,7 +147,7 @@ Deno.test("S3Lock passes conformance", async () => {
 Use `withMockedCommand` for datastores that shell out to CLI tools:
 
 ```typescript
-import { withMockedCommand } from "@systeminit/swamp-testing";
+import { withMockedCommand } from "@swamp-club/swamp-testing";
 
 await withMockedCommand((cmd, args) => {
   if (cmd === "rclone" && args.includes("sync")) {
@@ -165,7 +165,7 @@ await withMockedCommand((cmd, args) => {
 Use `withMockedFetch` for datastores that call `fetch()` directly:
 
 ```typescript
-import { withMockedFetch } from "@systeminit/swamp-testing";
+import { withMockedFetch } from "@swamp-club/swamp-testing";
 
 await withMockedFetch((req) => {
   if (req.method === "HEAD") return new Response(null, { status: 200 });
@@ -182,7 +182,7 @@ await withMockedFetch((req) => {
 For testing code that _consumes_ a datastore (not the datastore itself):
 
 ```typescript
-import { createDatastoreTestContext } from "@systeminit/swamp-testing";
+import { createDatastoreTestContext } from "@swamp-club/swamp-testing";
 
 const { provider, isLockHeld } = createDatastoreTestContext();
 ```

--- a/.claude/skills/swamp/references/extension/references/driver/testing.md
+++ b/.claude/skills/swamp/references/extension/references/driver/testing.md
@@ -1,16 +1,16 @@
 # Testing Execution Drivers
 
-The `@systeminit/swamp-testing` package provides test context factories and mock
+The `@swamp-club/swamp-testing` package provides test context factories and mock
 primitives for execution driver extensions.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 ## createDriverTestContext
 
 Builds a well-formed `ExecutionRequest` and callbacks that capture events:
 
 ```typescript
-import { createDriverTestContext } from "@systeminit/swamp-testing";
+import { createDriverTestContext } from "@swamp-club/swamp-testing";
 import { assertEquals } from "@std/assert";
 import { driver } from "./my_driver.ts";
 
@@ -64,7 +64,7 @@ Use `withMockedFetch` for drivers that make HTTP requests via `fetch()`:
 import {
   createDriverTestContext,
   withMockedFetch,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("driver calls remote API", async () => {
   const { calls } = await withMockedFetch((req) => {
@@ -91,7 +91,7 @@ Use `withMockedCommand` for drivers that use `Deno.Command`:
 import {
   createDriverTestContext,
   withMockedCommand,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("driver runs subprocess", async () => {
   const { result } = await withMockedCommand((cmd, args) => {

--- a/.claude/skills/swamp/references/extension/references/model/api.md
+++ b/.claude/skills/swamp/references/extension/references/model/api.md
@@ -479,7 +479,7 @@ execute: async (
 },
 ```
 
-Do NOT import `Environment` from `@systeminit/swamp-testing` in production
+Do NOT import `Environment` from `@swamp-club/swamp-testing` in production
 source — testing-named packages don't belong in production code. Do NOT import
 from `cel-js` directly unless your extension already pins cel-js for other
 runtime use; pinning a library just for a type is unnecessary churn.

--- a/.claude/skills/swamp/references/extension/references/model/testing.md
+++ b/.claude/skills/swamp/references/extension/references/model/testing.md
@@ -1,9 +1,9 @@
 # Unit Testing Extension Models
 
-The `@systeminit/swamp-testing` package provides `createModelTestContext()` for
+The `@swamp-club/swamp-testing` package provides `createModelTestContext()` for
 unit testing extension model `execute` functions without real infrastructure.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 > **If your `_test.ts` imports the model source directly and fails with TS7006
 > under strict mode**, see [typing.md](typing.md) for the

--- a/.claude/skills/swamp/references/extension/references/model/typing.md
+++ b/.claude/skills/swamp/references/extension/references/model/typing.md
@@ -103,10 +103,10 @@ use:
 
 If you prefer not to annotate each method individually, you can wrap the model
 literal with `satisfies ModelDefinition<typeof GlobalArgsSchema>` from
-`@systeminit/swamp-testing`:
+`@swamp-club/swamp-testing`:
 
 ```typescript
-import type { ModelDefinition } from "jsr:@systeminit/swamp-testing";
+import type { ModelDefinition } from "jsr:@swamp-club/swamp-testing";
 
 export const model = {
   type: "@myorg/my-model",
@@ -138,7 +138,7 @@ The testing package also exports `defineModel` — identical behaviour to
 `satisfies`, different call-site syntax:
 
 ```typescript
-import { defineModel } from "jsr:@systeminit/swamp-testing";
+import { defineModel } from "jsr:@swamp-club/swamp-testing";
 
 export const model = defineModel({
   type: "@myorg/my-model",

--- a/.claude/skills/swamp/references/extension/references/report/testing.md
+++ b/.claude/skills/swamp/references/extension/references/report/testing.md
@@ -1,17 +1,17 @@
 # Testing Report Extensions
 
-The `@systeminit/swamp-testing` package provides `createReportTestContext()` and
+The `@swamp-club/swamp-testing` package provides `createReportTestContext()` and
 mock primitives for unit testing report `execute` functions without running real
 model methods or accessing real data repositories.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 ## createReportTestContext
 
 Creates a fake `ReportContext` with pre-seeded data and definition repositories:
 
 ```typescript
-import { createReportTestContext } from "@systeminit/swamp-testing";
+import { createReportTestContext } from "@swamp-club/swamp-testing";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { report } from "./my_report.ts";
 
@@ -162,7 +162,7 @@ mock primitives to test without real infrastructure.
 import {
   createReportTestContext,
   withMockedFetch,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("report fetches pricing data", async () => {
   const { calls } = await withMockedFetch((req) => {
@@ -193,7 +193,7 @@ Deno.test("report fetches pricing data", async () => {
 import {
   createReportTestContext,
   withMockedCommand,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("report runs cost calculator CLI", async () => {
   await withMockedCommand((cmd, args) => {

--- a/.claude/skills/swamp/references/extension/references/vault/testing.md
+++ b/.claude/skills/swamp/references/extension/references/vault/testing.md
@@ -1,9 +1,9 @@
 # Testing Vault Extensions
 
-The `@systeminit/swamp-testing` package provides conformance suites, mock
+The `@swamp-club/swamp-testing` package provides conformance suites, mock
 primitives, and test doubles for vault extensions.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 ## Export Conformance
 
@@ -11,7 +11,7 @@ One call replaces all structural boilerplate tests (metadata, config schema,
 method existence):
 
 ```typescript
-import { assertVaultExportConformance } from "@systeminit/swamp-testing";
+import { assertVaultExportConformance } from "@swamp-club/swamp-testing";
 import { vault } from "./my_vault.ts";
 
 Deno.test("vault export conforms", () => {
@@ -31,7 +31,7 @@ an object with get/put/list/getName.
 Test the full VaultProvider contract against a real or mocked provider:
 
 ```typescript
-import { assertVaultConformance } from "@systeminit/swamp-testing";
+import { assertVaultConformance } from "@swamp-club/swamp-testing";
 
 Deno.test("vault contract", async () => {
   const provider = vault.createProvider("test", { region: "us-east-1" });
@@ -62,7 +62,7 @@ this **after** `assertVaultExportConformance`:
 import {
   assertVaultAnnotationExportConformance,
   assertVaultExportConformance,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 import { vault } from "./my_vault.ts";
 
 Deno.test("vault export conforms with annotations", () => {
@@ -83,7 +83,7 @@ This verifies: the provider has `getAnnotation`, `putAnnotation`,
 Test the full `VaultAnnotationProvider` contract:
 
 ```typescript
-import { assertVaultAnnotationConformance } from "@systeminit/swamp-testing";
+import { assertVaultAnnotationConformance } from "@swamp-club/swamp-testing";
 
 Deno.test("vault annotation contract", async () => {
   const provider = vault.createProvider("test", { region: "us-east-1" });
@@ -111,7 +111,7 @@ import {
   VaultAnnotation,
   type VaultAnnotationData,
   type VaultAnnotationProvider,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 // Create an annotation
 const annotation = VaultAnnotation.create({
@@ -138,7 +138,7 @@ modification to extension source code required.
 Use `withMockedCommand` to replace `Deno.Command` for the test duration:
 
 ```typescript
-import { withMockedCommand } from "@systeminit/swamp-testing";
+import { withMockedCommand } from "@swamp-club/swamp-testing";
 import { vault } from "./onepassword.ts";
 
 Deno.test("get reads secret via op CLI", async () => {
@@ -179,7 +179,7 @@ AWS SDK uses `node:https` internally, not `globalThis.fetch`. Use a local mock
 server with `AWS_ENDPOINT_URL` to intercept the exact production code path:
 
 ```typescript
-import { assertVaultConformance } from "@systeminit/swamp-testing";
+import { assertVaultConformance } from "@swamp-club/swamp-testing";
 import { vault } from "./aws_sm.ts";
 
 Deno.test({
@@ -239,7 +239,7 @@ Deno.test({
 Use `withMockedFetch` for vaults that call `fetch()` directly:
 
 ```typescript
-import { withMockedFetch } from "@systeminit/swamp-testing";
+import { withMockedFetch } from "@swamp-club/swamp-testing";
 
 await withMockedFetch(async (req) => {
   const body = await req.json();

--- a/.claude/skills/swamp/references/report/guide.md
+++ b/.claude/skills/swamp/references/report/guide.md
@@ -169,4 +169,4 @@ combine. Env vars: `SWAMP_REPORT_MAX_WIDTH`, `SWAMP_REPORT_MAX_COL_WIDTH`.
 - **Filtering**: See [references/filtering.md](references/filtering.md) for the
   full filtering semantics and precedence rules
 - **Testing**: See [references/testing.md](references/testing.md) for unit
-  testing report execute functions with `@systeminit/swamp-testing`
+  testing report execute functions with `@swamp-club/swamp-testing`

--- a/.claude/skills/swamp/references/report/references/testing.md
+++ b/.claude/skills/swamp/references/report/references/testing.md
@@ -1,17 +1,17 @@
 # Testing Report Extensions
 
-The `@systeminit/swamp-testing` package provides `createReportTestContext()` and
+The `@swamp-club/swamp-testing` package provides `createReportTestContext()` and
 mock primitives for unit testing report `execute` functions without running real
 model methods or accessing real data repositories.
 
-Install: `deno add jsr:@systeminit/swamp-testing`
+Install: `deno add jsr:@swamp-club/swamp-testing`
 
 ## createReportTestContext
 
 Creates a fake `ReportContext` with pre-seeded data and definition repositories:
 
 ```typescript
-import { createReportTestContext } from "@systeminit/swamp-testing";
+import { createReportTestContext } from "@swamp-club/swamp-testing";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { report } from "./my_report.ts";
 
@@ -162,7 +162,7 @@ mock primitives to test without real infrastructure.
 import {
   createReportTestContext,
   withMockedFetch,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("report fetches pricing data", async () => {
   const { calls } = await withMockedFetch((req) => {
@@ -193,7 +193,7 @@ Deno.test("report fetches pricing data", async () => {
 import {
   createReportTestContext,
   withMockedCommand,
-} from "@systeminit/swamp-testing";
+} from "@swamp-club/swamp-testing";
 
 Deno.test("report runs cost calculator CLI", async () => {
   await withMockedCommand((cmd, args) => {

--- a/packages/client/deno.json
+++ b/packages/client/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@systeminit/swamp-lib",
+  "name": "@swamp-club/swamp-lib",
   "version": "0.1.0",
   "license": "AGPL-3.0-only",
   "exports": "./mod.ts"

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -18,10 +18,10 @@
 // along with Swamp.  If not, see <https:\/\/www.gnu.org\/licenses\/>.
 
 /**
- * @systeminit/swamp-lib — TypeScript client for the swamp WebSocket API.
+ * @swamp-club/swamp-lib — TypeScript client for the swamp WebSocket API.
  *
  * ```typescript
- * import { SwampClient } from "@systeminit/swamp-lib";
+ * import { SwampClient } from "@swamp-club/swamp-lib";
  *
  * const client = new SwampClient("ws://localhost:9090");
  * await client.connect();

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,4 +1,4 @@
-# @systeminit/swamp-testing
+# @swamp-club/swamp-testing
 
 Test utilities for [swamp](https://github.com/swamp-club/swamp) extensions.
 Provides test factories for all extension types — models, vaults, datastores,
@@ -7,7 +7,7 @@ execution drivers, and reports — for unit testing without real infrastructure.
 ## Installation
 
 ```bash
-deno add jsr:@systeminit/swamp-testing
+deno add jsr:@swamp-club/swamp-testing
 ```
 
 Or add to your `deno.json` imports:
@@ -15,7 +15,7 @@ Or add to your `deno.json` imports:
 ```json
 {
   "imports": {
-    "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing"
+    "@swamp-club/swamp-testing": "jsr:@swamp-club/swamp-testing"
   }
 }
 ```
@@ -23,7 +23,7 @@ Or add to your `deno.json` imports:
 ## Usage
 
 ```typescript
-import { createModelTestContext } from "@systeminit/swamp-testing";
+import { createModelTestContext } from "@swamp-club/swamp-testing";
 import { assertEquals } from "@std/assert";
 import { model } from "./my_model.ts";
 
@@ -119,7 +119,7 @@ await model.methods.create.execute({ _s3Client: mockClient }, context);
 In-memory `VaultProvider` for testing code that reads/writes secrets.
 
 ```typescript
-import { createVaultTestContext } from "@systeminit/swamp-testing";
+import { createVaultTestContext } from "@swamp-club/swamp-testing";
 
 Deno.test("reads API key from vault", async () => {
   const { vault, getOperations } = createVaultTestContext({
@@ -143,7 +143,7 @@ Deno.test("reads API key from vault", async () => {
 In-memory `DatastoreProvider` with fake locking, health checks, and sync.
 
 ```typescript
-import { createDatastoreTestContext } from "@systeminit/swamp-testing";
+import { createDatastoreTestContext } from "@swamp-club/swamp-testing";
 
 Deno.test("lock acquire and release", async () => {
   const { provider, isLockHeld } = createDatastoreTestContext();
@@ -170,7 +170,7 @@ Test harness for `ExecutionDriver` implementations. Provides a well-formed
 `ExecutionRequest` and callbacks that capture events.
 
 ```typescript
-import { createDriverTestContext } from "@systeminit/swamp-testing";
+import { createDriverTestContext } from "@swamp-club/swamp-testing";
 
 Deno.test("driver executes method", async () => {
   const { request, callbacks, getCapturedLogs } = createDriverTestContext({
@@ -199,7 +199,7 @@ scopes (method, model, workflow) with pre-seeded data and definition
 repositories.
 
 ```typescript
-import { createReportTestContext } from "@systeminit/swamp-testing";
+import { createReportTestContext } from "@swamp-club/swamp-testing";
 
 Deno.test("report generates markdown", async () => {
   const { context } = createReportTestContext({
@@ -231,7 +231,7 @@ under strict mode. The escape hatch is a one-line wrap of the model literal:
 
 ```typescript
 import { z } from "npm:zod@4";
-import type { ModelDefinition } from "jsr:@systeminit/swamp-testing";
+import type { ModelDefinition } from "jsr:@swamp-club/swamp-testing";
 
 const GlobalArgsSchema = z.object({ region: z.string() });
 

--- a/packages/testing/datastore_conformance.ts
+++ b/packages/testing/datastore_conformance.ts
@@ -54,7 +54,7 @@ export interface DatastoreExportConformanceOptions {
  * createProvider returns a DatastoreProvider with required methods.
  *
  * ```typescript
- * import { assertDatastoreExportConformance } from "@systeminit/swamp-testing";
+ * import { assertDatastoreExportConformance } from "@swamp-club/swamp-testing";
  * import { datastore } from "./s3.ts";
  *
  * Deno.test("datastore export conforms", () => {
@@ -197,7 +197,7 @@ export function assertDatastoreExportConformance(
  * not, forceRelease with correct/wrong nonce, release is idempotent.
  *
  * ```typescript
- * import { assertLockConformance } from "@systeminit/swamp-testing";
+ * import { assertLockConformance } from "@swamp-club/swamp-testing";
  *
  * Deno.test("s3 lock contract", async () => {
  *   const lock = provider.createLock("/test/path");
@@ -345,7 +345,7 @@ export async function assertLockConformance(
  * Asserts that a DatastoreVerifier implementation returns a valid health result.
  *
  * ```typescript
- * import { assertVerifierConformance } from "@systeminit/swamp-testing";
+ * import { assertVerifierConformance } from "@swamp-club/swamp-testing";
  *
  * Deno.test("s3 verifier contract", async () => {
  *   const verifier = provider.createVerifier();
@@ -402,7 +402,7 @@ export interface SyncServiceConformanceOptions {
  * `scopedSync === true`.
  *
  * ```typescript
- * import { assertSyncServiceConformance } from "@systeminit/swamp-testing";
+ * import { assertSyncServiceConformance } from "@swamp-club/swamp-testing";
  *
  * Deno.test("s3 sync service contract", async () => {
  *   const syncService = provider.createSyncService!("/repo", "/cache");

--- a/packages/testing/datastore_test_context.ts
+++ b/packages/testing/datastore_test_context.ts
@@ -78,7 +78,7 @@ export interface DatastoreTestContextResult {
  * datastore implementations.
  *
  * ```typescript
- * import { createDatastoreTestContext } from "@systeminit/swamp-testing";
+ * import { createDatastoreTestContext } from "@swamp-club/swamp-testing";
  *
  * Deno.test("datastore creates a healthy verifier", async () => {
  *   const { provider } = createDatastoreTestContext();

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@systeminit/swamp-testing",
+  "name": "@swamp-club/swamp-testing",
   "version": "0.3.0",
   "license": "AGPL-3.0-only",
   "exports": "./mod.ts",

--- a/packages/testing/driver_test_context.ts
+++ b/packages/testing/driver_test_context.ts
@@ -66,7 +66,7 @@ export interface DriverTestContextResult {
  * for inspection.
  *
  * ```typescript
- * import { createDriverTestContext } from "@systeminit/swamp-testing";
+ * import { createDriverTestContext } from "@swamp-club/swamp-testing";
  *
  * Deno.test("driver executes method", async () => {
  *   const { request, callbacks, getCapturedLogs } = createDriverTestContext({

--- a/packages/testing/mock_command.ts
+++ b/packages/testing/mock_command.ts
@@ -58,7 +58,7 @@ export type CommandHandler = (
  *
  * **Simple mode** — sequential responses:
  * ```typescript
- * import { withMockedCommand } from "@systeminit/swamp-testing";
+ * import { withMockedCommand } from "@swamp-club/swamp-testing";
  *
  * const { result, calls } = await withMockedCommand([
  *   { stdout: "sk-test-123", code: 0 },

--- a/packages/testing/mock_fetch.ts
+++ b/packages/testing/mock_fetch.ts
@@ -52,7 +52,7 @@ export type FetchHandler = (
  *
  * **Simple mode** — sequential responses:
  * ```typescript
- * import { withMockedFetch } from "@systeminit/swamp-testing";
+ * import { withMockedFetch } from "@swamp-club/swamp-testing";
  *
  * const { result, calls } = await withMockedFetch([
  *   Response.json({ SecretString: "sk-test-123" }),

--- a/packages/testing/mod.ts
+++ b/packages/testing/mod.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * @systeminit/swamp-testing — Test utilities for swamp extensions.
+ * @swamp-club/swamp-testing — Test utilities for swamp extensions.
  *
  * Provides test factories and conformance suites for all extension types:
  * models, vaults, datastores, execution drivers, and reports.

--- a/packages/testing/report_test_context.ts
+++ b/packages/testing/report_test_context.ts
@@ -113,7 +113,7 @@ export interface ReportTestContextResult {
  * functions.
  *
  * ```typescript
- * import { createReportTestContext } from "@systeminit/swamp-testing";
+ * import { createReportTestContext } from "@swamp-club/swamp-testing";
  *
  * Deno.test("report generates markdown summary", async () => {
  *   const { context } = createReportTestContext({

--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -103,7 +103,7 @@ export interface ModelTestContextResult {
  * can be inspected via the returned helper functions.
  *
  * ```typescript
- * import { createModelTestContext } from "@systeminit/swamp-testing";
+ * import { createModelTestContext } from "@swamp-club/swamp-testing";
  * import { model } from "./my_model.ts";
  *
  * Deno.test("run method writes expected resource", async () => {

--- a/packages/testing/vault_conformance.ts
+++ b/packages/testing/vault_conformance.ts
@@ -56,7 +56,7 @@ export interface VaultExportConformanceOptions {
  * createProvider returns an object with get/put/list/getName.
  *
  * ```typescript
- * import { assertVaultExportConformance } from "@systeminit/swamp-testing";
+ * import { assertVaultExportConformance } from "@swamp-club/swamp-testing";
  * import { vault } from "./my_vault.ts";
  *
  * Deno.test("vault export conforms", () => {
@@ -167,7 +167,7 @@ export interface VaultConformanceOptions {
  * cleaned up by default.
  *
  * ```typescript
- * import { assertVaultConformance } from "@systeminit/swamp-testing";
+ * import { assertVaultConformance } from "@swamp-club/swamp-testing";
  *
  * Deno.test("aws-sm vault contract", async () => {
  *   const provider = vault.createProvider("test", { region: "us-east-1" });
@@ -306,7 +306,7 @@ export interface VaultAnnotationExportConformanceOptions {
  * import {
  *   assertVaultExportConformance,
  *   assertVaultAnnotationExportConformance,
- * } from "@systeminit/swamp-testing";
+ * } from "@swamp-club/swamp-testing";
  * import { vault } from "./my_vault.ts";
  *
  * Deno.test("vault export conforms with annotations", () => {
@@ -377,7 +377,7 @@ export interface VaultAnnotationConformanceOptions {
  * cleaned up by default.
  *
  * ```typescript
- * import { assertVaultAnnotationConformance } from "@systeminit/swamp-testing";
+ * import { assertVaultAnnotationConformance } from "@swamp-club/swamp-testing";
  *
  * Deno.test("vault annotation contract", async () => {
  *   const provider = vault.createProvider("test", { region: "us-east-1" });

--- a/packages/testing/vault_test_context.ts
+++ b/packages/testing/vault_test_context.ts
@@ -75,7 +75,7 @@ export interface VaultTestContextResult {
  * that interacts with vaults.
  *
  * ```typescript
- * import { createVaultTestContext } from "@systeminit/swamp-testing";
+ * import { createVaultTestContext } from "@swamp-club/swamp-testing";
  *
  * Deno.test("reads API key from vault", async () => {
  *   const { vault, getOperations } = createVaultTestContext({

--- a/src/domain/datastore/testing_package_compat_test.ts
+++ b/src/domain/datastore/testing_package_compat_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Type compatibility test for @systeminit/swamp-testing datastore types.
+ * Type compatibility test for @swamp-club/swamp-testing datastore types.
  *
  * Verifies that the testing package's datastore types remain structurally
  * compatible with swamp's canonical types. If someone changes the canonical

--- a/src/domain/drivers/testing_package_compat_test.ts
+++ b/src/domain/drivers/testing_package_compat_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Type compatibility test for @systeminit/swamp-testing driver types.
+ * Type compatibility test for @swamp-club/swamp-testing driver types.
  *
  * Verifies that the testing package's execution driver types remain
  * structurally compatible with swamp's canonical types.

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Type compatibility test for @systeminit/swamp-testing.
+ * Type compatibility test for @swamp-club/swamp-testing.
  *
  * This test verifies that the testing package's types remain structurally
  * compatible with swamp's canonical types. If someone changes MethodContext,

--- a/src/domain/reports/testing_package_compat_test.ts
+++ b/src/domain/reports/testing_package_compat_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Type compatibility test for @systeminit/swamp-testing report types.
+ * Type compatibility test for @swamp-club/swamp-testing report types.
  *
  * Verifies that the testing package's report types remain structurally
  * compatible with swamp's canonical types. The testing package uses

--- a/src/domain/vaults/testing_package_compat_test.ts
+++ b/src/domain/vaults/testing_package_compat_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Type compatibility test for @systeminit/swamp-testing vault types.
+ * Type compatibility test for @swamp-club/swamp-testing vault types.
  *
  * Verifies that the testing package's VaultProvider type remains structurally
  * compatible with swamp's canonical VaultProvider. If someone changes the


### PR DESCRIPTION
## Summary

- Rename `@systeminit/swamp-lib` → `@swamp-club/swamp-lib` and `@systeminit/swamp-testing` → `@swamp-club/swamp-testing` in `packages/*/deno.json`
- Update all `@systeminit` references in package source comments, README, compat tests, and skill reference docs (28 files, no functional changes)

## Manual steps after merge

1. Ensure the `@swamp-club` scope exists on [jsr.io](https://jsr.io) (create via web UI if needed)
2. Create the `swamp-lib` and `swamp-testing` packages under the new scope
3. Trigger the publish workflows (`publish-client.yml` and `publish-testing.yml`) via workflow_dispatch
4. Update the old `@systeminit/swamp-lib` and `@systeminit/swamp-testing` package descriptions on JSR to say "Moved to `@swamp-club/*`"
5. Archive the old `@systeminit/*` packages via JSR Settings → Archive
6. Update manual docs in `swamp-club/swamp-club` repo to reference the new scope

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — all 6768 tests pass
- [x] `deno run compile` succeeds

Closes swamp-club#545