### PR TITLE
feat(cli): deduplicate model type describe output and add --compact mode

### DIFF
--- a/.claude/skills/swamp-getting-started/SKILL.md
+++ b/.claude/skills/swamp-getting-started/SKILL.md
@@ -89,7 +89,7 @@ warnings to the user.
 
 - `command/shell`: `execute`
 - Local typed: a read-only method first (`sync`, `get`)
-- Extension: check `swamp model type describe <type> --json`
+- Extension: check `swamp model type describe <type> --compact --json`
 
 **Verify:** The run completes with `succeeded`.
 

--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -45,7 +45,7 @@ definitions referenced across multiple workflows.
 | Task                | Command                                                              |
 | ------------------- | -------------------------------------------------------------------- |
 | Search model types  | `swamp model type search [query] --json`                             |
-| Describe a type     | `swamp model type describe <type> --json`                            |
+| Describe a type     | `swamp model type describe <type> --compact --json`                  |
 | Create model input  | `swamp model create <type> <name> --json`                            |
 | Create with args    | `swamp model create <type> <name> --global-arg key=value --json`     |
 | Search models       | `swamp model search [query] --json`                                  |
@@ -110,36 +110,45 @@ swamp model type search "echo" --json
 
 ## Describe Model Types
 
-Get the full schema and available methods for a type.
+Get the methods and argument schemas for a type. Use `--compact` for a minimal
+digest suitable for agent discovery.
 
 ```bash
-swamp model type describe command/shell --json
+swamp model type describe command/shell --compact --json
 ```
 
-**Output shape:**
+**Compact output shape:**
 
 ```json
 {
   "type": { "raw": "command/shell", "normalized": "command/shell" },
   "version": "2026.02.09.1",
-  "globalArguments": {/* JSON Schema */},
-  "resourceAttributesSchema": {/* JSON Schema */},
+  "globalArguments": {
+    "properties": { "message": { "type": "string" } },
+    "required": ["message"]
+  },
+  "dataOutputSpecs": ["result"],
   "methods": [
     {
       "name": "execute",
       "description": "Execute a shell command and capture output",
-      "arguments": {/* JSON Schema */},
-      "inputs": {/* JSON Schema (same as arguments) */}
+      "arguments": {
+        "properties": { "cmd": { "type": "string" } },
+        "required": ["cmd"]
+      }
     }
   ]
 }
 ```
 
+Omit `--compact` for full JSON Schema detail on arguments and data output specs.
+
 **Key fields:**
 
 - `globalArguments` - JSON Schema for input YAML `globalArguments` section
-- `methods` - Available operations with their per-method `inputs` schemas (also
-  available as `arguments` for backward compatibility)
+- `dataOutputSpecs` - Output spec names (compact) or full specs (full mode), at
+  type level
+- `methods` - Available operations with their per-method `arguments` schemas
 
 ## Create Model Inputs
 
@@ -507,7 +516,7 @@ run concurrently. See
    instead of building from scratch
 2. **Search local types**: `swamp model type search "shell" --json`
 3. **Describe** to understand the schema:
-   `swamp model type describe command/shell --json`
+   `swamp model type describe command/shell --compact --json`
 4. **Create** an input file: `swamp model create command/shell my-shell --json`
 5. **Edit** the YAML file to set `methods.execute.arguments.run`
 6. **Validate** the model: `swamp model validate my-shell --json`

--- a/.claude/skills/terminal-output/SKILL.md
+++ b/.claude/skills/terminal-output/SKILL.md
@@ -113,12 +113,12 @@ Top-level key: value                    ← no indent
 Reuse these exported functions from `type_describe_output.ts`:
 
 - `formatSchemaAttributes(schema, indent)` - JSON Schema to attribute lines
-- `formatMethodLines(methods)` - Method descriptions with attributes and data
-  outputs
+- `formatMethodLines(methods)` - Method descriptions with argument attributes
 
-Reuse `toMethodDescribeData()` and `zodToJsonSchema()` from
-`src/cli/commands/type_describe.ts` to convert domain objects to presentation
-data.
+Reuse `toMethodDescribeData()`, `buildDataOutputSpecs()`, and
+`zodToJsonSchema()` from `src/cli/commands/type_describe.ts` to convert domain
+objects to presentation data. Data output specs are built at the type level via
+`buildDataOutputSpecs(resources, files)`, not per-method.
 
 ## Validation Output Pattern
 

