### PR TITLE
fix(docs): correct model delete --json output shape in skill guide (swamp-club#643)

### DIFF
--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -298,13 +298,16 @@ swamp model delete my-shell --json
 
 ```json
 {
-  "deleted": true,
-  "modelId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
-  "modelName": "my-shell",
-  "artifactsDeleted": {
-    "outputs": 5,
-    "dataItems": 3
-  }
+  "deleted": {
+    "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "name": "my-shell",
+    "type": "command/shell",
+    "inputPath": "models/command/shell/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.yaml"
+  },
+  "resourceDeleted": false,
+  "outputsDeleted": 0,
+  "evaluatedInputDeleted": false,
+  "dataDeleted": false
 }
 ```
 


### PR DESCRIPTION
## Summary

- Fixes the documented `model delete --json` output shape in the swamp skill guide to match the actual CLI output
- The docs showed `{deleted: true, modelId, modelName, artifactsDeleted}` but the CLI returns `{deleted: {id, name, type, inputPath}, resourceDeleted, outputsDeleted, evaluatedInputDeleted, dataDeleted}`
- The current code shape is intentional — it preserves the last known state of the deleted model

Fixes swamp-club#643

## Test Plan

- Reproduced the mismatch in a scratch repo by running `swamp model create` + `swamp model delete --json`
- Verified the updated documentation matches the actual CLI output