### PR TITLE
fix(doctor): fix orphan cross-attribution for nested scoped extensions (swamp-club#628)

### DIFF
--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -251,7 +251,11 @@ async function detectOrphanFiles(
     const tracked = new Set(trackedFiles);
     const roots = new Set<string>();
     for (const file of trackedFiles) {
-      const root = extractTopLevelRoot(file, normalizedSkillsDir);
+      const root = extractTopLevelRoot(
+        file,
+        normalizedSkillsDir,
+        extensionName,
+      );
       if (root !== null) {
         roots.add(root);
       }

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -305,6 +305,58 @@ Deno.test(
 );
 
 Deno.test(
+  "doctorExtensions: nested scoped siblings do not cross-attribute orphans",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });
+    try {
+      const iamDir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@swamp/aws/iam/models",
+      );
+      const s3Dir = join(
+        tmpDir,
+        ".swamp/pulled-extensions/@swamp/aws/s3/models",
+      );
+      await ensureDir(iamDir);
+      await ensureDir(s3Dir);
+      await Deno.writeTextFile(join(iamDir, "role.ts"), "// iam");
+      await Deno.writeTextFile(join(s3Dir, "bucket.ts"), "// s3");
+
+      const { deps } = buildDeps({
+        repoDir: tmpDir,
+        skillsDir: ".claude/skills",
+      });
+      const upstream: UpstreamExtensionsMap = {
+        "@swamp/aws/iam": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@swamp/aws/iam/models/role.ts"],
+        },
+        "@swamp/aws/s3": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@swamp/aws/s3/models/bucket.ts"],
+        },
+      };
+      deps.lockfileRepository = new LockfileRepository(
+        "/test/repo/upstream_extensions.json",
+        upstream,
+      );
+
+      const events = await collect(doctorExtensions(deps));
+      const completed = events.find((e) => e.kind === "completed");
+      if (completed?.kind !== "completed") {
+        throw new Error("expected completed event");
+      }
+
+      assertEquals(completed.report.orphanFiles.length, 0);
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
   "doctorExtensions: orphans do NOT change overallStatus from pass to fail",
   async () => {
     const tmpDir = await Deno.makeTempDir({ prefix: "swamp_doctor_orphan_" });

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -191,6 +191,7 @@ export function isSkillDirEntry(
 export function extractTopLevelRoot(
   filePath: string,
   skillsDir: string,
+  extensionName: string,
 ): string | null {
   // Legacy paths are out of scope for orphan detection; the migrate
   // flow in extensionInstall handles those.
@@ -205,18 +206,16 @@ export function extractTopLevelRoot(
     return null;
   }
 
-  // Per-extension subtree: pulled-extensions/<scope>/<name>/...
+  // Per-extension subtree: pulled-extensions/<extensionName>/...
   // (current-layout always begins with .swamp/pulled-extensions/).
   if (filePath.startsWith(PULLED_PREFIX)) {
+    const nameSegments = extensionName.split("/");
     const rest = filePath.slice(PULLED_PREFIX.length);
     const segments = rest.split("/");
-    if (segments.length === 0 || segments[0].length === 0) return null;
-    // Two segments for scoped names (@scope/name); one for flat.
-    if (segments[0].startsWith("@")) {
-      if (segments.length < 2) return null;
-      return `${PULLED_PREFIX}${segments[0]}/${segments[1]}`;
-    }
-    return `${PULLED_PREFIX}${segments[0]}`;
+    if (segments.length < nameSegments.length) return null;
+    return `${PULLED_PREFIX}${
+      segments.slice(0, nameSegments.length).join("/")
+    }`;
   }
 
   // Bundle namespaces: <kind>/<hash>/...

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -430,8 +430,28 @@ Deno.test("extractTopLevelRoot: per-extension scoped subtree", () => {
     extractTopLevelRoot(
       ".swamp/pulled-extensions/@hivemq/harvester/models/foo.ts",
       SKILLS_DIR,
+      "@hivemq/harvester",
     ),
     ".swamp/pulled-extensions/@hivemq/harvester",
+  );
+});
+
+Deno.test("extractTopLevelRoot: per-extension nested scoped subtree", () => {
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/pulled-extensions/@swamp/aws/iam/models/role.ts",
+      SKILLS_DIR,
+      "@swamp/aws/iam",
+    ),
+    ".swamp/pulled-extensions/@swamp/aws/iam",
+  );
+  assertEquals(
+    extractTopLevelRoot(
+      ".swamp/pulled-extensions/@swamp/aws/s3/models/bucket.ts",
+      SKILLS_DIR,
+      "@swamp/aws/s3",
+    ),
+    ".swamp/pulled-extensions/@swamp/aws/s3",
   );
 });
 
