### PR TITLE
feat(reports): add scope to report type search and make report list discoverable

### DIFF
--- a/design/reports.md
+++ b/design/reports.md
@@ -404,6 +404,23 @@ values.
 
 ## CLI
 
+### `swamp report list` / `swamp report type search`
+
+Lists registered report *definitions* — the report types currently loaded from
+extensions and builtins. This is distinct from `swamp report search`, which
+lists stored report *results* (artifacts from past runs).
+
+`swamp report list` is an alias for `swamp report type search`. Both open an
+interactive TUI picker showing each report's name, scope, and description.
+Pass `--json` for structured output.
+
+```bash
+swamp report list
+swamp report list cost
+swamp report type search
+swamp report type search --json
+```
+
 ### `swamp report get`
 
 Retrieves a stored report's content. Reports are persisted automatically after

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -19,7 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
-import { reportSearchAction, reportSearchCommand } from "./report_search.ts";
+import { reportSearchCommand } from "./report_search.ts";
 import { reportGetCommand } from "./report_get.ts";
 import { reportDescribeCommand } from "./report_describe.ts";
 import {
@@ -54,12 +54,7 @@ export const reportCommand = new Command()
   .command(
     "list",
     new Command()
-      .description("Alias for report search")
-      .hidden()
+      .description("List registered report definitions")
       .arguments("[query:string]")
-      .option(
-        "--repo-dir <dir:string>",
-        "Repository directory (env: SWAMP_REPO_DIR)",
-      )
-      .action(reportSearchAction),
+      .action(reportTypeSearchAction),
   );

--- a/src/cli/commands/report_type_search.ts
+++ b/src/cli/commands/report_type_search.ts
@@ -50,6 +50,10 @@ export async function reportTypeSearchAction(
 
   await reportRegistry.ensureLoaded();
 
+  for (const lazy of reportRegistry.getAllLazy()) {
+    await reportRegistry.ensureTypeLoaded(lazy.type);
+  }
+
   const deps: ReportTypeSearchDeps = {
     getReportTypes: () => getReportTypes(),
   };

--- a/src/domain/reports/report_types.ts
+++ b/src/domain/reports/report_types.ts
@@ -17,12 +17,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { ReportScope } from "./report.ts";
+import {
+  BUILTIN_METHOD_REPORTS,
+  BUILTIN_WORKFLOW_REPORTS,
+} from "./builtin/mod.ts";
 import { reportRegistry } from "./report_registry.ts";
+
+const BUILTIN_NAMES = new Set([
+  ...BUILTIN_METHOD_REPORTS,
+  ...BUILTIN_WORKFLOW_REPORTS,
+]);
 
 export interface ReportTypeInfo {
   type: string;
   name: string;
   description: string;
+  scope: ReportScope;
   isBuiltIn: boolean;
 }
 
@@ -35,7 +46,8 @@ export function getReportTypes(): ReportTypeInfo[] {
     type: name,
     name,
     description: report.description,
-    isBuiltIn: false,
+    scope: report.scope,
+    isBuiltIn: BUILTIN_NAMES.has(name),
   }));
   const loadedKeys = new Set(loaded.map((t) => t.type.toLowerCase()));
 
@@ -45,6 +57,7 @@ export function getReportTypes(): ReportTypeInfo[] {
       type: entry.type,
       name: entry.type,
       description: "",
+      scope: "method" as ReportScope,
       isBuiltIn: false,
     }));
 