--- a/src/cli/commands/type_describe.ts
+++ b/src/cli/commands/type_describe.ts
@@ -30,7 +30,11 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 
 // Re-export from libswamp for backward compatibility with existing importers
-export { toMethodDescribeData, zodToJsonSchema } from "../../libswamp/mod.ts";
+export {
+  buildDataOutputSpecs,
+  toMethodDescribeData,
+  zodToJsonSchema,
+} from "../../libswamp/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -38,7 +42,15 @@ type AnyOptions = any;
 export const typeDescribeCommand = new Command()
   .description("Describe a model type with schema details")
   .example("Describe a model type", "swamp type describe aws-ec2")
+  .example(
+    "Compact digest for agents",
+    "swamp type describe aws-ec2 --compact --json",
+  )
   .alias("get")
+  .option(
+    "--compact",
+    "Output a compact digest (method names, descriptions, argument types, output spec names)",
+  )
   .arguments("<type:model_type>")
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, typeArg: string) {
@@ -55,7 +67,8 @@ export const typeDescribeCommand = new Command()
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = createTypeDescribeDeps();
 
-    const renderer = createTypeDescribeRenderer(cliCtx.outputMode);
+    const compact = !!(options as Record<string, unknown>).compact;
+    const renderer = createTypeDescribeRenderer(cliCtx.outputMode, compact);
     await consumeStream(
       typeDescribe(ctx, deps, modelType),
       renderer.handlers(),

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -438,6 +438,7 @@ export {
   type TypeDescribeEvent,
 } from "./types/describe.ts";
 export {
+  buildDataOutputSpecs,
   type DataOutputSpecDescribeData,
   type MethodDescribeData,
   toMethodDescribeData,

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -254,13 +254,7 @@ export async function* modelCreate(
           : undefined,
         methods: modelDef
           ? Object.entries(modelDef.methods).map(
-            ([name, method]) =>
-              toMethodDescribeData(
-                name,
-                method,
-                modelDef.resources,
-                modelDef.files,
-              ),
+            ([name, method]) => toMethodDescribeData(name, method),
           )
           : undefined,
       };

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -126,13 +126,7 @@ export async function* modelGet(
           : undefined,
         methods: modelDef
           ? Object.entries(modelDef.methods).map(
-            ([name, method]) =>
-              toMethodDescribeData(
-                name,
-                method,
-                modelDef.resources,
-                modelDef.files,
-              ),
+            ([name, method]) => toMethodDescribeData(name, method),
           )
           : undefined,
       };

--- a/src/libswamp/models/method_describe.ts
+++ b/src/libswamp/models/method_describe.ts
@@ -27,6 +27,8 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 import {
+  buildDataOutputSpecs,
+  type DataOutputSpecDescribeData,
   type MethodDescribeData,
   toMethodDescribeData,
 } from "../types/schema_helpers.ts";
@@ -40,6 +42,7 @@ export interface ModelMethodDescribeData {
   modelType: string;
   version: string;
   method: MethodDescribeData;
+  dataOutputSpecs?: DataOutputSpecDescribeData[];
 }
 
 export type ModelMethodDescribeEvent =
@@ -114,9 +117,9 @@ export async function* modelMethodDescribe(
         return;
       }
 
-      const methodData = toMethodDescribeData(
-        methodName,
-        method,
+      const methodData = toMethodDescribeData(methodName, method);
+
+      const specs = buildDataOutputSpecs(
         modelDef.resources,
         modelDef.files,
       );
@@ -128,6 +131,7 @@ export async function* modelMethodDescribe(
           modelType: modelType.normalized,
           version: modelDef.version,
           method: methodData,
+          dataOutputSpecs: specs.length > 0 ? specs : undefined,
         },
       };
     })(),

--- a/src/libswamp/types/describe.ts
+++ b/src/libswamp/types/describe.ts
@@ -24,6 +24,8 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 import {
+  buildDataOutputSpecs,
+  type DataOutputSpecDescribeData,
   type MethodDescribeData,
   toMethodDescribeData,
   zodToJsonSchema,
@@ -40,6 +42,7 @@ export interface TypeDescribeData {
   };
   version: string;
   globalArguments?: object;
+  dataOutputSpecs?: DataOutputSpecDescribeData[];
   methods: MethodDescribeData[];
 }
 
@@ -95,15 +98,14 @@ export async function* typeDescribe(
         ? zodToJsonSchema(definition.globalArguments)
         : undefined;
 
+      const specs = buildDataOutputSpecs(
+        definition.resources,
+        definition.files,
+      );
+
       const methods: MethodDescribeData[] = Object.entries(definition.methods)
         .map(
-          ([name, method]) =>
-            toMethodDescribeData(
-              name,
-              method,
-              definition.resources,
-              definition.files,
-            ),
+          ([name, method]) => toMethodDescribeData(name, method),
         );
 
       yield {
@@ -115,6 +117,7 @@ export async function* typeDescribe(
           },
           version: definition.version,
           globalArguments,
+          dataOutputSpecs: specs.length > 0 ? specs : undefined,
           methods,
         },
       };

--- a/src/libswamp/types/describe_test.ts
+++ b/src/libswamp/types/describe_test.ts
@@ -47,6 +47,39 @@ function makeModelDefinition(): ModelDefinition {
   };
 }
 
