### PR TITLE
fix(cli): always return {query, results} envelope from search --json (swamp-club#642)

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -434,7 +434,7 @@ Deno.test("CLI: workflow search filters by query with multiple matches in JSON m
   });
 });
 
-Deno.test("CLI: workflow search with single match returns full details in JSON mode", async () => {
+Deno.test("CLI: workflow search with single match returns envelope in JSON mode", async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
     const repo = new YamlWorkflowRepository(repoDir);
@@ -461,13 +461,11 @@ Deno.test("CLI: workflow search with single match returns full details in JSON m
       `Command should succeed. stderr: ${result.stderr}`,
     );
 
-    // When single match, returns full workflow details (same as workflow get)
     const output = JSON.parse(result.stdout);
-    assertEquals(output.name, "alpha-workflow");
-    assertEquals(output.id, workflow1.id);
-    assertEquals(output.jobs.length, 2);
-    assertEquals(output.jobs[0].name, "build");
-    assertEquals(output.jobs[1].name, "test");
+    assertEquals(output.query, "alpha");
+    assertEquals(output.results.length, 1);
+    assertEquals(output.results[0].name, "alpha-workflow");
+    assertEquals(output.results[0].id, workflow1.id);
   });
 });
 

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -29,7 +29,6 @@ import {
   type ModelSearchItem,
 } from "../../libswamp/mod.ts";
 import { createModelSearchRenderer } from "../../presentation/renderers/model_search.tsx";
