### PR TITLE
fix(extensions): credentials-sensitive-field false positive on multi-line chains (swamp-club#601)

### DIFF
--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -201,21 +201,31 @@ export const DEFAULT_REVIEW_RULES: ReviewRule[] = [
     detect: (source) => {
       const messages: string[] = [];
       const lines = source.content.split("\n");
-      for (const raw of lines) {
-        const line = stripLineComment(raw);
-        // Heuristic: a schema field whose name suggests a secret, declared
-        // with a zod type, but not marked sensitive on the same line.
+      for (let i = 0; i < lines.length; i++) {
+        const line = stripLineComment(lines[i]);
         if (
-          SENSITIVE_FIELD_PATTERN.test(line) &&
-          /z\s*\./.test(line) &&
-          !/sensitive/i.test(line)
-        ) {
-          messages.push(
-            `Field on line "${line.trim()}" looks like a secret but is not ` +
-              "marked `.meta({ sensitive: true })`. Sensitive values must be " +
-              "vaulted.",
-          );
+          !SENSITIVE_FIELD_PATTERN.test(line) ||
+          !/z\s*\./.test(line)
+        ) continue;
+
+        if (/sensitive/i.test(line)) continue;
+
+        let foundSensitive = false;
+        for (let j = i + 1; j < lines.length; j++) {
+          const cont = stripLineComment(lines[j]);
+          if (!/^\s+\./.test(cont)) break;
+          if (/sensitive/i.test(cont)) {
+            foundSensitive = true;
+            break;
+          }
         }
+        if (foundSensitive) continue;
+
+        messages.push(
+          `Field on line "${line.trim()}" looks like a secret but is not ` +
+            "marked `.meta({ sensitive: true })`. Sensitive values must be " +
+            "vaulted.",
+        );
       }
       return messages;
     },

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -153,6 +153,73 @@ Deno.test("credentials-sensitive-field: no warning when marked sensitive", () =>
   assertEquals(result.warnings.length, 0);
 });
 
+Deno.test("credentials-sensitive-field: no warning when .meta({ sensitive: true }) is on a continuation line", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: `  oauthToken: z.string()
+    .startsWith("sk-ant", "must start with sk-ant")
+    .meta({ sensitive: true })
+    .describe("Claude Code OAuth token"),`,
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: warns on multi-line chain without sensitive", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: `  apiKey: z.string()
+    .min(1)
+    .describe("The API key"),`,
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    1,
+  );
+});
+
+Deno.test("credentials-sensitive-field: only warns on the unmarked field when mixed", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: `  oauthToken: z.string()
+    .meta({ sensitive: true }),
+  secretKey: z.string()
+    .min(1)
+    .describe("not marked"),`,
+    }),
+  ]);
+  const findings = result.warnings.filter((w) =>
+    w.ruleId === "credentials-sensitive-field"
+  );
+  assertEquals(findings.length, 1);
+  assert(findings[0].message.includes("secretKey"));
+});
+
+Deno.test("credentials-sensitive-field: lookahead stops at closing brace", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: `  password: z.string(),
+});
+const other = z.object({}).meta({ sensitive: true });`,
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    1,
+  );
+});
+
 Deno.test("testing-completeness: warns when entry point lacks a sibling test", () => {
   const result = evaluateReviewRules([
     source({ isEntryPoint: true, hasSiblingTest: false, content: "" }),


### PR DESCRIPTION
## Summary

- Fix the `credentials-sensitive-field` push-time rule to look ahead through method-chain continuation lines (lines matching `^\s+\.`) before deciding `.meta({ sensitive: true })` is absent. Previously the detector only checked the single physical line containing the field name, causing false positives when `deno fmt` breaks long Zod chains across lines.
- Add 4 test cases covering: multi-line chain with sensitive on continuation line, multi-line chain without sensitive, mixed fields (only unmarked warned), and chain ending at closing brace.

Fixes swamp-club#601

## Test Plan

- [x] Reproduced the false positive with `deno eval` against `evaluateReviewRules`
- [x] Verified the fix eliminates the false positive on the exact pattern from the issue
- [x] All 30 unit tests in `extension_review_rules_test.ts` pass (4 new + 26 existing)
- [x] Full test suite passes (6807 passed, 0 failed)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)