### PR TITLE
feat(serve): add auth config schema and mode flag (swamp-club#682)

### DIFF
--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -102,6 +102,14 @@ async function withServeRepo(
       repoContext,
       datastoreConfig,
       syncService,
+      authConfig: {
+        mode: "none" as const,
+        admins: [],
+        allowedCollectives: [],
+        allowedUsers: [],
+        oauthProvider: "https://swamp-club.com",
+        groupsField: "collectives",
+      },
     };
 
     const server = Deno.serve(

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -25,6 +25,7 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
 import { handleConnection } from "../../serve/connection.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
 import { CapabilityService } from "../../serve/capability_service.ts";
@@ -97,9 +98,42 @@ export const serveCommand = new Command()
     "Register a webhook endpoint: <route>:<workflow>:<secret>",
     { collect: true },
   )
+  .option(
+    "--auth-mode <mode:string>",
+    "Authentication mode: none (default), token, or oauth",
+    { default: "none" },
+  )
+  .option(
+    "--admins <principals:string>",
+    "Comma-separated principal IDs for admin access (e.g. user:oauth|user-123)",
+  )
+  .option(
+    "--allowed-collectives <list:string>",
+    "Comma-separated collective slugs for OAuth admission policy",
+  )
+  .option(
+    "--allowed-users <list:string>",
+    "Comma-separated user identifiers for OAuth admission policy",
+  )
+  .option(
+    "--oauth-provider <url:string>",
+    "OAuth authorization server URL (default: https://swamp-club.com)",
+  )
+  .option(
+    "--oauth-client-id <id:string>",
+    "OAuth client ID (required for oauth mode)",
+  )
+  .option(
+    "--groups-field <field:string>",
+    "Userinfo field name for group/collective memberships (default: collectives)",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
+  )
+  .example(
+    "Token auth",
+    "swamp serve --auth-mode token --admins 'user:oauth|user-123'",
   )
   .example(
     "Webhook trigger",
@@ -130,6 +164,23 @@ export const serveCommand = new Command()
       key = await Deno.readTextFile(keyFile);
     }
     const tlsEnabled = cert !== undefined;
+
+    const authConfig = buildServeAuthConfig({
+      authMode: options.authMode as string | undefined,
+      admins: options.admins as string | undefined,
+      allowedCollectives: options.allowedCollectives as string | undefined,
+      allowedUsers: options.allowedUsers as string | undefined,
+      oauthProvider: options.oauthProvider as string | undefined,
+      oauthClientId: options.oauthClientId as string | undefined,
+      groupsField: options.groupsField as string | undefined,
+    });
+
+    if (authConfig.mode === "none" && authConfig.admins.length > 0) {
+      logger.warn(
+        "--admins is set but --auth-mode is {mode} — admins will have no effect",
+        { mode: authConfig.mode },
+      );
+    }
 
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
@@ -223,6 +274,7 @@ export const serveCommand = new Command()
       syncService,
       workerGateway,
       policySnapshotLoader,
+      authConfig,
     };
 
     const ac = new AbortController();

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -62,6 +62,13 @@ export {
 } from "./resource_selector.ts";
 
 export {
+  type AuthMode,
+  buildServeAuthConfig,
+  type ServeAuthConfig,
+  type ServeAuthConfigInput,
+} from "./serve_auth_config.ts";
+
+export {
   parseSubject,
   type Subject,
   type SubjectKind,

--- a/src/domain/access/serve_auth_config.ts
+++ b/src/domain/access/serve_auth_config.ts
@@ -1,0 +1,121 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../errors.ts";
+import { parsePrincipal } from "./principal.ts";
+
+export type AuthMode = "none" | "token" | "oauth";
+
+export interface ServeAuthConfig {
+  mode: AuthMode;
+  admins: string[];
+  allowedCollectives: string[];
+  allowedUsers: string[];
+  oauthProvider: string;
+  oauthClientId?: string;
+  groupsField: string;
+}
+
+const VALID_AUTH_MODES: ReadonlySet<string> = new Set([
+  "none",
+  "token",
+  "oauth",
+]);
+const DEFAULT_OAUTH_PROVIDER = "https://swamp-club.com";
+const DEFAULT_GROUPS_FIELD = "collectives";
+
+export interface ServeAuthConfigInput {
+  authMode?: string;
+  admins?: string;
+  allowedCollectives?: string;
+  allowedUsers?: string;
+  oauthProvider?: string;
+  oauthClientId?: string;
+  groupsField?: string;
+}
+
+function parseCommaSeparated(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function validateAdmins(admins: string[]): void {
+  for (const admin of admins) {
+    try {
+      parsePrincipal(admin);
+    } catch {
+      throw new UserError(
+        `Invalid --admins value "${admin}": expected principal format "user:<id>" or "worker:<id>"`,
+      );
+    }
+  }
+}
+
+export function buildServeAuthConfig(
+  input: ServeAuthConfigInput,
+): ServeAuthConfig {
+  const mode = input.authMode ?? "none";
+  if (!VALID_AUTH_MODES.has(mode)) {
+    throw new UserError(
+      `Invalid --auth-mode value "${mode}": must be "none", "token", or "oauth"`,
+    );
+  }
+
+  const admins = parseCommaSeparated(input.admins);
+  const allowedCollectives = parseCommaSeparated(input.allowedCollectives);
+  const allowedUsers = parseCommaSeparated(input.allowedUsers);
+  const oauthProvider = input.oauthProvider ?? DEFAULT_OAUTH_PROVIDER;
+  const oauthClientId = input.oauthClientId;
+  const groupsField = input.groupsField ?? DEFAULT_GROUPS_FIELD;
+
+  if (admins.length > 0) {
+    validateAdmins(admins);
+  }
+
+  if (mode === "token") {
+    if (admins.length === 0) {
+      throw new UserError(
+        '--admins is required when --auth-mode is "token"',
+      );
+    }
+  }
+
+  if (mode === "oauth") {
+    if (admins.length === 0) {
+      throw new UserError(
+        '--admins is required when --auth-mode is "oauth"',
+      );
+    }
+    if (!oauthClientId) {
+      throw new UserError(
+        '--oauth-client-id is required when --auth-mode is "oauth"',
+      );
+    }
+  }
+
+  return {
+    mode: mode as AuthMode,
+    admins,
+    allowedCollectives,
+    allowedUsers,
+    oauthProvider,
+    oauthClientId,
+    groupsField,
+  };
+}

--- a/src/domain/access/serve_auth_config_test.ts
+++ b/src/domain/access/serve_auth_config_test.ts
@@ -1,0 +1,205 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { buildServeAuthConfig } from "./serve_auth_config.ts";
+import { UserError } from "../errors.ts";
+
+Deno.test("buildServeAuthConfig: mode none with no flags succeeds", () => {
+  const config = buildServeAuthConfig({});
+  assertEquals(config.mode, "none");
+  assertEquals(config.admins, []);
+  assertEquals(config.allowedCollectives, []);
+  assertEquals(config.allowedUsers, []);
+  assertEquals(config.oauthProvider, "https://swamp-club.com");
+  assertEquals(config.oauthClientId, undefined);
+  assertEquals(config.groupsField, "collectives");
+});
+
+Deno.test("buildServeAuthConfig: explicit mode none succeeds", () => {
+  const config = buildServeAuthConfig({ authMode: "none" });
+  assertEquals(config.mode, "none");
+});
+
+Deno.test("buildServeAuthConfig: mode token without admins refuses", () => {
+  assertThrows(
+    () => buildServeAuthConfig({ authMode: "token" }),
+    UserError,
+    '--admins is required when --auth-mode is "token"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: mode token with admins succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "token",
+    admins: "user:oauth|user-123",
+  });
+  assertEquals(config.mode, "token");
+  assertEquals(config.admins, ["user:oauth|user-123"]);
+});
+
+Deno.test("buildServeAuthConfig: mode token with multiple admins succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "token",
+    admins: "user:oauth|user-123, worker:agent-456",
+  });
+  assertEquals(config.admins, ["user:oauth|user-123", "worker:agent-456"]);
+});
+
+Deno.test("buildServeAuthConfig: mode oauth without admins refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "oauth",
+        oauthClientId: "my-client",
+      }),
+    UserError,
+    '--admins is required when --auth-mode is "oauth"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: mode oauth without client-id refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "oauth",
+        admins: "user:oauth|user-123",
+      }),
+    UserError,
+    '--oauth-client-id is required when --auth-mode is "oauth"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: mode oauth with all required flags succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "user:oauth|user-123",
+    oauthClientId: "my-client",
+  });
+  assertEquals(config.mode, "oauth");
+  assertEquals(config.admins, ["user:oauth|user-123"]);
+  assertEquals(config.oauthClientId, "my-client");
+  assertEquals(config.oauthProvider, "https://swamp-club.com");
+  assertEquals(config.groupsField, "collectives");
+});
+
+Deno.test("buildServeAuthConfig: mode oauth with all flags succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "user:oauth|user-123",
+    oauthClientId: "my-client",
+    oauthProvider: "https://auth.example.com",
+    allowedCollectives: "team-a, team-b",
+    allowedUsers: "user:alice, user:bob",
+    groupsField: "groups",
+  });
+  assertEquals(config.mode, "oauth");
+  assertEquals(config.oauthProvider, "https://auth.example.com");
+  assertEquals(config.oauthClientId, "my-client");
+  assertEquals(config.allowedCollectives, ["team-a", "team-b"]);
+  assertEquals(config.allowedUsers, ["user:alice", "user:bob"]);
+  assertEquals(config.groupsField, "groups");
+});
+
+Deno.test("buildServeAuthConfig: invalid auth-mode refuses", () => {
+  assertThrows(
+    () => buildServeAuthConfig({ authMode: "magic" }),
+    UserError,
+    'Invalid --auth-mode value "magic"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: invalid principal format in admins refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "token",
+        admins: "garbage-no-colon",
+      }),
+    UserError,
+    'Invalid --admins value "garbage-no-colon"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: invalid principal kind in admins refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "token",
+        admins: "sub:oauth|user-123",
+      }),
+    UserError,
+    'Invalid --admins value "sub:oauth|user-123"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: admins with empty name after colon refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "token",
+        admins: "user:",
+      }),
+    UserError,
+    'Invalid --admins value "user:"',
+  );
+});
+
+Deno.test("buildServeAuthConfig: default oauth-provider is swamp-club.com", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "user:oauth|user-123",
+    oauthClientId: "client",
+  });
+  assertEquals(config.oauthProvider, "https://swamp-club.com");
+});
+
+Deno.test("buildServeAuthConfig: default groups-field is collectives", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "user:oauth|user-123",
+    oauthClientId: "client",
+  });
+  assertEquals(config.groupsField, "collectives");
+});
+
+Deno.test("buildServeAuthConfig: comma-separated admins trims whitespace", () => {
+  const config = buildServeAuthConfig({
+    authMode: "token",
+    admins: " user:alice , user:bob , worker:agent-1 ",
+  });
+  assertEquals(config.admins, ["user:alice", "user:bob", "worker:agent-1"]);
+});
+
+Deno.test("buildServeAuthConfig: empty strings in comma list are filtered", () => {
+  const config = buildServeAuthConfig({
+    authMode: "token",
+    admins: "user:alice,,user:bob,",
+  });
+  assertEquals(config.admins, ["user:alice", "user:bob"]);
+});
+
+Deno.test("buildServeAuthConfig: mode none with admins succeeds with warning", () => {
+  const config = buildServeAuthConfig({
+    authMode: "none",
+    admins: "user:oauth|user-123",
+  });
+  assertEquals(config.mode, "none");
+  assertEquals(config.admins, ["user:oauth|user-123"]);
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -43,6 +43,7 @@ import { acquireModelLocks } from "../cli/repo_context.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { WorkerGateway } from "./worker_gateway.ts";
 import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
+import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -173,6 +174,7 @@ export interface ConnectionContext {
    */
   workerGateway?: WorkerGateway;
   policySnapshotLoader?: PolicySnapshotLoader;
+  authConfig: ServeAuthConfig;
 }
 
 export function handleConnection(


### PR DESCRIPTION
## Summary

- Add `ServeAuthConfig` value object in `src/domain/access/serve_auth_config.ts` with `buildServeAuthConfig()` factory that validates CLI flags per mode (`none`, `token`, `oauth`)
- Add 7 new CLI flags to `swamp serve`: `--auth-mode`, `--admins`, `--allowed-collectives`, `--allowed-users`, `--oauth-provider`, `--oauth-client-id`, `--groups-field`
- Add `authConfig: ServeAuthConfig` to `ConnectionContext` (non-optional) so downstream layer 4 handlers can access it
- No authentication implementation — config schema and validation only

Closes swamp-club#682

## Test Plan

- 18 unit tests covering the full validation matrix:
  - `mode: none` with no flags succeeds (today's behavior, unchanged)
  - `mode: token` without `--admins` refuses to start
  - `mode: token` with `--admins` succeeds
  - `mode: oauth` without `--admins` refuses to start
  - `mode: oauth` without `--oauth-client-id` refuses to start
  - `mode: oauth` with all required flags succeeds
  - Invalid `--auth-mode` value refuses to start
  - Invalid principal format in `--admins` refuses to start (e.g. `sub:` instead of `user:`)
  - Default values verified (`--oauth-provider` → `https://swamp-club.com`, `--groups-field` → `collectives`)
  - Comma-separated parsing trims whitespace, filters empty strings
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass