### PR TITLE
feat(access): add ServerToken built-in model (swamp-club#673)

### DIFF
--- a/src/domain/crypto/timing_safe_equal.ts
+++ b/src/domain/crypto/timing_safe_equal.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Constant-time string comparison so a presented credential cannot be
+ * probed byte-by-byte through timing.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  let diff = aBytes.length ^ bBytes.length;
+  const length = Math.max(aBytes.length, bBytes.length);
+  for (let i = 0; i < length; i++) {
+    diff |= (aBytes[i % Math.max(aBytes.length, 1)] ?? 0) ^
+      (bBytes[i % Math.max(bBytes.length, 1)] ?? 0);
+  }
+  return diff === 0;
+}

--- a/src/domain/crypto/timing_safe_equal_test.ts
+++ b/src/domain/crypto/timing_safe_equal_test.ts
@@ -1,0 +1,41 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { timingSafeEqual } from "./timing_safe_equal.ts";
+
+Deno.test("timingSafeEqual: equal strings return true", () => {
+  assertEquals(timingSafeEqual("abc", "abc"), true);
+});
+
+Deno.test("timingSafeEqual: unequal strings return false", () => {
+  assertEquals(timingSafeEqual("abc", "abd"), false);
+});
+
+Deno.test("timingSafeEqual: different lengths return false", () => {
+  assertEquals(timingSafeEqual("abc", "abcd"), false);
+});
+
+Deno.test("timingSafeEqual: empty strings are equal", () => {
+  assertEquals(timingSafeEqual("", ""), true);
+});
+
+Deno.test("timingSafeEqual: empty vs non-empty returns false", () => {
+  assertEquals(timingSafeEqual("", "x"), false);
+});

--- a/src/domain/models/access/ownership_validation_test.ts
+++ b/src/domain/models/access/ownership_validation_test.ts
@@ -24,6 +24,7 @@ import { CatalogStore } from "../../../infrastructure/persistence/catalog_store.
 import { Data } from "../../data/mod.ts";
 import { GRANT_MODEL_TYPE } from "./grant_model.ts";
 import { GROUP_MODEL_TYPE } from "./group_model.ts";
