### PR TITLE
feat(serve): add static TLS support via --cert-file and --key-file (swamp-club#675)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -73,9 +73,21 @@ export const serveCommand = new Command()
   .option("--host <host:string>", "Host to bind to", { default: "127.0.0.1" })
   .option("--no-schedule", "Disable scheduled workflow execution")
   .option(
+    "--cert-file <path:string>",
+    "Path to PEM-encoded TLS certificate (env: SWAMP_SERVE_CERT_FILE)",
+  )
+  .option(
+    "--key-file <path:string>",
+    "Path to PEM-encoded TLS private key (env: SWAMP_SERVE_KEY_FILE)",
+  )
+  .option(
     "--webhook <spec:string>",
     "Register a webhook endpoint: <route>:<workflow>:<secret>",
     { collect: true },
+  )
+  .example(
+    "Enable TLS",
+    "swamp serve --cert-file server.crt --key-file server.key",
   )
   .example(
     "Webhook trigger",
@@ -87,6 +99,25 @@ export const serveCommand = new Command()
     const port = options.port as number;
     const host = options.host as string;
     const isJson = ctx.outputMode === "json";
+
+    const certFile = (options.certFile as string | undefined) ??
+      Deno.env.get("SWAMP_SERVE_CERT_FILE") ?? undefined;
+    const keyFile = (options.keyFile as string | undefined) ??
+      Deno.env.get("SWAMP_SERVE_KEY_FILE") ?? undefined;
+
+    if ((certFile && !keyFile) || (!certFile && keyFile)) {
+      throw new Error(
+        "Both --cert-file and --key-file must be provided together for TLS",
+      );
+    }
+
+    let cert: string | undefined;
+    let key: string | undefined;
+    if (certFile && keyFile) {
+      cert = await Deno.readTextFile(certFile);
+      key = await Deno.readTextFile(keyFile);
+    }
+    const tlsEnabled = cert !== undefined;
 
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
@@ -294,24 +325,26 @@ export const serveCommand = new Command()
       }
     }
 
+    const wsScheme = tlsEnabled ? "wss" : "ws";
     const server = Deno.serve(
       {
         port,
         hostname: host,
         signal: ac.signal,
+        cert,
+        key,
         onListen({ hostname, port: listenPort }) {
           if (isJson) {
             console.log(JSON.stringify({
               status: "listening",
               host: hostname,
               port: listenPort,
-              url: `ws://${hostname}:${listenPort}`,
+              url: `${wsScheme}://${hostname}:${listenPort}`,
               schedulingEnabled: enableSchedule,
             }));
           } else {
-            logger.info("WebSocket API server listening on {host}:{port}", {
-              host: hostname,
-              port: listenPort,
+            logger.info("WebSocket API server listening on {url}", {
+              url: `${wsScheme}://${hostname}:${listenPort}`,
             });
           }
         },

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -60,3 +60,17 @@ Deno.test("serveCommand has --repo-dir option", async () => {
   const repoDirOpt = options.find((o) => o.name === "repo-dir");
   assertEquals(repoDirOpt !== undefined, true);
 });
+
+Deno.test("serveCommand has --cert-file option", async () => {
+  const { serveCommand } = await import("./serve.ts");
+  const options = serveCommand.getOptions();
+  const certOpt = options.find((o) => o.name === "cert-file");
+  assertEquals(certOpt !== undefined, true);
+});
+
+Deno.test("serveCommand has --key-file option", async () => {
+  const { serveCommand } = await import("./serve.ts");
+  const options = serveCommand.getOptions();
+  const keyOpt = options.find((o) => o.name === "key-file");
+  assertEquals(keyOpt !== undefined, true);
+});


### PR DESCRIPTION
## Summary

- Add `--cert-file` and `--key-file` CLI flags to `swamp serve` for static TLS support
- Both flags required together; PEM files read at startup for fail-fast validation
- Env var alternatives: `SWAMP_SERVE_CERT_FILE` / `SWAMP_SERVE_KEY_FILE`
- `onListen` output emits `wss://` instead of `ws://` in both log and JSON modes when TLS is enabled
- TLS is transparent at the `Deno.serve` level — no changes to data plane, worker gateway, or connection handler

Closes swamp-club#675

**Follow-up issues filed:**
- Docs: swamp-club#676 (server-side TLS reference)
- UAT: swamp-club/swamp-uat#272 (serve TLS flag validation tests)

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test src/cli/commands/serve_test.ts` — 7 tests pass (2 new: `--cert-file` and `--key-file` option registration)
- [ ] Manual: `swamp serve --cert-file <path>` without `--key-file` → error
- [ ] Manual: `swamp serve --cert-file server.crt --key-file server.key` → starts with `wss://` output