### PR TITLE
fix(extensions): use relative paths in package cache hash for cross-platform determinism

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -307,6 +307,7 @@ export const extensionPushCommand = new Command()
     // bytes. Cache miss falls back to packaging from scratch.
     const cacheHashInput = {
       manifest,
+      rootDir: repoDir,
       modelFilePaths: allModelFiles,
       vaultFilePaths: allVaultFiles,
       driverFilePaths: allDriverFiles,

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -163,6 +163,7 @@ export const extensionQualityCommand = new Command()
           },
           hashInput: {
             manifest: resolved.manifest,
+            rootDir: repoDir,
             modelFilePaths: resolved.allModelFiles,
             vaultFilePaths: resolved.allVaultFiles,
             driverFilePaths: resolved.allDriverFiles,

--- a/src/domain/extensions/extension_package_cache.ts
+++ b/src/domain/extensions/extension_package_cache.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { join, relative, SEPARATOR } from "@std/path";
 import type { ExtensionManifest } from "./extension_manifest.ts";
 
 function encodeHex(bytes: Uint8Array): string {
@@ -49,6 +49,7 @@ function encodeHex(bytes: Uint8Array): string {
  * affects the tarball must be represented here. */
 export interface PackageCacheHashInput {
   manifest: ExtensionManifest;
+  rootDir: string;
   modelFilePaths: string[];
   vaultFilePaths: string[];
   driverFilePaths: string[];
@@ -89,19 +90,26 @@ export async function computePackageCacheHash(
 ): Promise<string> {
   const parts: string[] = [];
 
+  const rootDir = input.rootDir;
+
   parts.push("manifest-v1");
   parts.push(serializeManifestForHash(input.manifest));
 
-  await appendFileGroup("models", input.modelFilePaths, parts);
-  await appendFileGroup("vaults", input.vaultFilePaths, parts);
-  await appendFileGroup("drivers", input.driverFilePaths, parts);
-  await appendFileGroup("datastores", input.datastoreFilePaths, parts);
-  await appendFileGroup("reports", input.reportFilePaths, parts);
-  await appendFileGroup("workflows", input.workflowFilePaths, parts);
-  await appendFileGroup("additional", input.additionalFilePaths, parts);
-  await appendFileGroup("binaries", input.binaryFilePaths, parts);
-  await appendFileGroup("skills", input.skillFilePaths, parts);
-  await appendFileGroup("include", input.includeFilePaths, parts);
+  await appendFileGroup("models", input.modelFilePaths, rootDir, parts);
+  await appendFileGroup("vaults", input.vaultFilePaths, rootDir, parts);
+  await appendFileGroup("drivers", input.driverFilePaths, rootDir, parts);
+  await appendFileGroup("datastores", input.datastoreFilePaths, rootDir, parts);
+  await appendFileGroup("reports", input.reportFilePaths, rootDir, parts);
+  await appendFileGroup("workflows", input.workflowFilePaths, rootDir, parts);
+  await appendFileGroup(
+    "additional",
+    input.additionalFilePaths,
+    rootDir,
+    parts,
+  );
+  await appendFileGroup("binaries", input.binaryFilePaths, rootDir, parts);
+  await appendFileGroup("skills", input.skillFilePaths, rootDir, parts);
+  await appendFileGroup("include", input.includeFilePaths, rootDir, parts);
 
   if (input.denoConfigPath) {
     parts.push("deno-config");
@@ -147,14 +155,23 @@ function serializeManifestForHash(manifest: ExtensionManifest): string {
 async function appendFileGroup(
   label: string,
   paths: string[],
+  rootDir: string,
   out: string[],
 ): Promise<void> {
-  const sorted = [...paths].sort();
+  const relPaths = paths.map((p) => ({
+    rel: normalizeToForwardSlash(relative(rootDir, p)),
+    abs: p,
+  }));
+  relPaths.sort((a, b) => a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0);
   out.push(`group=${label}`);
-  for (const p of sorted) {
-    out.push(`file=${p}`);
-    out.push(await readFileIfExists(p));
+  for (const { rel, abs } of relPaths) {
+    out.push(`file=${rel}`);
+    out.push(await readFileIfExists(abs));
   }
+}
+
+function normalizeToForwardSlash(p: string): string {
+  return SEPARATOR === "\\" ? p.replaceAll("\\", "/") : p;
 }
 
 async function readFileIfExists(path: string): Promise<string> {

--- a/src/domain/extensions/extension_package_cache_test.ts
+++ b/src/domain/extensions/extension_package_cache_test.ts
@@ -64,6 +64,7 @@ async function makeHashInput(
   await Deno.writeTextFile(model, "export function hi() {}\n");
   return {
     manifest: makeManifest(),
+    rootDir: tmp,
     modelFilePaths: [model],
     vaultFilePaths: [],
     driverFilePaths: [],
@@ -171,6 +172,24 @@ Deno.test("computePackageCacheHash: file order does not affect hash", async () =
     assertEquals(h1, h2);
   } finally {
     await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("computePackageCacheHash: same files under different roots produce identical hashes", async () => {
+  const tmp1 = await Deno.makeTempDir();
+  const tmp2 = await Deno.makeTempDir();
+  try {
+    const content = "export function hi() {}\n";
+    await Deno.writeTextFile(join(tmp1, "model.ts"), content);
+    await Deno.writeTextFile(join(tmp2, "model.ts"), content);
+    const input1 = await makeHashInput(tmp1);
+    const input2 = await makeHashInput(tmp2);
+    const h1 = await computePackageCacheHash(input1);
+    const h2 = await computePackageCacheHash(input2);
+    assertEquals(h1, h2);
+  } finally {
+    await Deno.remove(tmp1, { recursive: true });
+    await Deno.remove(tmp2, { recursive: true });
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes swamp-club#660.

- The content hash for extension package caching and adversarial-review report lookup included **absolute file paths** as labels in the hash material, making it dependent on the checkout directory. Reviews committed on macOS (`/Users/...`) never matched a Linux CI runner (`/home/runner/...`) because the path prefixes differed.
- Normalizes file path labels to be relative to `rootDir` (the repo directory) before hashing, so the hash is stable across platforms and checkout locations.
- Adds a `rootDir` field to `PackageCacheHashInput` and threads `repoDir` from both callers (`extension push`, `extension quality`).

**Note:** This changes the hash output — existing committed `.swamp-reviews/` reports and package caches will need regeneration.

## Test Plan

- Added `computePackageCacheHash: same files under different roots produce identical hashes` test that creates identical files in two separate temp directories and verifies the hashes match
- All 11 package cache tests pass
- Full test suite passes (7062 tests, 0 failures)
- `deno check`, `deno lint`, `deno fmt` all clean