### PR TITLE
docs: add OSS FAQ and update licensing/trademark docs

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,9 +1,10 @@
 Swamp, an Automation Framework
 
-Copyright (c) 2026, System Initiative, Inc.
+Copyright (c) 2026, Elder Swamp Club, Inc.
 
 Unless otherwise noted, such as with a LICENSE file in a directory, or a
 specific copyright notice on a file, all files in this repository are licensed
 under the GNU Affero General Public License version 3 (AGPLv3) (found in the
 "COPYING" file,) with the Swamp Extension and Definition Exception (found in 
-the "COPYING-EXCEPTION" file.)
+the "COPYING-EXCEPTION" file.) No rights to trademarks are granted, except
+those explicitly covered by our [trademark policy](./TRADEMARKS.md).

--- a/OSS-FAQ.md
+++ b/OSS-FAQ.md
@@ -1,0 +1,157 @@
+# Swamp software is Open Source
+
+The swamp software is open source (free software) under the
+[AGPLv3](https://www.gnu.org/licenses/agpl-3.0.html) with the
+[Swamp Extension and Definition Exception](https://git.swamp-club.com/swamp-club/swamp/src/branch/main/COPYING-EXCEPTION).
+
+# Swamp is a commercial product
+
+Swamp itself is a commercial product produced from the open source software,
+exclusively by Elder Swamp Club, Inc. It is distributed under our
+[software license agreement](https://swamp-club.com/software-license-agreement).
+
+Others are allowed to make their own distribution of the software, but they
+cannot use the Elder Swamp Club trademarks, cloud services, etc.
+
+If you are familiar with how Red Hat or Visual Studio Code works, Swamp is very
+similar.
+
+# What this means for you
+
+You are not allowed to distribute software that includes any of the Elder Swamp
+Club, Inc. trademarks. A distribution of the software means a package or service
+that can be consumed directly. For example, creating binary downloads, docker
+containers, running a software as a service, etc., are all "distributions" of
+the software. For more details of what you are and are not allowed to do with
+our marks, see the [trademark policy](./TRADEMARKS.md).
+
+When you create a distribution, you must remove all our visible trademarks from
+the product. For example, anywhere in the user interface that our logo appears,
+it must be removed or replaced with a different logo. Any written reference to
+the Elder Swamp Club trademarks that are visible to an end user must be removed.
+You do not need to alter every place “Swamp” or “Swamp Club” may appear in the
+source code - only places where an end user will see it (either on the web, or
+in a command line tool). For example, the 'swamp' command line tool must be
+renamed (it is customer facing), while functions using 'swamp' in the source
+code do not (they are not customer facing).
+
+You may not imply in any way that Elder Swamp Club, Inc. has any relationship
+with your distribution, other than that your distribution contains some Swamp
+source code. The build systems, quality control, telemetry, services, APIs and
+community infrastructure we have created are exclusively owned by Elder Swamp
+Club, Inc., and operated for the exclusive use of our customers. So you may not
+state, suggest or imply that your distribution is the same as ours, equivalent
+to ours, or performs the same functions in the same way as ours.
+
+This framework provides a level playing field for everyone. For Elder Swamp
+Club, Inc. to be as successful as possible, the community around the software
+must be as open as possible. The software is equally available to everyone to
+use, modify and distribute, under the terms of the AGPLv3.
+
+Our [contribution policy](./CONTRIBUTING.md) applies to collaborating with any
+distribution you might create. We are happy to work on bug reports and features
+upstream, but we will not accept any code contributions. By creating a unique
+distribution and removing our marks you take full responsibility for your
+distributions supply chain.
+
+# What services must I stop using if I make my own distribution?
+
+You may not use any services provided by Elder Swamp Club, Inc. That includes
+Swamp Club, Extensions, etc.
+
+# I don't like this!
+
+That's okay! If you don't like any of this, there is a clear solution: fork the
+software and go your own way. We look forward to collaborating with you on how swamp evolves.
+
+# Can you explain how this all works in more detail?
+
+Elder Swamp Club, Inc. is a venture-backed startup.
+
+Swamp is the product exclusively produced and distributed by Elder Swamp Club,
+Inc.
+
+Swamp software is the open source software we leverage to create our product.
+
+To understand this more fully, we need to talk about three important concepts:
+copyright, trademark, and patents. What follows is a (relatively) plain language
+summary, intended to give you a basic conceptual overview. To learn more, we
+recommend reading
+[“Intellectual Property and Open Source” by Van Lindberg](https://www.amazon.com/Intellectual-Property-Open-Source-Protecting/dp/0596517963).
+
+Copyright is easiest to understand as ownership over what you create. In
+general, when you make something yourself, you own the copyright. When you are
+employed or hired to create a work, the copyright for your work may belong to
+whomever engaged you, known as a
+“[work made for hire](https://www.copyright.gov/circs/circ30.pdf)”. Think of
+copyright as the lever you can use to determine whether others can use, copy,
+distribute or modify your work. By default, the answer is they cannot - it
+belongs to you, and nobody else can do these things. Open source licenses change
+that default, though, allowing others to do all of those things.
+
+Patents are how we gain exclusivity over our inventions, allowing inventors to
+profit from them. If you patented a better mousetrap, you would be the only
+person who can build a mousetrap that particular way. Patents have two business
+uses: offensive and defensive. Offensive patents generate revenue from those who
+may infringe on the patent. Someone builds a mouse trap like yours, so you sue
+them for damages and extract a royalty payment from them. Defensive patents
+exist to protect us from patent litigation and are deployed only when needed.
+Open source licenses also grant patent licenses in addition to the copyright
+license.
+
+Trademark is ownership of the brands you use for the product or service.
+Trademarks help consumers distinguish one product from another and trademark law
+ensures that this function is working properly for the consumers. When you put a
+product into the world, you own the trademark whether or not it is registered.
+Most companies also register their trademarks with various governments.
+
+The trademark owner decides what product or services the brand will be used for
+and their qualities and characteristics. For example - there are many kinds of
+computers in the world, but only Apple can create a MacBook Pro. That's because
+“Apple” and “MacBook Pro” are trademarks owned by Apple. For a trademark to
+remain valid, the owner has to proactively ensure that the mark is associated
+only with the owner and no one else, or that it doesn’t become the generic name
+for the product, like
+[“386,”](https://tedium.co/2017/05/18/intel-386-486-trademark-battles/) a
+practice often called “policing the mark.” Notably different from copyrights and
+patents though, open source licenses do not grant a trademark license.
+
+In our case, "Elder Swamp Club", "Swamp Club" and "Swamp" are all trademarks of
+Elder Swamp Club, Inc. They represent the company, the product we produce, the
+name of the software we build, and the brand promise that comes with it. No
+person or entity is allowed to use our trademarks for products or services of
+their own. In the terms of the AGPLv3, we explicitly revoke any trademarks under
+section 7. Our [trademark policy](./TRADEMARKS.md) provides more guidance on
+when your use of our trademarks is appropriate and when it is not. When in
+doubt, ask.
+
+Elder Swamp Club, Inc. owns the copyright to Swamp (the software), as we paid
+all the developers who created it. Per our
+[contribution policy](./CONTRIBUTING.md), we will remain the sole copyright
+holder for Swamp, as we will not allow code to be merged that does not originate
+from developers employed by Elder Swamp Club, Inc.
+
+Under the AGPLv3, every contributor also grants a patent license. It's scoped,
+not unlimited: each contributor licenses their "essential patent claims" — the
+patents that would be infringed by making, using, or selling the code they
+actually contributed — so you can run, modify, and pass along their work without
+a patent ambush from them. (It doesn't reach patents you'd only trip over by
+modifying the code further.)
+
+If you start patent litigation claiming the Program infringes your patents,
+you've broken the license, and your own rights to the software — including the
+patent licenses you were granted under it — terminate automatically. Think of it
+like a children's birthday party: the patent grant lets everyone play with the
+shared toys, but if you can't play nice, you don't get to stay. You don't get to
+confiscate the other kids' toys — you just lose your own seat at the table.
+
+To summarize how things work:
+
+- Elder Swamp Club, Swamp Club and Swamp are the trademarks of Elder Swamp Club,
+  Inc. Our software being open source doesn’t mean you can use those marks for
+  your own business.
+- Elder Swamp Club, Inc. markets products and services under the Swamp and Swamp
+  Club brand, protected by those trademarks.
+- Elder Swamp Club, Inc. open-sources the software used in their product and
+  refers to it as the swamp software.
+- Elder Swamp Club, Inc. makes a commercial distribution of the open source software, named Swamp.

--- a/OSS-FAQ.md
+++ b/OSS-FAQ.md
@@ -62,7 +62,8 @@ Swamp Club, Extensions, etc.
 # I don't like this!
 
 That's okay! If you don't like any of this, there is a clear solution: fork the
-software and go your own way. We look forward to collaborating with you on how swamp evolves.
+software and go your own way. We look forward to collaborating with you on how
+swamp evolves.
 
 # Can you explain how this all works in more detail?
 
@@ -154,4 +155,5 @@ To summarize how things work:
   Club brand, protected by those trademarks.
 - Elder Swamp Club, Inc. open-sources the software used in their product and
   refers to it as the swamp software.
-- Elder Swamp Club, Inc. makes a commercial distribution of the open source software, named Swamp.
+- Elder Swamp Club, Inc. makes a commercial distribution of the open source
+  software, named Swamp.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Swamp
 
-AI Native Automation, built for agents - Welcome to Swamp.
+Deterministic Automation for AI Agents.
 
 Swamp is a CLI that supercharges AI agents to create operational workflows that
 are reviewable, shareable, and accurate. Built for agents, there to empower
@@ -39,6 +39,13 @@ Start your AI agent in the repo and tell it what you want to do. Just ask:
 
 The agent will create models, wire up workflows, and run them — all reviewable
 in `.swamp/` before anything touches production.
+
+## Learn More
+
+You can
+[learn more about swamp by reading the manual](https://swamp-club.com/manual).
+[How Swamp Works](https://swamp-club.com/manual/explanation/how-swamp-works) is
+the best place to start - it provides an overview of the entire system.
 
 ## Core Concepts
 
@@ -413,5 +420,8 @@ env var → `.swamp.yaml` `telemetryDisabled: true`.
 ## License
 
 Swamp is licensed under the [GNU Affero General Public License v3.0](COPYING)
-with the [Swamp Extension and Definition Exception](COPYING-EXCEPTION). See
-[COPYRIGHT](COPYRIGHT) and [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+with the [Swamp Extension and Definition Exception](COPYING-EXCEPTION). No
+rights are granted for use of our
+[trademarks outside our explicit policy](./TRADEMARKS.md) See
+[COPYRIGHT](COPYRIGHT), [CONTRIBUTING.md](CONTRIBUTING.md) and
+[Open Source FAQ](./OSS-FAQ.md) for details.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -5,8 +5,9 @@
 This document, the "Policy," outlines the Swamp Club project's (the "Project")
 policy for the use of our trademarks. While our software is available under a
 free and open source software license, the copyright license does not include
-any right, express or implied, to use our trademarks. These guidelines are where
-we describe how you may use our trademarks.
+any right, express or implied, to use our trademarks (for the avoidance of
+doubt, this means we do not grant any rights under section 7 of the AGPLv3).
+These guidelines are where we describe how you may use our trademarks.
 
 The role of trademarks is to provide assurance about the quality of the products
 or services with which the trademark is associated. But because an open source
@@ -47,14 +48,15 @@ This Policy covers:
 
 1. Our word trademarks and service marks (the "Marks"):
 
-| Mark           | Common descriptive name for the goods or services |
-| -------------- | ------------------------------------------------- |
-| Swamp Club     | software platform                                 |
-| SWAMP CLUB     | software platform                                 |
-| Swamp          | software platform                                 |
-| swamp          | software platform                                 |
-| swamp.club     | software platform                                 |
-| swamp-club.com | software platform                                 |
+| Mark             | Common descriptive name for the goods or services |
+| ---------------- | ------------------------------------------------- |
+| Elder Swamp Club | company name                                      |
+| Swamp Club       | software platform                                 |
+| SWAMP CLUB       | software platform                                 |
+| Swamp            | software platform                                 |
+| swamp            | software platform                                 |
+| swamp.club       | software platform                                 |
+| swamp-club.com   | software platform                                 |
 
 Some Marks may not be registered, but registration does not equal ownership of
 trademarks. This Policy covers our Marks whether they are registered or not.


### PR DESCRIPTION
## Summary

Documentation-only updates clarifying the project's open-source licensing and trademark posture:

- **OSS-FAQ.md** (new) — explains that the swamp software is open source (AGPLv3 + Swamp Extension and Definition Exception) while Swamp itself is a commercial product of Elder Swamp Club, Inc., with a plain-language overview of copyright, trademark, and patents.
- **COPYRIGHT** — update copyright holder to Elder Swamp Club, Inc.
- **README.md** — refresh the tagline, add a "Learn More" section linking to the manual, and expand the License section with trademark and OSS FAQ references.
- **TRADEMARKS.md** — clarify that no rights are granted under section 7 of the AGPLv3, and add "Elder Swamp Club" to the marks table.

## Test Plan

- Docs-only change; `deno fmt --check` passes on all touched files.

---

⚠️ **Draft / on hold** — do not auto-merge. The `hold` label is applied to prevent auto-merge.