+import { SERVER_TOKEN_MODEL_TYPE } from "./server_token_model.ts";
 import { OwnershipValidationError } from "../../data/repositories.ts";
 
 const modelMethodOwner = {
@@ -151,6 +152,42 @@ Deno.test("ownership: different model-method ownerRef on same model is rejected"
           GRANT_MODEL_TYPE,
           "test-grant",
           otherMethodData,
+          content,
+        ),
+      OwnershipValidationError,
+      "does not match",
+    );
+  });
+});
+
+Deno.test("ownership: generic write to server-token data owned by model-method is rejected", async () => {
+  const serverTokenMethodOwner = {
+    ownerType: "model-method" as const,
+    ownerRef: "swamp/server-token:mint",
+  };
+  await withTempRepo(async (repo) => {
+    const modelData = Data.create({
+      name: "token-main",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 20,
+      tags: { type: "resource", specName: "token" },
+      ownerDefinition: serverTokenMethodOwner,
+    });
+    await repo.save(
+      SERVER_TOKEN_MODEL_TYPE,
+      "test-server-token",
+      modelData,
+      content,
+    );
+
+    const intruderData = makeGenericData("token-main");
+    await assertRejects(
+      () =>
+        repo.save(
+          SERVER_TOKEN_MODEL_TYPE,
+          "test-server-token",
+          intruderData,
           content,
         ),
       OwnershipValidationError,

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -1,0 +1,249 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+import { ModelType } from "../model_type.ts";
+import {
+  defineModel,
+  type MethodContext,
+  type MethodResult,
+  type ModelDefinition,
+} from "../model.ts";
+import { generateOpaqueToken } from "../../remote/session_credential.ts";
+import { timingSafeEqual } from "../../crypto/timing_safe_equal.ts";
+
+export const SERVER_TOKEN_MODEL_TYPE = ModelType.create(
+  "swamp/server-token",
+);
+
+const ServerTokenStateSchema = z.enum(["active", "expired", "revoked"]);
+
+export type ServerTokenState = z.infer<typeof ServerTokenStateSchema>;
+
+export const ServerTokenSchema = z.object({
+  name: z.string().describe("Token name (user-facing identifier)"),
+  state: ServerTokenStateSchema,
+  principalId: z.string().describe(
+    "Authenticated user's stable subject identifier (OAuth sub claim)",
+  ),
+  principalEmail: z.string().describe(
+    "Display email (informational, not used for matching)",
+  ),
+  createdAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  lastUsedAt: z.string().datetime().optional(),
+  vaultName: z.string(),
+  secretKey: z.string(),
+  revokedAt: z.string().datetime().optional(),
+});
+
+export type ServerToken = z.infer<typeof ServerTokenSchema>;
+
+const TOKEN_DATA_NAME = "token-main";
+
+const DEFAULT_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // ~30 days
+
+export function serverTokenSecretKey(tokenName: string): string {
+  return `server-token-${tokenName}`;
+}
+
+async function readToken(context: MethodContext): Promise<ServerToken> {
+  const raw = await context.readResource!(TOKEN_DATA_NAME);
+  if (raw === null) {
+    throw new Error(
+      `Server token '${context.definition.name}' does not exist — mint it first`,
+    );
+  }
+  return ServerTokenSchema.parse(raw);
+}
+
+function isExpired(token: ServerToken, nowMs: number): boolean {
+  return Date.parse(token.expiresAt) <= nowMs;
+}
+
+const MintArgsSchema = z.object({
+  principalId: z.string().min(1),
+  principalEmail: z.string().min(1),
+  vaultName: z.string().min(1),
+  durationMs: z.number().int().positive().optional(),
+});
+
+async function mint(
+  args: z.infer<typeof MintArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  if (!context.vaultService) {
+    throw new Error("Minting a server token requires a vault service");
+  }
+  const existing = await context.readResource!(TOKEN_DATA_NAME);
+  if (existing !== null) {
+    throw new Error(
+      `Server token '${context.definition.name}' already exists — revoke it first`,
+    );
+  }
+
+  const name = context.definition.name;
+  const secretKey = serverTokenSecretKey(name);
+  const plaintext = generateOpaqueToken();
+  await context.vaultService.put(args.vaultName, secretKey, plaintext);
+
+  const now = Date.now();
+  const durationMs = args.durationMs ?? DEFAULT_DURATION_MS;
+  const token: ServerToken = {
+    name,
+    state: "active",
+    principalId: args.principalId,
+    principalEmail: args.principalEmail,
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + durationMs).toISOString(),
+    vaultName: args.vaultName,
+    secretKey,
+  };
+  const handle = await context.writeResource!("token", TOKEN_DATA_NAME, token);
+  return { dataHandles: [handle] };
+}
+
+const RedeemArgsSchema = z.object({
+  presentedToken: z.string().min(1),
+});
+
+async function redeem(
+  args: z.infer<typeof RedeemArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  if (!context.vaultService) {
+    throw new Error("Redeeming a server token requires a vault service");
+  }
+
+  const dotIndex = args.presentedToken.indexOf(".");
+  if (dotIndex === -1) {
+    throw new Error("Invalid token format: expected <name>.<secret>");
+  }
+
+  const token = await readToken(context);
+  const name = context.definition.name;
+
+  if (token.state === "revoked") {
+    throw new Error(`Server token '${name}' has been revoked`);
+  }
+  if (token.state === "expired" || isExpired(token, Date.now())) {
+    throw new Error(`Server token '${name}' has expired`);
+  }
+
+  const presentedSecret = args.presentedToken.slice(dotIndex + 1);
+  const secret = await context.vaultService.get(
+    token.vaultName,
+    token.secretKey,
+  );
+  if (!timingSafeEqual(secret, presentedSecret)) {
+    throw new Error(`Server token '${name}' does not match`);
+  }
+
+  const updated: ServerToken = {
+    ...token,
+    lastUsedAt: new Date().toISOString(),
+  };
+  const handle = await context.writeResource!(
+    "token",
+    TOKEN_DATA_NAME,
+    updated,
+  );
+  return { dataHandles: [handle] };
+}
+
+const EmptyArgsSchema = z.object({});
+
+async function revoke(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const token = await readToken(context);
+  if (token.state === "revoked") {
+    return { dataHandles: [] };
+  }
+  const revoked: ServerToken = {
+    ...token,
+    state: "revoked",
+    revokedAt: new Date().toISOString(),
+  };
+  const handle = await context.writeResource!(
+    "token",
+    TOKEN_DATA_NAME,
+    revoked,
+  );
+  return { dataHandles: [handle] };
+}
+
+async function expire(
+  _args: z.infer<typeof EmptyArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  const token = await readToken(context);
+  if (token.state === "expired" || token.state === "revoked") {
+    return { dataHandles: [] };
+  }
+  const expired: ServerToken = { ...token, state: "expired" };
+  const handle = await context.writeResource!(
+    "token",
+    TOKEN_DATA_NAME,
+    expired,
+  );
+  return { dataHandles: [handle] };
+}
+
+export const serverTokenModel: ModelDefinition = defineModel({
+  type: SERVER_TOKEN_MODEL_TYPE,
+  version: "2026.06.18.1",
+  resources: {
+    "token": {
+      description: "Server token lifecycle (active → expired | revoked)",
+      schema: ServerTokenSchema,
+      lifetime: "infinite",
+      garbageCollection: 20,
+    },
+  },
+  methods: {
+    mint: {
+      description:
+        "Mint a server token: write the plaintext to a vault and record the lifecycle aggregate",
+      kind: "create",
+      arguments: MintArgsSchema,
+      execute: mint,
+    },
+    redeem: {
+      description:
+        "Validate a presented <name>.<secret> token, update lastUsedAt on success",
+      kind: "action",
+      arguments: RedeemArgsSchema,
+      execute: redeem,
+    },
+    revoke: {
+      description: "Revoke the token — takes effect immediately, idempotent",
+      kind: "action",
+      arguments: EmptyArgsSchema,
+      execute: revoke,
+    },
+    expire: {
+      description: "Record that the token lifetime has elapsed",
+      kind: "action",
+      arguments: EmptyArgsSchema,
+      execute: expire,
+    },
+  },
+});

--- a/src/domain/models/access/server_token_model_test.ts
+++ b/src/domain/models/access/server_token_model_test.ts
@@ -1,0 +1,273 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  serverTokenModel,
+  serverTokenSecretKey,
+} from "./server_token_model.ts";
+import { createInMemoryWorkerContext } from "../worker/worker_test_helpers.ts";
+
+const mintArgs = {
+  principalId: "oauth|user-123",
+  principalEmail: "user@example.com",
+  vaultName: "local",
+};
+
+async function mintToken(name = "user-token-1") {
+  const harness = createInMemoryWorkerContext(
+    SERVER_TOKEN_MODEL_TYPE,
+    name,
+  );
+  await serverTokenModel.methods.mint.execute(mintArgs, harness.context);
+  const plaintext = harness.vault.get(
+    `local/${serverTokenSecretKey(name)}`,
+  )!;
+  return {
+    ...harness,
+    plaintext,
+    fullToken: `${name}.${plaintext}`,
+  };
+}
+
+Deno.test("serverTokenModel: mint writes the secret to the vault, never to data", async () => {
+  const { store, plaintext } = await mintToken();
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "active");
+  assertEquals(token.vaultName, "local");
+  assertEquals(token.secretKey, serverTokenSecretKey("user-token-1"));
+  assertEquals(token.principalId, "oauth|user-123");
+  assertEquals(token.principalEmail, "user@example.com");
+  assertEquals(typeof plaintext, "string");
+  assertEquals(plaintext.length, 64);
+  assertEquals(JSON.stringify(token).includes(plaintext), false);
+});
+
+Deno.test("serverTokenModel: caller reads plaintext from vault after mint", async () => {
+  const { plaintext } = await mintToken();
+  assertEquals(typeof plaintext, "string");
+  assertEquals(plaintext.length, 64);
+});
+
+Deno.test("serverTokenModel: mint twice with the same name fails", async () => {
+  const { context } = await mintToken();
+  await assertRejects(
+    () => serverTokenModel.methods.mint.execute(mintArgs, context),
+    Error,
+    "already exists",
+  );
+});
+
+Deno.test("serverTokenModel: mint uses default 30-day expiry when durationMs not provided", async () => {
+  const { store } = await mintToken();
+  const token = store.get("token-main")!;
+  const createdAt = Date.parse(token.createdAt as string);
+  const expiresAt = Date.parse(token.expiresAt as string);
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+  assertEquals(expiresAt - createdAt, thirtyDaysMs);
+});
+
+Deno.test("serverTokenModel: mint respects custom durationMs", async () => {
+  const harness = createInMemoryWorkerContext(
+    SERVER_TOKEN_MODEL_TYPE,
+    "custom-duration",
+  );
+  await serverTokenModel.methods.mint.execute(
+    { ...mintArgs, durationMs: 60_000 },
+    harness.context,
+  );
+  const token = harness.store.get("token-main")!;
+  const createdAt = Date.parse(token.createdAt as string);
+  const expiresAt = Date.parse(token.expiresAt as string);
+  assertEquals(expiresAt - createdAt, 60_000);
+});
+
+Deno.test("serverTokenModel: redeem succeeds with valid token and updates lastUsedAt", async () => {
+  const { context, store, fullToken } = await mintToken();
+  await serverTokenModel.methods.redeem.execute(
+    { presentedToken: fullToken },
+    context,
+  );
+  const token = store.get("token-main")!;
+  assertEquals(typeof token.lastUsedAt, "string");
+});
+
+Deno.test("serverTokenModel: redeem with wrong secret fails", async () => {
+  const { context } = await mintToken();
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: "user-token-1.wrongsecret" },
+        context,
+      ),
+    Error,
+    "does not match",
+  );
+});
+
+Deno.test("serverTokenModel: redeem with malformed token (no dot) fails", async () => {
+  const { context } = await mintToken();
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: "nodottoken" },
+        context,
+      ),
+    Error,
+    "Invalid token format",
+  );
+});
+
+Deno.test("serverTokenModel: redeem of expired token fails", async () => {
+  const { context, store, fullToken } = await mintToken();
+  store.get("token-main")!.expiresAt = new Date(Date.now() - 1_000)
+    .toISOString();
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: fullToken },
+        context,
+      ),
+    Error,
+    "expired",
+  );
+});
+
+Deno.test("serverTokenModel: redeem of revoked token fails", async () => {
+  const { context, fullToken } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: fullToken },
+        context,
+      ),
+    Error,
+    "revoked",
+  );
+});
+
+Deno.test("serverTokenModel: revoke transitions active to revoked", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "revoked");
+  assertEquals(typeof token.revokedAt, "string");
+});
+
+Deno.test("serverTokenModel: revoke is idempotent", async () => {
+  const { context, versions } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  const after = versions.get("token-main");
+  await serverTokenModel.methods.revoke.execute({}, context);
+  assertEquals(versions.get("token-main"), after);
+});
+
+Deno.test("serverTokenModel: expire transitions active to expired", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.expire.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "expired");
+});
+
+Deno.test("serverTokenModel: expire is idempotent on expired", async () => {
+  const { context, versions } = await mintToken();
+  await serverTokenModel.methods.expire.execute({}, context);
+  const after = versions.get("token-main");
+  await serverTokenModel.methods.expire.execute({}, context);
+  assertEquals(versions.get("token-main"), after);
+});
+
+Deno.test("serverTokenModel: expire is idempotent on revoked", async () => {
+  const { context, versions } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  const after = versions.get("token-main");
+  await serverTokenModel.methods.expire.execute({}, context);
+  assertEquals(versions.get("token-main"), after);
+});
+
+Deno.test("serverTokenModel: lastUsedAt updates on each successful redeem", async () => {
+  const { context, store, fullToken } = await mintToken();
+  await serverTokenModel.methods.redeem.execute(
+    { presentedToken: fullToken },
+    context,
+  );
+  const firstUsedAt = store.get("token-main")!.lastUsedAt as string;
+
+  await new Promise((r) => setTimeout(r, 5));
+  await serverTokenModel.methods.redeem.execute(
+    { presentedToken: fullToken },
+    context,
+  );
+  const secondUsedAt = store.get("token-main")!.lastUsedAt as string;
+  assertNotEquals(firstUsedAt, secondUsedAt);
+});
+
+Deno.test("serverTokenModel: minted tokens are unique across instances", async () => {
+  const a = await mintToken("token-a");
+  const b = await mintToken("token-b");
+  assertNotEquals(a.plaintext, b.plaintext);
+});
+
+Deno.test("serverTokenModel: redeem does not bind to a machine (works from any caller)", async () => {
+  const { context, store, fullToken } = await mintToken();
+  await serverTokenModel.methods.redeem.execute(
+    { presentedToken: fullToken },
+    context,
+  );
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "active");
+  assertEquals("boundMachineId" in token, false);
+});
+
+Deno.test("serverTokenModel: mint without vault service throws", async () => {
+  const harness = createInMemoryWorkerContext(
+    SERVER_TOKEN_MODEL_TYPE,
+    "no-vault",
+  );
+  const ctx = { ...harness.context, vaultService: undefined };
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.mint.execute(
+        mintArgs,
+        ctx as typeof harness.context,
+      ),
+    Error,
+    "requires a vault service",
+  );
+});
+
+Deno.test("serverTokenModel: redeem without vault service throws", async () => {
+  const { context, fullToken } = await mintToken();
+  const ctx = { ...context, vaultService: undefined };
+  const error = await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: fullToken },
+        ctx as typeof context,
+      ),
+    Error,
+  );
+  assertStringIncludes(error.message, "requires a vault service");
+});

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -39,10 +39,11 @@ import "./worker/worker_model.ts";
 import "./worker/enrollment_token_model.ts";
 import "./worker/step_lease_model.ts";
 
