### PR TITLE
feat(extensions): allow extensions to declare resource specs

### DIFF
--- a/.claude/skills/swamp/references/extension/references/model/api.md
+++ b/.claude/skills/swamp/references/extension/references/model/api.md
@@ -632,6 +632,47 @@ modelRegistry.extend("aws/ec2/vpc", {}, {
 Check names must be unique -- conflicts with existing checks on the target model
 throw an error at registration time.
 
+### Extension Resources via export const extension
+
+Extensions can declare new resource specs that are merged into the target model
+type. Add an optional `resources` field to the extension object:
+
+```typescript
+export const extension = {
+  type: "aws/ec2/vpc",
+  resources: {
+    "audit": {
+      description: "Audit results for the VPC",
+      schema: z.object({
+        findings: z.array(z.string()),
+        summary: z.string(),
+      }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  },
+  methods: [
+    {
+      audit: {
+        description: "Audit the VPC",
+        arguments: z.object({}),
+        execute: async (args, context) => {
+          const handle = await context.writeResource("audit", "audit", {
+            findings: ["all good"],
+            summary: "No issues found",
+          });
+          return { dataHandles: [handle] };
+        },
+      },
+    },
+  ],
+};
+```
+
+Resource spec names must be unique -- conflicts with existing resource specs on
+the target model throw an error at registration time. The `resources` field uses
+the same `Record<string, ResourceOutputSpec>` shape as base model definitions.
+
 ---
 
 ## Logging API

--- a/.claude/skills/swamp/references/extension/references/model/examples.md
+++ b/.claude/skills/swamp/references/extension/references/model/examples.md
@@ -1614,7 +1614,7 @@ export const extension = {
           ) => Promise<{ name: string }>;
         },
       ) => {
-        // Extensions use the target model's resources/files
+        // Write to a resource declared on the target model
         const handle = await context.writeResource("result", "result", {
           exitCode: 0,
           command: `audit: ${context.definition.name}`,
@@ -1688,6 +1688,60 @@ export const extension = {
   }],
 };
 ```
+
+### Extension with Custom Resources
+
+Extensions can declare their own resource specs when the target model's existing
+resources don't fit the extension's output shape:
+
+```typescript
+// extensions/models/shell_audit_custom.ts
+import { z } from "npm:zod@4";
+
+export const extension = {
+  type: "command/shell",
+  resources: {
+    "audit": {
+      description: "Audit findings for the shell command",
+      schema: z.object({
+        findings: z.array(z.string()),
+        summary: z.string(),
+        auditedAt: z.string(),
+      }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  },
+  methods: [{
+    audit: {
+      description: "Audit the shell command with custom output",
+      arguments: z.object({}),
+      execute: async (
+        _args: Record<string, never>,
+        context: {
+          definition: { name: string };
+          writeResource: (
+            specName: string,
+            name: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        // Write to the extension-declared "audit" resource
+        const handle = await context.writeResource("audit", "audit", {
+          findings: ["command uses shell expansion safely"],
+          summary: "No issues found",
+          auditedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+  }],
+};
+```
+
+Resource spec names must not conflict with specs already declared on the target
+model type. The `resources` field uses the same shape as base model definitions.
 
 ### Nested Directory Organization
 

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -147,6 +147,7 @@ const UserModelSchema = z.object({
 
 const UserExtensionSchema = z.object({
   type: z.string(),
+  resources: z.record(z.string(), ResourceOutputSpecSchema).optional(),
   methods: z.array(z.record(z.string(), UserMethodSchema)),
   checks: z.array(z.record(z.string(), UserCheckSchema)).optional(),
 });
@@ -583,7 +584,7 @@ export const modelKindAdapter: KindAdapter = {
     }
 
     try {
-      modelRegistry.extend(ext.type, methods, checks);
+      modelRegistry.extend(ext.type, methods, checks, ext.resources);
       result.extended.push(file);
     } catch (error) {
       result.failed.push({ file, error: String(error) });

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -945,6 +945,7 @@ export class ModelRegistry {
     type: string | ModelType,
     methods: Record<string, MethodDefinition>,
     checks?: Record<string, CheckDefinition>,
+    resources?: Record<string, ResourceOutputSpec>,
     reports?: string[],
   ): void {
     const modelType = typeof type === "string" ? ModelType.create(type) : type;
@@ -975,12 +976,31 @@ export class ModelRegistry {
       }
     }
 
+    // Check for resource spec name conflicts
+    if (resources) {
+      for (const specName of Object.keys(resources)) {
+        if (existing.resources?.[specName]) {
+          throw new Error(
+            `Resource spec '${specName}' already exists on model type '${key}'`,
+          );
+        }
+      }
+    }
+
     // Create a new merged ModelDefinition (immutable)
     const merged: ModelDefinition = {
       ...existing,
       methods: { ...existing.methods, ...methods },
       ...(checks || existing.checks
         ? { checks: { ...(existing.checks ?? {}), ...(checks ?? {}) } }
+        : {}),
+      ...(resources || existing.resources
+        ? {
+          resources: {
+            ...(existing.resources ?? {}),
+            ...(resources ?? {}),
+          },
+        }
         : {}),
       ...(reports || existing.reports
         ? {

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -832,6 +832,92 @@ Deno.test("ModelRegistry.extend merges checks from extension with existing check
   assertEquals("check-b" in extended!.checks!, true);
 });
 
+// --- ModelRegistry.extend() with resources tests ---
+
+Deno.test("ModelRegistry.extend: adds resources to existing model", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/extend-resources"));
+
+  registry.extend("swamp/extend-resources", {}, undefined, {
+    "audit": {
+      description: "Audit results",
+      schema: z.object({ findings: z.array(z.string()) }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  });
+
+  const extended = registry.get("swamp/extend-resources");
+  assertEquals("data" in extended!.resources!, true);
+  assertEquals("audit" in extended!.resources!, true);
+  assertEquals(extended!.resources!["audit"].description, "Audit results");
+});
+
+Deno.test("ModelRegistry.extend: throws on resource spec name conflict", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/resource-conflict"));
+
+  assertThrows(
+    () => {
+      registry.extend("swamp/resource-conflict", {}, undefined, {
+        "data": {
+          description: "Conflicting resource",
+          schema: z.object({ value: z.string() }),
+          lifetime: "infinite",
+          garbageCollection: 5,
+        },
+      });
+    },
+    Error,
+    "Resource spec 'data' already exists on model type 'swamp/resource-conflict'",
+  );
+});
+
+Deno.test("ModelRegistry.extend: preserves existing resources when adding methods only", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/preserve-resources"));
+
+  registry.extend("swamp/preserve-resources", {
+    extra: {
+      description: "Extra method",
+      arguments: z.object({}),
+      execute: () => Promise.resolve({}),
+    },
+  });
+
+  const extended = registry.get("swamp/preserve-resources");
+  assertEquals("data" in extended!.resources!, true);
+  assertEquals(Object.keys(extended!.resources!).length, 1);
+});
+
+Deno.test("ModelRegistry.extend: adds resources to model with no existing resources", () => {
+  const registry = new ModelRegistry();
+  const model: ModelDefinition = {
+    type: ModelType.create("swamp/no-resources"),
+    version: "2026.02.09.1",
+    methods: {
+      noop: {
+        description: "No-op",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+  registry.register(model);
+
+  registry.extend("swamp/no-resources", {}, undefined, {
+    "state": {
+      description: "State resource",
+      schema: z.object({ value: z.string() }),
+      lifetime: "infinite",
+      garbageCollection: 3,
+    },
+  });
+
+  const extended = registry.get("swamp/no-resources");
+  assertEquals("state" in extended!.resources!, true);
+});
+
 // --- Lazy entry tests ---
 
 function createLazyEntry(typeString: string): LazyModelEntry {

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -1482,6 +1482,135 @@ export const extension = {
   );
 });
 
+Deno.test("UserModelLoader extension with resources merges into target model", async () => {
+  const ts = Date.now();
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@user/ext-resources-${ts}",
+  version: "2026.02.09.1",
+  globalArguments: z.object({ message: z.string() }),
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    write: {
+      description: "Write",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "@user/ext-resources-${ts}",
+  resources: {
+    "audit": {
+      description: "Audit results",
+      schema: z.object({ findings: z.array(z.string()) }),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  },
+  methods: [{
+    audit: {
+      description: "Audit",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  await withTempModels(
+    { "base.ts": modelCode, "ext.ts": extCode },
+    async (dir) => {
+      const loader = createTestLoader();
+      const result = await loader.load(dir);
+
+      assertEquals(result.loaded.length, 1);
+      assertEquals(result.extended.length, 1);
+      assertEquals(result.failed.length, 0);
+
+      const modelDef = modelRegistry.get(`@user/ext-resources-${ts}`);
+      assertEquals(modelDef !== undefined, true);
+      assertEquals("data" in modelDef!.resources!, true);
+      assertEquals("audit" in modelDef!.resources!, true);
+      assertEquals(modelDef!.resources!["audit"].description, "Audit results");
+      assertEquals(modelDef!.resources!["audit"].garbageCollection, 5);
+    },
+  );
+});
+
+Deno.test("UserModelLoader extension with conflicting resource spec fails gracefully", async () => {
+  const ts = Date.now();
+  const modelCode = `
+import { z } from "npm:zod@4";
+export const model = {
+  type: "@user/ext-res-conflict-${ts}",
+  version: "2026.02.09.1",
+  resources: {
+    "data": {
+      description: "Data output",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    write: {
+      description: "Write",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  },
+};
+`;
+  const extCode = `
+import { z } from "npm:zod@4";
+export const extension = {
+  type: "@user/ext-res-conflict-${ts}",
+  resources: {
+    "data": {
+      description: "Conflicting data",
+      schema: z.object({}),
+      lifetime: "infinite",
+      garbageCollection: 5,
+    },
+  },
+  methods: [{
+    audit: {
+      description: "Audit",
+      arguments: z.object({}),
+      execute: async () => ({ dataHandles: [] }),
+    },
+  }],
+};
+`;
+
+  await withTempModels(
+    { "base.ts": modelCode, "ext.ts": extCode },
+    async (dir) => {
+      const loader = createTestLoader();
+      const result = await loader.load(dir);
+
+      assertEquals(result.loaded.length, 1);
+      assertEquals(result.failed.length, 1);
+      assertStringIncludes(
+        result.failed[0].error,
+        "Resource spec 'data' already exists",
+      );
+    },
+  );
+});
+
 // --- resources/files validation tests ---
 
 Deno.test("UserModelLoader registers user-declared resources", async () => {


### PR DESCRIPTION
## Summary

Closes swamp-club#619.

- Adds an optional `resources` field to `UserExtensionSchema`, allowing `export const extension` to declare new resource specs on the target model type
- Extends `modelRegistry.extend()` with a `resources?` parameter that merges with conflict detection (same pattern as methods, checks, and reports)
- Updates `processSecondaryExport()` to pass extension-declared resources through to `extend()`

Previously, extensions could add methods and checks but not resource specs — if an extension method needed a different output shape than the target model's existing resources, the only option was to build a standalone model. Now extensions can declare their own resources and write to them.

## Test Plan

- Added 4 unit tests for `ModelRegistry.extend()` with resources: merge, conflict detection, preservation when absent, and adding to a model with no existing resources
- Added 2 integration tests in `user_model_loader_test.ts`: extension resource merge via loader, and conflict detection via loader
- Verified end-to-end in a scratch repo (`/tmp/swamp-repro-issue-619`):
  - **Before**: `swamp model method run my-widget audit` fails with `Undeclared resource spec 'audit' in model 'repro/widget'. Declared resource specs: state`
  - **After**: succeeds, writes audit data to the extension-declared `audit` resource with correct schema, garbage collection, and tags
- `deno check`, `deno lint`, `deno fmt`, `deno run test`, `deno run compile` all pass