### PR TITLE
fix(presentation): fix action key interception, stale preview, render hangs, and timer races

### DIFF
--- a/src/presentation/renderers/components/help_bar.tsx
+++ b/src/presentation/renderers/components/help_bar.tsx
@@ -57,7 +57,7 @@ export function HelpBar(props: HelpBarProps): React.ReactElement {
 
   if (actions && actions.length > 0) {
     for (const action of actions) {
-      parts.push(`${action.key} ${action.label.toLowerCase()}`);
+      parts.push(`Ctrl-${action.key} ${action.label.toLowerCase()}`);
     }
   }
 

--- a/src/presentation/renderers/components/hooks/use_preview_fetch.ts
+++ b/src/presentation/renderers/components/hooks/use_preview_fetch.ts
@@ -118,6 +118,9 @@ export function usePreviewFetch<T, D>(
       return;
     }
 
+    // Increment fetch ID to invalidate any in-flight fetch, even on cache hits
+    const currentFetchId = ++fetchIdRef.current;
+
     const key = keyFn(item);
 
     // Check cache first
@@ -126,9 +129,6 @@ export function usePreviewFetch<T, D>(
       setDetail(cached);
       return;
     }
-
-    // Increment fetch ID to invalidate any in-flight fetch
-    const currentFetchId = ++fetchIdRef.current;
 
     const timer = setTimeout(() => {
       fetchFn(item).then((result) => {

--- a/src/presentation/renderers/components/hooks/use_preview_fetch_test.tsx
+++ b/src/presentation/renderers/components/hooks/use_preview_fetch_test.tsx
@@ -17,8 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import React, { useState } from "react";
 import { assertEquals } from "@std/assert";
-import { LruCache } from "./use_preview_fetch.ts";
+import { render } from "ink-testing-library";
+import { Text } from "ink";
+import { LruCache, usePreviewFetch } from "./use_preview_fetch.ts";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+function tick(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// --- LruCache unit tests ---
 
 Deno.test("LruCache: get returns undefined for missing key", () => {
   const cache = new LruCache<string, number>(3);
@@ -98,4 +109,96 @@ Deno.test("LruCache: size 1 always evicts on new insert", () => {
   assertEquals(cache.size, 1);
   assertEquals(cache.get("a"), undefined);
   assertEquals(cache.get("b"), 2);
+});
+
+// --- usePreviewFetch hook tests ---
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function UpdatableProbe(props: {
+  initialItem: string | undefined;
+  fetchFn: (item: string) => Promise<string>;
+  onDetail: (detail: string | undefined) => void;
+}) {
+  const [item, setItem] = useState(props.initialItem);
+
+  const { detail } = usePreviewFetch(
+    item,
+    props.fetchFn,
+    (i) => i,
+    10,
+    10,
+  );
+
+  React.useEffect(() => {
+    props.onDetail(detail);
+  }, [detail]);
+
+  (globalThis as Record<string, unknown>).__setProbeItem = setItem;
+
+  return <Text>{detail ?? "none"}</Text>;
+}
+
+Deno.test({
+  name:
+    "usePreviewFetch: in-flight fetch for A is discarded after switching to cached B",
+  ...inkTestOptions,
+  fn: async () => {
+    const fetchA = deferred<string>();
+    let detail: string | undefined;
+    const bResult = "B-detail";
+
+    const fetchFn = (item: string): Promise<string> => {
+      if (item === "A") return fetchA.promise;
+      return Promise.resolve(bResult);
+    };
+
+    // Start with B to populate the LRU cache
+    const { unmount } = render(
+      <UpdatableProbe
+        initialItem="B"
+        fetchFn={fetchFn}
+        onDetail={(d) => {
+          detail = d;
+        }}
+      />,
+    );
+
+    await tick(200);
+    assertEquals(detail, bResult);
+
+    const setItem = (globalThis as Record<string, unknown>).__setProbeItem as (
+      item: string,
+    ) => void;
+
+    // Switch to A — starts an async fetch (uncached)
+    setItem("A");
+    await tick(50);
+
+    // Switch to B — cache hit, should show B's detail immediately
+    // and invalidate A's in-flight fetch via the fetch-id bump
+    setItem("B");
+    await tick(50);
+    assertEquals(detail, bResult);
+
+    // Resolve A's fetch — must NOT overwrite B's detail
+    fetchA.resolve("A-detail-stale");
+    await tick(50);
+
+    assertEquals(detail, bResult);
+
+    unmount();
+    delete (globalThis as Record<string, unknown>).__setProbeItem;
+  },
 });

--- a/src/presentation/renderers/components/search_picker.tsx
+++ b/src/presentation/renderers/components/search_picker.tsx
@@ -214,8 +214,8 @@ export function SearchPicker<T, D = T>(
       return;
     }
 
-    // Check for action keys
-    if (actions && input && !key.ctrl && !key.meta) {
+    // Action keys require Ctrl so they don't conflict with query input
+    if (actions && input && key.ctrl && !key.meta) {
       const action = actions.find((a) => a.key === input);
       if (action) {
         handleSelect(action.action);
@@ -450,7 +450,6 @@ export async function renderInteractivePicker<T, D = T>(
         emptyHint={options?.emptyHint}
         actions={options?.actions}
         onSelect={(item, scrollback, action) => {
-          cleanupTty();
           // Only print scrollback for default select (Enter), not action keys
           if (!action) {
             pendingScrollback = scrollback;
@@ -458,12 +457,16 @@ export async function renderInteractivePicker<T, D = T>(
           resolve({ item, action });
         }}
         onCancel={() => {
-          cleanupTty();
           resolve(undefined);
         }}
       />,
     );
-    waitUntilExit().catch(() => {});
+    waitUntilExit().then(() => {
+      cleanupTty();
+    }).catch(() => {
+      cleanupTty();
+      resolve(undefined);
+    });
   });
 
   // Exit alternate screen buffer — terminal restores to pre-picker state

--- a/src/presentation/renderers/components/search_picker_launch_test.tsx
+++ b/src/presentation/renderers/components/search_picker_launch_test.tsx
@@ -1,0 +1,54 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React from "react";
+import { assertEquals } from "@std/assert";
+import { renderInteractivePicker } from "./search_picker.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+Deno.test({
+  name:
+    "renderInteractivePicker: throwing renderPreview resolves to undefined instead of hanging",
+  ...inkTestOptions,
+  fn: async () => {
+    const items = [{ name: "alpha" }, { name: "bravo" }];
+
+    const result = await Promise.race([
+      renderInteractivePicker(
+        items,
+        "",
+        (item) => item.name,
+        (item) => <>{item.name}</>,
+        () => {
+          throw new Error("simulated render crash");
+        },
+        (item) => item.name,
+        "items",
+      ),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 3000)
+      ),
+    ]);
+
+    // Should resolve to undefined (from the .catch path), not timeout
+    assertEquals(result !== "timeout", true);
+  },
+});

--- a/src/presentation/renderers/components/search_picker_test.tsx
+++ b/src/presentation/renderers/components/search_picker_test.tsx
@@ -22,93 +22,13 @@ import React, { useState } from "react";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { render } from "ink-testing-library";
 import { Box, Text, useInput } from "ink";
-import { SearchPicker } from "./search_picker.tsx";
 import type { ActionDef } from "./help_bar.tsx";
 
 const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
 
-interface TestItem {
-  name: string;
-}
-
-const TEST_ITEMS: TestItem[] = [
-  { name: "alpha" },
-  { name: "bravo" },
-  { name: "charlie" },
-];
-
-function renderTestPicker(opts: {
-  onSelect?: (item: TestItem, scrollback: string, action?: string) => void;
-  onCancel?: () => void;
-  actions?: ActionDef[];
-}) {
-  return render(
-    <SearchPicker
-      items={TEST_ITEMS}
-      initialQuery=""
-      selector={(item) => item.name}
-      renderResultLine={(item) => <>{item.name}</>}
-      renderPreview={(item) => <>{item.name}</>}
-      renderScrollback={(item) => item.name}
-      itemLabel="items"
-      actions={opts.actions}
-      onSelect={opts.onSelect ?? (() => {})}
-      onCancel={opts.onCancel ?? (() => {})}
-    />,
-  );
-}
-
 function tick(ms = 50): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-Deno.test({
-  name:
-    "SearchPicker: plain action-key letter appends to query instead of triggering action",
-  ...inkTestOptions,
-  fn: async () => {
-    let actionFired: string | undefined;
-    const { stdin, lastFrame } = renderTestPicker({
-      actions: [{ key: "r", label: "Run", action: "run" }],
-      onSelect: (_item, _sb, action) => {
-        actionFired = action;
-      },
-    });
-
-    await tick();
-    stdin.write("r");
-    await tick();
-
-    assertEquals(actionFired, undefined);
-    const frame = lastFrame() ?? "";
-    assertStringIncludes(frame, "r");
-  },
-});
-
-Deno.test({
-  name:
-    "SearchPicker: query with action-key characters filters results normally",
-  ...inkTestOptions,
-  fn: async () => {
-    let actionFired: string | undefined;
-    const { stdin, lastFrame } = renderTestPicker({
-      actions: [{ key: "r", label: "Run", action: "run" }],
-      onSelect: (_item, _sb, action) => {
-        actionFired = action;
-      },
-    });
-
-    await tick();
-    stdin.write("b");
-    await tick();
-    stdin.write("r");
-    await tick();
-
-    assertEquals(actionFired, undefined);
-    const frame = lastFrame() ?? "";
-    assertStringIncludes(frame, "br");
-  },
-});
 
 /**
  * Minimal component that mirrors the SearchPicker's action-key logic in

--- a/src/presentation/renderers/components/search_picker_test.tsx
+++ b/src/presentation/renderers/components/search_picker_test.tsx
@@ -1,0 +1,210 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// deno-lint-ignore verbatim-module-syntax
+import React, { useState } from "react";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { render } from "ink-testing-library";
+import { Box, Text, useInput } from "ink";
+import { SearchPicker } from "./search_picker.tsx";
+import type { ActionDef } from "./help_bar.tsx";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+interface TestItem {
+  name: string;
+}
+
+const TEST_ITEMS: TestItem[] = [
+  { name: "alpha" },
+  { name: "bravo" },
+  { name: "charlie" },
+];
+
+function renderTestPicker(opts: {
+  onSelect?: (item: TestItem, scrollback: string, action?: string) => void;
+  onCancel?: () => void;
+  actions?: ActionDef[];
+}) {
+  return render(
+    <SearchPicker
+      items={TEST_ITEMS}
+      initialQuery=""
+      selector={(item) => item.name}
+      renderResultLine={(item) => <>{item.name}</>}
+      renderPreview={(item) => <>{item.name}</>}
+      renderScrollback={(item) => item.name}
+      itemLabel="items"
+      actions={opts.actions}
+      onSelect={opts.onSelect ?? (() => {})}
+      onCancel={opts.onCancel ?? (() => {})}
+    />,
+  );
+}
+
+function tick(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.test({
+  name:
+    "SearchPicker: plain action-key letter appends to query instead of triggering action",
+  ...inkTestOptions,
+  fn: async () => {
+    let actionFired: string | undefined;
+    const { stdin, lastFrame } = renderTestPicker({
+      actions: [{ key: "r", label: "Run", action: "run" }],
+      onSelect: (_item, _sb, action) => {
+        actionFired = action;
+      },
+    });
+
+    await tick();
+    stdin.write("r");
+    await tick();
+
+    assertEquals(actionFired, undefined);
+    const frame = lastFrame() ?? "";
+    assertStringIncludes(frame, "r");
+  },
+});
+
+Deno.test({
+  name:
+    "SearchPicker: query with action-key characters filters results normally",
+  ...inkTestOptions,
+  fn: async () => {
+    let actionFired: string | undefined;
+    const { stdin, lastFrame } = renderTestPicker({
+      actions: [{ key: "r", label: "Run", action: "run" }],
+      onSelect: (_item, _sb, action) => {
+        actionFired = action;
+      },
+    });
+
+    await tick();
+    stdin.write("b");
+    await tick();
+    stdin.write("r");
+    await tick();
+
+    assertEquals(actionFired, undefined);
+    const frame = lastFrame() ?? "";
+    assertStringIncludes(frame, "br");
+  },
+});
+
+/**
+ * Minimal component that mirrors the SearchPicker's action-key logic in
+ * isolation, avoiding the full fzf/layout/preview stack so we can directly
+ * observe what useInput receives for Ctrl+letter bytes.
+ */
+function ActionKeyProbe(props: {
+  actions: ActionDef[];
+  onAction: (action: string, input: string) => void;
+  onChar: (ch: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+  useInput((input, key) => {
+    if (key.escape || key.return) return;
+    if (key.backspace || key.delete) return;
+
+    if (props.actions && input && key.ctrl && !key.meta) {
+      const action = props.actions.find((a) => a.key === input);
+      if (action) {
+        props.onAction(action.action, input);
+        return;
+      }
+    }
+
+    if (input && !key.ctrl && !key.meta) {
+      setQuery((q) => q + input);
+      props.onChar(input);
+    }
+  });
+
+  return (
+    <Box>
+      <Text>query:{query}</Text>
+    </Box>
+  );
+}
+
+Deno.test({
+  name:
+    "SearchPicker: Ctrl+letter triggers action via useInput (isolated probe)",
+  ...inkTestOptions,
+  fn: async () => {
+    let firedAction: string | undefined;
+    let firedInput: string | undefined;
+    const chars: string[] = [];
+
+    const { stdin, lastFrame } = render(
+      <ActionKeyProbe
+        actions={[{ key: "r", label: "Run", action: "run" }]}
+        onAction={(action, input) => {
+          firedAction = action;
+          firedInput = input;
+        }}
+        onChar={(ch) => chars.push(ch)}
+      />,
+    );
+
+    await tick();
+    // Ctrl+r = byte 0x12
+    stdin.write("\x12");
+    await tick();
+
+    assertEquals(firedAction, "run");
+    assertEquals(firedInput, "r");
+    assertEquals(chars.length, 0);
+
+    // Verify the query didn't get the character
+    const frame = lastFrame() ?? "";
+    assertStringIncludes(frame, "query:");
+  },
+});
+
+Deno.test({
+  name: "SearchPicker: plain letter does NOT trigger action (isolated probe)",
+  ...inkTestOptions,
+  fn: async () => {
+    let firedAction: string | undefined;
+    const chars: string[] = [];
+
+    const { stdin, lastFrame } = render(
+      <ActionKeyProbe
+        actions={[{ key: "r", label: "Run", action: "run" }]}
+        onAction={(action) => {
+          firedAction = action;
+        }}
+        onChar={(ch) => chars.push(ch)}
+      />,
+    );
+
+    await tick();
+    stdin.write("r");
+    await tick();
+
+    assertEquals(firedAction, undefined);
+    assertEquals(chars, ["r"]);
+    const frame = lastFrame() ?? "";
+    assertStringIncludes(frame, "query:r");
+  },
+});

--- a/src/presentation/renderers/components/search_tui.tsx
+++ b/src/presentation/renderers/components/search_tui.tsx
@@ -206,15 +206,18 @@ export function renderInteractiveSearch<T>(
         itemLabel={itemLabel}
         emptyHint={emptyHint}
         onSelect={(item) => {
-          cleanupTty();
           resolve(item);
         }}
         onCancel={() => {
-          cleanupTty();
           resolve(undefined);
         }}
       />,
     );
-    waitUntilExit().catch(() => {});
+    waitUntilExit().then(() => {
+      cleanupTty();
+    }).catch(() => {
+      cleanupTty();
+      resolve(undefined);
+    });
   });
 }

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -94,7 +94,7 @@ class InkExtensionSearchRenderer implements ExtensionSearchRenderer {
           {
             previewKeyFn: (item) => item.name,
             actions: [
-              { key: "i", label: "Install", action: "install" },
+              { key: "n", label: "Install", action: "install" },
             ],
           },
         );

--- a/src/presentation/renderers/input_file_select.tsx
+++ b/src/presentation/renderers/input_file_select.tsx
@@ -86,16 +86,19 @@ function renderInteractiveInputFileSelect(
         hasDefaults={data.hasDefaults}
         searchDir={data.searchDir}
         onSelect={(selection) => {
-          cleanupTty();
           resolve(selection);
         }}
         onCancel={() => {
-          cleanupTty();
           resolve(undefined);
         }}
       />,
     );
-    waitUntilExit().catch(() => {});
+    waitUntilExit().then(() => {
+      cleanupTty();
+    }).catch(() => {
+      cleanupTty();
+      resolve(undefined);
+    });
   });
 }
 

--- a/src/presentation/renderers/workflow_action_select.tsx
+++ b/src/presentation/renderers/workflow_action_select.tsx
@@ -89,16 +89,19 @@ function renderInteractiveWorkflowActionSelect(
         workflowDescription={data.workflowDescription}
         hasInputs={data.hasInputs}
         onSelect={(action) => {
-          cleanupTty();
           resolve(action);
         }}
         onCancel={() => {
-          cleanupTty();
           resolve(undefined);
         }}
       />,
     );
-    waitUntilExit().catch(() => {});
+    waitUntilExit().then(() => {
+      cleanupTty();
+    }).catch(() => {
+      cleanupTty();
+      resolve(undefined);
+    });
   });
 }
 

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -33,6 +33,7 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
   private _failed = false;
   private bridge: EventBridge;
   private cleanup: (() => void) | null = null;
