### PR TITLE
fix(extensions): detect bare specifiers at CLI time (swamp-club#594)

### DIFF
--- a/.claude/skills/swamp/references/extension-publish/references/publishing.md
+++ b/.claude/skills/swamp/references/extension-publish/references/publishing.md
@@ -248,6 +248,9 @@ Other Deno-compatible imports (`npm:`, `jsr:`, `https://`) are inlined into the
 bundle by the swamp packager. Bare specifiers backed by `deno.json` or
 `package.json` work for the bundler, but follow the hermeticity rule above for
 anything that needs to score: prefer the inline form in entrypoint files.
+`swamp extension quality` detects bare specifiers before scoring and fails
+early; `swamp extension push` adds a review warning that the extension may show
+as unscored on the registry.
 
 - All imports must be static top-level imports — dynamic `import()` calls are
   rejected during push
@@ -396,12 +399,16 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo --json
 7. **Quality checks** — runs `deno fmt --check` and `deno lint` on model, vault,
    driver, datastore, and report files (using the project's `deno.json` config
    if present, otherwise default rules). Include files are excluded.
-8. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
+8. **Bare specifier check** — scans source files for bare import specifiers
+   (e.g. `from "zod"` instead of `from "npm:zod@3"`). The server-side scorer
+   cannot resolve bare specifiers, so a warning is added to the review warnings
+   prompting the user to confirm before push.
+9. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,
    datastores) to standalone JS. Include files are not bundled. If a `deno.json`
    is present, the import map governs dependency resolution.
-9. **Version check** — verifies version doesn't already exist (offers to bump)
-10. **Build archive** — creates tar.gz with all content types and their bundles
-11. **Upload** — three-phase push: initiate, upload archive, confirm
+10. **Version check** — verifies version doesn't already exist (offers to bump)
+11. **Build archive** — creates tar.gz with all content types and their bundles
+12. **Upload** — three-phase push: initiate, upload archive, confirm
 
 ## Extension Formatting
 

--- a/.claude/skills/swamp/references/extension/references/quality/templates.md
+++ b/.claude/skills/swamp/references/extension/references/quality/templates.md
@@ -187,6 +187,8 @@ Rules this example demonstrates:
   `swamp extension quality` run in a hermetic sandbox that strips the repo's
   `deno.json` and writes its own with no imports map, so a bare specifier cannot
   resolve at score time even when an import map maps it at bundle time.
