### PR TITLE
fix(data-writer): prevent duplicate DataHandles from createFileWriterFactory

### DIFF
--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -920,27 +920,13 @@ export function createFileWriterFactory(
 
     // Wrap write methods to track handles
     const originalWriteAll = writer.writeAll.bind(writer);
-    const originalWriteText = writer.writeText.bind(writer);
-    const originalWriteStream = writer.writeStream.bind(writer);
     const originalFinalize = writer.finalize.bind(writer);
 
+    // Only wrap the terminal methods (writeAll, finalize) — writeText delegates
+    // to writeAll and writeStream delegates to finalize, so wrapping those too
+    // would record each handle twice.
     writer.writeAll = async (content: Uint8Array) => {
       const handle = await originalWriteAll(content);
-      handles.push(handle);
-      return handle;
-    };
-
-    writer.writeText = async (text: string) => {
-      const handle = await originalWriteText(text);
-      handles.push(handle);
-      return handle;
-    };
-
-    writer.writeStream = async (
-      stream: ReadableStream<Uint8Array>,
-      opts?: { onLine?: (line: string) => void },
-    ) => {
-      const handle = await originalWriteStream(stream, opts);
       handles.push(handle);
       return handle;
     };

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1402,3 +1402,66 @@ Deno.test("createResourceWriter: succeeds for non-sensitive resources without va
   });
   assertEquals(handle.name, "main");
 });
+
+// --- getHandles deduplication tests ---
+
+Deno.test("createFileWriterFactory: getHandles returns one handle per writeText call", async () => {
+  const repo = createMockRepo();
+  const { createFileWriter, getHandles } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+  );
+
+  const writer = createFileWriter("log", "test-log");
+  await writer.writeText("hello");
+
+  assertEquals(getHandles().length, 1);
+});
+
+Deno.test("createFileWriterFactory: getHandles returns one handle per writeAll call", async () => {
+  const repo = createMockRepo();
+  const { createFileWriter, getHandles } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+  );
+
+  const writer = createFileWriter("log", "test-log");
+  await writer.writeAll(new TextEncoder().encode("hello"));
+
+  assertEquals(getHandles().length, 1);
+});
+
+Deno.test("createFileWriterFactory: getHandles returns one handle per writeStream call", async () => {
+  const tmpFile = await Deno.makeTempFile();
+  try {
+    const repo = {
+      ...createMockRepo(),
+      allocateVersion: () =>
+        Promise.resolve({ version: 1, contentPath: tmpFile }),
+    };
+    const { createFileWriter, getHandles } = createFileWriterFactory(
+      repo,
+      modelType,
+      modelId,
+      testFiles,
+    );
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("hello"));
+        controller.close();
+      },
+    });
+
+    const writer = createFileWriter("log", "test-log");
+    await writer.writeStream(stream);
+
+    assertEquals(getHandles().length, 1);
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary

- `createFileWriterFactory` wrapped all four writer methods (`writeAll`, `writeText`, `writeStream`, `finalize`) to track handles, but `writeText` delegates to `writeAll` and `writeStream` delegates to `finalize` on the same instance — so each handle was pushed twice into the tracking array.
- Removed the `writeText` and `writeStream` wrappers, keeping only the two terminal methods (`writeAll`, `finalize`) that actually mint handles via `buildHandle()`.
- This caused duplicate entries in persisted `ModelOutput.artifacts` and workflow `dataArtifacts` for any extension using `createFileWriter(...).writeText(...)` or `.writeStream(...)`.

## Test Plan

- Added three new tests covering `getHandles()` deduplication for `writeText`, `writeAll`, and `writeStream` paths
- All 6900 tests pass, `deno check`, `deno lint`, `deno fmt` clean