### PR TITLE
feat(extensions): discover co-located components in paths.base:manifest extensions (swamp-club#600)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -293,6 +293,16 @@ directory is searched first (e.g. `sub/.claude/skills/<name>/`), then
 project-local, then global. All enrolled tools are searched, not just
 the primary tool.
 
+Local source-loading honours `paths.base: manifest` — at startup, the
+loader scans all known extension directories for manifests with
+`paths.base: manifest`. When a manifest declares components of a kind
+different from its parent directory (e.g. a `reports:` entry in a
+manifest under `extensions/models/myext/`), the manifest's directory is
+added as an additional source directory for that kind. This closes the
+dev/prod parity gap where published bundles loaded all declared
+components but local source loading only discovered components matching
+their kind directory.
+
 The on-wire manifest in the archive preserves the field strings
 verbatim — no path rewriting, no normalization. WYSIWYG between what
 the author pushes and what the registry stores. The archive layout

--- a/design/reports.md
+++ b/design/reports.md
@@ -467,4 +467,10 @@ directories:
 2. `reportsDir` in `.swamp.yaml`
 3. Default: `extensions/reports/`
 
+Additionally, reports co-located with models in `paths.base: manifest`
+extensions are discovered automatically. When a manifest in e.g.
+`extensions/models/myext/manifest.yaml` declares `reports:` entries with
+`paths.base: manifest`, the manifest's directory is added as an additional
+report source directory at startup.
+
 See `src/cli/resolve_reports_dir.ts`.

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -146,7 +146,11 @@ import {
   readSwampSources,
   resolveSourceExtensionDirs,
 } from "../infrastructure/persistence/swamp_sources_repository.ts";
-import type { ResolvedSourceDirs } from "../domain/repo/swamp_sources.ts";
+import type {
+  ExtensionKind,
+  ResolvedSourceDirs,
+} from "../domain/repo/swamp_sources.ts";
+import { discoverManifestCrossKindDirs } from "../domain/extensions/manifest_cross_kind_discovery.ts";
 
 // Import models barrel to trigger self-registration
 import "../domain/models/models.ts";
@@ -296,6 +300,39 @@ export async function configureExtensionLoaders(
   );
   const sourceReportsDirs = collectDirsForKind(resolvedSources, "reports");
 
+  const resolveAbsoluteKindDir = (
+    resolveDir: (m: RepoMarkerData | null) => string,
+  ): string => {
+    const dir = resolveDir(marker);
+    return isAbsolute(dir) ? dir : resolve(effectiveExtDir, dir);
+  };
+
+  const kindDirs = new Map<ExtensionKind, string[]>([
+    ["models", [resolveAbsoluteKindDir(resolveModelsDir), ...sourceModelsDirs]],
+    ["vaults", [resolveAbsoluteKindDir(resolveVaultsDir), ...sourceVaultsDirs]],
+    [
+      "drivers",
+      [resolveAbsoluteKindDir(resolveDriversDir), ...sourceDriversDirs],
+    ],
+    [
+      "datastores",
+      [resolveAbsoluteKindDir(resolveDatastoresDir), ...sourceDatastoresDirs],
+    ],
+    [
+      "reports",
+      [resolveAbsoluteKindDir(resolveReportsDir), ...sourceReportsDirs],
+    ],
+  ]);
+  const manifestCrossKindDirs = await discoverManifestCrossKindDirs(kindDirs);
+
+  const mergeManifestDirs = (
+    sourceDirs: string[],
+    kind: ExtensionKind,
+  ): string[] => {
+    const extra = manifestCrossKindDirs.get(kind);
+    return extra ? [...sourceDirs, ...extra] : sourceDirs;
+  };
+
   let resolverPromise: Promise<DatastorePathResolver | undefined> | undefined;
   const lazyResolver = (): Promise<DatastorePathResolver | undefined> => {
     resolverPromise ??= resolveDatastoreConfig(marker, undefined, repoDir)
@@ -351,7 +388,7 @@ export async function configureExtensionLoaders(
       repoDir,
       marker,
       denoRuntime,
-      sourceModelsDirs,
+      mergeManifestDirs(sourceModelsDirs, "models"),
       lazyResolver,
       repository,
       quiet,
@@ -363,7 +400,7 @@ export async function configureExtensionLoaders(
       repoDir,
       marker,
       denoRuntime,
-      sourceVaultsDirs,
+      mergeManifestDirs(sourceVaultsDirs, "vaults"),
       lazyResolver,
       repository,
       quiet,
@@ -375,7 +412,7 @@ export async function configureExtensionLoaders(
       repoDir,
       marker,
       denoRuntime,
-      sourceDriversDirs,
+      mergeManifestDirs(sourceDriversDirs, "drivers"),
       lazyResolver,
       repository,
       quiet,
@@ -387,7 +424,7 @@ export async function configureExtensionLoaders(
       repoDir,
       marker,
       denoRuntime,
-      sourceDatastoresDirs,
+      mergeManifestDirs(sourceDatastoresDirs, "datastores"),
       repository,
       quiet,
       effectiveExtDir,
@@ -398,7 +435,7 @@ export async function configureExtensionLoaders(
       repoDir,
       marker,
       denoRuntime,
-      sourceReportsDirs,
+      mergeManifestDirs(sourceReportsDirs, "reports"),
       lazyResolver,
       repository,
       quiet,

--- a/src/domain/extensions/manifest_cross_kind_discovery.ts
+++ b/src/domain/extensions/manifest_cross_kind_discovery.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, SEPARATOR } from "@std/path";
+import { walk } from "@std/fs";
+import { parse as parseYaml } from "@std/yaml";
+import { getLogger } from "@logtape/logtape";
+import type { ExtensionKind } from "../repo/swamp_sources.ts";
+
+const logger = getLogger(["swamp", "extensions", "manifest-discovery"]);
+
+const MANIFEST_FILENAMES = new Set(["manifest.yaml", "manifest.yml"]);
+const MANIFEST_MAX_DEPTH = 3;
+const MANIFEST_MAX_BYTES = 64 * 1024;
+
+const MANIFEST_KIND_KEYS: readonly ExtensionKind[] = [
+  "models",
+  "vaults",
+  "drivers",
+  "datastores",
+  "reports",
+];
+
+/**
+ * Scans known kind directories for `manifest.yaml` files that use
+ * `paths.base: manifest`. For each manifest that declares components
+ * of a *different* kind, the manifest's directory is returned as an
+ * additional directory for that kind.
+ *
+ * This closes the dev/prod parity gap where `paths.base: manifest`
+ * extensions load fully when published but only partially from source
+ * (the kind matching the parent directory loads; co-located components
+ * of other kinds do not).
+ *
+ * @param kindDirs Map of extension kind to the directories already
+ *   resolved for that kind (repo-local dirs, source dirs, etc.).
+ *   Only these directories are scanned — no new filesystem roots are
+ *   introduced.
+ * @returns Map of extension kind to additional directories discovered
+ *   from manifests. Directories already present in `kindDirs` for the
+ *   target kind are excluded.
+ */
+export async function discoverManifestCrossKindDirs(
+  kindDirs: Map<ExtensionKind, string[]>,
+): Promise<Map<ExtensionKind, string[]>> {
+  const result = new Map<ExtensionKind, string[]>();
+
+  const seenManifests = new Set<string>();
+
+  for (const [_sourceKind, dirs] of kindDirs) {
+    for (const dir of dirs) {
+      try {
+        await Deno.stat(dir);
+      } catch {
+        continue;
+      }
+
+      for await (
+        const entry of walk(dir, {
+          maxDepth: MANIFEST_MAX_DEPTH,
+          includeDirs: false,
+          match: [/manifest\.ya?ml$/],
+        })
+      ) {
+        if (!MANIFEST_FILENAMES.has(entry.name)) continue;
+        if (seenManifests.has(entry.path)) continue;
+        seenManifests.add(entry.path);
+
+        const crossKinds = await extractManifestCrossKinds(entry.path);
+        if (!crossKinds) continue;
+
+        const manifestDir = dirname(entry.path);
+        for (const kind of crossKinds) {
+          if (isSubdirOfAny(manifestDir, kindDirs.get(kind))) {
+            continue;
+          }
+
+          let list = result.get(kind);
+          if (!list) {
+            list = [];
+            result.set(kind, list);
+          }
+          if (!list.includes(manifestDir)) {
+            list.push(manifestDir);
+            logger
+              .debug`Manifest cross-kind discovery: ${entry.path} contributes ${kind} dir ${manifestDir}`;
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function isSubdirOfAny(
+  candidate: string,
+  dirs: string[] | undefined,
+): boolean {
+  if (!dirs) return false;
+  for (const dir of dirs) {
+    if (candidate === dir) return true;
+    if (candidate.startsWith(dir + SEPARATOR)) return true;
+  }
+  return false;
+}
+
+/**
+ * Reads a manifest file and returns the extension kinds it declares
+ * entries for, if and only if `paths.base` is `"manifest"`. Returns
+ * `null` if the manifest is not manifest-based, unparseable, or too
+ * large.
+ */
+async function extractManifestCrossKinds(
+  manifestPath: string,
+): Promise<ExtensionKind[] | null> {
+  try {
+    const stat = await Deno.stat(manifestPath);
+    if (stat.size > MANIFEST_MAX_BYTES) return null;
+
+    const content = await Deno.readTextFile(manifestPath);
+    const raw = parseYaml(content);
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+    const obj = raw as Record<string, unknown>;
+    if (obj.manifestVersion !== 1) return null;
+
+    const paths = obj.paths;
+    if (
+      !paths || typeof paths !== "object" || Array.isArray(paths) ||
+      (paths as Record<string, unknown>).base !== "manifest"
+    ) {
+      return null;
+    }
+
+    const kinds: ExtensionKind[] = [];
+    for (const kind of MANIFEST_KIND_KEYS) {
+      const entries = obj[kind];
+      if (Array.isArray(entries) && entries.length > 0) {
+        kinds.push(kind);
+      }
+    }
+
+    return kinds.length > 0 ? kinds : null;
+  } catch {
+    logger.debug`Failed to read manifest at ${manifestPath}, skipping`;
+    return null;
+  }
+}

--- a/src/domain/extensions/manifest_cross_kind_discovery_test.ts
+++ b/src/domain/extensions/manifest_cross_kind_discovery_test.ts
@@ -1,0 +1,282 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
+import type { ExtensionKind } from "../repo/swamp_sources.ts";
+import { discoverManifestCrossKindDirs } from "./manifest_cross_kind_discovery.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({
+    prefix: "swamp-manifest-cross-kind-test-",
+  });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function writeManifest(
+  dir: string,
+  manifest: Record<string, unknown>,
+): Promise<void> {
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(
+    join(dir, "manifest.yaml"),
+    stringifyYaml(manifest),
+  );
+}
+
+Deno.test("discoverManifestCrossKindDirs: no manifests returns empty map", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: manifest with paths.base:typedDir is ignored", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "typedDir" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: manifest without paths field is ignored", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: paths.base:manifest with reports adds dir", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.get("reports"), [extDir]);
+    assertEquals(result.has("models"), false);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: multiple cross-kinds from one manifest", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+      vaults: ["vault.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.get("reports"), [extDir]);
+    assertEquals(result.get("vaults"), [extDir]);
+    assertEquals(result.has("models"), false);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: dir already in kindDirs is excluded", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+      ["reports", [extDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.has("reports"), false);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: invalid manifest is skipped gracefully", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await Deno.mkdir(extDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(extDir, "manifest.yaml"),
+      "this is not valid yaml: [",
+    );
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: manifest with wrong version is ignored", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 99,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: nonexistent directory is skipped", async () => {
+  const kindDirs = new Map<ExtensionKind, string[]>([
+    ["models", ["/tmp/nonexistent-swamp-test-dir-" + crypto.randomUUID()]],
+  ]);
+
+  const result = await discoverManifestCrossKindDirs(kindDirs);
+  assertEquals(result.size, 0);
+});
+
+Deno.test("discoverManifestCrossKindDirs: empty kind arrays in manifest are ignored", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const extDir = join(modelsDir, "myext");
+    await writeManifest(extDir, {
+      manifestVersion: 1,
+      name: "@test/myext",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: [],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.size, 0);
+  });
+});
+
+Deno.test("discoverManifestCrossKindDirs: multiple manifests across dirs", async () => {
+  await withTempDir(async (dir) => {
+    const modelsDir = join(dir, "models");
+    const ext1 = join(modelsDir, "ext1");
+    const ext2 = join(modelsDir, "ext2");
+
+    await writeManifest(ext1, {
+      manifestVersion: 1,
+      name: "@test/ext1",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      reports: ["report.ts"],
+    });
+
+    await writeManifest(ext2, {
+      manifestVersion: 1,
+      name: "@test/ext2",
+      version: "2026.01.01.1",
+      paths: { base: "manifest" },
+      models: ["model.ts"],
+      drivers: ["driver.ts"],
+    });
+
+    const kindDirs = new Map<ExtensionKind, string[]>([
+      ["models", [modelsDir]],
+    ]);
+
+    const result = await discoverManifestCrossKindDirs(kindDirs);
+    assertEquals(result.get("reports"), [ext1]);
+    assertEquals(result.get("drivers"), [ext2]);
+  });
+});


### PR DESCRIPTION
## Summary

- Local source-loading now discovers reports (and other kinds) co-located with models in `paths.base: manifest` extensions
- Adds `discoverManifestCrossKindDirs()` which scans known kind directories for manifests declaring cross-kind components
- Wires the discovered directories into each kind loader's `additionalDirs` in `configureExtensionLoaders()`
- Closes the dev/prod parity gap where published bundles loaded all declared components but local source loading only found components matching their kind directory

Fixes swamp-club#600

## Test Plan

- 11 unit tests for the discovery function covering: no manifests, `paths.base: typedDir` (ignored), cross-kind discovery (single/multiple kinds), deduplication, invalid manifests, wrong version, nonexistent dirs, empty arrays, multiple manifests
- Verified with scratch repo: model + co-located report in `extensions/models/myext/` with `paths.base: manifest`
  - Without fix: `swamp doctor extensions` shows model only, report missing
  - With fix: both model and report discovered, indexed, and report executes during method run
- Verified standard `extensions/reports/` path still works alongside co-located reports
- Full test suite: 6814 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)