### PR TITLE
fix(extensions): strip comments before bare-specifier detection (swamp-club#602)

### DIFF
--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -199,8 +199,117 @@ function isBareSpecifier(specifier: string): boolean {
   return true;
 }
 
+// See also: stripComments in extension_dependency_extractor.ts (import-line
+// only) and stripCommentsAndStrings in extension_quality_checker.ts (strips
+// both). This variant strips all comments while preserving string literals
+// so the import-specifier regex can still match real import strings.
+function stripSourceComments(source: string): string {
+  const result: string[] = [];
+  let i = 0;
+
+  while (i < source.length) {
+    // Single-line comment — blank to end of line
+    if (source[i] === "/" && i + 1 < source.length && source[i + 1] === "/") {
+      i += 2;
+      while (i < source.length && source[i] !== "\n") {
+        result.push(" ");
+        i++;
+      }
+      continue;
+    }
+
+    // Block comment — blank preserving newlines
+    if (source[i] === "/" && i + 1 < source.length && source[i + 1] === "*") {
+      result.push(" ", " ");
+      i += 2;
+      while (i < source.length) {
+        if (
+          source[i] === "*" && i + 1 < source.length &&
+          source[i + 1] === "/"
+        ) {
+          result.push(" ", " ");
+          i += 2;
+          break;
+        }
+        result.push(source[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      continue;
+    }
+
+    // Double-quoted string — preserve content (imports live here)
+    if (source[i] === '"') {
+      result.push(source[i]);
+      i++;
+      while (i < source.length && source[i] !== '"' && source[i] !== "\n") {
+        if (source[i] === "\\") {
+          result.push(source[i]);
+          i++;
+        }
+        if (i < source.length) {
+          result.push(source[i]);
+          i++;
+        }
+      }
+      if (i < source.length && source[i] === '"') {
+        result.push(source[i]);
+        i++;
+      }
+      continue;
+    }
+
+    // Single-quoted string — preserve content
+    if (source[i] === "'") {
+      result.push(source[i]);
+      i++;
+      while (i < source.length && source[i] !== "'" && source[i] !== "\n") {
+        if (source[i] === "\\") {
+          result.push(source[i]);
+          i++;
+        }
+        if (i < source.length) {
+          result.push(source[i]);
+          i++;
+        }
+      }
+      if (i < source.length && source[i] === "'") {
+        result.push(source[i]);
+        i++;
+      }
+      continue;
+    }
+
+    // Template literal — preserve content
+    if (source[i] === "`") {
+      result.push(source[i]);
+      i++;
+      while (i < source.length && source[i] !== "`") {
+        if (source[i] === "\\") {
+          result.push(source[i]);
+          i++;
+        }
+        if (i < source.length) {
+          result.push(source[i]);
+          i++;
+        }
+      }
+      if (i < source.length && source[i] === "`") {
+        result.push(source[i]);
+        i++;
+      }
+      continue;
+    }
+
+    result.push(source[i]);
+    i++;
+  }
+
+  return result.join("");
+}
+
 export function sourceHasBareSpecifiers(source: string): boolean {
-  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
+  const stripped = stripSourceComments(source);
+  for (const match of stripped.matchAll(IMPORT_SPECIFIER_RE)) {
     if (isBareSpecifier(match[1])) return true;
   }
   return false;
@@ -208,7 +317,8 @@ export function sourceHasBareSpecifiers(source: string): boolean {
 
 export function extractBareSpecifierNames(source: string): string[] {
   const bare = new Set<string>();
-  for (const match of source.matchAll(IMPORT_SPECIFIER_RE)) {
+  const stripped = stripSourceComments(source);
+  for (const match of stripped.matchAll(IMPORT_SPECIFIER_RE)) {
     if (isBareSpecifier(match[1])) bare.add(match[1]);
   }
   return [...bare];

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -652,6 +652,60 @@ Deno.test("extractBareSpecifierNames: handles re-exports", () => {
   );
 });
 
+// --- comment stripping regression tests (swamp-club#602) ---
+
+Deno.test("extractBareSpecifierNames: ignores quoted phrases in single-line comments", () => {
+  const source = `import { z } from "npm:zod@4";
+
+export function check() {
+  // Distinguish "policy attached but unreadable" from "no policy". When
+  // the value is absent it keeps its existing "no policy" behavior.
+  return z.object({}).parse({});
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: ignores from patterns in block comments", () => {
+  const source = `import { z } from "npm:zod@4";
+
+/*
+ * This export is derived from "legacy-pkg" but we no longer
+ * import from "legacy-pkg" directly.
+ */
+export function check() {
+  return z.object({}).parse({});
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: detects real bare imports adjacent to comments", () => {
+  const source = `// this comment mentions "no policy"
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: preserves string literals containing //", () => {
+  const source = `import { fetch } from "npm:undici@6";
+const url = "https://example.com/api";
+export function get() { return fetch(url); }
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("sourceHasBareSpecifiers: ignores quoted phrases in comments", () => {
+  const source = `import { z } from "npm:zod@4";
+
+export function check() {
+  // existing "no policy" behavior
+  return z.object({}).parse({});
+}
+`;
+  assertEquals(sourceHasBareSpecifiers(source), false);
+});
+
 Deno.test("uint8ArrayToBase64 handles large input without stack overflow", () => {
   // 1MB of data — would blow the stack with String.fromCharCode(...bytes)
   const size = 1_000_000;


### PR DESCRIPTION
## Summary

- Fix false-positive bare import specifier detection when extension source contains quoted phrases inside comments (e.g. `// existing "no policy" behavior`).
- Add a string-aware `stripSourceComments` function to `bundle.ts` that removes `//` and `/* */` comments while preserving string literals, applied in both `sourceHasBareSpecifiers` and `extractBareSpecifierNames` before running the import regex.
- The `IMPORT_SPECIFIER_RE` regex uses `[\s\S]*?` which spans newlines — an `export` keyword on one line could match `from "quoted phrase"` inside a comment on a later line.

Regression introduced in ed5f78a4 (swamp-club#594).

Closes swamp-club#602

## Test Plan

- Added 5 unit tests covering: single-line comment false positives, block comment false positives, real bare imports adjacent to comments, string literals containing `//`, and `sourceHasBareSpecifiers` with comments.
- Verified fix against scratch reproduction at `/tmp/swamp-repro-issue-602` — previously failing `swamp extension quality` now proceeds past bare specifier check.
- All 6808 existing tests pass.