### PR TITLE
feat(access): add Grant, Group aggregates and shared value objects (swamp-club#667)

### DIFF
--- a/src/domain/access/action.ts
+++ b/src/domain/access/action.ts
@@ -1,0 +1,24 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const ActionSchema = z.enum(["run", "read", "write", "admin"]);
+
+export type Action = z.infer<typeof ActionSchema>;

--- a/src/domain/access/effect.ts
+++ b/src/domain/access/effect.ts
@@ -1,0 +1,24 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const EffectSchema = z.enum(["allow", "deny"]);
+
+export type Effect = z.infer<typeof EffectSchema>;

--- a/src/domain/access/grant_source.ts
+++ b/src/domain/access/grant_source.ts
@@ -1,0 +1,47 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+const FIXED_SOURCES = ["method", "file", "config"] as const;
+
+export const GrantSourceSchema = z.string().min(1).refine(
+  (value) => {
+    if ((FIXED_SOURCES as readonly string[]).includes(value)) {
+      return true;
+    }
+    return value.startsWith("extension:");
+  },
+  {
+    message:
+      'Grant source must be "method", "file", "config", or "extension:<name>"',
+  },
+);
+
+export type GrantSource = z.infer<typeof GrantSourceSchema>;
+
+export function parseGrantSource(value: string): GrantSource {
+  const result = GrantSourceSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(
+      `Invalid grant source "${value}": must be "method", "file", "config", or "extension:<name>"`,
+    );
+  }
+  return result.data;
+}

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -1,0 +1,56 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export { type Action, ActionSchema } from "./action.ts";
+
+export { type Effect, EffectSchema } from "./effect.ts";
+
+export {
+  type GrantSource,
+  GrantSourceSchema,
+  parseGrantSource,
+} from "./grant_source.ts";
+
+export {
+  parsePrincipal,
+  type Principal,
+  type PrincipalKind,
+  PrincipalKindSchema,
+  PrincipalSchema,
+  principalToString,
+} from "./principal.ts";
+
+export {
+  parseResourceSelector,
+  type ResourceKind,
+  ResourceKindSchema,
+  type ResourceSelector,
+  resourceSelectorMatches,
+  ResourceSelectorSchema,
+  resourceSelectorToString,
+} from "./resource_selector.ts";
+
+export {
+  parseSubject,
+  type Subject,
+  type SubjectKind,
+  SubjectKindSchema,
+  SubjectSchema,
+  subjectToString,
+} from "./subject.ts";

--- a/src/domain/access/principal.ts
+++ b/src/domain/access/principal.ts
@@ -1,0 +1,56 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const PrincipalKindSchema = z.enum(["user", "worker"]);
+
+export type PrincipalKind = z.infer<typeof PrincipalKindSchema>;
+
+export const PrincipalSchema = z.object({
+  kind: PrincipalKindSchema,
+  id: z.string().min(1),
+});
+
+export type Principal = z.infer<typeof PrincipalSchema>;
+
+export function parsePrincipal(value: string): Principal {
+  const colonIndex = value.indexOf(":");
+  if (colonIndex === -1) {
+    throw new Error(
+      `Invalid principal "${value}": expected "user:<id>" or "worker:<id>"`,
+    );
+  }
+  const kind = value.slice(0, colonIndex);
+  const id = value.slice(colonIndex + 1);
+  if (id.length === 0) {
+    throw new Error(`Invalid principal "${value}": id cannot be empty`);
+  }
+  const parsed = PrincipalKindSchema.safeParse(kind);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid principal kind "${kind}": expected "user" or "worker"`,
+    );
+  }
+  return { kind: parsed.data, id };
+}
+
+export function principalToString(principal: Principal): string {
+  return `${principal.kind}:${principal.id}`;
+}

--- a/src/domain/access/principal_test.ts
+++ b/src/domain/access/principal_test.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { parsePrincipal, principalToString } from "./principal.ts";
+
+Deno.test("parsePrincipal: parses user principal", () => {
+  const p = parsePrincipal("user:adam");
+  assertEquals(p, { kind: "user", id: "adam" });
+});
+
+Deno.test("parsePrincipal: parses worker principal", () => {
+  const p = parsePrincipal("worker:build-runner-1");
+  assertEquals(p, { kind: "worker", id: "build-runner-1" });
+});
+
+Deno.test("parsePrincipal: handles id containing colons", () => {
+  const p = parsePrincipal("user:some:complex:id");
+  assertEquals(p, { kind: "user", id: "some:complex:id" });
+});
+
+Deno.test("parsePrincipal: rejects missing colon", () => {
+  assertThrows(
+    () => parsePrincipal("useradam"),
+    Error,
+    "expected",
+  );
+});
+
+Deno.test("parsePrincipal: rejects empty id", () => {
+  assertThrows(
+    () => parsePrincipal("user:"),
+    Error,
+    "id cannot be empty",
+  );
+});
+
+Deno.test("parsePrincipal: rejects invalid kind", () => {
+  assertThrows(
+    () => parsePrincipal("group:admins"),
+    Error,
+    'expected "user" or "worker"',
+  );
+});
+
+Deno.test("principalToString: roundtrips with parsePrincipal", () => {
+  const original = "worker:my-worker";
+  const parsed = parsePrincipal(original);
+  assertEquals(principalToString(parsed), original);
+});

--- a/src/domain/access/resource_selector.ts
+++ b/src/domain/access/resource_selector.ts
@@ -1,0 +1,85 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const ResourceKindSchema = z.enum([
+  "workflow",
+  "model",
+  "data",
+  "access",
+]);
+
+export type ResourceKind = z.infer<typeof ResourceKindSchema>;
+
+export const ResourceSelectorSchema = z.object({
+  kind: ResourceKindSchema,
+  pattern: z.string().min(1),
+});
+
+export type ResourceSelector = z.infer<typeof ResourceSelectorSchema>;
+
+export function parseResourceSelector(value: string): ResourceSelector {
+  const colonIndex = value.indexOf(":");
+  if (colonIndex === -1) {
+    throw new Error(
+      `Invalid resource selector "${value}": expected "<kind>:<pattern>" (e.g. "workflow:@acme/*")`,
+    );
+  }
+  const kind = value.slice(0, colonIndex);
+  const pattern = value.slice(colonIndex + 1);
+  if (pattern.length === 0) {
+    throw new Error(
+      `Invalid resource selector "${value}": pattern cannot be empty`,
+    );
+  }
+  const parsed = ResourceKindSchema.safeParse(kind);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid resource kind "${kind}": expected "workflow", "model", "data", or "access"`,
+    );
+  }
+  return { kind: parsed.data, pattern };
+}
+
+export function resourceSelectorToString(selector: ResourceSelector): string {
+  return `${selector.kind}:${selector.pattern}`;
+}
+
+/**
+ * Tests whether a resource name matches this selector's pattern.
+ * Patterns support a trailing `*` as a suffix wildcard:
+ * - `@acme/*` matches `@acme/deploy`, `@acme/build`
+ * - `@acme/deploy` matches only `@acme/deploy` (exact)
+ * - `*` matches everything
+ */
+export function resourceSelectorMatches(
+  selector: ResourceSelector,
+  resourceName: string,
+): boolean {
+  const { pattern } = selector;
+  if (pattern === "*") {
+    return true;
+  }
+  if (pattern.endsWith("*")) {
+    const prefix = pattern.slice(0, -1);
+    return resourceName.startsWith(prefix);
+  }
+  return pattern === resourceName;
+}

