### PR TITLE
fix(vaults): catch errors per vault so one bad config doesn't disable the rest

### DIFF
--- a/src/domain/drivers/driver_type_registry.ts
+++ b/src/domain/drivers/driver_type_registry.ts
@@ -108,8 +108,7 @@ export class DriverTypeRegistry {
 
   /**
    * Clears the extension-loaded flag so the next call to
-   * {@link ensureLoaded} re-runs the configured loader. Used by commands
-   * that re-scan extensions at runtime (e.g. `swamp open`).
+   * {@link ensureLoaded} re-runs the configured loader.
    */
   resetLoadedFlag(): void {
     this.extensionsLoaded = false;

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -790,9 +790,7 @@ export class ModelRegistry {
 
   /**
    * Clears the extension-loaded flag so the next call to
-   * {@link ensureLoaded} re-runs the configured loader. Used by commands
-   * that can re-scan extensions at runtime (e.g. `swamp open` after
-   * installing a new extension or switching repositories). Does not
+   * {@link ensureLoaded} re-runs the configured loader. Does not
    * clear already-registered models.
    */
   resetLoadedFlag(): void {

--- a/src/domain/reports/report_registry.ts
+++ b/src/domain/reports/report_registry.ts
@@ -88,8 +88,7 @@ export class ReportRegistry {
 
   /**
    * Clears the extension-loaded flag so the next call to
-   * {@link ensureLoaded} re-runs the configured loader. Used by commands
-   * that re-scan extensions at runtime (e.g. `swamp open`).
+   * {@link ensureLoaded} re-runs the configured loader.
    */
   resetLoadedFlag(): void {
     this.extensionsLoaded = false;

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -75,6 +75,9 @@ export class VaultService {
   ): Promise<VaultService> {
     await vaultTypeRegistry.ensureLoaded();
     const vaultService = new VaultService(refreshOptions);
+    let vaultConfigs: Awaited<
+      ReturnType<YamlVaultConfigRepository["findAll"]>
+    >;
     try {
       const effectiveVaultsDir = vaultsDir ?? join(repoDir, "vaults");
       const vaultRepo = new YamlVaultConfigRepository(
@@ -82,8 +85,14 @@ export class VaultService {
         undefined,
         effectiveVaultsDir,
       );
-      const vaultConfigs = await vaultRepo.findAll();
-      for (const vaultConfig of vaultConfigs) {
+      vaultConfigs = await vaultRepo.findAll();
+    } catch (error) {
+      getLogger("vaults").debug`Failed to load vault configs: ${error}`;
+      vaultService.ensureDefaultVaults();
+      return vaultService;
+    }
+    for (const vaultConfig of vaultConfigs) {
+      try {
         // Auto-remap renamed vault types so old configs load transparently
         let vaultType = vaultConfig.type;
         const renamedTo = RENAMED_VAULT_TYPES[vaultType.toLowerCase()];
@@ -114,17 +123,16 @@ export class VaultService {
           type: vaultType,
           config,
         });
-      }
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Unsupported vault type")
-      ) {
-        // Surface unsupported type errors as warnings so users see migration hints
-        getLogger("vaults").warn`${error.message}`;
-      } else {
-        // Repository may not exist yet, or vault config may be invalid
-        getLogger("vaults").debug`Failed to load vault configs: ${error}`;
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("Unsupported vault type")
+        ) {
+          getLogger("vaults").warn`${error.message}`;
+        } else {
+          getLogger("vaults")
+            .warn`Failed to load vault '${vaultConfig.name}': ${error}`;
+        }
       }
     }
     vaultService.ensureDefaultVaults();

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -469,6 +469,51 @@ Deno.test("VaultService - refresh-aware get", async (t) => {
   );
 });
 
+Deno.test("VaultService - fromRepository continues loading after a bad vault config", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    // Vault "bad" has an unsupported type — it should fail to load
+    const badDir = join(tempDir, "vaults", "bad");
+    await ensureDir(badDir);
+    await Deno.writeTextFile(
+      join(badDir, "bad-id.yaml"),
+      stringifyYaml({
+        id: "bad-id",
+        name: "bad",
+        type: "totally-bogus-type",
+        config: {},
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    // Vault "good" has a valid type — it should still load even though "bad" failed
+    const goodDir = join(tempDir, "vaults", "good");
+    await ensureDir(goodDir);
+    await Deno.writeTextFile(
+      join(goodDir, "good-id.yaml"),
+      stringifyYaml({
+        id: "good-id",
+        name: "good",
+        type: "mock",
+        config: { "key": "value" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    const vaultService = await VaultService.fromRepository(tempDir);
+    const names = vaultService.getVaultNames();
+
+    // "good" must be registered despite "bad" failing
+    assertStringIncludes(names.join(","), "good");
+
+    // Verify we can actually use the good vault
+    const secret = await vaultService.get("good", "key");
+    assertEquals(secret, "value");
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
+});
+
 Deno.test("VaultService - fromRepository auto-remaps renamed vault types", async (t) => {
   await t.step(
     "should remap 'aws' type to '@swamp/aws-sm' when loading from repository",

--- a/src/domain/vaults/vault_type_registry.ts
+++ b/src/domain/vaults/vault_type_registry.ts
@@ -112,8 +112,7 @@ export class VaultTypeRegistry {
 
   /**
    * Clears the extension-loaded flag so the next call to
-   * {@link ensureLoaded} re-runs the configured loader. Used by commands
-   * that re-scan extensions at runtime (e.g. `swamp open`).
+   * {@link ensureLoaded} re-runs the configured loader.
    */
   resetLoadedFlag(): void {
     this.extensionsLoaded = false;


### PR DESCRIPTION
## Summary

- **Per-iteration error handling in `VaultService.fromRepository`**: The entire vault config loop was wrapped in a single `try/catch`, so one bad vault (unsupported type, broken extension, bad config) aborted iteration and silently prevented all subsequent vaults from loading. Split into an outer catch for `findAll()` failures and a per-iteration catch that logs at `warn` and continues.
- **Log level upgrade**: Per-vault errors now log at `warn` instead of `debug`, so users see which vault failed and why instead of a misleading "Vault 'x' not found" downstream.
- **Stale comment cleanup**: Removed references to the removed `swamp open` command from JSDoc in four registry files.

## Test Plan

- Added `VaultService - fromRepository continues loading after a bad vault config` test: creates a bad vault (unsupported type) and a good vault (mock) on disk, asserts the good vault is registered and usable despite the bad one failing first.
- All 6892 existing tests pass (178 steps), `deno check`, `deno lint`, `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)