### PR TITLE
fix(extensions): validate lockfile paths stay within repo boundary

### DIFF
--- a/src/infrastructure/persistence/directory_cleanup.ts
+++ b/src/infrastructure/persistence/directory_cleanup.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { dirname, join } from "@std/path";
+import { assertContainedPath } from "./safe_path.ts";
 
 /**
  * Removes a list of repo-relative paths and reports which were actually
@@ -44,6 +45,7 @@ export async function pruneOrphanFiles(
 ): Promise<string[]> {
   const removed: string[] = [];
   for (const file of orphanPaths) {
+    assertContainedPath(file, repoDir);
     const absolutePath = join(repoDir, file);
     try {
       await Deno.remove(absolutePath, { recursive: true });

--- a/src/infrastructure/persistence/directory_cleanup_test.ts
+++ b/src/infrastructure/persistence/directory_cleanup_test.ts
@@ -17,10 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir, exists } from "@std/fs";
-import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
+import {
+  cleanupEmptyParentDirs,
+  pruneOrphanFiles,
+} from "./directory_cleanup.ts";
+import { PathTraversalError } from "./safe_path.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-cleanup-test-" });
@@ -141,5 +145,45 @@ Deno.test("cleanupEmptyParentDirs does not go above stop directory", async () =>
     // But data and swamp should still exist
     assertEquals(await exists(dataDir), true);
     assertEquals(await exists(swampDir), true);
+  });
+});
+
+Deno.test("pruneOrphanFiles rejects path traversal in orphan paths", async () => {
+  await withTempDir(async (tempDir) => {
+    const repoDir = join(tempDir, "repo");
+    await ensureDir(repoDir);
+
+    const victimDir = join(tempDir, "victim");
+    await ensureDir(victimDir);
+    await Deno.writeTextFile(join(victimDir, "secret.txt"), "sensitive");
+
+    await assertRejects(
+      () => pruneOrphanFiles(["../victim"], repoDir),
+      PathTraversalError,
+    );
+
+    assertEquals(await exists(victimDir), true);
+    assertEquals(
+      await Deno.readTextFile(join(victimDir, "secret.txt")),
+      "sensitive",
+    );
+  });
+});
+
+Deno.test("pruneOrphanFiles removes valid orphan paths", async () => {
+  await withTempDir(async (tempDir) => {
+    const repoDir = join(tempDir, "repo");
+    await ensureDir(repoDir);
+    const orphanFile = join(repoDir, ".swamp", "pulled-extensions", "old.ts");
+    await ensureDir(join(repoDir, ".swamp", "pulled-extensions"));
+    await Deno.writeTextFile(orphanFile, "old content");
+
+    const removed = await pruneOrphanFiles(
+      [".swamp/pulled-extensions/old.ts"],
+      repoDir,
+    );
+
+    assertEquals(removed, [".swamp/pulled-extensions/old.ts"]);
+    assertEquals(await exists(orphanFile), false);
   });
 });

--- a/src/infrastructure/persistence/safe_path.ts
+++ b/src/infrastructure/persistence/safe_path.ts
@@ -114,3 +114,42 @@ export async function assertSafePath(
     throw new PathTraversalError(path, boundary, resolvedPath);
   }
 }
+
+/**
+ * Synchronous, lexical containment check for repo-relative paths.
+ * Rejects absolute paths, null bytes, and `..` traversal BEFORE any
+ * filesystem I/O occurs. Use this to validate untrusted paths from
+ * committed lockfiles or other repo-controlled data before passing
+ * them to `Deno.stat`, `Deno.remove`, or similar operations.
+ *
+ * @param relativePath - The repo-relative path to validate
+ * @param boundary - The absolute directory the path must stay within
+ * @throws {PathTraversalError} if the resolved path escapes the boundary
+ */
+export function assertContainedPath(
+  relativePath: string,
+  boundary: string,
+): void {
+  if (relativePath.includes("\0")) {
+    throw new PathTraversalError(
+      relativePath,
+      boundary,
+      "(contains null byte)",
+    );
+  }
+  if (relativePath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(relativePath)) {
+    throw new PathTraversalError(
+      relativePath,
+      boundary,
+      "(absolute path)",
+    );
+  }
+  const resolvedBoundary = resolve(boundary);
+  const resolvedPath = resolve(join(resolvedBoundary, relativePath));
+  if (
+    resolvedPath !== resolvedBoundary &&
+    !resolvedPath.startsWith(resolvedBoundary + SEPARATOR)
+  ) {
+    throw new PathTraversalError(relativePath, boundary, resolvedPath);
+  }
+}

