### PR TITLE
fix(skill): check for existing issue model before running start

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -52,7 +52,15 @@ resuming an issue in the `triaging` phase. Covers: starting the lifecycle (using
 direct type execution to auto-create the model and fetch issue context in one
 command), reading the codebase, classifying the issue, and reproducing bugs.
 
-The first command to run for a new issue is always:
+The first command to run is always the existence check:
+
+```
+swamp data get issue-<N> state-main --json
+```
+
+- If this **returns data**, the model already exists — check the `phase` field
+  and go to the "Resuming a Session" table below. **Do NOT call `start`.**
+- If this **fails** (model not found), the issue is new — run:
 
 ```
 swamp model @swamp/issue-lifecycle method run start issue-<N> --input issueNumber=<N>


### PR DESCRIPTION
## Summary

- The previous change (#1565) inlined the `start` command as "the first command to run" in SKILL.md, which caused it to fire before checking whether the issue model already exists
- This resets in-progress issues back to `triaging`, destroying classification, plans, and approvals
- Now the existence check (`swamp data get issue-<N> state-main --json`) comes first, and `start` only runs when no model is found

## Test plan

- [ ] Trigger the skill with `triage issue <N>` on a **new** issue — should run the existence check, get "model not found", then run `start`
- [ ] Trigger the skill with `triage issue <N>` on an **existing** issue — should run the existence check, find data, and resume from the current phase without calling `start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)