-import { createModelGetRenderer } from "../../presentation/renderers/model_get.ts";
 import {
   createContext,
   type GlobalOptions,
@@ -100,19 +99,8 @@ export async function modelSearchAction(
   const selected = renderer.selectedItem();
   if (selected) {
     ctx.logger.debug`Selected model: ${selected.name} (${selected.id})`;
-    // In JSON mode, still display the full model get output after auto-select
-    if (effectiveMode === "json") {
-      const getRenderer = createModelGetRenderer(effectiveMode);
-      const getDeps = await createModelGetDeps(repoDir);
-      await consumeStream(
-        modelGet(libCtx, getDeps, selected.name),
-        getRenderer.handlers(),
-      );
-    }
-    // In interactive mode, the scrollback from the picker already contains
-    // the model detail, so no additional modelGet call is needed.
   } else {
-    ctx.logger.debug`Search cancelled`;
+    ctx.logger.debug`Search completed`;
   }
 
   ctx.logger.debug("Model search command completed");

--- a/src/cli/commands/report_search.ts
+++ b/src/cli/commands/report_search.ts
@@ -31,7 +31,6 @@ import { createDefinitionId } from "../../domain/definitions/definition.ts";
 import {
   consumeStream,
   createLibSwampContext,
-  type LibSwampContext,
   reportGet,
   type ReportGetDeps,
   reportSearch,
@@ -40,9 +39,7 @@ import {
   type StoredReportSummary,
 } from "../../libswamp/mod.ts";
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
-import type { OutputMode } from "../../presentation/output/output.ts";
 import { createReportSearchRenderer } from "../../presentation/renderers/report_search.tsx";
-import { createReportGetRenderer } from "../../presentation/renderers/report_get.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -137,28 +134,6 @@ function createReportFetchPreview(
   };
 }
 
-/**
- * Fetches and displays full report content for a selected summary.
- */
-async function displayReportDetail(
-  summary: StoredReportSummary,
-  repoContext: RepositoryContext,
-  libCtx: LibSwampContext,
-  outputMode: OutputMode,
-): Promise<void> {
-  const getDeps = buildGetDeps(repoContext);
-  const renderer = createReportGetRenderer(outputMode);
-  await consumeStream(
-    reportGet(libCtx, getDeps, {
-      reportName: summary.reportName,
-      model: summary.workflowName ? undefined : summary.modelName,
-      workflow: summary.workflowName,
-      variant: summary.varySuffix,
-    }),
-    renderer.handlers(),
-  );
-}
-
 export async function reportSearchAction(
   options: AnyOptions,
   query?: string,
@@ -200,16 +175,8 @@ export async function reportSearchAction(
   const selected = searchRenderer.selectedItem();
   if (selected) {
     ctx.logger.debug`Selected report: ${selected.reportName}`;
-    if (effectiveMode === "json") {
-      await displayReportDetail(
-        selected,
-        repoContext,
-        libCtx,
-        effectiveMode,
-      );
-    }
   } else {
-    ctx.logger.debug`Search cancelled`;
+    ctx.logger.debug`Search completed`;
   }
 
   ctx.logger.debug("Report search command completed");

--- a/src/cli/commands/workflow_search.ts
+++ b/src/cli/commands/workflow_search.ts
@@ -21,7 +21,6 @@ import { Command } from "@cliffy/command";
 import {
   consumeStream,
   createLibSwampContext,
-  type WorkflowGetData,
   workflowSearch,
   type WorkflowSearchDeps,
 } from "../../libswamp/mod.ts";
@@ -30,7 +29,6 @@ import {
   type WorkflowPreviewDetail,
   type WorkflowPreviewFetcher,
 } from "../../presentation/renderers/workflow_search.tsx";
-import { renderWorkflowGet } from "../../presentation/renderers/workflow_get.ts";
 import {
   createContext,
   type GlobalOptions,
@@ -38,7 +36,6 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { UserError } from "../../domain/errors.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -61,39 +58,6 @@ function createWorkflowFetchPreview(
     const yaml = await Deno.readTextFile(path);
     return { yaml, name: workflow.name };
   };
-}
-
-/**
- * Displays the workflow get output for JSON mode.
- */
-async function displayWorkflowGet(
-  name: string,
-  repo: WorkflowRepository,
-  outputMode: "json" | "log",
-): Promise<void> {
-  const workflow = await repo.findByName(name);
-  if (!workflow) {
-    throw new UserError(`Workflow not found: ${name}`);
-  }
-
-  const data: WorkflowGetData = {
-    id: workflow.id,
-    name: workflow.name,
-    description: workflow.description,
-    version: workflow.version,
-    jobs: workflow.jobs.map((job) => ({
-      name: job.name,
-      description: job.description,
-      steps: job.steps.map((step) => ({
-        name: step.name,
-        description: step.description,
-        task: step.task.toData(),
-      })),
-    })),
-    path: repo.getPath(workflow.id),
-  };
-
-  renderWorkflowGet(data, outputMode);
 }
 
 export async function workflowSearchAction(
@@ -144,11 +108,9 @@ export async function workflowSearchAction(
       if (!status.success) {
         Deno.exit(status.code);
       }
-    } else if (effectiveMode === "json") {
-      await displayWorkflowGet(selected.name, repo, effectiveMode);
     }
   } else {
-    ctx.logger.debug`Search cancelled`;
+    ctx.logger.debug`Search completed`;
   }
 
   ctx.logger.debug("Workflow search command completed");

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -84,16 +84,11 @@ class JsonModelSearchRenderer implements ModelSearchRenderer {
       resolving: () => {},
       completed: (e) => {
         const filtered = filterModels(e.data.results, e.data.query);
-        // Auto-select when query matches exactly one model
-        if (e.data.query && filtered.length === 1) {
-          this._selected = filtered[0];
-        } else {
-          const output: ModelSearchData = {
-            query: e.data.query,
-            results: filtered,
-          };
-          console.log(JSON.stringify(output, null, 2));
-        }
+        const output: ModelSearchData = {
+          query: e.data.query,
+          results: filtered,
+        };
+        console.log(JSON.stringify(output, null, 2));
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/model_search_test.ts
+++ b/src/presentation/renderers/model_search_test.ts
@@ -1,0 +1,95 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ModelSearchData, ModelSearchItem } from "../../libswamp/mod.ts";
+import { createModelSearchRenderer } from "./model_search.tsx";
+
+Deno.test("JsonModelSearchRenderer: single match returns envelope shape", () => {
+  const renderer = createModelSearchRenderer("json");
+  const handlers = renderer.handlers();
+
+  const items: ModelSearchItem[] = [
+    { id: "id-1", name: "unique-model", type: "swamp/echo" },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    const data: ModelSearchData = { query: "unique", results: items };
+    handlers.completed({ kind: "completed", data });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assertEquals(logs.length, 1);
+  const parsed = JSON.parse(logs[0]);
+  assertEquals(parsed.query, "unique");
+  assertEquals(parsed.results.length, 1);
+  assertEquals(parsed.results[0].name, "unique-model");
+  assertEquals(renderer.selectedItem(), undefined);
+});
+
+Deno.test("JsonModelSearchRenderer: multiple matches returns envelope shape", () => {
+  const renderer = createModelSearchRenderer("json");
+  const handlers = renderer.handlers();
+
+  const items: ModelSearchItem[] = [
+    { id: "id-1", name: "model-a", type: "swamp/echo" },
+    { id: "id-2", name: "model-b", type: "swamp/echo" },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    const data: ModelSearchData = { query: "model", results: items };
+    handlers.completed({ kind: "completed", data });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assertEquals(logs.length, 1);
+  const parsed = JSON.parse(logs[0]);
+  assertEquals(parsed.query, "model");
+  assertEquals(parsed.results.length, 2);
+  assertEquals(renderer.selectedItem(), undefined);
+});
+
+Deno.test("JsonModelSearchRenderer: zero matches returns envelope shape", () => {
+  const renderer = createModelSearchRenderer("json");
+  const handlers = renderer.handlers();
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    const data: ModelSearchData = { query: "nonexistent", results: [] };
+    handlers.completed({ kind: "completed", data });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assertEquals(logs.length, 1);
+  const parsed = JSON.parse(logs[0]);
+  assertEquals(parsed.query, "nonexistent");
+  assertEquals(parsed.results.length, 0);
+  assertEquals(renderer.selectedItem(), undefined);
+});

--- a/src/presentation/renderers/report_search.tsx
+++ b/src/presentation/renderers/report_search.tsx
@@ -95,18 +95,13 @@ class JsonReportSearchRenderer implements ReportSearchRenderer {
       resolving: () => {},
       completed: (e) => {
         const filtered = filterReports(e.data.reports, this.query);
-        // Auto-select when query matches exactly one report
-        if (this.query && filtered.length === 1) {
-          this._selected = filtered[0];
-        } else {
-          console.log(
-            JSON.stringify(
-              { query: this.query, results: filtered },
-              null,
-              2,
-            ),
-          );
-        }
+        console.log(
+          JSON.stringify(
+            { query: this.query, results: filtered },
+            null,
+            2,
+          ),
+        );
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/workflow_search.tsx
+++ b/src/presentation/renderers/workflow_search.tsx
@@ -90,11 +90,6 @@ class JsonWorkflowSearchRenderer implements WorkflowSearchRenderer {
       resolving: () => {},
       completed: (e) => {
         const filtered = filterWorkflows(e.data.results, e.data.query);
-        // Auto-select when query matches exactly one workflow
-        if (e.data.query && filtered.length === 1) {
-          this._selected = filtered[0];
-          return;
-        }
         const output: WorkflowSearchData = {
           query: e.data.query,
           results: filtered,


### PR DESCRIPTION
## Summary

Closes swamp-club#642.

- `model search`, `workflow search`, and `report search` all had a JSON-mode
  auto-select path that bypassed the `{query, results}` envelope when exactly
  one result matched, outputting a bare detail object instead. Scripts parsing
  `.results[]` broke on single-match queries.
- Removed the auto-select branch from all three JSON renderers so they always
  return the consistent envelope regardless of match count.
- Removed the now-dead JSON-mode detail chaining (`modelGet`,
  `displayWorkflowGet`, `displayReportDetail`) from the command handlers and
  cleaned up unused imports.

## Test Plan

- Added `src/presentation/renderers/model_search_test.ts` with 3 tests
  verifying the JSON renderer returns the envelope for 0, 1, and multiple
  matches
- Updated integration test
  `CLI: workflow search with single match returns envelope in JSON mode` to
  assert envelope shape instead of bare object
- Verified against a scratch repo with the compiled binary: all three match
  counts (0, 1, N) return `{query, results}` for model search
- Full test suite: 7050 passed, 1 unrelated failure (flaky extension pull
  network test)
- Checked swamp-uat tests — no single-match-with-query tests exist; all
  existing UAT tests validate the envelope via typed schemas and pass