--- a/src/infrastructure/persistence/safe_path.ts
+++ b/src/infrastructure/persistence/safe_path.ts
@@ -130,6 +130,13 @@ export function assertContainedPath(
   relativePath: string,
   boundary: string,
 ): void {
+  if (!relativePath || relativePath === ".") {
+    throw new PathTraversalError(
+      relativePath,
+      boundary,
+      "(empty or identity path)",
+    );
+  }
   if (relativePath.includes("\0")) {
     throw new PathTraversalError(
       relativePath,

--- a/src/infrastructure/persistence/safe_path_test.ts
+++ b/src/infrastructure/persistence/safe_path_test.ts
@@ -17,9 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { dirname, join } from "@std/path";
-import { assertSafePath, PathTraversalError } from "./safe_path.ts";
+import {
+  assertContainedPath,
+  assertSafePath,
+  PathTraversalError,
+} from "./safe_path.ts";
 
 Deno.test("assertSafePath", async (t) => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp-safe-path-" });
@@ -231,4 +235,53 @@ Deno.test("assertSafePath", async (t) => {
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
+});
+
+Deno.test("assertContainedPath", async (t) => {
+  const boundary = "/fake/repo";
+
+  await t.step("accepts simple relative paths", () => {
+    assertContainedPath(".swamp/pulled-extensions/model.ts", boundary);
+    assertContainedPath("extensions/models/foo.ts", boundary);
+    assertContainedPath("a/b/c/d.txt", boundary);
+  });
+
+  await t.step("rejects .. traversal", () => {
+    assertThrows(
+      () => assertContainedPath("../victim-data", boundary),
+      PathTraversalError,
+    );
+    assertThrows(
+      () => assertContainedPath("a/../../outside", boundary),
+      PathTraversalError,
+    );
+    assertThrows(
+      () => assertContainedPath(".swamp/../../../etc/passwd", boundary),
+      PathTraversalError,
+    );
+  });
+
+  await t.step("rejects absolute paths", () => {
+    assertThrows(
+      () => assertContainedPath("/etc/passwd", boundary),
+      PathTraversalError,
+    );
+    assertThrows(
+      () => assertContainedPath("/tmp/evil", boundary),
+      PathTraversalError,
+    );
+  });
+
+  await t.step("rejects null bytes", () => {
+    assertThrows(
+      () => assertContainedPath("file\0.txt", boundary),
+      PathTraversalError,
+    );
+  });
+
+  await t.step("accepts filenames starting with ..", () => {
+    assertContainedPath("..foo", boundary);
+    assertContainedPath("dir/..config", boundary);
+    assertContainedPath("...hidden.txt", boundary);
+  });
 });

--- a/src/infrastructure/persistence/safe_path_test.ts
+++ b/src/infrastructure/persistence/safe_path_test.ts
@@ -246,6 +246,17 @@ Deno.test("assertContainedPath", async (t) => {
     assertContainedPath("a/b/c/d.txt", boundary);
   });
 
+  await t.step("rejects empty string and identity path", () => {
+    assertThrows(
+      () => assertContainedPath("", boundary),
+      PathTraversalError,
+    );
+    assertThrows(
+      () => assertContainedPath(".", boundary),
+      PathTraversalError,
+    );
+  });
+
   await t.step("rejects .. traversal", () => {
     assertThrows(
       () => assertContainedPath("../victim-data", boundary),

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -20,6 +20,7 @@
 import { join } from "@std/path";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
+import { assertContainedPath } from "../../infrastructure/persistence/safe_path.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
@@ -273,6 +274,7 @@ export async function needsInstallOrMigration(
 ): Promise<"install" | "migrate" | "up_to_date"> {
   let hasLegacy = false;
   for (const file of files) {
+    assertContainedPath(file, repoDir);
     const absolutePath = join(repoDir, file);
     try {
       await Deno.stat(absolutePath);
@@ -321,6 +323,7 @@ export async function sweepLegacyPaths(
   skillsDirRelative?: string,
 ): Promise<void> {
   for (const file of originalFiles) {
+    assertContainedPath(file, repoDir);
     if (isSkillDirEntry(file, skillsDirRelative)) {
       continue;
     }

--- a/src/libswamp/extensions/remove_extension_service.ts
+++ b/src/libswamp/extensions/remove_extension_service.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { dirname, join, resolve } from "@std/path";
+import { assertContainedPath } from "../../infrastructure/persistence/safe_path.ts";
 import { tombstoneAll } from "../../domain/extensions/extension.ts";
 import type { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
 import type { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
@@ -138,6 +139,7 @@ export class RemoveExtensionService {
     let filesSkipped = 0;
     const parentDirs: string[] = [];
     for (const filePath of trackedFiles) {
+      assertContainedPath(filePath, this.repoDir);
       const absolutePath = join(this.repoDir, filePath);
       try {
         const stat = await Deno.stat(absolutePath);


### PR DESCRIPTION
## Summary

- Lockfile `files[]` entries from `upstream_extensions.json` are repo-controlled data that reached filesystem operations (`Deno.stat`, `Deno.remove`) without path containment checks. A crafted lockfile with `../` paths could cause orphan cleanup to delete files outside the checkout.
- Adds `assertContainedPath()` to `safe_path.ts` — a synchronous, lexical check that rejects `..` traversal, absolute paths (Unix and Windows), and null bytes before any I/O.
- Applied at all four affected call sites: `pruneOrphanFiles`, `needsInstallOrMigration`, `sweepLegacyPaths`, and `RemoveExtensionService.execute()`.

## Test plan

- [x] `assertContainedPath` unit tests: accepts valid relative paths, rejects `../`, absolute paths, null bytes, accepts `..foo`-style filenames
- [x] `pruneOrphanFiles` integration test: confirms `../victim` path is rejected and victim directory is untouched
- [x] `pruneOrphanFiles` integration test: confirms valid orphan paths are still removed correctly
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)