### PR TITLE
feat(extensions): add --version-suffix epoch flag to extension push (swamp-club#664)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -30,6 +30,16 @@ This is the same versioning scheme used by models (see [./models.md]).
 The registry enforces unique name+version tuples. If a version conflict occurs
 during push, the CLI offers to bump the version automatically.
 
+### Epoch suffix
+
+`swamp extension push manifest.yaml --version-suffix epoch` replaces the micro
+segment with the current Unix epoch seconds, producing versions like
+`2026.06.18.1750263600`. This eliminates push collisions in CI pipelines where
+interactive version bumps aren't possible — each push gets a unique,
+monotonically increasing version without prompts. The date prefix stays
+human-readable; the epoch suffix handles uniqueness and encodes the exact
+publish time.
+
 Use `swamp extension version <name>` to query the registry for the latest
 published version and compute the next CalVer version. Accepts an extension
 name directly or `--manifest <path>` to read the name from a manifest file.

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -67,6 +67,7 @@ interface ExtensionPushOptions extends GlobalOptions {
   dryRun?: boolean;
   releaseNotes?: string;
   channel?: string;
+  versionSuffix?: string;
 }
 
 async function promptConfirmation(message: string): Promise<boolean> {
@@ -204,6 +205,10 @@ export const extensionPushCommand = new Command()
     "--channel <channel:string>",
     "Release channel: 'beta' or 'rc' (default: stable)",
   )
+  .option(
+    "--version-suffix <type:string>",
+    "Override version micro segment: 'epoch' uses Unix timestamp (e.g. 2026.06.18.1750263600)",
+  )
   .action(async function (options: ExtensionPushOptions, manifestPath: string) {
     if (
       options.channel !== undefined &&
@@ -211,6 +216,14 @@ export const extensionPushCommand = new Command()
     ) {
       throw new UserError(
         `Invalid channel: "${options.channel}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
+      );
+    }
+    if (
+      options.versionSuffix !== undefined &&
+      options.versionSuffix !== "epoch"
+    ) {
+      throw new UserError(
+        `Invalid version suffix: "${options.versionSuffix}". Must be "epoch".`,
       );
     }
     const cliCtx = createContext(options, ["extension", "push"]);
@@ -254,6 +267,13 @@ export const extensionPushCommand = new Command()
       additionalFilePaths,
       binaryFilePaths,
     } = resolved;
+
+    // 2a. Override version micro with epoch seconds when requested.
+    if (options.versionSuffix === "epoch") {
+      manifest.version = CalVer.withEpochMicro().value;
+      cliCtx.logger
+        .debug`Version overridden with epoch suffix: ${manifest.version}`;
+    }
 
     // 2b. Detect project config for project-aware bundling and quality checks.
     const absoluteManifestPath = resolve(repoDir, manifestPath);

--- a/src/domain/models/calver.ts
+++ b/src/domain/models/calver.ts
@@ -121,6 +121,22 @@ export class CalVer {
   }
 
   /**
+   * Creates a CalVer version using the current date prefix and Unix epoch
+   * seconds as the micro segment, e.g. `2026.06.18.1750263600`.
+   *
+   * Designed for CI pipelines where each push needs a unique,
+   * monotonically increasing version without interactive prompts.
+   */
+  static withEpochMicro(): CalVer {
+    const now = new Date();
+    const yyyy = String(now.getFullYear());
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const epochSeconds = Math.floor(now.getTime() / 1000);
+    return new CalVer(`${yyyy}.${mm}.${dd}.${epochSeconds}`);
+  }
+
+  /**
    * Value equality.
    */
   equals(other: CalVer): boolean {

--- a/src/domain/models/calver_test.ts
+++ b/src/domain/models/calver_test.ts
@@ -176,6 +176,31 @@ Deno.test("CalVer.bump resets micro to 1 when previous has different date", () =
   assertEquals(result.value, `${yyyy}.${mm}.${dd}.1`);
 });
 
+// --- withEpochMicro ---
+
+Deno.test("CalVer.withEpochMicro returns today's date with epoch seconds micro", () => {
+  const before = Math.floor(Date.now() / 1000);
+  const result = CalVer.withEpochMicro();
+  const after = Math.floor(Date.now() / 1000);
+
+  const now = new Date();
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const expectedPrefix = `${yyyy}.${mm}.${dd}.`;
+
+  assertEquals(result.value.startsWith(expectedPrefix), true);
+
+  const micro = Number(result.value.split(".")[3]);
+  assertEquals(micro >= before, true);
+  assertEquals(micro <= after, true);
+});
+
+Deno.test("CalVer.withEpochMicro produces a valid CalVer", () => {
+  const result = CalVer.withEpochMicro();
+  assertEquals(CalVer.isValid(result.value), true);
+});
+
 // --- toString ---
 
 Deno.test("CalVer.toString returns the raw string", () => {


### PR DESCRIPTION
## Summary

- Add `--version-suffix epoch` flag to `swamp extension push` that overrides the CalVer micro segment with Unix epoch seconds (e.g. `2026.06.18.1750263600`)
- Add `CalVer.withEpochMicro()` factory method to the CalVer value object
- Eliminates push collisions in CI pipelines where interactive version bumps aren't available

Closes swamp-club#664

## Test Plan

- [x] Unit tests for `CalVer.withEpochMicro()` (format, date prefix, epoch range, validity)
- [x] Compiled binary and verified `--version-suffix epoch` in a dry-run push produces epoch-stamped version
- [x] Verified invalid suffix values are rejected with clear error
- [x] Verified omitting the flag preserves existing behavior (manifest version used as-is)
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass