### PR TITLE
feat(extensions): add release channel support (beta, rc, stable) (swamp-club#311)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -35,6 +35,90 @@ published version and compute the next CalVer version. Accepts an extension
 name directly or `--manifest <path>` to read the name from a manifest file.
 Does not require a swamp repository — works from any directory.
 
+## Release Channels
+
+Extensions support three release channels with a strict promotion ladder:
+
+```
+beta → rc → stable
+  └──────────┘  (can skip rc)
+```
+
+- **stable** — the default channel. All existing versions are stable. Omitting
+  `--channel` on push and pull means stable. Auto-resolve only considers
+  stable versions.
+- **rc** — release candidate. Opt-in via `--channel rc`.
+- **beta** — early preview. Opt-in via `--channel beta`.
+
+### Version uniqueness
+
+A version string (CalVer) is globally unique per extension regardless of
+channel. You cannot push `2026.06.10.1` as both beta and stable. This enables
+promotion as a metadata-only operation — the archive bytes and checksum are
+unchanged.
+
+### Push
+
+`swamp extension push manifest.yaml --channel rc` pushes to the rc channel.
+`swamp extension push manifest.yaml --channel beta` pushes to beta. No
+`--channel` flag pushes to stable.
+
+### Pull
+
+`swamp extension pull @name` resolves the latest stable version.
+`swamp extension pull @name --channel rc` resolves the latest rc version.
+`swamp extension pull @name --channel beta` resolves the latest beta version.
+Explicit version pinning (`@name@2026.06.10.1`) ignores channel since versions
+are globally unique.
+
+### Search and Versions
+
+`swamp extension search --channel rc --channel beta` filters to extensions
+with versions in either channel. `--channel` is a collect flag (multiple
+allowed). No `--channel` shows stable-only results.
+
+`swamp extension versions @name --channel rc` lists version history filtered
+by channel. No `--channel` shows all versions.
+
+### Info
+
+`swamp extension info @name` shows per-channel latest versions (stable, rc,
+beta) when they exist. No flag needed — info always shows all channels.
+
+### Promotion
+
+`swamp extension promote @name 2026.06.10.1 --channel rc` promotes a beta
+version to rc. `--channel stable` promotes to stable. Only forward transitions
+are allowed:
+
+- beta → rc ✅
+- beta → stable ✅
+- rc → stable ✅
+- stable → rc ❌
+- rc → beta ❌
+- stable → beta ❌
+
+Promotion is a metadata-only operation on the registry — the archive is not
+re-uploaded. The server recalculates per-channel latest after promotion.
+
+### Auto-resolve safety
+
+Beta and rc versions are never auto-resolved via trusted collectives. Only
+stable versions participate in auto-resolution. Lockfile-pinned restores
+fetch by exact version regardless of channel.
+
+### Lockfile
+
+The `upstream_extensions.json` entry records the channel the extension was
+installed from (`channel` field). Pre-channel entries default to `"stable"`
+on read. The update service checks for updates within the installed channel.
+
+### Update cache
+
+The extension update check cache (`.swamp/extension-update-checks.json`) uses
+channel-aware keys: stable uses the bare extension name (backward compatible),
+non-stable uses `name:channel` (e.g. `@swamp/aws:rc`).
+
 ## Freshness
 
 Two opt-in user-facing surfaces report whether installed extensions are

--- a/src/cli/commands/extension.ts
+++ b/src/cli/commands/extension.ts
@@ -37,6 +37,7 @@ import { extensionDeprecateCommand } from "./extension_deprecate.ts";
 import { extensionUndeprecateCommand } from "./extension_undeprecate.ts";
 import { extensionTrustCommand } from "./extension_trust.ts";
 import { extensionSourceCommand } from "./extension_source.ts";
+import { extensionPromoteCommand } from "./extension_promote.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const extensionCommand = new Command()
@@ -61,4 +62,5 @@ export const extensionCommand = new Command()
   .command("deprecate", extensionDeprecateCommand)
   .command("undeprecate", extensionUndeprecateCommand)
   .command("trust", extensionTrustCommand)
-  .command("source", extensionSourceCommand);
+  .command("source", extensionSourceCommand)
+  .command("promote", extensionPromoteCommand);

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -146,8 +146,16 @@ export const extensionListCommand = new Command()
       const identity = await loadIdentity();
       const apiClient = new ExtensionApiClient(resolveServerUrl(), identity);
       const freshnessDeps: ExtensionListFreshnessDeps = {
-        getLatestVersion: async (name) => {
+        getLatestVersion: async (name, channel?) => {
           try {
+            if (channel && channel !== "stable") {
+              const versionInfo = await apiClient.getLatestVersion(
+                name,
+                undefined,
+                channel,
+              );
+              return versionInfo?.version ?? null;
+            }
             const info = await apiClient.getExtension(name);
             return info?.latestVersion ?? null;
           } catch {

--- a/src/cli/commands/extension_list_freshness.ts
+++ b/src/cli/commands/extension_list_freshness.ts
@@ -19,6 +19,7 @@
 
 import type { ExtensionListEntry } from "../../libswamp/mod.ts";
 import {
+  extensionCacheKey,
   type ExtensionUpdateCheckMap,
   type ExtensionUpdateCheckRepository,
   isExtensionCheckStale,
@@ -29,7 +30,10 @@ import type { EnrichedExtensionListEntry } from "../../presentation/renderers/ex
 /** Dependencies for the freshness composer. */
 export interface ExtensionListFreshnessDeps {
   /** Look up the latest version for an extension. Return null on failure. */
-  getLatestVersion: (name: string) => Promise<string | null>;
+  getLatestVersion: (
+    name: string,
+    channel?: string,
+  ) => Promise<string | null>;
   /** Cache repository for the 24h check cooldown. */
   cacheRepository: ExtensionUpdateCheckRepository;
   /** Returns the current time. Injected for testability. */
@@ -66,12 +70,18 @@ export async function enrichExtensionList(
     index: number;
     name: string;
     installedVersion: string;
+    channel?: string;
   };
   const stale: StaleTarget[] = [];
   for (let i = 0; i < entries.length; i++) {
     const e = entries[i];
-    if (isExtensionCheckStale(cache, e.name, now)) {
-      stale.push({ index: i, name: e.name, installedVersion: e.version });
+    if (isExtensionCheckStale(cache, e.name, now, e.channel)) {
+      stale.push({
+        index: i,
+        name: e.name,
+        installedVersion: e.version,
+        channel: e.channel,
+      });
     }
   }
 
@@ -79,6 +89,7 @@ export async function enrichExtensionList(
   type FetchResult = {
     index: number;
     name: string;
+    channel?: string;
     latestVersion: string | null;
     failed: boolean;
   };
@@ -92,10 +103,14 @@ export async function enrichExtensionList(
     deps.concurrency,
     async (target) => {
       try {
-        const latest = await deps.getLatestVersion(target.name);
+        const latest = await deps.getLatestVersion(
+          target.name,
+          target.channel,
+        );
         return {
           index: target.index,
           name: target.name,
+          channel: target.channel,
           latestVersion: latest,
           failed: latest === null,
         };
@@ -103,6 +118,7 @@ export async function enrichExtensionList(
         return {
           index: target.index,
           name: target.name,
+          channel: target.channel,
           latestVersion: null,
           failed: true,
         };
@@ -113,7 +129,8 @@ export async function enrichExtensionList(
   // Mutate cache map in-memory; ONE atomic write at the end.
   const checkedAtIso = now.toISOString();
   for (const r of fetched) {
-    cache[r.name] = {
+    const key = extensionCacheKey(r.name, r.channel);
+    cache[key] = {
       checkedAt: checkedAtIso,
       // On registry failure, stamp with installedVersion to suppress
       // retries for 24h.
@@ -146,7 +163,8 @@ export async function enrichExtensionList(
       };
     }
     const latestFromFetch = fetchedEntry?.latestVersion ?? null;
-    const latestFromCache = cache[e.name]?.latestVersion ?? null;
+    const cacheKey = extensionCacheKey(e.name, e.channel);
+    const latestFromCache = cache[cacheKey]?.latestVersion ?? null;
     const latest = latestFromFetch ?? latestFromCache;
     if (latest === null) return { ...e };
 

--- a/src/cli/commands/extension_promote.ts
+++ b/src/cli/commands/extension_promote.ts
@@ -20,10 +20,16 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveServerUrl, validateExtensionName } from "../../libswamp/mod.ts";
-import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
-import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
-import { loadIdentity } from "../load_identity.ts";
+import {
+  consumeStream,
+  createExtensionPromoteDeps,
+  createLibSwampContext,
+  extensionPromote,
+  extensionPromoteValidate,
+  validateExtensionName,
+} from "../../libswamp/mod.ts";
+import { createExtensionPromoteRenderer } from "../../presentation/renderers/extension_promote.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -47,6 +53,10 @@ export const extensionPromoteCommand = new Command()
     "Target channel to promote to: 'rc' or 'stable'",
     { required: true },
   )
+  .option(
+    "--from-channel <fromChannel:string>",
+    "Source channel to promote from (for client-side validation)",
+  )
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -61,36 +71,57 @@ export const extensionPromoteCommand = new Command()
     validateExtensionName(extension);
 
     const toChannel = options.channel as string;
-    if (toChannel !== "rc" && toChannel !== "stable") {
+    if (!ReleaseChannel.isValid(toChannel)) {
       throw new UserError(
         `Invalid target channel: "${toChannel}". Must be 'rc' or 'stable'.`,
       );
     }
-
-    const authRepo = new AuthRepository();
-    const creds = await authRepo.load();
-    if (!creds) {
+    const target = ReleaseChannel.create(toChannel);
+    if (!ReleaseChannel.BETA.canPromoteTo(target) && toChannel !== "stable") {
       throw new UserError(
-        "Not authenticated. Run 'swamp auth login' first.",
+        `Invalid target channel: "${toChannel}". Promote targets must be 'rc' or 'stable'.`,
       );
     }
 
-    const serverUrl = creds.serverUrl ?? resolveServerUrl();
-    const identity = await loadIdentity();
-    const client = new ExtensionApiClient(serverUrl, identity);
+    // Client-side validation of promotion direction when --from-channel is given
+    const fromChannel = options.fromChannel as string | undefined;
+    if (fromChannel) {
+      if (!ReleaseChannel.isValid(fromChannel)) {
+        throw new UserError(
+          `Invalid source channel: "${fromChannel}". Must be one of: beta, rc, stable`,
+        );
+      }
+      const source = ReleaseChannel.create(fromChannel);
+      if (!source.canPromoteTo(target)) {
+        throw new UserError(
+          `Cannot promote from ${fromChannel} to ${toChannel}. Promotion must move to a higher channel.`,
+        );
+      }
+    }
 
-    const result = await client.promoteExtension(
-      extension,
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createExtensionPromoteDeps();
+    const input = {
+      extensionName: extension,
       version,
       toChannel,
-      creds.apiKey,
-    );
+      fromChannel,
+    };
 
-    if (cliCtx.outputMode === "json") {
-      console.log(JSON.stringify(result));
-    } else {
-      console.log(result.message);
+    try {
+      extensionPromoteValidate(input);
+    } catch (error) {
+      if ("code" in (error as Record<string, unknown>)) {
+        throw new UserError((error as { message: string }).message);
+      }
+      throw error;
     }
+
+    const renderer = createExtensionPromoteRenderer(cliCtx.outputMode);
+    await consumeStream(
+      extensionPromote(ctx, deps, input),
+      renderer.handlers(),
+    );
 
     cliCtx.logger.debug("Extension promote command completed");
   });

--- a/src/cli/commands/extension_promote.ts
+++ b/src/cli/commands/extension_promote.ts
@@ -54,7 +54,7 @@ export const extensionPromoteCommand = new Command()
   )
   .option(
     "--from-channel <fromChannel:string>",
-    "Source channel (beta or rc) — enables pre-flight direction check before contacting the server",
+    "Source channel ('beta' or 'rc'); skips direction validation if omitted",
   )
   .action(async function (
     options: AnyOptions,

--- a/src/cli/commands/extension_promote.ts
+++ b/src/cli/commands/extension_promote.ts
@@ -1,0 +1,96 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { resolveServerUrl, validateExtensionName } from "../../libswamp/mod.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { loadIdentity } from "../load_identity.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const extensionPromoteCommand = new Command()
+  .name("promote")
+  .description(
+    "Promote an extension version to a higher release channel (beta→rc, beta→stable, rc→stable)",
+  )
+  .example(
+    "Promote beta to rc",
+    "swamp extension promote @myorg/ext 2026.06.10.1 --channel rc",
+  )
+  .example(
+    "Promote rc to stable",
+    "swamp extension promote @myorg/ext 2026.06.10.1 --channel stable",
+  )
+  .arguments("<extension:string> <version:string>")
+  .option(
+    "--channel <channel:string>",
+    "Target channel to promote to: 'rc' or 'stable'",
+    { required: true },
+  )
+  .action(async function (
+    options: AnyOptions,
+    extension: string,
+    version: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "extension",
+      "promote",
+    ]);
+    cliCtx.logger.debug`Starting extension promote`;
+
+    validateExtensionName(extension);
+
+    const toChannel = options.channel as string;
+    if (toChannel !== "rc" && toChannel !== "stable") {
+      throw new UserError(
+        `Invalid target channel: "${toChannel}". Must be 'rc' or 'stable'.`,
+      );
+    }
+
+    const authRepo = new AuthRepository();
+    const creds = await authRepo.load();
+    if (!creds) {
+      throw new UserError(
+        "Not authenticated. Run 'swamp auth login' first.",
+      );
+    }
+
+    const serverUrl = creds.serverUrl ?? resolveServerUrl();
+    const identity = await loadIdentity();
+    const client = new ExtensionApiClient(serverUrl, identity);
+
+    const result = await client.promoteExtension(
+      extension,
+      version,
+      toChannel,
+      creds.apiKey,
+    );
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify(result));
+    } else {
+      console.log(result.message);
+    }
+
+    cliCtx.logger.debug("Extension promote command completed");
+  });

--- a/src/cli/commands/extension_promote.ts
+++ b/src/cli/commands/extension_promote.ts
@@ -29,7 +29,6 @@ import {
   validateExtensionName,
 } from "../../libswamp/mod.ts";
 import { createExtensionPromoteRenderer } from "../../presentation/renderers/extension_promote.ts";
-import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -55,7 +54,7 @@ export const extensionPromoteCommand = new Command()
   )
   .option(
     "--from-channel <fromChannel:string>",
-    "Source channel to promote from (for client-side validation)",
+    "Source channel (beta or rc) — enables pre-flight direction check before contacting the server",
   )
   .action(async function (
     options: AnyOptions,
@@ -71,36 +70,7 @@ export const extensionPromoteCommand = new Command()
     validateExtensionName(extension);
 
     const toChannel = options.channel as string;
-    if (!ReleaseChannel.isValid(toChannel)) {
-      throw new UserError(
-        `Invalid target channel: "${toChannel}". Must be 'rc' or 'stable'.`,
-      );
-    }
-    const target = ReleaseChannel.create(toChannel);
-    if (!ReleaseChannel.BETA.canPromoteTo(target) && toChannel !== "stable") {
-      throw new UserError(
-        `Invalid target channel: "${toChannel}". Promote targets must be 'rc' or 'stable'.`,
-      );
-    }
-
-    // Client-side validation of promotion direction when --from-channel is given
     const fromChannel = options.fromChannel as string | undefined;
-    if (fromChannel) {
-      if (!ReleaseChannel.isValid(fromChannel)) {
-        throw new UserError(
-          `Invalid source channel: "${fromChannel}". Must be one of: beta, rc, stable`,
-        );
-      }
-      const source = ReleaseChannel.create(fromChannel);
-      if (!source.canPromoteTo(target)) {
-        throw new UserError(
-          `Cannot promote from ${fromChannel} to ${toChannel}. Promotion must move to a higher channel.`,
-        );
-      }
-    }
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createExtensionPromoteDeps();
     const input = {
       extensionName: extension,
       version,
@@ -116,6 +86,9 @@ export const extensionPromoteCommand = new Command()
       }
       throw error;
     }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createExtensionPromoteDeps();
 
     const renderer = createExtensionPromoteRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -209,7 +209,7 @@ export const extensionPullCommand = new Command()
       channel !== undefined && !ReleaseChannel.isPrereleaseName(channel)
     ) {
       throw new UserError(
-        `Invalid release channel: "${channel}". Must be 'beta' or 'rc'.`,
+        `Invalid channel: "${channel}". Must be one of: beta, rc`,
       );
     }
 

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -55,6 +55,7 @@ import {
   createExtensionPullRenderer,
   renderExtensionPullCancelled,
 } from "../../presentation/renderers/extension_pull.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 // Re-export types that other CLI commands depend on
 export {
@@ -91,6 +92,10 @@ async function promptConfirmation(message: string): Promise<boolean> {
 /** PullContext for use by extension_search.ts and other callers. */
 export interface PullContext {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
+  getLatestVersion?: (
+    name: string,
+    channel: string,
+  ) => Promise<string | null>;
   downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
   getChecksum: (name: string, version: string) => Promise<string | null>;
   logger: Logger;
@@ -106,6 +111,7 @@ export interface PullContext {
   outputMode: "log" | "json";
   alreadyPulled: Set<string>;
   depth: number;
+  channel?: string;
   /**
    * W2 service deps. When BOTH are provided, `extensionPull` routes
    * through {@link InstallExtensionService} so phase 8 fires (catalog
@@ -129,6 +135,7 @@ export async function pullExtension(
   const libCtx = createLibSwampContext({ logger: ctx.logger });
   const deps: ExtensionPullDeps = {
     getExtension: ctx.getExtension,
+    getLatestVersion: ctx.getLatestVersion,
     downloadArchive: ctx.downloadArchive,
     getChecksum: ctx.getChecksum,
     lockfileRepository: ctx.lockfileRepository,
@@ -143,7 +150,11 @@ export async function pullExtension(
 
   try {
     await consumeStream(
-      extensionPull(libCtx, deps, { ref, force: ctx.force }),
+      extensionPull(libCtx, deps, {
+        ref,
+        force: ctx.force,
+        channel: ctx.channel,
+      }),
       renderer.handlers(),
     );
   } catch (error) {
@@ -164,7 +175,11 @@ export async function pullExtension(
       // Retry with force, reset alreadyPulled so the extension can be retried
       deps.alreadyPulled.delete(ref.name);
       await consumeStream(
-        extensionPull(libCtx, deps, { ref, force: true }),
+        extensionPull(libCtx, deps, {
+          ref,
+          force: true,
+          channel: ctx.channel,
+        }),
         renderer.handlers(),
       );
     } else {
@@ -184,7 +199,20 @@ export const extensionPullCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--force", "Overwrite existing files without prompting")
+  .option(
+    "--channel <channel:string>",
+    "Release channel: 'beta' or 'rc' (default: stable)",
+  )
   .action(async function (options: AnyOptions, extension: string) {
+    const channel: string | undefined = options.channel;
+    if (
+      channel !== undefined && !ReleaseChannel.isPrereleaseName(channel)
+    ) {
+      throw new UserError(
+        `Invalid release channel: "${channel}". Must be 'beta' or 'rc'.`,
+      );
+    }
+
     const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);
     ctx.logger.debug`Starting extension pull`;
 
@@ -245,6 +273,7 @@ export const extensionPullCommand = new Command()
 
       await pullExtension(ref, {
         getExtension: deps.getExtension,
+        getLatestVersion: deps.getLatestVersion,
         downloadArchive: deps.downloadArchive,
         getChecksum: deps.getChecksum,
         logger: ctx.logger,
@@ -255,6 +284,7 @@ export const extensionPullCommand = new Command()
         outputMode: ctx.outputMode,
         alreadyPulled: new Set(),
         depth: 0,
+        channel,
         denoRuntime,
         repository,
       });

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -209,7 +209,7 @@ export const extensionPullCommand = new Command()
       channel !== undefined && !ReleaseChannel.isPrereleaseName(channel)
     ) {
       throw new UserError(
-        `Invalid channel: "${channel}". Must be one of: beta, rc`,
+        `Invalid channel: "${channel}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
       );
     }
 

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -210,7 +210,7 @@ export const extensionPushCommand = new Command()
       !ReleaseChannel.isPrereleaseName(options.channel)
     ) {
       throw new UserError(
-        `Invalid release channel: "${options.channel}". Must be 'beta' or 'rc'.`,
+        `Invalid channel: "${options.channel}". Must be one of: beta, rc`,
       );
     }
     const cliCtx = createContext(options, ["extension", "push"]);

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -58,6 +58,7 @@ import type {
 } from "../../domain/extensions/extension_collective_validator.ts";
 import type { CompilationError, SwampError } from "../../libswamp/mod.ts";
 import { loadIdentity } from "../load_identity.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir?: string;
@@ -65,6 +66,7 @@ interface ExtensionPushOptions extends GlobalOptions {
   yes?: boolean;
   dryRun?: boolean;
   releaseNotes?: string;
+  channel?: string;
 }
 
 async function promptConfirmation(message: string): Promise<boolean> {
@@ -198,7 +200,19 @@ export const extensionPushCommand = new Command()
     "--release-notes <text:string>",
     "Per-version release notes (max 5000 chars)",
   )
+  .option(
+    "--channel <channel:string>",
+    "Release channel: 'beta' or 'rc' (default: stable)",
+  )
   .action(async function (options: ExtensionPushOptions, manifestPath: string) {
+    if (
+      options.channel !== undefined &&
+      !ReleaseChannel.isPrereleaseName(options.channel)
+    ) {
+      throw new UserError(
+        `Invalid release channel: "${options.channel}". Must be 'beta' or 'rc'.`,
+      );
+    }
     const cliCtx = createContext(options, ["extension", "push"]);
     cliCtx.logger.debug`Starting extension push`;
 
@@ -545,6 +559,7 @@ export const extensionPushCommand = new Command()
         contentMetadata: prepared.contentMetadata,
         counts: prepared.counts,
         releaseNotes: options.releaseNotes,
+        channel: options.channel,
       }),
       renderer.handlers(),
     );

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -210,7 +210,7 @@ export const extensionPushCommand = new Command()
       !ReleaseChannel.isPrereleaseName(options.channel)
     ) {
       throw new UserError(
-        `Invalid channel: "${options.channel}". Must be one of: beta, rc`,
+        `Invalid channel: "${options.channel}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
       );
     }
     const cliCtx = createContext(options, ["extension", "push"]);

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -77,6 +77,11 @@ export const extensionSearchCommand = new Command()
     "--sort <sort:string>",
     "Sort order: relevance, new, updated, name",
   )
+  .option(
+    "--channel <channel:string>",
+    "Filter by release channel: 'rc' or 'beta'",
+    { collect: true },
+  )
   .option("--per-page <perPage:number>", "Results per page", { default: 20 })
   .option("--page <page:number>", "Page number", { default: 1 })
   .example("Browse all extensions", "swamp extension search")
@@ -129,6 +134,18 @@ export const extensionSearchCommand = new Command()
       }
     }
 
+    // Validate channel values
+    const validChannels = ["rc", "beta"];
+    for (const ch of options.channel ?? []) {
+      if (!validChannels.includes(ch)) {
+        throw new UserError(
+          `Invalid channel: "${ch}". Must be one of: ${
+            validChannels.join(", ")
+          }`,
+        );
+      }
+    }
+
     // Validate sort option value
     const validSorts = ["relevance", "new", "updated", "name"];
     if (options.sort && !validSorts.includes(options.sort)) {
@@ -174,6 +191,7 @@ export const extensionSearchCommand = new Command()
           platform: options.platform,
           label: options.label,
           contentType: options.contentType,
+          channel: options.channel,
           sort: options.sort,
           perPage: options.perPage,
           page: options.page,

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -135,13 +135,11 @@ export const extensionSearchCommand = new Command()
     }
 
     // Validate channel values
-    const validChannels = ["rc", "beta"];
+    const validChannels = ["beta", "rc"];
     for (const ch of options.channel ?? []) {
       if (!validChannels.includes(ch)) {
         throw new UserError(
-          `Invalid channel: "${ch}". Must be one of: ${
-            validChannels.join(", ")
-          }`,
+          `Invalid channel: "${ch}". Must be one of: beta, rc`,
         );
       }
     }

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -79,7 +79,7 @@ export const extensionSearchCommand = new Command()
   )
   .option(
     "--channel <channel:string>",
-    "Filter by release channel: 'rc' or 'beta'",
+    "Filter by release channel: 'beta' or 'rc' (default: stable only)",
     { collect: true },
   )
   .option("--per-page <perPage:number>", "Results per page", { default: 20 })
@@ -139,7 +139,7 @@ export const extensionSearchCommand = new Command()
     for (const ch of options.channel ?? []) {
       if (!validChannels.includes(ch)) {
         throw new UserError(
-          `Invalid channel: "${ch}". Must be one of: beta, rc`,
+          `Invalid channel: "${ch}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
         );
       }
     }

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -120,7 +120,11 @@ export const extensionUpdateCommand = new Command()
         lockfilePath,
         serverUrl,
         identity,
-        installExtension: async (name: string, version: string) => {
+        installExtension: async (
+          name: string,
+          version: string,
+          channel?: string,
+        ) => {
           // Construct a fresh InstallContext per upgrade — captures a
           // current snapshot of the lockfile per the
           // InstallContext.lockfileRepository single-use rule. Reusing one
@@ -132,6 +136,7 @@ export const extensionUpdateCommand = new Command()
             repoDir,
             force: true,
             identity,
+            channel,
           });
           // Build a fresh ExtensionRepository per upgrade so its lockfile
           // snapshot lines up with the InstallContext's. Catalog is

--- a/src/domain/extensions/extension_update_check_cache.ts
+++ b/src/domain/extensions/extension_update_check_cache.ts
@@ -41,6 +41,20 @@ export interface ExtensionUpdateCheckRepository {
 }
 
 /**
+ * Builds a cache key from extension name and optional channel.
+ * Stable (or absent) channel uses the bare name for backward compat.
+ */
+export function extensionCacheKey(
+  extensionName: string,
+  channel?: string,
+): string {
+  if (channel && channel !== "stable") {
+    return `${extensionName}:${channel}`;
+  }
+  return extensionName;
+}
+
+/**
  * Returns true if the cache entry for the given extension is stale
  * (older than 24 hours) or does not exist.
  */
@@ -48,8 +62,10 @@ export function isExtensionCheckStale(
   cache: ExtensionUpdateCheckMap,
   extensionName: string,
   now: Date,
+  channel?: string,
 ): boolean {
-  const entry = cache[extensionName];
+  const key = extensionCacheKey(extensionName, channel);
+  const entry = cache[key];
   if (!entry) return true;
 
   const checkedAt = new Date(entry.checkedAt);

--- a/src/domain/extensions/extension_update_check_cache_test.ts
+++ b/src/domain/extensions/extension_update_check_cache_test.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { isExtensionCheckStale } from "./extension_update_check_cache.ts";
+import {
+  extensionCacheKey,
+  isExtensionCheckStale,
+} from "./extension_update_check_cache.ts";
 import { CHECK_INTERVAL_MS } from "../update/update_check_cache.ts";
 
 Deno.test("isExtensionCheckStale: returns true for missing entry", () => {
@@ -76,4 +79,41 @@ Deno.test("isExtensionCheckStale: different extensions are independent", () => {
   };
   assertEquals(isExtensionCheckStale(cache, "@swamp/s3-datastore", now), false);
   assertEquals(isExtensionCheckStale(cache, "@swamp/other-store", now), true);
+});
+
+Deno.test("extensionCacheKey: returns bare name for stable channel", () => {
+  assertEquals(extensionCacheKey("@swamp/ext", "stable"), "@swamp/ext");
+});
+
+Deno.test("extensionCacheKey: returns bare name for absent channel", () => {
+  assertEquals(extensionCacheKey("@swamp/ext"), "@swamp/ext");
+  assertEquals(extensionCacheKey("@swamp/ext", undefined), "@swamp/ext");
+});
+
+Deno.test("extensionCacheKey: returns name:channel for beta", () => {
+  assertEquals(extensionCacheKey("@swamp/ext", "beta"), "@swamp/ext:beta");
+});
+
+Deno.test("extensionCacheKey: returns name:channel for rc", () => {
+  assertEquals(extensionCacheKey("@swamp/ext", "rc"), "@swamp/ext:rc");
+});
+
+Deno.test("isExtensionCheckStale: with channel looks up correct key", () => {
+  const now = new Date();
+  const freshTime = new Date(now.getTime() - 1000);
+  const cache = {
+    "@swamp/ext:beta": {
+      checkedAt: freshTime.toISOString(),
+      latestVersion: "2026.03.15.1",
+    },
+  };
+  // The beta-keyed entry is fresh
+  assertEquals(
+    isExtensionCheckStale(cache, "@swamp/ext", now, "beta"),
+    false,
+  );
+  // The bare (stable) key is missing, so stale
+  assertEquals(isExtensionCheckStale(cache, "@swamp/ext", now), true);
+  // rc key is also missing
+  assertEquals(isExtensionCheckStale(cache, "@swamp/ext", now, "rc"), true);
 });

--- a/src/domain/extensions/release_channel.ts
+++ b/src/domain/extensions/release_channel.ts
@@ -1,0 +1,69 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+const CHANNEL_ORDER = { beta: 0, rc: 1, stable: 2 } as const;
+
+export type ReleaseChannelName = keyof typeof CHANNEL_ORDER;
+
+const VALID_NAMES = new Set<string>(Object.keys(CHANNEL_ORDER));
+
+export class ReleaseChannel {
+  static readonly BETA = new ReleaseChannel("beta");
+  static readonly RC = new ReleaseChannel("rc");
+  static readonly STABLE = new ReleaseChannel("stable");
+
+  private constructor(readonly name: ReleaseChannelName) {}
+
+  static create(name: string): ReleaseChannel {
+    if (!VALID_NAMES.has(name)) {
+      throw new Error(
+        `Invalid release channel: "${name}". Must be one of: beta, rc, stable`,
+      );
+    }
+    return new ReleaseChannel(name as ReleaseChannelName);
+  }
+
+  static isValid(name: string): boolean {
+    return VALID_NAMES.has(name);
+  }
+
+  static isPrereleaseName(name: string): boolean {
+    return name === "beta" || name === "rc";
+  }
+
+  private get order(): number {
+    return CHANNEL_ORDER[this.name];
+  }
+
+  isPrerelease(): boolean {
+    return this.name !== "stable";
+  }
+
+  canPromoteTo(target: ReleaseChannel): boolean {
+    return target.order > this.order;
+  }
+
+  equals(other: ReleaseChannel): boolean {
+    return this.name === other.name;
+  }
+
+  toString(): string {
+    return this.name;
+  }
+}

--- a/src/domain/extensions/release_channel_test.ts
+++ b/src/domain/extensions/release_channel_test.ts
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { ReleaseChannel } from "./release_channel.ts";
+
+// --- Validation ---
+
+Deno.test("ReleaseChannel.create: accepts valid channel names", () => {
+  assertEquals(ReleaseChannel.create("beta").name, "beta");
+  assertEquals(ReleaseChannel.create("rc").name, "rc");
+  assertEquals(ReleaseChannel.create("stable").name, "stable");
+});
+
+Deno.test("ReleaseChannel.create: rejects invalid channel names", () => {
+  assertThrows(
+    () => ReleaseChannel.create("alpha"),
+    Error,
+    'Invalid release channel: "alpha"',
+  );
+  assertThrows(
+    () => ReleaseChannel.create("nightly"),
+    Error,
+    'Invalid release channel: "nightly"',
+  );
+  assertThrows(
+    () => ReleaseChannel.create(""),
+    Error,
+    'Invalid release channel: ""',
+  );
+  assertThrows(
+    () => ReleaseChannel.create("BETA"),
+    Error,
+    'Invalid release channel: "BETA"',
+  );
+});
+
+Deno.test("ReleaseChannel.isValid: returns true for valid names", () => {
+  assertEquals(ReleaseChannel.isValid("beta"), true);
+  assertEquals(ReleaseChannel.isValid("rc"), true);
+  assertEquals(ReleaseChannel.isValid("stable"), true);
+});
+
+Deno.test("ReleaseChannel.isValid: returns false for invalid names", () => {
+  assertEquals(ReleaseChannel.isValid("alpha"), false);
+  assertEquals(ReleaseChannel.isValid(""), false);
+  assertEquals(ReleaseChannel.isValid("STABLE"), false);
+});
+
+// --- Static instances ---
+
+Deno.test("ReleaseChannel: static instances have correct names", () => {
+  assertEquals(ReleaseChannel.BETA.name, "beta");
+  assertEquals(ReleaseChannel.RC.name, "rc");
+  assertEquals(ReleaseChannel.STABLE.name, "stable");
+});
+
+// --- isPrerelease ---
+
+Deno.test("ReleaseChannel.isPrerelease: beta is prerelease", () => {
+  assertEquals(ReleaseChannel.BETA.isPrerelease(), true);
+});
+
+Deno.test("ReleaseChannel.isPrerelease: rc is prerelease", () => {
+  assertEquals(ReleaseChannel.RC.isPrerelease(), true);
+});
+
+Deno.test("ReleaseChannel.isPrerelease: stable is not prerelease", () => {
+  assertEquals(ReleaseChannel.STABLE.isPrerelease(), false);
+});
+
+Deno.test("ReleaseChannel.isPrereleaseName: checks name strings", () => {
+  assertEquals(ReleaseChannel.isPrereleaseName("beta"), true);
+  assertEquals(ReleaseChannel.isPrereleaseName("rc"), true);
+  assertEquals(ReleaseChannel.isPrereleaseName("stable"), false);
+  assertEquals(ReleaseChannel.isPrereleaseName("other"), false);
+});
+
+// --- canPromoteTo (promotion ladder) ---
+
+Deno.test("ReleaseChannel.canPromoteTo: beta can promote to rc", () => {
+  assertEquals(ReleaseChannel.BETA.canPromoteTo(ReleaseChannel.RC), true);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: beta can promote to stable", () => {
+  assertEquals(ReleaseChannel.BETA.canPromoteTo(ReleaseChannel.STABLE), true);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: rc can promote to stable", () => {
+  assertEquals(ReleaseChannel.RC.canPromoteTo(ReleaseChannel.STABLE), true);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: stable cannot promote to rc", () => {
+  assertEquals(ReleaseChannel.STABLE.canPromoteTo(ReleaseChannel.RC), false);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: stable cannot promote to beta", () => {
+  assertEquals(ReleaseChannel.STABLE.canPromoteTo(ReleaseChannel.BETA), false);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: rc cannot promote to beta", () => {
+  assertEquals(ReleaseChannel.RC.canPromoteTo(ReleaseChannel.BETA), false);
+});
+
+Deno.test("ReleaseChannel.canPromoteTo: cannot promote to same channel", () => {
+  assertEquals(ReleaseChannel.BETA.canPromoteTo(ReleaseChannel.BETA), false);
+  assertEquals(ReleaseChannel.RC.canPromoteTo(ReleaseChannel.RC), false);
+  assertEquals(
+    ReleaseChannel.STABLE.canPromoteTo(ReleaseChannel.STABLE),
+    false,
+  );
+});
+
+// --- Equality ---
+
+Deno.test("ReleaseChannel.equals: same channels are equal", () => {
+  assertEquals(ReleaseChannel.BETA.equals(ReleaseChannel.create("beta")), true);
+  assertEquals(ReleaseChannel.RC.equals(ReleaseChannel.create("rc")), true);
+  assertEquals(
+    ReleaseChannel.STABLE.equals(ReleaseChannel.create("stable")),
+    true,
+  );
+});
+
+Deno.test("ReleaseChannel.equals: different channels are not equal", () => {
+  assertEquals(ReleaseChannel.BETA.equals(ReleaseChannel.RC), false);
+  assertEquals(ReleaseChannel.RC.equals(ReleaseChannel.STABLE), false);
+  assertEquals(ReleaseChannel.STABLE.equals(ReleaseChannel.BETA), false);
+});
+
+// --- toString ---
+
+Deno.test("ReleaseChannel.toString: returns channel name", () => {
+  assertEquals(ReleaseChannel.BETA.toString(), "beta");
+  assertEquals(ReleaseChannel.RC.toString(), "rc");
+  assertEquals(ReleaseChannel.STABLE.toString(), "stable");
+});

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -38,6 +38,7 @@ export interface PushMetadata {
   repository?: string;
   releaseNotes?: string;
   binaries?: string[];
+  channel?: string;
 }
 
 /** Metadata sent during push confirmation (extends PushMetadata with content metadata). */
@@ -63,6 +64,7 @@ export interface ConfirmPushResult {
 export interface LatestVersionInfo {
   version: string;
   publishedAt: string;
+  channel?: string;
 }
 
 /** Extension author metadata. */
@@ -105,6 +107,8 @@ export interface ExtensionInfo {
   repositoryVerifiedUrl: string | null;
   pullCount: number;
   score: ExtensionScoreSummary | null;
+  latestRc: string | null;
+  latestBeta: string | null;
 }
 
 /** Parameters for the extension search endpoint. */
@@ -114,6 +118,7 @@ export interface ExtensionSearchParams {
   platform?: string[];
   label?: string[];
   contentType?: string[];
+  channel?: string[];
   sort?: "relevance" | "new" | "updated" | "name";
   perPage?: number;
   page?: number;
@@ -174,6 +179,32 @@ export interface UndeprecateResult {
   message: string;
 }
 
+/** Response from the promote endpoint. */
+export interface PromoteResult {
+  name: string;
+  version: string;
+  previousChannel: string;
+  channel: string;
+  message: string;
+}
+
+/** A single version entry in the versions list. */
+export interface VersionEntry {
+  version: string;
+  channel: string;
+  publishedAt: string;
+}
+
+/** Response from the list versions endpoint. */
+export interface ListVersionsResponse {
+  versions: VersionEntry[];
+  meta: {
+    total: number;
+    page: number;
+    perPage: number;
+  };
+}
+
 /**
  * HTTP client for the swamp-club extension registry API.
  *
@@ -188,16 +219,19 @@ export class ExtensionApiClient {
 
   /**
    * Pre-flight: check latest published version.
-   * Returns null if the extension has never been published.
+   * Returns null if the extension has never been published
+   * or has no versions in the requested channel.
    */
   async getLatestVersion(
     name: string,
     apiKey?: string,
+    channel?: string,
   ): Promise<LatestVersionInfo | null> {
     const encodedName = encodeURIComponent(name);
     const headers = apiKey ? this.authHeaders(apiKey) : {};
+    const qs = channel ? `?channel=${encodeURIComponent(channel)}` : "";
     const res = await this.fetch(
-      `/api/v1/extensions/${encodedName}/latest`,
+      `/api/v1/extensions/${encodedName}/latest${qs}`,
       {
         method: "GET",
         headers,
@@ -317,6 +351,7 @@ export class ExtensionApiClient {
     for (const p of params.platform ?? []) qs.append("platform", p);
     for (const l of params.label ?? []) qs.append("label", l);
     for (const ct of params.contentType ?? []) qs.append("contentType", ct);
+    for (const ch of params.channel ?? []) qs.append("channel", ch);
 
     const query = qs.toString();
     const path = `/api/v1/extensions/search${query ? `?${query}` : ""}`;
@@ -549,6 +584,69 @@ export class ExtensionApiClient {
       method: "POST",
       headers: this.authHeaders(apiKey),
     });
+
+    await this.checkResponse(res);
+    return await res.json();
+  }
+
+  /**
+   * Promote an extension version to a higher channel.
+   * Only forward transitions are allowed (beta→rc, beta→stable, rc→stable).
+   */
+  async promoteExtension(
+    name: string,
+    version: string,
+    toChannel: string,
+    apiKey: string,
+  ): Promise<PromoteResult> {
+    const encodedName = encodeURIComponent(name);
+    const res = await this.fetch(
+      `/api/v1/extensions/${encodedName}/promote`,
+      {
+        method: "POST",
+        headers: {
+          ...this.authHeaders(apiKey),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ version, toChannel }),
+      },
+    );
+
+    await this.checkResponse(res);
+    return await res.json();
+  }
+
+  /**
+   * List published versions for an extension with optional channel filtering.
+   */
+  async listVersions(
+    name: string,
+    options?: {
+      channel?: string[];
+      perPage?: number;
+      page?: number;
+    },
+    apiKey?: string,
+  ): Promise<ListVersionsResponse> {
+    const encodedName = encodeURIComponent(name);
+    const qs = new URLSearchParams();
+    for (const ch of options?.channel ?? []) qs.append("channel", ch);
+    if (options?.perPage !== undefined) {
+      qs.set("perPage", String(options.perPage));
+    }
+    if (options?.page !== undefined) qs.set("page", String(options.page));
+
+    const query = qs.toString();
+    const path = `/api/v1/extensions/${encodedName}/versions${
+      query ? `?${query}` : ""
+    }`;
+    const headers = apiKey ? this.authHeaders(apiKey) : {};
+    const res = await this.fetch(path, { method: "GET", headers });
+
+    if (res.status === 404) {
+      await res.body?.cancel();
+      return { versions: [], meta: { total: 0, page: 1, perPage: 20 } };
+    }
 
     await this.checkResponse(res);
     return await res.json();

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -645,7 +645,14 @@ export class ExtensionApiClient {
 
     if (res.status === 404) {
       await res.body?.cancel();
-      return { versions: [], meta: { total: 0, page: 1, perPage: 20 } };
+      return {
+        versions: [],
+        meta: {
+          total: 0,
+          page: options?.page ?? 1,
+          perPage: options?.perPage ?? 20,
+        },
+      };
     }
 
     await this.checkResponse(res);

--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -35,6 +35,7 @@ export interface WriteEntryOptions {
   checksum?: string;
   filesChecksum?: string;
   serverUrl?: string;
+  channel?: string;
 }
 
 /**
@@ -147,6 +148,7 @@ export class LockfileRepository {
           ? { filesChecksum: options.filesChecksum }
           : {}),
         ...(options?.serverUrl ? { serverUrl: options.serverUrl } : {}),
+        ...(options?.channel ? { channel: options.channel } : {}),
       };
       await atomicWriteTextFile(
         this.lockfilePath,

--- a/src/infrastructure/persistence/upstream_extensions.ts
+++ b/src/infrastructure/persistence/upstream_extensions.ts
@@ -35,6 +35,11 @@ export interface UpstreamExtensionEntry {
   filesChecksum?: string;
   /** Registry server URL used when pulling, for non-default registries. */
   serverUrl?: string;
+  /**
+   * Release channel the extension was installed from. Absent on pre-channel
+   * lockfile entries — consumers default to "stable" when missing.
+   */
+  channel?: string;
 }
 
 /** Shape of upstream_extensions.json. */

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -42,6 +42,8 @@ export interface ExtensionInfoData {
   contentTypes: string[];
   contentNames: string[];
   latestVersion: string;
+  latestRc: string | null;
+  latestBeta: string | null;
   author: ExtensionAuthor | null;
   createdAt: string;
   updatedAt: string;
@@ -120,6 +122,8 @@ export async function* extensionInfo(
             contentTypes: info.contentTypes,
             contentNames: info.contentNames,
             latestVersion: info.latestVersion,
+            latestRc: info.latestRc ?? null,
+            latestBeta: info.latestBeta ?? null,
             author: info.author,
             createdAt: info.createdAt,
             updatedAt: info.updatedAt,

--- a/src/libswamp/extensions/info_test.ts
+++ b/src/libswamp/extensions/info_test.ts
@@ -57,6 +57,8 @@ function makeFullExtensionInfo(
     repositoryVerifiedUrl: "https://github.com/stack72/swamp-aws-ec2",
     pullCount: 142,
     score: { percentage: 85, grade: "A" },
+    latestRc: null,
+    latestBeta: null,
     ...overrides,
   };
 }

--- a/src/libswamp/extensions/list.ts
+++ b/src/libswamp/extensions/list.ts
@@ -33,6 +33,7 @@ export interface ExtensionListEntry {
   version: string;
   pulledAt: string;
   files: string[];
+  channel?: string;
 }
 
 /** Data payload for the completed event. */
@@ -89,6 +90,7 @@ export async function* extensionList(
           version: entry.version,
           pulledAt: entry.pulledAt ?? "",
           files: entry.files ?? [],
+          ...(entry.channel ? { channel: entry.channel } : {}),
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
 

--- a/src/libswamp/extensions/promote.ts
+++ b/src/libswamp/extensions/promote.ts
@@ -1,0 +1,161 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
+import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
+import type { PromoteResult } from "../../infrastructure/http/extension_api_client.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { notAuthenticated, validationFailed } from "../errors.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+
+const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
+
+export interface ExtensionPromoteData {
+  name: string;
+  version: string;
+  previousChannel: string;
+  channel: string;
+  message: string;
+}
+
+export type ExtensionPromoteEvent =
+  | { kind: "promoting" }
+  | { kind: "completed"; data: ExtensionPromoteData }
+  | { kind: "error"; error: SwampError };
+
+export interface ExtensionPromoteInput {
+  extensionName: string;
+  version: string;
+  toChannel: string;
+  fromChannel?: string;
+}
+
+export interface ExtensionPromoteDeps {
+  loadCredentials: () => Promise<
+    { serverUrl: string; apiKey: string } | null
+  >;
+  promoteExtension: (
+    serverUrl: string,
+    name: string,
+    version: string,
+    toChannel: string,
+    apiKey: string,
+  ) => Promise<PromoteResult>;
+}
+
+function resolveServerUrl(): string {
+  return Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
+}
+
+export function createExtensionPromoteDeps(): ExtensionPromoteDeps {
+  const authRepo = new AuthRepository();
+  return {
+    loadCredentials: async () => {
+      const creds = await authRepo.load();
+      if (!creds) return null;
+      return {
+        serverUrl: creds.serverUrl ?? resolveServerUrl(),
+        apiKey: creds.apiKey,
+      };
+    },
+    promoteExtension: async (
+      serverUrl: string,
+      name: string,
+      version: string,
+      toChannel: string,
+      apiKey: string,
+    ) => {
+      const client = new ExtensionApiClient(serverUrl);
+      return await client.promoteExtension(name, version, toChannel, apiKey);
+    },
+  };
+}
+
+export function extensionPromoteValidate(
+  input: ExtensionPromoteInput,
+): void {
+  if (!SCOPED_NAME_PATTERN.test(input.extensionName)) {
+    throw validationFailed(
+      `Invalid extension name: "${input.extensionName}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores, additional /segments allowed).`,
+    );
+  }
+
+  if (!ReleaseChannel.isValid(input.toChannel)) {
+    throw validationFailed(
+      `Invalid target channel: "${input.toChannel}". Must be 'rc' or 'stable'.`,
+    );
+  }
+
+  const target = ReleaseChannel.create(input.toChannel);
+  if (input.fromChannel) {
+    const source = ReleaseChannel.create(input.fromChannel);
+    if (!source.canPromoteTo(target)) {
+      throw validationFailed(
+        `Cannot promote from ${input.fromChannel} to ${input.toChannel}. Promotion must move to a higher channel.`,
+      );
+    }
+  }
+}
+
+export async function* extensionPromote(
+  ctx: LibSwampContext,
+  deps: ExtensionPromoteDeps,
+  input: ExtensionPromoteInput,
+): AsyncIterable<ExtensionPromoteEvent> {
+  yield* withGeneratorSpan(
+    "swamp.extension.promote",
+    {},
+    (async function* () {
+      yield { kind: "promoting" } as const;
+
+      ctx.logger.debug`Executing extension promote`;
+
+      const credentials = await deps.loadCredentials();
+      if (!credentials) {
+        yield { kind: "error", error: notAuthenticated() };
+        return;
+      }
+
+      const result = await deps.promoteExtension(
+        credentials.serverUrl,
+        input.extensionName,
+        input.version,
+        input.toChannel,
+        credentials.apiKey,
+      );
+
+      ctx.logger
+        .debug`Promoted extension ${input.extensionName}@${input.version} to ${input.toChannel}`;
+
+      yield {
+        kind: "completed",
+        data: {
+          name: result.name,
+          version: result.version,
+          previousChannel: result.previousChannel,
+          channel: result.channel,
+          message: result.message,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/extensions/promote.ts
+++ b/src/libswamp/extensions/promote.ts
@@ -99,7 +99,9 @@ export function extensionPromoteValidate(
     );
   }
 
-  if (!ReleaseChannel.isValid(input.toChannel)) {
+  if (
+    input.toChannel !== "rc" && input.toChannel !== "stable"
+  ) {
     throw validationFailed(
       `Invalid target channel: "${input.toChannel}". Must be 'rc' or 'stable'.`,
     );
@@ -135,13 +137,23 @@ export async function* extensionPromote(
         return;
       }
 
-      const result = await deps.promoteExtension(
-        credentials.serverUrl,
-        input.extensionName,
-        input.version,
-        input.toChannel,
-        credentials.apiKey,
-      );
+      let result: PromoteResult;
+      try {
+        result = await deps.promoteExtension(
+          credentials.serverUrl,
+          input.extensionName,
+          input.version,
+          input.toChannel,
+          credentials.apiKey,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        yield {
+          kind: "error" as const,
+          error: validationFailed(message),
+        };
+        return;
+      }
 
       ctx.logger
         .debug`Promoted extension ${input.extensionName}@${input.version} to ${input.toChannel}`;

--- a/src/libswamp/extensions/promote.ts
+++ b/src/libswamp/extensions/promote.ts
@@ -22,7 +22,8 @@ import { ExtensionApiClient } from "../../infrastructure/http/extension_api_clie
 import type { PromoteResult } from "../../infrastructure/http/extension_api_client.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
-import { notAuthenticated, validationFailed } from "../errors.ts";
+import { notAuthenticated, notFound, validationFailed } from "../errors.ts";
+import { UserError } from "../../domain/errors.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
@@ -109,6 +110,11 @@ export function extensionPromoteValidate(
 
   const target = ReleaseChannel.create(input.toChannel);
   if (input.fromChannel) {
+    if (!ReleaseChannel.isValid(input.fromChannel)) {
+      throw validationFailed(
+        `Invalid source channel: "${input.fromChannel}". Must be one of: beta, rc, stable`,
+      );
+    }
     const source = ReleaseChannel.create(input.fromChannel);
     if (!source.canPromoteTo(target)) {
       throw validationFailed(
@@ -148,9 +154,18 @@ export async function* extensionPromote(
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        const isAuth = error instanceof UserError &&
+          message.includes("Not authenticated");
+        const is404 = error instanceof UserError &&
+          (message.includes("not found") || message.includes("Not Found"));
         yield {
           kind: "error" as const,
-          error: validationFailed(message),
+          error: isAuth ? notAuthenticated() : is404
+            ? notFound(
+              "extension version",
+              `${input.extensionName}@${input.version}`,
+            )
+            : validationFailed(message),
         };
         return;
       }

--- a/src/libswamp/extensions/promote_test.ts
+++ b/src/libswamp/extensions/promote_test.ts
@@ -160,6 +160,25 @@ Deno.test("extensionPromoteValidate: rejects backward promotion", () => {
   }
 });
 
+Deno.test("extensionPromoteValidate: rejects beta as target without fromChannel", () => {
+  try {
+    extensionPromoteValidate({
+      extensionName: "@test/ext",
+      version: "2026.06.10.1",
+      toChannel: "beta",
+    });
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "validation_failed");
+    assertEquals(
+      (error as { message: string }).message.includes(
+        "Must be 'rc' or 'stable'",
+      ),
+      true,
+    );
+  }
+});
+
 Deno.test("extensionPromoteValidate: accepts valid forward promotion", () => {
   // Should not throw
   extensionPromoteValidate({
@@ -168,4 +187,20 @@ Deno.test("extensionPromoteValidate: accepts valid forward promotion", () => {
     toChannel: "stable",
     fromChannel: "beta",
   });
+});
+
+Deno.test("extensionPromote: yields error when API call fails", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    promoteExtension: () => Promise.reject(new Error("Version not found")),
+  });
+  const input: ExtensionPromoteInput = {
+    extensionName: "@test/ext",
+    version: "2026.06.10.99",
+    toChannel: "rc",
+  };
+  await assertErrors<ExtensionPromoteEvent>(
+    extensionPromote(ctx, deps, input),
+    "validation_failed",
+  );
 });

--- a/src/libswamp/extensions/promote_test.ts
+++ b/src/libswamp/extensions/promote_test.ts
@@ -1,0 +1,171 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { assertCompletes, assertErrors } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  extensionPromote,
+  type ExtensionPromoteDeps,
+  type ExtensionPromoteEvent,
+  type ExtensionPromoteInput,
+  extensionPromoteValidate,
+} from "./promote.ts";
+
+function fakeDeps(
+  overrides?: Partial<ExtensionPromoteDeps>,
+): ExtensionPromoteDeps {
+  return {
+    loadCredentials: () =>
+      Promise.resolve({
+        serverUrl: "https://test.club",
+        apiKey: "key-123",
+      }),
+    promoteExtension: () =>
+      Promise.resolve({
+        name: "@test/ext",
+        version: "2026.06.10.1",
+        previousChannel: "beta",
+        channel: "rc",
+        message: "Promoted",
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("extensionPromote: promotes beta to rc", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps();
+  const input: ExtensionPromoteInput = {
+    extensionName: "@test/ext",
+    version: "2026.06.10.1",
+    toChannel: "rc",
+  };
+  await assertCompletes<ExtensionPromoteEvent>(
+    extensionPromote(ctx, deps, input),
+    {
+      kind: "completed",
+      data: {
+        name: "@test/ext",
+        version: "2026.06.10.1",
+        previousChannel: "beta",
+        channel: "rc",
+        message: "Promoted",
+      },
+    },
+  );
+});
+
+Deno.test("extensionPromote: promotes rc to stable", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    promoteExtension: () =>
+      Promise.resolve({
+        name: "@test/ext",
+        version: "2026.06.10.1",
+        previousChannel: "rc",
+        channel: "stable",
+        message: "Promoted to stable",
+      }),
+  });
+  const input: ExtensionPromoteInput = {
+    extensionName: "@test/ext",
+    version: "2026.06.10.1",
+    toChannel: "stable",
+  };
+  await assertCompletes<ExtensionPromoteEvent>(
+    extensionPromote(ctx, deps, input),
+    {
+      kind: "completed",
+      data: {
+        name: "@test/ext",
+        version: "2026.06.10.1",
+        previousChannel: "rc",
+        channel: "stable",
+        message: "Promoted to stable",
+      },
+    },
+  );
+});
+
+Deno.test("extensionPromote: errors when not authenticated", async () => {
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    loadCredentials: () => Promise.resolve(null),
+  });
+  const input: ExtensionPromoteInput = {
+    extensionName: "@test/ext",
+    version: "2026.06.10.1",
+    toChannel: "rc",
+  };
+  await assertErrors<ExtensionPromoteEvent>(
+    extensionPromote(ctx, deps, input),
+    "not_authenticated",
+  );
+});
+
+Deno.test("extensionPromoteValidate: rejects invalid extension name", () => {
+  try {
+    extensionPromoteValidate({
+      extensionName: "invalid-name",
+      version: "2026.06.10.1",
+      toChannel: "rc",
+    });
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "validation_failed");
+  }
+});
+
+Deno.test("extensionPromoteValidate: rejects invalid target channel", () => {
+  try {
+    extensionPromoteValidate({
+      extensionName: "@test/ext",
+      version: "2026.06.10.1",
+      toChannel: "nightly",
+    });
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "validation_failed");
+  }
+});
+
+Deno.test("extensionPromoteValidate: rejects backward promotion", () => {
+  try {
+    extensionPromoteValidate({
+      extensionName: "@test/ext",
+      version: "2026.06.10.1",
+      toChannel: "beta",
+      fromChannel: "rc",
+    });
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "validation_failed");
+  }
+});
+
+Deno.test("extensionPromoteValidate: accepts valid forward promotion", () => {
+  // Should not throw
+  extensionPromoteValidate({
+    extensionName: "@test/ext",
+    version: "2026.06.10.1",
+    toChannel: "stable",
+    fromChannel: "beta",
+  });
+});

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -1131,6 +1131,7 @@ export async function installExtension(
           const depResult = await installExtension(depRef, {
             ...ctx,
             depth: ctx.depth + 1,
+            channel: undefined,
           });
           if (depResult) {
             dependencyResults.push(depResult);

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -73,6 +73,8 @@ export interface ExtensionRegistryInfo {
   name: string;
   description: string;
   latestVersion: string;
+  latestRc?: string | null;
+  latestBeta?: string | null;
   deprecatedAt?: string | null;
   deprecationReason?: string | null;
   supersededBy?: string | null;
@@ -159,6 +161,8 @@ export interface InstallContext {
    * whatever bytes the registry currently serves.
    */
   expectedChecksum?: string;
+  /** Release channel to record in the lockfile entry. */
+  channel?: string;
 }
 
 /** Thrown when file conflicts are detected and force is false. */
@@ -195,11 +199,16 @@ export type ExtensionPullEvent =
 export interface ExtensionPullInput {
   ref: ExtensionRef;
   force: boolean;
+  channel?: string;
 }
 
 /** Dependencies for the extension pull operation. */
 export interface ExtensionPullDeps {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
+  getLatestVersion?: (
+    name: string,
+    channel: string,
+  ) => Promise<string | null>;
   downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
   getChecksum: (name: string, version: string) => Promise<string | null>;
   /**
@@ -1100,6 +1109,7 @@ export async function installExtension(
         checksum: localChecksum,
         filesChecksum: filesChecksum ?? undefined,
         serverUrl: resolveServerUrl(),
+        channel: ctx.channel,
       },
     );
 
@@ -1178,6 +1188,29 @@ export async function* extensionPull(
         };
       }
 
+      // Resolve channel-specific version when --channel is set and
+      // no explicit version is pinned. The resolved ref always carries
+      // an explicit version so installExtension doesn't need channel
+      // awareness — it just installs the pinned version.
+      let resolvedRef = input.ref;
+      if (input.channel && !input.ref.version) {
+        if (!deps.getLatestVersion) {
+          throw new UserError(
+            "Channel-aware pull requires getLatestVersion support.",
+          );
+        }
+        const channelVersion = await deps.getLatestVersion(
+          input.ref.name,
+          input.channel,
+        );
+        if (!channelVersion) {
+          throw new UserError(
+            `Extension ${input.ref.name} has no published ${input.channel} versions.`,
+          );
+        }
+        resolvedRef = { name: input.ref.name, version: channelVersion };
+      }
+
       const installCtx: InstallContext = {
         getExtension: (name) =>
           name === input.ref.name && prefetchedInfo
@@ -1192,6 +1225,7 @@ export async function* extensionPull(
         force: input.force,
         alreadyPulled: deps.alreadyPulled,
         depth: deps.depth,
+        channel: input.channel,
       };
 
       // Let ConflictError propagate — CLI catches it for the two-phase prompt
@@ -1212,7 +1246,7 @@ export async function* extensionPull(
               repository: repo,
             }).execute(r, c)
           : installExtension);
-      const result = await install(input.ref, installCtx);
+      const result = await install(resolvedRef, installCtx);
       if (result) {
         if (result.pruned.length > 0) {
           yield {
@@ -1258,6 +1292,10 @@ export async function createExtensionPullDeps(
   const lockfileRepository = await LockfileRepository.create(lockfilePath);
   return {
     getExtension: (name) => client.getExtension(name),
+    getLatestVersion: async (name, channel) => {
+      const info = await client.getLatestVersion(name, undefined, channel);
+      return info?.version ?? null;
+    },
     downloadArchive: (name, version) => client.downloadArchive(name, version),
     getChecksum: (name, version) => client.getChecksum(name, version),
     lockfileRepository,

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -1324,6 +1324,7 @@ export async function createInstallContext(
     force: boolean;
     logger?: Logger;
     identity?: ClientIdentity;
+    channel?: string;
   },
 ): Promise<InstallContext> {
   const client = new ExtensionApiClient(serverUrl, opts.identity);
@@ -1339,5 +1340,6 @@ export async function createInstallContext(
     force: opts.force,
     alreadyPulled: new Set(),
     depth: 0,
+    channel: opts.channel,
   };
 }

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -222,6 +222,7 @@ export interface ExtensionPushExecuteInput {
   contentMetadata: ExtensionContentMetadata | undefined;
   counts: ExtensionPushCounts;
   releaseNotes?: string;
+  channel?: string;
 }
 
 export type ExtensionPushEvent =
@@ -295,6 +296,7 @@ export interface ExtensionPushMetadata {
   repository?: string;
   releaseNotes?: string;
   binaries?: string[];
+  channel?: string;
   contentMetadata?: ExtensionContentMetadata;
 }
 
@@ -861,6 +863,7 @@ export async function* extensionPush(
         ...(input.manifest.binaries.length > 0
           ? { binaries: input.manifest.binaries }
           : {}),
+        ...(input.channel ? { channel: input.channel } : {}),
       };
 
       // Phase 1: Initiate

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -60,6 +60,7 @@ export interface ExtensionSearchInput {
   platform?: string[];
   label?: string[];
   contentType?: string[];
+  channel?: string[];
   sort?: string;
   perPage?: number;
   page?: number;
@@ -73,6 +74,7 @@ export interface ExtensionSearchDeps {
     platform?: string[];
     label?: string[];
     contentType?: string[];
+    channel?: string[];
     sort?: string;
     perPage?: number;
     page?: number;
@@ -117,6 +119,7 @@ export async function* extensionSearch(
         platform: input.platform,
         label: input.label,
         contentType: input.contentType,
+        channel: input.channel,
         sort: input.sort,
         perPage: input.perPage,
         page: input.page,

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -90,6 +90,7 @@ export interface ExtensionUpdateDeps {
   installExtension: (
     name: string,
     version: string,
+    channel?: string,
   ) => Promise<InstallResult | undefined>;
 }
 
@@ -101,6 +102,7 @@ export async function createExtensionUpdateDeps(options: {
   installExtension: (
     name: string,
     version: string,
+    channel?: string,
   ) => Promise<InstallResult | undefined>;
 }): Promise<ExtensionUpdateDeps> {
   const extensionClient = new ExtensionApiClient(
@@ -237,6 +239,7 @@ export async function* extensionUpdate(
             const result = await deps.installExtension(
               s.name,
               s.latestVersion,
+              upstream[s.name]?.channel,
             );
             if (result && result.pruned.length > 0) {
               yield {

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -69,9 +69,10 @@ export interface ExtensionUpdateDeps {
    * construction.
    */
   lockfileRepository: LockfileRepository;
-  /** Get extension info from registry (latest version). */
+  /** Get extension info from registry (latest version in channel). */
   getExtension: (
     name: string,
+    channel?: string,
   ) => Promise<
     {
       latestVersion: string | null;
@@ -108,8 +109,23 @@ export async function createExtensionUpdateDeps(options: {
   );
   return {
     lockfileRepository: await LockfileRepository.create(options.lockfilePath),
-    getExtension: async (name) => {
+    getExtension: async (name, channel?) => {
       try {
+        if (channel && channel !== "stable") {
+          const versionInfo = await extensionClient.getLatestVersion(
+            name,
+            undefined,
+            channel,
+          );
+          if (!versionInfo) return null;
+          const info = await extensionClient.getExtension(name);
+          return {
+            latestVersion: versionInfo.version,
+            deprecatedAt: info?.deprecatedAt ?? null,
+            deprecationReason: info?.deprecationReason ?? null,
+            supersededBy: info?.supersededBy ?? null,
+          };
+        }
         const info = await extensionClient.getExtension(name);
         if (!info) return null;
         return {
@@ -174,8 +190,9 @@ export async function* extensionUpdate(
       for (const name of targetNames) {
         yield { kind: "checking", name };
         const installedVersion = upstream[name].version;
+        const installedChannel = upstream[name].channel;
 
-        const extInfo = await deps.getExtension(name);
+        const extInfo = await deps.getExtension(name, installedChannel);
         if (!extInfo) {
           statuses.push({
             status: "not_found",

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -676,6 +676,15 @@ export {
   extensionUndeprecatePreview,
 } from "./extensions/undeprecate.ts";
 export {
+  createExtensionPromoteDeps,
+  extensionPromote,
+  type ExtensionPromoteData,
+  type ExtensionPromoteDeps,
+  type ExtensionPromoteEvent,
+  type ExtensionPromoteInput,
+  extensionPromoteValidate,
+} from "./extensions/promote.ts";
+export {
   createExtensionQualityDeps,
   extensionQuality,
   type ExtensionQualityData,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -724,6 +724,7 @@ export {
   type LocalEditsStatus,
 } from "./extensions/local_edits.ts";
 export {
+  extensionCacheKey,
   type ExtensionUpdateCheckMap,
   type ExtensionUpdateCheckRepository,
   isExtensionCheckStale,

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -75,6 +75,13 @@ class LogExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
 
         logger.info``;
 
+        if (d.latestRc) {
+          logger.info`Latest RC:   ${d.latestRc}`;
+        }
+        if (d.latestBeta) {
+          logger.info`Latest Beta: ${d.latestBeta}`;
+        }
+
         logger.info`Downloads:   ${d.pullCount}`;
         if (d.score) {
           logger.info`Quality:     ${d.score.grade} (${d.score.percentage}%)`;

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -77,8 +77,13 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
           Math.floor(cols * 0.4),
         );
         const maxVersion = Math.max(
-          ...exts.map((ext) => ext.version.length + 1),
-        ); // +1 for "v" prefix
+          ...exts.map((ext) => {
+            const tag = ext.channel && ext.channel !== "stable"
+              ? ` [${ext.channel}]`
+              : "";
+            return ext.version.length + 1 + tag.length;
+          }),
+        );
         const maxLatest = enriched
           ? Math.max(
             ...exts.map((ext) =>
@@ -96,7 +101,7 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
             ? ` [${ext.channel}]`
             : "";
           const paddedVersion = `v${ext.version}${channelTag}`.padEnd(
-            maxVersion + (channelTag ? channelTag.length : 0),
+            maxVersion,
           );
           let line = `${paddedName}  ${paddedVersion}`;
           if (enriched) {

--- a/src/presentation/renderers/extension_list.ts
+++ b/src/presentation/renderers/extension_list.ts
@@ -92,7 +92,12 @@ class LogExtensionListRenderer implements Renderer<EnrichedExtensionListEvent> {
             ? ext.name.substring(0, maxName - 1) + "…"
             : ext.name;
           const paddedName = name.padEnd(maxName);
-          const paddedVersion = `v${ext.version}`.padEnd(maxVersion);
+          const channelTag = ext.channel && ext.channel !== "stable"
+            ? ` [${ext.channel}]`
+            : "";
+          const paddedVersion = `v${ext.version}${channelTag}`.padEnd(
+            maxVersion + (channelTag ? channelTag.length : 0),
+          );
           let line = `${paddedName}  ${paddedVersion}`;
           if (enriched) {
             const latestText = ext.latestVersion

--- a/src/presentation/renderers/extension_promote.ts
+++ b/src/presentation/renderers/extension_promote.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  EventHandlers,
+  ExtensionPromoteEvent,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogExtensionPromoteRenderer implements Renderer<ExtensionPromoteEvent> {
+  handlers(): EventHandlers<ExtensionPromoteEvent> {
+    const logger = getSwampLogger(["extension", "promote"]);
+    return {
+      promoting: () => {},
+      completed: (e) => {
+        logger.info(
+          "Promoted {name}@{version} from {previousChannel} to {channel}",
+          {
+            name: e.data.name,
+            version: e.data.version,
+            previousChannel: e.data.previousChannel,
+            channel: e.data.channel,
+          },
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonExtensionPromoteRenderer implements Renderer<ExtensionPromoteEvent> {
+  handlers(): EventHandlers<ExtensionPromoteEvent> {
+    return {
+      promoting: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createExtensionPromoteRenderer(
+  mode: OutputMode,
+): Renderer<ExtensionPromoteEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonExtensionPromoteRenderer();
+    case "log":
+      return new LogExtensionPromoteRenderer();
+  }
+}

--- a/src/presentation/renderers/extension_promote.ts
+++ b/src/presentation/renderers/extension_promote.ts
@@ -30,7 +30,9 @@ class LogExtensionPromoteRenderer implements Renderer<ExtensionPromoteEvent> {
   handlers(): EventHandlers<ExtensionPromoteEvent> {
     const logger = getSwampLogger(["extension", "promote"]);
     return {
-      promoting: () => {},
+      promoting: () => {
+        logger.info`Promoting...`;
+      },
       completed: (e) => {
         logger.info(
           "Promoted {name}@{version} from {previousChannel} to {channel}",


### PR DESCRIPTION
## Summary

Adds release channel support to the extension system — a promotion ladder of `beta → rc → stable` that lets publishers push pre-release versions without contaminating the stable channel. Closes #311.

- **ReleaseChannel value object** (`src/domain/extensions/release_channel.ts`) with three fixed values, strict ordering, and `canPromoteTo()` validation (19 tests)
- **`--channel` flag** on push, pull, and search commands — consistent across all commands
- **`swamp extension promote`** new command for forward-only channel promotion
- **API client** updated with channel params on push/pull/search, plus new `promoteExtension()` and `listVersions()` methods
- **Lockfile** records installed channel; update service checks within installed channel
- **Update cache** uses channel-aware keys to prevent cross-channel cache poisoning
- **Auto-resolve** restricted to stable only — beta/rc never auto-install
- **Extension list** surfaces channel field from lockfile
- **`design/extension.md`** updated with full release channels documentation

### CLI UX

| Command | `--channel` behavior | Default |
|---------|---------------------|---------|
| `push` | single value: `rc`, `beta` | stable (no flag) |
| `pull` | single value: `rc`, `beta` | stable (no flag) |
| `search` | collect (multiple): `rc`, `beta` | stable only |
| `promote` | target: `rc`, `stable` | required |
| `info` | no flag — shows all channels | all |

### Promotion ladder

```
beta → rc → stable
  └──────────┘  (can skip rc)
```

Forward-only: server enforces, client validates as convenience.

### Requires

API-side support from swamp-club/swamp-club#661 (push/confirm accept channel, GET /latest?channel=, POST /promote, GET /versions).

## Test Plan

- [x] 6845 tests pass (19 new ReleaseChannel tests, 1 pre-existing flaky test)
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] End-to-end verified against dev server:
  - Push with `--channel beta` → version stored as beta ✅
  - Push with `--channel rc` → version stored as rc ✅
  - Push stable (no flag) → version stored as stable ✅
  - Invalid channel rejected client-side ✅
  - Pull default → gets stable version ✅
  - Pull `--channel beta` → gets beta version, lockfile records channel ✅
  - Pull `--channel rc` → gets rc version, lockfile records channel ✅
  - Promote beta→rc ✅
  - Promote rc→stable ✅
  - Backward promotion rejected ✅
  - Promoted version appears in new channel ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)