### PR TITLE
feat(extensions): add --channel flag to yank and unyank commands

### DIFF
--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -33,6 +33,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
 import { loadIdentity } from "../load_identity.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -64,8 +65,16 @@ export const extensionUnyankCommand = new Command()
     "Unyank specific version",
     `swamp extension unyank @stack72/aws-ec2 2026.3.1`,
   )
+  .example(
+    "Unyank only the stable channel",
+    `swamp extension unyank @stack72/aws-ec2 --channel stable`,
+  )
   .arguments("<extension:string> [version:string]")
   .option("--reason <reason:string>", "Optional reason (audit log only)")
+  .option(
+    "--channel <channel:string>",
+    "Release channel to unyank: 'stable', 'beta', or 'rc' (default: all channels)",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .action(async function (
     options: AnyOptions,
@@ -81,12 +90,24 @@ export const extensionUnyankCommand = new Command()
     const ref = parseExtensionRef(extension);
     const resolvedVersion = version ?? ref.version ?? null;
 
+    // Validate --channel if provided
+    const channel = (options.channel as string | undefined) ?? null;
+    if (
+      channel !== null &&
+      !ReleaseChannel.isValid(channel)
+    ) {
+      throw new UserError(
+        `Invalid channel: "${channel}". Must be one of: stable, beta, rc.`,
+      );
+    }
+
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const identity = await loadIdentity();
     const deps = createExtensionUnyankDeps(identity);
     const input = {
       extensionName: ref.name,
       version: resolvedVersion,
+      channel,
       reason: (options.reason as string | undefined) ?? null,
     };
 
@@ -103,6 +124,8 @@ export const extensionUnyankCommand = new Command()
     if (cliCtx.outputMode === "log" && !options.yes) {
       const prompt = preview.version
         ? `Unyank ${preview.extensionName}@${preview.version}? This will restore availability.`
+        : preview.channel
+        ? `Unyank all ${preview.channel} versions of ${preview.extensionName}?`
         : `Unyank ALL versions of ${preview.extensionName}? This will restore availability and allow future pushes.`;
       const confirmed = await promptConfirmation(prompt);
       if (!confirmed) {

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -33,6 +33,7 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
 import { loadIdentity } from "../load_identity.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -64,8 +65,16 @@ export const extensionYankCommand = new Command()
     "Yank one version (future versions can still be pushed)",
     `swamp extension yank @stack72/aws-ec2 2026.3.1 --reason "broken release"`,
   )
+  .example(
+    "Yank only the stable channel (beta/rc remain available)",
+    `swamp extension yank @stack72/aws-ec2 --channel stable --reason "withdrawing from stable"`,
+  )
   .arguments("<extension:string> [version:string]")
   .option("--reason <reason:string>", "Reason for yanking", { required: true })
+  .option(
+    "--channel <channel:string>",
+    "Release channel to yank: 'stable', 'beta', or 'rc' (default: all channels)",
+  )
   .option("-y, --yes", "Skip confirmation prompt")
   .action(async function (
     options: AnyOptions,
@@ -82,12 +91,24 @@ export const extensionYankCommand = new Command()
     const ref = parseExtensionRef(extension);
     const resolvedVersion = version ?? ref.version ?? null;
 
+    // Validate --channel if provided
+    const channel = (options.channel as string | undefined) ?? null;
+    if (
+      channel !== null &&
+      !ReleaseChannel.isValid(channel)
+    ) {
+      throw new UserError(
+        `Invalid channel: "${channel}". Must be one of: stable, beta, rc.`,
+      );
+    }
+
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const identity = await loadIdentity();
     const deps = createExtensionYankDeps(identity);
     const input = {
       extensionName: ref.name,
       version: resolvedVersion,
+      channel,
       reason: options.reason as string,
     };
 
@@ -106,6 +127,8 @@ export const extensionYankCommand = new Command()
     if (cliCtx.outputMode === "log" && !options.yes) {
       const prompt = preview.version
         ? `Yank ${preview.extensionName}@${preview.version}? This will mark it yanked.`
+        : preview.channel
+        ? `Yank all ${preview.channel} versions of ${preview.extensionName}?`
         : `Yank ALL versions of ${preview.extensionName}? Future pushes will be blocked until you run \`swamp extension unyank\`.`;
       const confirmed = await promptConfirmation(prompt);
       if (!confirmed) {

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -491,6 +491,7 @@ export class ExtensionApiClient {
   async yankExtension(
     name: string,
     version: string | null,
+    channel: string | null,
     reason: string,
     apiKey: string,
   ): Promise<YankResult> {
@@ -501,13 +502,17 @@ export class ExtensionApiClient {
     const path = encodedVersion
       ? `/api/v1/extensions/${encodedName}@${encodedVersion}/yank`
       : `/api/v1/extensions/${encodedName}/yank`;
+    const body: Record<string, string> = { reason };
+    if (channel !== null) {
+      body.channel = channel;
+    }
     const res = await this.fetch(path, {
       method: "POST",
       headers: {
         ...this.authHeaders(apiKey),
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ reason }),
+      body: JSON.stringify(body),
     });
 
     await this.checkResponse(res);
@@ -522,6 +527,7 @@ export class ExtensionApiClient {
   async unyankExtension(
     name: string,
     version: string | null,
+    channel: string | null,
     reason: string | null,
     apiKey: string,
   ): Promise<UnyankResult> {
@@ -533,16 +539,25 @@ export class ExtensionApiClient {
       ? `/api/v1/extensions/${encodedName}@${encodedVersion}/unyank`
       : `/api/v1/extensions/${encodedName}/unyank`;
 
-    const init: RequestInit = reason === null
-      ? { method: "POST", headers: this.authHeaders(apiKey) }
-      : {
+    const body: Record<string, string> = {};
+    if (channel !== null) {
+      body.channel = channel;
+    }
+    if (reason !== null) {
+      body.reason = reason;
+    }
+    const hasBody = Object.keys(body).length > 0;
+
+    const init: RequestInit = hasBody
+      ? {
         method: "POST",
         headers: {
           ...this.authHeaders(apiKey),
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ reason }),
-      };
+        body: JSON.stringify(body),
+      }
+      : { method: "POST", headers: this.authHeaders(apiKey) };
 
     const res = await this.fetch(path, init);
     await this.checkResponse(res);

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -282,6 +282,7 @@ Deno.test("ExtensionApiClient.yankExtension sends POST with reason to version ya
   const result = await client.yankExtension(
     "@test/ext",
     "2026.02.26.1",
+    null,
     "Security vulnerability",
     "swamp_fake-key",
   );
@@ -292,7 +293,9 @@ Deno.test("ExtensionApiClient.yankExtension sends POST with reason to version ya
     "/api/v1/extensions/%40test%2Fext@2026.02.26.1/yank",
   );
   assertEquals(capturedAuth, "swamp_fake-key");
-  assertEquals(JSON.parse(capturedBody).reason, "Security vulnerability");
+  const parsedBody = JSON.parse(capturedBody);
+  assertEquals(parsedBody.reason, "Security vulnerability");
+  assertEquals(parsedBody.channel, undefined);
   assertStringIncludes(result.message, "Yanked");
   await server.shutdown();
 });
@@ -310,6 +313,7 @@ Deno.test("ExtensionApiClient.yankExtension sends POST to extension yank endpoin
   const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
   await client.yankExtension(
     "@test/ext",
+    null,
     null,
     "Policy violation",
     "swamp_fake-key",
@@ -329,10 +333,41 @@ Deno.test("ExtensionApiClient.yankExtension throws UserError on 410 already yank
   const addr = server.addr;
   const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
   const error = await assertRejects(
-    () => client.yankExtension("@test/ext", null, "reason", "swamp_fake-key"),
+    () =>
+      client.yankExtension(
+        "@test/ext",
+        null,
+        null,
+        "reason",
+        "swamp_fake-key",
+      ),
     UserError,
   );
   assertStringIncludes(error.message, "already yanked");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.yankExtension includes channel in body when provided", async () => {
+  let capturedBody = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    capturedBody = await req.text();
+    return new Response(
+      JSON.stringify({ message: "Yanked @test/ext (stable channel)" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  await client.yankExtension(
+    "@test/ext",
+    null,
+    "stable",
+    "withdrawing from stable",
+    "swamp_fake-key",
+  );
+  const parsedBody = JSON.parse(capturedBody);
+  assertEquals(parsedBody.channel, "stable");
+  assertEquals(parsedBody.reason, "withdrawing from stable");
   await server.shutdown();
 });
 
@@ -343,6 +378,7 @@ Deno.test("ExtensionApiClient.yankExtension throws UserError on connection failu
       client.yankExtension(
         "@test/ext",
         "2026.02.26.1",
+        null,
         "reason",
         "fake-key",
       ),
@@ -373,6 +409,7 @@ Deno.test("ExtensionApiClient.unyankExtension sends POST with reason to version 
   const result = await client.unyankExtension(
     "@test/ext",
     "2026.02.26.1",
+    null,
     "Mistake yank",
     "swamp_fake-key",
   );
@@ -403,6 +440,7 @@ Deno.test("ExtensionApiClient.unyankExtension sends POST to extension unyank end
   await client.unyankExtension(
     "@test/ext",
     null,
+    null,
     "restoring name",
     "swamp_fake-key",
   );
@@ -428,10 +466,38 @@ Deno.test("ExtensionApiClient.unyankExtension sends POST with no body and no Con
     "@test/ext",
     null,
     null,
+    null,
     "swamp_fake-key",
   );
   assertEquals(capturedBody, "");
   assertEquals(capturedContentType, null);
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.unyankExtension includes channel in body when provided", async () => {
+  let capturedBody = "";
+  let capturedContentType = "";
+  const server = Deno.serve({ port: 0, onListen: () => {} }, async (req) => {
+    capturedContentType = req.headers.get("content-type") ?? "";
+    capturedBody = await req.text();
+    return new Response(
+      JSON.stringify({ message: "Unyanked @test/ext (beta channel)" }),
+      { headers: { "content-type": "application/json" } },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  await client.unyankExtension(
+    "@test/ext",
+    null,
+    "beta",
+    null,
+    "swamp_fake-key",
+  );
+  assertEquals(capturedContentType, "application/json");
+  const parsedBody = JSON.parse(capturedBody);
+  assertEquals(parsedBody.channel, "beta");
+  assertEquals(parsedBody.reason, undefined);
   await server.shutdown();
 });
 
@@ -445,7 +511,14 @@ Deno.test("ExtensionApiClient.unyankExtension throws UserError on 409 not yanked
   const addr = server.addr;
   const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
   const error = await assertRejects(
-    () => client.unyankExtension("@test/ext", null, null, "swamp_fake-key"),
+    () =>
+      client.unyankExtension(
+        "@test/ext",
+        null,
+        null,
+        null,
+        "swamp_fake-key",
+      ),
     UserError,
   );
   assertStringIncludes(error.message, "not yanked");
@@ -462,7 +535,14 @@ Deno.test("ExtensionApiClient.unyankExtension throws UserError on 404 not found"
   const addr = server.addr;
   const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
   const error = await assertRejects(
-    () => client.unyankExtension("@test/ext", null, null, "swamp_fake-key"),
+    () =>
+      client.unyankExtension(
+        "@test/ext",
+        null,
+        null,
+        null,
+        "swamp_fake-key",
+      ),
     UserError,
   );
   assertStringIncludes(error.message, "not found");
@@ -476,6 +556,7 @@ Deno.test("ExtensionApiClient.unyankExtension throws UserError on connection fai
       client.unyankExtension(
         "@test/ext",
         "2026.02.26.1",
+        null,
         "reason",
         "fake-key",
       ),
@@ -520,12 +601,24 @@ Deno.test("ExtensionApiClient version-scoped methods URL-encode version path seg
   const expectedBase = `/api/v1/extensions/%40test%2Fext@${encoded}`;
 
   try {
-    await client.yankExtension("@test/ext", hostileVersion, "reason", "key");
+    await client.yankExtension(
+      "@test/ext",
+      hostileVersion,
+      null,
+      "reason",
+      "key",
+    );
     const yankUrl = new URL(captured.yank);
     assertEquals(yankUrl.pathname, `${expectedBase}/yank`);
     assertEquals(yankUrl.search, "");
 
-    await client.unyankExtension("@test/ext", hostileVersion, null, "key");
+    await client.unyankExtension(
+      "@test/ext",
+      hostileVersion,
+      null,
+      null,
+      "key",
+    );
     const unyankUrl = new URL(captured.unyank);
     assertEquals(unyankUrl.pathname, `${expectedBase}/unyank`);
     assertEquals(unyankUrl.search, "");
@@ -737,6 +830,7 @@ Deno.test("ExtensionApiClient lets caller-supplied x-api-key coexist with constr
     await client.yankExtension(
       "@test/ext",
       "2026.01.01.1",
+      null,
       "test reason",
       "swamp_caller-key",
     );

--- a/src/libswamp/extensions/unyank.ts
+++ b/src/libswamp/extensions/unyank.ts
@@ -38,6 +38,7 @@ const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 export interface ExtensionUnyankData {
   name: string;
   version: string | null;
+  channel: string | null;
   reason: string | null;
 }
 
@@ -49,6 +50,7 @@ export type ExtensionUnyankEvent =
 export interface ExtensionUnyankInput {
   extensionName: string;
   version: string | null;
+  channel: string | null;
   reason: string | null;
 }
 
@@ -56,6 +58,7 @@ export interface ExtensionUnyankInput {
 export interface ExtensionUnyankPreview {
   extensionName: string;
   version: string | null;
+  channel: string | null;
   reason: string | null;
 }
 
@@ -68,6 +71,7 @@ export interface ExtensionUnyankDeps {
     serverUrl: string,
     name: string,
     version: string | null,
+    channel: string | null,
     reason: string | null,
     apiKey: string,
   ) => Promise<void>;
@@ -91,11 +95,12 @@ export function createExtensionUnyankDeps(
       serverUrl: string,
       name: string,
       version: string | null,
+      channel: string | null,
       reason: string | null,
       apiKey: string,
     ) => {
       const client = new ExtensionApiClient(serverUrl, identity);
-      await client.unyankExtension(name, version, reason, apiKey);
+      await client.unyankExtension(name, version, channel, reason, apiKey);
     },
   };
 }
@@ -126,6 +131,7 @@ export async function extensionUnyankPreview(
   return {
     extensionName: input.extensionName,
     version: input.version,
+    channel: input.channel,
     reason: input.reason,
   };
 }
@@ -152,6 +158,7 @@ export async function* extensionUnyank(
         credentials.serverUrl,
         input.extensionName,
         input.version,
+        input.channel,
         input.reason,
         credentials.apiKey,
       );
@@ -163,6 +170,7 @@ export async function* extensionUnyank(
         data: {
           name: input.extensionName,
           version: input.version,
+          channel: input.channel,
           reason: input.reason,
         },
       };

--- a/src/libswamp/extensions/unyank_test.ts
+++ b/src/libswamp/extensions/unyank_test.ts
@@ -48,13 +48,19 @@ Deno.test("extensionUnyank: unyanks specific version", async () => {
   const input: ExtensionUnyankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "recovered",
   };
   await assertCompletes<ExtensionUnyankEvent>(
     extensionUnyank(ctx, deps, input),
     {
       kind: "completed",
-      data: { name: "@test/ext", version: "2025.01", reason: "recovered" },
+      data: {
+        name: "@test/ext",
+        version: "2025.01",
+        channel: null,
+        reason: "recovered",
+      },
     },
   );
 });
@@ -65,13 +71,19 @@ Deno.test("extensionUnyank: unyanks extension when version is null", async () =>
   const input: ExtensionUnyankInput = {
     extensionName: "@test/ext",
     version: null,
+    channel: null,
     reason: "restoring name",
   };
   await assertCompletes<ExtensionUnyankEvent>(
     extensionUnyank(ctx, deps, input),
     {
       kind: "completed",
-      data: { name: "@test/ext", version: null, reason: "restoring name" },
+      data: {
+        name: "@test/ext",
+        version: null,
+        channel: null,
+        reason: "restoring name",
+      },
     },
   );
 });
@@ -82,15 +94,58 @@ Deno.test("extensionUnyank: accepts null reason", async () => {
   const input: ExtensionUnyankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: null,
   };
   await assertCompletes<ExtensionUnyankEvent>(
     extensionUnyank(ctx, deps, input),
     {
       kind: "completed",
-      data: { name: "@test/ext", version: "2025.01", reason: null },
+      data: {
+        name: "@test/ext",
+        version: "2025.01",
+        channel: null,
+        reason: null,
+      },
     },
   );
+});
+
+Deno.test("extensionUnyank: unyanks by channel", async () => {
+  let capturedChannel: string | null = null;
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    unyankExtension: (
+      _serverUrl: string,
+      _name: string,
+      _version: string | null,
+      channel: string | null,
+      _reason: string | null,
+      _apiKey: string,
+    ) => {
+      capturedChannel = channel;
+      return Promise.resolve();
+    },
+  });
+  const input: ExtensionUnyankInput = {
+    extensionName: "@test/ext",
+    version: null,
+    channel: "beta",
+    reason: "restoring beta",
+  };
+  await assertCompletes<ExtensionUnyankEvent>(
+    extensionUnyank(ctx, deps, input),
+    {
+      kind: "completed",
+      data: {
+        name: "@test/ext",
+        version: null,
+        channel: "beta",
+        reason: "restoring beta",
+      },
+    },
+  );
+  assertEquals(capturedChannel, "beta");
 });
 
 Deno.test("extensionUnyank: errors when not authenticated", async () => {
@@ -101,6 +156,7 @@ Deno.test("extensionUnyank: errors when not authenticated", async () => {
   const input: ExtensionUnyankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "recovered",
   };
   await assertErrors<ExtensionUnyankEvent>(
@@ -115,6 +171,7 @@ Deno.test("extensionUnyankPreview: rejects invalid extension name", async () => 
   const input: ExtensionUnyankInput = {
     extensionName: "invalid-name",
     version: "2025.01",
+    channel: null,
     reason: "recovered",
   };
   try {
@@ -133,6 +190,7 @@ Deno.test("extensionUnyankPreview: rejects when not authenticated", async () => 
   const input: ExtensionUnyankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "recovered",
   };
   try {

--- a/src/libswamp/extensions/yank.ts
+++ b/src/libswamp/extensions/yank.ts
@@ -32,6 +32,7 @@ const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 export interface ExtensionYankData {
   name: string;
   version: string | null;
+  channel: string | null;
   reason: string;
 }
 
@@ -43,6 +44,7 @@ export type ExtensionYankEvent =
 export interface ExtensionYankInput {
   extensionName: string;
   version: string | null;
+  channel: string | null;
   reason: string;
 }
 
@@ -50,6 +52,7 @@ export interface ExtensionYankInput {
 export interface ExtensionYankPreview {
   extensionName: string;
   version: string | null;
+  channel: string | null;
   reason: string;
 }
 
@@ -62,6 +65,7 @@ export interface ExtensionYankDeps {
     serverUrl: string,
     name: string,
     version: string | null,
+    channel: string | null,
     reason: string,
     apiKey: string,
   ) => Promise<void>;
@@ -85,11 +89,12 @@ export function createExtensionYankDeps(
       serverUrl: string,
       name: string,
       version: string | null,
+      channel: string | null,
       reason: string,
       apiKey: string,
     ) => {
       const client = new ExtensionApiClient(serverUrl, identity);
-      await client.yankExtension(name, version, reason, apiKey);
+      await client.yankExtension(name, version, channel, reason, apiKey);
     },
   };
 }
@@ -122,6 +127,7 @@ export async function extensionYankPreview(
   return {
     extensionName: input.extensionName,
     version: input.version,
+    channel: input.channel,
     reason: input.reason,
   };
 }
@@ -149,6 +155,7 @@ export async function* extensionYank(
         credentials.serverUrl,
         input.extensionName,
         input.version,
+        input.channel,
         input.reason,
         credentials.apiKey,
       );
@@ -160,6 +167,7 @@ export async function* extensionYank(
         data: {
           name: input.extensionName,
           version: input.version,
+          channel: input.channel,
           reason: input.reason,
         },
       };

--- a/src/libswamp/extensions/yank_test.ts
+++ b/src/libswamp/extensions/yank_test.ts
@@ -48,11 +48,17 @@ Deno.test("extensionYank: yanks specific version", async () => {
   const input: ExtensionYankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "broken",
   };
   await assertCompletes<ExtensionYankEvent>(extensionYank(ctx, deps, input), {
     kind: "completed",
-    data: { name: "@test/ext", version: "2025.01", reason: "broken" },
+    data: {
+      name: "@test/ext",
+      version: "2025.01",
+      channel: null,
+      reason: "broken",
+    },
   });
 });
 
@@ -62,12 +68,52 @@ Deno.test("extensionYank: yanks all versions when version is null", async () => 
   const input: ExtensionYankInput = {
     extensionName: "@test/ext",
     version: null,
+    channel: null,
     reason: "deprecated",
   };
   await assertCompletes<ExtensionYankEvent>(extensionYank(ctx, deps, input), {
     kind: "completed",
-    data: { name: "@test/ext", version: null, reason: "deprecated" },
+    data: {
+      name: "@test/ext",
+      version: null,
+      channel: null,
+      reason: "deprecated",
+    },
   });
+});
+
+Deno.test("extensionYank: yanks by channel", async () => {
+  let capturedChannel: string | null = null;
+  const ctx = createLibSwampContext();
+  const deps = fakeDeps({
+    yankExtension: (
+      _serverUrl: string,
+      _name: string,
+      _version: string | null,
+      channel: string | null,
+      _reason: string,
+      _apiKey: string,
+    ) => {
+      capturedChannel = channel;
+      return Promise.resolve();
+    },
+  });
+  const input: ExtensionYankInput = {
+    extensionName: "@test/ext",
+    version: null,
+    channel: "stable",
+    reason: "withdrawing from stable",
+  };
+  await assertCompletes<ExtensionYankEvent>(extensionYank(ctx, deps, input), {
+    kind: "completed",
+    data: {
+      name: "@test/ext",
+      version: null,
+      channel: "stable",
+      reason: "withdrawing from stable",
+    },
+  });
+  assertEquals(capturedChannel, "stable");
 });
 
 Deno.test("extensionYank: errors when not authenticated", async () => {
@@ -78,6 +124,7 @@ Deno.test("extensionYank: errors when not authenticated", async () => {
   const input: ExtensionYankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "broken",
   };
   await assertErrors<ExtensionYankEvent>(
@@ -92,6 +139,7 @@ Deno.test("extensionYankPreview: rejects invalid extension name", async () => {
   const input: ExtensionYankInput = {
     extensionName: "invalid-name",
     version: "2025.01",
+    channel: null,
     reason: "broken",
   };
   try {
@@ -110,6 +158,7 @@ Deno.test("extensionYankPreview: rejects when not authenticated", async () => {
   const input: ExtensionYankInput = {
     extensionName: "@test/ext",
     version: "2025.01",
+    channel: null,
     reason: "broken",
   };
   try {

--- a/src/presentation/renderers/extension_unyank.ts
+++ b/src/presentation/renderers/extension_unyank.ts
@@ -36,6 +36,11 @@ class LogExtensionUnyankRenderer implements Renderer<ExtensionUnyankEvent> {
             name: e.data.name,
             version: e.data.version,
           });
+        } else if (e.data.channel) {
+          logger.info("Unyanked {name} ({channel} channel)", {
+            name: e.data.name,
+            channel: e.data.channel,
+          });
         } else {
           logger.info("Unyanked {name} (all versions)", {
             name: e.data.name,

--- a/src/presentation/renderers/extension_yank.ts
+++ b/src/presentation/renderers/extension_yank.ts
@@ -33,6 +33,11 @@ class LogExtensionYankRenderer implements Renderer<ExtensionYankEvent> {
             name: e.data.name,
             version: e.data.version,
           });
+        } else if (e.data.channel) {
+          logger.info("Yanked {name} ({channel} channel)", {
+            name: e.data.name,
+            channel: e.data.channel,
+          });
         } else {
           logger.info("Yanked {name} (all versions)", { name: e.data.name });
         }


### PR DESCRIPTION
## Summary

Adds `--channel <stable|beta|rc>` to `swamp extension yank` and `swamp extension unyank` so maintainers can scope yank/unyank to a specific release channel instead of affecting all channels at once.

- Without `--channel`: preserves today's all-channel behavior (backward compatible)
- With `--channel stable`: yanks/unyanks only versions on the stable channel, leaving beta/rc discoverable
- Channel validated using existing `ReleaseChannel.isValid()`
- Confirmation prompts and log/JSON output reflect the channel scope

Requires backend support from swamp-club/swamp-club#668.

Closes #626

## Test Plan

- [x] Updated unit tests for `extensionYank` and `extensionUnyank` service functions
- [x] Added channel-scoped test cases verifying channel is threaded to deps
- [x] Updated `ExtensionApiClient` tests — channel included in POST body when provided, omitted when null
- [x] All 6906 tests pass (`deno run test`), type check, lint, format clean
- [x] Binary compiles (`deno run compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)