### PR TITLE
feat(access): add --server flag for remote grant management (swamp-club#681)

### DIFF
--- a/.github/actions/adversarial-review/action.yml
+++ b/.github/actions/adversarial-review/action.yml
@@ -164,9 +164,9 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
       run: |
-        latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
-          --json state,author \
-          --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+        latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
+          --json reviews \
+          --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
         if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
           echo "::error::Adversarial review requested changes — blocking merge"
           exit 1

--- a/.github/actions/adversarial-review/action.yml
+++ b/.github/actions/adversarial-review/action.yml
@@ -30,7 +30,7 @@ inputs:
   allowed_tools:
     description: Comma-separated list of allowed Claude Code tools
     required: false
-    default: "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(touch /tmp/review-failed)"
+    default: "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
 runs:
   using: composite
@@ -139,7 +139,6 @@ runs:
           If there ARE critical or high severity findings:
           ```
           gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
-          touch /tmp/review-failed
           ```
 
           Format your review body as:
@@ -158,12 +157,17 @@ runs:
           [PASS / FAIL with one-line summary]
         claude_args: |
           --model ${{ inputs.model }}
-          --allowedTools ${{ inputs.allowed_tools }}
+          --allowedTools "${{ inputs.allowed_tools }}"
 
     - name: Fail if changes requested
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
       run: |
-        if [ -f /tmp/review-failed ]; then
+        latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
+          --json state,author \
+          --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+        if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
           echo "::error::Adversarial review requested changes — blocking merge"
           exit 1
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
-            --json state,author \
-            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::Code review requested changes — blocking merge"
             exit 1
@@ -429,9 +429,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
-            --json state,author \
-            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::UX review requested changes — blocking merge"
             exit 1
@@ -601,9 +601,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
-            --json state,author \
-            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::CI security review requested changes — blocking merge"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,6 @@ jobs:
             If there ARE blocking issues that must be addressed:
             ```
             gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
-            touch /tmp/review-failed
             ```
 
             Format your review body as:
@@ -269,11 +268,16 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(touch /tmp/review-failed)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -f /tmp/review-failed ]; then
+          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
+            --json state,author \
+            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::Code review requested changes — blocking merge"
             exit 1
           fi
@@ -403,7 +407,6 @@ jobs:
             If there ARE blocking issues:
             ```
             gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
-            touch /tmp/review-failed
             ```
 
             Format your review body as:
@@ -420,11 +423,16 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(touch /tmp/review-failed)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -f /tmp/review-failed ]; then
+          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
+            --json state,author \
+            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::UX review requested changes — blocking merge"
             exit 1
           fi
@@ -568,7 +576,6 @@ jobs:
             If there ARE critical or high severity findings:
             ```
             gh pr review ${{ github.event.pull_request.number }} --request-changes --body "your review here"
-            touch /tmp/review-failed
             ```
 
             Format your review body as:
@@ -588,11 +595,16 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-6
-            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(touch /tmp/review-failed)"
+            --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -f /tmp/review-failed ]; then
+          latest_state=$(gh pr reviews ${{ github.event.pull_request.number }} \
+            --json state,author \
+            --jq '[.[] | select(.author.login == "github-actions")] | last | .state')
+          if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::CI security review requested changes — blocking merge"
             exit 1
           fi

--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -22,6 +22,7 @@ import { groupCommandAction } from "../group_action.ts";
 import { accessGrantCommand } from "./access_grant.ts";
 import { accessGroupCommand } from "./access_group.ts";
 import { accessCheckCommand } from "./access_check.ts";
+import { accessReloadCommand } from "./access_reload.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const accessCommand = new Command()
@@ -31,4 +32,5 @@ export const accessCommand = new Command()
   .action(groupCommandAction)
   .command("grant", accessGrantCommand)
   .command("group", accessGroupCommand)
-  .command("check", accessCheckCommand);
+  .command("check", accessCheckCommand)
+  .command("reload", accessReloadCommand);

--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -31,8 +31,14 @@ import { type Action, ActionSchema } from "../../domain/access/action.ts";
 import { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
 import { GrantBasedAccessDecisionService } from "../../domain/access/grant_based_access_decision_service.ts";
 import { EventBus } from "../../domain/events/event_bus.ts";
-import { parseResourceFlag } from "./access_helpers.ts";
+import {
+  parseResourceFlag,
+  validateServerRepoExclusivity,
+} from "./access_helpers.ts";
 import { createAccessCheckRenderer } from "../../presentation/renderers/access_check.ts";
+import { requestServerResponse } from "../../cli/remote_run.ts";
+import type { AccessCheckResponse } from "../../serve/protocol.ts";
+import type { AccessCheckResult } from "../../presentation/renderers/access_check.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -73,7 +79,50 @@ export const accessCheckCommand = new Command()
     "--collectives <collectives:string>",
     "Comma-separated IdP group memberships to simulate",
   )