+function makeModelDefinitionWithSpecs(): ModelDefinition {
+  return {
+    type: makeModelType(),
+    version: "2026.01.01.1",
+    resources: {
+      state: {
+        description: "Current state",
+        schema: z.object({ phase: z.string() }),
+        lifetime: "infinite",
+        garbageCollection: 5,
+      },
+      output: {
+        description: "Output data",
+        schema: z.object({ result: z.string() }),
+        lifetime: "infinite",
+        garbageCollection: 5,
+      },
+    },
+    methods: {
+      start: {
+        description: "Start the resource",
+        arguments: z.object({ name: z.string() }),
+        execute: () => Promise.resolve({}),
+      },
+      stop: {
+        description: "Stop the resource",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+}
+
 function makeDeps(
   overrides: Partial<TypeDescribeDeps> = {},
 ): TypeDescribeDeps {
@@ -124,4 +157,57 @@ Deno.test("typeDescribe error derives correct search term for non-namespaced typ
   const last = events[1] as Extract<TypeDescribeEvent, { kind: "error" }>;
   assertStringIncludes(last.error.message, "swamp extension search run");
   assertStringIncludes(last.error.message, "swamp extension pull @docker/run");
+});
+
+Deno.test("typeDescribe: dataOutputSpecs are at type level, not per-method", async () => {
+  const modelDef = makeModelDefinitionWithSpecs();
+  const deps = makeDeps({
+    resolveModelType: () => Promise.resolve(modelDef),
+  });
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, makeModelType()),
+  );
+
+  const completed = events[1] as Extract<
+    TypeDescribeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.dataOutputSpecs?.length, 2);
+  assertEquals(completed.data.dataOutputSpecs?.[0].specName, "state");
+  assertEquals(completed.data.dataOutputSpecs?.[1].specName, "output");
+  for (const method of completed.data.methods) {
+    assertEquals(Object.keys(method).sort(), [
+      "arguments",
+      "description",
+      "name",
+    ]);
+  }
+});
+
+Deno.test("typeDescribe: methods have no inputs or dataOutputSpecs fields", async () => {
+  const deps = makeDeps();
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, makeModelType()),
+  );
+
+  const completed = events[1] as Extract<
+    TypeDescribeEvent,
+    { kind: "completed" }
+  >;
+  const method = completed.data.methods[0];
+  assertEquals("inputs" in method, false);
+  assertEquals("dataOutputSpecs" in method, false);
+});
+
+Deno.test("typeDescribe: dataOutputSpecs is undefined when type has no specs", async () => {
+  const deps = makeDeps();
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, makeModelType()),
+  );
+
+  const completed = events[1] as Extract<
+    TypeDescribeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.dataOutputSpecs, undefined);
 });

--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -46,8 +46,6 @@ export interface MethodDescribeData {
   name: string;
   description: string;
   arguments: object;
-  inputs: object;
-  dataOutputSpecs?: DataOutputSpecDescribeData[];
 }
 
 /**
@@ -220,9 +218,21 @@ function stripDefaultsFromRequired(
 export function toMethodDescribeData(
   name: string,
   method: MethodDefinition,
+): MethodDescribeData {
+  return {
+    name,
+    description: method.description,
+    arguments: zodToJsonSchema(method.arguments),
+  };
+}
+
+/**
+ * Builds type-level DataOutputSpecDescribeData from resource and file output specs.
+ */
+export function buildDataOutputSpecs(
   resources?: Record<string, ResourceOutputSpec>,
   files?: Record<string, FileOutputSpec>,
-): MethodDescribeData {
+): DataOutputSpecDescribeData[] {
   const resourceSpecs = resources
     ? Object.entries(resources).map(
       ([specName, spec]) => ({
@@ -252,14 +262,5 @@ export function toMethodDescribeData(
     )
     : [];
 
-  const dataOutputSpecs = [...resourceSpecs, ...fileSpecs];
-
-  const schema = zodToJsonSchema(method.arguments);
-  return {
-    name,
-    description: method.description,
-    arguments: schema,
-    inputs: schema,
-    dataOutputSpecs: dataOutputSpecs.length > 0 ? dataOutputSpecs : undefined,
-  };
+  return [...resourceSpecs, ...fileSpecs];
 }

--- a/src/libswamp/types/schema_helpers_test.ts
+++ b/src/libswamp/types/schema_helpers_test.ts
@@ -19,7 +19,12 @@
 
 import { assertEquals } from "@std/assert";
 import { z } from "zod";
-import { zodToJsonSchema } from "./schema_helpers.ts";
+import {
+  buildDataOutputSpecs,
+  toMethodDescribeData,
+  zodToJsonSchema,
+} from "./schema_helpers.ts";
+import type { ResourceOutputSpec } from "../../domain/models/model.ts";
 
 Deno.test("zodToJsonSchema: handles z.record(z.unknown())", () => {
   const schema = z.record(z.string(), z.unknown());
@@ -126,4 +131,43 @@ Deno.test("zodToJsonSchema: optional field is not required", () => {
   const required = result.required as string[];
   assertEquals(required.includes("name"), true);
   assertEquals(required.includes("tag"), false);
+});
+
+Deno.test("toMethodDescribeData: returns name, description, and arguments only", () => {
+  const method = {
+    description: "Start the resource",
+    arguments: z.object({ name: z.string() }),
+    execute: () => Promise.resolve({}),
+  };
+  const result = toMethodDescribeData("start", method);
+  assertEquals(result.name, "start");
+  assertEquals(result.description, "Start the resource");
+  assertEquals(typeof result.arguments, "object");
+  assertEquals(Object.keys(result).sort(), [
+    "arguments",
+    "description",
+    "name",
+  ]);
+});
+
+Deno.test("buildDataOutputSpecs: builds specs from resources and files", () => {
+  const resources: Record<string, ResourceOutputSpec> = {
+    state: {
+      description: "Current state",
+      schema: z.object({ phase: z.string() }),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  };
+  const result = buildDataOutputSpecs(resources, undefined);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].specName, "state");
+  assertEquals(result[0].kind, "resource");
+  assertEquals(result[0].description, "Current state");
+  assertEquals(result[0].lifetime, "infinite");
+});
+
+Deno.test("buildDataOutputSpecs: returns empty array when no specs", () => {
+  const result = buildDataOutputSpecs(undefined, undefined);
+  assertEquals(result.length, 0);
 });

--- a/src/presentation/output/type_describe_output_test.ts
+++ b/src/presentation/output/type_describe_output_test.ts
@@ -50,13 +50,6 @@ const testData: TypeDescribeData = {
         },
         required: ["message"],
       },
-      inputs: {
-        type: "object",
-        properties: {
-          message: { type: "string", minLength: 1 },
-        },
-        required: ["message"],
-      },
     },
   ],
 };
@@ -75,6 +68,15 @@ const testDataWithSpecs: TypeDescribeData = {
     },
     required: ["cidrBlock"],
   },