--- a/src/domain/access/resource_selector_test.ts
+++ b/src/domain/access/resource_selector_test.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  parseResourceSelector,
+  resourceSelectorMatches,
+  resourceSelectorToString,
+} from "./resource_selector.ts";
+
+Deno.test("parseResourceSelector: parses workflow selector", () => {
+  const s = parseResourceSelector("workflow:@acme/*");
+  assertEquals(s, { kind: "workflow", pattern: "@acme/*" });
+});
+
+Deno.test("parseResourceSelector: parses model selector", () => {
+  const s = parseResourceSelector("model:@acme/deploy");
+  assertEquals(s, { kind: "model", pattern: "@acme/deploy" });
+});
+
+Deno.test("parseResourceSelector: parses data selector", () => {
+  const s = parseResourceSelector("data:@acme/reports-*");
+  assertEquals(s, { kind: "data", pattern: "@acme/reports-*" });
+});
+
+Deno.test("parseResourceSelector: parses access selector", () => {
+  const s = parseResourceSelector("access:*");
+  assertEquals(s, { kind: "access", pattern: "*" });
+});
+
+Deno.test("parseResourceSelector: rejects missing colon", () => {
+  assertThrows(
+    () => parseResourceSelector("workflow"),
+    Error,
+    "expected",
+  );
+});
+
+Deno.test("parseResourceSelector: rejects empty pattern", () => {
+  assertThrows(
+    () => parseResourceSelector("workflow:"),
+    Error,
+    "pattern cannot be empty",
+  );
+});
+
+Deno.test("parseResourceSelector: rejects invalid kind", () => {
+  assertThrows(
+    () => parseResourceSelector("secret:my-secret"),
+    Error,
+    'expected "workflow", "model", "data", or "access"',
+  );
+});
+
+Deno.test("resourceSelectorToString: roundtrips with parseResourceSelector", () => {
+  const original = "data:@acme/reports-*";
+  const parsed = parseResourceSelector(original);
+  assertEquals(resourceSelectorToString(parsed), original);
+});
+
+Deno.test("resourceSelectorMatches: exact match", () => {
+  const selector = parseResourceSelector("workflow:@acme/deploy");
+  assertEquals(resourceSelectorMatches(selector, "@acme/deploy"), true);
+  assertEquals(resourceSelectorMatches(selector, "@acme/build"), false);
+});
+
+Deno.test("resourceSelectorMatches: suffix wildcard", () => {
+  const selector = parseResourceSelector("workflow:@acme/*");
+  assertEquals(resourceSelectorMatches(selector, "@acme/deploy"), true);
+  assertEquals(resourceSelectorMatches(selector, "@acme/build"), true);
+  assertEquals(resourceSelectorMatches(selector, "@other/deploy"), false);
+});
+
+Deno.test("resourceSelectorMatches: global wildcard", () => {
+  const selector = parseResourceSelector("model:*");
+  assertEquals(resourceSelectorMatches(selector, "@acme/deploy"), true);
+  assertEquals(resourceSelectorMatches(selector, "anything"), true);
+});
+
+Deno.test("resourceSelectorMatches: prefix wildcard does not match mid-string", () => {
+  const selector = parseResourceSelector("data:@acme/reports-*");
+  assertEquals(resourceSelectorMatches(selector, "@acme/reports-q1"), true);
+  assertEquals(resourceSelectorMatches(selector, "@acme/reports-"), true);
+  assertEquals(resourceSelectorMatches(selector, "@acme/other"), false);
+});

