### PR TITLE
feat(workflow): validate globalArgument input references (swamp-club#622)

### DIFF
--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -27,6 +27,7 @@ import {
   type GraphNode,
   TopologicalSortService,
 } from "./topological_sort_service.ts";
+import { extractInputReferences } from "../expressions/expression_parser.ts";
 
 /**
  * Value object representing the result of a single validation.
@@ -75,6 +76,7 @@ export type MethodResolution =
     status: "resolved";
     requiredArgs: string[];
     definitionProvidedArgs?: string[];
+    definitionProvidedArgValues?: Record<string, unknown>;
   }
   | { status: "model_not_found" }
   | { status: "method_not_found"; modelType: string }
@@ -106,6 +108,7 @@ export interface ModelMethodResolver {
  * 6. No cyclic dependencies between jobs
  * 7. No cyclic dependencies between steps within jobs
  * 8. Step inputs match method/workflow required arguments
+ * 9. GlobalArgument expressions reference declared workflow inputs
  */
 export interface WorkflowValidationService {
   /**
@@ -156,6 +159,13 @@ export class DefaultWorkflowValidationService
     // 8. Step inputs match required arguments
     if (this.methodResolver || this.workflowRepo) {
       results.push(...await this.validateStepInputs(workflow));
+    }
+
+    // 9. GlobalArgument expressions reference declared workflow inputs
+    if (this.methodResolver) {
+      results.push(
+        ...await this.validateGlobalArgInputRefs(workflow),
+      );
     }
 
     return results;
@@ -533,5 +543,73 @@ export class DefaultWorkflowValidationService
     }
 
     return [WorkflowValidationResult.pass(checkName)];
+  }
+
+  private async validateGlobalArgInputRefs(
+    workflow: Workflow,
+  ): Promise<WorkflowValidationResult[]> {
+    const results: WorkflowValidationResult[] = [];
+    const declaredInputs = new Set(
+      Object.keys(workflow.inputs?.properties ?? {}),
+    );
+
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        const task = step.task;
+        if (!task) continue;
+
+        const taskData = task.data;
+        if (taskData.type !== "model_method") continue;
+
+        const modelRef = taskData.modelIdOrName ?? taskData.modelName;
+        if (!modelRef) continue;
+        if (modelRef.includes("${{")) continue;
+        if (taskData.modelType?.includes("${{")) continue;
+
+        const checkName =
+          `GlobalArgument input references for '${step.name}' in job '${job.name}' (${modelRef}.${taskData.methodName})`;
+
+        const resolution = await this.methodResolver!.resolve(
+          modelRef,
+          taskData.methodName,
+          taskData.modelType,
+        );
+
+        if (
+          resolution.status !== "resolved" ||
+          !resolution.definitionProvidedArgValues
+        ) {
+          continue;
+        }
+
+        const referencedInputs = extractInputReferences(
+          resolution.definitionProvidedArgValues,
+        );
+
+        if (referencedInputs.size === 0) {
+          results.push(WorkflowValidationResult.pass(checkName));
+          continue;
+        }
+
+        const missing = [...referencedInputs].filter(
+          (name) => !declaredInputs.has(name),
+        );
+
+        if (missing.length > 0) {
+          results.push(
+            WorkflowValidationResult.fail(
+              checkName,
+              `Model definition references undeclared workflow input(s): ${
+                missing.join(", ")
+              }`,
+            ),
+          );
+        } else {
+          results.push(WorkflowValidationResult.pass(checkName));
+        }
+      }
+    }
+
+    return results;
   }
 }

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1326,3 +1326,255 @@ Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips
   const inputResult = results.find((r) => r.name.includes("Step inputs"));
   assertEquals(inputResult?.passed, true);
 });
+
+// ---------- validateGlobalArgInputRefs ----------
+
+Deno.test("validateGlobalArgInputRefs: fails when globalArguments reference undeclared workflow inputs", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: "echo ${{ inputs.recordHost }} ${{ inputs.dnsZone }}",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    inputs: {
+      properties: {
+        recordHost: { type: "string" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, false);
+  assertEquals(result?.error?.includes("dnsZone"), true);
+});
+
+Deno.test("validateGlobalArgInputRefs: passes when all referenced inputs are declared", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: "echo ${{ inputs.recordHost }} ${{ inputs.dnsZone }}",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    inputs: {
+      properties: {
+        recordHost: { type: "string" },
+        dnsZone: { type: "string" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, true);
+});
+
+Deno.test("validateGlobalArgInputRefs: passes when no expressions in globalArguments", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: "echo hello",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, true);
+});
+
+Deno.test("validateGlobalArgInputRefs: fails when workflow has no inputs but globalArguments reference them", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: "${{ inputs.host }}",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, false);
+  assertEquals(result?.error?.includes("host"), true);
+});
+
+Deno.test("validateGlobalArgInputRefs: skips when model reference contains CEL expression", async () => {
+  const resolver = mockResolver({});
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("${{ inputs.model_name }}", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result, undefined);
+});
+
+Deno.test("validateGlobalArgInputRefs: skips when resolution has no definitionProvidedArgValues", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: ["run"],
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result, undefined);
+});
+
+Deno.test("validateGlobalArgInputRefs: handles bracket notation input references", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: '${{ inputs["record-host"] }}',
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    inputs: {
+      properties: {
+        "record-host": { type: "string" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("my-model", "execute"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, true);
+});

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -135,14 +135,25 @@ function createModelMethodResolver(
       // including unresolved ${{ ... }} expressions: invalid CEL is a runtime
       // concern, not a validator concern.
       const { definition } = lookupResult;
+      const methodArgValues = definition.getMethodArguments(methodName);
       const definitionProvidedArgs = Array.from(
         new Set([
-          ...Object.keys(definition.getMethodArguments(methodName)),
+          ...Object.keys(methodArgValues),
           ...Object.keys(definition.globalArguments),
         ]),
       );
 
-      return { status: "resolved", requiredArgs, definitionProvidedArgs };
+      const definitionProvidedArgValues: Record<string, unknown> = {
+        ...definition.globalArguments,
+        ...methodArgValues,
+      };
+
+      return {
+        status: "resolved",
+        requiredArgs,
+        definitionProvidedArgs,
+        definitionProvidedArgValues,
+      };
     },
   };
 }


### PR DESCRIPTION
## Summary

- Adds a new validation check (#9) to `swamp workflow validate` that scans model definition `globalArguments` and method-level argument defaults for `${{ inputs.* }}` expressions and verifies each referenced input is declared by the calling workflow
- Previously, these expression references were only resolved at runtime — a missing input declaration would pass validation but fail during execution with `Unresolved expression in globalArguments`
- Extends `MethodResolution` with `definitionProvidedArgValues` to carry raw argument values from the resolver, then uses the existing `extractInputReferences()` utility to find `inputs.*` references in those values

Fixes swamp-club#622

## Test Plan

- 7 new unit tests in `validation_service_test.ts` covering: undeclared input references (fail), all inputs declared (pass), no expressions (pass), no workflow inputs (fail), CEL model reference skip, missing `definitionProvidedArgValues` skip, bracket notation
- Full test suite passes (7023 tests, 0 failed)
- Verified against reproduction: model with `globalArguments: { run: "echo ${{ inputs.recordHost }} ${{ inputs.dnsZone }}" }` + workflow declaring only `recordHost` → previously passed validation, now correctly fails with `Model definition references undeclared workflow input(s): dnsZone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)