### PR TITLE
fix(vault): write secret value to stdout without log formatting (swamp-club#646)

### DIFF
--- a/src/presentation/renderers/vault_read_secret.ts
+++ b/src/presentation/renderers/vault_read_secret.ts
@@ -23,17 +23,15 @@ import type {
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
-
-const logger = getSwampLogger(["vault", "read-secret"]);
 
 class LogVaultReadSecretRenderer implements Renderer<VaultReadSecretEvent> {
   handlers(): EventHandlers<VaultReadSecretEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        logger.info`${e.data.value}`;
+        writeOutput(e.data.value);
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/vault_read_secret_test.ts
+++ b/src/presentation/renderers/vault_read_secret_test.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  consumeStream,
+  type VaultReadSecretEvent,
+} from "../../libswamp/mod.ts";
+import { createVaultReadSecretRenderer } from "./vault_read_secret.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function makeData() {
+  return {
+    vaultName: "test-vault",
+    secretKey: "my-key",
+    vaultType: "local_encryption",
+    value: "super_secret_value",
+  };
+}
+
+async function* toStream(
+  events: VaultReadSecretEvent[],
+): AsyncGenerator<VaultReadSecretEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+Deno.test("LogVaultReadSecretRenderer: writes only the secret value to stdout", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createVaultReadSecretRenderer("log");
+    const events: VaultReadSecretEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: makeData() },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    assertEquals(logs[0], "super_secret_value");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("LogVaultReadSecretRenderer: error event throws UserError", () => {
+  const renderer = createVaultReadSecretRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error({
+        kind: "error",
+        error: { code: "vault_not_found", message: "Vault not found" },
+      }),
+    UserError,
+    "Vault not found",
+  );
+});
+
+Deno.test("JsonVaultReadSecretRenderer: completed serializes correct JSON", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createVaultReadSecretRenderer("json");
+    const events: VaultReadSecretEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: makeData() },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.vaultName, "test-vault");
+    assertEquals(parsed.secretKey, "my-key");
+    assertEquals(parsed.value, "super_secret_value");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonVaultReadSecretRenderer: error event throws UserError", () => {
+  const renderer = createVaultReadSecretRenderer("json");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error({
+        kind: "error",
+        error: { code: "vault_not_found", message: "Vault not found" },
+      }),
+    UserError,
+    "Vault not found",
+  );
+});


### PR DESCRIPTION
## Summary

- `vault read-secret` used `logger.info` to output the secret value, which prepended timestamp, level, and category formatting (e.g. `10:00:15.092 INF vault·read-secret "value"`) to stdout — breaking `$(swamp vault read-secret ...)` shell substitution
- Switched to `writeOutput()` for undecorated stdout, matching the established pattern used by 15+ other renderers
- Added unit tests for both log and JSON output modes

## Test Plan

- [x] Reproduced the bug in a scratch repo: `swamp vault read-secret ... --force 2>/dev/null | od -c` showed log prefix in stdout
- [x] Verified the fix: same command now shows only the raw secret value
- [x] New unit tests pass: `deno run test src/presentation/renderers/vault_read_secret_test.ts`
- [x] Full test suite passes (7032 passed, 1 pre-existing unrelated failure in `http_update_checker_test.ts`)
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#646