### PR TITLE
feat(access): add swamp access CLI commands (swamp-club#678)

### DIFF
--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -1,0 +1,34 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { groupCommandAction } from "../group_action.ts";
+import { accessGrantCommand } from "./access_grant.ts";
+import { accessGroupCommand } from "./access_group.ts";
+import { accessCheckCommand } from "./access_check.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+
+export const accessCommand = new Command()
+  .name("access")
+  .description("Manage authorization grants, groups, and access checks")
+  .error(unknownCommandErrorHandler)
+  .action(groupCommandAction)
+  .command("grant", accessGrantCommand)
+  .command("group", accessGroupCommand)
+  .command("check", accessCheckCommand);

--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { parsePrincipal } from "../../domain/access/principal.ts";
+import { type Action, ActionSchema } from "../../domain/access/action.ts";
+import { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
+import { GrantBasedAccessDecisionService } from "../../domain/access/grant_based_access_decision_service.ts";
+import { EventBus } from "../../domain/events/event_bus.ts";
+import { parseResourceFlag } from "./access_grant.ts";
+import { createAccessCheckRenderer } from "../../presentation/renderers/access_check.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessCheckCommand = new Command()
+  .name("check")
+  .description(
+    "Explain whether a subject can perform an action on a resource",
+  )
+  .example(
+    "Check access",
+    "swamp access check --subject user:adam --action run --on workflow:@acme/deploy",
+  )
+  .example(
+    "With simulated IdP groups",
+    "swamp access check --subject user:adam --action run --on workflow:@acme/deploy --collectives platform-eng,ops",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--subject <subject:string>",
+    "Subject to check (e.g. user:adam)",
+    { required: true },
+  )
+  .option(
+    "--action <action:string>",
+    "Action to check (run, read, write, admin)",
+    { required: true },
+  )
+  .option(
+    "--on <resource:string>",
+    "Resource to check (e.g. workflow:@acme/deploy)",
+    { required: true },
+  )
+  .option(
+    "--collectives <collectives:string>",
+    "Comma-separated IdP group memberships to simulate",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "check",
+    ]);
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+    await modelRegistry.ensureLoaded();
+
+    const principal = parsePrincipal(options.subject as string);
+    const actionResult = ActionSchema.safeParse(options.action);
+    if (!actionResult.success) {
+      throw new UserError(
+        `Invalid action "${options.action}": must be one of run, read, write, admin`,
+      );
+    }
+    const action: Action = actionResult.data;
+    const resource = parseResourceFlag(options.on as string);
+
+    const collectives = options.collectives
+      ? (options.collectives as string).split(",").map((c: string) => c.trim())
+        .filter((c: string) => c.length > 0)
+      : [];
+
+    const eventBus = new EventBus();
+    const loader = new PolicySnapshotLoader(
+      repoContext.dataQueryService,
+      eventBus,
+    );
+
+    try {
+      const snapshot = await loader.load();
+      const service = new GrantBasedAccessDecisionService(snapshot);
+
+      const accessPrincipal = { principal, collectives };
+      const accessResource = {
+        kind: resource.kind as "workflow" | "model" | "data" | "access",
+        name: resource.pattern,
+        fields: {},
+      };
+
+      const decisions = service.explain(
+        accessPrincipal,
+        action,
+        accessResource,
+      );
+
+      const renderer = createAccessCheckRenderer(ctx.outputMode);
+      renderer.render({
+        subject: options.subject as string,
+        action: options.action as string,
+        resource: options.on as string,
+        collectives,
+        decisions,
+      });
+    } finally {
+      loader.dispose();
+    }
+  });

