### PR TITLE
fix(datastore): prevent data loss when mergeDirInto encounters file collisions

### DIFF
--- a/integration/giga_swamp_namespace_migrate_test.ts
+++ b/integration/giga_swamp_namespace_migrate_test.ts
@@ -36,6 +36,10 @@ import {
 import { collect } from "../src/libswamp/testing.ts";
 import { DEFAULT_DATASTORE_SUBDIRS } from "../src/domain/datastore/datastore_config.ts";
 import {
+  findFileCollisions,
+  mergeDirInto,
+} from "../src/infrastructure/persistence/directory_merge.ts";
+import {
   removeNamespaceManifest,
   writeNamespaceManifest,
 } from "../src/infrastructure/persistence/namespace_manifest.ts";
@@ -130,30 +134,10 @@ function buildDeps(
     dirSize,
     renameDir: (source: string, destination: string) =>
       Deno.rename(source, destination),
-    mergeDirInto: async (source: string, destination: string) => {
-      let moved = 0;
-      const mergeRecursive = async (
-        src: string,
-        dst: string,
-      ): Promise<void> => {
-        for await (const entry of Deno.readDir(src)) {
-          const srcPath = join(src, entry.name);
-          const dstPath = join(dst, entry.name);
-          try {
-            await Deno.stat(dstPath);
-            if (entry.isDirectory) await mergeRecursive(srcPath, dstPath);
-          } catch {
-            await Deno.rename(srcPath, dstPath);
-            moved++;
-          }
-        }
-      };
-      await mergeRecursive(source, destination);
-      try {
-        await Deno.remove(source, { recursive: true });
-      } catch { /* best-effort */ }
-      return moved;
-    },
+    findFileCollisions: (source: string, destination: string) =>
+      findFileCollisions(source, destination),
+    mergeDirInto: (source: string, destination: string) =>
+      mergeDirInto(source, destination),
     ensureDir: (path: string) => ensureDir(path),
     invalidateCatalog: () => catalogStore.invalidate(),
     markDirtyBulk: () => Promise.resolve(),

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -64,6 +64,10 @@ import {
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { UserError } from "../../domain/errors.ts";
+import {
+  findFileCollisions,
+  mergeDirInto,
+} from "../../infrastructure/persistence/directory_merge.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -342,39 +346,10 @@ function buildMigrateDeps(
     dirSize,
     renameDir: (source: string, destination: string) =>
       Deno.rename(source, destination),
-    mergeDirInto: async (source: string, destination: string) => {
-      const mergeRecursive = async (
-        src: string,
-        dst: string,
-      ): Promise<number> => {
-        let moved = 0;
-        for await (const entry of Deno.readDir(src)) {
-          const srcPath = join(src, entry.name);
-          const dstPath = join(dst, entry.name);
-          let dstExists = false;
-          try {
-            await Deno.stat(dstPath);
-            dstExists = true;
-          } catch {
-            // doesn't exist
-          }
-          if (!dstExists) {
-            await Deno.rename(srcPath, dstPath);
-            moved++;
-          } else if (entry.isDirectory) {
-            moved += await mergeRecursive(srcPath, dstPath);
-          }
-        }
-        return moved;
-      };
-      const moved = await mergeRecursive(source, destination);
-      try {
-        await Deno.remove(source, { recursive: true });
-      } catch {
-        // Best-effort cleanup
-      }
-      return moved;
-    },
+    findFileCollisions: (source: string, destination: string) =>
+      findFileCollisions(source, destination),
+    mergeDirInto: (source: string, destination: string) =>
+      mergeDirInto(source, destination),
     ensureDir: (path: string) => ensureDir(path),
     invalidateCatalog: () => {
       catalogStore = createCatalogStore(repoDir);

--- a/src/infrastructure/persistence/directory_merge.ts
+++ b/src/infrastructure/persistence/directory_merge.ts
@@ -1,0 +1,127 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { MergeDirResult } from "../../libswamp/mod.ts";
+
+export async function findFileCollisions(
+  source: string,
+  destination: string,
+): Promise<string[]> {
+  const collisions: string[] = [];
+  const walkRecursive = async (
+    src: string,
+    dst: string,
+    relPrefix: string,
+  ): Promise<void> => {
+    for await (const entry of Deno.readDir(src)) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      const relPath = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory && !entry.isSymlink) {
+        try {
+          const dstStat = await Deno.stat(dstPath);
+          if (dstStat.isDirectory) {
+            await walkRecursive(srcPath, dstPath, relPath);
+          } else {
+            collisions.push(relPath);
+          }
+        } catch {
+          // Destination doesn't exist — no collision
+        }
+      } else {
+        try {
+          await Deno.stat(dstPath);
+          collisions.push(relPath);
+        } catch {
+          // Destination doesn't exist — no collision
+        }
+      }
+    }
+  };
+  await walkRecursive(source, destination, "");
+  return collisions;
+}
+
+export async function mergeDirInto(
+  source: string,
+  destination: string,
+): Promise<MergeDirResult> {
+  const skippedPaths: string[] = [];
+  const mergeRecursive = async (
+    src: string,
+    dst: string,
+    relPrefix: string,
+  ): Promise<number> => {
+    let moved = 0;
+    for await (const entry of Deno.readDir(src)) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      const relPath = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      let dstExists = false;
+      try {
+        await Deno.stat(dstPath);
+        dstExists = true;
+      } catch {
+        // doesn't exist
+      }
+      if (!dstExists) {
+        await Deno.rename(srcPath, dstPath);
+        moved++;
+      } else if (entry.isDirectory && !entry.isSymlink) {
+        moved += await mergeRecursive(srcPath, dstPath, relPath);
+      } else {
+        skippedPaths.push(relPath);
+      }
+    }
+    return moved;
+  };
+  const moved = await mergeRecursive(source, destination, "");
+  try {
+    await removeEmptyDirs(source);
+  } catch {
+    // Best-effort cleanup
+  }
+  return { moved, skipped: skippedPaths.length, skippedPaths };
+}
+
+export async function removeEmptyDirs(dir: string): Promise<boolean> {
+  const entries: Deno.DirEntry[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    entries.push(entry);
+  }
+  let allRemoved = true;
+  for (const entry of entries) {
+    if (entry.isDirectory && !entry.isSymlink) {
+      const childRemoved = await removeEmptyDirs(join(dir, entry.name));
+      if (!childRemoved) allRemoved = false;
+    } else {
+      allRemoved = false;
+    }
+  }
+  if (allRemoved) {
+    try {
+      await Deno.remove(dir);
+    } catch {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}

--- a/src/infrastructure/persistence/directory_merge_test.ts
+++ b/src/infrastructure/persistence/directory_merge_test.ts
@@ -1,0 +1,340 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir, exists } from "@std/fs";
+import {
+  findFileCollisions,
+  mergeDirInto,
+  removeEmptyDirs,
+} from "./directory_merge.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-merge-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+// --- findFileCollisions ---
+
+Deno.test("findFileCollisions: detects top-level file collision", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(src);
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "a.yaml"), "src");
+    await Deno.writeTextFile(join(dst, "a.yaml"), "dst");
+    await Deno.writeTextFile(join(src, "b.yaml"), "only-in-src");
+
+    const collisions = await findFileCollisions(src, dst);
+    assertEquals(collisions, ["a.yaml"]);
+  });
+});
+
+Deno.test("findFileCollisions: detects nested collision two levels deep", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(join(src, "model-a", "v1"));
+    await ensureDir(join(dst, "model-a", "v1"));
+
+    await Deno.writeTextFile(join(src, "model-a", "v1", "raw"), "src");
+    await Deno.writeTextFile(join(dst, "model-a", "v1", "raw"), "dst");
+    await Deno.writeTextFile(join(src, "model-a", "unique"), "src-only");
+
+    const collisions = await findFileCollisions(src, dst);
+    assertEquals(collisions, ["model-a/v1/raw"]);
+  });
+});
+
+Deno.test("findFileCollisions: returns empty when no collisions", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(src);
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "a.yaml"), "src");
+    await Deno.writeTextFile(join(dst, "b.yaml"), "dst");
+
+    const collisions = await findFileCollisions(src, dst);
+    assertEquals(collisions, []);
+  });
+});
+
+Deno.test("findFileCollisions: detects symlink collision", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(src);
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "target"), "src");
+    await Deno.symlink(join(src, "target"), join(src, "latest"), {
+      type: "file",
+    });
+    await Deno.writeTextFile(join(dst, "target"), "dst");
+    await Deno.symlink(join(dst, "target"), join(dst, "latest"), {
+      type: "file",
+    });
+
+    const collisions = await findFileCollisions(src, dst);
+    collisions.sort();
+    assertEquals(collisions, ["latest", "target"]);
+  });
+});
+
+// --- mergeDirInto ---
+
+Deno.test("mergeDirInto: moves non-colliding files and preserves colliding source files", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(src);
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "colliding.yaml"), "source-version");
+    await Deno.writeTextFile(join(dst, "colliding.yaml"), "dest-version");
+    await Deno.writeTextFile(join(src, "unique.yaml"), "moved-data");
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(result.moved, 1);
+    assertEquals(result.skipped, 1);
+    assertEquals(result.skippedPaths, ["colliding.yaml"]);
+
+    assertEquals(
+      await Deno.readTextFile(join(dst, "colliding.yaml")),
+      "dest-version",
+    );
+    assertEquals(
+      await Deno.readTextFile(join(dst, "unique.yaml")),
+      "moved-data",
+    );
+
+    assertEquals(
+      await Deno.readTextFile(join(src, "colliding.yaml")),
+      "source-version",
+    );
+  });
+});
+
+Deno.test("mergeDirInto: nested collision preserves source and ancestor dirs", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(join(src, "model-a", "v1"));
+    await ensureDir(join(dst, "model-a", "v1"));
+
+    await Deno.writeTextFile(
+      join(src, "model-a", "v1", "raw"),
+      "src-content",
+    );
+    await Deno.writeTextFile(
+      join(dst, "model-a", "v1", "raw"),
+      "dst-content",
+    );
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(result.skipped, 1);
+    assertEquals(result.skippedPaths, ["model-a/v1/raw"]);
+
+    assertEquals(
+      await Deno.readTextFile(join(src, "model-a", "v1", "raw")),
+      "src-content",
+    );
+    assertEquals(
+      await Deno.readTextFile(join(dst, "model-a", "v1", "raw")),
+      "dst-content",
+    );
+
+    assertEquals(await exists(join(src, "model-a", "v1")), true);
+    assertEquals(await exists(join(src, "model-a")), true);
+    assertEquals(await exists(src), true);
+  });
+});
+
+Deno.test("mergeDirInto: cleans up empty source dirs after full merge", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(join(src, "nested"));
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "a.yaml"), "data");
+    await Deno.writeTextFile(join(src, "nested", "b.yaml"), "data");
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(result.moved, 2);
+    assertEquals(result.skipped, 0);
+    assertEquals(result.skippedPaths, []);
+
+    assertEquals(await Deno.readTextFile(join(dst, "a.yaml")), "data");
+    assertEquals(
+      await Deno.readTextFile(join(dst, "nested", "b.yaml")),
+      "data",
+    );
+
+    assertEquals(await exists(src), false);
+  });
+});
+
+Deno.test("mergeDirInto: moves symlink-to-directory as an entry", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(join(src, "versions"));
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "versions", "v1.yaml"), "v1");
+    // Relative symlink — stays valid after the move
+    await Deno.symlink("versions", join(src, "latest"), { type: "dir" });
+    await Deno.writeTextFile(join(dst, "other.yaml"), "existing");
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(
+      await Deno.readTextFile(join(dst, "versions", "v1.yaml")),
+      "v1",
+    );
+    const latestStat = await Deno.lstat(join(dst, "latest"));
+    assertEquals(latestStat.isSymlink, true);
+
+    assertEquals(result.skipped, 0);
+    assertEquals(await exists(src), false);
+  });
+});
+
+Deno.test("mergeDirInto: colliding symlink is skipped and source preserved", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+    await ensureDir(src);
+    await ensureDir(dst);
+
+    await Deno.writeTextFile(join(src, "target"), "src-data");
+    await Deno.symlink(join(src, "target"), join(src, "latest"), {
+      type: "file",
+    });
+    await Deno.writeTextFile(join(dst, "target"), "dst-data");
+    await Deno.symlink(join(dst, "target"), join(dst, "latest"), {
+      type: "file",
+    });
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(result.skipped, 2);
+    result.skippedPaths.sort();
+    assertEquals(result.skippedPaths, ["latest", "target"]);
+
+    assertEquals(
+      await Deno.readTextFile(join(src, "target")),
+      "src-data",
+    );
+    assertEquals(
+      await Deno.readTextFile(join(dst, "target")),
+      "dst-data",
+    );
+  });
+});
+
+Deno.test("mergeDirInto: mixed tree — partial collision preserves only colliding branch", async () => {
+  await withTempDir(async (root) => {
+    const src = join(root, "src");
+    const dst = join(root, "dst");
+
+    await ensureDir(join(src, "model-a"));
+    await ensureDir(join(src, "model-b"));
+    await ensureDir(join(dst, "model-a"));
+
+    await Deno.writeTextFile(join(src, "model-a", "raw"), "src-a");
+    await Deno.writeTextFile(join(dst, "model-a", "raw"), "dst-a");
+    await Deno.writeTextFile(join(src, "model-b", "raw"), "src-b");
+
+    const result = await mergeDirInto(src, dst);
+
+    assertEquals(result.moved, 1);
+    assertEquals(result.skipped, 1);
+    assertEquals(result.skippedPaths, ["model-a/raw"]);
+
+    assertEquals(
+      await Deno.readTextFile(join(src, "model-a", "raw")),
+      "src-a",
+    );
+    assertEquals(await exists(join(src, "model-b")), false);
+    assertEquals(await exists(join(src, "model-a")), true);
+
+    assertEquals(
+      await Deno.readTextFile(join(dst, "model-b", "raw")),
+      "src-b",
+    );
+  });
+});
+
+// --- removeEmptyDirs ---
+
+Deno.test("removeEmptyDirs: removes fully empty tree", async () => {
+  await withTempDir(async (root) => {
+    const dir = join(root, "empty");
+    await ensureDir(join(dir, "a", "b"));
+    await ensureDir(join(dir, "c"));
+
+    const removed = await removeEmptyDirs(dir);
+    assertEquals(removed, true);
+    assertEquals(await exists(dir), false);
+  });
+});
+
+Deno.test("removeEmptyDirs: preserves dir containing a file", async () => {
+  await withTempDir(async (root) => {
+    const dir = join(root, "notempty");
+    await ensureDir(join(dir, "a"));
+    await Deno.writeTextFile(join(dir, "a", "keep.txt"), "data");
+
+    const removed = await removeEmptyDirs(dir);
+    assertEquals(removed, false);
+    assertEquals(await exists(join(dir, "a", "keep.txt")), true);
+  });
+});
+
+Deno.test("removeEmptyDirs: removes empty siblings but preserves occupied dir", async () => {
+  await withTempDir(async (root) => {
+    const dir = join(root, "mixed");
+    await ensureDir(join(dir, "empty-child"));
+    await ensureDir(join(dir, "occupied"));
+    await Deno.writeTextFile(join(dir, "occupied", "file"), "data");
+
+    const removed = await removeEmptyDirs(dir);
+    assertEquals(removed, false);
+    assertEquals(await exists(join(dir, "empty-child")), false);
+    assertEquals(await exists(join(dir, "occupied", "file")), true);
+  });
+});

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -49,6 +49,13 @@ export interface NamespaceMigrateProgressData {
   destination: string;
 }
 
