### PR TITLE
perf(models): skip CEL evaluation for expression-free definitions (swamp-club#606)

### DIFF
--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -470,10 +470,7 @@ export async function* modelMethodRun(
           }
           evaluatedDefinition = lastEval;
         } else {
-          if (
-            evaluationService.hasDefinitionExpressions(definition) ||
-            Object.keys(inputs).length > 0
-          ) {
+          if (evaluationService.hasDefinitionExpressions(definition)) {
             const evalResult = await evaluationService.evaluateDefinition(
               definition,
               modelType,


### PR DESCRIPTION
## Summary

- `model method run` entered the full CEL evaluation path — including
  `buildContext()` which scans every model definition and data record in
  the repo — whenever `--input` flags were present, even when the model
  definition contained zero `${{ }}` expressions
- For repos with large data volumes, `buildContext()` alone can take
  several seconds (reporter measured ~5s overhead on their repo)
- Remove the `Object.keys(inputs).length > 0` guard that forced this
  path — models without expressions now skip `evaluateDefinition()` and
  `buildContext()` entirely
- Inputs still reach method arguments through the existing override-merge
  logic (line 495+), which is independent of CEL evaluation

### Why this is safe

The guard was added defensively in the original inputs feature (PR #232)
but `evaluateDefinition()` already short-circuits at line 221 when it
finds zero expressions — it returns the original definition unchanged
and never reads the inputs from context. The original code before PR #232
was just `hasDefinitionExpressions(definition)` without the inputs check.

### Expected impact

Models with no CEL expressions (like `@mgreten/macos-say-tts`) skip the
expensive `buildContext()` → `findAllGlobal()` path. The reporter's
`--last-evaluated` benchmarks confirm this path is the bottleneck:
6.4s → 1.7s. This fix achieves the same skip automatically.

Fixes swamp-club#606

## Test Plan

- 6812 unit/integration tests pass, 0 failures
- `deno check` / `deno lint` / `deno fmt` all clean
- Verified inputs still flow correctly through the override path with
  the reporter's `@mgreten/macos-say-tts` extension (char counts match
  input text: 5, 18, 52 chars)
- Verified `--last-evaluated` still works (definition is still saved
  via `saveEvaluatedDefinition` on every non-`--last-evaluated` run)
- `deno run compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)