### PR TITLE
fix(archive): validate symlink targets in tar extraction to prevent zip-slip

### DIFF
--- a/src/infrastructure/archive/tar_archive.ts
+++ b/src/infrastructure/archive/tar_archive.ts
@@ -18,7 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { basename, dirname, join, normalize, relative } from "@std/path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+} from "@std/path";
 import { TarStream, type TarStreamInput } from "@std/tar/tar-stream";
 import { UntarStream } from "@std/tar/untar-stream";
 
@@ -198,20 +205,43 @@ export async function extractTarGz(
     }
 
     if (isSymlink) {
+      const linkTarget = entry.header.linkname;
+
+      // Reject absolute symlink targets — they always escape the root.
+      // `isAbsolute` handles POSIX `/`, Windows `\`, and drive-letter `C:\`.
+      if (isAbsolute(linkTarget)) {
+        throw new Error(
+          `Archive contains symlink with absolute target: ${entry.path} → ${linkTarget}`,
+        );
+      }
+
+      // Resolve the relative target against the symlink's parent directory
+      // and verify it stays within the extract root.
+      const resolvedLinkTarget = normalize(
+        join(dirname(targetPath), linkTarget),
+      );
+      ensureNoTraversal(resolvedLinkTarget, root);
+
+      // Defense-in-depth: verify the symlink's parent directory hasn't been
+      // redirected outside root by an earlier symlink entry.
+      await ensureDir(dirname(targetPath));
+      const realSymlinkParent = await Deno.realPath(dirname(targetPath));
+      ensureNoTraversal(realSymlinkParent, root);
+
       // Determine link type by probing the resolved symlink target — Windows
       // refuses dir symlinks pointing at a missing target without { type }.
       // POSIX ignores the `type` argument.
       let linkType: "file" | "dir" = "file";
       try {
         const stat = await Deno.stat(
-          join(dirname(targetPath), entry.header.linkname),
+          join(dirname(targetPath), linkTarget),
         );
         if (stat.isDirectory) linkType = "dir";
       } catch {
         // Broken or not-yet-extracted target — default to "file"
       }
       try {
-        await Deno.symlink(entry.header.linkname, targetPath, {
+        await Deno.symlink(linkTarget, targetPath, {
           type: linkType,
         });
       } catch (error) {
@@ -236,6 +266,13 @@ export async function extractTarGz(
     }
 
     await ensureDir(dirname(targetPath));
+
+    // Defense-in-depth: resolve the real path of the parent directory to
+    // catch symlink-through-directory escapes where an earlier entry planted
+    // a symlink that redirects this write outside the extract root.
+    const realParent = await Deno.realPath(dirname(targetPath));
+    ensureNoTraversal(realParent, root);
+
     const file = await Deno.open(targetPath, {
       write: true,
       create: true,

--- a/src/infrastructure/archive/tar_archive_test.ts
+++ b/src/infrastructure/archive/tar_archive_test.ts
@@ -189,6 +189,180 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "extractTarGz: rejects symlink with absolute target",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      const { TarStream } = await import("@std/tar/tar-stream");
+      const archivePath = join(root, "bad.tar.gz");
+      const file = await Deno.open(archivePath, {
+        write: true,
+        create: true,
+        truncate: true,
+      });
+      await ReadableStream.from([
+        {
+          type: "directory" as const,
+          path: "extension/",
+        },
+        {
+          type: "symlink" as const,
+          path: "extension/escape",
+          linkname: "/tmp/evil",
+        },
+      ])
+        .pipeThrough(new TarStream())
+        .pipeThrough(new CompressionStream("gzip"))
+        .pipeTo(file.writable);
+
+      const dst = join(root, "dst");
+      await ensureDir(dst);
+      const bytes = await Deno.readFile(archivePath);
+      await assertRejects(
+        () => extractTarGz(streamFromBytes(bytes), dst),
+        Error,
+        "absolute target",
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "extractTarGz: rejects symlink with relative target escaping root",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      const { TarStream } = await import("@std/tar/tar-stream");
+      const archivePath = join(root, "bad.tar.gz");
+      const file = await Deno.open(archivePath, {
+        write: true,
+        create: true,
+        truncate: true,
+      });
+      await ReadableStream.from([
+        {
+          type: "directory" as const,
+          path: "extension/",
+        },
+        {
+          type: "symlink" as const,
+          path: "extension/escape",
+          linkname: "../../../../../../tmp/evil",
+        },
+      ])
+        .pipeThrough(new TarStream())
+        .pipeThrough(new CompressionStream("gzip"))
+        .pipeTo(file.writable);
+
+      const dst = join(root, "dst");
+      await ensureDir(dst);
+      const bytes = await Deno.readFile(archivePath);
+      await assertRejects(
+        () => extractTarGz(streamFromBytes(bytes), dst),
+        Error,
+        "escapes extract root",
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "extractTarGz: allows symlink with target staying within root",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      const { TarStream } = await import("@std/tar/tar-stream");
+      const archivePath = join(root, "good.tar.gz");
+      const file = await Deno.open(archivePath, {
+        write: true,
+        create: true,
+        truncate: true,
+      });
+      const payload = new TextEncoder().encode("hello");
+      await ReadableStream.from([
+        {
+          type: "directory" as const,
+          path: "extension/",
+        },
+        {
+          type: "file" as const,
+          path: "extension/real.txt",
+          size: payload.length,
+          readable: streamFromBytes(payload),
+        },
+        {
+          type: "symlink" as const,
+          path: "extension/link.txt",
+          linkname: "real.txt",
+        },
+      ])
+        .pipeThrough(new TarStream())
+        .pipeThrough(new CompressionStream("gzip"))
+        .pipeTo(file.writable);
+
+      const dst = join(root, "dst");
+      await ensureDir(dst);
+      const bytes = await Deno.readFile(archivePath);
+      await extractTarGz(streamFromBytes(bytes), dst);
+
+      const linkPath = join(dst, "extension", "link.txt");
+      const stat = await Deno.lstat(linkPath);
+      assert(stat.isSymlink, "link.txt should be a symlink");
+      assertEquals(await Deno.readLink(linkPath), "real.txt");
+    });
+  },
+});
+
+Deno.test({
+  name: "extractTarGz: blocks file write through symlink that escapes root",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (root) => {
+      // Craft an archive where a symlink points outside root,
+      // followed by a file write through that symlink.
+      // The symlink validation should catch this before the file is written.
+      const { TarStream } = await import("@std/tar/tar-stream");
+      const archivePath = join(root, "bad.tar.gz");
+      const file = await Deno.open(archivePath, {
+        write: true,
+        create: true,
+        truncate: true,
+      });
+      const payload = new TextEncoder().encode("malicious");
+      await ReadableStream.from([
+        {
+          type: "directory" as const,
+          path: "extension/",
+        },
+        {
+          type: "symlink" as const,
+          path: "extension/escape",
+          linkname: "../../../../../../tmp",
+        },
+        {
+          type: "file" as const,
+          path: "extension/escape/payload.txt",
+          size: payload.length,
+          readable: streamFromBytes(payload),
+        },
+      ])
+        .pipeThrough(new TarStream())
+        .pipeThrough(new CompressionStream("gzip"))
+        .pipeTo(file.writable);
+
+      const dst = join(root, "dst");
+      await ensureDir(dst);
+      const bytes = await Deno.readFile(archivePath);
+      await assertRejects(
+        () => extractTarGz(streamFromBytes(bytes), dst),
+        Error,
+        "escapes extract root",
+      );
+    });
+  },
+});
+
 Deno.test("extractTarGz: applies file mode bits on POSIX", async () => {
   await withTempDir(async (root) => {
     const top = join(root, "src", "ext");

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -253,7 +253,7 @@ Deno.test("downloadAndExtract throws on download failure", async () => {
   }
 });
 
-Deno.test("downloadAndExtract skips symlinks escaping via relative path", async () => {
+Deno.test("downloadAndExtract rejects symlinks escaping via relative path", async () => {
   const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
   try {
     const archiveRoot = join(tempDir, "archive");
@@ -293,27 +293,11 @@ Deno.test("downloadAndExtract skips symlinks escaping via relative path", async 
     const targetDir = join(tempDir, "target");
     await ensureDir(targetDir);
 
-    const fileCount = await testDownloader.downloadAndExtract(
-      "main",
-      targetDir,
+    await assertRejects(
+      () => testDownloader.downloadAndExtract("main", targetDir),
+      UserError,
+      "escapes extract root",
     );
-
-    assertEquals(fileCount, 1);
-    assertEquals(
-      await Deno.readTextFile(join(targetDir, "safe.txt")),
-      "safe",
-    );
-
-    // The escaping symlink should NOT have been created
-    let exists = true;
-    try {
-      await Deno.lstat(join(targetDir, "escape-link"));
-    } catch (e) {
-      if (e instanceof Deno.errors.NotFound) {
-        exists = false;
-      }
-    }
-    assertFalse(exists, "symlink escaping via relative path should be skipped");
 
     await server.shutdown();
   } finally {
@@ -391,7 +375,7 @@ Deno.test("downloadAndExtract rejects version with fragment", async () => {
   }
 });
 
-Deno.test("downloadAndExtract skips symlinks escaping via absolute path", async () => {
+Deno.test("downloadAndExtract rejects symlinks escaping via absolute path", async () => {
   const tempDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
   try {
     const archiveRoot = join(tempDir, "archive");
@@ -431,29 +415,10 @@ Deno.test("downloadAndExtract skips symlinks escaping via absolute path", async 
     const targetDir = join(tempDir, "target");
     await ensureDir(targetDir);
 
-    const fileCount = await testDownloader.downloadAndExtract(
-      "main",
-      targetDir,
-    );
-
-    assertEquals(fileCount, 1);
-    assertEquals(
-      await Deno.readTextFile(join(targetDir, "safe.txt")),
-      "safe",
-    );
-
-    // The escaping symlink should NOT have been created
-    let exists = true;
-    try {
-      await Deno.lstat(join(targetDir, "abs-escape-link"));
-    } catch (e) {
-      if (e instanceof Deno.errors.NotFound) {
-        exists = false;
-      }
-    }
-    assertFalse(
-      exists,
-      "symlink escaping via absolute path should be skipped",
+    await assertRejects(
+      () => testDownloader.downloadAndExtract("main", targetDir),
+      UserError,
+      "absolute target",
     );
 
     await server.shutdown();

--- a/src/infrastructure/source/http_source_downloader_test.ts
+++ b/src/infrastructure/source/http_source_downloader_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals, assertFalse, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { HttpSourceDownloader } from "./http_source_downloader.ts";


### PR DESCRIPTION
## Summary

- **Security fix**: `extractTarGz` created symlinks from raw `entry.header.linkname` with no validation that the target stayed within the extract root. A crafted archive could plant a symlink pointing outside root, then write files through it — escaping the extraction directory. Reachable from `swamp extension pull` against attacker-publishable registry content.
- Adds two layers of defense: (1) reject absolute symlink targets and verify relative targets resolve within root before creation, (2) `realPath` check on parent directories before writing files or creating symlinks to catch symlink-through-directory escapes.
- Updates `http_source_downloader_test.ts` tests that previously expected symlink-escaping archives to be silently handled — they now correctly expect hard rejection.

## Test Plan

- 4 new unit tests in `tar_archive_test.ts`: absolute target rejected, relative-escaping target rejected, within-root symlink allowed (positive case), full zip-slip attack chain blocked
- Existing symlink round-trip test continues to pass
- `http_source_downloader_test.ts` symlink escape tests updated to expect `assertRejects`
- PoC script verified: unfixed code writes `"you have been pwned"` outside root; fixed code throws `Archive entry escapes extract root`
- Full test suite: 6829 passed, 0 related failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)