### PR TITLE
feat(access): add sealed CEL grant-condition environment (swamp-club#670)

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -7,9 +7,9 @@ should be able to reference models by name, then grab data from definitions or
 data, and manipulate it in place (such as string manipulation, concatenating
 array members, etc).
 
-## Two CEL Surfaces
+## Three CEL Surfaces
 
-Swamp has two distinct CEL surfaces:
+Swamp has three distinct CEL surfaces:
 
 1. **Internal**: `CelEvaluator` (`src/infrastructure/cel/cel_evaluator.ts`) is
    used to evaluate expressions in workflow conditions, data queries,
@@ -23,13 +23,24 @@ Swamp has two distinct CEL surfaces:
    already holds (e.g. selector predicates over a fleet of hosts).
    Extensions register their own functions, types, and operators on the
    returned Environment — registrations on one instance do not affect any
-   other. See `.claude/skills/swamp/references/extension/references/model/api.md` for
+   other. See
+   `.claude/skills/swamp/references/extension/references/model/api.md` for
    the extension-author guide.
+3. **Grant-condition**: `createGrantConditionEnvironment()`
+   (`src/infrastructure/cel/grant_condition_environment.ts`) is a sealed,
+   purpose-built environment for evaluating authorization grant conditions.
+   It declares explicit variables per resource kind (workflow, model, data,
+   access) and a `principal.*` namespace, with
+   `unlistedVariablesAreDyn: false` so references to undeclared fields fail
+   at write-time validation. No I/O receivers (`data.*`, `file.*`,
+   `vault.*`, `env.*`), no extension registrations, no host functions beyond
+   the arithmetic baseline. The seal is permanent — conditions are
+   deterministic pure functions over (resource fields, principal context).
 
-The two surfaces share the same arithmetic-overload registrations
-(bigint/double mixes) so a CEL expression parsed against either evaluates
-arithmetic identically. They diverge only on what receiver methods are
-visible.
+All three surfaces share the same arithmetic-overload registrations
+(bigint/double mixes via `registerArithmeticOverloads()`) so a CEL
+expression parsed against any surface evaluates arithmetic identically.
+They diverge on what variables and receiver methods are visible.
 
 ## Model Data
 

--- a/src/domain/models/access/grant_model.ts
+++ b/src/domain/models/access/grant_model.ts
@@ -34,6 +34,7 @@ import {
 } from "../../access/resource_selector.ts";
 import { parseSubject, SubjectSchema } from "../../access/subject.ts";
 import { parsePrincipal, PrincipalSchema } from "../../access/principal.ts";
+import { validateGrantCondition } from "../../../infrastructure/cel/grant_condition_environment.ts";
 
 export const GRANT_MODEL_TYPE = ModelType.create("swamp/grant");
 
@@ -77,7 +78,7 @@ const CreateArgsSchema = z.object({
     'Resource pattern (e.g. "@acme/*", "@acme/deploy")',
   ),
   condition: z.string().optional().describe(
-    "Optional CEL expression (stored as string, validated by CEL environment in a sibling issue)",
+    "Optional CEL condition over resource fields and principal context",
   ),
   source: GrantSourceSchema,
   createdBy: z.string().min(1).describe(
@@ -101,6 +102,15 @@ async function create(
     `${args.resourceKind}:${args.resourcePattern}`,
   );
   const createdBy = parsePrincipal(args.createdBy);
+
+  if (args.condition) {
+    const validation = validateGrantCondition(args.condition, resource.kind);
+    if (!validation.valid) {
+      throw new Error(
+        `Invalid grant condition: ${validation.error}`,
+      );
+    }
+  }
 
   const grant: Grant = {
     id: crypto.randomUUID(),

--- a/src/domain/models/access/grant_model_test.ts
+++ b/src/domain/models/access/grant_model_test.ts
@@ -63,19 +63,55 @@ Deno.test("create: rejects duplicate grant", async () => {
   );
 });
 
-Deno.test("create: stores condition as string", async () => {
+Deno.test("create: stores valid condition as string", async () => {
   const { context, store } = createTestContext();
   await grantModel.methods.create.execute(
     {
       ...VALID_CREATE_ARGS,
-      condition: "request.time < timestamp('2026-12-31T00:00:00Z')",
+      condition: 'tags.env == "staging"',
     },
     context,
   );
   const grant = store.get("grant-main") as unknown as Grant;
-  assertEquals(
-    grant.condition,
-    "request.time < timestamp('2026-12-31T00:00:00Z')",
+  assertEquals(grant.condition, 'tags.env == "staging"');
+});
+
+Deno.test("create: rejects invalid condition syntax", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () =>
+      grantModel.methods.create.execute(
+        { ...VALID_CREATE_ARGS, condition: "name ==" },
+        context,
+      ),
+    Error,
+    "Invalid grant condition",
+  );
+});
+
+Deno.test("create: rejects condition with unknown field", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () =>
+      grantModel.methods.create.execute(
+        { ...VALID_CREATE_ARGS, condition: 'unknown_field == "value"' },
+        context,
+      ),
+    Error,
+    "Invalid grant condition",
+  );
+});
+
+Deno.test("create: rejects condition exceeding length limit", async () => {
+  const { context } = createTestContext();
+  await assertRejects(
+    () =>
+      grantModel.methods.create.execute(
+        { ...VALID_CREATE_ARGS, condition: "a".repeat(1025) },
+        context,
+      ),
+    Error,
+    "maximum length",
   );
 });
 

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -192,12 +192,7 @@ export class CelDataNamespace {
  * own expression surface. Callers may freely register their own
  * functions, types, and operators on the returned Environment.
  */
-export function createExtensionCelEnvironment(): Environment {
-  const env = new Environment({ unlistedVariablesAreDyn: true });
-
-  // Register mixed-type arithmetic overloads. Context values from model
-  // attributes are JS numbers (double), but CEL integer literals are bigint
-  // (int). Without these, expressions like `count * 2` fail.
+function registerArithmeticOverloads(env: Environment): void {
   env.registerOperator(
     "double + int",
     (a: number, b: bigint) => a + Number(b),
@@ -238,7 +233,13 @@ export function createExtensionCelEnvironment(): Environment {
     "int % double",
     (a: bigint, b: number) => Number(a) % b,
   );
+}
 
+export { registerArithmeticOverloads };
+
+export function createExtensionCelEnvironment(): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: true });
+  registerArithmeticOverloads(env);
   return env;
 }
 

--- a/src/infrastructure/cel/grant_condition_environment.ts
+++ b/src/infrastructure/cel/grant_condition_environment.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Environment } from "cel-js";
+import type { ResourceKind } from "../../domain/access/resource_selector.ts";
+import { registerArithmeticOverloads } from "./cel_evaluator.ts";
+
+const MAX_CONDITION_LENGTH = 1024;
+
+export interface GrantConditionValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export interface PrincipalContext {
+  sub: string;
+  email?: string;
+  groups: string[];
+  collectives: string[];
+}
+
+const RESOURCE_FIELDS: Record<ResourceKind, string[]> = {
+  workflow: ["name", "tags", "collective"],
+  model: ["modelType", "collective"],
+  data: ["name", "ns", "tags", "owner"],
+  access: ["name"],
+};
+
+function createGrantConditionEnvironment(kind: ResourceKind): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: false });
+  registerArithmeticOverloads(env);
+
+  for (const field of RESOURCE_FIELDS[kind]) {
+    env.registerVariable(
+      field,
+      field === "tags" || field === "owner"
+        ? "map"
+        : field === "name" || field === "ns" || field === "modelType" ||
+            field === "collective"
+        ? "string"
+        : "dyn",
+    );
+  }
+
+  env.registerVariable("principal", "map");
+
+  return env;
+}
+
+export function validateGrantCondition(
+  condition: string,
+  resourceKind: ResourceKind,
+): GrantConditionValidationResult {
+  if (condition.length > MAX_CONDITION_LENGTH) {
+    return {
+      valid: false,
+      error:
+        `Condition exceeds maximum length of ${MAX_CONDITION_LENGTH} bytes (got ${condition.length})`,
+    };
+  }
+
+  const env = createGrantConditionEnvironment(resourceKind);
+
+  try {
+    env.parse(condition);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { valid: false, error: `CEL syntax error: ${message}` };
+  }
+
+  const checkResult = env.check(condition);
+  if (!checkResult.valid) {
+    const message = checkResult.error instanceof Error
+      ? checkResult.error.message
+      : String(checkResult.error);
+    return { valid: false, error: `CEL type error: ${message}` };
+  }
+
+  return { valid: true };
+}
+
+export function evaluateGrantCondition(
+  condition: string,
+  resourceKind: ResourceKind,
+  resourceFields: Record<string, unknown>,
+  principalContext: PrincipalContext,
+): boolean {
+  const env = createGrantConditionEnvironment(resourceKind);
+
+  const context: Record<string, unknown> = { ...resourceFields };
+  context.principal = principalContext;
+
+  const result = env.evaluate(condition, context);
+  return result === true;
+}

