### PR TITLE
fix(workflows): propagate source stream errors through merge instead of swallowing them

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1669,6 +1669,17 @@ export class WorkflowExecutionService {
         runSpan.setStatus({ code: SpanStatusCode.OK });
         return;
       }
+      if (workflowRun) {
+        workflowRun.complete();
+        await this.saveRun(
+          createWorkflowId(workflowRun.workflowId),
+          workflowRun,
+        );
+        yield { kind: "completed" as const, run: workflowRun };
+      }
+      if (workflowLogCategory) {
+        runFileSink.unregister(workflowLogCategory);
+      }
       runSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),
@@ -1923,8 +1934,8 @@ export class WorkflowExecutionService {
       await this.saveRun(workflow.id, existingRun);
       runFileSink.unregister(workflowLogCategory);
     } catch (error) {
-      runFileSink.unregister(workflowLogCategory);
       if (error instanceof WorkflowSuspendedError) {
+        runFileSink.unregister(workflowLogCategory);
         yield {
           kind: "suspended" as const,
           run: existingRun,
@@ -1935,6 +1946,10 @@ export class WorkflowExecutionService {
         };
         return;
       }
+      existingRun.complete();
+      await this.saveRun(workflow.id, existingRun);
+      yield { kind: "completed" as const, run: existingRun };
+      runFileSink.unregister(workflowLogCategory);
       throw error;
     }
   }

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -619,8 +619,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
    * Marks the workflow run as completed (succeeded or failed based on job results).
    */
   complete(): void {
-    const anyFailed = this._jobs.some((j) => j.status === "failed");
-    this._status = anyFailed ? "failed" : "succeeded";
+    const anyNonTerminal = this._jobs.some((j) =>
+      j.status !== "succeeded" && j.status !== "skipped"
+    );
+    this._status = anyNonTerminal ? "failed" : "succeeded";
     this._completedAt = new Date();
   }
 

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -343,6 +343,46 @@ Deno.test("WorkflowRun.complete marks run as failed when any job failed", () => 
   assertEquals(run.status, "failed");
 });
 
