### PR TITLE
fix(access,auth): followup fixes for ServerToken and credential storage

### DIFF
--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -146,6 +146,13 @@ async function redeem(
     throw new Error(`Server token '${name}' has expired`);
   }
 
+  const presentedName = args.presentedToken.slice(0, dotIndex);
+  if (presentedName !== name) {
+    throw new Error(
+      `Server token name mismatch: expected '${name}'`,
+    );
+  }
+
   const presentedSecret = args.presentedToken.slice(dotIndex + 1);
   const secret = await context.vaultService.get(
     token.vaultName,

--- a/src/domain/models/access/server_token_model_test.ts
+++ b/src/domain/models/access/server_token_model_test.ts
@@ -127,6 +127,19 @@ Deno.test("serverTokenModel: redeem with wrong secret fails", async () => {
   );
 });
 
+Deno.test("serverTokenModel: redeem rejects token with wrong name prefix", async () => {
+  const { context, plaintext } = await mintToken();
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: `wrong-name.${plaintext}` },
+        context,
+      ),
+    Error,
+    "name mismatch",
+  );
+});
+
 Deno.test("serverTokenModel: redeem with malformed token (no dot) fails", async () => {
   const { context } = await mintToken();
   await assertRejects(

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -43,8 +43,6 @@ import {
 import { generateOpaqueToken } from "../../remote/session_credential.ts";
 import { timingSafeEqual } from "../../crypto/timing_safe_equal.ts";
 
-export { timingSafeEqual };
-
 export const ENROLLMENT_TOKEN_MODEL_TYPE = ModelType.create(
   "swamp/enrollment-token",
 );

--- a/src/domain/models/worker/enrollment_token_model_test.ts
+++ b/src/domain/models/worker/enrollment_token_model_test.ts
@@ -26,9 +26,9 @@ import {
 import {
   ENROLLMENT_TOKEN_MODEL_TYPE,
   enrollmentTokenModel,
-  timingSafeEqual,
   tokenSecretKey,
 } from "./enrollment_token_model.ts";
+import { timingSafeEqual } from "../../crypto/timing_safe_equal.ts";
 import { createInMemoryWorkerContext } from "./worker_test_helpers.ts";
 
 const mintArgs = { durationMs: 60_000, vaultName: "local" };

--- a/src/infrastructure/persistence/server_credential_repository_test.ts
+++ b/src/infrastructure/persistence/server_credential_repository_test.ts
@@ -39,7 +39,7 @@ const TEST_CREDENTIAL_2: ServerCredential = {
   obtainedAt: "2026-06-18T01:00:00Z",
 };
 
-Deno.test("FileServerCredentialRepository - save and get round trip", async () => {
+Deno.test("FileServerCredentialRepository.save: round-trips credential", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -59,11 +59,11 @@ Deno.test("FileServerCredentialRepository - save and get round trip", async () =
     assertEquals(loaded.displayName, TEST_CREDENTIAL.displayName);
     assertEquals(loaded.obtainedAt, TEST_CREDENTIAL.obtainedAt);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - get returns null when no file exists", async () => {
+Deno.test("FileServerCredentialRepository.get: returns null when no file exists", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -75,11 +75,11 @@ Deno.test("FileServerCredentialRepository - get returns null when no file exists
     const loaded = await repo.get("https://nonexistent.server.com");
     assertEquals(loaded, null);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - remove deletes a credential", async () => {
+Deno.test("FileServerCredentialRepository.remove: deletes a credential", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -94,11 +94,11 @@ Deno.test("FileServerCredentialRepository - remove deletes a credential", async 
     await repo.remove(TEST_CREDENTIAL.serverUrl);
     assertEquals(await repo.get(TEST_CREDENTIAL.serverUrl), null);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - remove is idempotent (no error when missing)", async () => {
+Deno.test("FileServerCredentialRepository.remove: is idempotent when missing", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -109,11 +109,11 @@ Deno.test("FileServerCredentialRepository - remove is idempotent (no error when 
 
     await repo.remove("https://nonexistent.server.com");
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - list returns all credentials", async () => {
+Deno.test("FileServerCredentialRepository.list: returns all credentials", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -134,11 +134,11 @@ Deno.test("FileServerCredentialRepository - list returns all credentials", async
       "https://swamp.acme.internal:9090",
     ]);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - list returns empty array when no file", async () => {
+Deno.test("FileServerCredentialRepository.list: returns empty array when no file", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -150,11 +150,11 @@ Deno.test("FileServerCredentialRepository - list returns empty array when no fil
     const all = await repo.list();
     assertEquals(all, []);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - save normalizes URL key", async () => {
+Deno.test("FileServerCredentialRepository.save: normalizes URL key", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -172,11 +172,11 @@ Deno.test("FileServerCredentialRepository - save normalizes URL key", async () =
     assertExists(loaded);
     assertEquals(loaded.serverUrl, "https://swamp.acme.internal:9090");
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - get normalizes URL for lookup", async () => {
+Deno.test("FileServerCredentialRepository.get: normalizes URL for lookup", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -191,11 +191,11 @@ Deno.test("FileServerCredentialRepository - get normalizes URL for lookup", asyn
     assertExists(loaded);
     assertEquals(loaded.tokenName, TEST_CREDENTIAL.tokenName);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - save overwrites existing credential for same URL", async () => {
+Deno.test("FileServerCredentialRepository.save: overwrites existing credential for same URL", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -217,11 +217,11 @@ Deno.test("FileServerCredentialRepository - save overwrites existing credential 
     const all = await repo.list();
     assertEquals(all.length, 1);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - remove does not affect other credentials", async () => {
+Deno.test("FileServerCredentialRepository.remove: does not affect other credentials", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -238,11 +238,11 @@ Deno.test("FileServerCredentialRepository - remove does not affect other credent
     assertEquals(await repo.get(TEST_CREDENTIAL.serverUrl), null);
     assertExists(await repo.get(TEST_CREDENTIAL_2.serverUrl));
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - save sets restrictive file permissions", async () => {
+Deno.test("FileServerCredentialRepository.save: sets restrictive file permissions", async () => {
   if (Deno.build.os === "windows") return;
   const tmpDir = await Deno.makeTempDir();
   try {
@@ -257,13 +257,13 @@ Deno.test("FileServerCredentialRepository - save sets restrictive file permissio
     const stat = await Deno.stat(join(tmpDir, "swamp", "servers.json"));
     assertEquals(stat.mode !== null && (stat.mode & 0o777) === 0o600, true);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
 // ── SWAMP_SERVER_TOKEN override tests ─────────────────────────────────
 
-Deno.test("FileServerCredentialRepository - get returns env var credential when SWAMP_SERVER_TOKEN matches URL", async () => {
+Deno.test("FileServerCredentialRepository.get: returns env var credential when SWAMP_SERVER_TOKEN matches URL", async () => {
   const repo = new FileServerCredentialRepository({
     getServerToken: () => "env_token_123",
     getServerUrl: () => "https://swamp.example.com",
@@ -278,7 +278,7 @@ Deno.test("FileServerCredentialRepository - get returns env var credential when 
   assertEquals(loaded.principalId, "");
 });
 
-Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN takes precedence over file", async () => {
+Deno.test("FileServerCredentialRepository.get: SWAMP_SERVER_TOKEN takes precedence over file", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const fileRepo = new FileServerCredentialRepository({
@@ -301,11 +301,11 @@ Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN takes precedence 
     assertExists(loaded);
     assertEquals(loaded.token, "env_override_token");
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN does not match different URL", async () => {
+Deno.test("FileServerCredentialRepository.get: SWAMP_SERVER_TOKEN does not match different URL", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -319,11 +319,11 @@ Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN does not match di
     assertExists(loaded);
     assertEquals(loaded.token, TEST_CREDENTIAL.token);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN without SWAMP_SERVER_URL falls through to file", async () => {
+Deno.test("FileServerCredentialRepository.get: SWAMP_SERVER_TOKEN without SWAMP_SERVER_URL falls through to file", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const repo = new FileServerCredentialRepository({
@@ -337,11 +337,11 @@ Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN without SWAMP_SER
     assertExists(loaded);
     assertEquals(loaded.token, TEST_CREDENTIAL.token);
   } finally {
-    await Deno.remove(tmpDir, { recursive: true });
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
-Deno.test("FileServerCredentialRepository - SWAMP_SERVER_TOKEN normalizes env URL for comparison", async () => {
+Deno.test("FileServerCredentialRepository.get: SWAMP_SERVER_TOKEN normalizes env URL for comparison", async () => {
   const repo = new FileServerCredentialRepository({
     getServerToken: () => "env_token_normalized",
     getServerUrl: () => "https://SWAMP.EXAMPLE.COM:443/",


### PR DESCRIPTION
## Summary

Followup fixes for the recently merged ServerToken (#1596) and credential storage (#1597) PRs:

- **Drop `timingSafeEqual` re-export** from `enrollment_token_model.ts` — the test now imports directly from `crypto/timing_safe_equal.ts`
- **Validate name prefix in `redeem`** — `server_token_model.ts` now checks the presented token's name portion matches the definition name, preventing cross-name token reuse
- **Fix test naming convention** — all 16 tests in `server_credential_repository_test.ts` renamed from `" - "` to `": "` per codebase convention
- **Add Windows EBUSY guard** — `.catch(() => {})` on all temp dir cleanup calls in `server_credential_repository_test.ts`

## Test Plan

- All 7248 tests pass (`deno run test`)
- New test: `serverTokenModel: redeem rejects token with wrong name prefix`
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)