### PR TITLE
fix(extensions): detect ghost-row conflicts in extension pull (swamp-club#658)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1316,7 +1316,12 @@ handler renders a clean single-line message in log mode and a structured
 ```
 
 The user-visible message points the user at
-`swamp extension rm <existing-name>` to recover.
+`swamp extension rm <existing-name>` to recover. When the conflict is caused
+by a **ghost catalog row** (an entry whose source file was deleted outside
+swamp), the service detects the missing path via `Deno.stat` and instead
+suggests `swamp doctor extensions` — the correct recovery for orphaned rows.
+The `isGhostRow` flag on `DuplicateTypeUserError` is `true` in this case and
+is included in the `--json` output's `duplicateType` object.
 
 ### Bounded atomicity
 

--- a/src/domain/extensions/duplicate_type_user_error.ts
+++ b/src/domain/extensions/duplicate_type_user_error.ts
@@ -82,26 +82,34 @@ export class DuplicateTypeUserError extends UserError {
   readonly typeNormalized: string;
   readonly existing: DuplicateTypeOccupant;
   readonly conflicting: DuplicateTypeOccupant;
+  readonly isGhostRow: boolean;
 
   constructor(args: {
     kind: DuplicateTypeKind;
     typeNormalized: string;
     existing: DuplicateTypeOccupant;
     conflicting: DuplicateTypeOccupant;
+    isGhostRow?: boolean;
   }) {
+    const ghostRow = args.isGhostRow ?? false;
+    const recovery = ghostRow
+      ? "Ghost catalog entry detected (source deleted outside swamp). " +
+        "Run `swamp doctor extensions` to reclassify and retry."
+      : `Run \`swamp extension rm ${args.existing.extensionName}\` first if ` +
+        `you intended to replace it.`;
     super(
       `Type "${args.typeNormalized}" (kind=${args.kind}) is already claimed by ` +
         `${args.existing.extensionName}@${args.existing.extensionVersion} ` +
         `at ${args.existing.canonicalPath}. Cannot install ` +
         `${args.conflicting.extensionName}@${args.conflicting.extensionVersion} ` +
         `at ${args.conflicting.canonicalPath} — filesystem changes rolled back. ` +
-        `Run \`swamp extension rm ${args.existing.extensionName}\` first if ` +
-        `you intended to replace it.`,
+        recovery,
     );
     this.name = "DuplicateTypeUserError";
     this.kind = args.kind;
     this.typeNormalized = args.typeNormalized;
     this.existing = args.existing;
     this.conflicting = args.conflicting;
+    this.isGhostRow = ghostRow;
   }
 }