--- a/src/cli/commands/access_check_test.ts
+++ b/src/cli/commands/access_check_test.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("accessCheckCommand: module loads", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  assertEquals(accessCheckCommand.getName(), "check");
+});
+
+Deno.test("accessCheckCommand: has correct description", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  assertEquals(
+    accessCheckCommand.getDescription(),
+    "Explain whether a subject can perform an action on a resource",
+  );
+});
+
+Deno.test("accessCheckCommand: has --subject option", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  const options = accessCheckCommand.getOptions();
+  const opt = options.find((o) => o.name === "subject");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCheckCommand: has --action option", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  const options = accessCheckCommand.getOptions();
+  const opt = options.find((o) => o.name === "action");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCheckCommand: has --on option", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  const options = accessCheckCommand.getOptions();
+  const opt = options.find((o) => o.name === "on");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCheckCommand: has --collectives option", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  const options = accessCheckCommand.getOptions();
+  const opt = options.find((o) => o.name === "collectives");
+  assertEquals(opt !== undefined, true);
+});

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -1,0 +1,522 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { groupCommandAction } from "../group_action.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoReadOnly,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../auto_resolver_context.ts";
+import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import { runFileSink } from "../../infrastructure/logging/logger.ts";
+import { GIT_SHA } from "./version.ts";
+import { join } from "@std/path";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { SecretRedactor } from "../../domain/secrets/mod.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  modelMethodRun,
+  type ModelMethodRunDeps,
+} from "../../libswamp/mod.ts";
+import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
+import {
+  type Grant,
+  GRANT_MODEL_TYPE,
+  GrantSchema,
+} from "../../domain/models/access/grant_model.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import { createAccessGrantListRenderer } from "../../presentation/renderers/access_grant.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const LOCAL_PRINCIPAL = "user:local";
+
+export function parseResourceFlag(
+  value: string,
+): { kind: string; pattern: string } {
+  const colonIdx = value.indexOf(":");
+  if (colonIdx === -1) {
+    throw new UserError(
+      `Invalid resource selector "${value}": expected format "kind:pattern" (e.g. "workflow:@acme/*")`,
+    );
+  }
+  const kind = value.substring(0, colonIdx);
+  const pattern = value.substring(colonIdx + 1);
+  const validKinds = ["workflow", "model", "data", "access"];
+  if (!validKinds.includes(kind)) {
+    throw new UserError(
+      `Invalid resource kind "${kind}": must be one of ${
+        validKinds.join(", ")
+      }`,
+    );
+  }
+  return { kind, pattern };
+}
+
+function parseActionsFlag(value: string): string[] {
+  const actions = value.split(",").map((a) => a.trim()).filter((a) =>
+    a.length > 0
+  );
+  const validActions = ["run", "read", "write", "admin"];
+  for (const action of actions) {
+    if (!validActions.includes(action)) {
+      throw new UserError(
+        `Invalid action "${action}": must be one of ${validActions.join(", ")}`,
+      );
+    }
+  }
+  if (actions.length === 0) {
+    throw new UserError("At least one action is required");
+  }
+  return actions;
+}
+
+function buildModelMethodRunDeps(
+  repoDir: string,
+  repoContext: RepositoryContext,
+  isDirectExecution: boolean,
+): ModelMethodRunDeps {
+  return {
+    repoDir,
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+    getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+    createEvaluationService: () => {
+      const dqs = new DataQueryService(
+        repoContext.catalogStore,
+        repoContext.unifiedDataRepo,
+      );
+      return new ExpressionEvaluationService(
+        repoContext.definitionRepo,
+        repoDir,
+        {
+          dataRepo: repoContext.unifiedDataRepo,
+          dataQueryService: dqs,
+        },
+      );
+    },
+    loadEvaluatedDefinition: (type, name) =>
+      repoContext.evaluatedDefinitionRepo.findByName(type, name),
+    saveEvaluatedDefinition: (type, definition) =>
+      repoContext.evaluatedDefinitionRepo.save(type, definition),
+    createExecutionService: () => new DefaultMethodExecutionService(),
+    createVaultService: () => VaultService.fromRepository(repoDir),
+    dataRepo: repoContext.unifiedDataRepo,
+    definitionRepo: repoContext.definitionRepo,
+    outputRepo: repoContext.outputRepo,
+    dataQueryService: new DataQueryService(
+      repoContext.catalogStore,
+      repoContext.unifiedDataRepo,
+    ),
+    createRunLog: async (modelType, method, definitionId) => {
+      const redactor = new SecretRedactor();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const logFilePath = join(
+        swampPath(repoDir, SWAMP_SUBDIRS.outputs),
+        modelType.normalized,
+        method,
+        `${definitionId}-${timestamp}.log`,
+      );
+      const logCategory: string[] = [];
+      await runFileSink.register(
+        logCategory,
+        logFilePath,
+        redactor,
+        swampPath(repoDir),
+      );
+      return {
+        logFilePath,
+        redactor,
+        cleanup: () => runFileSink.unregister(logCategory),
+      };
+    },
+    createAndSaveDefinition: isDirectExecution
+      ? async (type, definition) => {
+        const autoDefRepo = new YamlDefinitionRepository(
+          repoDir,
+          undefined,
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          false,
+        );
+        await autoDefRepo.save(type, definition);
+      }
+      : undefined,
+    getDefinitionPath: isDirectExecution
+      ? (type, id) => {
+        return join(
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          type.toDirectoryPath(),
+          `${id}.yaml`,
+        );
+      }
+      : undefined,
+  };
+}
+
+export async function queryGrants(
+  repoContext: RepositoryContext,
+): Promise<{ grant: Grant; instanceName: string }[]> {
+  const records = await repoContext.dataQueryService.query(
+    `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
+    { loadAttributes: true },
+  );
+
+  const results: { grant: Grant; instanceName: string }[] = [];
+  for (const record of records) {
+    const dataRecord = record as DataRecord;
+    const parsed = GrantSchema.safeParse(dataRecord.attributes);
+    if (parsed.success) {
+      results.push({
+        grant: parsed.data,
+        instanceName: dataRecord.modelName ?? "",
+      });
+    }
+  }
+  return results;
+}
+
+const accessGrantCreateCommand = new Command()
+  .name("create")
+  .description("Create a new authorization grant")
+  .example(
+    "Allow a group to run workflows",
+    "swamp access grant create --subject idp-group:platform-eng --allow run --on 'workflow:@acme/*'",
+  )
+  .example(
+    "With a CEL condition",
+    "swamp access grant create --subject idp-group:platform-eng --allow run --on 'workflow:@acme/*' --when 'tags.env == \"staging\"'",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--subject <subject:string>",
+    "Grant subject (e.g. user:adam, group:release-managers, idp-group:platform-eng)",
+    { required: true },
+  )
+  .option("--allow <actions:string>", "Actions to allow (comma-separated)")
+  .option("--deny <actions:string>", "Actions to deny (comma-separated)")
+  .option(
+    "--on <resource:string>",
+    "Resource selector (e.g. workflow:@acme/*, model:@acme/deploy)",
+    { required: true },
+  )
+  .option("--when <condition:string>", "Optional CEL condition")
+  .action(async function (options: AnyOptions) {
+    if (!options.allow && !options.deny) {
+      throw new UserError("Either --allow or --deny must be specified");
+    }
+    if (options.allow && options.deny) {
+      throw new UserError("Cannot specify both --allow and --deny");
+    }
+
+    const effect = options.allow ? "allow" : "deny";
+    const actions = parseActionsFlag(
+      (options.allow ?? options.deny) as string,
+    );
+    const resource = parseResourceFlag(options.on as string);
+
+    const instanceName = `grant-${crypto.randomUUID().slice(0, 8)}`;
+
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "grant",
+      "create",
+    ]);
+    const { repoDir, repoContext, datastoreConfig, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: ctx.outputMode,
+      });
+
+    await Promise.all([
+      modelRegistry.ensureLoaded(),
+      vaultTypeRegistry.ensureLoaded(),
+      reportRegistry.ensureLoaded(),
+    ]);
+
+    const deps = buildModelMethodRunDeps(repoDir, repoContext, true);
+
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      instanceName,
+    );
+    let flushModelLocks: (() => Promise<void>) | null = null;
+    if (preResult) {
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+      flushModelLocks = lockResult.flush;
+    }
+
+    try {
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: instanceName,
+        methodName: "create",
+      });
+
+      await consumeStream(
+        modelMethodRun(createLibSwampContext(), deps, {
+          modelIdOrName: `@${GRANT_MODEL_TYPE.normalized}`,
+          methodName: "create",
+          inputs: {
+            subject: options.subject as string,
+            effect,
+            actions,
+            resourceKind: resource.kind,
+            resourcePattern: resource.pattern,
+            condition: options.when as string | undefined,
+            source: "method",
+            createdBy: LOCAL_PRINCIPAL,
+          },
+          lastEvaluated: false,
+          typeArg: `@${GRANT_MODEL_TYPE.normalized}`,
+          definitionName: instanceName,
+          skipAllReports: true,
+          swampSha: GIT_SHA || undefined,
+        }),
+        renderer.handlers(),
+      );
+
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+    } catch (error) {
+      if (error instanceof UserError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new UserError(`Grant creation failed: ${message}`);
+    } finally {
+      if (flushModelLocks) {
+        try {
+          await flushModelLocks();
+        } catch (releaseError) {
+          ctx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
+    }
+  });
+
+const accessGrantListCommand = new Command()
+  .name("list")
+  .description("List authorization grants")
+  .example("List all grants", "swamp access grant list")
+  .example(
+    "Filter by subject",
+    "swamp access grant list --subject idp-group:platform-eng",
+  )
+  .example(
+    "Filter by resource",
+    "swamp access grant list --on 'workflow:@acme/*'",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--subject <subject:string>", "Filter by subject")
+  .option("--on <resource:string>", "Filter by resource selector")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "grant",
+      "list",
+    ]);
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+    await modelRegistry.ensureLoaded();
+
+    let results = await queryGrants(repoContext);
+
+    results = results.filter((r) => r.grant.state === "active");
+
+    if (options.subject) {
+      const subjectFilter = options.subject as string;
+      results = results.filter((r) => {
+        const subjectStr = `${r.grant.subject.kind}:${r.grant.subject.name}`;
+        return subjectStr === subjectFilter;
+      });
+    }
+
+    if (options.on) {
+      const resource = parseResourceFlag(options.on as string);
+      results = results.filter((r) =>
+        r.grant.resource.kind === resource.kind &&
+        r.grant.resource.pattern === resource.pattern
+      );
+    }
+
+    const grants = results.map((r) => r.grant);
+    const renderer = createAccessGrantListRenderer(ctx.outputMode);
+    renderer.render(grants);
+  });
+
+const accessGrantRevokeCommand = new Command()
+  .name("revoke")
+  .description("Revoke an authorization grant")
+  .example("Revoke a grant", "swamp access grant revoke 7f3a1b2c-...")
+  .arguments("<grant_id:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions, grantId: string) {
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "grant",
+      "revoke",
+    ]);
+    const { repoDir, repoContext, datastoreConfig, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: ctx.outputMode,
+      });
+
+    await Promise.all([
+      modelRegistry.ensureLoaded(),
+      vaultTypeRegistry.ensureLoaded(),
+      reportRegistry.ensureLoaded(),
+    ]);
+
+    const allGrants = await queryGrants(repoContext);
+    const match = allGrants.find((r) => r.grant.id === grantId);
+    if (!match) {
+      throw new UserError(`Grant not found: ${grantId}`);
+    }
+    if (match.grant.state === "revoked") {
+      ctx.logger.info`Grant ${grantId} is already revoked`;
+      return;
+    }
+
+    const deps = buildModelMethodRunDeps(repoDir, repoContext, false);
+
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      match.instanceName,
+    );
+    let flushModelLocks: (() => Promise<void>) | null = null;
+    if (preResult) {
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+      flushModelLocks = lockResult.flush;
+    }
+
+    try {
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: match.instanceName,
+        methodName: "revoke",
+      });
+
+      await consumeStream(
+        modelMethodRun(createLibSwampContext(), deps, {
+          modelIdOrName: match.instanceName,
+          methodName: "revoke",
+          inputs: {},
+          lastEvaluated: false,
+          skipAllReports: true,
+          swampSha: GIT_SHA || undefined,
+        }),
+        renderer.handlers(),
+      );
+
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+    } catch (error) {
+      if (error instanceof UserError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new UserError(`Grant revocation failed: ${message}`);
+    } finally {
+      if (flushModelLocks) {
+        try {
+          await flushModelLocks();
+        } catch (releaseError) {
+          ctx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
+    }
+  });
+
+export const accessGrantCommand = new Command()
+  .name("grant")
+  .description("Manage authorization grants")
+  .action(groupCommandAction)
+  .command("create", accessGrantCreateCommand)
+  .command("list", accessGrantListCommand)
+  .command("revoke", accessGrantRevokeCommand);

--- a/src/cli/commands/access_grant_test.ts
+++ b/src/cli/commands/access_grant_test.ts
@@ -1,0 +1,153 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("accessGrantCommand: module loads", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  assertEquals(accessGrantCommand.getName(), "grant");
+});
+
+Deno.test("accessGrantCommand: has correct description", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  assertEquals(
+    accessGrantCommand.getDescription(),
+    "Manage authorization grants",
+  );
+});
+
+Deno.test("accessGrantCommand: has create subcommand", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create");
+  assertEquals(createCmd !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: has list subcommand", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const listCmd = commands.find((c) => c.getName() === "list");
+  assertEquals(listCmd !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: has revoke subcommand", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const revokeCmd = commands.find((c) => c.getName() === "revoke");
+  assertEquals(revokeCmd !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: create has --subject option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const subjectOpt = options.find((o) => o.name === "subject");
+  assertEquals(subjectOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: create has --allow option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const allowOpt = options.find((o) => o.name === "allow");
+  assertEquals(allowOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: create has --deny option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const denyOpt = options.find((o) => o.name === "deny");
+  assertEquals(denyOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: create has --on option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const onOpt = options.find((o) => o.name === "on");
+  assertEquals(onOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: create has --when option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const whenOpt = options.find((o) => o.name === "when");
+  assertEquals(whenOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: revoke accepts grant_id argument", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const revokeCmd = commands.find((c) => c.getName() === "revoke")!;
+  const args = revokeCmd.getArguments();
+  assertEquals(args.length, 1);
+});
+
+Deno.test("parseResourceFlag: parses workflow resource", async () => {
+  const { parseResourceFlag } = await import("./access_grant.ts");
+  const result = parseResourceFlag("workflow:@acme/*");
+  assertEquals(result.kind, "workflow");
+  assertEquals(result.pattern, "@acme/*");
+});
+
+Deno.test("parseResourceFlag: parses model resource", async () => {
+  const { parseResourceFlag } = await import("./access_grant.ts");
+  const result = parseResourceFlag("model:@acme/deploy");
+  assertEquals(result.kind, "model");
+  assertEquals(result.pattern, "@acme/deploy");
+});
+
+Deno.test("parseResourceFlag: preserves colons in pattern", async () => {
+  const { parseResourceFlag } = await import("./access_grant.ts");
+  const result = parseResourceFlag("data:ns:name");
+  assertEquals(result.kind, "data");
+  assertEquals(result.pattern, "ns:name");
+});
+
+Deno.test("parseResourceFlag: throws on missing colon", async () => {
+  const { parseResourceFlag } = await import("./access_grant.ts");
+  assertThrows(
+    () => parseResourceFlag("invalid"),
+    Error,
+    "expected format",
+  );
+});
+
+Deno.test("parseResourceFlag: throws on invalid kind", async () => {
+  const { parseResourceFlag } = await import("./access_grant.ts");
+  assertThrows(
+    () => parseResourceFlag("unknown:pattern"),
+    Error,
+    "Invalid resource kind",
+  );
+});

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -1,0 +1,415 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { groupCommandAction } from "../group_action.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoReadOnly,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../auto_resolver_context.ts";
+import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import { runFileSink } from "../../infrastructure/logging/logger.ts";
+import { GIT_SHA } from "./version.ts";
+import { join } from "@std/path";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { SecretRedactor } from "../../domain/secrets/mod.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  modelMethodRun,
+  type ModelMethodRunDeps,
+} from "../../libswamp/mod.ts";
+import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
+import {
+  type Group,
+  GROUP_MODEL_TYPE,
+  GroupSchema,
+} from "../../domain/models/access/group_model.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import { createAccessGroupListRenderer } from "../../presentation/renderers/access_group.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const LOCAL_PRINCIPAL = "user:local";
+
+function buildModelMethodRunDeps(
+  repoDir: string,
+  repoContext: RepositoryContext,
+  isDirectExecution: boolean,
+): ModelMethodRunDeps {
+  return {
+    repoDir,
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+    getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+    createEvaluationService: () => {
+      const dqs = new DataQueryService(
+        repoContext.catalogStore,
+        repoContext.unifiedDataRepo,
+      );
+      return new ExpressionEvaluationService(
+        repoContext.definitionRepo,
+        repoDir,
+        {
+          dataRepo: repoContext.unifiedDataRepo,
+          dataQueryService: dqs,
+        },
+      );
+    },
+    loadEvaluatedDefinition: (type, name) =>
+      repoContext.evaluatedDefinitionRepo.findByName(type, name),
+    saveEvaluatedDefinition: (type, definition) =>
+      repoContext.evaluatedDefinitionRepo.save(type, definition),
+    createExecutionService: () => new DefaultMethodExecutionService(),
+    createVaultService: () => VaultService.fromRepository(repoDir),
+    dataRepo: repoContext.unifiedDataRepo,
+    definitionRepo: repoContext.definitionRepo,
+    outputRepo: repoContext.outputRepo,
+    dataQueryService: new DataQueryService(
+      repoContext.catalogStore,
+      repoContext.unifiedDataRepo,
+    ),
+    createRunLog: async (modelType, method, definitionId) => {
+      const redactor = new SecretRedactor();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const logFilePath = join(
+        swampPath(repoDir, SWAMP_SUBDIRS.outputs),
+        modelType.normalized,
+        method,
+        `${definitionId}-${timestamp}.log`,
+      );
+      const logCategory: string[] = [];
+      await runFileSink.register(
+        logCategory,
+        logFilePath,
+        redactor,
+        swampPath(repoDir),
+      );
+      return {
+        logFilePath,
+        redactor,
+        cleanup: () => runFileSink.unregister(logCategory),
+      };
+    },
+    createAndSaveDefinition: isDirectExecution
+      ? async (type, definition) => {
+        const autoDefRepo = new YamlDefinitionRepository(
+          repoDir,
+          undefined,
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          false,
+        );
+        await autoDefRepo.save(type, definition);
+      }
+      : undefined,
+    getDefinitionPath: isDirectExecution
+      ? (type, id) => {
+        return join(
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          type.toDirectoryPath(),
+          `${id}.yaml`,
+        );
+      }
+      : undefined,
+  };
+}
+
+async function queryGroups(
+  repoContext: RepositoryContext,
+): Promise<{ group: Group; instanceName: string }[]> {
+  const records = await repoContext.dataQueryService.query(
+    `modelType == "${GROUP_MODEL_TYPE.normalized}"`,
+    { loadAttributes: true },
+  );
+
+  const results: { group: Group; instanceName: string }[] = [];
+  for (const record of records) {
+    const dataRecord = record as DataRecord;
+    const parsed = GroupSchema.safeParse(dataRecord.attributes);
+    if (parsed.success) {
+      results.push({
+        group: parsed.data,
+        instanceName: dataRecord.modelName ?? "",
+      });
+    }
+  }
+  return results;
+}
+
+async function runGroupMethod(
+  options: AnyOptions,
+  instanceName: string,
+  methodName: string,
+  inputs: Record<string, unknown>,
+  loggerCategory: string[],
+  isDirectExecution: boolean,
+): Promise<void> {
+  const ctx = createContext(options as GlobalOptions, loggerCategory);
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+  await Promise.all([
+    modelRegistry.ensureLoaded(),
+    vaultTypeRegistry.ensureLoaded(),
+    reportRegistry.ensureLoaded(),
+  ]);
+
+  const deps = buildModelMethodRunDeps(repoDir, repoContext, isDirectExecution);
+
+  const preResult = await findDefinitionByIdOrName(
+    repoContext.definitionRepo,
+    instanceName,
+  );
+  let flushModelLocks: (() => Promise<void>) | null = null;
+  if (preResult) {
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
+      repoDir,
+      syncService,
+      repoContext.catalogStore,
+    );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+    flushModelLocks = lockResult.flush;
+  }
+
+  try {
+    const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+      modelName: instanceName,
+      methodName,
+    });
+
+    const typeArg = isDirectExecution
+      ? `@${GROUP_MODEL_TYPE.normalized}`
+      : undefined;
+    const definitionName = isDirectExecution ? instanceName : undefined;
+
+    await consumeStream(
+      modelMethodRun(createLibSwampContext(), deps, {
+        modelIdOrName: isDirectExecution
+          ? `@${GROUP_MODEL_TYPE.normalized}`
+          : instanceName,
+        methodName,
+        inputs,
+        lastEvaluated: false,
+        typeArg,
+        definitionName,
+        skipAllReports: true,
+        swampSha: GIT_SHA || undefined,
+      }),
+      renderer.handlers(),
+    );
+
+    if (renderer.runFailed()) {
+      Deno.exitCode = 1;
+    }
+  } catch (error) {
+    if (error instanceof UserError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UserError(`Group operation failed: ${message}`);
+  } finally {
+    if (flushModelLocks) {
+      try {
+        await flushModelLocks();
+      } catch (releaseError) {
+        ctx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
+          },
+        );
+      }
+    }
+  }
+}
+
+const accessGroupCreateCommand = new Command()
+  .name("create")
+  .description("Create a local group")
+  .example("Create a group", "swamp access group create release-managers")
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    await runGroupMethod(
+      options,
+      name,
+      "create",
+      { createdBy: LOCAL_PRINCIPAL },
+      ["access", "group", "create"],
+      true,
+    );
+  });
+
+const accessGroupAddMemberCommand = new Command()
+  .name("add-member")
+  .description("Add a principal to a group")
+  .example(
+    "Add a user",
+    "swamp access group add-member release-managers user:adam",
+  )
+  .arguments("<group:string> <principal:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (
+    options: AnyOptions,
+    group: string,
+    principal: string,
+  ) {
+    await runGroupMethod(
+      options,
+      group,
+      "add-member",
+      { principal },
+      ["access", "group", "add-member"],
+      false,
+    );
+  });
+
+const accessGroupRemoveMemberCommand = new Command()
+  .name("remove-member")
+  .description("Remove a principal from a group")
+  .example(
+    "Remove a user",
+    "swamp access group remove-member release-managers user:adam",
+  )
+  .arguments("<group:string> <principal:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (
+    options: AnyOptions,
+    group: string,
+    principal: string,
+  ) {
+    await runGroupMethod(
+      options,
+      group,
+      "remove-member",
+      { principal },
+      ["access", "group", "remove-member"],
+      false,
+    );
+  });
+
+const accessGroupListCommand = new Command()
+  .name("list")
+  .description("List all groups")
+  .example("List groups", "swamp access group list")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "group",
+      "list",
+    ]);
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+    await modelRegistry.ensureLoaded();
+
+    const results = await queryGroups(repoContext);
+    const groups = results.map((r) => r.group);
+    const renderer = createAccessGroupListRenderer(ctx.outputMode);
+    renderer.renderList(groups);
+  });
+
+const accessGroupMembersCommand = new Command()
+  .name("members")
+  .description("List members of a group")
+  .example("Show members", "swamp access group members release-managers")
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "group",
+      "members",
+    ]);
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+    await modelRegistry.ensureLoaded();
+
+    const results = await queryGroups(repoContext);
+    const match = results.find((r) => r.group.name === name);
+    if (!match) {
+      throw new UserError(`Group not found: ${name}`);
+    }
+
+    const renderer = createAccessGroupListRenderer(ctx.outputMode);
+    renderer.renderMembers(match.group);
+  });
+
+export const accessGroupCommand = new Command()
+  .name("group")
+  .description("Manage local groups")
+  .action(groupCommandAction)
+  .command("create", accessGroupCreateCommand)
+  .command("add-member", accessGroupAddMemberCommand)
+  .command("remove-member", accessGroupRemoveMemberCommand)
+  .command("list", accessGroupListCommand)
+  .command("members", accessGroupMembersCommand);

--- a/src/cli/commands/access_group_test.ts
+++ b/src/cli/commands/access_group_test.ts
@@ -1,0 +1,99 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("accessGroupCommand: module loads", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  assertEquals(accessGroupCommand.getName(), "group");
+});
+
+Deno.test("accessGroupCommand: has correct description", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  assertEquals(
+    accessGroupCommand.getDescription(),
+    "Manage local groups",
+  );
+});
+
+Deno.test("accessGroupCommand: has create subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "create");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: has add-member subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "add-member");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: has remove-member subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "remove-member");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: has list subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "list");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: has members subcommand", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const cmd = commands.find((c) => c.getName() === "members");
+  assertEquals(cmd !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: create accepts name argument", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const args = createCmd.getArguments();
+  assertEquals(args.length, 1);
+});
+
+Deno.test("accessGroupCommand: add-member accepts group and principal arguments", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const addCmd = commands.find((c) => c.getName() === "add-member")!;
+  const args = addCmd.getArguments();
+  assertEquals(args.length, 2);
+});
+
+Deno.test("accessGroupCommand: members accepts name argument", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const membersCmd = commands.find((c) => c.getName() === "members")!;
+  const args = membersCmd.getArguments();
+  assertEquals(args.length, 1);
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -38,6 +38,7 @@ import { auditCommand } from "./commands/audit.ts";
 import { updateCommand } from "./commands/update.ts";
 import { configCommand } from "./commands/config.ts";
 import { sourceCommand } from "./commands/source.ts";
+import { accessCommand } from "./commands/access.ts";
 import { authCommand } from "./commands/auth.ts";
 import { extensionCommand } from "./commands/extension.ts";
 import { summariseCommand } from "./commands/summarise.ts";
@@ -1230,6 +1231,7 @@ export async function runCli(args: string[]): Promise<void> {
     })
     .error(unknownCommandErrorHandler)
     .action(groupCommandAction)
+    .command("access", accessCommand)
     .command("version", versionCommand)
     .command("model", modelCommand)
     .command("init", repoInitCommand)

--- a/src/presentation/renderers/access_check.ts
+++ b/src/presentation/renderers/access_check.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AccessDecision } from "../../domain/access/access_decision_service.ts";
+import type { OutputMode } from "../output/output.ts";
+
+export interface AccessCheckResult {
+  subject: string;
+  action: string;
+  resource: string;
+  collectives: string[];
+  decisions: AccessDecision[];
+}
+
+export interface AccessCheckRenderer {
+  render(result: AccessCheckResult): void;
+}
+
+function formatSubject(subject: AccessDecision["subject"]): string {
+  return `${subject.kind}:${subject.name}`;
+}
+
+class LogAccessCheckRenderer implements AccessCheckRenderer {
+  render(result: AccessCheckResult): void {
+    if (result.decisions.length === 0) {
+      console.log(
+        `DENY (implicit) — no matching grants for ${result.subject} ${result.action} ${result.resource}`,
+      );
+      return;
+    }
+
+    const firstDecision = result.decisions[0];
+    const effect = firstDecision.effect.toUpperCase();
+    const via = `grant ${firstDecision.grantId.slice(0, 8)}…`;
+    const subject = formatSubject(firstDecision.subject);
+    console.log(
+      `${effect} via ${via} (${subject} → ${result.action} → ${result.resource})`,
+    );
+
+    if (result.decisions.length > 1) {
+      console.log();
+      console.log("All matching grants:");
+      for (const decision of result.decisions) {
+        const e = decision.effect.toUpperCase().padEnd(5);
+        const g = decision.grantId.slice(0, 8);
+        const s = formatSubject(decision.subject);
+        const cond = decision.condition ? ` [when: ${decision.condition}]` : "";
+        console.log(`  ${e}  ${g}…  via ${s}${cond}`);
+      }
+    }
+  }
+}
+
+class JsonAccessCheckRenderer implements AccessCheckRenderer {
+  render(result: AccessCheckResult): void {
+    const finalEffect = result.decisions.length > 0
+      ? result.decisions[0].effect
+      : "deny";
+    console.log(
+      JSON.stringify(
+        {
+          subject: result.subject,
+          action: result.action,
+          resource: result.resource,
+          collectives: result.collectives,
+          effect: finalEffect,
+          matchingGrants: result.decisions,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+export function createAccessCheckRenderer(
+  mode: OutputMode,
+): AccessCheckRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessCheckRenderer();
+    case "log":
+      return new LogAccessCheckRenderer();
+  }
+}

--- a/src/presentation/renderers/access_check_test.ts
+++ b/src/presentation/renderers/access_check_test.ts
@@ -1,0 +1,98 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import {
+  type AccessCheckResult,
+  createAccessCheckRenderer,
+} from "./access_check.ts";
+
+function makeResult(
+  overrides: Partial<AccessCheckResult> = {},
+): AccessCheckResult {
+  return {
+    subject: "user:adam",
+    action: "run",
+    resource: "workflow:@acme/deploy",
+    collectives: [],
+    decisions: [{
+      effect: "allow",
+      grantId: "test-uuid-1234-5678-abcd-ef0123456789",
+      subject: { kind: "idp-group", name: "platform-eng" },
+    }],
+    ...overrides,
+  };
+}
+
+Deno.test("accessCheckRenderer log: shows ALLOW", () => {
+  const renderer = createAccessCheckRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult());
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "ALLOW");
+  assertStringIncludes(output[0], "test-uui");
+});
+
+Deno.test("accessCheckRenderer log: shows DENY when no decisions", () => {
+  const renderer = createAccessCheckRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult({ decisions: [] }));
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "DENY");
+  assertStringIncludes(output[0], "no matching grants");
+});
+
+Deno.test("accessCheckRenderer json: outputs structured JSON", () => {
+  const renderer = createAccessCheckRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult());
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertStringIncludes(parsed.effect, "allow");
+  assertStringIncludes(parsed.subject, "user:adam");
+});
+
+Deno.test("accessCheckRenderer json: implicit deny when no grants", () => {
+  const renderer = createAccessCheckRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(makeResult({ decisions: [] }));
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertStringIncludes(parsed.effect, "deny");
+});

--- a/src/presentation/renderers/access_grant.ts
+++ b/src/presentation/renderers/access_grant.ts
@@ -1,0 +1,80 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Grant } from "../../domain/models/access/grant_model.ts";
+import type { OutputMode } from "../output/output.ts";
+
+export interface AccessGrantListRenderer {
+  render(grants: Grant[]): void;
+}
+
+function formatSubject(subject: Grant["subject"]): string {
+  return `${subject.kind}:${subject.name}`;
+}
+
+function formatResource(resource: Grant["resource"]): string {
+  return `${resource.kind}:${resource.pattern}`;
+}
+
+class LogAccessGrantListRenderer implements AccessGrantListRenderer {
+  render(grants: Grant[]): void {
+    if (grants.length === 0) {
+      console.log("No active grants found.");
+      return;
+    }
+
+    const idWidth = 8;
+    const header = `${"ID".padEnd(idWidth)}  ${"SUBJECT".padEnd(28)}  ${
+      "EFFECT".padEnd(6)
+    }  ${"ACTIONS".padEnd(20)}  ${"RESOURCE".padEnd(28)}  ${
+      "CONDITION".padEnd(20)
+    }  SOURCE`;
+    console.log(header);
+
+    for (const grant of grants) {
+      const id = grant.id.slice(0, idWidth);
+      const subject = formatSubject(grant.subject).padEnd(28);
+      const effect = grant.effect.padEnd(6);
+      const actions = grant.actions.join(",").padEnd(20);
+      const resource = formatResource(grant.resource).padEnd(28);
+      const condition = (grant.condition ?? "").padEnd(20);
+      const source = grant.source;
+      console.log(
+        `${id}  ${subject}  ${effect}  ${actions}  ${resource}  ${condition}  ${source}`,
+      );
+    }
+  }
+}
+
+class JsonAccessGrantListRenderer implements AccessGrantListRenderer {
+  render(grants: Grant[]): void {
+    console.log(JSON.stringify(grants, null, 2));
+  }
+}
+
+export function createAccessGrantListRenderer(
+  mode: OutputMode,
+): AccessGrantListRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessGrantListRenderer();
+    case "log":
+      return new LogAccessGrantListRenderer();
+  }
+}

--- a/src/presentation/renderers/access_grant_test.ts
+++ b/src/presentation/renderers/access_grant_test.ts
@@ -1,0 +1,95 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { createAccessGrantListRenderer } from "./access_grant.ts";
+import type { Grant } from "../../domain/models/access/grant_model.ts";
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: "test-uuid-1234-5678-abcd-ef0123456789",
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "local" },
+    createdAt: "2026-06-18T00:00:00Z",
+    ...overrides,
+  };
+}
+
+Deno.test("accessGrantListRenderer log: shows header", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "ID");
+  assertStringIncludes(output[0], "SUBJECT");
+  assertStringIncludes(output[0], "EFFECT");
+});
+
+Deno.test("accessGrantListRenderer log: shows grant data", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "test-uui");
+  assertStringIncludes(output[1], "user:adam");
+  assertStringIncludes(output[1], "allow");
+  assertStringIncludes(output[1], "workflow:@acme/*");
+});
+
+Deno.test("accessGrantListRenderer log: shows empty message", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "No active grants found");
+});
+
+Deno.test("accessGrantListRenderer json: outputs JSON array", () => {
+  const renderer = createAccessGrantListRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant()]);
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertStringIncludes(parsed[0].id, "test-uuid");
+});

--- a/src/presentation/renderers/access_group.ts
+++ b/src/presentation/renderers/access_group.ts
@@ -1,0 +1,85 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Group } from "../../domain/models/access/group_model.ts";
+import type { OutputMode } from "../output/output.ts";
+
+export interface AccessGroupListRenderer {
+  renderList(groups: Group[]): void;
+  renderMembers(group: Group): void;
+}
+
+function formatPrincipal(p: { kind: string; id: string }): string {
+  return `${p.kind}:${p.id}`;
+}
+
+class LogAccessGroupListRenderer implements AccessGroupListRenderer {
+  renderList(groups: Group[]): void {
+    if (groups.length === 0) {
+      console.log("No groups found.");
+      return;
+    }
+
+    const header = `${"NAME".padEnd(30)}  ${"MEMBERS".padEnd(8)}  ${
+      "CREATED BY".padEnd(20)
+    }  CREATED AT`;
+    console.log(header);
+
+    for (const group of groups) {
+      const name = group.name.padEnd(30);
+      const members = String(group.members.length).padEnd(8);
+      const createdBy = formatPrincipal(group.createdBy).padEnd(20);
+      const createdAt = group.createdAt.slice(0, 10);
+      console.log(`${name}  ${members}  ${createdBy}  ${createdAt}`);
+    }
+  }
+
+  renderMembers(group: Group): void {
+    if (group.members.length === 0) {
+      console.log(`Group "${group.name}" has no members.`);
+      return;
+    }
+
+    console.log(`Members of "${group.name}":`);
+    for (const member of group.members) {
+      console.log(`  ${formatPrincipal(member)}`);
+    }
+  }
+}
+
+class JsonAccessGroupListRenderer implements AccessGroupListRenderer {
+  renderList(groups: Group[]): void {
+    console.log(JSON.stringify(groups, null, 2));
+  }
+
+  renderMembers(group: Group): void {
+    console.log(JSON.stringify(group, null, 2));
+  }
+}
+
+export function createAccessGroupListRenderer(
+  mode: OutputMode,
+): AccessGroupListRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessGroupListRenderer();
+    case "log":
+      return new LogAccessGroupListRenderer();
+  }
+}

--- a/src/presentation/renderers/access_group_test.ts
+++ b/src/presentation/renderers/access_group_test.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { createAccessGroupListRenderer } from "./access_group.ts";
+import type { Group } from "../../domain/models/access/group_model.ts";
+
+function makeGroup(overrides: Partial<Group> = {}): Group {
+  return {
+    name: "release-managers",
+    members: [{ kind: "user", id: "adam" }],
+    createdBy: { kind: "user", id: "local" },
+    createdAt: "2026-06-18T00:00:00Z",
+    ...overrides,
+  };
+}
+
+Deno.test("accessGroupListRenderer log: shows header", () => {
+  const renderer = createAccessGroupListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([makeGroup()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "NAME");
+  assertStringIncludes(output[0], "MEMBERS");
+});
+
+Deno.test("accessGroupListRenderer log: shows group data", () => {
+  const renderer = createAccessGroupListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([makeGroup()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[1], "release-managers");
+  assertStringIncludes(output[1], "1");
+});
+
+Deno.test("accessGroupListRenderer log: shows empty message", () => {
+  const renderer = createAccessGroupListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "No groups found");
+});
+
+Deno.test("accessGroupListRenderer log: shows members", () => {
+  const renderer = createAccessGroupListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderMembers(makeGroup());
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "release-managers");
+  assertStringIncludes(output[1], "user:adam");
+});
+
+Deno.test("accessGroupListRenderer json: outputs JSON array", () => {
+  const renderer = createAccessGroupListRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.renderList([makeGroup()]);
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertStringIncludes(parsed[0].name, "release-managers");
+});


### PR DESCRIPTION
## Summary

- Add `swamp access` command namespace with 10 leaf commands for managing authorization grants, groups, and access checks (Layer 2 of #662)
- Grant/group CRUD operations delegate to `modelMethodRun` with `createdBy: user:local` for local CLI operations
- `access check` builds a `PolicySnapshot` via `PolicySnapshotLoader` and calls `GrantBasedAccessDecisionService.explain()`, disposing the loader after use

### Commands

| Command | Description |
|---------|-------------|
| `swamp access grant create` | Create a grant with `--subject`, `--allow`/`--deny`, `--on`, `--when` |
| `swamp access grant list` | List active grants, filterable by `--subject` and `--on` |
| `swamp access grant revoke <id>` | Revoke a grant by its UUID |
| `swamp access group create <name>` | Create a local group |
| `swamp access group add-member <group> <principal>` | Add a principal to a group |
| `swamp access group remove-member <group> <principal>` | Remove a principal from a group |
| `swamp access group list` | List all groups |
| `swamp access group members <name>` | List members of a group |
| `swamp access check` | Explain access with `--subject`, `--action`, `--on`, `--collectives` |

## Test Plan

- 45 unit tests covering command registration, option shapes, renderers (log + json modes), and `parseResourceFlag` edge cases
- `deno check` — full project type check passes
- `deno lint` — clean
- `deno fmt` — clean
- `deno run compile` — binary compiles and `./swamp access --help` renders correctly

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)