@@ -440,6 +460,7 @@ Deno.test("extractTopLevelRoot: per-extension flat (unscoped) subtree", () => {
     extractTopLevelRoot(
       ".swamp/pulled-extensions/myext/models/foo.ts",
       SKILLS_DIR,
+      "myext",
     ),
     ".swamp/pulled-extensions/myext",
   );
@@ -450,6 +471,7 @@ Deno.test("extractTopLevelRoot: bundle namespace", () => {
     extractTopLevelRoot(
       ".swamp/bundles/abc123/foo.js",
       SKILLS_DIR,
+      "@x/y",
     ),
     ".swamp/bundles/abc123",
   );
@@ -469,6 +491,7 @@ Deno.test("extractTopLevelRoot: each bundle kind", () => {
       extractTopLevelRoot(
         `.swamp/${kind}/hash123/foo.js`,
         SKILLS_DIR,
+        "@x/y",
       ),
       `.swamp/${kind}/hash123`,
     );
@@ -477,18 +500,18 @@ Deno.test("extractTopLevelRoot: each bundle kind", () => {
 
 Deno.test("extractTopLevelRoot: skill dir returns null", () => {
   assertEquals(
-    extractTopLevelRoot(".claude/skills/foo", SKILLS_DIR),
+    extractTopLevelRoot(".claude/skills/foo", SKILLS_DIR, "@x/y"),
     null,
   );
   assertEquals(
-    extractTopLevelRoot(".claude/skills/foo/SKILL.md", SKILLS_DIR),
+    extractTopLevelRoot(".claude/skills/foo/SKILL.md", SKILLS_DIR, "@x/y"),
     null,
   );
 });
 
 Deno.test("extractTopLevelRoot: gen-1 path returns null", () => {
   assertEquals(
-    extractTopLevelRoot("extensions/models/legacy.ts", SKILLS_DIR),
+    extractTopLevelRoot("extensions/models/legacy.ts", SKILLS_DIR, "@x/y"),
     null,
   );
 });
@@ -498,6 +521,7 @@ Deno.test("extractTopLevelRoot: gen-2 path returns null", () => {
     extractTopLevelRoot(
       ".swamp/pulled-extensions/models/flat.ts",
       SKILLS_DIR,
+      "@x/y",
     ),
     null,
   );
@@ -505,14 +529,18 @@ Deno.test("extractTopLevelRoot: gen-2 path returns null", () => {
 
 Deno.test("extractTopLevelRoot: unknown current-layout path returns null", () => {
   assertEquals(
-    extractTopLevelRoot(".swamp/some-other-place/foo.ts", SKILLS_DIR),
+    extractTopLevelRoot(".swamp/some-other-place/foo.ts", SKILLS_DIR, "@x/y"),
     null,
   );
 });
 
 Deno.test("extractTopLevelRoot: handles trailing-slash skillsDir", () => {
   assertEquals(
-    extractTopLevelRoot(".claude/skills/foo/SKILL.md", ".claude/skills/"),
+    extractTopLevelRoot(
+      ".claude/skills/foo/SKILL.md",
+      ".claude/skills/",
+      "@x/y",
+    ),
     null,
   );
 });
@@ -526,11 +554,11 @@ Deno.test(
     // they still bottom out at the trailing `return null` rather than
     // leaking into a misidentified per-extension or bundle root.
     assertEquals(
-      extractTopLevelRoot("random/file.ts", SKILLS_DIR),
+      extractTopLevelRoot("random/file.ts", SKILLS_DIR, "@x/y"),
       null,
     );
     assertEquals(
-      extractTopLevelRoot("extensions/unknown-type/foo.ts", SKILLS_DIR),
+      extractTopLevelRoot("extensions/unknown-type/foo.ts", SKILLS_DIR, "@x/y"),
       null,
     );
   },


### PR DESCRIPTION
## Summary

- Fix `extractTopLevelRoot()` to handle nested scoped extension names with 3+
  segments (e.g. `@swamp/aws/iam`, `@swamp/aws/s3`)
- The function hardcoded a 2-segment assumption for scoped names, causing
  sibling nested extensions to extract to the same root directory and
  cross-attribute each other's files as false orphans
- Add `extensionName` parameter so the function uses the actual segment count
  to determine the correct per-extension root depth

Closes swamp-club#628

## Test Plan

- [x] Unit tests for `extractTopLevelRoot` with 3-segment scoped names
- [x] Integration test verifying sibling nested extensions don't cross-attribute
  orphans
- [x] All existing tests updated and passing
- [x] Reproduced the bug in a scratch repo (`/tmp/swamp-repro-issue-628`) and
  verified the compiled binary reports 0 false orphans after the fix
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)