--- a/src/domain/extensions/duplicate_type_user_error.ts
+++ b/src/domain/extensions/duplicate_type_user_error.ts
@@ -59,6 +59,7 @@ export interface DuplicateTypeOccupant {
  *   "duplicateType": {
  *     "kind": "model",
  *     "type": "@scope/foo",
+ *     "isGhostRow": false,
  *     "existing": {
  *       "extensionName": "@scopeA/aa",
  *       "extensionVersion": "1.0.0",

--- a/src/libswamp/extensions/install_extension_service.ts
+++ b/src/libswamp/extensions/install_extension_service.ts
@@ -182,7 +182,8 @@ export class InstallExtensionService {
     } catch (error) {
       if (error instanceof DuplicateTypeError) {
         await this.rollbackOnCollision(result, priorEntry, ctx);
-        throw mapDuplicateTypeErrorToUserError(error);
+        const ghostRow = await isGhostRow(error);
+        throw mapDuplicateTypeErrorToUserError(error, ghostRow);
       }
       // Half-state from a non-DuplicateTypeError fault during phase 8.
       // Files + lockfile entry are on disk (the install service does
@@ -444,11 +445,24 @@ async function collectTsFiles(dir: string): Promise<string[]> {
  */
 function mapDuplicateTypeErrorToUserError(
   error: DuplicateTypeError,
+  ghostRow: boolean,
 ): DuplicateTypeUserError {
   return new DuplicateTypeUserError({
     kind: error.kind,
     typeNormalized: error.typeNormalized,
     existing: error.firstSource,
     conflicting: error.secondSource,
+    isGhostRow: ghostRow,
   });
+}
+
+async function isGhostRow(error: DuplicateTypeError): Promise<boolean> {
+  for (const occupant of [error.firstSource, error.secondSource]) {
+    try {
+      await Deno.stat(occupant.canonicalPath);
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return true;
+    }
+  }
+  return false;
 }

--- a/src/libswamp/extensions/install_extension_service.ts
+++ b/src/libswamp/extensions/install_extension_service.ts
@@ -457,12 +457,14 @@ function mapDuplicateTypeErrorToUserError(
 }
 
 async function isGhostRow(error: DuplicateTypeError): Promise<boolean> {
-  for (const occupant of [error.firstSource, error.secondSource]) {
-    try {
-      await Deno.stat(occupant.canonicalPath);
-    } catch (e) {
-      if (e instanceof Deno.errors.NotFound) return true;
-    }
+  // Only check firstSource (the pre-existing catalog occupant).
+  // secondSource is the extension being installed — its files are
+  // always absent after rollbackOnCollision, so it can never be a
+  // meaningful ghost-row signal.
+  try {
+    await Deno.stat(error.firstSource.canonicalPath);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return true;
   }
   return false;
 }

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { InstallExtensionService } from "./install_extension_service.ts";
@@ -28,6 +28,7 @@ import { FaultingStubRepository } from "../../infrastructure/persistence/test_he
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { UserError } from "../../domain/errors.ts";
+import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_user_error.ts";
 import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 
 // Required so the model loader's test bootstrap finds command/shell
@@ -394,6 +395,82 @@ Deno.test(
         // is preserved, B's never landed.
         assertEquals(repository.loadByName(extA).length, 1);
         assertEquals(repository.loadByName(extB).length, 0);
+      },
+    );
+  },
+);
+
+Deno.test(
+  "InstallExtensionService.execute: ghost-row conflict suggests swamp doctor extensions",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, lockfileRepository }) => {
+        const ts = Date.now();
+        const typeId = `@test/ghost-${ts}`;
+        const extA = `@test/ghost-a-${ts}`;
+        const extB = `@test/ghost-b-${ts}`;
+
+        // Install A so its type claims a catalog slot.
+        const aModelPath = await stageModel(
+          repoDir,
+          extA,
+          "model.ts",
+          MINIMAL_MODEL_CODE(typeId),
+        );
+        await lockfileRepository.writeEntry(extA, "1.0.0", [
+          `.swamp/pulled-extensions/${extA}/models/model.ts`,
+        ]);
+        const serviceA = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: () =>
+            Promise.resolve(
+              makeStubInstallResult(extA, "1.0.0", [
+                `.swamp/pulled-extensions/${extA}/models/model.ts`,
+              ]),
+            ),
+        });
+        await serviceA.execute(
+          { name: extA, version: "1.0.0" } as ExtensionRef,
+          makeInstallContext(repoDir, lockfileRepository),
+        );
+        assertEquals(repository.loadByName(extA).length, 1);
+
+        // Delete A's source file — simulating "rm -rf" outside swamp.
+        await Deno.remove(aModelPath);
+
+        // Install B claiming the SAME type. The catalog still has A's
+        // ghost row, so I-Repo-1 fires. The error should detect the
+        // ghost and suggest `swamp doctor extensions`.
+        await stageModel(
+          repoDir,
+          extB,
+          "model.ts",
+          MINIMAL_MODEL_CODE(typeId),
+        );
+
+        const serviceB = new InstallExtensionService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          installExtensionFn: () =>
+            Promise.resolve(
+              makeStubInstallResult(extB, "1.0.0", [
+                `.swamp/pulled-extensions/${extB}/models/model.ts`,
+              ]),
+            ),
+        });
+
+        const thrown = await assertRejects(
+          () =>
+            serviceB.execute(
+              { name: extB, version: "1.0.0" } as ExtensionRef,
+              makeInstallContext(repoDir, lockfileRepository),
+            ),
+          DuplicateTypeUserError,
+        );
+        assertEquals(thrown.isGhostRow, true);
+        assertStringIncludes(thrown.message, "swamp doctor extensions");
+        assertStringIncludes(thrown.message, "Ghost catalog entry detected");
       },
     );
   },

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -359,15 +359,21 @@ Deno.test(
             ),
         });
 
-        await assertRejects(
+        const thrown = await assertRejects(
           () =>
             serviceB.execute(
               { name: extB, version: "1.0.0" } as ExtensionRef,
               makeInstallContext(repoDir, lockfileRepository),
             ),
-          UserError,
+          DuplicateTypeUserError,
           "Cannot install",
         );
+        assertEquals(
+          thrown.isGhostRow,
+          false,
+          "genuine collision must NOT be flagged as ghost row",
+        );
+        assertStringIncludes(thrown.message, "swamp extension rm");
 
         // FS rollback: B's staged file is gone.
         let bStillExists = true;

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -64,6 +64,7 @@ export function buildErrorJson(err: Error): Record<string, unknown> {
     data.duplicateType = {
       kind: err.kind,
       type: err.typeNormalized,
+      isGhostRow: err.isGhostRow,
       existing: {
         extensionName: err.existing.extensionName,
         extensionVersion: err.existing.extensionVersion,


### PR DESCRIPTION
## Summary

- When `extension pull` hits a `DuplicateTypeError` caused by a stale catalog row whose source file was deleted outside swamp (a "ghost row"), the error now suggests `swamp doctor extensions` instead of the incorrect `swamp extension rm`
- Adds `isGhostRow` boolean to `DuplicateTypeUserError` and the `--json` error envelope so programmatic consumers can distinguish ghost-row conflicts from genuine cross-extension collisions
- Updates `design/extension.md` to document the ghost-row error variant

Closes swamp-club/lab#658

## Test Plan

- [x] New unit test: `InstallExtensionService.execute: ghost-row conflict suggests swamp doctor extensions` — stages extension A, saves to catalog, deletes A's source file, installs extension B claiming the same type, asserts `isGhostRow=true` and message contains `swamp doctor extensions`
- [x] Manual end-to-end verification: created scratch repo, pulled `@stateless/review`, removed it, created local stub claiming same type, indexed, deleted local files, ran `extension pull @stateless/review` — confirmed ghost-row message appears in both log and JSON mode
- [x] Full test suite: 7062 passed, 0 failed
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)