### PR TITLE
fix(update): handle missing crontab binary on distros without cron

### DIFF
--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -59,26 +59,34 @@ function crontabCommandForUser(
 
 async function readCrontab(mode: LaunchdMode = "agent"): Promise<string> {
   const { command, args } = crontabCommand(mode, ["-l"]);
-  const cmd = new Deno.Command(command, {
-    args,
-    stdout: "piped",
-    stderr: "null",
-  });
-  const result = await cmd.output();
-  if (!result.success) return "";
-  return new TextDecoder().decode(result.stdout);
+  try {
+    const cmd = new Deno.Command(command, {
+      args,
+      stdout: "piped",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) return "";
+    return new TextDecoder().decode(result.stdout);
+  } catch {
+    return "";
+  }
 }
 
 async function readCrontabForUser(user: string): Promise<string> {
   const { command, args } = crontabCommandForUser(user, ["-l"]);
-  const cmd = new Deno.Command(command, {
-    args,
-    stdout: "piped",
-    stderr: "null",
-  });
-  const result = await cmd.output();
-  if (!result.success) return "";
-  return new TextDecoder().decode(result.stdout);
+  try {
+    const cmd = new Deno.Command(command, {
+      args,
+      stdout: "piped",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) return "";
+    return new TextDecoder().decode(result.stdout);
+  } catch {
+    return "";
+  }
 }
 
 async function writeCrontab(
@@ -86,13 +94,20 @@ async function writeCrontab(
   mode: LaunchdMode = "agent",
 ): Promise<void> {
   const { command, args } = crontabCommand(mode, ["-"]);
-  const cmd = new Deno.Command(command, {
-    args,
-    stdin: "piped",
-    stdout: "null",
-    stderr: "null",
-  });
-  const process = cmd.spawn();
+  let process: Deno.ChildProcess;
+  try {
+    const cmd = new Deno.Command(command, {
+      args,
+      stdin: "piped",
+      stdout: "null",
+      stderr: "null",
+    });
+    process = cmd.spawn();
+  } catch {
+    throw new Error(
+      "crontab is not installed on this system. Use systemd timers instead.",
+    );
+  }
   const writer = process.stdin.getWriter();
   await writer.write(new TextEncoder().encode(content));
   await writer.close();
@@ -107,13 +122,20 @@ async function writeCrontabForUser(
   user: string,
 ): Promise<void> {
   const { command, args } = crontabCommandForUser(user, ["-"]);
-  const cmd = new Deno.Command(command, {
-    args,
-    stdin: "piped",
-    stdout: "null",
-    stderr: "null",
-  });
-  const process = cmd.spawn();
+  let process: Deno.ChildProcess;
+  try {
+    const cmd = new Deno.Command(command, {
+      args,
+      stdin: "piped",
+      stdout: "null",
+      stderr: "null",
+    });
+    process = cmd.spawn();
+  } catch {
+    throw new Error(
+      "crontab is not installed on this system. Use systemd timers instead.",
+    );
+  }
   const writer = process.stdin.getWriter();
   await writer.write(new TextEncoder().encode(content));
   await writer.close();

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -40,6 +40,7 @@ import {
   cadenceFromSchedule,
   cronLogPath,
   cronSchedule,
+  detectInstalledCronMode,
   escapeShellPath,
 } from "./cron_scheduler.ts";
 
@@ -262,4 +263,24 @@ Deno.test({
 Deno.test("cronLogPath: daemon mode returns /var/log/swamp path", () => {
   assertPathStringIncludes(cronLogPath("daemon"), "var/log/swamp");
   assertPathStringIncludes(cronLogPath("daemon"), "autoupdate-cron.log");
+});
+
+// --- Cron missing-binary resilience tests ---
+
+Deno.test({
+  name:
+    "detectInstalledCronMode: returns null when crontab binary is not installed",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const originalPath = Deno.env.get("PATH");
+    try {
+      Deno.env.set("PATH", "/nonexistent");
+      const result = await detectInstalledCronMode();
+      assertEquals(result, null);
+    } finally {
+      if (originalPath !== undefined) {
+        Deno.env.set("PATH", originalPath);
+      }
+    }
+  },
 });


### PR DESCRIPTION
## Summary

On immutable distros like Bluefin/Fedora Silverblue, the `crontab` binary is not installed. `swamp update --setup-auto` crashes with `NotFound: Failed to spawn 'crontab'` because `detectInstalledCronMode()` spawns `crontab` to check for existing cron-based autoupdate installations, and the spawn error is unhandled.

The crash occurs before the scheduler factory can select systemd — even though systemd is available and would be the correct scheduler on these systems.

**Fix:** Wrap `readCrontab()` and `readCrontabForUser()` in try/catch to return empty string on spawn failure (matching the existing `hasSystemctl()` pattern). Also wrap `writeCrontab()` and `writeCrontabForUser()` to throw a clear error message if crontab is missing when actually writing.

## Changes

- `src/infrastructure/update/cron_scheduler.ts` — add try/catch around all four crontab spawn sites
- `src/infrastructure/update/scheduler_helpers_test.ts` — add test verifying `detectInstalledCronMode()` returns `null` when crontab is unavailable

## Test Plan

- All 42 scheduler helper tests pass (41 existing + 1 new)
- New test sets PATH to `/nonexistent` to simulate missing crontab binary, confirms `detectInstalledCronMode()` returns `null` without throwing
- Full suite: 6891 passed, 2 failed (pre-existing flaky failures unrelated to this change)
- `deno check`, `deno lint`, `deno fmt` all pass