### PR TITLE
fix(stream): prevent unhandled rejection on event bridge cancellation

### DIFF
--- a/src/infrastructure/stream/event_bridge.ts
+++ b/src/infrastructure/stream/event_bridge.ts
@@ -47,9 +47,17 @@ export async function* withEventBridge<TEvent, TResult>(
     .finally(() => {
       queue.close();
     });
-  for await (const event of queue) {
-    yield event;
+  try {
+    for await (const event of queue) {
+      yield event;
+    }
+    await promise;
+    return result;
+  } finally {
+    // When the generator is returned early (abort/cancellation), the yield
+    // exits without reaching `await promise`. Close the queue so the executor
+    // sees the signal, and absorb any rejection so it doesn't become unhandled.
+    queue.close();
+    await promise.catch(() => {});
   }
-  await promise;
-  return result;
 }

--- a/src/infrastructure/stream/event_bridge_test.ts
+++ b/src/infrastructure/stream/event_bridge_test.ts
@@ -119,6 +119,46 @@ Deno.test("withEventBridge handles zero events", async () => {
   assertEquals(result.value, "done");
 });
 
+Deno.test("withEventBridge: early return does not leak unhandled rejection", async () => {
+  const deferred = Promise.withResolvers<void>();
+
+  async function* run(): AsyncGenerator<string> {
+    yield* withEventBridge<string, void>((push) => {
+      push("first");
+      return deferred.promise;
+    });
+  }
+
+  const gen = run();
+  const first = await gen.next();
+  assertEquals(first.value, "first");
+
+  // Reject concurrently — gen.return() awaits the promise in its finally block
+  const returnPromise = gen.return(undefined as unknown as string);
+  deferred.reject(new Error("late rejection after cancellation"));
+  await returnPromise;
+});
+
+Deno.test("withEventBridge: early return with resolving promise does not leak", async () => {
+  const deferred = Promise.withResolvers<string>();
+
+  async function* run(): AsyncGenerator<string> {
+    const result = yield* withEventBridge<string, string>((push) => {
+      push("event");
+      return deferred.promise;
+    });
+    return result;
+  }
+
+  const gen = run();
+  const first = await gen.next();
+  assertEquals(first.value, "event");
+
+  const returnPromise = gen.return(undefined as unknown as string);
+  deferred.resolve("late result");
+  await returnPromise;
+});
+
 Deno.test("withEventBridge handles push after error gracefully", async () => {
   // If the callback pushes events then rejects, events before the
   // rejection should still be yielded and the error should propagate.


### PR DESCRIPTION
## Summary

- `withEventBridge` had no `try/finally` around its yield + await sequence, so when a consumer cancelled the generator mid-yield (e.g. via abort signal), the in-flight executor promise rejected with no handler — crashing the process as an unhandled rejection
- Wrapped the yield loop and promise await in `try/finally` that closes the queue and absorbs orphaned rejections on early return
- Added two tests exercising the cancellation path with both rejecting and resolving in-flight promises

## Test Plan

- New test `early return does not leak unhandled rejection` — reproduces the crash (unhandled rejection from a deferred reject after `gen.return()`) and verifies it's absorbed
- New test `early return with resolving promise does not leak` — verifies clean cancellation when the executor resolves after early return
- All 6843 existing tests pass, including the 8 event_bridge tests
- `deno check`, `deno lint`, `deno fmt` all clean