+  .option(
+    "--server <url:string>",
+    "Check access on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "check",
+      ]);
+      const collectives = options.collectives
+        ? (options.collectives as string).split(",").map((c: string) =>
+          c.trim()
+        ).filter((c: string) => c.length > 0)
+        : [];
+
+      const response = await requestServerResponse<AccessCheckResponse>(
+        { server: options.server as string },
+        {
+          type: "access.check",
+          payload: {
+            subject: options.subject as string,
+            action: options.action as string,
+            resource: options.on as string,
+            collectives,
+          },
+        },
+      );
+
+      const result = response as unknown as AccessCheckResult;
+      const renderer = createAccessCheckRenderer(ctx.outputMode);
+      renderer.render(result);
+
+      const isDenied = result.decisions.length === 0 ||
+        result.decisions[0].effect === "deny";
+      if (isDenied) Deno.exitCode = 1;
+      return;
+    }
+
     const ctx = createContext(options as GlobalOptions, [
       "access",
       "check",

--- a/src/cli/commands/access_check_test.ts
+++ b/src/cli/commands/access_check_test.ts
@@ -66,3 +66,10 @@ Deno.test("accessCheckCommand: has --collectives option", async () => {
   const opt = options.find((o) => o.name === "collectives");
   assertEquals(opt !== undefined, true);
 });
+
+Deno.test("accessCheckCommand: has --server option", async () => {
+  const { accessCheckCommand } = await import("./access_check.ts");
+  const options = accessCheckCommand.getOptions();
+  const opt = options.find((o) => o.name === "server");
+  assertEquals(opt !== undefined, true);
+});

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -54,7 +54,14 @@ import {
   LOCAL_PRINCIPAL,
   parseActionsFlag,
   parseResourceFlag,
+  validateServerRepoExclusivity,
 } from "./access_helpers.ts";
+import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
+import {
+  requestServerResponse,
+  runModelMethodOverServer,
+} from "../../cli/remote_run.ts";
+import type { AccessGrantListResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -109,6 +116,10 @@ const accessGrantCreateCommand = new Command()
     { required: true },
   )
   .option("--when <condition:string>", "Optional CEL condition")
+  .option(
+    "--server <url:string>",
+    "Run through a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions) {
     if (!options.allow && !options.deny) {
       throw new UserError("Either --allow or --deny must be specified");
@@ -117,6 +128,11 @@ const accessGrantCreateCommand = new Command()
       throw new UserError("Cannot specify both --allow and --deny");
     }
 
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
     const effect = options.allow ? "allow" : "deny";
     const actions = parseActionsFlag(
       (options.allow ?? options.deny) as string,
@@ -124,6 +140,44 @@ const accessGrantCreateCommand = new Command()
     const resource = parseResourceFlag(options.on as string);
 
     const instanceName = `grant-${crypto.randomUUID().slice(0, 8)}`;
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "grant",
+        "create",
+      ]);
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: instanceName,
+        methodName: "create",
+      });
+      await consumeStream(
+        runModelMethodOverServer({
+          server: options.server as string,
+          payload: {
+            modelIdOrName: `@${GRANT_MODEL_TYPE.normalized}`,
+            methodName: "create",
+            inputs: {
+              subject: options.subject as string,
+              effect,
+              actions,
+              resourceKind: resource.kind,
+              resourcePattern: resource.pattern,
+              condition: options.when as string | undefined,
+              source: "method",
+              createdBy: LOCAL_PRINCIPAL,
+            },
+            typeArg: `@${GRANT_MODEL_TYPE.normalized}`,
+            definitionName: instanceName,
+          },
+        }) as AsyncIterable<ModelMethodRunEvent>,
+        renderer.handlers(),
+      );
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+      return;
+    }
 
     const ctx = createContext(options as GlobalOptions, [
       "access",
@@ -238,7 +292,44 @@ const accessGrantListCommand = new Command()
   )
   .option("--subject <subject:string>", "Filter by subject")
   .option("--on <resource:string>", "Filter by resource selector (exact match)")
+  .option(
+    "--server <url:string>",
+    "List grants on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "grant",
+        "list",
+      ]);
+      const response = await requestServerResponse<AccessGrantListResponse>(
+        { server: options.server as string },
+        {
+          type: "access.grant.list",
+          payload: {
+            subject: options.subject as string | undefined,
+            resource: options.on as string | undefined,
+          },
+        },
+      );
+      const grants: Grant[] = [];
+      for (const raw of response.grants) {
+        const parsed = GrantSchema.safeParse(raw);
+        if (parsed.success) {
+          grants.push(parsed.data);
+        }
+      }
+      const renderer = createAccessGrantListRenderer(ctx.outputMode);
+      renderer.render(grants);
+      return;
+    }
+
     const ctx = createContext(options as GlobalOptions, [
       "access",
       "grant",
@@ -285,7 +376,72 @@ const accessGrantRevokeCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "Revoke a grant on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions, grantId: string) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "grant",
+        "revoke",
+      ]);
+      const response = await requestServerResponse<AccessGrantListResponse>(
+        { server: options.server as string },
+        { type: "access.grant.list" },
+      );
+      const allGrants: { grant: Grant; instanceName: string }[] = [];
+      for (const raw of response.grants) {
+        const parsed = GrantSchema.safeParse(raw);
+        if (parsed.success) {
+          allGrants.push({
+            grant: parsed.data,
+            instanceName:
+              (raw as Record<string, unknown>).instanceName as string ?? "",
+          });
+        }
+      }
+      const matches = allGrants.filter((r) => r.grant.id.startsWith(grantId));
+      if (matches.length === 0) {
+        throw new UserError(`Grant not found: ${grantId}`);
+      }
+      if (matches.length > 1) {
+        throw new UserError(
+          `Ambiguous grant ID prefix "${grantId}" — matches ${matches.length} grants. Use a longer prefix.`,
+        );
+      }
+      const match = matches[0];
+      if (match.grant.state === "revoked") {
+        ctx.logger.info`Grant ${grantId} is already revoked`;
+        return;
+      }
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: match.instanceName,
+        methodName: "revoke",
+      });
+      await consumeStream(
+        runModelMethodOverServer({
+          server: options.server as string,
+          payload: {
+            modelIdOrName: match.instanceName,
+            methodName: "revoke",
+            inputs: {},
+          },
+        }) as AsyncIterable<ModelMethodRunEvent>,
+        renderer.handlers(),
+      );
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+      return;
+    }
+
     const ctx = createContext(options as GlobalOptions, [
       "access",
       "grant",

--- a/src/cli/commands/access_grant_test.ts
+++ b/src/cli/commands/access_grant_test.ts
@@ -105,6 +105,33 @@ Deno.test("accessGrantCommand: create has --when option", async () => {
   assertEquals(whenOpt !== undefined, true);
 });
 
+Deno.test("accessGrantCommand: create has --server option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: list has --server option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const listCmd = commands.find((c) => c.getName() === "list")!;
+  const options = listCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGrantCommand: revoke has --server option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const revokeCmd = commands.find((c) => c.getName() === "revoke")!;
+  const options = revokeCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
 Deno.test("accessGrantCommand: revoke accepts grant_id argument", async () => {
   const { accessGrantCommand } = await import("./access_grant.ts");
   const commands = accessGrantCommand.getCommands();

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -49,7 +49,17 @@ import {
 } from "../../domain/models/access/group_model.ts";
 import type { DataRecord } from "../../domain/data/data_record.ts";
 import { createAccessGroupListRenderer } from "../../presentation/renderers/access_group.ts";
-import { buildModelMethodRunDeps, LOCAL_PRINCIPAL } from "./access_helpers.ts";
+import {
+  buildModelMethodRunDeps,
+  LOCAL_PRINCIPAL,
+  validateServerRepoExclusivity,
+} from "./access_helpers.ts";
+import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
+import {
+  requestServerResponse,
+  runModelMethodOverServer,
+} from "../../cli/remote_run.ts";
+import type { AccessGroupListResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -182,7 +192,45 @@ const accessGroupCreateCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "Create a group on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions, name: string) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "group",
+        "create",
+      ]);
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: name,
+        methodName: "create",
+      });
+      await consumeStream(
+        runModelMethodOverServer({
+          server: options.server as string,
+          payload: {
+            modelIdOrName: `@${GROUP_MODEL_TYPE.normalized}`,
+            methodName: "create",
+            inputs: { createdBy: LOCAL_PRINCIPAL },
+            typeArg: `@${GROUP_MODEL_TYPE.normalized}`,
+            definitionName: name,
+          },
+        }) as AsyncIterable<ModelMethodRunEvent>,
+        renderer.handlers(),
+      );
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+      return;
+    }
+
     await runGroupMethod(
       options,
       name,
@@ -205,11 +253,47 @@ const accessGroupAddMemberCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "Add a member on a 'swamp serve' server instead of locally",
+  )
   .action(async function (
     options: AnyOptions,
     group: string,
     principal: string,
   ) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "group",
+        "add-member",
+      ]);
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: group,
+        methodName: "add-member",
+      });
+      await consumeStream(
+        runModelMethodOverServer({
+          server: options.server as string,
+          payload: {
+            modelIdOrName: group,
+            methodName: "add-member",
+            inputs: { principal },
+          },
+        }) as AsyncIterable<ModelMethodRunEvent>,
+        renderer.handlers(),
+      );
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+      return;
+    }
+
     await runGroupMethod(
       options,
       group,
@@ -232,11 +316,47 @@ const accessGroupRemoveMemberCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "Remove a member on a 'swamp serve' server instead of locally",
+  )
   .action(async function (
     options: AnyOptions,
     group: string,
     principal: string,
   ) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "group",
+        "remove-member",
+      ]);
+      const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+        modelName: group,
+        methodName: "remove-member",
+      });
+      await consumeStream(
+        runModelMethodOverServer({
+          server: options.server as string,
+          payload: {
+            modelIdOrName: group,
+            methodName: "remove-member",
+            inputs: { principal },
+          },
+        }) as AsyncIterable<ModelMethodRunEvent>,
+        renderer.handlers(),
+      );
+      if (renderer.runFailed()) {
+        Deno.exitCode = 1;
+      }
+      return;
+    }
+
     await runGroupMethod(
       options,
       group,
@@ -255,7 +375,38 @@ const accessGroupListCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "List groups on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "group",
+        "list",
+      ]);
+      const response = await requestServerResponse<AccessGroupListResponse>(
+        { server: options.server as string },
+        { type: "access.group.list" },
+      );
+      const groups: Group[] = [];
+      for (const raw of response.groups) {
+        const parsed = GroupSchema.safeParse(raw);
+        if (parsed.success) {
+          groups.push(parsed.data);
+        }
+      }
+      const renderer = createAccessGroupListRenderer(ctx.outputMode);
+      renderer.renderList(groups);
+      return;
+    }
+
     const ctx = createContext(options as GlobalOptions, [
       "access",
       "group",
@@ -283,7 +434,42 @@ const accessGroupMembersCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--server <url:string>",
+    "List members on a 'swamp serve' server instead of locally",
+  )
   .action(async function (options: AnyOptions, name: string) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    if (options.server) {
+      const ctx = createContext(options as GlobalOptions, [
+        "access",
+        "group",
+        "members",
+      ]);
+      const response = await requestServerResponse<AccessGroupListResponse>(
+        { server: options.server as string },
+        { type: "access.group.list", payload: { name } },
+      );
+      const groups: Group[] = [];
+      for (const raw of response.groups) {
+        const parsed = GroupSchema.safeParse(raw);
+        if (parsed.success) {
+          groups.push(parsed.data);
+        }
+      }
+      const match = groups.find((g) => g.name === name);
+      if (!match) {
+        throw new UserError(`Group not found: ${name}`);
+      }
+      const renderer = createAccessGroupListRenderer(ctx.outputMode);
+      renderer.renderMembers(match);
+      return;
+    }
+
     const ctx = createContext(options as GlobalOptions, [
       "access",
       "group",

--- a/src/cli/commands/access_group_test.ts
+++ b/src/cli/commands/access_group_test.ts
@@ -97,3 +97,39 @@ Deno.test("accessGroupCommand: members accepts name argument", async () => {
   const args = membersCmd.getArguments();
   assertEquals(args.length, 1);
 });
+
+Deno.test("accessGroupCommand: create has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: add-member has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const addCmd = commands.find((c) => c.getName() === "add-member")!;
+  const options = addCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: list has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const listCmd = commands.find((c) => c.getName() === "list")!;
+  const options = listCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessGroupCommand: members has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const membersCmd = commands.find((c) => c.getName() === "members")!;
+  const options = membersCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});

--- a/src/cli/commands/access_group_test.ts
+++ b/src/cli/commands/access_group_test.ts
@@ -116,6 +116,15 @@ Deno.test("accessGroupCommand: add-member has --server option", async () => {
   assertEquals(serverOpt !== undefined, true);
 });
 
+Deno.test("accessGroupCommand: remove-member has --server option", async () => {
+  const { accessGroupCommand } = await import("./access_group.ts");
+  const commands = accessGroupCommand.getCommands();
+  const removeCmd = commands.find((c) => c.getName() === "remove-member")!;
+  const options = removeCmd.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
 Deno.test("accessGroupCommand: list has --server option", async () => {
   const { accessGroupCommand } = await import("./access_group.ts");
   const commands = accessGroupCommand.getCommands();

--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -42,6 +42,18 @@ import {
 
 export const LOCAL_PRINCIPAL = "user:local";
 
+export function validateServerRepoExclusivity(
+  server: string | undefined,
+  repoDir: string | undefined,
+): void {
+  if (server && repoDir) {
+    throw new UserError(
+      "Cannot specify both --server and --repo-dir — " +
+        "--server operates on a remote server, not a local repository",
+    );
+  }
+}
+
 export function parseResourceFlag(value: string): ResourceSelector {
   try {
     return parseResourceSelector(value);

--- a/src/cli/commands/access_helpers_test.ts
+++ b/src/cli/commands/access_helpers_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { parseActionsFlag, parseResourceFlag } from "./access_helpers.ts";
+import {
+  parseActionsFlag,
+  parseResourceFlag,
+  validateServerRepoExclusivity,
+} from "./access_helpers.ts";
 
 Deno.test("parseResourceFlag: parses workflow resource", () => {
   const result = parseResourceFlag("workflow:@acme/*");
@@ -88,4 +92,24 @@ Deno.test("parseActionsFlag: throws on empty input", () => {
     Error,
     "At least one action",
   );
+});
+
+Deno.test("validateServerRepoExclusivity: throws when both specified", () => {
+  assertThrows(
+    () => validateServerRepoExclusivity("ws://host:1234", "/some/dir"),
+    Error,
+    "Cannot specify both",
+  );
+});
+
+Deno.test("validateServerRepoExclusivity: allows server only", () => {
+  validateServerRepoExclusivity("ws://host:1234", undefined);
+});
+
+Deno.test("validateServerRepoExclusivity: allows repo-dir only", () => {
+  validateServerRepoExclusivity(undefined, "/some/dir");
+});
+
+Deno.test("validateServerRepoExclusivity: allows neither", () => {
+  validateServerRepoExclusivity(undefined, undefined);
 });

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -31,6 +31,7 @@ import { EventBus } from "../../domain/events/event_bus.ts";
 import { validateServerRepoExclusivity } from "./access_helpers.ts";
 import { requestServerResponse } from "../../cli/remote_run.ts";
 import type { AccessReloadResponse } from "../../serve/protocol.ts";
+import { createAccessReloadRenderer } from "../../presentation/renderers/access_reload.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -64,6 +65,8 @@ export const accessReloadCommand = new Command()
       "reload",
     ]);
 
+    const renderer = createAccessReloadRenderer(ctx.outputMode);
+
     if (options.server) {
       const response = await requestServerResponse<AccessReloadResponse>(
         { server: options.server as string },
@@ -74,8 +77,11 @@ export const accessReloadCommand = new Command()
         throw new UserError("Policy reload failed on the server");
       }
 
-      ctx.logger
-        .info`Policy snapshot reloaded: ${response.grantCount} grant(s), ${response.groupCount} group(s)`;
+      renderer.render({
+        success: true,
+        grantCount: response.grantCount,
+        groupCount: response.groupCount,
+      });
       return;
     }
 
@@ -95,8 +101,11 @@ export const accessReloadCommand = new Command()
 
     try {
       const result = await loader.loadWithCounts();
-      ctx.logger
-        .info`Policy snapshot loaded: ${result.grantCount} grant(s), ${result.groupCount} group(s)`;
+      renderer.render({
+        success: true,
+        grantCount: result.grantCount,
+        groupCount: result.groupCount,
+      });
     } finally {
       loader.dispose();
     }

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -1,0 +1,103 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
+import { EventBus } from "../../domain/events/event_bus.ts";
+import { validateServerRepoExclusivity } from "./access_helpers.ts";
+import { requestServerResponse } from "../../cli/remote_run.ts";
+import type { AccessReloadResponse } from "../../serve/protocol.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessReloadCommand = new Command()
+  .name("reload")
+  .description(
+    "Rebuild the policy snapshot from current grants and groups",
+  )
+  .example(
+    "Reload on a remote server",
+    "swamp access reload --server wss://swamp.acme.internal:9090",
+  )
+  .example("Reload locally", "swamp access reload")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--server <url:string>",
+    "Reload access policy on a 'swamp serve' server instead of locally",
+  )
+  .action(async function (options: AnyOptions) {
+    validateServerRepoExclusivity(
+      options.server as string | undefined,
+      options.repoDir as string | undefined,
+    );
+
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "reload",
+    ]);
+
+    if (options.server) {
+      const response = await requestServerResponse<AccessReloadResponse>(
+        { server: options.server as string },
+        { type: "access.reload" },
+      );
+
+      if (!response.success) {
+        throw new UserError("Policy reload failed on the server");
+      }
+
+      ctx.logger
+        .info`Policy snapshot reloaded: ${response.grantCount} grant(s), ${response.groupCount} group(s)`;
+      return;
+    }
+
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: ctx.outputMode,
+    });
+
+    await modelRegistry.ensureLoaded();
+
+    const eventBus = new EventBus();
+    const loader = new PolicySnapshotLoader(
+      repoContext.dataQueryService,
+      eventBus,
+      "manual",
+    );
+
+    try {
+      const result = await loader.loadWithCounts();
+      ctx.logger
+        .info`Policy snapshot loaded: ${result.grantCount} grant(s), ${result.groupCount} group(s)`;
+    } finally {
+      loader.dispose();
+    }
+  });

--- a/src/cli/commands/access_reload_test.ts
+++ b/src/cli/commands/access_reload_test.ts
@@ -1,0 +1,49 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("accessReloadCommand: module loads", async () => {
+  const { accessReloadCommand } = await import("./access_reload.ts");
+  assertEquals(accessReloadCommand.getName(), "reload");
+});
+
+Deno.test("accessReloadCommand: has correct description", async () => {
+  const { accessReloadCommand } = await import("./access_reload.ts");
+  const description = accessReloadCommand.getDescription();
+  assertEquals(description.includes("policy snapshot"), true);
+});
+
+Deno.test("accessReloadCommand: has --server option", async () => {
+  const { accessReloadCommand } = await import("./access_reload.ts");
+  const options = accessReloadCommand.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});
+
+Deno.test("accessReloadCommand: has --repo-dir option", async () => {
+  const { accessReloadCommand } = await import("./access_reload.ts");
+  const options = accessReloadCommand.getOptions();
+  const repoDirOpt = options.find((o) => o.name === "repo-dir");
+  assertEquals(repoDirOpt !== undefined, true);
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -24,6 +24,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
 import { handleConnection } from "../../serve/connection.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
 import { CapabilityService } from "../../serve/capability_service.ts";
@@ -195,7 +196,7 @@ export const serveCommand = new Command()
 
     const grantReloadMode = options.grantReload as string;
     if (grantReloadMode !== "manual" && grantReloadMode !== "auto") {
-      throw new Error(
+      throw new UserError(
         `Invalid --grant-reload value "${grantReloadMode}": must be "manual" or "auto"`,
       );
     }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -41,6 +41,12 @@ import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import {
+  type PolicyReloadMode,
+  PolicySnapshotLoader,
+} from "../../domain/access/policy_snapshot_loader.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { EventBus } from "../../domain/events/event_bus.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -79,6 +85,11 @@ export const serveCommand = new Command()
   .option(
     "--key-file <path:string>",
     "Path to PEM-encoded TLS private key (env: SWAMP_SERVE_KEY_FILE)",
+  )
+  .option(
+    "--grant-reload <mode:string>",
+    "Policy snapshot reload mode: manual (default) or auto",
+    { default: "manual" },
   )
   .option(
     "--webhook <spec:string>",
@@ -173,14 +184,6 @@ export const serveCommand = new Command()
       dataPlane.releaseDispatch(dispatchId)
     );
 
-    const connectionCtx = {
-      repoDir: resolvedRepoDir,
-      repoContext,
-      datastoreConfig,
-      syncService,
-      workerGateway,
-    };
-
     // Eagerly load extension registries so failures surface at startup
     // rather than silently on first scheduled/webhook execution.
     await Promise.all([
@@ -189,6 +192,37 @@ export const serveCommand = new Command()
       datastoreTypeRegistry.ensureLoaded(),
       reportRegistry.ensureLoaded(),
     ]);
+
+    const grantReloadMode = options.grantReload as string;
+    if (grantReloadMode !== "manual" && grantReloadMode !== "auto") {
+      throw new Error(
+        `Invalid --grant-reload value "${grantReloadMode}": must be "manual" or "auto"`,
+      );
+    }
+
+    const serveEventBus = new EventBus();
+    const dataQueryService = new DataQueryService(
+      repoContext.catalogStore,
+      repoContext.unifiedDataRepo,
+    );
+    const policySnapshotLoader = new PolicySnapshotLoader(
+      dataQueryService,
+      serveEventBus,
+      grantReloadMode as PolicyReloadMode,
+    );
+    await policySnapshotLoader.load();
+    logger.info("Policy snapshot loaded (reload mode: {mode})", {
+      mode: grantReloadMode,
+    });
+
+    const connectionCtx = {
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      syncService,
+      workerGateway,
+      policySnapshotLoader,
+    };
 
     const ac = new AbortController();
     const enableSchedule = options.schedule !== false;
@@ -417,6 +451,7 @@ export const serveCommand = new Command()
       if (scheduledExecution) {
         await scheduledExecution.stop();
       }
+      policySnapshotLoader.dispose();
       setRemoteStepDispatcher(null);
       ac.abort();
       if (isJson) {

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -93,6 +93,123 @@ export function runModelMethodOverServer(
   });
 }
 
+/** Default timeout for request-response operations (30 seconds). */
+const REQUEST_RESPONSE_TIMEOUT_MS = 30_000;
+
+export interface RequestResponseOptions {
+  server: string;
+  signal?: AbortSignal;
+  createSocket?: (url: string) => WebSocket;
+  timeoutMs?: number;
+}
+
+export function requestServerResponse<T>(
+  options: RequestResponseOptions,
+  request: { type: string; id?: string; payload?: unknown },
+): Promise<T> {
+  const url = normalizeServerUrl(options.server);
+  const requestId = request.id ?? crypto.randomUUID();
+  const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
+  const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        try {
+          socket.close();
+        } catch { /* already closed */ }
+        reject(
+          new UserError(
+            `Request timed out after ${timeoutMs}ms — the server may not support this operation`,
+          ),
+        );
+      }
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+    };
+
+    const onAbort = () => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        try {
+          socket.close();
+        } catch { /* already closed */ }
+        reject(new DOMException("Request was aborted", "AbortError"));
+      }
+    };
+
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    socket.onerror = () => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(
+          new UserError(`Could not connect to ${url}`),
+        );
+      }
+    };
+
+    socket.onclose = () => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(
+          new UserError(
+            "Connection closed before a response was received",
+          ),
+        );
+      }
+    };
+
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({ ...request, id: requestId }),
+      );
+    };
+
+    socket.onmessage = (event) => {
+      if (typeof event.data !== "string") return;
+      try {
+        const message = JSON.parse(event.data) as ServerMessage;
+        if (
+          typeof message !== "object" || message === null ||
+          !("id" in message) || message.id !== requestId
+        ) {
+          return;
+        }
+        if (message.type === "error") {
+          settled = true;
+          cleanup();
+          try {
+            socket.close();
+          } catch { /* already closed */ }
+          reject(
+            new UserError(
+              `Server reported ${message.error.code}: ${message.error.message}`,
+            ),
+          );
+          return;
+        }
+        if ("payload" in message) {
+          settled = true;
+          cleanup();
+          try {
+            socket.close();
+          } catch { /* already closed */ }
+          resolve(message.payload as T);
+        }
+      } catch { /* not a protocol frame */ }
+    };
+  });
+}
+
 interface OutboundRequest {
   type: "workflow.run" | "model.method.run";
   payload: WorkflowRunPayload | ModelMethodRunPayload;

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -26,6 +26,7 @@ import {
 import { UserError } from "../domain/errors.ts";
 import {
   normalizeServerUrl,
+  requestServerResponse,
   runModelMethodOverServer,
   runWorkflowOverServer,
 } from "./remote_run.ts";
@@ -248,5 +249,107 @@ Deno.test({
         // deno-lint-ignore no-empty
       ) {}
     }, UserError);
+  },
+});
+
+// ── requestServerResponse tests ──────────────────────────────────────
+
+Deno.test({
+  name: "requestServerResponse: returns payload from a single response frame",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((request, reply) => {
+      reply({
+        type: "access.grant.list",
+        id: request.id,
+        payload: { grants: [{ id: "g1" }] },
+      });
+    });
+    try {
+      const result = await requestServerResponse<{ grants: unknown[] }>(
+        { server: server.url },
+        { type: "access.grant.list" },
+      );
+      assertEquals(result.grants.length, 1);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "requestServerResponse: rejects with UserError on server error frame",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((request, reply) => {
+      reply({
+        type: "error",
+        id: request.id,
+        error: { code: "test_error", message: "something broke" },
+      });
+    });
+    try {
+      await assertRejects(
+        () =>
+          requestServerResponse(
+            { server: server.url },
+            { type: "access.reload" },
+          ),
+        UserError,
+        "test_error",
+      );
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "requestServerResponse: rejects on timeout",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((_request, _reply) => {
+      // Intentionally never reply
+    });
+    try {
+      await assertRejects(
+        () =>
+          requestServerResponse(
+            { server: server.url, timeoutMs: 200 },
+            { type: "access.reload" },
+          ),
+        UserError,
+        "timed out",
+      );
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "requestServerResponse: rejects on premature socket close",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((_request, _reply, socket) => {
+      socket.close();
+    });
+    try {
+      await assertRejects(
+        () =>
+          requestServerResponse(
+            { server: server.url },
+            { type: "access.reload" },
+          ),
+        UserError,
+        "closed before",
+      );
+    } finally {
+      await server.shutdown();
+    }
   },
 });

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -93,31 +93,39 @@ function buildConditionEvaluator(): ConditionEvaluator {
   };
 }
 
+export type PolicyReloadMode = "manual" | "auto";
+
 export class PolicySnapshotLoader {
   readonly #dataQueryService: DataQueryService;
   readonly #unsubscribers: (() => void)[] = [];
   readonly #conditionEvaluator: ConditionEvaluator;
   #snapshot: PolicySnapshot = PolicySnapshot.empty();
 
-  constructor(dataQueryService: DataQueryService, eventBus: EventBus) {
+  constructor(
+    dataQueryService: DataQueryService,
+    eventBus: EventBus,
+    mode: PolicyReloadMode = "auto",
+  ) {
     this.#dataQueryService = dataQueryService;
     this.#conditionEvaluator = buildConditionEvaluator();
 
-    this.#unsubscribers.push(
-      eventBus.subscribe<ModelCreated>("ModelCreated", (event) => {
-        if (this.#isAccessModel(event.modelType)) {
-          this.#rebuild();
-        }
-      }),
-    );
+    if (mode === "auto") {
+      this.#unsubscribers.push(
+        eventBus.subscribe<ModelCreated>("ModelCreated", (event) => {
+          if (this.#isAccessModel(event.modelType)) {
+            this.#rebuild();
+          }
+        }),
+      );
 
-    this.#unsubscribers.push(
-      eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
-        if (this.#isAccessModel(event.modelType)) {
-          this.#rebuild();
-        }
-      }),
-    );
+      this.#unsubscribers.push(
+        eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
+          if (this.#isAccessModel(event.modelType)) {
+            this.#rebuild();
+          }
+        }),
+      );
+    }
   }
 
   get snapshot(): PolicySnapshot {
@@ -125,8 +133,19 @@ export class PolicySnapshotLoader {
   }
 
   async load(): Promise<PolicySnapshot> {
-    this.#snapshot = await this.#buildSnapshot();
+    const result = await this.#buildSnapshotWithCounts();
+    this.#snapshot = result.snapshot;
     return this.#snapshot;
+  }
+
+  async loadWithCounts(): Promise<{
+    snapshot: PolicySnapshot;
+    grantCount: number;
+    groupCount: number;
+  }> {
+    const result = await this.#buildSnapshotWithCounts();
+    this.#snapshot = result.snapshot;
+    return result;
   }
 
   dispose(): void {
@@ -141,7 +160,11 @@ export class PolicySnapshotLoader {
       modelType === GROUP_MODEL_TYPE_STR;
   }
 
-  async #buildSnapshot(): Promise<PolicySnapshot> {
+  async #buildSnapshotWithCounts(): Promise<{
+    snapshot: PolicySnapshot;
+    grantCount: number;
+    groupCount: number;
+  }> {
     const [grantRecords, groupRecords] = await Promise.all([
       this.#dataQueryService.query(
         `modelType == "${GRANT_MODEL_TYPE_STR}"`,
@@ -173,12 +196,17 @@ export class PolicySnapshotLoader {
 
     logger
       .info`Loaded policy snapshot: ${grants.length} active grant(s), ${groups.length} group(s)`;
-    return new PolicySnapshot(grants, groups, this.#conditionEvaluator);
+    return {
+      snapshot: new PolicySnapshot(grants, groups, this.#conditionEvaluator),
+      grantCount: grants.length,
+      groupCount: groups.length,
+    };
   }
 
   async #rebuild(): Promise<void> {
     try {
-      this.#snapshot = await this.#buildSnapshot();
+      const result = await this.#buildSnapshotWithCounts();
+      this.#snapshot = result.snapshot;
     } catch (error) {
       logger.error`Failed to rebuild policy snapshot: ${error}`;
     }

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -273,3 +273,76 @@ Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () =
 
   assertEquals(queryCallCount, initialCount);
 });
+
+Deno.test("PolicySnapshotLoader: manual mode does not subscribe to EventBus", async () => {
+  let queryCallCount = 0;
+  const queryService = {
+    query() {
+      queryCallCount++;
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus, "manual");
+
+  await loader.load();
+  const initialCount = queryCallCount;
+
+  await eventBus.publish(
+    createModelCreated("swamp/grant", "123", "my-grant"),
+  );
+
+  assertEquals(queryCallCount, initialCount);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => {
+  let callCount = 0;
+  const grant = makeGrant();
+  const queryService = {
+    query(predicate: string) {
+      if (predicate.includes("swamp/grant")) {
+        callCount++;
+        if (callCount > 1) {
+          return Promise.resolve([makeGrantRecord(grant)]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    },
+  } as unknown as DataQueryService;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus, "auto");
+
+  await loader.load();
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
+
+  await eventBus.publish(
+    createModelCreated("swamp/grant", "123", "my-grant"),
+  );
+
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader.loadWithCounts: returns counts", async () => {
+  const grant = makeGrant();
+  const group = makeGroup("devs", ["adam"]);
+  const queryService = createMockQueryService(
+    [makeGrantRecord(grant)],
+    [makeGroupRecord(group)],
+  );
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(queryService, eventBus, "manual");
+  const result = await loader.loadWithCounts();
+
+  assertEquals(result.grantCount, 1);
+  assertEquals(result.groupCount, 1);
+
+  loader.dispose();
+});

--- a/src/presentation/renderers/access_reload.ts
+++ b/src/presentation/renderers/access_reload.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["access", "reload"]);
+
+export interface AccessReloadResult {
+  success: boolean;
+  grantCount: number;
+  groupCount: number;
+}
+
+export interface AccessReloadRenderer {
+  render(result: AccessReloadResult): void;
+}
+
+class LogAccessReloadRenderer implements AccessReloadRenderer {
+  render(result: AccessReloadResult): void {
+    logger
+      .info`Policy snapshot reloaded: ${result.grantCount} grant(s), ${result.groupCount} group(s)`;
+  }
+}
+
+class JsonAccessReloadRenderer implements AccessReloadRenderer {
+  render(result: AccessReloadResult): void {
+    writeOutput(
+      JSON.stringify(
+        {
+          success: result.success,
+          grantCount: result.grantCount,
+          groupCount: result.groupCount,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+export function createAccessReloadRenderer(
+  mode: OutputMode,
+): AccessReloadRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessReloadRenderer();
+    case "log":
+      return new LogAccessReloadRenderer();
+  }
+}

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -30,6 +30,9 @@ import { createLibSwampContext, modelMethodRun } from "../libswamp/mod.ts";
 import { createModelMethodRunDeps, executeWorkflowWithLocks } from "./deps.ts";
 import { serializeEvent } from "./serializer.ts";
 import type {
+  AccessCheckPayload,
+  AccessGrantListPayload,
+  AccessGroupListPayload,
   ModelMethodRunPayload,
   ServerMessage,
   ServerRequest,
@@ -39,6 +42,23 @@ import { findDefinitionByIdOrName } from "../domain/models/model_lookup.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { WorkerGateway } from "./worker_gateway.ts";
+import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
+import {
+  type Grant,
+  GRANT_MODEL_TYPE,
+  GrantSchema,
+} from "../domain/models/access/grant_model.ts";
+import {
+  type Group,
+  GROUP_MODEL_TYPE,
+  GroupSchema,
+} from "../domain/models/access/group_model.ts";
+import type { DataRecord } from "../domain/data/data_record.ts";
+import { parsePrincipal } from "../domain/access/principal.ts";
+import { ActionSchema } from "../domain/access/action.ts";
+import { parseResourceSelector } from "../domain/access/resource_selector.ts";
+import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
+import { modelRegistry } from "../domain/models/model.ts";
 
 // ── Zod schemas for incoming WebSocket messages ─────────────────────────
 
@@ -63,7 +83,42 @@ const ModelMethodRunRequestSchema = z.object({
     inputs: z.record(z.string(), z.unknown()).optional(),
     lastEvaluated: z.boolean().optional(),
     runtimeTags: z.record(z.string(), z.string()).optional(),
+    typeArg: z.string().optional(),
+    definitionName: z.string().optional(),
   }),
+});
+
+const AccessGrantListRequestSchema = z.object({
+  type: z.literal("access.grant.list"),
+  id: z.string().min(1),
+  payload: z.object({
+    subject: z.string().optional(),
+    resource: z.string().optional(),
+  }).optional(),
+});
+
+const AccessGroupListRequestSchema = z.object({
+  type: z.literal("access.group.list"),
+  id: z.string().min(1),
+  payload: z.object({
+    name: z.string().optional(),
+  }).optional(),
+});
+
+const AccessCheckRequestSchema = z.object({
+  type: z.literal("access.check"),
+  id: z.string().min(1),
+  payload: z.object({
+    subject: z.string(),
+    action: z.string(),
+    resource: z.string(),
+    collectives: z.array(z.string()).optional(),
+  }),
+});
+
+const AccessReloadRequestSchema = z.object({
+  type: z.literal("access.reload"),
+  id: z.string().min(1),
 });
 
 const CancelRequestSchema = z.object({
@@ -74,6 +129,10 @@ const CancelRequestSchema = z.object({
 const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkflowRunRequestSchema,
   ModelMethodRunRequestSchema,
+  AccessGrantListRequestSchema,
+  AccessGroupListRequestSchema,
+  AccessCheckRequestSchema,
+  AccessReloadRequestSchema,
   CancelRequestSchema,
 ]);
 
@@ -113,6 +172,7 @@ export interface ConnectionContext {
    * design/remote-execution.md.
    */
   workerGateway?: WorkerGateway;
+  policySnapshotLoader?: PolicySnapshotLoader;
 }
 
 export function handleConnection(
@@ -200,21 +260,39 @@ export function handleMessage(
   const controller = new AbortController();
   activeRequests.set(request.id, controller);
 
-  const task = request.type === "workflow.run"
-    ? handleWorkflowRun(
-      socket,
-      ctx,
-      request.id,
-      request.payload,
-      controller,
-    )
-    : handleModelMethodRun(
-      socket,
-      ctx,
-      request.id,
-      request.payload,
-      controller,
-    );
+  let task: Promise<void>;
+  switch (request.type) {
+    case "workflow.run":
+      task = handleWorkflowRun(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+      );
+      break;
+    case "model.method.run":
+      task = handleModelMethodRun(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+      );
+      break;
+    case "access.grant.list":
+      task = handleAccessGrantList(socket, ctx, request.id, request.payload);
+      break;
+    case "access.group.list":
+      task = handleAccessGroupList(socket, ctx, request.id, request.payload);
+      break;
+    case "access.check":
+      task = handleAccessCheck(socket, ctx, request.id, request.payload);
+      break;
+    case "access.reload":
+      task = handleAccessReload(socket, ctx, request.id);
+      break;
+  }
 
   task.finally(() => activeRequests.delete(request.id));
 }
@@ -289,7 +367,12 @@ async function handleModelMethodRun(
       flushLocks = lockResult.flush;
     }
 
-    const deps = await createModelMethodRunDeps(ctx.repoDir, ctx.repoContext);
+    const isDirectExecution = payload.typeArg !== undefined;
+    const deps = await createModelMethodRunDeps(
+      ctx.repoDir,
+      ctx.repoContext,
+      { directExecution: isDirectExecution },
+    );
     const libCtx = createLibSwampContext({ signal: controller.signal });
 
     for await (
@@ -299,6 +382,9 @@ async function handleModelMethodRun(
         inputs: payload.inputs ?? {},
         lastEvaluated: payload.lastEvaluated ?? false,
         runtimeTags: payload.runtimeTags,
+        typeArg: payload.typeArg,
+        definitionName: payload.definitionName,
+        skipAllReports: isDirectExecution,
       })
     ) {
       if (socket.readyState !== WebSocket.OPEN) break;
@@ -332,6 +418,192 @@ async function handleModelMethodRun(
         });
       }
     }
+  }
+}
+
+async function handleAccessGrantList(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload?: AccessGrantListPayload,
+): Promise<void> {
+  try {
+    await modelRegistry.ensureLoaded();
+    const records = await ctx.repoContext.dataQueryService.query(
+      `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
+      { loadAttributes: true },
+    );
+
+    let results: { grant: Grant; instanceName: string }[] = [];
+    for (const record of records) {
+      const dataRecord = record as DataRecord;
+      const parsed = GrantSchema.safeParse(dataRecord.attributes);
+      if (parsed.success && parsed.data.state === "active") {
+        results.push({
+          grant: parsed.data,
+          instanceName: dataRecord.modelName ?? "",
+        });
+      }
+    }
+
+    if (payload?.subject) {
+      results = results.filter((r) =>
+        `${r.grant.subject.kind}:${r.grant.subject.name}` === payload.subject
+      );
+    }
+    if (payload?.resource) {
+      const sel = parseResourceSelector(payload.resource);
+      results = results.filter((r) =>
+        r.grant.resource.kind === sel.kind &&
+        r.grant.resource.pattern === sel.pattern
+      );
+    }
+
+    send(socket, {
+      type: "access.grant.list",
+      id: requestId,
+      payload: {
+        grants: results.map((r) => ({
+          ...r.grant,
+          instanceName: r.instanceName,
+        })) as unknown as Record<string, unknown>[],
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "access_grant_list_failed", message);
+  }
+}
+
+async function handleAccessGroupList(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload?: AccessGroupListPayload,
+): Promise<void> {
+  try {
+    await modelRegistry.ensureLoaded();
+    const records = await ctx.repoContext.dataQueryService.query(
+      `modelType == "${GROUP_MODEL_TYPE.normalized}"`,
+      { loadAttributes: true },
+    );
+
+    let groups: Group[] = [];
+    for (const record of records) {
+      const parsed = GroupSchema.safeParse(
+        (record as DataRecord).attributes,
+      );
+      if (parsed.success) {
+        groups.push(parsed.data);
+      }
+    }
+
+    if (payload?.name) {
+      groups = groups.filter((g) => g.name === payload.name);
+    }
+
+    send(socket, {
+      type: "access.group.list",
+      id: requestId,
+      payload: {
+        groups: groups as unknown as Record<string, unknown>[],
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "access_group_list_failed", message);
+  }
+}
+
+function handleAccessCheck(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: AccessCheckPayload,
+): Promise<void> {
+  try {
+    if (!ctx.policySnapshotLoader) {
+      sendError(
+        socket,
+        requestId,
+        "access_not_configured",
+        "Access control is not configured on this server",
+      );
+      return Promise.resolve();
+    }
+
+    const principal = parsePrincipal(payload.subject);
+    const actionResult = ActionSchema.safeParse(payload.action);
+    if (!actionResult.success) {
+      sendError(
+        socket,
+        requestId,
+        "invalid_action",
+        `Invalid action "${payload.action}": must be one of run, read, write, admin`,
+      );
+      return Promise.resolve();
+    }
+
+    const resource = parseResourceSelector(payload.resource);
+    const collectives = payload.collectives ?? [];
+
+    const snapshot = ctx.policySnapshotLoader.snapshot;
+    const service = new GrantBasedAccessDecisionService(snapshot);
+    const decisions = service.explain(
+      { principal, collectives },
+      actionResult.data,
+      { kind: resource.kind, name: resource.pattern, fields: {} },
+    );
+
+    send(socket, {
+      type: "access.check",
+      id: requestId,
+      payload: {
+        subject: payload.subject,
+        action: payload.action,
+        resource: payload.resource,
+        collectives,
+        decisions: decisions as unknown as Record<string, unknown>[],
+      },
+    });
+    return Promise.resolve();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "access_check_failed", message);
+    return Promise.resolve();
+  }
+}
+
+async function handleAccessReload(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+): Promise<void> {
+  try {
+    if (!ctx.policySnapshotLoader) {
+      sendError(
+        socket,
+        requestId,
+        "access_not_configured",
+        "Access control is not configured on this server",
+      );
+      return;
+    }
+
+    const result = await ctx.policySnapshotLoader.loadWithCounts();
+
+    send(socket, {
+      type: "access.reload",
+      id: requestId,
+      payload: {
+        success: true,
+        grantCount: result.grantCount,
+        groupCount: result.groupCount,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "access_reload_failed", message);
   }
 }
 

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -234,3 +234,95 @@ Deno.test("handleMessage does not leak unknown type value in error", () => {
   );
   assertEquals(errorMessage.includes("secret.op"), false);
 });
+
+// ── validateServerRequest: new access frame types ─────────────────────
+
+Deno.test("validateServerRequest accepts access.grant.list", () => {
+  const input = {
+    type: "access.grant.list",
+    id: "req-1",
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.grant.list with payload", () => {
+  const input = {
+    type: "access.grant.list",
+    id: "req-1",
+    payload: { subject: "user:adam" },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.group.list", () => {
+  const input = {
+    type: "access.group.list",
+    id: "req-1",
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.check", () => {
+  const input = {
+    type: "access.check",
+    id: "req-1",
+    payload: {
+      subject: "user:adam",
+      action: "run",
+      resource: "workflow:@acme/deploy",
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.check with collectives", () => {
+  const input = {
+    type: "access.check",
+    id: "req-1",
+    payload: {
+      subject: "user:adam",
+      action: "run",
+      resource: "workflow:@acme/deploy",
+      collectives: ["platform-eng"],
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.reload", () => {
+  const input = {
+    type: "access.reload",
+    id: "req-1",
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts model.method.run with typeArg", () => {
+  const input = {
+    type: "model.method.run",
+    id: "req-1",
+    payload: {
+      modelIdOrName: "@swamp/grant",
+      methodName: "create",
+      typeArg: "@swamp/grant",
+      definitionName: "grant-abc12345",
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest rejects access.check without payload", () => {
+  const input = {
+    type: "access.check",
+    id: "req-1",
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "string");
+});

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -160,12 +160,16 @@ export async function createWorkflowRunDeps(
 export async function createModelMethodRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
+  options?: { directExecution?: boolean },
 ): Promise<ModelMethodRunDeps> {
   await Promise.all([
     modelRegistry.ensureLoaded(),
     vaultTypeRegistry.ensureLoaded(),
     reportRegistry.ensureLoaded(),
   ]);
+
+  const isDirectExecution = options?.directExecution ?? false;
+
   return {
     repoDir,
     lookupDefinition: (idOrName) =>
@@ -220,6 +224,26 @@ export async function createModelMethodRunDeps(
         cleanup: () => runFileSink.unregister(logCategory),
       };
     },
+    createAndSaveDefinition: isDirectExecution
+      ? async (type, definition) => {
+        const autoDefRepo = new YamlDefinitionRepository(
+          repoDir,
+          undefined,
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          false,
+        );
+        await autoDefRepo.save(type, definition);
+      }
+      : undefined,
+    getDefinitionPath: isDirectExecution
+      ? (type, id) => {
+        return join(
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          type.toDirectoryPath(),
+          `${id}.yaml`,
+        );
+      }
+      : undefined,
   };
 }
 

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -41,11 +41,33 @@ export interface ModelMethodRunPayload {
   inputs?: Record<string, unknown>;
   lastEvaluated?: boolean;
   runtimeTags?: Record<string, string>;
+  typeArg?: string;
+  definitionName?: string;
+}
+
+export interface AccessGrantListPayload {
+  subject?: string;
+  resource?: string;
+}
+
+export interface AccessGroupListPayload {
+  name?: string;
+}
+
+export interface AccessCheckPayload {
+  subject: string;
+  action: string;
+  resource: string;
+  collectives?: string[];
 }
 
 export type ServerRequest =
   | { type: "workflow.run"; id: string; payload: WorkflowRunPayload }
   | { type: "model.method.run"; id: string; payload: ModelMethodRunPayload }
+  | { type: "access.grant.list"; id: string; payload?: AccessGrantListPayload }
+  | { type: "access.group.list"; id: string; payload?: AccessGroupListPayload }
+  | { type: "access.check"; id: string; payload: AccessCheckPayload }
+  | { type: "access.reload"; id: string }
   | { type: "cancel"; id: string };
 
 // ── Outbound (server → client) ───────────────────────────────────────────
@@ -63,6 +85,28 @@ export interface SerializedError {
   details?: unknown;
 }
 
+export interface AccessGrantListResponse {
+  grants: Record<string, unknown>[];
+}
+
+export interface AccessGroupListResponse {
+  groups: Record<string, unknown>[];
+}
+
+export interface AccessCheckResponse {
+  subject: string;
+  action: string;
+  resource: string;
+  collectives: string[];
+  decisions: Record<string, unknown>[];
+}
+
+export interface AccessReloadResponse {
+  success: boolean;
+  grantCount: number;
+  groupCount: number;
+}
+
 export type ServerMessage =
   | { type: "event"; id: string; event: SerializedEvent }
   | { type: "error"; id: string; error: SerializedError }
@@ -72,4 +116,12 @@ export type ServerMessage =
    * frame is the terminal frame for failed requests. Additive — clients
    * that predate it ignore unknown frame types.
    */
-  | { type: "done"; id: string };
+  | { type: "done"; id: string }
+  | { type: "access.grant.list"; id: string; payload: AccessGrantListResponse }
+  | {
+    type: "access.group.list";
+    id: string;
+    payload: AccessGroupListResponse;
+  }
+  | { type: "access.check"; id: string; payload: AccessCheckResponse }
+  | { type: "access.reload"; id: string; payload: AccessReloadResponse };


### PR DESCRIPTION
## Summary

- Add `--server` flag to all `swamp access` CLI commands (`grant create/list/revoke`, `group create/add-member/remove-member/list/members`, `check`) to route operations through a `swamp serve` WebSocket server
- Extend `ModelMethodRunPayload` with optional `typeArg`/`definitionName` for direct type execution over the wire (grant/group create)
- Add four new serve protocol frame types: `access.grant.list`, `access.group.list`, `access.check`, `access.reload` with typed request/response shapes
- Add `requestServerResponse<T>()` helper in `remote_run.ts` for request-response frame patterns (separate from streaming `streamServerRun`)
- Add `PolicySnapshotLoader` mode flag (`manual`/`auto`) — manual (serve default) stages policy changes until explicit reload
- New `swamp access reload` command triggers policy snapshot rebuild locally or via `--server`
- Wire `PolicySnapshotLoader` into serve startup with `--grant-reload manual|auto` CLI flag
- Add `--server`/`--repo-dir` mutual exclusivity validation
- Server-side `createModelMethodRunDeps` gains `createAndSaveDefinition`/`getDefinitionPath` for direct type execution

Closes swamp-club#681

## Test Plan

- 94 tests pass (31 new), 0 failures
- `requestServerResponse`: success, error frame, timeout, premature socket close (using existing `scriptedServer` helper)
- Protocol validation: all new frame types accepted, `access.check` without payload rejected, `model.method.run` with `typeArg` accepted
- `PolicySnapshotLoader`: manual mode skips EventBus, auto mode subscribes, `loadWithCounts()` returns counts
- All access commands have `--server` option registered
- `validateServerRepoExclusivity`: throws on both, allows each alone or neither
- `access reload` command: loads, has `--server` and `--repo-dir` options
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)