--- a/src/infrastructure/cel/grant_condition_environment_test.ts
+++ b/src/infrastructure/cel/grant_condition_environment_test.ts
@@ -1,0 +1,264 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  evaluateGrantCondition,
+  type PrincipalContext,
+  validateGrantCondition,
+} from "./grant_condition_environment.ts";
+
+const PRINCIPAL: PrincipalContext = {
+  sub: "user-123",
+  email: "alice@example.com",
+  groups: ["release-managers", "platform"],
+  collectives: ["acme", "ops"],
+};
+
+// --- Validation: valid conditions per resource kind ---
+
+Deno.test("validateGrantCondition: workflow tags condition", () => {
+  const result = validateGrantCondition(
+    'tags.env == "staging"',
+    "workflow",
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: workflow name condition", () => {
+  const result = validateGrantCondition('name == "deploy"', "workflow");
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: workflow collective condition", () => {
+  const result = validateGrantCondition(
+    'collective == "acme"',
+    "workflow",
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: model modelType condition", () => {
+  const result = validateGrantCondition('modelType == "aws/ec2"', "model");
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: data ns and tags condition", () => {
+  const result = validateGrantCondition(
+    'ns == "infra" && tags.env == "prod"',
+    "data",
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: data owner condition", () => {
+  const result = validateGrantCondition(
+    "owner.createdBy == principal.sub",
+    "data",
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: access name condition", () => {
+  const result = validateGrantCondition('name == "admin-grant"', "access");
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: principal context access", () => {
+  const result = validateGrantCondition(
+    '"acme" in principal.collectives',
+    "workflow",
+  );
+  assertEquals(result, { valid: true });
+});
+
+Deno.test("validateGrantCondition: compound condition", () => {
+  const result = validateGrantCondition(
+    'tags.env == "staging" && collective in principal.collectives',
+    "workflow",
+  );
+  assertEquals(result, { valid: true });
+});
+
+// --- Validation: type errors caught ---
+
+Deno.test("validateGrantCondition: rejects typo field (tag instead of tags)", () => {
+  const result = validateGrantCondition('tag.env == "staging"', "workflow");
+  assertEquals(result.valid, false);
+  assertEquals(typeof result.error, "string");
+});
+
+Deno.test("validateGrantCondition: rejects field not available for resource kind", () => {
+  const result = validateGrantCondition('ns == "infra"', "workflow");
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateGrantCondition: rejects unknown top-level field", () => {
+  const result = validateGrantCondition(
+    'nonexistent.field == "value"',
+    "workflow",
+  );
+  assertEquals(result.valid, false);
+});
+
+// --- Validation: syntax errors ---
+
+Deno.test("validateGrantCondition: rejects invalid syntax", () => {
+  const result = validateGrantCondition("name ==", "workflow");
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.startsWith("CEL syntax error:"), true);
+});
+
+Deno.test("validateGrantCondition: rejects unclosed string", () => {
+  const result = validateGrantCondition('name == "unclosed', "workflow");
+  assertEquals(result.valid, false);
+});
+
+// --- Validation: length limit ---
+
+Deno.test("validateGrantCondition: rejects condition over 1KB", () => {
+  const condition = "a".repeat(1025);
+  const result = validateGrantCondition(condition, "workflow");
+  assertEquals(result.valid, false);
+  assertEquals(result.error?.includes("maximum length"), true);
+});
+
+Deno.test("validateGrantCondition: accepts condition at exactly 1KB", () => {
+  const padding = " ".repeat(1024 - 'name == "x"'.length);
+  const condition = `name == "x"${padding}`;
+  assertEquals(condition.length, 1024);
+  const result = validateGrantCondition(condition, "workflow");
+  assertEquals(result, { valid: true });
+});
+
+// --- Seal tests: no I/O receivers ---
+
+Deno.test("validateGrantCondition: seal rejects data.latest()", () => {
+  const result = validateGrantCondition(
+    'data.latest("model", "data") == "value"',
+    "workflow",
+  );
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateGrantCondition: seal rejects file.contents()", () => {
+  const result = validateGrantCondition(
+    'file.contents("model", "spec") == "value"',
+    "workflow",
+  );
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateGrantCondition: seal rejects vault.get()", () => {
+  const result = validateGrantCondition(
+    'vault.get("secret") == "value"',
+    "workflow",
+  );
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateGrantCondition: seal rejects env.HOME", () => {
+  const result = validateGrantCondition('env.HOME == "/root"', "workflow");
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateGrantCondition: seal rejects arbitrary unknown variable", () => {
+  const result = validateGrantCondition(
+    "someExtension.func() == true",
+    "workflow",
+  );
+  assertEquals(result.valid, false);
+});
+
+// --- Evaluation ---
+
+Deno.test("evaluateGrantCondition: returns true when condition matches", () => {
+  const result = evaluateGrantCondition(
+    'tags.env == "staging"',
+    "workflow",
+    { name: "deploy", tags: { env: "staging" }, collective: "acme" },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("evaluateGrantCondition: returns false when condition does not match", () => {
+  const result = evaluateGrantCondition(
+    'tags.env == "prod"',
+    "workflow",
+    { name: "deploy", tags: { env: "staging" }, collective: "acme" },
+    PRINCIPAL,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("evaluateGrantCondition: evaluates principal context", () => {
+  const result = evaluateGrantCondition(
+    '"acme" in principal.collectives',
+    "workflow",
+    { name: "deploy", tags: {}, collective: "acme" },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("evaluateGrantCondition: evaluates principal.sub", () => {
+  const result = evaluateGrantCondition(
+    "owner.createdBy == principal.sub",
+    "data",
+    {
+      name: "report",
+      ns: "default",
+      tags: {},
+      owner: { createdBy: "user-123" },
+    },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("evaluateGrantCondition: evaluates compound condition", () => {
+  const result = evaluateGrantCondition(
+    'tags.env == "staging" && "ops" in principal.collectives',
+    "workflow",
+    { name: "deploy", tags: { env: "staging" }, collective: "acme" },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("evaluateGrantCondition: returns false for non-boolean result", () => {
+  const result = evaluateGrantCondition(
+    "name",
+    "access",
+    { name: "admin-grant" },
+    PRINCIPAL,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("evaluateGrantCondition: arithmetic works with mixed types", () => {
+  const result = evaluateGrantCondition(
+    "size(principal.groups) > 1",
+    "workflow",
+    { name: "deploy", tags: {}, collective: "acme" },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});


### PR DESCRIPTION
## Summary

Closes swamp-club#670

Add a third CEL surface — the **grant-condition environment** — for evaluating conditions attached to authorization grants. This environment is permanently sealed: no I/O receivers (`data.*`, `file.*`, `vault.*`, `env.*`), no extension registrations, deterministic pure functions over (resource fields, principal context) → boolean.

- **Arithmetic baseline extraction**: moved the 10 mixed-type arithmetic overloads into a shared `registerArithmeticOverloads()` helper, called by both `createExtensionCelEnvironment()` and the new factory — zero behavioral change to existing surfaces
- **Factory**: `createGrantConditionEnvironment(kind: ResourceKind)` with `unlistedVariablesAreDyn: false` and explicit variable declarations per resource kind (workflow: name/tags/collective, model: modelType/collective, data: name/ns/tags/owner, access: name) plus `principal.*` namespace
- **Write-time validation**: `validateGrantCondition(condition, resourceKind)` — 1KB length limit, CEL syntax check (try/catch on `parse()`), type check via `check()` catching unknown fields like `tag.env` (typo for `tags.env`)
- **Runtime evaluation**: `evaluateGrantCondition(condition, resourceKind, resourceFields, principalContext)` → boolean (fail-closed: non-boolean results return `false`)
- **Grant model wiring**: `Grant.create()` now validates conditions against the resource kind before persisting — invalid conditions rejected with clear CEL error messages
- **Design doc**: updated `design/expressions.md` to document the third surface

### Design decisions

- Used `modelType` instead of `type` for model resource fields because `type` is a reserved CEL builtin function (`type(x)`)
- Validation function is a direct import (pure, stateless) rather than injected via MethodContext — consistent with how Zod validation works in the same code path
- `evaluateGrantCondition` creates a fresh Environment per call — correct for now; the AccessDecisionService (item 4) can cache per resource kind when needed

## Test Plan

- 28 new grant-condition environment tests covering:
  - Valid conditions for all 4 resource kinds
  - Type errors caught at validation (typos, wrong-kind fields, unknown fields)
  - Syntax errors caught and wrapped cleanly
  - 1KB length limit (boundary: 1024 passes, 1025 fails)
  - **Seal verification**: `data.latest()`, `file.contents()`, `vault.get()`, `env.HOME`, arbitrary unknown variables all rejected
  - Evaluation correctness: matching, non-matching, principal context, compound conditions, mixed-type arithmetic, non-boolean fail-closed
- 4 new grant model tests: valid condition passes, invalid syntax rejects, unknown field rejects, over-limit rejects
- All 58 existing `cel_evaluator_test.ts` tests pass (arithmetic extraction is behavioral no-op)
- All 7,156 tests across the full test suite pass, 0 failures