### PR TITLE
fix(workflow): exclude Zod-defaulted fields from JSON Schema required array

### DIFF
--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -139,7 +139,8 @@ function manualZodToJsonSchema(schema: z.ZodTypeAny): object {
         const required: string[] = [];
         for (const [key, value] of Object.entries(def.shape)) {
           properties[key] = manualZodToJsonSchema(value);
-          if (getSchemaType(value) !== "optional") {
+          const valueType = getSchemaType(value);
+          if (valueType !== "optional" && valueType !== "default") {
             required.push(key);
           }
         }
@@ -175,10 +176,42 @@ function manualZodToJsonSchema(schema: z.ZodTypeAny): object {
  */
 export function zodToJsonSchema(schema: z.ZodTypeAny): object {
   try {
-    return z.toJSONSchema(schema);
+    const result = z.toJSONSchema(schema);
+    return stripDefaultsFromRequired(result);
   } catch {
     return manualZodToJsonSchema(schema);
   }
+}
+
+/**
+ * Removes fields that have a `default` value from the JSON Schema `required`
+ * array. Zod's `z.toJSONSchema()` lists defaulted fields as required (valid
+ * per the JSON Schema spec), but swamp treats a schema default as satisfying
+ * the requirement at runtime.
+ */
+function stripDefaultsFromRequired(
+  jsonSchema: object,
+): object {
+  const schema = jsonSchema as Record<string, unknown>;
+  const required = schema.required;
+  const properties = schema.properties;
+  if (
+    !Array.isArray(required) || typeof properties !== "object" ||
+    properties === null
+  ) {
+    return jsonSchema;
+  }
+  const props = properties as Record<string, Record<string, unknown>>;
+  const filtered = required.filter((key: string) =>
+    !(key in props && "default" in props[key])
+  );
+  const result = { ...schema };
+  if (filtered.length > 0) {
+    result.required = filtered;
+  } else {
+    delete result.required;
+  }
+  return result;
 }
 
 /**

--- a/src/libswamp/types/schema_helpers_test.ts
+++ b/src/libswamp/types/schema_helpers_test.ts
@@ -83,3 +83,47 @@ Deno.test("zodToJsonSchema: handles z.enum()", () => {
   // Zod's toJSONSchema may succeed for enum, but verify it works either way
   assertEquals(Array.isArray(result.enum), true);
 });
+
+Deno.test("zodToJsonSchema: field with .default() is not required", () => {
+  const schema = z.object({
+    limit: z.number().default(15),
+  });
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  assertEquals(result.type, "object");
+  const required = result.required as string[] | undefined;
+  assertEquals(required, undefined);
+});
+
+Deno.test("zodToJsonSchema: field without .default() is still required", () => {
+  const schema = z.object({
+    name: z.string(),
+  });
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  const required = result.required as string[];
+  assertEquals(required.includes("name"), true);
+});
+
+Deno.test("zodToJsonSchema: mixed defaulted and required fields", () => {
+  const schema = z.object({
+    name: z.string(),
+    limit: z.number().int().min(1).max(100).default(15),
+    verbose: z.boolean().default(false),
+  });
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  const required = result.required as string[];
+  assertEquals(required, ["name"]);
+  const props = result.properties as Record<string, Record<string, unknown>>;
+  assertEquals(props.limit.default, 15);
+  assertEquals(props.verbose.default, false);
+});
+
+Deno.test("zodToJsonSchema: optional field is not required", () => {
+  const schema = z.object({
+    name: z.string(),
+    tag: z.string().optional(),
+  });
+  const result = zodToJsonSchema(schema) as Record<string, unknown>;
+  const required = result.required as string[];
+  assertEquals(required.includes("name"), true);
+  assertEquals(required.includes("tag"), false);
+});


### PR DESCRIPTION
## Summary

- Fixes `swamp workflow validate` incorrectly treating Zod `.default()` fields as required inputs, causing false validation failures for steps that omit defaulted arguments
- Post-processes `z.toJSONSchema()` output to strip fields with a `default` value from the `required` array, and fixes the manual fallback to also exclude the `"default"` schema type
- Adds unit tests covering default-only, required-only, mixed, and optional field scenarios

Closes swamp-club#617

## Test Plan

- [x] Unit tests for `zodToJsonSchema` covering `.default()` exclusion from `required`
- [x] Verified against reproduction at `/tmp/swamp-repro-issue-617`: `swamp workflow validate` now passes for steps omitting defaulted args
- [x] `swamp model method run` continues to work with defaults applied at runtime
- [x] `swamp model type describe` output correctly omits defaulted fields from `required`
- [x] Full test suite passes (6895 passed, 1 flaky unrelated integration test)
- [x] `deno check`, `deno lint`, `deno fmt` all clean