--- a/src/domain/reports/report_types_test.ts
+++ b/src/domain/reports/report_types_test.ts
@@ -1,0 +1,110 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { reportRegistry } from "./report_registry.ts";
+import { getReportTypes } from "./report_types.ts";
+import type { ReportDefinition } from "./report.ts";
+
+function makeReport(
+  overrides: Partial<ReportDefinition> = {},
+): ReportDefinition {
+  return {
+    description: "test report",
+    scope: "method",
+    execute: () => Promise.resolve({ markdown: "", json: {} }),
+    ...overrides,
+  };
+}
+
+Deno.test("getReportTypes: includes scope from loaded reports", () => {
+  const original = reportRegistry.getAll;
+  const originalLazy = reportRegistry.getAllLazy;
+
+  const methodReport = makeReport({ scope: "method", description: "m" });
+  const workflowReport = makeReport({ scope: "workflow", description: "w" });
+
+  reportRegistry.getAll = () => [
+    { name: "@test/method-report", report: methodReport },
+    { name: "@test/workflow-report", report: workflowReport },
+  ];
+  reportRegistry.getAllLazy = () => [];
+
+  try {
+    const types = getReportTypes();
+    assertEquals(types.length, 2);
+    assertEquals(types[0].scope, "method");
+    assertEquals(types[1].scope, "workflow");
+  } finally {
+    reportRegistry.getAll = original;
+    reportRegistry.getAllLazy = originalLazy;
+  }
+});
+
+Deno.test("getReportTypes: marks built-in reports correctly", () => {
+  const original = reportRegistry.getAll;
+  const originalLazy = reportRegistry.getAllLazy;
+
+  const builtinReport = makeReport({ scope: "method", description: "builtin" });
+  const userReport = makeReport({ scope: "model", description: "user" });
+
+  reportRegistry.getAll = () => [
+    { name: "@swamp/method-summary", report: builtinReport },
+    { name: "@user/custom-report", report: userReport },
+  ];
+  reportRegistry.getAllLazy = () => [];
+
+  try {
+    const types = getReportTypes();
+    assertEquals(types.length, 2);
+    const builtin = types.find((t) => t.name === "@swamp/method-summary")!;
+    const user = types.find((t) => t.name === "@user/custom-report")!;
+    assertEquals(builtin.isBuiltIn, true);
+    assertEquals(user.isBuiltIn, false);
+  } finally {
+    reportRegistry.getAll = original;
+    reportRegistry.getAllLazy = originalLazy;
+  }
+});
+
+Deno.test("getReportTypes: lazy entries have default scope", () => {
+  const original = reportRegistry.getAll;
+  const originalLazy = reportRegistry.getAllLazy;
+
+  reportRegistry.getAll = () => [];
+  reportRegistry.getAllLazy = () => [
+    {
+      type: "@user/lazy-report",
+      bundlePath: "/tmp/bundle.js",
+      sourcePath: "/tmp/report.ts",
+      version: "1.0.0",
+    },
+  ];
+
+  try {
+    const types = getReportTypes();
+    assertEquals(types.length, 1);
+    assertEquals(types[0].scope, "method");
+    assertEquals(types[0].isBuiltIn, false);
+    assertEquals(types[0].description, "");
+  } finally {
+    reportRegistry.getAll = original;
+    reportRegistry.getAllLazy = originalLazy;
+  }
+});

--- a/src/libswamp/reports/type_search.ts
+++ b/src/libswamp/reports/type_search.ts
@@ -25,6 +25,7 @@ export interface ReportTypeSearchItem {
   type: string;
   name: string;
   description: string;
+  scope: string;
 }
 
 export interface ReportTypeSearchData {
@@ -42,6 +43,7 @@ export interface ReportTypeSearchDeps {
     type: string;
     name: string;
     description: string;
+    scope: string;
   }>;
 }
 
@@ -65,6 +67,7 @@ export async function* reportTypeSearch(
         type: t.type,
         name: t.name,
         description: t.description,
+        scope: t.scope,
       }));
 
       yield {

--- a/src/libswamp/reports/type_search_test.ts
+++ b/src/libswamp/reports/type_search_test.ts
@@ -35,11 +35,13 @@ function makeDeps(
         type: "@swamp/method-summary",
         name: "@swamp/method-summary",
         description: "Summary of method execution results",
+        scope: "method",
       },
       {
         type: "@swamp/cost-report",
         name: "@swamp/cost-report",
         description: "Cost breakdown for model operations",
+        scope: "model",
       },
     ],
     ...overrides,