+  private exitPromise: Promise<void> | null = null;
   private workflowName: string;
 
   constructor(opts: WorkflowRunRenderOpts) {
@@ -52,6 +53,10 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
         }}
       />,
       { maxFps: 15 },
+    );
+    this.exitPromise = instance.waitUntilExit().then(
+      () => {},
+      () => {},
     );
     this.cleanup = () => {
       instance.unmount();
@@ -84,29 +89,29 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
       report_started: forward,
       report_completed: forward,
       report_failed: forward,
-      completed: (e) => {
+      completed: async (e) => {
         if (e.run.status === "failed") this._failed = true;
         forward(e);
         this.bridge.close();
-        setTimeout(() => this.cleanup?.(), 100);
+        await this.exitPromise;
+        this.cleanup?.();
       },
-      suspended: (e) => {
+      suspended: async (e) => {
         forward(e);
         this.bridge.close();
-        setTimeout(() => {
-          this.cleanup?.();
-          const wf = this.workflowName;
-          const step = e.stepId;
-          console.log("");
-          console.log(
-            `Workflow suspended — awaiting approval on step "${step}"`,
-          );
-          console.log("");
-          console.log(`  swamp workflow approve ${wf} ${step}`);
-          console.log(`  swamp workflow reject  ${wf} ${step}`);
-          console.log("");
-          console.log(`After approval: swamp workflow resume ${wf}`);
-        }, 100);
+        await this.exitPromise;
+        this.cleanup?.();
+        const wf = this.workflowName;
+        const step = e.stepId;
+        console.log("");
+        console.log(
+          `Workflow suspended — awaiting approval on step "${step}"`,
+        );
+        console.log("");
+        console.log(`  swamp workflow approve ${wf} ${step}`);
+        console.log(`  swamp workflow reject  ${wf} ${step}`);
+        console.log("");
+        console.log(`After approval: swamp workflow resume ${wf}`);
       },
       error: (e) => {
         forward(e);

--- a/src/presentation/renderers/workflow_run_tree/renderer_handler_test.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer_handler_test.tsx
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { InkWorkflowRunRenderer } from "./renderer.tsx";
+import type { WorkflowRunEvent } from "../../../libswamp/mod.ts";
+
+const inkTestOptions = { sanitizeOps: false, sanitizeResources: false };
+
+function tick(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeCompletedEvent(): Extract<
+  WorkflowRunEvent,
+  { kind: "completed" }
+> {
+  return {
+    kind: "completed",
+    run: {
+      id: "run-1",
+      workflowId: "wf-1",
+      workflowName: "test-wf",
+      status: "succeeded",
+      jobs: [],
+    },
+  } as Extract<WorkflowRunEvent, { kind: "completed" }>;
+}
+
+function makeSuspendedEvent(): Extract<
+  WorkflowRunEvent,
+  { kind: "suspended" }
+> {
+  return {
+    kind: "suspended",
+    run: {
+      id: "run-1",
+      workflowId: "wf-1",
+      workflowName: "test-wf",
+      status: "suspended",
+      jobs: [],
+    },
+    jobId: "job-1",
+    stepId: "approve-deploy",
+    prompt: "Approve?",
+  } as Extract<WorkflowRunEvent, { kind: "suspended" }>;
+}
+
+Deno.test({
+  name:
+    "InkWorkflowRunRenderer: completed handler returns a promise that resolves after cleanup",
+  ...inkTestOptions,
+  fn: async () => {
+    const renderer = new InkWorkflowRunRenderer({
+      workflowName: "test-wf",
+    });
+    const handlers = renderer.handlers();
+
+    // Feed the required started event so the component can transition to done
+    handlers.started({
+      kind: "started",
+      runId: "run-1",
+      workflowName: "test-wf",
+      jobs: [],
+    });
+    await tick(100);
+
+    // The completed handler should be async and await cleanup
+    const completedResult = handlers.completed(makeCompletedEvent());
+    // Should return a promise (async handler)
+    assertEquals(completedResult instanceof Promise, true);
+
+    // Await it — if cleanup races, this would hang or the process would
+    // exit before cleanup completes (which was the original H11 bug)
+    const raceResult = await Promise.race([
+      Promise.resolve(completedResult).then(() => "resolved" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 2000)),
+    ]);
+
+    assertEquals(raceResult, "resolved");
+  },
+});
+
+Deno.test({
+  name:
+    "InkWorkflowRunRenderer: suspended handler resolves without timeout (no deferred cleanup)",
+  ...inkTestOptions,
+  fn: async () => {
+    const renderer = new InkWorkflowRunRenderer({
+      workflowName: "my-deploy",
+    });
+    const handlers = renderer.handlers();
+
+    handlers.started({
+      kind: "started",
+      runId: "run-1",
+      workflowName: "my-deploy",
+      jobs: [],
+    });
+    await tick(100);
+
+    // The suspended handler should be async and resolve deterministically
+    // (not deferred behind a setTimeout that races Deno.exit)
+    const suspendedResult = handlers.suspended(makeSuspendedEvent());
+    assertEquals(suspendedResult instanceof Promise, true);
+
+    const raceResult = await Promise.race([
+      Promise.resolve(suspendedResult).then(() => "resolved" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 2000)),
+    ]);
+
+    assertEquals(raceResult, "resolved");
+  },
+});


### PR DESCRIPTION
## Summary

Fixes four presentation-layer bugs identified by static analysis:

- **H8 — Action keys intercepted before query input:** Action keys (`r`/Run, `n`/Install) now require `Ctrl` modifier so plain letters go to the search query. Remapped extension install from `i` to `n` since `Ctrl-i` is byte-identical to Tab and unreachable via Ink's input handling.
- **H9 — Stale preview shown after item change:** Preview fetch-id is incremented before the cache check (not only on cache miss), so navigating from an uncached item to a cached one invalidates any in-flight fetch and prevents stale data from overwriting the current detail.
- **H10 — Render errors swallowed; CLI hangs:** All four Ink launcher functions now resolve the outer promise via `waitUntilExit().catch()` instead of silently discarding render errors, preventing the CLI from hanging in the alternate screen buffer.
- **H11 — Cleanup deferred behind timers that race Deno.exit:** Workflow run tree renderer replaces `setTimeout`-deferred cleanup with `await exitPromise` so approval/resume instructions print deterministically before the process exits.

## Test Plan

- 4 new tests for H8: plain action-key letter appends to query; multi-char query with action-key chars; isolated probe verifies `Ctrl+r` fires action; isolated probe verifies plain `r` does not
- 1 new test for H9: reproduces uncached→cached item switch race, asserts stale fetch result does not overwrite current detail
- 1 new test for H10: calls real `renderInteractivePicker` with a throwing `renderPreview`, asserts promise resolves instead of hanging
- 2 new tests for H11: both `completed` and `suspended` handlers return promises that resolve within timeout (no deferred cleanup race)
- All 6899 existing tests pass
- `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)