+  `swamp extension quality` detects bare specifiers before scoring and fails
+  early; `swamp extension push` warns that the extension may show as unscored.
 
 ## Pre-publish command sequence
 

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -186,23 +186,32 @@ export interface BundleOptions {
  * preferred over re-bundling when no deno.json is available (pulled
  * extensions with bare specifiers would always fail to rebundle locally).
  */
+const IMPORT_SPECIFIER_RE =
+  /(?:import|export)\s+[\s\S]*?from\s+["']([^"']+)["']/g;
+
+function isBareSpecifier(specifier: string): boolean {
+  if (specifier.startsWith(".")) return false;
+  if (specifier.startsWith("npm:")) return false;
+  if (specifier.startsWith("jsr:")) return false;
+  if (specifier.startsWith("https:")) return false;
+  if (specifier.startsWith("http:")) return false;
+  if (specifier.startsWith("node:")) return false;
+  return true;
+}
+
 export function sourceHasBareSpecifiers(source: string): boolean {
-  const importPattern = /(?:import|export)\s+[\s\S]*?from\s+["']([^"']+)["']/g;
-  for (const match of source.matchAll(importPattern)) {
-    const specifier = match[1];
-    // Relative imports resolve by path — not bare.
-    if (specifier.startsWith(".")) continue;
-    // Non-local specifiers resolve without an import map — not bare.
-    if (specifier.startsWith("npm:")) continue;
-    if (specifier.startsWith("jsr:")) continue;
-    if (specifier.startsWith("https:")) continue;
-    if (specifier.startsWith("http:")) continue;
-    // Node built-ins pass through unchanged — not bare.
-    if (specifier.startsWith("node:")) continue;
-    // Anything else is a bare specifier that needs an import map.
-    return true;
+  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
+    if (isBareSpecifier(match[1])) return true;
   }
   return false;
+}
+
+export function extractBareSpecifierNames(source: string): string[] {
+  const bare = new Set<string>();
+  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
+    if (isBareSpecifier(match[1])) bare.add(match[1]);
+  }
+  return [...bare];
 }
 
 /**

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -22,6 +22,7 @@ import { join } from "@std/path";
 import { z } from "zod";
 import {
   bundleExtension,
+  extractBareSpecifierNames,
   fixCjsEsmInterop,
   installZodGlobal,
   isExpectedBundleFailure,
@@ -554,6 +555,101 @@ import { helper } from "./helpers.ts";
 export { foo } from "../shared.ts";
 `;
   assertEquals(sourceHasBareSpecifiers(source), false);
+});
+
+// --- extractBareSpecifierNames unit tests ---
+
+Deno.test("extractBareSpecifierNames: returns bare specifier names", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { z } from "zod";'),
+    ["zod"],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: returns scoped bare specifiers", () => {
+  assertEquals(
+    extractBareSpecifierNames(
+      'import { Client } from "@aws-sdk/client-secrets-manager";',
+    ),
+    ["@aws-sdk/client-secrets-manager"],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: collects multiple unique specifiers", () => {
+  const source = `
+import { z } from "zod";
+import { decode } from "he";
+import { z as z2 } from "zod";
+`;
+  const result = extractBareSpecifierNames(source);
+  assertEquals(result.sort(), ["he", "zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: ignores npm: prefixed imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { z } from "npm:zod@4";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores jsr: prefixed imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { assert } from "jsr:@std/assert";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores relative imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { helper } from "./helpers.ts";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores parent-relative imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { shared } from "../shared.ts";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores node: imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { readFile } from "node:fs";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores https: imports", () => {
+  assertEquals(
+    extractBareSpecifierNames(
+      'import { delay } from "https://deno.land/std@0.224.0/async/delay.ts";',
+    ),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: ignores http: imports", () => {
+  assertEquals(
+    extractBareSpecifierNames('import { x } from "http://example.com/mod.ts";'),
+    [],
+  );
+});
+
+Deno.test("extractBareSpecifierNames: returns empty for no bare specifiers", () => {
+  const source = `
+import { z } from "npm:zod@4";
+import { helper } from "./helpers.ts";
+export { foo } from "../shared.ts";
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: handles re-exports", () => {
+  assertEquals(
+    extractBareSpecifierNames('export { z } from "zod";'),
+    ["zod"],
+  );
 });
 
 Deno.test("uint8ArrayToBase64 handles large input without stack overflow", () => {

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -20,6 +20,7 @@
 import { dirname, extname, join, relative } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { createTarGz } from "../../infrastructure/archive/tar_archive.ts";
+import { extractBareSpecifierNames } from "../../domain/models/bundle.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import { validateContentCollectives } from "../../domain/extensions/extension_collective_validator.ts";
 import type {
@@ -738,6 +739,32 @@ export async function extensionPushPrepare(
       "Extension review found issues that must be resolved before pushing.",
       { reviewRuleErrors: reviewRulesResult.errors },
     );
+  }
+
+  // 10c. Bare specifier check — warn that the server-side scorer cannot
+  // resolve bare imports (it strips deno.json and writes a controlled one).
+  const bareSpecifiers = new Set<string>();
+  for (const file of sourceFiles) {
+    try {
+      const src = await Deno.readTextFile(file);
+      for (const name of extractBareSpecifierNames(src)) {
+        bareSpecifiers.add(name);
+      }
+    } catch {
+      // File unreadable — skip.
+    }
+  }
+  if (bareSpecifiers.size > 0) {
+    const names = [...bareSpecifiers].sort();
+    reviewRulesResult.warnings.push({
+      ruleId: "bare-specifiers",
+      dimension: "scoring",
+      severity: "medium",
+      file: "",
+      message: `Extension uses bare import specifiers (${
+        names.map((s) => `"${s}"`).join(", ")
+      }) which cannot be scored by the server. The extension will be published but may show as unscored.`,
+    });
   }
 
   // 11. Bundle entry points + build archive — skip on cache hit

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -760,7 +760,7 @@ export async function extensionPushPrepare(
       ruleId: "bare-specifiers",
       dimension: "scoring",
       severity: "medium",
-      file: "",
+      file: "(multiple files)",
       message: `Extension uses bare import specifiers (${
         names.map((s) => `"${s}"`).join(", ")
       }) which cannot be scored by the server. The extension will be published but may show as unscored.`,

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -29,11 +29,13 @@ import {
   type RubricScoreDeps,
   scoreExtensionTarball,
 } from "../../domain/extensions/extension_rubric_scorer.ts";
+import { extractBareSpecifierNames } from "../../domain/models/bundle.ts";
 import { extractTarGz } from "../../infrastructure/archive/tar_archive.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import type { LibSwampContext } from "../context.ts";
+import { validationFailed } from "../errors.ts";
 import type { SwampError } from "../errors.ts";
 import {
   extensionPushPrepare,
@@ -180,6 +182,37 @@ export async function* extensionQuality(
           rubricVersion: RUBRIC_VERSION,
         });
         ctx.logger.debug`Cache put: ${archiveBytes.length} bytes at ${hash}`;
+      }
+
+      const allSourceFiles = [
+        ...input.prepareInput.allModelFiles,
+        ...input.prepareInput.allVaultFiles,
+        ...input.prepareInput.allDriverFiles,
+        ...input.prepareInput.allDatastoreFiles,
+        ...input.prepareInput.allReportFiles,
+      ];
+      const bareSpecifiers = new Set<string>();
+      for (const file of allSourceFiles) {
+        try {
+          const src = await Deno.readTextFile(file);
+          for (const name of extractBareSpecifierNames(src)) {
+            bareSpecifiers.add(name);
+          }
+        } catch {
+          // File unreadable — skip.
+        }
+      }
+      if (bareSpecifiers.size > 0) {
+        const names = [...bareSpecifiers].sort();
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Extension uses bare import specifiers that cannot be resolved by the server-side scorer: ${
+              names.map((s) => `"${s}"`).join(", ")
+            }. Use explicit npm: or jsr: prefixes (e.g., "npm:zod@3.25.67") or add them to your deno.json imports.`,
+          ),
+        };
+        return;
       }
 
       yield { kind: "scoring" };

--- a/src/libswamp/extensions/quality.ts
+++ b/src/libswamp/extensions/quality.ts
@@ -209,7 +209,7 @@ export async function* extensionQuality(
           error: validationFailed(
             `Extension uses bare import specifiers that cannot be resolved by the server-side scorer: ${
               names.map((s) => `"${s}"`).join(", ")
-            }. Use explicit npm: or jsr: prefixes (e.g., "npm:zod@3.25.67") or add them to your deno.json imports.`,
+            }. Use explicit npm: or jsr: prefixes in your source files (e.g., "npm:package@version").`,
           ),
         };
         return;


### PR DESCRIPTION
## Summary

- Detect bare import specifiers (e.g. `from "zod"` instead of `from "npm:zod@3"`) at CLI time instead of letting the server-side scorer fail opaquely.
- `swamp extension quality` fails early with a clear message listing the offending specifiers and suggesting `npm:` or `jsr:` prefixes.
- `swamp extension push` adds a medium-severity review warning to the "Continue with push despite warnings?" prompt so the user can confirm and proceed knowing the extension may show as unscored.
- Updated extension-publish and quality skills to document the new check.

Closes swamp-club#594

## Test Plan

- 12 unit tests for `extractBareSpecifierNames` covering bare imports (single, scoped, multiple/deduplicated, re-exports) and verifying npm:, jsr:, https:, http:, relative, parent-relative, and node: prefixed imports are NOT flagged.
- Full test suite passes (6803 passed).
- Manually verified with compiled binary against test extensions:
  - `quality` with bare specifiers + deno.json → fails with `Extension uses bare import specifiers that cannot be resolved by the server-side scorer: "he", "zod"...`
  - `quality` with npm:-prefixed specifiers → passes bare specifier check, proceeds to scoring
  - `push --dry-run` with bare specifiers → shows `[medium] scoring` review warning
  - `push --dry-run` with prefixed specifiers → no bare specifier warning