@@ -78,6 +80,20 @@ Deno.test("reportTypeSearch: passes query through in data", async () => {
   >;
   assertEquals(completed.data.query, "cost");
   assertEquals(completed.data.results.length, 2);
+});
+
+Deno.test("reportTypeSearch: includes scope in results", async () => {
+  const deps = makeDeps();
+  const events = await collect<ReportTypeSearchEvent>(
+    reportTypeSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    ReportTypeSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results[0].scope, "method");
+  assertEquals(completed.data.results[1].scope, "model");
 });
 
 Deno.test("reportTypeSearch: returns empty results when no report types", async () => {

--- a/src/presentation/renderers/report_type_search.tsx
+++ b/src/presentation/renderers/report_type_search.tsx
@@ -41,7 +41,8 @@ function filterReportTypes(
     (t) =>
       t.type.toLowerCase().includes(lowerQuery) ||
       t.name.toLowerCase().includes(lowerQuery) ||
-      t.description.toLowerCase().includes(lowerQuery),
+      t.description.toLowerCase().includes(lowerQuery) ||
+      t.scope.toLowerCase().includes(lowerQuery),
   );
 }
 
@@ -89,7 +90,8 @@ class InkReportTypeSearchRenderer implements ReportTypeSearchRenderer {
         const result = await renderInteractivePicker<ReportTypeSearchItem>(
           e.data.results,
           e.data.query,
-          (item) => `${item.type} ${item.name} ${item.description}`,
+          (item) =>
+            `${item.type} ${item.name} ${item.description} ${item.scope}`,
           renderReportTypeResultLine,
           renderReportTypePreview,
           renderReportTypeScrollback,
@@ -125,7 +127,7 @@ function renderReportTypeResultLine(
 ): React.ReactElement {
   return (
     <Text>
-      {item.type} <Text dimColor>- {item.name}</Text>
+      {item.type} <Text dimColor>[{item.scope}]</Text>
     </Text>
   );
 }
@@ -140,7 +142,7 @@ function renderReportTypePreview(
   return (
     <Box flexDirection="column" marginLeft={1} width={innerWidth}>
       <Text bold wrap="truncate-end">{item.type}</Text>
-      <Text dimColor wrap="truncate-end">name: {item.name}</Text>
+      <Text dimColor wrap="truncate-end">scope: {item.scope}</Text>
       <Text dimColor wrap="truncate-end">{item.description}</Text>
     </Box>
   );
@@ -150,5 +152,5 @@ function renderReportTypeScrollback(
   item: ReportTypeSearchItem,
   _detail: ReportTypeSearchItem | undefined,
 ): string {
-  return `${item.type} - ${item.name}\n${item.description}`;
+  return `${item.type} [${item.scope}]\n${item.description}`;
 }


### PR DESCRIPTION
## Summary

- Enrich `report type search` with a **scope** field so users can see whether a report targets method, model, or workflow scope — shown in the TUI picker, preview, and JSON output
- Make the top-level `report list` alias **visible** and redirect it to report type search (definitions) instead of report search (stored results), so users can discover registered report definitions without knowing about the `type` subcommand
- Fix `isBuiltIn` detection to correctly identify `@swamp/*` built-in reports using the `BUILTIN_METHOD_REPORTS` and `BUILTIN_WORKFLOW_REPORTS` constants
- Force-load lazy report entries before listing to ensure scope and description are always populated (not just on cold cache)

Closes swamp-club#621

## Test Plan

- Added unit tests for `getReportTypes()` verifying scope and isBuiltIn fields
- Added test for scope passthrough in `reportTypeSearch` generator
- Updated existing `type_search_test.ts` mock data to include scope
- Compiled binary and manually verified in a scratch repo with custom method-scope and workflow-scope reports:
  - `swamp report list --json` shows all registered definitions with correct scope
  - Works on both cold cache (fresh bundle) and warm cache (catalog-backed lazy entries)
  - Scope-based query filtering works (`report list workflow` filters correctly)
- Full test suite passes (6907 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)