### PR TITLE
fix(tests): close resource leaks in rubric scorer and worker gateway tests (swamp-club#645)

### DIFF
--- a/src/domain/extensions/extension_rubric_scorer.ts
+++ b/src/domain/extensions/extension_rubric_scorer.ts
@@ -579,18 +579,14 @@ export async function scoreExtensionTarball(
 ): Promise<RubricScore> {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_quality_" });
   try {
-    const tarballPath = join(tmpDir, "archive.tar.gz");
     const extractDir = join(tmpDir, "extract");
-    await Deno.writeFile(tarballPath, tarballBytes);
     await Deno.mkdir(extractDir);
 
-    // Extract via the injected tarball extractor (libswamp wires in
-    // `extractTarGz` from infrastructure/archive). The CLI built this
-    // tarball itself, so we skip the server-side Zip-Slip / type checks —
-    // we trust our own output.
     try {
-      const tarFile = await Deno.open(tarballPath, { read: true });
-      await deps.extractTarball(tarFile.readable, extractDir);
+      await deps.extractTarball(
+        ReadableStream.from([tarballBytes]),
+        extractDir,
+      );
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to extract tarball for scoring: ${message}`);

--- a/src/serve/worker_gateway_test.ts
+++ b/src/serve/worker_gateway_test.ts
@@ -402,7 +402,7 @@ Deno.test("WorkerGateway: a different instance cannot enroll while a worker is c
 });
 
 Deno.test("WorkerGateway: dispatch ending after a socket drop does not mark idle", async () => {
-  const h = createHarness({ graceWindowMs: 500 });
+  const h = createHarness({ graceWindowMs: 30 });
   const { workerChannel, dropSocket } = connectWorkerSocket(h.gateway);
   await enroll(workerChannel);
 
@@ -424,6 +424,7 @@ Deno.test("WorkerGateway: dispatch ending after a socket drop does not mark idle
   // No idle status write may follow the disconnect record.
   assertEquals(h.transitions.at(-1)?.inputs.status, "disconnected");
   assertEquals(h.idle.length, 1); // only the enrollment idle
+  await new Promise((r) => setTimeout(r, 50));
 });
 
 Deno.test("WorkerGateway: a cancelled dispatch frees the worker only after it unwinds", async () => {


### PR DESCRIPTION
## Summary

Fixes two pre-existing test failures on main caught by Deno's resource leak sanitizer on Linux:

- **`extension_rubric_scorer_test.ts`**: `scoreExtensionTarball` opened a file with `Deno.open()` and passed `tarFile.readable` to the injected `extractTarball`, but the fd leaked when the consumer didn't fully consume the stream. Replaced with `ReadableStream.from([tarballBytes])` — the bytes are already in memory, so the disk write + re-read was unnecessary.
- **`worker_gateway_test.ts`**: "dispatch ending after a socket drop" test started a 500ms grace-window timer via `dropSocket()` but exited without waiting for it, leaking the async op. Shortened to 30ms and added a 50ms wait at the end, matching the cleanup pattern of other tests in the file.

## Test Plan

- `deno run test src/domain/extensions/extension_rubric_scorer_test.ts` — 71/71 pass
- `deno run test src/serve/worker_gateway_test.ts` — 17/17 pass
- `deno check`, `deno lint`, `deno fmt --check` all clean