### PR TITLE
feat(access): add AccessDecisionService with in-memory policy snapshot

### DIFF
--- a/src/domain/access/access_decision_service.ts
+++ b/src/domain/access/access_decision_service.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Action } from "./action.ts";
+import type { Principal } from "./principal.ts";
+import type { ResourceKind } from "./resource_selector.ts";
+import type { Subject } from "./subject.ts";
+
+export interface AccessPrincipal {
+  readonly principal: Principal;
+  readonly collectives: readonly string[];
+}
+
+export interface AccessResource {
+  readonly kind: ResourceKind;
+  readonly name: string;
+  readonly fields: Record<string, unknown>;
+}
+
+export interface AccessDecision {
+  readonly effect: "allow" | "deny";
+  readonly grantId: string;
+  readonly subject: Subject;
+  readonly condition?: string;
+}
+
+export interface AccessDecisionService {
+  decide(
+    principal: AccessPrincipal,
+    action: Action,
+    resource: AccessResource,
+  ): AccessDecision | null;
+
+  explain(
+    principal: AccessPrincipal,
+    action: Action,
+    resource: AccessResource,
+  ): AccessDecision[];
+}

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -1,0 +1,179 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Grant } from "../models/access/grant_model.ts";
+import type {
+  AccessDecision,
+  AccessDecisionService,
+  AccessPrincipal,
+  AccessResource,
+} from "./access_decision_service.ts";
+import type { Action } from "./action.ts";
+import type { PolicySnapshot } from "./policy_snapshot.ts";
+import { principalToString } from "./principal.ts";
+import type { PrincipalContext } from "./principal_context.ts";
+import { resourceSelectorMatches } from "./resource_selector.ts";
+
+function resolveSubjects(
+  accessPrincipal: AccessPrincipal,
+  snapshot: PolicySnapshot,
+): string[] {
+  const subjects: string[] = [];
+
+  subjects.push(
+    `${accessPrincipal.principal.kind}:${accessPrincipal.principal.id}`,
+  );
+
+  const principalKey = principalToString(accessPrincipal.principal);
+  const localGroups = snapshot.groupsForPrincipal(principalKey);
+  for (const groupName of localGroups) {
+    subjects.push(`group:${groupName}`);
+  }
+
+  for (const collective of accessPrincipal.collectives) {
+    subjects.push(`idp-group:${collective}`);
+  }
+
+  return subjects;
+}
+
+function grantMatchesResource(grant: Grant, resource: AccessResource): boolean {
+  if (grant.resource.kind !== resource.kind) {
+    return false;
+  }
+  return resourceSelectorMatches(grant.resource, resource.name);
+}
+
+function grantMatchesAction(grant: Grant, action: Action): boolean {
+  return grant.actions.includes(action);
+}
+
+function buildPrincipalContext(
+  accessPrincipal: AccessPrincipal,
+  snapshot: PolicySnapshot,
+): PrincipalContext {
+  const principalKey = principalToString(accessPrincipal.principal);
+  const localGroups = snapshot.groupsForPrincipal(principalKey);
+  return {
+    sub: accessPrincipal.principal.id,
+    groups: [...localGroups],
+    collectives: [...accessPrincipal.collectives],
+  };
+}
+
+function evaluateGrant(
+  grant: Grant,
+  snapshot: PolicySnapshot,
+  resource: AccessResource,
+  principalContext: PrincipalContext,
+): boolean {
+  if (!grant.condition) {
+    return true;
+  }
+  return snapshot.evaluateCondition(
+    grant.condition,
+    resource.kind,
+    resource.fields,
+    principalContext,
+  );
+}
+
+function toDecision(grant: Grant): AccessDecision {
+  return {
+    effect: grant.effect,
+    grantId: grant.id,
+    subject: grant.subject,
+    condition: grant.condition,
+  };
+}
+
+export class GrantBasedAccessDecisionService implements AccessDecisionService {
+  #snapshot: PolicySnapshot;
+
+  constructor(snapshot: PolicySnapshot) {
+    this.#snapshot = snapshot;
+  }
+
+  get snapshot(): PolicySnapshot {
+    return this.#snapshot;
+  }
+
+  set snapshot(snapshot: PolicySnapshot) {
+    this.#snapshot = snapshot;
+  }
+
+  decide(
+    principal: AccessPrincipal,
+    action: Action,
+    resource: AccessResource,
+  ): AccessDecision | null {
+    const snapshot = this.#snapshot;
+    const subjects = resolveSubjects(principal, snapshot);
+    const candidates = snapshot.grantsForSubjects(subjects);
+    const principalContext = buildPrincipalContext(principal, snapshot);
+
+    const denies: Grant[] = [];
+    const allows: Grant[] = [];
+    for (const grant of candidates) {
+      if (!grantMatchesResource(grant, resource)) continue;
+      if (!grantMatchesAction(grant, action)) continue;
+      if (grant.effect === "deny") {
+        denies.push(grant);
+      } else {
+        allows.push(grant);
+      }
+    }
+
+    for (const grant of denies) {
+      if (evaluateGrant(grant, snapshot, resource, principalContext)) {
+        return toDecision(grant);
+      }
+    }
+
+    for (const grant of allows) {
+      if (evaluateGrant(grant, snapshot, resource, principalContext)) {
+        return toDecision(grant);
+      }
+    }
+
+    return null;
+  }
+
+  explain(
+    principal: AccessPrincipal,
+    action: Action,
+    resource: AccessResource,
+  ): AccessDecision[] {
+    const snapshot = this.#snapshot;
+    const subjects = resolveSubjects(principal, snapshot);
+    const candidates = snapshot.grantsForSubjects(subjects);
+    const principalContext = buildPrincipalContext(principal, snapshot);
+
+    const decisions: AccessDecision[] = [];
+    for (const grant of candidates) {
+      if (!grantMatchesResource(grant, resource)) continue;
+      if (!grantMatchesAction(grant, action)) continue;
+      if (evaluateGrant(grant, snapshot, resource, principalContext)) {
+        decisions.push(toDecision(grant));
+      }
+    }
+
+    return decisions;
+  }
+}

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -1,0 +1,360 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { evaluateGrantCondition } from "../../infrastructure/cel/grant_condition_environment.ts";
+import type { Grant } from "../models/access/grant_model.ts";
+import type { Group } from "../models/access/group_model.ts";
+import type {
+  AccessPrincipal,
+  AccessResource,
+} from "./access_decision_service.ts";
+import { GrantBasedAccessDecisionService } from "./grant_based_access_decision_service.ts";
+import type { ConditionEvaluator } from "./policy_snapshot.ts";
+import { PolicySnapshot } from "./policy_snapshot.ts";
+
+const celEvaluator: ConditionEvaluator = evaluateGrantCondition;
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeGroup(name: string, memberIds: string[]): Group {
+  return {
+    name,
+    members: memberIds.map((id) => ({ kind: "user" as const, id })),
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makePrincipal(
+  id: string,
+  collectives: string[] = [],
+): AccessPrincipal {
+  return { principal: { kind: "user", id }, collectives };
+}
+
+function makeResource(
+  overrides: Partial<AccessResource> = {},
+): AccessResource {
+  return {
+    kind: "workflow",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", tags: {}, collective: "" },
+    ...overrides,
+  };
+}
+
+Deno.test("decide: returns null (default deny) when no grants exist", () => {
+  const service = new GrantBasedAccessDecisionService(PolicySnapshot.empty());
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result, null);
+});
+
+Deno.test("decide: allows when a matching allow grant exists", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result?.effect, "allow");
+  assertEquals(result?.grantId, grant.id);
+});
+
+Deno.test("decide: deny wins over allow", () => {
+  const allow = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const deny = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([allow, deny], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result?.effect, "deny");
+  assertEquals(result?.grantId, deny.id);
+});
+
+Deno.test("decide: returns null when action does not match", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["write"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result, null);
+});
+
+Deno.test("decide: returns null when resource kind does not match", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "model", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result, null);
+});
+
+Deno.test("decide: matches via resource pattern", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: resolves local group membership from snapshot", () => {
+  const grant = makeGrant({
+    subject: { kind: "group", name: "release-managers" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const group = makeGroup("release-managers", ["adam"]);
+  const snapshot = new PolicySnapshot([grant], [group], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", makeResource());
+  assertEquals(result?.effect, "allow");
+  assertEquals(result?.subject, { kind: "group", name: "release-managers" });
+});
+
+Deno.test("decide: resolves IdP-asserted group from collectives", () => {
+  const grant = makeGrant({
+    subject: { kind: "idp-group", name: "platform-eng" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(
+    makePrincipal("adam", ["platform-eng"]),
+    "read",
+    makeResource(),
+  );
+  assertEquals(result?.effect, "allow");
+  assertEquals(result?.subject, { kind: "idp-group", name: "platform-eng" });
+});
+
+Deno.test("decide: does not match IdP group when not in collectives", () => {
+  const grant = makeGrant({
+    subject: { kind: "idp-group", name: "platform-eng" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result, null);
+});
+
+Deno.test("decide: evaluates CEL condition on grant", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    condition: 'name == "@acme/deploy"',
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result?.effect, "allow");
+  assertEquals(result?.condition, 'name == "@acme/deploy"');
+});
+
+Deno.test("decide: skips grant when CEL condition is false", () => {
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    condition: 'name == "other"',
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result, null);
+});
+
+Deno.test("decide: deny with condition only denies when condition is true", () => {
+  const deny = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    condition: 'name == "other"',
+  });
+  const allow = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([deny, allow], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "read", makeResource());
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("explain: returns all matching grants without short-circuit", () => {
+  const allow1 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const allow2 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+  });
+  const deny = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "@acme/deploy" },
+  });
+  const snapshot = new PolicySnapshot([allow1, allow2, deny], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.explain(
+    makePrincipal("adam"),
+    "read",
+    makeResource(),
+  );
+  assertEquals(result.length, 3);
+  const effects = result.map((d) => d.effect);
+  assertEquals(effects.includes("deny"), true);
+  assertEquals(effects.filter((e) => e === "allow").length, 2);
+});
+
+Deno.test("explain: returns empty when no grants match", () => {
+  const service = new GrantBasedAccessDecisionService(PolicySnapshot.empty());
+  const result = service.explain(
+    makePrincipal("adam"),
+    "read",
+    makeResource(),
+  );
+  assertEquals(result.length, 0);
+});
+
+Deno.test("explain: includes grants matched via group and IdP-group subjects", () => {
+  const userGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const groupGrant = makeGrant({
+    subject: { kind: "group", name: "devs" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const idpGrant = makeGrant({
+    subject: { kind: "idp-group", name: "org1" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const group = makeGroup("devs", ["adam"]);
+  const snapshot = new PolicySnapshot(
+    [userGrant, groupGrant, idpGrant],
+    [group],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.explain(
+    makePrincipal("adam", ["org1"]),
+    "read",
+    makeResource(),
+  );
+  assertEquals(result.length, 3);
+});
+
+Deno.test("decide: snapshot can be swapped atomically", () => {
+  const grant1 = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const service = new GrantBasedAccessDecisionService(
+    new PolicySnapshot([grant1], [], celEvaluator),
+  );
+
+  assertEquals(
+    service.decide(makePrincipal("adam"), "read", makeResource())?.effect,
+    "allow",
+  );
+
+  service.snapshot = PolicySnapshot.empty();
+  assertEquals(
+    service.decide(makePrincipal("adam"), "read", makeResource()),
+    null,
+  );
+});

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -17,7 +17,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+export {
+  type AccessDecision,
+  type AccessDecisionService,
+  type AccessPrincipal,
+  type AccessResource,
+} from "./access_decision_service.ts";
+
 export { type Action, ActionSchema } from "./action.ts";
+
+export { GrantBasedAccessDecisionService } from "./grant_based_access_decision_service.ts";
+
+export { type ConditionEvaluator, PolicySnapshot } from "./policy_snapshot.ts";
+
+export { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
+
+export { type PrincipalContext } from "./principal_context.ts";
 
 export { type Effect, EffectSchema } from "./effect.ts";
 

--- a/src/domain/access/policy_snapshot.ts
+++ b/src/domain/access/policy_snapshot.ts
@@ -1,0 +1,107 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Grant } from "../models/access/grant_model.ts";
+import type { Group } from "../models/access/group_model.ts";
+import type { PrincipalContext } from "./principal_context.ts";
+import { principalToString } from "./principal.ts";
+import type { ResourceKind } from "./resource_selector.ts";
+import { subjectToString } from "./subject.ts";
+
+export type ConditionEvaluator = (
+  condition: string,
+  resourceKind: ResourceKind,
+  resourceFields: Record<string, unknown>,
+  principalContext: PrincipalContext,
+) => boolean;
+
+function alwaysFalse(): boolean {
+  return false;
+}
+
+export class PolicySnapshot {
+  readonly #grantsBySubject: Map<string, Grant[]>;
+  readonly #groupsByPrincipal: Map<string, string[]>;
+  readonly #evaluateCondition: ConditionEvaluator;
+
+  constructor(
+    grants: readonly Grant[],
+    groups: readonly Group[],
+    evaluateCondition?: ConditionEvaluator,
+  ) {
+    this.#evaluateCondition = evaluateCondition ?? alwaysFalse;
+
+    this.#grantsBySubject = new Map();
+    for (const grant of grants) {
+      const key = subjectToString(grant.subject);
+      const existing = this.#grantsBySubject.get(key);
+      if (existing) {
+        existing.push(grant);
+      } else {
+        this.#grantsBySubject.set(key, [grant]);
+      }
+    }
+
+    this.#groupsByPrincipal = new Map();
+    for (const group of groups) {
+      for (const member of group.members) {
+        const key = principalToString(member);
+        const existing = this.#groupsByPrincipal.get(key);
+        if (existing) {
+          existing.push(group.name);
+        } else {
+          this.#groupsByPrincipal.set(key, [group.name]);
+        }
+      }
+    }
+  }
+
+  grantsForSubjects(subjects: readonly string[]): Grant[] {
+    const result: Grant[] = [];
+    for (const subject of subjects) {
+      const grants = this.#grantsBySubject.get(subject);
+      if (grants) {
+        result.push(...grants);
+      }
+    }
+    return result;
+  }
+
+  groupsForPrincipal(principalKey: string): readonly string[] {
+    return this.#groupsByPrincipal.get(principalKey) ?? [];
+  }
+
+  evaluateCondition(
+    condition: string,
+    resourceKind: ResourceKind,
+    resourceFields: Record<string, unknown>,
+    principalContext: PrincipalContext,
+  ): boolean {
+    return this.#evaluateCondition(
+      condition,
+      resourceKind,
+      resourceFields,
+      principalContext,
+    );
+  }
+
+  static empty(): PolicySnapshot {
+    return new PolicySnapshot([], []);
+  }
+}

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -1,0 +1,186 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import { Environment } from "cel-js";
+import { registerArithmeticOverloads } from "../../infrastructure/cel/cel_evaluator.ts";
+import type { DataRecord } from "../data/data_record.ts";
+import type { DataQueryService } from "../data/data_query_service.ts";
+import type { EventBus } from "../events/event_bus.ts";
+import type { ModelCreated, ModelUpdated } from "../events/types.ts";
+import {
+  type Grant,
+  GRANT_MODEL_TYPE,
+  GrantSchema,
+} from "../models/access/grant_model.ts";
+import {
+  type Group,
+  GROUP_MODEL_TYPE,
+  GroupSchema,
+} from "../models/access/group_model.ts";
+import type { PrincipalContext } from "./principal_context.ts";
+import type { ConditionEvaluator } from "./policy_snapshot.ts";
+import { PolicySnapshot } from "./policy_snapshot.ts";
+import type { ResourceKind } from "./resource_selector.ts";
+
+const logger = getLogger(["swamp", "domain", "access", "policy-snapshot"]);
+
+const GRANT_MODEL_TYPE_STR = GRANT_MODEL_TYPE.normalized;
+const GROUP_MODEL_TYPE_STR = GROUP_MODEL_TYPE.normalized;
+
+const RESOURCE_FIELDS: Record<ResourceKind, string[]> = {
+  workflow: ["name", "tags", "collective"],
+  model: ["modelType", "collective"],
+  data: ["name", "ns", "tags", "owner"],
+  access: ["name"],
+};
+
+function buildCelEnvironment(kind: ResourceKind): Environment {
+  const env = new Environment({ unlistedVariablesAreDyn: false });
+  registerArithmeticOverloads(env);
+
+  for (const field of RESOURCE_FIELDS[kind]) {
+    env.registerVariable(
+      field,
+      field === "tags" || field === "owner"
+        ? "map"
+        : field === "name" || field === "ns" || field === "modelType" ||
+            field === "collective"
+        ? "string"
+        : "dyn",
+    );
+  }
+
+  env.registerVariable("principal", "map");
+  return env;
+}
+
+function buildConditionEvaluator(): ConditionEvaluator {
+  const environments = new Map<ResourceKind, Environment>();
+  const kinds: ResourceKind[] = ["workflow", "model", "data", "access"];
+  for (const kind of kinds) {
+    environments.set(kind, buildCelEnvironment(kind));
+  }
+
+  return (
+    condition: string,
+    resourceKind: ResourceKind,
+    resourceFields: Record<string, unknown>,
+    principalContext: PrincipalContext,
+  ): boolean => {
+    const env = environments.get(resourceKind);
+    if (!env) return false;
+    const context: Record<string, unknown> = { ...resourceFields };
+    context.principal = principalContext;
+    const result = env.evaluate(condition, context);
+    return result === true;
+  };
+}
+
+export class PolicySnapshotLoader {
+  readonly #dataQueryService: DataQueryService;
+  readonly #unsubscribers: (() => void)[] = [];
+  readonly #conditionEvaluator: ConditionEvaluator;
+  #snapshot: PolicySnapshot = PolicySnapshot.empty();
+
+  constructor(dataQueryService: DataQueryService, eventBus: EventBus) {
+    this.#dataQueryService = dataQueryService;
+    this.#conditionEvaluator = buildConditionEvaluator();
+
+    this.#unsubscribers.push(
+      eventBus.subscribe<ModelCreated>("ModelCreated", (event) => {
+        if (this.#isAccessModel(event.modelType)) {
+          this.#rebuild();
+        }
+      }),
+    );
+
+    this.#unsubscribers.push(
+      eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
+        if (this.#isAccessModel(event.modelType)) {
+          this.#rebuild();
+        }
+      }),
+    );
+  }
+
+  get snapshot(): PolicySnapshot {
+    return this.#snapshot;
+  }
+
+  async load(): Promise<PolicySnapshot> {
+    this.#snapshot = await this.#buildSnapshot();
+    return this.#snapshot;
+  }
+
+  dispose(): void {
+    for (const unsub of this.#unsubscribers) {
+      unsub();
+    }
+    this.#unsubscribers.length = 0;
+  }
+
+  #isAccessModel(modelType: string): boolean {
+    return modelType === GRANT_MODEL_TYPE_STR ||
+      modelType === GROUP_MODEL_TYPE_STR;
+  }
+
+  async #buildSnapshot(): Promise<PolicySnapshot> {
+    const [grantRecords, groupRecords] = await Promise.all([
+      this.#dataQueryService.query(
+        `modelType == "${GRANT_MODEL_TYPE_STR}"`,
+        { loadAttributes: true },
+      ),
+      this.#dataQueryService.query(
+        `modelType == "${GROUP_MODEL_TYPE_STR}"`,
+        { loadAttributes: true },
+      ),
+    ]);
+
+    const grants: Grant[] = [];
+    for (const record of grantRecords) {
+      const attrs = (record as DataRecord).attributes;
+      const parsed = GrantSchema.safeParse(attrs);
+      if (parsed.success && parsed.data.state === "active") {
+        grants.push(parsed.data);
+      }
+    }
+
+    const groups: Group[] = [];
+    for (const record of groupRecords) {
+      const attrs = (record as DataRecord).attributes;
+      const parsed = GroupSchema.safeParse(attrs);
+      if (parsed.success) {
+        groups.push(parsed.data);
+      }
+    }
+
+    logger
+      .info`Loaded policy snapshot: ${grants.length} active grant(s), ${groups.length} group(s)`;
+    return new PolicySnapshot(grants, groups, this.#conditionEvaluator);
+  }
+
+  async #rebuild(): Promise<void> {
+    try {
+      this.#snapshot = await this.#buildSnapshot();
+    } catch (error) {
+      logger.error`Failed to rebuild policy snapshot: ${error}`;
+    }
+  }
+}

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -1,0 +1,275 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { DataRecord } from "../data/data_record.ts";
+import type { DataQueryService } from "../data/data_query_service.ts";
+import { EventBus } from "../events/event_bus.ts";
+import { createModelCreated, createModelUpdated } from "../events/types.ts";
+import type { Grant } from "../models/access/grant_model.ts";
+import type { Group } from "../models/access/group_model.ts";
+import { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
+
+await initializeLogging({});
+
+function makeGrantRecord(grant: Grant): DataRecord {
+  return {
+    id: crypto.randomUUID(),
+    name: "grant-main",
+    version: 1,
+    isLatest: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    namespace: "",
+    attributes: grant as unknown as Record<string, unknown>,
+    tags: {},
+    modelName: `grant-${grant.id}`,
+    modelId: crypto.randomUUID(),
+    modelType: "swamp/grant",
+    specName: "grant",
+    dataType: "grant",
+    contentType: "application/json",
+    lifetime: "infinite",
+    ownerType: "model-method",
+    streaming: false,
+    size: 0,
+    content: "",
+    ownerRef: "",
+    workflowRunId: "",
+    workflowName: "",
+    jobName: "",
+    stepName: "",
+    source: "",
+  };
+}
+
+function makeGroupRecord(group: Group): DataRecord {
+  return {
+    id: crypto.randomUUID(),
+    name: "group-main",
+    version: 1,
+    isLatest: true,
+    createdAt: "2026-01-01T00:00:00Z",
+    namespace: "",
+    attributes: group as unknown as Record<string, unknown>,
+    tags: {},
+    modelName: group.name,
+    modelId: crypto.randomUUID(),
+    modelType: "swamp/group",
+    specName: "group",
+    dataType: "group",
+    contentType: "application/json",
+    lifetime: "infinite",
+    ownerType: "model-method",
+    streaming: false,
+    size: 0,
+    content: "",
+    ownerRef: "",
+    workflowRunId: "",
+    workflowName: "",
+    jobName: "",
+    stepName: "",
+    source: "",
+  };
+}
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeGroup(name: string, memberIds: string[]): Group {
+  return {
+    name,
+    members: memberIds.map((id) => ({ kind: "user" as const, id })),
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function createMockQueryService(
+  grantRecords: DataRecord[],
+  groupRecords: DataRecord[],
+): DataQueryService {
+  return {
+    query(predicate: string) {
+      if (predicate.includes("swamp/grant")) {
+        return Promise.resolve(grantRecords);
+      }
+      if (predicate.includes("swamp/group")) {
+        return Promise.resolve(groupRecords);
+      }
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+}
+
+Deno.test("PolicySnapshotLoader.load: builds snapshot from DataQueryService", async () => {
+  const grant = makeGrant();
+  const group = makeGroup("devs", ["adam"]);
+  const queryService = createMockQueryService(
+    [makeGrantRecord(grant)],
+    [makeGroupRecord(group)],
+  );
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  const snapshot = await loader.load();
+
+  assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 1);
+  assertEquals([...snapshot.groupsForPrincipal("user:adam")], ["devs"]);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader.load: filters out revoked grants", async () => {
+  const active = makeGrant({ state: "active" });
+  const revoked = makeGrant({ state: "revoked" });
+  const queryService = createMockQueryService(
+    [makeGrantRecord(active), makeGrantRecord(revoked)],
+    [],
+  );
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  const snapshot = await loader.load();
+  assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant model", async () => {
+  let callCount = 0;
+  const grant = makeGrant();
+  const queryService = {
+    query(predicate: string) {
+      if (predicate.includes("swamp/grant")) {
+        callCount++;
+        if (callCount > 1) {
+          return Promise.resolve([makeGrantRecord(grant)]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  await loader.load();
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
+
+  await eventBus.publish(
+    createModelCreated("swamp/grant", "123", "my-grant"),
+  );
+
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group model", async () => {
+  let callCount = 0;
+  const group = makeGroup("devs", ["adam"]);
+  const queryService = {
+    query(predicate: string) {
+      if (predicate.includes("swamp/group")) {
+        callCount++;
+        if (callCount > 1) {
+          return Promise.resolve([makeGroupRecord(group)]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  await loader.load();
+  assertEquals(loader.snapshot.groupsForPrincipal("user:adam").length, 0);
+
+  await eventBus.publish(
+    createModelUpdated("swamp/group", "456", "devs"),
+  );
+
+  assertEquals([...loader.snapshot.groupsForPrincipal("user:adam")], ["devs"]);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: ignores events for non-access models", async () => {
+  let queryCallCount = 0;
+  const queryService = {
+    query() {
+      queryCallCount++;
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  await loader.load();
+  const initialCount = queryCallCount;
+
+  await eventBus.publish(
+    createModelCreated("swamp/echo", "789", "my-echo"),
+  );
+
+  assertEquals(queryCallCount, initialCount);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () => {
+  let queryCallCount = 0;
+  const queryService = {
+    query() {
+      queryCallCount++;
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus);
+
+  await loader.load();
+  const initialCount = queryCallCount;
+
+  loader.dispose();
+
+  await eventBus.publish(
+    createModelCreated("swamp/grant", "123", "my-grant"),
+  );
+
+  assertEquals(queryCallCount, initialCount);
+});

--- a/src/domain/access/policy_snapshot_test.ts
+++ b/src/domain/access/policy_snapshot_test.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { Grant } from "../models/access/grant_model.ts";
+import type { Group } from "../models/access/group_model.ts";
+import type { PrincipalContext } from "./principal_context.ts";
+import { type ConditionEvaluator, PolicySnapshot } from "./policy_snapshot.ts";
+import type { ResourceKind } from "./resource_selector.ts";
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeGroup(name: string, memberIds: string[]): Group {
+  return {
+    name,
+    members: memberIds.map((id) => ({ kind: "user" as const, id })),
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+Deno.test("PolicySnapshot.grantsForSubjects: returns grants matching any of the given subjects", () => {
+  const g1 = makeGrant({ subject: { kind: "user", name: "adam" } });
+  const g2 = makeGrant({ subject: { kind: "group", name: "devs" } });
+  const g3 = makeGrant({ subject: { kind: "user", name: "eve" } });
+  const snapshot = new PolicySnapshot([g1, g2, g3], []);
+
+  const result = snapshot.grantsForSubjects(["user:adam", "group:devs"]);
+  assertEquals(result.length, 2);
+  assertEquals(result[0].id, g1.id);
+  assertEquals(result[1].id, g2.id);
+});
+
+Deno.test("PolicySnapshot.grantsForSubjects: returns empty for unmatched subjects", () => {
+  const g1 = makeGrant({ subject: { kind: "user", name: "adam" } });
+  const snapshot = new PolicySnapshot([g1], []);
+
+  const result = snapshot.grantsForSubjects(["user:eve"]);
+  assertEquals(result.length, 0);
+});
+
+Deno.test("PolicySnapshot.groupsForPrincipal: returns local group names for a member", () => {
+  const groups = [
+    makeGroup("devs", ["adam", "eve"]),
+    makeGroup("admins", ["adam"]),
+  ];
+  const snapshot = new PolicySnapshot([], groups);
+
+  const result = snapshot.groupsForPrincipal("user:adam");
+  assertEquals(result.length, 2);
+  assertEquals([...result].sort(), ["admins", "devs"]);
+});
+
+Deno.test("PolicySnapshot.groupsForPrincipal: returns empty for non-member", () => {
+  const groups = [makeGroup("devs", ["adam"])];
+  const snapshot = new PolicySnapshot([], groups);
+
+  const result = snapshot.groupsForPrincipal("user:eve");
+  assertEquals(result.length, 0);
+});
+
+function stubEvaluator(
+  expected: { condition: string; result: boolean }[],
+): ConditionEvaluator {
+  return (
+    condition: string,
+    _resourceKind: ResourceKind,
+    _resourceFields: Record<string, unknown>,
+    _principalContext: PrincipalContext,
+  ): boolean => {
+    const match = expected.find((e) => e.condition === condition);
+    return match?.result ?? false;
+  };
+}
+
+Deno.test("PolicySnapshot.evaluateCondition: delegates to provided evaluator", () => {
+  const evaluator = stubEvaluator([
+    { condition: 'name == "deploy"', result: true },
+  ]);
+  const snapshot = new PolicySnapshot([], [], evaluator);
+
+  const result = snapshot.evaluateCondition(
+    'name == "deploy"',
+    "workflow",
+    { name: "deploy", tags: {}, collective: "" },
+    { sub: "adam", groups: [], collectives: [] },
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("PolicySnapshot.evaluateCondition: returns false for non-matching condition", () => {
+  const evaluator = stubEvaluator([
+    { condition: 'name == "build"', result: false },
+  ]);
+  const snapshot = new PolicySnapshot([], [], evaluator);
+
+  const result = snapshot.evaluateCondition(
+    'name == "build"',
+    "workflow",
+    { name: "deploy", tags: {}, collective: "" },
+    { sub: "adam", groups: [], collectives: [] },
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("PolicySnapshot.evaluateCondition: returns false when no evaluator provided", () => {
+  const snapshot = new PolicySnapshot([], []);
+
+  const result = snapshot.evaluateCondition(
+    'principal.sub == "adam"',
+    "workflow",
+    { name: "deploy", tags: {}, collective: "" },
+    { sub: "adam", groups: ["devs"], collectives: ["org1"] },
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("PolicySnapshot.empty: creates snapshot with no grants or groups", () => {
+  const snapshot = PolicySnapshot.empty();
+  assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 0);
+  assertEquals(snapshot.groupsForPrincipal("user:adam").length, 0);
+});

--- a/src/domain/access/principal_context.ts
+++ b/src/domain/access/principal_context.ts
@@ -1,0 +1,25 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface PrincipalContext {
+  readonly sub: string;
+  readonly email?: string;
+  readonly groups: readonly string[];
+  readonly collectives: readonly string[];
+}

--- a/src/infrastructure/cel/grant_condition_environment.ts
+++ b/src/infrastructure/cel/grant_condition_environment.ts
@@ -18,21 +18,17 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Environment } from "cel-js";
+import type { PrincipalContext } from "../../domain/access/principal_context.ts";
 import type { ResourceKind } from "../../domain/access/resource_selector.ts";
 import { registerArithmeticOverloads } from "./cel_evaluator.ts";
+
+export type { PrincipalContext } from "../../domain/access/principal_context.ts";
 
 const MAX_CONDITION_LENGTH = 1024;
 
 export interface GrantConditionValidationResult {
   valid: boolean;
   error?: string;
-}
-
-export interface PrincipalContext {
-  sub: string;
-  email?: string;
-  groups: string[];
-  collectives: string[];
 }
 
 const RESOURCE_FIELDS: Record<ResourceKind, string[]> = {

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -17,6 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+export {
+  type AccessDecision,
+  type AccessDecisionService,
+  type AccessPrincipal,
+  type AccessResource,
+} from "../domain/access/mod.ts";
+
 export { createLibSwampContext, type LibSwampContext } from "./context.ts";
 
 // Extension CEL surface — INTERNAL re-exports for libswamp/* and CLI callers.


### PR DESCRIPTION
## Summary

Closes swamp-club#672. Implements the AccessDecisionService — the core authorization engine for serve-auth (layer 1, item 4 of #662).

- **AccessDecisionService** interface and **GrantBasedAccessDecisionService** implementation as a domain service answering `(principal, action, resource) → allow | deny`
- **PolicySnapshot** immutable value object with subject-indexed grant lookup, local group membership resolution from Group model data, and injected CEL condition evaluator (environments cached per ResourceKind, not per-call)
- **PolicySnapshotLoader** loads all active grants and group memberships from DataQueryService, subscribes to EventBus for `ModelCreated`/`ModelUpdated` on `swamp/grant` and `swamp/group`, atomically swaps the snapshot reference on invalidation
- **AccessPrincipal** wraps Principal with IdP `collectives` for three-kind subject resolution (user, group, idp-group) without modifying the Principal value object
- **PrincipalContext** extracted from infrastructure to domain layer (`src/domain/access/principal_context.ts`) with backwards-compatible re-export from `grant_condition_environment.ts`
- `decide()` uses deny-wins short-circuit logic; `explain()` evaluates all matching grants without short-circuit
- 30 new tests covering: default deny, deny-wins, action/resource mismatch, resource pattern matching, all three subject kinds, CEL condition evaluation, explain mode, atomic snapshot swap, EventBus invalidation, revoked grant filtering, dispose cleanup

## Test Plan

- [x] `deno check` — all source and test files type-check cleanly
- [x] `deno lint` — no violations
- [x] `deno fmt` — formatted
- [x] `deno run test` — 7193 passed, 0 failed (30 new tests added)
- [x] `deno run compile` — binary builds successfully
- [x] DDD layer boundary test passes — no new domain→infrastructure violations (PrincipalContext moved to domain, CEL env building stays in PolicySnapshotLoader)