+export interface NamespaceMigrateWarningData {
+  subdir: string;
+  source: string;
+  destination: string;
+  skippedPaths: string[];
+}
+
 export interface NamespaceMigrateCompletedData {
   namespace: string;
   datastorePath: string;
@@ -62,6 +69,7 @@ export interface NamespaceMigrateCompletedData {
 export type NamespaceMigrateEvent =
   | { kind: "preview"; data: NamespaceMigratePreviewData }
   | { kind: "progress"; data: NamespaceMigrateProgressData }
+  | { kind: "warning"; data: NamespaceMigrateWarningData }
   | { kind: "completed"; data: NamespaceMigrateCompletedData }
   | {
     kind: "error";
@@ -78,6 +86,12 @@ export interface NamespaceMigrateInput {
 export interface DirSize {
   fileCount: number;
   totalBytes: number;
+}
+
+export interface MergeDirResult {
+  moved: number;
+  skipped: number;
+  skippedPaths: string[];
 }
 
 export const INFRASTRUCTURE_FILES = new Set([
@@ -100,7 +114,14 @@ export interface NamespaceMigrateDeps {
   dirHasDataFiles: (path: string) => Promise<boolean>;
   dirSize: (path: string) => Promise<DirSize>;
   renameDir: (source: string, destination: string) => Promise<void>;
-  mergeDirInto: (source: string, destination: string) => Promise<number>;
+  mergeDirInto: (
+    source: string,
+    destination: string,
+  ) => Promise<MergeDirResult>;
+  findFileCollisions: (
+    source: string,
+    destination: string,
+  ) => Promise<string[]>;
   ensureDir: (path: string) => Promise<void>;
   invalidateCatalog: () => void;
   markDirtyBulk: () => Promise<void>;
@@ -131,6 +152,7 @@ export async function* datastoreNamespaceMigrate(
 
       const datastorePath = deps.getDatastorePath();
       const directories: SubdirPreview[] = [];
+      const allCollisions: Array<{ subdir: string; paths: string[] }> = [];
 
       for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
         const source = input.reverse
@@ -160,6 +182,16 @@ export async function* datastoreNamespaceMigrate(
           return;
         }
 
+        if (!input.reverse && await deps.dirExists(destination)) {
+          const collidingPaths = await deps.findFileCollisions(
+            source,
+            destination,
+          );
+          if (collidingPaths.length > 0) {
+            allCollisions.push({ subdir, paths: collidingPaths });
+          }
+        }
+
         const size = await deps.dirSize(source);
         directories.push({
           subdir,
@@ -168,6 +200,26 @@ export async function* datastoreNamespaceMigrate(
           fileCount: size.fileCount,
           totalBytes: size.totalBytes,
         });
+      }
+
+      if (allCollisions.length > 0) {
+        const totalCollisions = allCollisions.reduce(
+          (sum, c) => sum + c.paths.length,
+          0,
+        );
+        const listing = allCollisions
+          .flatMap((c) => c.paths.map((p) => `  ${c.subdir}/${p}`))
+          .join("\n");
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Cannot migrate: ${totalCollisions} file(s) already exist at the ` +
+              `destination and would be lost during merge. Remove or rename ` +
+              `the conflicting files first:\n${listing}`,
+          ),
+          succeededDirectories: [],
+        };
+        return;
       }
 
       if (directories.length === 0) {
@@ -229,7 +281,21 @@ export async function* datastoreNamespaceMigrate(
         try {
           await deps.ensureDir(dirname(dir.destination));
           if (await deps.dirExists(dir.destination)) {
-            await deps.mergeDirInto(dir.source, dir.destination);
+            const result = await deps.mergeDirInto(
+              dir.source,
+              dir.destination,
+            );
+            if (result.skipped > 0) {
+              yield {
+                kind: "warning",
+                data: {
+                  subdir: dir.subdir,
+                  source: dir.source,
+                  destination: dir.destination,
+                  skippedPaths: result.skippedPaths,
+                },
+              };
+            }
           } else {
             await deps.renameDir(dir.source, dir.destination);
           }

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -23,6 +23,7 @@ import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
   datastoreNamespaceMigrate,
+  type MergeDirResult,
   type NamespaceMigrateDeps,
   type NamespaceMigrateEvent,
 } from "./namespace_migrate.ts";
@@ -40,7 +41,9 @@ function makeDeps(
     dirHasDataFiles: () => Promise.resolve(false),
     dirSize: () => Promise.resolve({ fileCount: 0, totalBytes: 0 }),
     renameDir: () => Promise.resolve(),
-    mergeDirInto: () => Promise.resolve(0),
+    mergeDirInto: (): Promise<MergeDirResult> =>
+      Promise.resolve({ moved: 0, skipped: 0, skippedPaths: [] }),
+    findFileCollisions: () => Promise.resolve([]),
     ensureDir: () => Promise.resolve(),
     invalidateCatalog: () => {},
     markDirtyBulk: () => Promise.resolve(),
@@ -294,4 +297,180 @@ Deno.test("datastoreNamespaceMigrate: skips nonexistent subdirs", async () => {
     assertEquals(events[0].data.directories.length, 1);
     assertEquals(events[0].data.directories[0].subdir, "data");
   }
+});
+
+Deno.test("datastoreNamespaceMigrate: pre-flight aborts on file collisions in forward migration", async () => {
+  const ctx = createLibSwampContext({});
+  const allPaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, NAMESPACE, "data"),
+  ]);
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(allPaths.has(path)),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+    findFileCollisions: (_src, _dst) =>
+      Promise.resolve(["model-a/latest.yaml", "model-b/v1.yaml"]),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "error");
+  if (events[0].kind === "error") {
+    assertStringIncludes(events[0].error.message, "2 file(s) already exist");
+    assertStringIncludes(events[0].error.message, "model-a/latest.yaml");
+    assertStringIncludes(events[0].error.message, "model-b/v1.yaml");
+    assertEquals(events[0].succeededDirectories, []);
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: re-run after partial failure detects collisions before mutation", async () => {
+  const ctx = createLibSwampContext({});
+  const existingPaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, "outputs"),
+    join(DS_PATH, NAMESPACE, "data"),
+  ]);
+  let renameCalled = false;
+  let mergeCalled = false;
+
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(existingPaths.has(path)),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+    findFileCollisions: (src, _dst) => {
+      if (src === join(DS_PATH, "data")) {
+        return Promise.resolve(["colliding-file.yaml"]);
+      }
+      return Promise.resolve([]);
+    },
+    renameDir: () => {
+      renameCalled = true;
+      return Promise.resolve();
+    },
+    mergeDirInto: () => {
+      mergeCalled = true;
+      return Promise.resolve({ moved: 0, skipped: 0, skippedPaths: [] });
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const errorEvent = events.find((e) => e.kind === "error");
+  assertEquals(errorEvent?.kind, "error");
+  if (errorEvent?.kind === "error") {
+    assertStringIncludes(
+      errorEvent.error.message,
+      "1 file(s) already exist",
+    );
+    assertStringIncludes(errorEvent.error.message, "colliding-file.yaml");
+  }
+  assertEquals(renameCalled, false);
+  assertEquals(mergeCalled, false);
+});
+
+Deno.test("datastoreNamespaceMigrate: nested collisions across multiple subdirs are all reported", async () => {
+  const ctx = createLibSwampContext({});
+  const allPaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, NAMESPACE, "data"),
+    join(DS_PATH, "outputs"),
+    join(DS_PATH, NAMESPACE, "outputs"),
+  ]);
+
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(allPaths.has(path)),
+    dirSize: () => Promise.resolve({ fileCount: 3, totalBytes: 1000 }),
+    findFileCollisions: (src, _dst) => {
+      if (src === join(DS_PATH, "data")) {
+        return Promise.resolve(["a/b/deep-file.yaml"]);
+      }
+      if (src === join(DS_PATH, "outputs")) {
+        return Promise.resolve(["report.json"]);
+      }
+      return Promise.resolve([]);
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: false, reverse: false }),
+  );
+
+  assertEquals(events.length, 1);
+  assertEquals(events[0].kind, "error");
+  if (events[0].kind === "error") {
+    assertStringIncludes(events[0].error.message, "2 file(s)");
+    assertStringIncludes(events[0].error.message, "data/a/b/deep-file.yaml");
+    assertStringIncludes(events[0].error.message, "outputs/report.json");
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: mergeDirInto skipped files yield warning event", async () => {
+  const ctx = createLibSwampContext({});
+  const allPaths = new Set([
+    join(DS_PATH, "data"),
+    join(DS_PATH, NAMESPACE, "data"),
+  ]);
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(allPaths.has(path)),
+    dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
+    findFileCollisions: () => Promise.resolve([]),
+    mergeDirInto: () =>
+      Promise.resolve({
+        moved: 3,
+        skipped: 1,
+        skippedPaths: ["leftover.yaml"],
+      }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const warningEvent = events.find((e) => e.kind === "warning");
+  assertEquals(warningEvent?.kind, "warning");
+  if (warningEvent?.kind === "warning") {
+    assertEquals(warningEvent.data.subdir, "data");
+    assertEquals(warningEvent.data.skippedPaths, ["leftover.yaml"]);
+    assertEquals(warningEvent.data.source, join(DS_PATH, "data"));
+    assertEquals(
+      warningEvent.data.destination,
+      join(DS_PATH, NAMESPACE, "data"),
+    );
+  }
+
+  const completedEvent = events.find((e) => e.kind === "completed");
+  assertEquals(completedEvent?.kind, "completed");
+});
+
+Deno.test("datastoreNamespaceMigrate: no collision check on reverse migration", async () => {
+  const ctx = createLibSwampContext({});
+  const existingDirs = new Set([
+    join(DS_PATH, NAMESPACE, "bundles"),
+    join(DS_PATH, "bundles"),
+  ]);
+  let collisionCheckCalled = false;
+
+  const deps = makeDeps({
+    dirExists: (path) => Promise.resolve(existingDirs.has(path)),
+    dirHasDataFiles: () => Promise.resolve(false),
+    dirSize: () => Promise.resolve({ fileCount: 3, totalBytes: 1000 }),
+    findFileCollisions: () => {
+      collisionCheckCalled = true;
+      return Promise.resolve([]);
+    },
+    mergeDirInto: () =>
+      Promise.resolve({ moved: 3, skipped: 0, skippedPaths: [] }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: true }),
+  );
+
+  assertEquals(collisionCheckCalled, false);
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1268,11 +1268,13 @@ export {
   datastoreNamespaceMigrate,
   type DirSize,
   INFRASTRUCTURE_FILES,
+  type MergeDirResult,
   type NamespaceMigrateCompletedData,
   type NamespaceMigrateDeps,
   type NamespaceMigrateEvent,
   type NamespaceMigrateInput,
   type NamespaceMigratePreviewData,
   type NamespaceMigrateProgressData,
+  type NamespaceMigrateWarningData,
   type SubdirPreview,
 } from "./datastores/namespace_migrate.ts";

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -22,6 +22,7 @@ import type {
   EventHandlers,
   NamespaceMigrateEvent,
   NamespaceMigratePreviewData,
+  NamespaceMigrateWarningData,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
@@ -71,6 +72,16 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
       progress: (e) => {
         writeOutput(green(`  ✓ ${e.data.subdir}`));
       },
+      warning: (e) => {
+        const lines = [
+          yellow(
+            `  ⚠ ${e.data.subdir}: ${e.data.skippedPaths.length} file(s) skipped (already exist at destination)`,
+          ),
+          `    Source copies preserved at: ${e.data.source}`,
+          ...e.data.skippedPaths.map((p) => `      ${p}`),
+        ];
+        writeOutput(lines.join("\n"));
+      },
       completed: (e) => {
         if (e.data.migratedDirectories.length === 0) return;
 
@@ -118,6 +129,7 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
 
 class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
   #previewData: NamespaceMigratePreviewData | null = null;
+  #warnings: NamespaceMigrateWarningData[] = [];
 
   handlers(): EventHandlers<NamespaceMigrateEvent> {
     return {
@@ -125,9 +137,15 @@ class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
         this.#previewData = e.data;
       },
       progress: () => {},
+      warning: (e) => {
+        this.#warnings.push(e.data);
+      },
       completed: (e) => {
         if (e.data.migratedDirectories.length > 0) {
-          writeOutput(JSON.stringify(e.data, null, 2));
+          const output = this.#warnings.length > 0
+            ? { ...e.data, warnings: this.#warnings }
+            : e.data;
+          writeOutput(JSON.stringify(output, null, 2));
         } else {
           writeOutput(JSON.stringify(this.#previewData, null, 2));
         }


### PR DESCRIPTION
## Summary

- **Pre-flight collision detection** on forward migration: scans source and destination trees for overlapping files before any mutation. If collisions exist, aborts with an error listing every conflicting path — no partial state, no data loss. Mirrors the reverse migration's existing pre-flight check.
- **Defensive `mergeDirInto` fix**: tracks skipped (colliding) files, replaces `Deno.remove(source, {recursive: true})` with bottom-up empty-directory-only cleanup, and returns `{ moved, skipped, skippedPaths }`. Colliding source files survive.
- **Structured warning event** (`kind: "warning"`) yielded if collisions slip past pre-flight (TOCTOU defense-in-depth). Surfaces in both log and JSON output modes per the dual-mode rule.
- **Extracted** `findFileCollisions`, `mergeDirInto`, and `removeEmptyDirs` into `src/infrastructure/persistence/directory_merge.ts` with 13 real-filesystem tests covering: top-level and nested collisions, symlink collisions, symlink-to-directory handling, empty-dir cleanup, mixed-tree partial collisions, and `removeEmptyDirs` edge cases.

Closes H6: `mergeDirInto` silently deleted source files that collided with the destination. Reachable when re-running `swamp datastore namespace migrate --confirm` after a partial failure.

## Test Plan

- 6857 tests pass (0 failures), including 13 new real-filesystem tests and 5 new generator-level tests
- Verified before/after with compiled binary:
  - **Before**: colliding source file destroyed — `DATA LOSS`
  - **After**: pre-flight detects collision, aborts with actionable error, all files survive
- Symlink handling verified: collisions detected, `latest`-style symlinks preserved
- Remote/extension datastores unaffected — merge operates on local paths only; `markDirtyBulk` flags changes for explicit push

🤖 Generated with [Claude Code](https://claude.com/claude-code)