### PR TITLE
feat(auth): add client-side server credential storage (swamp-club#674)

### DIFF
--- a/src/domain/auth/server_credential.ts
+++ b/src/domain/auth/server_credential.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** Stored authentication credential for a swamp serve instance. */
+export interface ServerCredential {
+  /** Normalized URL of the serve instance (e.g. "https://swamp.acme.internal:9090"). */
+  serverUrl: string;
+  /** The name portion of the <name>.<secret> token. */
+  tokenName: string;
+  /** The full <name>.<secret> plaintext token. */
+  token: string;
+  /** The user's principal ID (sub from OAuth login). */
+  principalId: string;
+  /** The user's display name, if available. */
+  displayName?: string;
+  /** ISO 8601 timestamp of when the credential was obtained. */
+  obtainedAt: string;
+}
+
+/** Persistence abstraction for server credentials, keyed by normalized server URL. */
+export interface ServerCredentialRepository {
+  get(serverUrl: string): Promise<ServerCredential | null>;
+  save(credential: ServerCredential): Promise<void>;
+  remove(serverUrl: string): Promise<void>;
+  list(): Promise<ServerCredential[]>;
+}

--- a/src/domain/auth/server_url.ts
+++ b/src/domain/auth/server_url.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Normalize a server URL for use as a credential map key.
+ *
+ * Lowercases the hostname, strips trailing slashes from the path,
+ * and removes default ports (80 for http, 443 for https).
+ *
+ * @throws {TypeError} if the input is not a valid URL
+ */
+export function normalizeServerUrl(url: string): string {
+  const parsed = new URL(url);
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new TypeError(
+      `Unsupported protocol: ${parsed.protocol} (expected http: or https:)`,
+    );
+  }
+
+  // new URL already lowercases the hostname.
+  // Strip default ports — URL parser stores them in .port as "" when they
+  // match the scheme default, but explicit ":443" / ":80" may be present
+  // in the original string and preserved by some environments.
+  let host = parsed.hostname;
+  if (parsed.port) {
+    const isDefaultPort =
+      (parsed.protocol === "https:" && parsed.port === "443") ||
+      (parsed.protocol === "http:" && parsed.port === "80");
+    if (!isDefaultPort) {
+      host = `${host}:${parsed.port}`;
+    }
+  }
+
+  // Strip trailing slashes from the pathname, but preserve non-root paths.
+  const pathname = parsed.pathname.replace(/\/+$/, "") || "";
+
+  return `${parsed.protocol}//${host}${pathname}`;
+}

--- a/src/domain/auth/server_url_test.ts
+++ b/src/domain/auth/server_url_test.ts
@@ -1,0 +1,102 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { normalizeServerUrl } from "./server_url.ts";
+
+Deno.test("normalizeServerUrl: strips trailing slash", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com/"),
+    "https://swamp.example.com",
+  );
+});
+
+Deno.test("normalizeServerUrl: strips multiple trailing slashes", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com///"),
+    "https://swamp.example.com",
+  );
+});
+
+Deno.test("normalizeServerUrl: lowercases hostname", () => {
+  assertEquals(
+    normalizeServerUrl("https://SWAMP.Example.COM"),
+    "https://swamp.example.com",
+  );
+});
+
+Deno.test("normalizeServerUrl: preserves non-default port", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com:9090"),
+    "https://swamp.example.com:9090",
+  );
+});
+
+Deno.test("normalizeServerUrl: strips default https port 443", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com:443"),
+    "https://swamp.example.com",
+  );
+});
+
+Deno.test("normalizeServerUrl: strips default http port 80", () => {
+  assertEquals(
+    normalizeServerUrl("http://swamp.example.com:80"),
+    "http://swamp.example.com",
+  );
+});
+
+Deno.test("normalizeServerUrl: preserves non-root path", () => {
+  assertEquals(
+    normalizeServerUrl("https://swamp.example.com/api/v1/"),
+    "https://swamp.example.com/api/v1",
+  );
+});
+
+Deno.test("normalizeServerUrl: handles IPv6 address", () => {
+  assertEquals(
+    normalizeServerUrl("https://[::1]:9090"),
+    "https://[::1]:9090",
+  );
+});
+
+Deno.test("normalizeServerUrl: same URL normalizes identically", () => {
+  const a = normalizeServerUrl("https://Swamp.Example.COM:443/");
+  const b = normalizeServerUrl("https://swamp.example.com");
+  assertEquals(a, b);
+});
+
+Deno.test("normalizeServerUrl: throws on invalid URL", () => {
+  assertThrows(() => normalizeServerUrl("not a url"), TypeError);
+});
+
+Deno.test("normalizeServerUrl: throws on unsupported protocol", () => {
+  assertThrows(
+    () => normalizeServerUrl("ftp://swamp.example.com"),
+    TypeError,
+    "Unsupported protocol",
+  );
+});
+
+Deno.test("normalizeServerUrl: http scheme preserved", () => {
+  assertEquals(
+    normalizeServerUrl("http://localhost:8080"),
+    "http://localhost:8080",
+  );
+});

