### PR TITLE
fix(telemetry): reduce flush timeout from 2s to 200ms (swamp-club#671)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1280,9 +1280,9 @@ export async function runCli(args: string[]): Promise<void> {
       if (telemetryCtx) {
         await telemetryCtx.service.recordSuccess(commandInfo, startTime);
 
-        // Flush telemetry to remote endpoint with a 2-second cancellation
-        // timeout. If the endpoint is slow or unreachable, data stays local
-        // and will be flushed on the next invocation.
+        // Flush telemetry to remote endpoint with a 200ms timeout — fast/local
+        // endpoints flush within the window; slow endpoints rely on the
+        // next-invocation retry (data is already persisted to the spool).
         const sender = new HttpTelemetrySender(
           telemetryCtx.telemetryEndpoint,
           USER_AGENT,
@@ -1293,7 +1293,7 @@ export async function runCli(args: string[]): Promise<void> {
           repoId: telemetryCtx.repoId,
           authToken: telemetryCtx.authToken ?? undefined,
           keepFlushed: telemetryCtx.keepFlushed,
-          signal: AbortSignal.timeout(2000),
+          signal: AbortSignal.timeout(200),
         });
 
         // Trigger cleanup asynchronously (fire-and-forget)
@@ -1424,7 +1424,7 @@ export async function runCli(args: string[]): Promise<void> {
         repoId: telemetryCtx.repoId,
         authToken: telemetryCtx.authToken ?? undefined,
         keepFlushed: telemetryCtx.keepFlushed,
-        signal: AbortSignal.timeout(2000),
+        signal: AbortSignal.timeout(200),
       });
     }
     throw error;


### PR DESCRIPTION
## Summary

- Reduces the `AbortSignal.timeout` on both telemetry flush calls (`src/cli/mod.ts` success and error teardown paths) from 2000ms to 200ms
- Events are already persisted to the local spool before the flush — the HTTP POST is best-effort with a next-invocation retry safety net
- Fast/local endpoints still flush inline; slow endpoints no longer block CLI exit

Fixes swamp-club#671

## Investigation

We explored three approaches before landing on the simplest:

1. **Detached subprocess flush** — spawn a `Deno.Command` child to flush in the background. Rejected: the compiled binary's cold-start (~200-300ms) means the child can't finish within any timeout shorter than its own startup time, making it functionally identical to fire-and-forget.

2. **Subprocess + 200ms grace window** — await the child briefly, then unref. Rejected for the same cold-start reason: the child hasn't even started flushing by the time the timeout fires.

3. **Tighter inline timeout (this PR)** — reduce the existing `AbortSignal.timeout` from 2s to 200ms. Same code, same pattern, just a tuning change. This caps worst-case latency at ~200ms while preserving delivery for fast endpoints and the existing spool-and-retry fallback for slow ones.

### Future considerations

For ephemeral repos (CI, containers) with slow telemetry endpoints, the spool-and-retry design inherently can't guarantee delivery from single-invocation environments. A future improvement could use a persistent background daemon or lightweight flusher process, but that's a larger change beyond the scope of this fix.

## Test Plan

- [ ] `deno check` passes
- [ ] `deno lint` passes
- [ ] `deno fmt --check` passes
- [ ] A/B timing benchmarks confirm delta vs `SWAMP_NO_TELEMETRY=1` drops from ~1.2s to ≤200ms