### PR TITLE
fix(datastore): exclude secrets from migration to prevent vault breakage (swamp-club#650)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -151,8 +151,10 @@ Legacy `s3:bucket-name/prefix` format is auto-remapped to the
 Two optional fields control which data goes to the datastore:
 
 - **`directories`** — which subdirectories belong to the datastore. Defaults to
-  all runtime subdirectories (`data`, `outputs`, `workflow-runs`, `secrets`,
-  `audit`, `telemetry`, etc.). Anything not listed stays in local `.swamp/`.
+  all runtime subdirectories (`data`, `outputs`, `workflow-runs`, `audit`,
+  `telemetry`, etc.). Anything not listed stays in local `.swamp/`. Note:
+  `secrets` is always local regardless of this setting — see
+  `ALWAYS_LOCAL_SUBDIRS` in `datastore_config.ts`.
 - **`exclude`** — gitignore-style glob patterns. Files matching these patterns
   stay local even if their parent directory is in the datastore.
 

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -33,7 +33,7 @@
  * Note: definitions, workflows, and vault configs now live in top-level
  * directories (models/, workflows/, vaults/) and are no longer .swamp/ subdirs.
  */
-export const ALWAYS_LOCAL_SUBDIRS = [] as const;
+export const ALWAYS_LOCAL_SUBDIRS = ["secrets"] as const;
 
 /**
  * Default subdirectories that belong to the datastore tier.

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -17,11 +17,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertFalse } from "@std/assert";
 import {
+  ALWAYS_LOCAL_SUBDIRS,
   type CustomDatastoreConfig,
+  DEFAULT_DATASTORE_SUBDIRS,
   DEFAULT_SYNC_TIMEOUT_MS,
   type FilesystemDatastoreConfig,
+  getDatastoreDirectories,
+  isAlwaysLocal,
   resolveSyncTimeoutMs,
   SYNC_TIMEOUT_ENV_VAR,
 } from "./datastore_config.ts";
@@ -102,4 +106,63 @@ Deno.test("resolveSyncTimeoutMs: no override, no config, no env returns default"
   withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
     assertEquals(resolveSyncTimeoutMs(customConfig), DEFAULT_SYNC_TIMEOUT_MS);
   });
+});
+
+// --- getDatastoreDirectories / ALWAYS_LOCAL_SUBDIRS ---
+
+Deno.test("getDatastoreDirectories: excludes secrets from default list", () => {
+  const dirs = getDatastoreDirectories(filesystemConfig);
+  assertFalse(
+    dirs.includes("secrets"),
+    "secrets must not appear in datastore directories",
+  );
+});
+
+Deno.test("getDatastoreDirectories: excludes secrets even when explicitly listed in config", () => {
+  const config: FilesystemDatastoreConfig = {
+    ...filesystemConfig,
+    directories: ["data", "secrets", "outputs"],
+  };
+  const dirs = getDatastoreDirectories(config);
+  assertFalse(
+    dirs.includes("secrets"),
+    "secrets must be filtered even when explicitly configured",
+  );
+});
+
+Deno.test("getDatastoreDirectories: excludes secrets for custom datastore config", () => {
+  const dirs = getDatastoreDirectories(customConfig);
+  assertFalse(
+    dirs.includes("secrets"),
+    "secrets must not appear for custom datastore configs",
+  );
+});
+
+Deno.test("getDatastoreDirectories: returns other default subdirs", () => {
+  const dirs = getDatastoreDirectories(filesystemConfig);
+  assertEquals(dirs.includes("data"), true);
+  assertEquals(dirs.includes("outputs"), true);
+  assertEquals(dirs.includes("workflow-runs"), true);
+});
+
+Deno.test("isAlwaysLocal: returns true for secrets", () => {
+  assertEquals(isAlwaysLocal("secrets"), true);
+});
+
+Deno.test("isAlwaysLocal: returns false for data", () => {
+  assertEquals(isAlwaysLocal("data"), false);
+});
+
+Deno.test("ALWAYS_LOCAL_SUBDIRS: contains secrets", () => {
+  assertEquals(
+    (ALWAYS_LOCAL_SUBDIRS as readonly string[]).includes("secrets"),
+    true,
+  );
+});
+
+Deno.test("DEFAULT_DATASTORE_SUBDIRS: still lists secrets for backwards compatibility", () => {
+  assertEquals(
+    (DEFAULT_DATASTORE_SUBDIRS as readonly string[]).includes("secrets"),
+    true,
+  );
 });

--- a/src/domain/datastore/datastore_migration_service_test.ts
+++ b/src/domain/datastore/datastore_migration_service_test.ts
@@ -1,0 +1,141 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertFalse } from "@std/assert";
+import { join } from "@std/path";
+import type { FilesystemDatastoreConfig } from "./datastore_config.ts";
+import { migrateDatastore } from "./datastore_migration_service.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-migration-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test("migrateDatastore: does not migrate secrets directory", async () => {
+  await withTempDir(async (tmpDir) => {
+    const sourceDir = join(tmpDir, "source");
+    const destDir = join(tmpDir, "dest");
+
+    // Create source with secrets and data dirs
+    await Deno.mkdir(join(sourceDir, "secrets", "local_encryption", "v1"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      join(sourceDir, "secrets", "local_encryption", "v1", "KEY.enc"),
+      "encrypted",
+    );
+    await Deno.mkdir(join(sourceDir, "data"), { recursive: true });
+    await Deno.writeTextFile(
+      join(sourceDir, "data", "test.json"),
+      "{}",
+    );
+    await Deno.mkdir(destDir, { recursive: true });
+
+    const config: FilesystemDatastoreConfig = {
+      type: "filesystem",
+      path: destDir,
+    };
+
+    const result = await migrateDatastore(sourceDir, destDir, config);
+
+    assertFalse(
+      result.directoriesMigrated.includes("secrets"),
+      "secrets must not be in directoriesMigrated",
+    );
+    assertEquals(
+      result.directoriesMigrated.includes("data"),
+      true,
+      "data should be migrated",
+    );
+
+    // Source secrets dir must remain intact
+    assertEquals(
+      await exists(
+        join(sourceDir, "secrets", "local_encryption", "v1", "KEY.enc"),
+      ),
+      true,
+      "source secrets must not be touched",
+    );
+
+    // Dest must not have secrets
+    assertFalse(
+      await exists(join(destDir, "secrets")),
+      "secrets must not appear in destination",
+    );
+
+    // Data should have been migrated
+    assertEquals(
+      await exists(join(destDir, "data", "test.json")),
+      true,
+      "data should be copied to destination",
+    );
+  });
+});
+
+Deno.test("migrateDatastore: secrets survives full migration-then-cleanup cycle", async () => {
+  await withTempDir(async (tmpDir) => {
+    const sourceDir = join(tmpDir, "source");
+    const destDir = join(tmpDir, "dest");
+
+    await Deno.mkdir(join(sourceDir, "secrets", "local_encryption"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      join(sourceDir, "secrets", "local_encryption", ".key"),
+      "symmetric-key",
+    );
+    await Deno.mkdir(join(sourceDir, "data"), { recursive: true });
+    await Deno.writeTextFile(join(sourceDir, "data", "d.json"), "{}");
+    await Deno.mkdir(destDir, { recursive: true });
+
+    const config: FilesystemDatastoreConfig = {
+      type: "filesystem",
+      path: destDir,
+    };
+
+    const result = await migrateDatastore(sourceDir, destDir, config);
+
+    // Simulate cleanupSourceDirs (setup.ts:463)
+    for (const subdir of result.directoriesMigrated) {
+      await Deno.remove(join(sourceDir, subdir), { recursive: true });
+    }
+
+    // Secrets must survive the cleanup
+    assertEquals(
+      await exists(join(sourceDir, "secrets", "local_encryption", ".key")),
+      true,
+      "secrets dir must survive cleanup because it was never migrated",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `"secrets"` to `ALWAYS_LOCAL_SUBDIRS` in `datastore_config.ts` so the datastore migration never copies or deletes `.swamp/secrets/`. This prevents `vault.get` from breaking after `swamp datastore setup` runs without `--skip-migration`.
- Add unit tests for `getDatastoreDirectories` confirming secrets is excluded across all config shapes.
- Add integration tests for `migrateDatastore` confirming secrets survives the full migration-then-cleanup cycle.
- Update `design/datastores.md` to reflect that secrets is always local.

Fixes swamp-club#650

## Test Plan

- Reproduced the bug before the fix: `migrateDatastore` copied `.swamp/secrets/` to the cache, `cleanupSourceDirs` deleted the original, and the vault path no longer existed.
- After the fix, re-ran the same reproduction script: `secrets` is no longer in `directoriesMigrated`, the source directory survives cleanup, and `vault.get` would succeed.
- All 7061 existing tests pass.
- New unit tests verify `getDatastoreDirectories` excludes secrets for filesystem, custom, and explicit-directory configs.
- New integration tests verify `migrateDatastore` skips secrets and the directory survives the cleanup cycle.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>