--- a/src/infrastructure/persistence/server_credential_repository.ts
+++ b/src/infrastructure/persistence/server_credential_repository.ts
@@ -1,0 +1,143 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type {
+  ServerCredential,
+  ServerCredentialRepository,
+} from "../../domain/auth/server_credential.ts";
+import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+import { getSwampConfigDir } from "./paths.ts";
+
+const SERVERS_FILE = "servers.json";
+
+/**
+ * Optional overrides for `FileServerCredentialRepository`. Used by tests to
+ * bypass the shared `Deno.env` global, which races across files when
+ * `deno test --parallel` runs multiple test files concurrently.
+ */
+export interface FileServerCredentialRepositoryOptions {
+  /** Override the config dir; default is `getSwampConfigDir()`. */
+  configDir?: string;
+  /**
+   * Override the SWAMP_SERVER_TOKEN lookup; default reads
+   * `Deno.env.get("SWAMP_SERVER_TOKEN")` lazily at call time.
+   */
+  getServerToken?: () => string | undefined;
+  /**
+   * Override the SWAMP_SERVER_URL lookup used with the token env var;
+   * default reads `Deno.env.get("SWAMP_SERVER_URL")` lazily at call time.
+   */
+  getServerUrl?: () => string | undefined;
+}
+
+/**
+ * File-based implementation of ServerCredentialRepository.
+ * Stores credentials at ~/.config/swamp/servers.json
+ * (or $XDG_CONFIG_HOME/swamp/servers.json) as a JSON object
+ * keyed by normalized server URL.
+ *
+ * Precedence: SWAMP_SERVER_TOKEN env var > servers.json file.
+ */
+export class FileServerCredentialRepository
+  implements ServerCredentialRepository {
+  private readonly getConfigDir: () => string;
+  private readonly getServerToken: () => string | undefined;
+  private readonly getServerUrl: () => string | undefined;
+
+  constructor(options: FileServerCredentialRepositoryOptions = {}) {
+    this.getConfigDir = options.configDir !== undefined
+      ? () => options.configDir!
+      : getSwampConfigDir;
+    this.getServerToken = options.getServerToken ??
+      (() => Deno.env.get("SWAMP_SERVER_TOKEN"));
+    this.getServerUrl = options.getServerUrl ??
+      (() => Deno.env.get("SWAMP_SERVER_URL"));
+  }
+
+  private getServersPath(): string {
+    return join(this.getConfigDir(), SERVERS_FILE);
+  }
+
+  private async loadAll(): Promise<Record<string, ServerCredential>> {
+    try {
+      const content = await Deno.readTextFile(this.getServersPath());
+      return JSON.parse(content) as Record<string, ServerCredential>;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return {};
+      }
+      throw error;
+    }
+  }
+
+  private async saveAll(
+    credentials: Record<string, ServerCredential>,
+  ): Promise<void> {
+    await Deno.mkdir(this.getConfigDir(), { recursive: true });
+    await atomicWriteTextFile(
+      this.getServersPath(),
+      JSON.stringify(credentials, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  }
+
+  async get(serverUrl: string): Promise<ServerCredential | null> {
+    const key = normalizeServerUrl(serverUrl);
+
+    const envToken = this.getServerToken();
+    if (envToken) {
+      const envUrl = this.getServerUrl();
+      if (envUrl && normalizeServerUrl(envUrl) === key) {
+        return {
+          serverUrl: key,
+          tokenName: "",
+          token: envToken,
+          principalId: "",
+          obtainedAt: "",
+        };
+      }
+    }
+
+    const all = await this.loadAll();
+    return all[key] ?? null;
+  }
+
+  async save(credential: ServerCredential): Promise<void> {
+    const key = normalizeServerUrl(credential.serverUrl);
+    const all = await this.loadAll();
+    all[key] = { ...credential, serverUrl: key };
+    await this.saveAll(all);
+  }
+
+  async remove(serverUrl: string): Promise<void> {
+    const key = normalizeServerUrl(serverUrl);
+    const all = await this.loadAll();
+    if (key in all) {
+      delete all[key];
+      await this.saveAll(all);
+    }
+  }
+
+  async list(): Promise<ServerCredential[]> {
+    const all = await this.loadAll();
+    return Object.values(all);
+  }
+}

--- a/src/infrastructure/persistence/server_credential_repository_test.ts
+++ b/src/infrastructure/persistence/server_credential_repository_test.ts
@@ -1,0 +1,354 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { join } from "@std/path";
+import { FileServerCredentialRepository } from "./server_credential_repository.ts";
+import type { ServerCredential } from "../../domain/auth/server_credential.ts";
+
+const TEST_CREDENTIAL: ServerCredential = {
+  serverUrl: "https://swamp.acme.internal:9090",
+  tokenName: "tkn_abc",
+  token: "tkn_abc.secret123",
+  principalId: "user-uuid-1",
+  displayName: "Test User",
+  obtainedAt: "2026-06-18T00:00:00Z",
+};
+
+const TEST_CREDENTIAL_2: ServerCredential = {
+  serverUrl: "https://other.server.com",
+  tokenName: "tkn_xyz",
+  token: "tkn_xyz.secret456",
+  principalId: "user-uuid-2",
+  obtainedAt: "2026-06-18T01:00:00Z",
+};
+
+Deno.test("FileServerCredentialRepository - save and get round trip", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+    const loaded = await repo.get(TEST_CREDENTIAL.serverUrl);
+
+    assertExists(loaded);
+    assertEquals(loaded.serverUrl, TEST_CREDENTIAL.serverUrl);
+    assertEquals(loaded.tokenName, TEST_CREDENTIAL.tokenName);
+    assertEquals(loaded.token, TEST_CREDENTIAL.token);
+    assertEquals(loaded.principalId, TEST_CREDENTIAL.principalId);
+    assertEquals(loaded.displayName, TEST_CREDENTIAL.displayName);
+    assertEquals(loaded.obtainedAt, TEST_CREDENTIAL.obtainedAt);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - get returns null when no file exists", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    const loaded = await repo.get("https://nonexistent.server.com");
+    assertEquals(loaded, null);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - remove deletes a credential", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+    assertExists(await repo.get(TEST_CREDENTIAL.serverUrl));
+
+    await repo.remove(TEST_CREDENTIAL.serverUrl);
+    assertEquals(await repo.get(TEST_CREDENTIAL.serverUrl), null);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - remove is idempotent (no error when missing)", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.remove("https://nonexistent.server.com");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - list returns all credentials", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+    await repo.save(TEST_CREDENTIAL_2);
+
+    const all = await repo.list();
+    assertEquals(all.length, 2);
+
+    const urls = all.map((c) => c.serverUrl).sort();
+    assertEquals(urls, [
+      "https://other.server.com",
+      "https://swamp.acme.internal:9090",
+    ]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - list returns empty array when no file", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    const all = await repo.list();
+    assertEquals(all, []);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - save normalizes URL key", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save({
+      ...TEST_CREDENTIAL,
+      serverUrl: "https://SWAMP.ACME.INTERNAL:9090/",
+    });
+
+    const loaded = await repo.get("https://swamp.acme.internal:9090");
+    assertExists(loaded);
+    assertEquals(loaded.serverUrl, "https://swamp.acme.internal:9090");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - get normalizes URL for lookup", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+
+    const loaded = await repo.get("https://SWAMP.ACME.INTERNAL:9090/");
+    assertExists(loaded);
+    assertEquals(loaded.tokenName, TEST_CREDENTIAL.tokenName);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - save overwrites existing credential for same URL", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+    await repo.save({
+      ...TEST_CREDENTIAL,
+      token: "tkn_abc.newsecret",
+    });
+
+    const loaded = await repo.get(TEST_CREDENTIAL.serverUrl);
+    assertExists(loaded);
+    assertEquals(loaded.token, "tkn_abc.newsecret");
+
+    const all = await repo.list();
+    assertEquals(all.length, 1);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - remove does not affect other credentials", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+    await repo.save(TEST_CREDENTIAL_2);
+
+    await repo.remove(TEST_CREDENTIAL.serverUrl);
+
+    assertEquals(await repo.get(TEST_CREDENTIAL.serverUrl), null);
+    assertExists(await repo.get(TEST_CREDENTIAL_2.serverUrl));
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - save sets restrictive file permissions", async () => {
+  if (Deno.build.os === "windows") return;
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIAL);
+
+    const stat = await Deno.stat(join(tmpDir, "swamp", "servers.json"));
+    assertEquals(stat.mode !== null && (stat.mode & 0o777) === 0o600, true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+// ── SWAMP_SERVER_TOKEN override tests ─────────────────────────────────
+
+Deno.test("FileServerCredentialRepository - get returns env var credential when SWAMP_SERVER_TOKEN matches URL", async () => {
+  const repo = new FileServerCredentialRepository({
+    getServerToken: () => "env_token_123",
+    getServerUrl: () => "https://swamp.example.com",
+  });
+
+  const loaded = await repo.get("https://swamp.example.com");
+
+  assertExists(loaded);
+  assertEquals(loaded.token, "env_token_123");
+  assertEquals(loaded.serverUrl, "https://swamp.example.com");
+  assertEquals(loaded.tokenName, "");
+  assertEquals(loaded.principalId, "");
+});
+
+Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN takes precedence over file", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const fileRepo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => undefined,
+      getServerUrl: () => undefined,
+    });
+    await fileRepo.save({
+      ...TEST_CREDENTIAL,
+      serverUrl: "https://swamp.example.com",
+    });
+
+    const envRepo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => "env_override_token",
+      getServerUrl: () => "https://swamp.example.com",
+    });
+    const loaded = await envRepo.get("https://swamp.example.com");
+
+    assertExists(loaded);
+    assertEquals(loaded.token, "env_override_token");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN does not match different URL", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => "env_token_123",
+      getServerUrl: () => "https://other.server.com",
+    });
+    await repo.save(TEST_CREDENTIAL);
+
+    const loaded = await repo.get(TEST_CREDENTIAL.serverUrl);
+    assertExists(loaded);
+    assertEquals(loaded.token, TEST_CREDENTIAL.token);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN without SWAMP_SERVER_URL falls through to file", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new FileServerCredentialRepository({
+      configDir: join(tmpDir, "swamp"),
+      getServerToken: () => "env_token_123",
+      getServerUrl: () => undefined,
+    });
+    await repo.save(TEST_CREDENTIAL);
+
+    const loaded = await repo.get(TEST_CREDENTIAL.serverUrl);
+    assertExists(loaded);
+    assertEquals(loaded.token, TEST_CREDENTIAL.token);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN normalizes env URL for comparison", async () => {
+  const repo = new FileServerCredentialRepository({
+    getServerToken: () => "env_token_normalized",
+    getServerUrl: () => "https://SWAMP.EXAMPLE.COM:443/",
+  });
+
+  const loaded = await repo.get("https://swamp.example.com");
+
+  assertExists(loaded);
+  assertEquals(loaded.token, "env_token_normalized");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1084,6 +1084,17 @@ export {
   createAuthLogoutDeps,
 } from "./auth/logout.ts";
 