+Deno.test("WorkflowRun.complete marks run as failed when a job is still running", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+
+  run.start();
+  run.getJob("job1")?.start();
+  run.getJob("job1")?.succeed();
+  run.getJob("job2")?.start();
+  // job2 stays "running" — simulates a crashed generator
+  run.complete();
+
+  assertEquals(run.status, "failed");
+});
+
+Deno.test("WorkflowRun.complete marks run as failed when a job is still pending", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+
+  run.start();
+  run.getJob("job1")?.start();
+  run.getJob("job1")?.succeed();
+  // job2 stays "pending"
+  run.complete();
+
+  assertEquals(run.status, "failed");
+});
+
+Deno.test("WorkflowRun.complete marks run as succeeded when all jobs succeeded or skipped", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+
+  run.start();
+  run.getJob("job1")?.start();
+  run.getJob("job1")?.succeed();
+  run.getJob("job2")?.skip();
+  run.complete();
+
+  assertEquals(run.status, "succeeded");
+});
+
 Deno.test("WorkflowRun.toData returns correct structure", () => {
   const workflow = createTestWorkflow();
   const run = WorkflowRun.create(workflow);

--- a/src/infrastructure/stream/merge.ts
+++ b/src/infrastructure/stream/merge.ts
@@ -41,6 +41,8 @@ export async function* merge<T>(
 
   const queue = new AsyncQueue<T>();
   let remaining = streams.length;
+  let firstStreamError: unknown;
+  let errorWasAbortInduced = false;
 
   // Close queue early when signal aborts
   let abortHandler: (() => void) | undefined;
@@ -55,10 +57,20 @@ export async function* merge<T>(
   const drainStream = async (stream: AsyncIterable<T>) => {
     try {
       for await (const item of stream) {
-        queue.push(item);
+        try {
+          queue.push(item);
+        } catch {
+          // Queue already closed (abort or sibling stream error) — stop draining
+          return;
+        }
       }
-    } catch {
-      // Silently handle errors from closed queue (abort scenario)
+    } catch (error) {
+      // Source stream threw — record and abort the queue so the consumer exits
+      if (firstStreamError === undefined) {
+        firstStreamError = error;
+        errorWasAbortInduced = signal?.aborted ?? false;
+      }
+      queue.abort();
     } finally {
       remaining--;
       if (remaining === 0) {
@@ -79,6 +91,9 @@ export async function* merge<T>(
     }
     // Ensure all drain tasks complete (they may throw)
     await Promise.allSettled(tasks);
+  }
+  if (firstStreamError !== undefined && !errorWasAbortInduced) {
+    throw firstStreamError;
   }
 }
 
@@ -101,6 +116,8 @@ export async function* mergeWithConcurrency<T>(
   const queue = new AsyncQueue<T>();
   let remaining = streams.length;
   const sem = new Semaphore(limit);
+  let firstStreamError: unknown;
+  let errorWasAbortInduced = false;
 
   let abortHandler: (() => void) | undefined;
   if (signal) {
@@ -117,10 +134,20 @@ export async function* mergeWithConcurrency<T>(
     }
     try {
       for await (const item of stream) {
-        queue.push(item);
+        try {
+          queue.push(item);
+        } catch {
+          // Queue already closed (abort or sibling stream error) — stop draining
+          return;
+        }
       }
-    } catch {
-      // Silently handle errors from closed queue (abort scenario)
+    } catch (error) {
+      // Source stream threw — record and abort the queue so the consumer exits
+      if (firstStreamError === undefined) {
+        firstStreamError = error;
+        errorWasAbortInduced = signal?.aborted ?? false;
+      }
+      queue.abort();
     } finally {
       sem.release();
       remaining--;
@@ -139,5 +166,8 @@ export async function* mergeWithConcurrency<T>(
       signal.removeEventListener("abort", abortHandler);
     }
     await Promise.allSettled(tasks);
+  }
+  if (firstStreamError !== undefined && !errorWasAbortInduced) {
+    throw firstStreamError;
   }
 }

--- a/src/infrastructure/stream/merge_test.ts
+++ b/src/infrastructure/stream/merge_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { merge, mergeWithConcurrency } from "./merge.ts";
 
 async function* fromArray<T>(items: T[]): AsyncGenerator<T> {
@@ -163,4 +163,102 @@ Deno.test("mergeWithConcurrency: with pre-aborted signal yields nothing", async 
     controller.signal,
   ));
   assertEquals(items, []);
+});
+
+// Error propagation tests
+
+async function* throwAfter<T>(
+  items: T[],
+  error: Error,
+): AsyncGenerator<T> {
+  for (const item of items) {
+    yield item;
+  }
+  throw error;
+}
+
+function throwImmediately<T>(error: Error): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          return Promise.reject(error);
+        },
+      };
+    },
+  };
+}
+
+Deno.test("merge propagates source stream error", async () => {
+  const err = new Error("generator crashed");
+  await assertRejects(
+    () => collect(merge([throwAfter([1, 2], err)])),
+    Error,
+    "generator crashed",
+  );
+});
+
+Deno.test("merge propagates error from one of multiple streams", async () => {
+  const err = new Error("stream B crashed");
+  await assertRejects(
+    () =>
+      collect(merge([
+        fromArray([1, 2]),
+        throwImmediately(err),
+      ])),
+    Error,
+    "stream B crashed",
+  );
+});
+
+Deno.test("merge does not propagate stream error when signal is aborted", async () => {
+  const controller = new AbortController();
+  function abortThenThrow(): AsyncIterable<number> {
+    return {
+      [Symbol.asyncIterator]() {
+        let called = false;
+        return {
+          async next() {
+            if (!called) {
+              called = true;
+              controller.abort();
+              await new Promise((r) => setTimeout(r, 10));
+              throw new Error("should be suppressed");
+            }
+            return { value: undefined as unknown as number, done: true };
+          },
+        };
+      },
+    };
+  }
+  // Should NOT throw — the abort came first
+  const items = await collect(merge(
+    [fromArray([1]), abortThenThrow()],
+    controller.signal,
+  ));
+  // May or may not contain 1 depending on timing, but must not throw
+  assertEquals(items.length <= 1, true);
+});
+
+Deno.test("mergeWithConcurrency propagates source stream error", async () => {
+  const err = new Error("generator crashed");
+  await assertRejects(
+    () => collect(mergeWithConcurrency([throwAfter([1, 2], err)], 1)),
+    Error,
+    "generator crashed",
+  );
+});
+
+Deno.test("mergeWithConcurrency propagates error from one of multiple streams", async () => {
+  const err = new Error("step exploded");
+  await assertRejects(
+    () =>
+      collect(mergeWithConcurrency([
+        delayed([1, 2], 5),
+        throwImmediately(err),
+        fromArray([3, 4]),
+      ], 2)),
+    Error,
+    "step exploded",
+  );
 });


### PR DESCRIPTION
## Summary

- **merge.ts**: The bare `catch {}` in `merge()`/`mergeWithConcurrency()` swallowed all errors from source stream generators, not just `queue.push()` failures during abort. A crashed job generator stayed "running" while `WorkflowRun.complete()` only checked for `status === "failed"`, so the workflow was persisted and reported as "succeeded". Split into an inner catch for push-to-closed-queue errors and an outer catch that records source stream errors and re-throws them after drain tasks complete. Abort-induced stream errors are suppressed by capturing `signal.aborted` at error time.
- **workflow_run.ts**: Defense-in-depth — `complete()` now treats any job not in `succeeded`/`skipped` as a failure, catching residual cases where a job generator returns without throwing yet leaves its JobRun in `running`.
- **execution_service.ts**: The `run()` and `resume()` error paths now call `complete()`, persist the run record, yield the `completed` event, and unregister the log-file sink before re-throwing. Previously a propagated error left the run stuck as "running" in persistence with a leaked log sink.

## Test Plan

- Added 5 new merge tests: single-stream error propagation, multi-stream error propagation, abort-suppression, and variants for `mergeWithConcurrency`
- Added 3 new `WorkflowRun.complete()` tests: job stuck in running, job stuck in pending, all jobs succeeded/skipped
- All 388 workflow domain tests pass (including suspend/approval suites)
- Full test suite passes: 6838 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)