--- a/src/domain/access/subject.ts
+++ b/src/domain/access/subject.ts
@@ -1,0 +1,56 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+export const SubjectKindSchema = z.enum(["user", "group", "idp-group"]);
+
+export type SubjectKind = z.infer<typeof SubjectKindSchema>;
+
+export const SubjectSchema = z.object({
+  kind: SubjectKindSchema,
+  name: z.string().min(1),
+});
+
+export type Subject = z.infer<typeof SubjectSchema>;
+
+export function parseSubject(value: string): Subject {
+  const colonIndex = value.indexOf(":");
+  if (colonIndex === -1) {
+    throw new Error(
+      `Invalid subject "${value}": expected "user:<name>", "group:<name>", or "idp-group:<name>"`,
+    );
+  }
+  const kind = value.slice(0, colonIndex);
+  const name = value.slice(colonIndex + 1);
+  if (name.length === 0) {
+    throw new Error(`Invalid subject "${value}": name cannot be empty`);
+  }
+  const parsed = SubjectKindSchema.safeParse(kind);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid subject kind "${kind}": expected "user", "group", or "idp-group"`,
+    );
+  }
+  return { kind: parsed.data, name };
+}
+
+export function subjectToString(subject: Subject): string {
+  return `${subject.kind}:${subject.name}`;
+}

--- a/src/domain/access/subject_test.ts
+++ b/src/domain/access/subject_test.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { parseSubject, subjectToString } from "./subject.ts";
+
+Deno.test("parseSubject: parses user subject", () => {
+  const s = parseSubject("user:adam");
+  assertEquals(s, { kind: "user", name: "adam" });
+});
+
+Deno.test("parseSubject: parses group subject", () => {
+  const s = parseSubject("group:release-managers");
+  assertEquals(s, { kind: "group", name: "release-managers" });
+});
+
+Deno.test("parseSubject: parses idp-group subject", () => {
+  const s = parseSubject("idp-group:platform-eng");
+  assertEquals(s, { kind: "idp-group", name: "platform-eng" });
+});
+
+Deno.test("parseSubject: handles name containing colons", () => {
+  const s = parseSubject("group:team:alpha");
+  assertEquals(s, { kind: "group", name: "team:alpha" });
+});
+
+Deno.test("parseSubject: rejects missing colon", () => {
+  assertThrows(
+    () => parseSubject("useradam"),
+    Error,
+    "expected",
+  );
+});
+
+Deno.test("parseSubject: rejects empty name", () => {
+  assertThrows(
+    () => parseSubject("user:"),
+    Error,
+    "name cannot be empty",
+  );
+});
+
+Deno.test("parseSubject: rejects invalid kind", () => {
+  assertThrows(
+    () => parseSubject("worker:build-1"),
+    Error,
+    'expected "user", "group", or "idp-group"',
+  );
+});
+
+Deno.test("subjectToString: roundtrips with parseSubject", () => {
+  const original = "idp-group:platform-eng";
+  const parsed = parseSubject(original);
+  assertEquals(subjectToString(parsed), original);
+});

--- a/src/domain/models/access/access_test_helpers.ts
+++ b/src/domain/models/access/access_test_helpers.ts
@@ -1,0 +1,84 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { DataHandle, MethodContext } from "../model.ts";
+import type { ModelType } from "../model_type.ts";
+import { generateDataId } from "../../data/data_id.ts";
+
+export interface InMemoryAccessContext {
+  context: MethodContext;
+  store: Map<string, Record<string, unknown>>;
+  versions: Map<string, number>;
+}
+
+export function createInMemoryAccessContext(
+  modelType: ModelType,
+  instanceName: string,
+): InMemoryAccessContext {
+  const store = new Map<string, Record<string, unknown>>();
+  const versions = new Map<string, number>();
+
+  const writeResource = (
+    specName: string,
+    name: string,
+    data: Record<string, unknown>,
+  ): Promise<DataHandle> => {
+    store.set(name, structuredClone(data));
+    const version = (versions.get(name) ?? 0) + 1;
+    versions.set(name, version);
+    const handle: DataHandle = {
+      name,
+      specName,
+      kind: "resource",
+      dataId: generateDataId(),
+      version,
+      size: JSON.stringify(data).length,
+      tags: {},
+      metadata: {} as DataHandle["metadata"],
+    };
+    return Promise.resolve(handle);
+  };
+
+  const context = {
+    signal: new AbortController().signal,
+    repoDir: "/tmp",
+    modelType,
+    modelId: crypto.randomUUID(),
+    globalArgs: {},
+    definition: { id: "test-id", name: instanceName, version: 1, tags: {} },
+    methodName: "test",
+    logger: getLogger(["test"]),
+    writeResource,
+    readResource: (name: string) =>
+      Promise.resolve(
+        store.has(name) ? structuredClone(store.get(name)!) : null,
+      ),
+    extensionFile: () => {
+      throw new Error("extensionFile not available in access model tests");
+    },
+    createCelEnvironment: () => {
+      throw new Error(
+        "createCelEnvironment not available in access model tests",
+      );
+    },
+  } as unknown as MethodContext;
+
+  return { context, store, versions };
+}

--- a/src/domain/models/access/grant_model.ts
+++ b/src/domain/models/access/grant_model.ts
@@ -1,0 +1,192 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+import { ModelType } from "../model_type.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../model.ts";
+import { ActionSchema } from "../../access/action.ts";
+import { EffectSchema } from "../../access/effect.ts";
+import { GrantSourceSchema } from "../../access/grant_source.ts";
+import {
+  parseResourceSelector,
+  ResourceSelectorSchema,
+} from "../../access/resource_selector.ts";
+import { parseSubject, SubjectSchema } from "../../access/subject.ts";
+import { parsePrincipal, PrincipalSchema } from "../../access/principal.ts";
+
+export const GRANT_MODEL_TYPE = ModelType.create("swamp/grant");
+
+const GrantStateSchema = z.enum(["active", "revoked"]);
+
+export type GrantState = z.infer<typeof GrantStateSchema>;
+
+export const GrantSchema = z.object({
+  id: z.string(),
+  subject: SubjectSchema,
+  effect: EffectSchema,
+  actions: z.array(ActionSchema).min(1),
+  resource: ResourceSelectorSchema,
+  condition: z.string().optional(),
+  state: GrantStateSchema,
+  source: GrantSourceSchema,
+  createdBy: PrincipalSchema,
+  createdAt: z.string().datetime(),
+});
+
+export type Grant = z.infer<typeof GrantSchema>;
+
+const GRANT_DATA_NAME = "grant-main";
+
+async function readGrant(context: MethodContext): Promise<Grant | null> {
+  const raw = await context.readResource!(GRANT_DATA_NAME);
+  if (raw === null) return null;
+  return GrantSchema.parse(raw);
+}
+
+const CreateArgsSchema = z.object({
+  subject: z.string().min(1).describe(
+    'Grant subject (e.g. "user:adam", "group:release-managers")',
+  ),
+  effect: EffectSchema,
+  actions: z.array(ActionSchema).min(1),
+  resourceKind: z.string().min(1).describe(
+    'Resource kind: "workflow", "model", "data", or "access"',
+  ),
+  resourcePattern: z.string().min(1).describe(
+    'Resource pattern (e.g. "@acme/*", "@acme/deploy")',
+  ),
+  condition: z.string().optional().describe(
+    "Optional CEL expression (stored as string, validated by CEL environment in a sibling issue)",
+  ),
+  source: GrantSourceSchema,
+  createdBy: z.string().min(1).describe(
+    'Principal who created this grant (e.g. "user:adam")',
+  ),
+});
+
+async function create(
+  args: z.infer<typeof CreateArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const existing = await readGrant(context);
+  if (existing !== null) {
+    throw new Error(
+      `Grant '${context.definition.name}' already exists — revoke it first`,
+    );
+  }
+
+  const subject = parseSubject(args.subject);
+  const resource = parseResourceSelector(
+    `${args.resourceKind}:${args.resourcePattern}`,
+  );
+  const createdBy = parsePrincipal(args.createdBy);
+
+  const grant: Grant = {
+    id: crypto.randomUUID(),
+    subject,
+    effect: args.effect,
+    actions: args.actions,
+    resource,
+    condition: args.condition,
+    state: "active",
+    source: args.source,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  };
+
+  const handle = await context.writeResource!("grant", GRANT_DATA_NAME, grant);
+  return { dataHandles: [handle] };
+}
+
+const EmptyArgsSchema = z.object({});
+
+async function revoke(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const grant = await readGrant(context);
+  if (grant === null) {
+    throw new Error(
+      `Grant '${context.definition.name}' does not exist`,
+    );
+  }
+  if (grant.state === "revoked") {
+    return { dataHandles: [] };
+  }
+
+  const revoked: Grant = { ...grant, state: "revoked" };
+  const handle = await context.writeResource!(
+    "grant",
+    GRANT_DATA_NAME,
+    revoked,
+  );
+  return { dataHandles: [handle] };
+}
+
+async function list(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const grant = await readGrant(context);
+  if (grant === null) {
+    return { dataHandles: [] };
+  }
+  return { dataHandles: [] };
+}
+
+export const grantModel: ModelDefinition = defineModel({
+  type: GRANT_MODEL_TYPE,
+  version: "2026.06.17.1",
+  resources: {
+    "grant": {
+      description:
+        "Grant lifecycle (active → revoked; never deleted, history retained)",
+      schema: GrantSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description:
+        "Create a new grant — validates subject/resource shapes, records source (immutable after creation)",
+      kind: "create",
+      arguments: CreateArgsSchema,
+      execute: create,
+    },
+    revoke: {
+      description:
+        "Transition active → revoked (idempotent if already revoked; state change, never a delete)",
+      kind: "action",
+      arguments: EmptyArgsSchema,
+      execute: revoke,
+    },
+    list: {
+      description: "Query active grants, filterable by subject and resource",
+      kind: "list",
+      arguments: EmptyArgsSchema,
+      execute: list,
+    },
+  },
+});

--- a/src/domain/models/access/grant_model_test.ts
+++ b/src/domain/models/access/grant_model_test.ts
@@ -1,0 +1,168 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { type Grant, GRANT_MODEL_TYPE, grantModel } from "./grant_model.ts";
+import { createInMemoryAccessContext } from "./access_test_helpers.ts";
+import { GrantSourceSchema } from "../../access/grant_source.ts";
+
+function createTestContext(instanceName = "test-grant") {
+  return createInMemoryAccessContext(GRANT_MODEL_TYPE, instanceName);
+}
+
+const VALID_CREATE_ARGS = {
+  subject: "user:adam",
+  effect: "allow" as const,
+  actions: ["read" as const, "run" as const],
+  resourceKind: "workflow",
+  resourcePattern: "@acme/*",
+  source: "method",
+  createdBy: "user:admin",
+};
+
+Deno.test("create: creates a new grant", async () => {
+  const { context, store } = createTestContext();
+  const result = await grantModel.methods.create.execute(
+    VALID_CREATE_ARGS,
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 1);
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.subject, { kind: "user", name: "adam" });
+  assertEquals(grant.effect, "allow");
+  assertEquals(grant.actions, ["read", "run"]);
+  assertEquals(grant.resource, { kind: "workflow", pattern: "@acme/*" });
+  assertEquals(grant.state, "active");
+  assertEquals(grant.source, "method");
+  assertEquals(grant.createdBy, { kind: "user", id: "admin" });
+});
+
+Deno.test("create: rejects duplicate grant", async () => {
+  const { context } = createTestContext();
+  await grantModel.methods.create.execute(VALID_CREATE_ARGS, context);
+  await assertRejects(
+    () => grantModel.methods.create.execute(VALID_CREATE_ARGS, context),
+    Error,
+    "already exists",
+  );
+});
+
+Deno.test("create: stores condition as string", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    {
+      ...VALID_CREATE_ARGS,
+      condition: "request.time < timestamp('2026-12-31T00:00:00Z')",
+    },
+    context,
+  );
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(
+    grant.condition,
+    "request.time < timestamp('2026-12-31T00:00:00Z')",
+  );
+});
+
+Deno.test("create: accepts extension source", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    { ...VALID_CREATE_ARGS, source: "extension:my-ext" },
+    context,
+  );
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.source, "extension:my-ext");
+});
+
+Deno.test("create: accepts idp-group subject", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    { ...VALID_CREATE_ARGS, subject: "idp-group:platform-eng" },
+    context,
+  );
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.subject, { kind: "idp-group", name: "platform-eng" });
+});
+
+Deno.test("revoke: transitions active to revoked", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(VALID_CREATE_ARGS, context);
+  const result = await grantModel.methods.revoke.execute({}, context);
+  assertEquals(result.dataHandles?.length, 1);
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.state, "revoked");
+});
+
+Deno.test("revoke: is idempotent on already-revoked grant", async () => {
+  const { context } = createTestContext();
+  await grantModel.methods.create.execute(VALID_CREATE_ARGS, context);
+  await grantModel.methods.revoke.execute({}, context);
+  const result = await grantModel.methods.revoke.execute({}, context);
+  assertEquals(result.dataHandles?.length, 0);
+});
+
+Deno.test("revoke: rejects when grant does not exist", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () => grantModel.methods.revoke.execute({}, context),
+    Error,
+    "does not exist",
+  );
+});
+
+Deno.test("revoke: preserves all fields except state", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(VALID_CREATE_ARGS, context);
+  const beforeRevoke = structuredClone(
+    store.get("grant-main") as unknown as Grant,
+  );
+  await grantModel.methods.revoke.execute({}, context);
+  const afterRevoke = store.get("grant-main") as unknown as Grant;
+  assertEquals(afterRevoke.id, beforeRevoke.id);
+  assertEquals(afterRevoke.subject, beforeRevoke.subject);
+  assertEquals(afterRevoke.source, beforeRevoke.source);
+  assertEquals(afterRevoke.createdBy, beforeRevoke.createdBy);
+  assertEquals(afterRevoke.createdAt, beforeRevoke.createdAt);
+  assertEquals(afterRevoke.state, "revoked");
+});
+
+Deno.test("create: schema rejects invalid source value", () => {
+  const result = GrantSourceSchema.safeParse("invalid");
+  assertEquals(result.success, false);
+});
+
+Deno.test("create: schema accepts valid source values", () => {
+  for (const source of ["method", "file", "config", "extension:my-ext"]) {
+    const result = GrantSourceSchema.safeParse(source);
+    assertEquals(result.success, true, `Expected "${source}" to be valid`);
+  }
+});
+
+Deno.test("create: source field is set at creation and persisted", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    { ...VALID_CREATE_ARGS, source: "file" },
+    context,
+  );
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.source, "file");
+
+  await grantModel.methods.revoke.execute({}, context);
+  const revoked = store.get("grant-main") as unknown as Grant;
+  assertEquals(revoked.source, "file");
+});

--- a/src/domain/models/access/group_model.ts
+++ b/src/domain/models/access/group_model.ts
@@ -1,0 +1,223 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+import { ModelType } from "../model_type.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../model.ts";
+import {
+  parsePrincipal,
+  PrincipalSchema,
+  principalToString,
+} from "../../access/principal.ts";
+
+export const GROUP_MODEL_TYPE = ModelType.create("swamp/group");
+
+export const GroupSchema = z.object({
+  name: z.string().min(1),
+  members: z.array(PrincipalSchema),
+  createdBy: PrincipalSchema,
+  createdAt: z.string().datetime(),
+});
+
+export type Group = z.infer<typeof GroupSchema>;
+
+const GROUP_DATA_NAME = "group-main";
+
+async function readGroup(context: MethodContext): Promise<Group | null> {
+  const raw = await context.readResource!(GROUP_DATA_NAME);
+  if (raw === null) return null;
+  return GroupSchema.parse(raw);
+}
+
+const CreateArgsSchema = z.object({
+  createdBy: z.string().min(1).describe(
+    'Principal who created this group (e.g. "user:adam")',
+  ),
+});
+
+async function create(
+  args: z.infer<typeof CreateArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const existing = await readGroup(context);
+  if (existing !== null) {
+    throw new Error(
+      `Group '${context.definition.name}' already exists`,
+    );
+  }
+
+  const createdBy = parsePrincipal(args.createdBy);
+
+  const group: Group = {
+    name: context.definition.name,
+    members: [],
+    createdBy,
+    createdAt: new Date().toISOString(),
+  };
+
+  const handle = await context.writeResource!(
+    "group",
+    GROUP_DATA_NAME,
+    group,
+  );
+  return { dataHandles: [handle] };
+}
+
+const MemberArgsSchema = z.object({
+  principal: z.string().min(1).describe(
+    'Principal to add/remove (e.g. "user:adam")',
+  ),
+});
+
+async function addMember(
+  args: z.infer<typeof MemberArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const group = await readGroup(context);
+  if (group === null) {
+    throw new Error(
+      `Group '${context.definition.name}' does not exist — create it first`,
+    );
+  }
+
+  const principal = parsePrincipal(args.principal);
+  const principalStr = principalToString(principal);
+
+  const alreadyMember = group.members.some(
+    (m) => principalToString(m) === principalStr,
+  );
+  if (alreadyMember) {
+    return { dataHandles: [] };
+  }
+
+  const updated: Group = {
+    ...group,
+    members: [...group.members, principal],
+  };
+  const handle = await context.writeResource!(
+    "group",
+    GROUP_DATA_NAME,
+    updated,
+  );
+  return { dataHandles: [handle] };
+}
+
+async function removeMember(
+  args: z.infer<typeof MemberArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const group = await readGroup(context);
+  if (group === null) {
+    throw new Error(
+      `Group '${context.definition.name}' does not exist — create it first`,
+    );
+  }
+
+  const principal = parsePrincipal(args.principal);
+  const principalStr = principalToString(principal);
+
+  const filtered = group.members.filter(
+    (m) => principalToString(m) !== principalStr,
+  );
+  if (filtered.length === group.members.length) {
+    return { dataHandles: [] };
+  }
+
+  const updated: Group = { ...group, members: filtered };
+  const handle = await context.writeResource!(
+    "group",
+    GROUP_DATA_NAME,
+    updated,
+  );
+  return { dataHandles: [handle] };
+}
+
+const EmptyArgsSchema = z.object({});
+
+async function list(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  await readGroup(context);
+  return { dataHandles: [] };
+}
+
+async function members(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const group = await readGroup(context);
+  if (group === null) {
+    throw new Error(
+      `Group '${context.definition.name}' does not exist`,
+    );
+  }
+  return { dataHandles: [] };
+}
+
+export const groupModel: ModelDefinition = defineModel({
+  type: GROUP_MODEL_TYPE,
+  version: "2026.06.17.1",
+  resources: {
+    "group": {
+      description: "Group membership (locally-managed principals)",
+      schema: GroupSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a new named group",
+      kind: "create",
+      arguments: CreateArgsSchema,
+      execute: create,
+    },
+    "add-member": {
+      description:
+        "Add a principal to the group (idempotent if already a member)",
+      kind: "action",
+      arguments: MemberArgsSchema,
+      execute: addMember,
+    },
+    "remove-member": {
+      description: "Remove a principal from the group (no-op if not a member)",
+      kind: "action",
+      arguments: MemberArgsSchema,
+      execute: removeMember,
+    },
+    list: {
+      description: "List all groups",
+      kind: "list",
+      arguments: EmptyArgsSchema,
+      execute: list,
+    },
+    members: {
+      description: "List members of a specific group",
+      kind: "read",
+      arguments: EmptyArgsSchema,
+      execute: members,
+    },
+  },
+});

--- a/src/domain/models/access/group_model_test.ts
+++ b/src/domain/models/access/group_model_test.ts
@@ -1,0 +1,166 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { type Group, GROUP_MODEL_TYPE, groupModel } from "./group_model.ts";
+import { createInMemoryAccessContext } from "./access_test_helpers.ts";
+
+function createTestContext(instanceName = "release-managers") {
+  return createInMemoryAccessContext(GROUP_MODEL_TYPE, instanceName);
+}
+
+Deno.test("create: creates a new empty group", async () => {
+  const { context, store } = createTestContext();
+  const result = await groupModel.methods.create.execute(
+    { createdBy: "user:admin" },
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 1);
+  const group = store.get("group-main") as unknown as Group;
+  assertEquals(group.name, "release-managers");
+  assertEquals(group.members, []);
+  assertEquals(group.createdBy, { kind: "user", id: "admin" });
+});
+
+Deno.test("create: rejects duplicate group", async () => {
+  const { context } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  await assertRejects(
+    () =>
+      groupModel.methods.create.execute({ createdBy: "user:admin" }, context),
+    Error,
+    "already exists",
+  );
+});
+
+Deno.test("add-member: adds a principal to the group", async () => {
+  const { context, store } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  const result = await groupModel.methods["add-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 1);
+  const group = store.get("group-main") as unknown as Group;
+  assertEquals(group.members, [{ kind: "user", id: "adam" }]);
+});
+
+Deno.test("add-member: is idempotent for existing member", async () => {
+  const { context } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  await groupModel.methods["add-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  const result = await groupModel.methods["add-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 0);
+});
+
+Deno.test("add-member: supports multiple members", async () => {
+  const { context, store } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  await groupModel.methods["add-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  await groupModel.methods["add-member"].execute(
+    { principal: "user:eve" },
+    context,
+  );
+  const group = store.get("group-main") as unknown as Group;
+  assertEquals(group.members.length, 2);
+});
+
+Deno.test("add-member: rejects when group does not exist", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () =>
+      groupModel.methods["add-member"].execute(
+        { principal: "user:adam" },
+        context,
+      ),
+    Error,
+    "does not exist",
+  );
+});
+
+Deno.test("remove-member: removes a principal from the group", async () => {
+  const { context, store } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  await groupModel.methods["add-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  await groupModel.methods["add-member"].execute(
+    { principal: "user:eve" },
+    context,
+  );
+  const result = await groupModel.methods["remove-member"].execute(
+    { principal: "user:adam" },
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 1);
+  const group = store.get("group-main") as unknown as Group;
+  assertEquals(group.members, [{ kind: "user", id: "eve" }]);
+});
+
+Deno.test("remove-member: is a no-op for non-member", async () => {
+  const { context } = createTestContext();
+  await groupModel.methods.create.execute({ createdBy: "user:admin" }, context);
+  const result = await groupModel.methods["remove-member"].execute(
+    { principal: "user:nobody" },
+    context,
+  );
+  assertEquals(result.dataHandles?.length, 0);
+});
+
+Deno.test("remove-member: rejects when group does not exist", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () =>
+      groupModel.methods["remove-member"].execute(
+        { principal: "user:adam" },
+        context,
+      ),
+    Error,
+    "does not exist",
+  );
+});
+
+Deno.test("members: rejects when group does not exist", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () => groupModel.methods.members.execute({}, context),
+    Error,
+    "does not exist",
+  );
+});
+
+Deno.test("create: preserves group name from instance name", async () => {
+  const { context, store } = createTestContext("platform-team");
+  await groupModel.methods.create.execute(
+    { createdBy: "user:admin" },
+    context,
+  );
+  const group = store.get("group-main") as unknown as Group;
+  assertEquals(group.name, "platform-team");
+});

--- a/src/domain/models/access/ownership_validation_test.ts
+++ b/src/domain/models/access/ownership_validation_test.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { FileSystemUnifiedDataRepository } from "../../../infrastructure/persistence/unified_data_repository.ts";
+import { CatalogStore } from "../../../infrastructure/persistence/catalog_store.ts";
+import { Data } from "../../data/mod.ts";
+import { GRANT_MODEL_TYPE } from "./grant_model.ts";
+import { GROUP_MODEL_TYPE } from "./group_model.ts";
+import { OwnershipValidationError } from "../../data/repositories.ts";
+
+const modelMethodOwner = {
+  ownerType: "model-method" as const,
+  ownerRef: "swamp/grant:create",
+};
+
+const genericOwner = {
+  ownerType: "workflow-step" as const,
+  ownerRef: "some-workflow:some-step",
+};
+
+function makeModelOwnedData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource", specName: "grant" },
+    ownerDefinition: modelMethodOwner,
+  });
+}
+
+function makeGenericData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "resource" },
+    ownerDefinition: genericOwner,
+  });
+}
+
+async function withTempRepo(
+  fn: (repo: FileSystemUnifiedDataRepository) => Promise<void>,
+): Promise<void> {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    await fn(repo);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+}
+
+const content = new TextEncoder().encode(JSON.stringify({ test: true }));
+
+Deno.test("ownership: generic write to grant data owned by model-method is rejected", async () => {
+  await withTempRepo(async (repo) => {
+    const modelData = makeModelOwnedData("grant-main");
+    await repo.save(GRANT_MODEL_TYPE, "test-grant", modelData, content);
+
+    const intruderData = makeGenericData("grant-main");
+    await assertRejects(
+      () => repo.save(GRANT_MODEL_TYPE, "test-grant", intruderData, content),
+      OwnershipValidationError,
+      "does not match",
+    );
+  });
+});
+
+Deno.test("ownership: generic write to group data owned by model-method is rejected", async () => {
+  const groupMethodOwner = {
+    ownerType: "model-method" as const,
+    ownerRef: "swamp/group:create",
+  };
+  await withTempRepo(async (repo) => {
+    const modelData = Data.create({
+      name: "group-main",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource", specName: "group" },
+      ownerDefinition: groupMethodOwner,
+    });
+    await repo.save(GROUP_MODEL_TYPE, "test-group", modelData, content);
+
+    const intruderData = makeGenericData("group-main");
+    await assertRejects(
+      () => repo.save(GROUP_MODEL_TYPE, "test-group", intruderData, content),
+      OwnershipValidationError,
+      "does not match",
+    );
+  });
+});
+
+Deno.test("ownership: same model-method owner can write successive versions", async () => {
+  await withTempRepo(async (repo) => {
+    const data1 = makeModelOwnedData("grant-main");
+    await repo.save(GRANT_MODEL_TYPE, "test-grant", data1, content);
+
+    const data2 = makeModelOwnedData("grant-main");
+    const v2Content = new TextEncoder().encode(
+      JSON.stringify({ test: true, version: 2 }),
+    );
+    await repo.save(GRANT_MODEL_TYPE, "test-grant", data2, v2Content);
+  });
+});
+
+Deno.test("ownership: different model-method ownerRef on same model is rejected", async () => {
+  await withTempRepo(async (repo) => {
+    const modelData = makeModelOwnedData("grant-main");
+    await repo.save(GRANT_MODEL_TYPE, "test-grant", modelData, content);
+
+    const otherMethodData = Data.create({
+      name: "grant-main",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      tags: { type: "resource" },
+      ownerDefinition: {
+        ownerType: "model-method",
+        ownerRef: "swamp/grant:revoke",
+      },
+    });
+    await assertRejects(
+      () =>
+        repo.save(
+          GRANT_MODEL_TYPE,
+          "test-grant",
+          otherMethodData,
+          content,
+        ),
+      OwnershipValidationError,
+      "does not match",
+    );
+  });
+});

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -39,6 +39,11 @@ import "./worker/worker_model.ts";
 import "./worker/enrollment_token_model.ts";
 import "./worker/step_lease_model.ts";
 
+// Access control models (grants, groups) — see src/domain/access/ for
+// the bounded context's shared value objects.
+import "./access/grant_model.ts";
+import "./access/group_model.ts";
+
 // Import all of the AWS models - the models in this file are created by the clover pipeline
 import "./aws/aws_models.ts";
 


### PR DESCRIPTION
## Summary

- Create the `src/domain/access/` bounded context with shared value objects: `Principal` (user|worker), `Subject` (user|group|idp-group), `ResourceSelector` (workflow|model|data|access with suffix-wildcard glob), `Action`, `Effect`, `GrantSource` — all with `parse()`/`toString()` for colon-separated string representation
- Add `Grant` and `Group` built-in model definitions in `src/domain/models/access/` following the worker model convention — Grant has create/revoke/list methods with `active→revoked` state machine and immutable `source` field; Group has create/add-member/remove-member/list/members methods
- Register both models in the model barrel (`src/domain/models/models.ts`)
- Add ownership validation security tests using `FileSystemUnifiedDataRepository` proving generic data writes to access model data are rejected with `OwnershipValidationError`

## Test Plan

- 54 tests total, all passing:
  - 27 value object tests (parse/toString roundtrip, validation, rejection of invalid inputs, glob matching)
  - 23 model method tests (create, revoke idempotency, source immutability through revocation, member management, duplicate rejection, schema validation)
  - 4 ownership validation integration tests (generic write rejected for grant data, generic write rejected for group data, same owner successive writes allowed, different ownerRef on same model rejected)
- Full verification suite passes: `deno check`, `deno lint`, `deno fmt`, `deno run test` (7121 tests, 0 failures), `deno run compile`

Closes swamp-club#667