+// Server credential storage
+export type {
+  ServerCredential,
+  ServerCredentialRepository,
+} from "../domain/auth/server_credential.ts";
+export { normalizeServerUrl } from "../domain/auth/server_url.ts";
+export {
+  FileServerCredentialRepository,
+  type FileServerCredentialRepositoryOptions,
+} from "../infrastructure/persistence/server_credential_repository.ts";
+
 // Repo init/upgrade operations
 export {
   createRepoInitDeps,


### PR DESCRIPTION
## Summary

- Add `ServerCredential` value object and `ServerCredentialRepository` interface in `src/domain/auth/server_credential.ts` (domain layer)
- Add `normalizeServerUrl` utility in `src/domain/auth/server_url.ts` for consistent URL key normalization (lowercase hostname, strip trailing slashes, remove default ports)
- Add `FileServerCredentialRepository` in `src/infrastructure/persistence/server_credential_repository.ts` — persists to `~/.config/swamp/servers.json` with atomic writes, `0o600` permissions, and `SWAMP_SERVER_TOKEN` env var override
- Export new types from `src/libswamp/mod.ts` for layer 4 readiness

Closes swamp-club#674

## Test Plan

- 12 unit tests for URL normalization (trailing slashes, hostname case, default ports, IPv6, invalid URLs, unsupported protocols)
- 16 unit tests for `FileServerCredentialRepository` (save/get/remove/list round-trip, file permissions, env var precedence, URL normalization on keys, multi-credential storage, idempotent remove)
- All 7221 existing tests pass
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)