### PR TITLE
feat(issue-lifecycle): add regressionIntroducedIn to triage classification

### DIFF
--- a/.claude/skills/issue-lifecycle/references/triage.md
+++ b/.claude/skills/issue-lifecycle/references/triage.md
@@ -88,6 +88,12 @@ showing the affected code was recently modified. A regression is still
 classified as `type: bug` — `isRegression` is a detail on the classification
 record.
 
+When `isRegression=true`, also provide
+`--input regressionIntroducedIn=<version>`. Check `git log` on the affected
+files and cross-reference with recent releases to identify which version
+introduced the breakage. If the introducing version cannot be determined, omit
+the field.
+
 **If you cannot classify confidently**, do NOT guess. Ask the human first, or
 call `triage` with `confidence=low` and `clarifyingQuestions` populated, then
 wait for the human's response before moving on.

--- a/extensions/models/README.md
+++ b/extensions/models/README.md
@@ -182,6 +182,9 @@ Classification types (`triage`) match swamp-club's issue types:
 
 Regressions are classified as `type: bug` with `isRegression: true` on the
 classification record — swamp-club does not have a separate `regression` type.
+When the introducing version can be identified, set `regressionIntroducedIn` to
+the version string (e.g. `"2026.06.12.1"`) — this enables time-to-detection
+metrics on the swamp-club side.
 
 Status transitions in swamp-club:
 

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -130,6 +130,9 @@ export const ClassificationSchema = z.object({
   isRegression: z.boolean().optional().describe(
     "True if this is a regression (something that previously worked). Implies type=bug.",
   ),
+  regressionIntroducedIn: z.string().optional().describe(
+    "Version that introduced the regression (e.g. '2026.06.12.1'). Only set when isRegression is true.",
+  ),
   clarifyingQuestions: z.array(z.string()).optional(),
   classifiedAt: z.string(),
 });

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -70,7 +70,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.05.21.1",
+  version: "2026.06.18.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -133,6 +133,13 @@ export const model = {
         "ship() and complete() now transition to notify instead of done. " +
         "New notify method posts a thank-you ripple and transitions to done. " +
         "Issue data now includes author field.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.06.18.1",
+      description: "Add regressionIntroducedIn to triage classification — " +
+        "captures the version that introduced a regression for time-to-detection metrics. " +
+        "No globalArguments changes.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],
@@ -552,6 +559,9 @@ export const model = {
         isRegression: z.boolean().optional().describe(
           "True if this is a regression (something that previously worked). Implies type=bug.",
         ),
+        regressionIntroducedIn: z.string().optional().describe(
+          "Version that introduced the regression (e.g. '2026.06.12.1'). Only set when isRegression is true.",
+        ),
         clarifyingQuestions: z.array(z.string()).optional(),
       }),
       execute: async (
@@ -560,6 +570,7 @@ export const model = {
           confidence: "high" | "medium" | "low";
           reasoning: string;
           isRegression?: boolean;
+          regressionIntroducedIn?: string;
           clarifyingQuestions?: string[];
         },
         context: {
@@ -587,6 +598,7 @@ export const model = {
               confidence: args.confidence,
               reasoning: args.reasoning,
               isRegression: args.isRegression,
+              regressionIntroducedIn: args.regressionIntroducedIn,
               clarifyingQuestions: args.clarifyingQuestions,
               classifiedAt: new Date().toISOString(),
             },
@@ -629,6 +641,7 @@ export const model = {
               confidence: args.confidence,
               reasoning: args.reasoning,
               isRegression: args.isRegression ?? false,
+              regressionIntroducedIn: args.regressionIntroducedIn,
               clarifyingQuestions: args.clarifyingQuestions,
             },
             isVerbose: false,

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.05.21.1", () => {
-  assertEquals(model.version, "2026.05.21.1");
+Deno.test("model: version bumped to 2026.06.18.1", () => {
+  assertEquals(model.version, "2026.06.18.1");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add optional `regressionIntroducedIn` string field to the triage method, capturing which version introduced a regression (e.g. `"2026.06.12.1"`)
- Thread the field through the `ClassificationSchema`, triage resource write, and lifecycle entry payload so the swamp-club API receives it for time-to-detection metrics
- Bump model version to `2026.06.18.1` with upgrade stanza

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 35 issue lifecycle tests pass (including updated version assertion)
- Field is optional — fully backwards-compatible with existing model instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)