### PR TITLE
fix(extensions): include channel in extension outdated --json output

### DIFF
--- a/src/domain/extensions/extension_update_service.ts
+++ b/src/domain/extensions/extension_update_service.ts
@@ -25,6 +25,7 @@ export interface UpToDateStatus {
   name: string;
   installedVersion: string;
   latestVersion: string;
+  channel?: string;
 }
 
 /** A newer version is available in the registry. */
@@ -33,6 +34,7 @@ export interface UpdateAvailableStatus {
   name: string;
   installedVersion: string;
   latestVersion: string;
+  channel?: string;
 }
 
 /** Extension was successfully updated. */
@@ -41,6 +43,7 @@ export interface UpdatedStatus {
   name: string;
   previousVersion: string;
   newVersion: string;
+  channel?: string;
 }
 
 /** Extension was not found in the registry. */
@@ -49,6 +52,7 @@ export interface NotFoundStatus {
   name: string;
   installedVersion: string;
   error: string;
+  channel?: string;
 }
 
 /** Extension install failed during update (network, safety, integrity, etc.). */
@@ -57,6 +61,7 @@ export interface FailedStatus {
   name: string;
   installedVersion: string;
   error: string;
+  channel?: string;
 }
 
 /** Extension is deprecated in the registry. */
@@ -66,6 +71,7 @@ export interface DeprecatedStatus {
   installedVersion: string;
   deprecationReason: string | null;
   supersededBy: string | null;
+  channel?: string;
 }
 
 /** Discriminated union of all possible update statuses. */
@@ -108,6 +114,7 @@ export function checkExtensionVersion(
     deprecationReason: string | null;
     supersededBy: string | null;
   },
+  channel?: string,
 ): UpToDateStatus | UpdateAvailableStatus | NotFoundStatus | DeprecatedStatus {
   if (latestVersion === null) {
     return {
@@ -115,6 +122,7 @@ export function checkExtensionVersion(
       name,
       installedVersion,
       error: `Extension ${name} not found in the registry.`,
+      channel,
     };
   }
 
@@ -132,6 +140,7 @@ export function checkExtensionVersion(
       name,
       installedVersion,
       latestVersion,
+      channel,
     };
   }
 
@@ -142,6 +151,7 @@ export function checkExtensionVersion(
       installedVersion,
       deprecationReason: deprecation.deprecationReason,
       supersededBy: deprecation.supersededBy,
+      channel,
     };
   }
 
@@ -150,6 +160,7 @@ export function checkExtensionVersion(
     name,
     installedVersion,
     latestVersion,
+    channel,
   };
 }
 

--- a/src/domain/extensions/extension_update_service_test.ts
+++ b/src/domain/extensions/extension_update_service_test.ts
@@ -280,6 +280,78 @@ Deno.test("buildUpdateResult counts deprecated as total but not upToDate, update
   assertEquals(result.summary.failed, 0);
 });
 
+Deno.test("checkExtensionVersion passes channel through to update_available status", () => {
+  const result = checkExtensionVersion(
+    "@test/ext",
+    "2026.01.15.1",
+    "2026.02.01.1",
+    undefined,
+    "beta",
+  );
+  assertEquals(result.status, "update_available");
+  if (result.status === "update_available") {
+    assertEquals(result.channel, "beta");
+  }
+});
+
+Deno.test("checkExtensionVersion passes channel through to up_to_date status", () => {
+  const result = checkExtensionVersion(
+    "@test/ext",
+    "2026.01.15.1",
+    "2026.01.15.1",
+    undefined,
+    "beta",
+  );
+  assertEquals(result.status, "up_to_date");
+  if (result.status === "up_to_date") {
+    assertEquals(result.channel, "beta");
+  }
+});
+
+Deno.test("checkExtensionVersion passes channel through to not_found status", () => {
+  const result = checkExtensionVersion(
+    "@test/ext",
+    "2026.01.15.1",
+    null,
+    undefined,
+    "beta",
+  );
+  assertEquals(result.status, "not_found");
+  if (result.status === "not_found") {
+    assertEquals(result.channel, "beta");
+  }
+});
+
+Deno.test("checkExtensionVersion passes channel through to deprecated status", () => {
+  const result = checkExtensionVersion(
+    "@test/ext",
+    "2026.01.15.1",
+    "2026.01.15.1",
+    {
+      deprecatedAt: "2026-01-01T00:00:00Z",
+      deprecationReason: "EOL",
+      supersededBy: "@other/ext",
+    },
+    "beta",
+  );
+  assertEquals(result.status, "deprecated");
+  if (result.status === "deprecated") {
+    assertEquals(result.channel, "beta");
+  }
+});
+
+Deno.test("checkExtensionVersion omits channel when not provided", () => {
+  const result = checkExtensionVersion(
+    "@test/ext",
+    "2026.01.15.1",
+    "2026.01.15.1",
+  );
+  assertEquals(result.status, "up_to_date");
+  if (result.status === "up_to_date") {
+    assertEquals(result.channel, undefined);
+  }
+});
+
 Deno.test("buildUpdateResult handles empty array", () => {
   const result = buildUpdateResult([]);
   assertEquals(result.summary.total, 0);

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -201,16 +201,23 @@ export async function* extensionUpdate(
             name,
             installedVersion,
             error: `Failed to fetch registry info for ${name}.`,
+            channel: installedChannel,
           });
           continue;
         }
 
         statuses.push(
-          checkExtensionVersion(name, installedVersion, extInfo.latestVersion, {
-            deprecatedAt: extInfo.deprecatedAt ?? null,
-            deprecationReason: extInfo.deprecationReason ?? null,
-            supersededBy: extInfo.supersededBy ?? null,
-          }),
+          checkExtensionVersion(
+            name,
+            installedVersion,
+            extInfo.latestVersion,
+            {
+              deprecatedAt: extInfo.deprecatedAt ?? null,
+              deprecationReason: extInfo.deprecationReason ?? null,
+              supersededBy: extInfo.supersededBy ?? null,
+            },
+            installedChannel,
+          ),
         );
       }
 
