### PR TITLE
fix(quality): prevent false-positive bare-import detection on string literals (swamp-club#657)

### DIFF
--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -187,7 +187,7 @@ export interface BundleOptions {
  * extensions with bare specifiers would always fail to rebundle locally).
  */
 const IMPORT_SPECIFIER_RE =
-  /(?:import|export)\s+[\s\S]*?from\s+["']([^"']+)["']/g;
+  /(?:import|export)\s+[^;()]*?from\s+["']([^"']+)["']/g;
 
 function isBareSpecifier(specifier: string): boolean {
   if (specifier.startsWith(".")) return false;

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -695,6 +695,79 @@ export function get() { return fetch(url); }
   assertEquals(extractBareSpecifierNames(source), []);
 });
 
+// --- string-literal false-positive regression tests (swamp-club#657) ---
+
+Deno.test("extractBareSpecifierNames: ignores from-pattern in template literal", () => {
+  const source = `export function getAdvice(mode: string): string {
+  if (mode === "flexible") {
+    return \`You should upgrade from "flexible" to "full" for security\`;
+  }
+  return "";
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: ignores from-pattern in single-quoted string", () => {
+  const source = `export function logMessage(mode: string): void {
+  const msg = 'Migrate from "flexible" to "full"';
+  console.log(msg);
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: ignores template interpolation as specifier", () => {
+  const source = `export function getAdvice(mode: string): string {
+  return \`You should migrate from "\${mode}" to "full"\`;
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: real-world mixed imports with string false positives", () => {
+  const source =
+    `import { CloudflareClient } from "npm:@webframp/cloudflare@1.0.0";
+import { z } from "npm:zod@4";
+
+export function analyzeZones(client: CloudflareClient): Finding[] {
+  const zones = client.getZones();
+  for (const zone of zones) {
+    const ssl = zone.sslMode;
+    if (ssl === "off") {
+      findings.push({ severity: "critical" });
+    } else if (ssl === "flexible") {
+      findings.push({
+        severity: "warn",
+        message: \`SSL mode is "flexible" — upgrade from "flexible" to "full"\`,
+      });
+    }
+  }
+  return findings;
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("sourceHasBareSpecifiers: ignores from-pattern in string literals", () => {
+  const source = `export function getMessage(): string {
+  return 'Migrate from "flexible" to "full"';
+}
+`;
+  assertEquals(sourceHasBareSpecifiers(source), false);
+});
+
+Deno.test("extractBareSpecifierNames: multi-line import spanning 4+ lines still detected", () => {
+  const source = `import {
+  foo,
+  bar,
+  baz,
+  qux,
+} from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
 Deno.test("sourceHasBareSpecifiers: ignores quoted phrases in comments", () => {
   const source = `import { z } from "npm:zod@4";
 


### PR DESCRIPTION
## Summary

- Fix `IMPORT_SPECIFIER_RE` regex in `bundle.ts` that used `[\s\S]*?` between the `import`/`export` keyword and `from`, allowing it to span across line boundaries into string literal contents and falsely flag strings like `"flexible"` as bare import specifiers
- Restrict the character class to `[^;()]*?` so the regex cannot cross statement boundaries (semicolons) or function signatures (parentheses), while still supporting multi-line import/export declarations
- Add 6 regression tests covering template literals, single-quoted strings, template interpolation, real-world mixed scenarios, and multi-line imports spanning 4+ lines

Fixes swamp-club#657

## Test Plan

- [x] All 64 existing bundle tests pass (no regressions)
- [x] 6 new regression tests verify false positives are eliminated
- [x] Multi-line import spanning 4+ lines still correctly detected
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)