### PR TITLE
chore(docker): relocate Docker image to swampclub org (swamp-club#546)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
           context: docker-build/linux-amd64
           platforms: linux/amd64
           push: true
-          tags: systeminit/swamp:${{ env.docker_tag }}-amd64
+          tags: swampclub/swamp:${{ env.docker_tag }}-amd64
           provenance: mode=max
           sbom: true
 
@@ -228,13 +228,13 @@ jobs:
           context: docker-build/linux-arm64
           platforms: linux/arm64
           push: true
-          tags: systeminit/swamp:${{ env.docker_tag }}-arm64
+          tags: swampclub/swamp:${{ env.docker_tag }}-arm64
           provenance: mode=max
           sbom: true
 
       - name: Create and push multi-arch manifest
         run: |
           docker buildx imagetools create \
-            -t systeminit/swamp:${{ env.docker_tag }} \
-            systeminit/swamp:${{ env.docker_tag }}-amd64 \
-            systeminit/swamp:${{ env.docker_tag }}-arm64
+            -t swampclub/swamp:${{ env.docker_tag }} \
+            swampclub/swamp:${{ env.docker_tag }}-amd64 \
+            swampclub/swamp:${{ env.docker_tag }}-arm64


### PR DESCRIPTION
## Summary

- Move the Docker image from `systeminit/swamp` to `swampclub/swamp` on Docker Hub to align with the project's new organizational home under `swamp-club`

## Prerequisites

Before merging, ensure:
- The `swampclub` Docker Hub organization has a `swamp` repository created
- GitHub Actions secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are updated with credentials that can push to `swampclub/swamp`

## Post-merge

After merging, manually update the old `systeminit/swamp` Docker Hub repository:
- Update the repository description to indicate it is deprecated
- Update the README to point users to `swampclub/swamp`

## Test Plan

- CI/CD-only change (GitHub Actions workflow YAML) — no application code affected
- Verified no other files in the repo reference `systeminit/swamp` as a Docker image
- The README only mentions Docker for Jaeger tracing, not for swamp installation

Closes swamp-club#546