@@ -255,6 +262,7 @@ export async function* extensionUpdate(
               name: s.name,
               previousVersion: s.installedVersion,
               newVersion: s.latestVersion,
+              channel: s.channel,
             });
           } catch (error) {
             const message = error instanceof Error
@@ -265,6 +273,7 @@ export async function* extensionUpdate(
               name: s.name,
               installedVersion: s.installedVersion,
               error: `Update failed: ${message}`,
+              channel: s.channel,
             });
           }
         } else {

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -299,6 +299,70 @@ Deno.test(
   },
 );
 
+Deno.test("extensionUpdate: check mode includes channel from lockfile in status", async () => {
+  const deps: ExtensionUpdateDeps = {
+    lockfileRepository: new LockfileRepository(
+      "/test/repo/upstream_extensions.json",
+      {
+        "@ns/a": {
+          version: "2026.01.01.1",
+          pulledAt: "1970-01-01T00:00:00.000Z",
+          channel: "beta",
+        },
+      },
+    ),
+    getExtension: () => Promise.resolve({ latestVersion: "2026.02.01.1" }),
+    installExtension: () => Promise.resolve(undefined),
+  };
+  const input: ExtensionUpdateInput = { checkOnly: true };
+
+  const events = await collect<ExtensionUpdateEvent>(
+    extensionUpdate(makeCtx(), deps, input),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    const ext = completed.data.extensions[0];
+    assertEquals(ext.status, "update_available");
+    if (ext.status === "update_available") {
+      assertEquals(ext.channel, "beta");
+    }
+  }
+});
+
+Deno.test("extensionUpdate: update mode includes channel from lockfile in updated status", async () => {
+  const deps: ExtensionUpdateDeps = {
+    lockfileRepository: new LockfileRepository(
+      "/test/repo/upstream_extensions.json",
+      {
+        "@ns/a": {
+          version: "2026.01.01.1",
+          pulledAt: "1970-01-01T00:00:00.000Z",
+          channel: "beta",
+        },
+      },
+    ),
+    getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+    installExtension: () => Promise.resolve(undefined),
+  };
+  const input: ExtensionUpdateInput = { checkOnly: false };
+
+  const events = await collect<ExtensionUpdateEvent>(
+    extensionUpdate(makeCtx(), deps, input),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    const ext = completed.data.extensions[0];
+    assertEquals(ext.status, "updated");
+    if (ext.status === "updated") {
+      assertEquals(ext.channel, "beta");
+    }
+  }
+});
+
 Deno.test(
   "extensionUpdate: NO orphans-pruned event when result has empty pruned list",
   async () => {


### PR DESCRIPTION
## Summary

- Add `channel?: string` to all installed-extension status types (`UpToDateStatus`, `UpdateAvailableStatus`, `UpdatedStatus`, `NotFoundStatus`, `FailedStatus`, `DeprecatedStatus`)
- Thread `installedChannel` from the lockfile through `checkExtensionVersion` and all status construction sites in the update generator
- No renderer changes needed — `extension_outdated.ts` already serializes status objects directly via `JSON.stringify`

## Test Plan

- Added 5 unit tests for `checkExtensionVersion` channel pass-through (all status variants + undefined case)
- Added 2 integration tests for `extensionUpdate` generator verifying channel flows from lockfile to completed event in both check and update modes
- All 33 tests pass; `deno check`, `deno lint`, `deno fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)