### PR TITLE
feat(evals): add Fable as model target in multi-skill eval tests

### DIFF
--- a/.github/workflows/multi-model-eval.yml
+++ b/.github/workflows/multi-model-eval.yml
@@ -31,6 +31,8 @@ jobs:
             concurrency: 20
           - model: gemini-3.1-pro
             concurrency: 20
+          - model: fable
+            concurrency: 20
     steps:
       - name: Check if model is selected
         id: check

--- a/evals/promptfoo/generate_config.ts
+++ b/evals/promptfoo/generate_config.ts
@@ -36,6 +36,8 @@ interface ProviderDefinition {
   id: string;
   apiKeyEnv: string;
   delay?: number;
+  noToolChoice?: boolean;
+  thinking?: Record<string, string>;
 }
 
 const PROVIDER_REGISTRY: Record<string, ProviderDefinition> = {
@@ -46,6 +48,12 @@ const PROVIDER_REGISTRY: Record<string, ProviderDefinition> = {
   "opus": {
     id: "anthropic:messages:claude-opus-4-6",
     apiKeyEnv: "ANTHROPIC_API_KEY",
+  },
+  "fable": {
+    id: "anthropic:messages:claude-fable-5",
+    apiKeyEnv: "ANTHROPIC_API_KEY",
+    noToolChoice: true,
+    thinking: { type: "adaptive" },
   },
   "gpt-5.4": {
     id: "openai:gpt-5.4",
@@ -262,11 +270,13 @@ async function main(): Promise<void> {
       {
         id: provider.id,
         config: {
-          temperature: 0,
-          max_tokens: 200,
+          ...(provider.thinking
+            ? { thinking: provider.thinking }
+            : { temperature: 0 }),
+          max_tokens: provider.thinking ? 2048 : 200,
           systemMessage,
           tools,
-          tool_choice: "required",
+          ...(provider.noToolChoice ? {} : { tool_choice: "required" }),
         },
         ...(provider.delay ? { delay: provider.delay } : {}),
       },

--- a/evals/promptfoo/generate_routing_config.ts
+++ b/evals/promptfoo/generate_routing_config.ts
@@ -36,6 +36,8 @@ interface ProviderDefinition {
   id: string;
   apiKeyEnv: string;
   delay?: number;
+  noToolChoice?: boolean;
+  thinking?: Record<string, string>;
 }
 
 const PROVIDER_REGISTRY: Record<string, ProviderDefinition> = {
@@ -46,6 +48,12 @@ const PROVIDER_REGISTRY: Record<string, ProviderDefinition> = {
   "opus": {
     id: "anthropic:messages:claude-opus-4-6",
     apiKeyEnv: "ANTHROPIC_API_KEY",
+  },
+  "fable": {
+    id: "anthropic:messages:claude-fable-5",
+    apiKeyEnv: "ANTHROPIC_API_KEY",
+    noToolChoice: true,
+    thinking: { type: "adaptive" },
   },
   "gpt-5.4": {
     id: "openai:gpt-5.4",
@@ -211,11 +219,13 @@ async function main(): Promise<void> {
       {
         id: provider.id,
         config: {
-          temperature: 0,
-          max_tokens: 200,
+          ...(provider.thinking
+            ? { thinking: provider.thinking }
+            : { temperature: 0 }),
+          max_tokens: provider.thinking ? 2048 : 200,
           systemMessage,
           tools,
-          tool_choice: "required",
+          ...(provider.noToolChoice ? {} : { tool_choice: "required" }),
         },
         ...(provider.delay ? { delay: provider.delay } : {}),
       },

--- a/evals/promptfoo/package.json
+++ b/evals/promptfoo/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "promptfoo": "0.121.12"
+    "promptfoo": "0.121.15"
   }
 }

--- a/scripts/eval_skill_triggers_promptfoo.ts
+++ b/scripts/eval_skill_triggers_promptfoo.ts
@@ -24,7 +24,7 @@
  *
  * Usage: deno run eval-skill-triggers [--model <alias>] [--concurrency <n>] [--threshold <0.0-1.0>]
  *
- * Supported models: sonnet (default), opus, gpt-5.4, gemini-2.5-pro
+ * Supported models: sonnet (default), opus, fable, gpt-5.4, gemini-2.5-pro
  *
  * Environment:
  *   ANTHROPIC_API_KEY - Required for sonnet/opus models.
@@ -38,6 +38,7 @@ import { join } from "@std/path";
 const API_KEY_ENV: Record<string, string> = {
   "sonnet": "ANTHROPIC_API_KEY",
   "opus": "ANTHROPIC_API_KEY",
+  "fable": "ANTHROPIC_API_KEY",
   "gpt-5.4": "OPENAI_API_KEY",
   "gemini-2.5-pro": "GOOGLE_API_KEY",
   "gemini-3.1-pro": "GOOGLE_API_KEY",
@@ -47,6 +48,7 @@ const API_KEY_ENV: Record<string, string> = {
 const PREFLIGHT_MODEL_ID: Record<string, string> = {
   "sonnet": "claude-sonnet-4-5",
   "opus": "claude-opus-4-6",
+  "fable": "claude-fable-5",
   "gpt-5.4": "gpt-5.4",
   "gemini-2.5-pro": "gemini-2.5-pro",
   "gemini-3.1-pro": "gemini-3.1-pro-preview",
@@ -63,7 +65,7 @@ function buildPreflightRequest(
   apiKey: string,
 ): PreflightConfig {
   const modelId = PREFLIGHT_MODEL_ID[model];
-  if (model === "sonnet" || model === "opus") {
+  if (model === "sonnet" || model === "opus" || model === "fable") {
     return {
       url: "https://api.anthropic.com/v1/messages",
       headers: {
@@ -138,6 +140,7 @@ async function preflightCheck(model: string): Promise<void> {
 const TOKEN_PRICING: Record<string, { prompt: number; completion: number }> = {
   "sonnet": { prompt: 3.0, completion: 15.0 },
   "opus": { prompt: 15.0, completion: 75.0 },
+  "fable": { prompt: 10.0, completion: 50.0 },
   "gpt-5.4": { prompt: 2.0, completion: 8.0 },
   "gemini-2.5-pro": { prompt: 1.25, completion: 10.0 },
   "gemini-3.1-pro": { prompt: 1.25, completion: 10.0 },


### PR DESCRIPTION
## Summary

Adds `claude-fable-5` (Fable) as a model target in the multi-skill eval test runner, alongside the existing opus, sonnet, gpt-5.4, and gemini models.

- Added `fable` to the GitHub Actions workflow matrix (concurrency: 20)
- Added Fable to all model configuration dicts (`API_KEY_ENV`, `PREFLIGHT_MODEL_ID`, `TOKEN_PRICING`) and the `buildPreflightRequest` Anthropic branch
- Added Fable to `PROVIDER_REGISTRY` in both promptfoo config generators
- Bumped promptfoo from 0.121.12 to 0.121.15

**Fable API compatibility:** Fable doesn't support `temperature` or forced `tool_choice`. The config generators use adaptive thinking for Fable (which also suppresses temperature in promptfoo's Anthropic provider) and skip `tool_choice`. Once [promptfoo#9671](https://github.com/promptfoo/promptfoo/pull/9671) ships, the thinking workaround can be simplified.

## Test Plan

- [x] Ran `deno run eval-skill-triggers --model fable` — 77/78 tests pass (98.7%)
- [x] Verified Fable provider ID in promptfoo output: `anthropic:messages:claude-fable-5`
- [x] Confirmed existing `--model opus` still works unchanged
- [x] `deno fmt`, `deno lint`, `deno run test` all pass

Closes swamp-club#612