### PR TITLE
fix(reports): make reports.require failures loud (swamp-club#640)

### DIFF
--- a/design/reports.md
+++ b/design/reports.md
@@ -299,6 +299,32 @@ filtering pipeline. The algorithm:
 7. **Inclusion filters** — `--report <name>` and `--report-label <label>`
    narrow the remaining set to only matching reports.
 
+### Unresolvable Required Reports
+
+A name in `selection.require` that resolves to nothing — neither loaded nor
+lazy-indexed after the promotion pass — is a contract violation, not a silent
+no-op (swamp-club#640). `executeReports` logs a warning naming the report,
+emits a `report_failed` event, persists a fallback error artifact (so
+`swamp report search` surfaces the failure), and counts it in
+`ReportExecutionSummary.failures` — which flips a `swamp model method run` to
+failed, exactly as a required report that loads and then throws would. Names
+that also appear in `selection.skip` are exempt (skip wins over require, so
+the report was never going to run).
+
+Runners that call `executeReports` more than once with the same selection
+(method + model scope passes) suppress the duplicate via the
+`emitUnresolvableRequireFailures` parameter, passing `true` on exactly one
+call.
+
+### Filter Options Are Optional
+
+`ReportFilterOptions` carries CLI flags; callers of the workflow execution
+service that have no CLI flags to thread (workflow resume, embedded runs)
+simply omit it. An absent filter means "no filtering" — the service defaults
+it to `{}` so reports, including required ones, always execute. Report
+execution must never depend on presentation-layer plumbing supplying an
+options object.
+
 Key invariants:
 
 - **Skip always wins over require.** If a report is in both `skip` and
@@ -352,6 +378,11 @@ The fallback JSON artifact contains:
 
 Consumers can check the `error` field to distinguish a successful report result
 from a fallback error artifact.
+
+The same fallback artifact is generated for a required report that cannot be
+resolved at all (see "Unresolvable Required Reports" above) — the `message`
+field then carries the "Required report not found" diagnostic instead of a
+throw from `execute()`.
 
 If persisting the fallback artifact itself fails, the error is silently absorbed
 to avoid masking the original report error. In this case, only the `WRN` log

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -324,6 +324,7 @@ export async function executeReports(
   methodName?: string,
   modelTypeReports?: string[],
   varySuffix?: string,
+  emitUnresolvableRequireFailures = true,
 ): Promise<ReportExecutionSummary> {
   // Promote lazy-registered reports for every candidate name before calling
   // getAll(). getAll() only returns fully-loaded entries from the registry's
@@ -357,6 +358,83 @@ export async function executeReports(
     Array.from(candidateNames, (name) => registry.ensureTypeLoaded(name)),
   );
 
+  const results: ReportExecutionResult[] = [];
+  let failures = 0;
+
+  // A required report still absent from the registry after the promotion
+  // pass is unresolvable — no loaded or lazy-indexed report matches the
+  // name (missing pull, typo, or broken catalog entry). `require` is a
+  // contract: fail loudly instead of silently dropping the name from the
+  // candidate set. Counted in `failures` so the surrounding run reports as
+  // failed, matching required reports that load and then throw — and like
+  // that path, repeated runs accumulate error-artifact versions. Names in
+  // selection.skip are exempt (skip wins over require, so the report was
+  // never going to run). Callers that invoke executeReports more than once
+  // with the same selection set emitUnresolvableRequireFailures on exactly
+  // one call to avoid duplicate failures.
+  if (emitUnresolvableRequireFailures) {
+    const skipNames = new Set(selection?.skip ?? []);
+    const seen = new Set<string>();
+    for (const ref of selection?.require ?? []) {
+      const name = getReportRefName(ref);
+      if (seen.has(name) || skipNames.has(name)) continue;
+      seen.add(name);
+      if (registry.get(name)) continue;
+
+      const errorMessage = `Required report not found: ${name}. ` +
+        `No loaded or indexed report matches this name — check the ` +
+        `reports.require entry, pull the extension that provides it, or ` +
+        `run 'swamp doctor extensions --repair'.`;
+      context.logger.warn(
+        "Required report not found: {report} — check the reports.require " +
+          "entry, pull the extension that provides it, or run " +
+          "'swamp doctor extensions --repair'",
+        { report: name },
+      );
+
+      events?.onReportStarted(name, context.scope);
+
+      // Persist an error artifact so `swamp report search` surfaces the
+      // failure instead of returning nothing for the report.
+      let errorDataHandles: DataHandle[] | undefined;
+      try {
+        const fallback = buildReportErrorResult(
+          name,
+          context.scope,
+          errorMessage,
+        );
+        errorDataHandles = await persistReportData(
+          context.dataRepository,
+          modelType,
+          modelId,
+          name,
+          context.scope,
+          fallback.markdown,
+          fallback.json,
+          varySuffix,
+        );
+      } catch {
+        // Best-effort — the failure event carries the message regardless.
+      }
+
+      events?.onReportFailed(
+        name,
+        context.scope,
+        errorMessage,
+        errorDataHandles,
+      );
+
+      results.push({
+        name,
+        scope: context.scope,
+        success: false,
+        error: errorMessage,
+        dataHandles: errorDataHandles,
+      });
+      failures++;
+    }
+  }
+
   const allReports = registry.getAll();
   const applicable = filterReports(
     allReports,
@@ -368,11 +446,8 @@ export async function executeReports(
   );
 
   if (applicable.length === 0) {
-    return { results: [], failures: 0 };
+    return { results, failures };
   }
-
-  const results: ReportExecutionResult[] = [];
-  let failures = 0;
 
   context.redactSensitiveArgs = buildRedactSensitiveArgs(context);
 

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -1512,3 +1512,167 @@ Deno.test("executeReports: onReportFailed callback receives data handles", async
   assertEquals(failedHandles !== undefined, true);
   assertEquals(failedHandles!.length, 2);
 });
+
+// --- executeReports unresolvable-require tests (swamp-club#640) ---
+
+Deno.test("executeReports: unresolvable required report fails loudly", async () => {
+  const registry = new ReportRegistry();
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  let failedName: string | undefined;
+  let failedError: string | undefined;
+  let failedHandles: DataHandle[] | undefined;
+  const events = {
+    onReportStarted: () => {},
+    onReportCompleted: () => {},
+    onReportFailed: (
+      name: string,
+      _scope: string,
+      error: string,
+      dataHandles?: DataHandle[],
+    ) => {
+      failedName = name;
+      failedError = error;
+      failedHandles = dataHandles;
+    },
+  };
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/missing"] },
+    {},
+    events,
+    "run",
+  );
+
+  assertEquals(summary.failures, 1);
+  assertEquals(summary.results.length, 1);
+  assertEquals(summary.results[0].name, "@test/missing");
+  assertEquals(summary.results[0].success, false);
+  assertStringIncludes(summary.results[0].error!, "Required report not found");
+
+  assertEquals(failedName, "@test/missing");
+  assertStringIncludes(failedError!, "Required report not found");
+  assertEquals(failedHandles !== undefined, true);
+
+  // Error artifact persisted so `swamp report search` surfaces the failure
+  assertEquals(saved.length, 2);
+  assertEquals(saved[0].name, "report-test-missing");
+  assertEquals(saved[1].name, "report-test-missing-json");
+  assertStringIncludes(saved[0].content, "Required report not found");
+});
+
+Deno.test("executeReports: unresolvable require suppressed when emitUnresolvableRequireFailures is false", async () => {
+  const registry = new ReportRegistry();
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/missing"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+    undefined,
+    false,
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 0);
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("executeReports: unresolvable require exempt when also in skip", async () => {
+  const registry = new ReportRegistry();
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/missing"], skip: ["@test/missing"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 0);
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("executeReports: sibling reports still run when a required report is unresolvable", async () => {
+  const registry = new ReportRegistry();
+  registry.register("@test/present", makeReport("method"));
+
+  const { repo } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/missing", "@test/present"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(summary.failures, 1);
+  assertEquals(summary.results.length, 2);
+  const missing = summary.results.find((r) => r.name === "@test/missing");
+  const present = summary.results.find((r) => r.name === "@test/present");
+  assertEquals(missing?.success, false);
+  assertEquals(present?.success, true);
+});
+
+Deno.test("executeReports: unresolvable require failure survives artifact persistence errors", async () => {
+  const registry = new ReportRegistry();
+
+  const modelType = ModelType.create("test/model");
+  const brokenRepo = {
+    nextId: () => generateDataId(),
+    findByName: () => Promise.resolve(null),
+    listVersions: () => Promise.resolve([]),
+    save: () => Promise.reject(new Error("disk full")),
+  };
+  const context = makeMethodContext(
+    // deno-lint-ignore no-explicit-any
+    brokenRepo as any,
+    modelType,
+  );
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["@test/missing"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  // Persistence failed, but the failure is still reported
+  assertEquals(summary.failures, 1);
+  assertEquals(summary.results[0].success, false);
+  assertEquals(summary.results[0].dataHandles, undefined);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1436,7 +1436,9 @@ export class WorkflowExecutionService {
         runtimeTags: options?.runtimeTags,
         secretRedactor,
         signal: options?.signal,
-        reportFilterOptions: options?.reportFilterOptions,
+        // Default so per-step reports run even when the caller doesn't
+        // thread CLI report flags — absent filter means "no filtering".
+        reportFilterOptions: options?.reportFilterOptions ?? {},
         swampSha: options?.swampSha,
         skipCheckNames: options?.skipCheckNames,
         skipCheckLabels: options?.skipCheckLabels,
@@ -1751,7 +1753,9 @@ export class WorkflowExecutionService {
       runtimeTags: options?.runtimeTags,
       secretRedactor,
       signal: options?.signal,
-      reportFilterOptions: options?.reportFilterOptions,
+      // workflow resume never receives CLI report flags — default so
+      // resumed runs still execute reports instead of silently skipping.
+      reportFilterOptions: options?.reportFilterOptions ?? {},
       swampSha: options?.swampSha,
     };
 
@@ -2610,9 +2614,10 @@ export class WorkflowExecutionService {
       | import("../reports/report_execution_service.ts").ReportFilterOptions
       | undefined,
   ): AsyncGenerator<WorkflowExecutionEvent> {
-    if (!reportFilterOptions) {
-      return;
-    }
+    // Callers that don't thread CLI report flags (workflow resume, embedded
+    // runs) still execute reports — required reports must not silently
+    // skip. An absent filter means "no filtering", not "no reports".
+    const filterOptions = reportFilterOptions ?? {};
 
     const stepExecutions: WorkflowStepExecutionDetail[] = [];
     for (const [key, info] of modelInfoByStep) {
@@ -2672,7 +2677,7 @@ export class WorkflowExecutionService {
       workflowRunId: run.id,
       workflowStatus: run.status === "succeeded" ? "succeeded" : "failed",
       stepExecutions,
-      reportFilterOptions,
+      reportFilterOptions: filterOptions,
       repoDir: this.repoDir,
       runLogger: getWorkflowRunLogger(workflow.name),
       unifiedDataRepo: this.dataRepo,

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -27,6 +27,7 @@ import {
   WorkflowExecutionService,
 } from "./execution_service.ts";
 import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { reportRegistry } from "../reports/report_registry.ts";
 import { Workflow } from "./workflow.ts";
 import { Job } from "./job.ts";
 import { Step } from "./step.ts";
@@ -2144,6 +2145,116 @@ Deno.test("check skip options and swampSha are threaded to step context", async 
   });
 });
 
+// --- report execution without CLI report flags (swamp-club#640) ---
+//
+// Callers that don't thread reportFilterOptions (workflow resume, embedded
+// runs) must still execute reports — before #640 the absent options object
+// silently skipped all workflow-scope and step-scope reports.
+
+Deno.test("run() executes workflow-scope required reports when reportFilterOptions is not supplied", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const reportName = "@test640/wf-required";
+    if (!reportRegistry.get(reportName)) {
+      reportRegistry.register(reportName, {
+        description: "issue 640 regression report",
+        scope: "workflow",
+        execute: () =>
+          Promise.resolve({ markdown: "# 640", json: { ok: true } }),
+      });
+    }
+
+    const workflow = Workflow.create({
+      name: "issue-640-require-test",
+      reports: { require: [reportName] },
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "step1",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const completedReports: string[] = [];
+    // No reportFilterOptions passed — reports must still run.
+    for await (const event of service.run(workflow.name, {})) {
+      if (event.kind === "report_completed") {
+        completedReports.push(event.reportName);
+      }
+    }
+
+    assertEquals(completedReports.includes(reportName), true);
+  });
+});
+
+Deno.test("run() defaults reportFilterOptions in step context when not supplied", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    class ContextCapturingExecutor implements StepExecutor {
+      capturedContexts: StepExecutionContext[] = [];
+      execute(_step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.capturedContexts.push(ctx);
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new ContextCapturingExecutor();
+
+    const workflow = Workflow.create({
+      name: "issue-640-default-filter-test",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "step1",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    for await (const _event of service.run(workflow.name, {})) {
+      // Drain events
+    }
+
+    assertEquals(executor.capturedContexts.length, 1);
+    assertEquals(executor.capturedContexts[0].reportFilterOptions, {});
+  });
+});
+
 // --- forEach step name expansion regression tests (Issue #976 / PR #973) ---
 
 Deno.test("expandForEachSteps: multi-expression step name produces unique names for items sharing a field", async () => {
@@ -2782,6 +2893,10 @@ Deno.test("CONTRACT: success run emits events in exact order", async () => {
       "step_started",
       "step_completed",
       "job_completed",
+      // Workflow-scope reports run even without reportFilterOptions
+      // (swamp-club#640) — the builtin workflow summary emits here.
+      "report_started",
+      "report_completed",
       "completed",
     ]);
   });
@@ -2820,6 +2935,10 @@ Deno.test("CONTRACT: step failure emits events in exact order", async () => {
       "step_started",
       "step_failed",
       "job_completed",
+      // Workflow-scope reports run even without reportFilterOptions
+      // (swamp-club#640) — the builtin workflow summary emits here.
+      "report_started",
+      "report_completed",
       "completed",
     ]);
     // The workflow itself must reflect failure even though the lifecycle

--- a/src/domain/workflows/method_report_runner.ts
+++ b/src/domain/workflows/method_report_runner.ts
@@ -207,7 +207,9 @@ export class MethodReportRunner {
       args.reportVarySuffix,
     );
 
-    // Model scope
+    // Model scope. The method-scope call above already emitted failures
+    // for unresolvable required reports — suppress them here to avoid
+    // duplicates.
     await executeReports(
       reportRegistry,
       { ...methodContext, scope: "model" },
@@ -219,6 +221,7 @@ export class MethodReportRunner {
       args.methodName,
       stepModelTypeReports,
       args.reportVarySuffix,
+      false,
     );
 
     return collected;
@@ -311,7 +314,10 @@ export class MethodReportRunner {
         stepModelTypeReports,
       );
     } catch (reportError) {
-      args.runLogger.debug(
+      // Swallowed so a broken report cannot replace the real execution
+      // error, but logged at warn so the failure is visible at default
+      // log level.
+      args.runLogger.warn(
         "Failed to run reports for failed method: {error}",
         {
           error: reportError instanceof Error

--- a/src/domain/workflows/workflow_report_runner.ts
+++ b/src/domain/workflows/workflow_report_runner.ts
@@ -161,7 +161,9 @@ export class WorkflowReportRunner {
         BUILTIN_WORKFLOW_REPORTS,
       );
     } catch (reportError) {
-      args.runLogger.debug(
+      // Swallowed so a broken report cannot mask the workflow result, but
+      // logged at warn so the failure is visible at default log level.
+      args.runLogger.warn(
         "Failed to run workflow-scope reports: {error}",
         {
           error: reportError instanceof Error

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -920,6 +920,10 @@ export async function* modelMethodRun(
             },
             input.methodName,
             [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
+            undefined,
+            // The method-scope call above already emitted failures for
+            // unresolvable required reports — suppress duplicates.
+            false,
           );
 
           for (const result of modelSummary.results) {


### PR DESCRIPTION
## Summary

Fixes swamp-club#640, where a pulled extension report named in a workflow's `reports.require` was silently skipped — no error, no warning, no artifact — while `--report <name>` and local extension reports worked.

The root symptom is that an unresolvable required report was dropped from the candidate set with zero diagnostics. This PR makes `reports.require` a real contract and closes two adjacent silent-skip paths found during investigation.

### Changes

1. **Loud unresolvable requires** (`report_execution_service.ts`): after the lazy-promotion pass, any `reports.require` name still absent from the registry now logs a warning naming the report and the remedy, emits a `report_failed` event, persists a searchable error artifact (so `swamp report search` surfaces it), and counts as a failure — which fails a `swamp model method run`, matching how a required report that loads then throws already behaves. Names also in `reports.skip` are exempt. A new `emitUnresolvableRequireFailures` parameter lets the method+model scope callers dedup the warning.

2. **Surfaced swallowed errors**: report-runner catch blocks in `workflow_report_runner.ts` and `method_report_runner.ts` now log at `warn` instead of `debug`, so a broken required bundle is visible at the default log level (errors are still swallowed so a broken report can't mask the run result).

3. **`reportFilterOptions` defaults to `{}`** in `WorkflowExecutionService.run`/`resume`. `swamp workflow resume` never threaded the CLI report flags, so resumed runs silently skipped **all** workflow- and step-scope reports, required ones included. An absent filter now means "no filtering", not "no reports".

### Behavior change (intentional)

A model definition or workflow with a missing/typo'd required report changes from **silent success** to a **failed run**. This is the point of the fix — a required report that never runs should not pass silently.

### Note on the original report

We could not reproduce the silent skip on Linux, at the reporter's exact build (873563f2) or at HEAD — the pulled `@webframp/terraform-drift-report` auto-executes via `require` on cold and warm catalog runs. `--report` is a pure narrowing filter over the same candidate set, so the reported symptom pair implies the repo state changed between runs (likely an `extension pull` repairing a broken catalog entry). A diagnostics request is posted on the issue; regardless of the original trigger, every path here is now loud.

## Test Plan

- New unit tests in `report_execution_service_test.ts`: unresolvable require emits `report_failed` + counts a failure + persists an error artifact + does not throw + sibling reports still run; `emitUnresolvableRequireFailures=false` suppresses the duplicate; skip exempts the name; persistence failure still reports the failure.
- New regression tests in `execution_service_test.ts`: `run()` executes workflow-scope required reports with no `reportFilterOptions`; step context defaults the options to `{}`. Two CONTRACT tests updated to reflect that the builtin workflow summary now emits on a bare `service.run()`.
- Manual verification against a real pulled `@webframp/aws/terraform-drift` repo with the compiled binary: drift report still runs exactly once per run; a workflow/model requiring a nonexistent report now warns, emits `report_failed`, writes a `report search`-visible artifact, and exits non-zero.
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` clean. Full suite green except pre-existing unrelated failures on `main` (filed as swamp-club#645).

Docs: `design/reports.md` updated; manual-docs follow-up filed as swamp-club Lab #648. UAT coverage gap filed as swamp-club/swamp-uat#264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)