-// Access control models (grants, groups) — see src/domain/access/ for
-// the bounded context's shared value objects.
+// Access control models (grants, groups, server tokens) — see
+// src/domain/access/ for the bounded context's shared value objects.
 import "./access/grant_model.ts";
 import "./access/group_model.ts";
+import "./access/server_token_model.ts";
 
 // Import all of the AWS models - the models in this file are created by the clover pipeline
 import "./aws/aws_models.ts";

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -41,6 +41,9 @@ import {
   type ModelDefinition,
 } from "../model.ts";
 import { generateOpaqueToken } from "../../remote/session_credential.ts";
+import { timingSafeEqual } from "../../crypto/timing_safe_equal.ts";
+
+export { timingSafeEqual };
 
 export const ENROLLMENT_TOKEN_MODEL_TYPE = ModelType.create(
   "swamp/enrollment-token",
@@ -77,23 +80,6 @@ const TOKEN_DATA_NAME = "token-main";
 /** Vault key under which a token's plaintext is stored. */
 export function tokenSecretKey(tokenName: string): string {
   return `worker-token-${tokenName}`;
-}
-
-/**
- * Constant-time string comparison so a presented token cannot be probed
- * byte-by-byte through timing.
- */
-export function timingSafeEqual(a: string, b: string): boolean {
-  const encoder = new TextEncoder();
-  const aBytes = encoder.encode(a);
-  const bBytes = encoder.encode(b);
-  let diff = aBytes.length ^ bBytes.length;
-  const length = Math.max(aBytes.length, bBytes.length);
-  for (let i = 0; i < length; i++) {
-    diff |= (aBytes[i % Math.max(aBytes.length, 1)] ?? 0) ^
-      (bBytes[i % Math.max(bBytes.length, 1)] ?? 0);
-  }
-  return diff === 0;
 }
 
 async function readToken(context: MethodContext): Promise<EnrollmentToken> {


### PR DESCRIPTION
## Summary

Implements the `ServerToken` built-in model (`swamp/server-token`) for serve authentication, closing the server-side half of user credential management (layer 1, item 5 of #662).

- **New model** in `src/domain/models/access/server_token_model.ts` with `mint`, `redeem`, `revoke`, and `expire` methods following the enrollment token pattern
- **Key differences from enrollment tokens**: no machine binding, `lastUsedAt` tracking on each successful redeem, `principalId`/`principalEmail` fields linking tokens to authenticated users, configurable expiry (default ~30 days)
- **Shared crypto utility**: extracts `timingSafeEqual` from the enrollment token model to `src/domain/crypto/timing_safe_equal.ts` — both models now import from the shared location
- **Plaintext in vault**: consistent with enrollment tokens, the secret is stored as plaintext in the vault (not hashed) and compared via constant-time comparison
- **GC set to 20** to accommodate `lastUsedAt` version churn on frequent redemptions
- **Ownership validation test** ensures generic data writes cannot modify server token records

## Test Plan

- 18 unit tests for the server token model covering all methods and edge cases (mint success/duplicate, redeem valid/expired/revoked/wrong-secret/malformed, revoke/expire idempotency, lastUsedAt progression, no machine binding, no-vault-service errors)
- 5 unit tests for the extracted `timingSafeEqual` function
- 1 ownership validation test for server token data
- Enrollment token tests (14) pass unchanged — extraction didn't break anything
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

Closes swamp-club#673