+  dataOutputSpecs: [
+    {
+      specName: "resource",
+      kind: "resource" as const,
+      description: "VPC resource state",
+      contentType: "application/json",
+      lifetime: "persistent",
+    },
+  ],
   methods: [
     {
       name: "create",
@@ -86,22 +88,6 @@ const testDataWithSpecs: TypeDescribeData = {
         },
         required: ["cidrBlock"],
       },
-      inputs: {
-        type: "object",
-        properties: {
-          cidrBlock: { type: "string" },
-        },
-        required: ["cidrBlock"],
-      },
-      dataOutputSpecs: [
-        {
-          specName: "resource",
-          kind: "resource" as const,
-          description: "VPC resource state",
-          contentType: "application/json",
-          lifetime: "persistent",
-        },
-      ],
     },
   ],
 };

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -89,23 +89,12 @@ export function formatMethodLines(methods: MethodDescribeData[]): string[] {
     );
 
     const methodAttrs = formatSchemaAttributes(
-      method.inputs,
+      method.arguments,
       "      ",
     );
     if (methodAttrs.length > 0) {
       lines.push(`    ${cyan("Inputs:")}`);
       lines.push(...methodAttrs);
-    }
-
-    if (method.dataOutputSpecs && method.dataOutputSpecs.length > 0) {
-      lines.push(`    ${cyan("Data Outputs:")}`);
-      for (const spec of method.dataOutputSpecs) {
-        const parts = [`${spec.specName} ${dim(`[${spec.kind}]`)}`];
-        if (spec.description) parts.push(`${dim("-")} ${spec.description}`);
-        const meta = [spec.contentType, spec.lifetime].filter(Boolean);
-        if (meta.length > 0) parts.push(dim(`(${meta.join(", ")})`));
-        lines.push(`      ${parts.join(" ")}`);
-      }
     }
   }
   return lines;

