### PR TITLE
feat(type-describe): show feature-request hint for @swamp/* extension types

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -21,7 +21,9 @@ via `swamp-extension-publish`.
    `swamp extension pull <package>` and use it. Stop.
 2. `swamp model type search <query>` — check built-in/installed local types.
 3. Extend an existing type (including `@swamp` extensions) if it covers the
-   domain but lacks the method you need.
+   domain but lacks the method you need. If the type is an official `@swamp/*`
+   extension, also file a feature request so the maintainers learn about the
+   gap: `swamp issue feature --extension @swamp/<name>`.
 4. For local or private extensions, use `swamp extension source add <path>`.
 5. Only create a new extension if nothing fits.
 

--- a/src/presentation/renderers/type_describe.ts
+++ b/src/presentation/renderers/type_describe.ts
@@ -59,6 +59,15 @@ class LogTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
           lines.push(...formatMethodLines(data.methods));
         }
 
+        if (data.type.normalized.startsWith("@swamp/")) {
+          lines.push("");
+          lines.push(
+            dim(
+              `Missing a capability? swamp issue feature --extension ${data.type.normalized}`,
+            ),
+          );
+        }
+
         writeOutput(lines.join("\n"));
       },
       error: (e) => {

--- a/src/presentation/renderers/type_describe_test.ts
+++ b/src/presentation/renderers/type_describe_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { consumeStream } from "../../libswamp/mod.ts";
 import type { TypeDescribeEvent } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -101,6 +101,51 @@ Deno.test("JsonTypeDescribeRenderer - error event throws UserError", () => {
     UserError,
     "Type not found",
   );
+});
+
+Deno.test("LogTypeDescribeRenderer: includes feature hint footer for @swamp/* types", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createTypeDescribeRenderer("log");
+    const swampData = {
+      ...testData,
+      type: { raw: "@swamp/aws", normalized: "@swamp/aws" },
+    };
+    const events: TypeDescribeEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: swampData },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    const output = logs.join("\n");
+    assertStringIncludes(
+      output,
+      "swamp issue feature --extension @swamp/aws",
+    );
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("LogTypeDescribeRenderer: omits feature hint footer for non-swamp types", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createTypeDescribeRenderer("log");
+    const events: TypeDescribeEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: testData },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    const output = logs.join("\n");
+    assertEquals(output.includes("swamp issue feature"), false);
+  } finally {
+    console.log = originalLog;
+  }
 });
 
 Deno.test("createTypeDescribeRenderer - factory returns correct type per mode", () => {


### PR DESCRIPTION
## Summary

- When `swamp model type describe` displays an official `@swamp/*` extension type, a dimmed footer now suggests `swamp issue feature --extension @swamp/<name>` so users and agents know how to request missing capabilities upstream
- The hint appears only in log mode — JSON output is unchanged
- Updates the extension skill guide to nudge toward filing feature requests when extending an `@swamp/*` type

Closes #610
Closes #611

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt` — formatting passes
- [x] `deno run test` — all 6847 tests pass (1 pre-existing flaky integration test excluded)
- [x] `deno run compile` — binary compiles successfully
- [x] Manual verification: `swamp model type describe @swamp/aws/s3/bucket` shows footer hint
- [x] Manual verification: `swamp model type describe command/shell` shows no footer
- [x] UAT gap filed as swamp-club/swamp-uat#260

🤖 Generated with [Claude Code](https://claude.com/claude-code)