--- a/src/presentation/renderers/model_method_describe.ts
+++ b/src/presentation/renderers/model_method_describe.ts
@@ -47,20 +47,20 @@ class LogModelMethodDescribeRenderer
           } ${data.method.description}`,
         );
 
-        const argAttrs = formatSchemaAttributes(data.method.inputs, "  ");
+        const argAttrs = formatSchemaAttributes(
+          data.method.arguments,
+          "  ",
+        );
         if (argAttrs.length > 0) {
           lines.push("");
           lines.push(bold(cyan("Inputs:")));
           lines.push(...argAttrs);
         }
 
-        if (
-          data.method.dataOutputSpecs &&
-          data.method.dataOutputSpecs.length > 0
-        ) {
+        if (data.dataOutputSpecs && data.dataOutputSpecs.length > 0) {
           lines.push("");
           lines.push(bold(cyan("Data Outputs:")));
-          for (const spec of data.method.dataOutputSpecs) {
+          for (const spec of data.dataOutputSpecs) {
             const parts = [`${spec.specName} ${dim(`[${spec.kind}]`)}`];
             if (spec.description) {
               parts.push(`${dim("-")} ${spec.description}`);

--- a/src/presentation/renderers/model_method_describe_test.ts
+++ b/src/presentation/renderers/model_method_describe_test.ts
@@ -31,8 +31,6 @@ const testData = {
     name: "run",
     description: "Run the command",
     arguments: { type: "object", properties: {}, required: [] },
-    inputs: { type: "object", properties: {}, required: [] },
-    dataOutputSpecs: [],
   },
 };
 

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -255,32 +255,6 @@ function renderModelPreview(
           }
         }
       }
-
-      // Inline data output specs
-      if (method.dataOutputSpecs && method.dataOutputSpecs.length > 0) {
-        lines.push(
-          <Text
-            key={`do-hdr-${method.name}`}
-            color="cyan"
-            wrap="truncate-end"
-          >
-            {INDENT_4}Data Outputs:
-          </Text>,
-        );
-        for (const spec of method.dataOutputSpecs) {
-          lines.push(
-            <Text
-              key={`do-${method.name}-${spec.specName}`}
-              dimColor
-              wrap="truncate-end"
-            >
-              {"      "}
-              {spec.specName} [{spec.kind}]
-              {spec.description ? ` - ${spec.description}` : ""}
-            </Text>,
-          );
-        }
-      }
     }
   }
 

--- a/src/presentation/renderers/type_describe.ts
+++ b/src/presentation/renderers/type_describe.ts
@@ -19,6 +19,7 @@
 
 import { bold, cyan, dim } from "@std/fmt/colors";
 import type {
+  DataOutputSpecDescribeData,
   EventHandlers,
   TypeDescribeData,
   TypeDescribeEvent,
@@ -29,7 +30,81 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { formatMethodLines, formatSchemaAttributes } from "./model_get.ts";
 
+function formatDataOutputSpecs(
+  specs: DataOutputSpecDescribeData[],
+): string[] {
+  const lines: string[] = [];
+  for (const spec of specs) {
+    const parts = [`${spec.specName} ${dim(`[${spec.kind}]`)}`];
+    if (spec.description) parts.push(`${dim("-")} ${spec.description}`);
+    const meta = [spec.contentType, spec.lifetime].filter(Boolean);
+    if (meta.length > 0) parts.push(dim(`(${meta.join(", ")})`));
+    lines.push(`  ${parts.join(" ")}`);
+  }
+  return lines;
+}
+
+interface CompactMethod {
+  name: string;
+  description: string;
+  arguments: object;
+}
+
+interface CompactTypeDescribe {
+  type: { raw: string; normalized: string };
+  version: string;
+  globalArguments?: object;
+  dataOutputSpecs?: string[];
+  methods: CompactMethod[];
+}
+
+function toCompactOutput(data: TypeDescribeData): CompactTypeDescribe {
+  return {
+    type: data.type,
+    version: data.version,
+    globalArguments: data.globalArguments
+      ? compactSchema(data.globalArguments)
+      : undefined,
+    dataOutputSpecs: data.dataOutputSpecs?.map((s) => s.specName),
+    methods: data.methods.map((m) => ({
+      name: m.name,
+      description: m.description,
+      arguments: compactSchema(m.arguments),
+    })),
+  };
+}
+
+interface JsonSchemaLike {
+  type?: string | string[];
+  properties?: Record<string, { type?: string | string[]; enum?: string[] }>;
+  required?: string[];
+}
+
+function compactSchema(schema: object): object {
+  const s = schema as JsonSchemaLike;
+  if (!s.properties) return {};
+  const result: Record<string, unknown> = {};
+  const props: Record<string, object> = {};
+  for (const [key, val] of Object.entries(s.properties)) {
+    const entry: Record<string, unknown> = {};
+    if (val.type) entry.type = val.type;
+    if (val.enum) entry.enum = val.enum;
+    props[key] = entry;
+  }
+  result.properties = props;
+  if (s.required && s.required.length > 0) {
+    result.required = s.required;
+  }
+  return result;
+}
+
 class LogTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
+  #compact: boolean;
+
+  constructor(compact: boolean) {
+    this.#compact = compact;
+  }
+
   handlers(): EventHandlers<TypeDescribeEvent> {
     return {
       resolving: () => {},
@@ -50,6 +125,26 @@ class LogTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
             lines.push("");
             lines.push(bold(cyan("Global Arguments:")));
             lines.push(...attrs);
+          }
+        }
+
+        if (
+          !this.#compact && data.dataOutputSpecs &&
+          data.dataOutputSpecs.length > 0
+        ) {
+          lines.push("");
+          lines.push(bold(cyan("Data Outputs:")));
+          lines.push(...formatDataOutputSpecs(data.dataOutputSpecs));
+        }
+
+        if (
+          this.#compact && data.dataOutputSpecs &&
+          data.dataOutputSpecs.length > 0
+        ) {
+          lines.push("");
+          lines.push(bold(cyan("Data Outputs:")));
+          for (const spec of data.dataOutputSpecs) {
+            lines.push(`  ${spec.specName} ${dim(`[${spec.kind}]`)}`);
           }
         }
 
@@ -78,11 +173,18 @@ class LogTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
 }
 
 class JsonTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
+  #compact: boolean;
+
+  constructor(compact: boolean) {
+    this.#compact = compact;
+  }
+
   handlers(): EventHandlers<TypeDescribeEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        console.log(JSON.stringify(e.data, null, 2));
+        const output = this.#compact ? toCompactOutput(e.data) : e.data;
+        console.log(JSON.stringify(output, null, 2));
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -93,12 +195,13 @@ class JsonTypeDescribeRenderer implements Renderer<TypeDescribeEvent> {
 
 export function createTypeDescribeRenderer(
   mode: OutputMode,
+  compact = false,
 ): Renderer<TypeDescribeEvent> {
   switch (mode) {
     case "json":
-      return new JsonTypeDescribeRenderer();
+      return new JsonTypeDescribeRenderer(compact);
     case "log":
-      return new LogTypeDescribeRenderer();
+      return new LogTypeDescribeRenderer(compact);
   }
 }
 

--- a/src/presentation/renderers/type_describe_test.ts
+++ b/src/presentation/renderers/type_describe_test.ts
@@ -31,8 +31,6 @@ const testData = {
       name: "run",
       description: "Run",
       arguments: { type: "object", properties: {}, required: [] },
-      inputs: { type: "object", properties: {}, required: [] },
-      dataOutputSpecs: [],
     },
   ],
 };
@@ -153,4 +151,74 @@ Deno.test("createTypeDescribeRenderer - factory returns correct type per mode", 
   const jsonRenderer = createTypeDescribeRenderer("json");
   assertEquals(typeof logRenderer.handlers, "function");
   assertEquals(typeof jsonRenderer.handlers, "function");
+});
+
+const testDataWithSpecs = {
+  type: { raw: "command/shell", normalized: "command/shell" },
+  version: "1.0.0",
+  dataOutputSpecs: [
+    {
+      specName: "result",
+      kind: "resource" as const,
+      description: "Command result",
+      schema: { type: "object", properties: { code: { type: "number" } } },
+      lifetime: "infinite",
+    },
+  ],
+  methods: [
+    {
+      name: "run",
+      description: "Run a shell command",
+      arguments: {
+        type: "object",
+        properties: { cmd: { type: "string" }, timeout: { type: "number" } },
+        required: ["cmd"],
+      },
+    },
+  ],
+};
+
+Deno.test("JsonTypeDescribeRenderer compact mode: outputs spec names only and simplified arguments", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createTypeDescribeRenderer("json", true);
+    const events: TypeDescribeEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: testDataWithSpecs },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.dataOutputSpecs, ["result"]);
+    assertEquals(parsed.methods[0].name, "run");
+    assertEquals(parsed.methods[0].arguments.properties.cmd.type, "string");
+    assertEquals(typeof parsed.dataOutputSpecs[0], "string");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonTypeDescribeRenderer full mode: outputs complete spec objects at type level", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createTypeDescribeRenderer("json", false);
+    const events: TypeDescribeEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: testDataWithSpecs },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.dataOutputSpecs[0].specName, "result");
+    assertEquals(parsed.dataOutputSpecs[0].kind, "resource");
+    assertEquals(typeof parsed.dataOutputSpecs[0].schema, "object");
+    assertEquals("inputs" in parsed.methods[0], false);
+  } finally {
+    console.log = originalLog;
+  }
 });


### PR DESCRIPTION
## Summary

Fixes swamp-club#615 — `model type describe --json` was duplicating all output specs into every method (40% bloat, 220KB for a 16-method type) and carrying a redundant `inputs` field identical to `arguments`.

- **Hoist `dataOutputSpecs` to type level** in `TypeDescribeData`, removing per-method duplication. Matches the domain model where specs are defined on the type, not per-method.
- **Add `--compact` flag** producing a minimal digest (~3-5KB): method names, descriptions, argument property names/types/required, output spec names only. Designed for the agent discovery hot path.
- **Drop `inputs` field** from `MethodDescribeData` (was a byte-for-byte duplicate of `arguments`).
- Update all renderers (`type_describe`, `model_get`, `model_method_describe`, `model_search`) and generators (`describe`, `get`, `create`, `method_describe`).
- Update swamp, swamp-getting-started, and terminal-output skills to recommend `--compact --json` for discovery.

## Test Plan

- [x] New unit tests for `toMethodDescribeData` (no specs/inputs), `buildDataOutputSpecs`, type-level specs in describe output, compact vs full JSON rendering
- [x] All existing tests updated for new output shape
- [x] `deno check` / `deno lint` / `deno fmt` / `deno run test` — 7037 tests pass, 0 failures
- [x] `deno run compile` succeeds
- [x] Filed UAT issue: swamp-club/swamp-uat#266
- [x] Filed docs issue: swamp-club#651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Magistr <umag@users.noreply.github.com>