### PR TITLE
feat(serve-auth): materialize admin grants from config at startup (swamp-club#683)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -49,6 +49,10 @@ import {
 } from "../../domain/access/policy_snapshot_loader.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { EventBus } from "../../domain/events/event_bus.ts";
+import {
+  createAdminGrantStore,
+  materializeAdmins,
+} from "../../domain/access/admin_materializer.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -257,6 +261,24 @@ export const serveCommand = new Command()
       repoContext.catalogStore,
       repoContext.unifiedDataRepo,
     );
+    const adminGrantStore = createAdminGrantStore(
+      dataQueryService,
+      repoContext.definitionRepo,
+      repoContext.unifiedDataRepo,
+    );
+    const materializeResult = await materializeAdmins(
+      authConfig.mode,
+      authConfig.admins,
+      adminGrantStore,
+    );
+    if (
+      materializeResult.created > 0 || materializeResult.revoked > 0 ||
+      materializeResult.reactivated > 0
+    ) {
+      logger
+        .info`Admin grants materialized: ${materializeResult.created} created, ${materializeResult.revoked} revoked, ${materializeResult.reactivated} reactivated, ${materializeResult.unchanged} unchanged`;
+    }
+
     const policySnapshotLoader = new PolicySnapshotLoader(
       dataQueryService,
       serveEventBus,

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -26,7 +26,7 @@ import {
   grantModel,
   GrantSchema,
 } from "../models/access/grant_model.ts";
-import { parseSubject } from "./subject.ts";
+import { parseSubject, subjectToString } from "./subject.ts";
 import { parseResourceSelector } from "./resource_selector.ts";
 import type { AuthMode } from "./serve_auth_config.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
@@ -169,8 +169,9 @@ export async function materializeAdmins(
 
   const configGrants = await store.queryConfigGrants();
   const desiredInstanceNames = new Set<string>();
+  const uniqueAdmins = [...new Set(admins)];
 
-  for (const admin of admins) {
+  for (const admin of uniqueAdmins) {
     const hash = await hashPrincipal(admin);
     const instanceName = instanceNameForAdmin(hash);
     desiredInstanceNames.add(instanceName);
@@ -186,7 +187,7 @@ export async function materializeAdmins(
       const reactivated: Grant = { ...existing.grant, state: "active" };
       await store.writeGrant(existing.modelId, instanceName, reactivated);
       result.reactivated++;
-      logger.info("Re-activated admin grant for {admin}", { admin });
+      logger.info`Re-activated admin grant for ${admin}`;
       continue;
     }
 
@@ -194,7 +195,7 @@ export async function materializeAdmins(
     const grant = buildAdminGrant(admin);
     await store.writeGrant(modelId, instanceName, grant);
     result.created++;
-    logger.info("Created admin grant for {admin}", { admin });
+    logger.info`Created admin grant for ${admin}`;
   }
 
   for (const [instanceName, { grant, modelId }] of configGrants) {
@@ -206,8 +207,9 @@ export async function materializeAdmins(
 
     const revoked: Grant = { ...grant, state: "revoked" };
     await store.writeGrant(modelId, instanceName, revoked);
+    const revokedSubject = subjectToString(grant.subject);
     result.revoked++;
-    logger.info("Revoked admin grant for {instanceName}", { instanceName });
+    logger.info`Revoked admin grant for ${revokedSubject}`;
   }
 
   return result;

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -1,0 +1,214 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { DataQueryService } from "../data/data_query_service.ts";
+import type { DataRecord } from "../data/data_record.ts";
+import {
+  type Grant,
+  GRANT_MODEL_TYPE,
+  grantModel,
+  GrantSchema,
+} from "../models/access/grant_model.ts";
+import { parseSubject } from "./subject.ts";
+import { parseResourceSelector } from "./resource_selector.ts";
+import type { AuthMode } from "./serve_auth_config.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+import { Definition } from "../definitions/definition.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
+import { createResourceWriter } from "../models/data_writer.ts";
+
+const logger = getLogger(["swamp", "admin-materializer"]);
+
+const GRANT_DATA_NAME = "grant-main";
+
+export interface MaterializeResult {
+  created: number;
+  revoked: number;
+  reactivated: number;
+  unchanged: number;
+}
+
+export interface AdminGrantStore {
+  queryConfigGrants(): Promise<
+    Map<string, { grant: Grant; modelId: string }>
+  >;
+  ensureDefinition(instanceName: string): Promise<string>;
+  writeGrant(
+    modelId: string,
+    instanceName: string,
+    grant: Grant,
+  ): Promise<void>;
+}
+
+export async function hashPrincipal(principalId: string): Promise<string> {
+  const data = new TextEncoder().encode(principalId);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(hash);
+  return Array.from(bytes.slice(0, 8))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function instanceNameForAdmin(hash: string): string {
+  return `grant-config-${hash}`;
+}
+
+function buildAdminGrant(adminPrincipal: string): Grant {
+  const subject = parseSubject(adminPrincipal);
+  const resource = parseResourceSelector("access:*");
+  return {
+    id: crypto.randomUUID(),
+    subject,
+    effect: "allow",
+    actions: ["admin"],
+    resource,
+    state: "active",
+    source: "config",
+    createdBy: { kind: "user", id: "system" },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function createAdminGrantStore(
+  dataQueryService: DataQueryService,
+  definitionRepo: DefinitionRepository,
+  dataRepo: UnifiedDataRepository,
+): AdminGrantStore {
+  return {
+    async queryConfigGrants() {
+      const records = await dataQueryService.query(
+        `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
+        { loadAttributes: true },
+      );
+
+      const configGrants = new Map<
+        string,
+        { grant: Grant; modelId: string }
+      >();
+      for (const record of records) {
+        const dataRecord = record as DataRecord;
+        const parsed = GrantSchema.safeParse(dataRecord.attributes);
+        if (parsed.success && parsed.data.source === "config") {
+          configGrants.set(dataRecord.modelName, {
+            grant: parsed.data,
+            modelId: dataRecord.modelId,
+          });
+        }
+      }
+      return configGrants;
+    },
+
+    async ensureDefinition(instanceName: string) {
+      let def = await definitionRepo.findByName(
+        GRANT_MODEL_TYPE,
+        instanceName,
+      );
+      if (!def) {
+        def = Definition.create({
+          type: GRANT_MODEL_TYPE.normalized,
+          name: instanceName,
+        });
+        await definitionRepo.save(GRANT_MODEL_TYPE, def);
+      }
+      return def.id;
+    },
+
+    async writeGrant(modelId: string, instanceName: string, grant: Grant) {
+      const { writeResource } = createResourceWriter(
+        dataRepo,
+        GRANT_MODEL_TYPE,
+        modelId,
+        grantModel.resources!,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        instanceName,
+      );
+      await writeResource(
+        "grant",
+        GRANT_DATA_NAME,
+        grant as unknown as Record<string, unknown>,
+      );
+    },
+  };
+}
+
+export async function materializeAdmins(
+  mode: AuthMode,
+  admins: string[],
+  store: AdminGrantStore,
+): Promise<MaterializeResult> {
+  if (mode === "none") {
+    return { created: 0, revoked: 0, reactivated: 0, unchanged: 0 };
+  }
+
+  const result: MaterializeResult = {
+    created: 0,
+    revoked: 0,
+    reactivated: 0,
+    unchanged: 0,
+  };
+
+  const configGrants = await store.queryConfigGrants();
+  const desiredInstanceNames = new Set<string>();
+
+  for (const admin of admins) {
+    const hash = await hashPrincipal(admin);
+    const instanceName = instanceNameForAdmin(hash);
+    desiredInstanceNames.add(instanceName);
+
+    const existing = configGrants.get(instanceName);
+
+    if (existing && existing.grant.state === "active") {
+      result.unchanged++;
+      continue;
+    }
+
+    if (existing && existing.grant.state === "revoked") {
+      const reactivated: Grant = { ...existing.grant, state: "active" };
+      await store.writeGrant(existing.modelId, instanceName, reactivated);
+      result.reactivated++;
+      logger.info("Re-activated admin grant for {admin}", { admin });
+      continue;
+    }
+
+    const modelId = await store.ensureDefinition(instanceName);
+    const grant = buildAdminGrant(admin);
+    await store.writeGrant(modelId, instanceName, grant);
+    result.created++;
+    logger.info("Created admin grant for {admin}", { admin });
+  }
+
+  for (const [instanceName, { grant, modelId }] of configGrants) {
+    if (desiredInstanceNames.has(instanceName)) continue;
+    if (grant.state === "revoked") {
+      result.unchanged++;
+      continue;
+    }
+
+    const revoked: Grant = { ...grant, state: "revoked" };
+    await store.writeGrant(modelId, instanceName, revoked);
+    result.revoked++;
+    logger.info("Revoked admin grant for {instanceName}", { instanceName });
+  }
+
+  return result;
+}

--- a/src/domain/access/admin_materializer_test.ts
+++ b/src/domain/access/admin_materializer_test.ts
@@ -1,0 +1,260 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { Grant } from "../models/access/grant_model.ts";
+import {
+  type AdminGrantStore,
+  hashPrincipal,
+  instanceNameForAdmin,
+  materializeAdmins,
+} from "./admin_materializer.ts";
+
+await initializeLogging({});
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+    state: "active",
+    source: "config",
+    createdBy: { kind: "user", id: "system" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMockStore(
+  existingGrants: Map<string, { grant: Grant; modelId: string }> = new Map(),
+): AdminGrantStore & {
+  written: Map<string, Grant>;
+  definitions: Set<string>;
+} {
+  const written = new Map<string, Grant>();
+  const definitions = new Set<string>();
+  const grants = new Map(existingGrants);
+
+  return {
+    written,
+    definitions,
+    queryConfigGrants() {
+      return Promise.resolve(new Map(grants));
+    },
+    ensureDefinition(instanceName: string) {
+      definitions.add(instanceName);
+      return Promise.resolve(`model-id-for-${instanceName}`);
+    },
+    writeGrant(
+      _modelId: string,
+      instanceName: string,
+      grant: Grant,
+    ) {
+      written.set(instanceName, grant);
+      grants.set(instanceName, { grant, modelId: _modelId });
+      return Promise.resolve();
+    },
+  };
+}
+
+Deno.test("materializeAdmins: creates grants for new admins", async () => {
+  const store = createMockStore();
+  const result = await materializeAdmins("token", ["user:adam"], store);
+
+  assertEquals(result.created, 1);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 0);
+
+  const hash = await hashPrincipal("user:adam");
+  const instanceName = instanceNameForAdmin(hash);
+  const grant = store.written.get(instanceName)!;
+  assertEquals(grant.subject, { kind: "user", name: "adam" });
+  assertEquals(grant.effect, "allow");
+  assertEquals(grant.actions, ["admin"]);
+  assertEquals(grant.resource, { kind: "access", pattern: "*" });
+  assertEquals(grant.state, "active");
+  assertEquals(grant.source, "config");
+  assertEquals(grant.createdBy, { kind: "user", id: "system" });
+  assertEquals(store.definitions.has(instanceName), true);
+});
+
+Deno.test("materializeAdmins: idempotent on second run with same admins", async () => {
+  const hash = await hashPrincipal("user:adam");
+  const instanceName = instanceNameForAdmin(hash);
+  const existing = new Map([
+    [instanceName, { grant: makeGrant(), modelId: "model-1" }],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await materializeAdmins("token", ["user:adam"], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 1);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("materializeAdmins: revokes grants for removed admins", async () => {
+  const hashAdam = await hashPrincipal("user:adam");
+  const hashSarah = await hashPrincipal("user:sarah");
+  const nameAdam = instanceNameForAdmin(hashAdam);
+  const nameSarah = instanceNameForAdmin(hashSarah);
+  const existing = new Map([
+    [nameAdam, { grant: makeGrant(), modelId: "model-1" }],
+    [
+      nameSarah,
+      {
+        grant: makeGrant({ subject: { kind: "user", name: "sarah" } }),
+        modelId: "model-2",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await materializeAdmins("token", ["user:adam"], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 1);
+  assertEquals(result.unchanged, 1);
+
+  const revokedGrant = store.written.get(nameSarah)!;
+  assertEquals(revokedGrant.state, "revoked");
+});
+
+Deno.test("materializeAdmins: idempotent after revocation", async () => {
+  const hashAdam = await hashPrincipal("user:adam");
+  const hashSarah = await hashPrincipal("user:sarah");
+  const nameAdam = instanceNameForAdmin(hashAdam);
+  const nameSarah = instanceNameForAdmin(hashSarah);
+  const existing = new Map([
+    [nameAdam, { grant: makeGrant(), modelId: "model-1" }],
+    [
+      nameSarah,
+      {
+        grant: makeGrant({
+          subject: { kind: "user", name: "sarah" },
+          state: "revoked",
+        }),
+        modelId: "model-2",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await materializeAdmins("token", ["user:adam"], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 2);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("materializeAdmins: re-activates grant after add-remove-re-add cycle", async () => {
+  const hash = await hashPrincipal("user:adam");
+  const instanceName = instanceNameForAdmin(hash);
+
+  const store = createMockStore();
+
+  const r1 = await materializeAdmins("token", ["user:adam"], store);
+  assertEquals(r1.created, 1);
+
+  const r2 = await materializeAdmins("token", [], store);
+  assertEquals(r2.revoked, 1);
+  const revokedGrant = store.written.get(instanceName)!;
+  assertEquals(revokedGrant.state, "revoked");
+
+  const r3 = await materializeAdmins("token", ["user:adam"], store);
+  assertEquals(r3.reactivated, 1);
+  const reactivatedGrant = store.written.get(instanceName)!;
+  assertEquals(reactivatedGrant.state, "active");
+});
+
+Deno.test("materializeAdmins: runtime source:method grants are untouched", async () => {
+  // Source:method grants are filtered out by queryConfigGrants,
+  // so the materializer never sees them. Verify it only creates
+  // the requested admin grant and doesn't touch other instances.
+  const store = createMockStore();
+
+  const result = await materializeAdmins("token", ["user:adam"], store);
+
+  assertEquals(result.created, 1);
+  assertEquals(result.revoked, 0);
+
+  const hash = await hashPrincipal("user:adam");
+  const instanceName = instanceNameForAdmin(hash);
+  assertEquals(store.written.has(instanceName), true);
+  assertEquals(store.written.has("grant-tom"), false);
+});
+
+Deno.test("materializeAdmins: mode none skips entirely", async () => {
+  const store = createMockStore();
+  const result = await materializeAdmins("none", ["user:adam"], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 0);
+  assertEquals(store.written.size, 0);
+  assertEquals(store.definitions.size, 0);
+});
+
+Deno.test("materializeAdmins: handles multiple admins", async () => {
+  const store = createMockStore();
+  const result = await materializeAdmins(
+    "token",
+    ["user:adam", "user:sarah", "user:agent-1"],
+    store,
+  );
+
+  assertEquals(result.created, 3);
+  assertEquals(store.written.size, 3);
+  assertEquals(store.definitions.size, 3);
+});
+
+Deno.test("materializeAdmins: works with oauth mode", async () => {
+  const store = createMockStore();
+  const result = await materializeAdmins("oauth", ["user:adam"], store);
+
+  assertEquals(result.created, 1);
+});
+
+Deno.test("hashPrincipal: deterministic across calls", async () => {
+  const h1 = await hashPrincipal("user:adam");
+  const h2 = await hashPrincipal("user:adam");
+  assertEquals(h1, h2);
+});
+
+Deno.test("hashPrincipal: different principals produce different hashes", async () => {
+  const h1 = await hashPrincipal("user:adam");
+  const h2 = await hashPrincipal("user:sarah");
+  assertEquals(h1 !== h2, true);
+});
+
+Deno.test("instanceNameForAdmin: produces grant-config- prefix", () => {
+  assertEquals(
+    instanceNameForAdmin("abc123").startsWith("grant-config-"),
+    true,
+  );
+});

--- a/src/domain/access/serve_auth_config.ts
+++ b/src/domain/access/serve_auth_config.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../errors.ts";
-import { parsePrincipal } from "./principal.ts";
+import { parseSubject } from "./subject.ts";
 
 export type AuthMode = "none" | "token" | "oauth";
 
@@ -58,10 +58,10 @@ function parseCommaSeparated(value: string | undefined): string[] {
 function validateAdmins(admins: string[]): void {
   for (const admin of admins) {
     try {
-      parsePrincipal(admin);
+      parseSubject(admin);
     } catch {
       throw new UserError(
-        `Invalid --admins value "${admin}": expected principal format "user:<id>" or "worker:<id>"`,
+        `Invalid --admins value "${admin}": expected format "user:<id>", "group:<name>", or "idp-group:<name>"`,
       );
     }
   }

--- a/src/domain/access/serve_auth_config_test.ts
+++ b/src/domain/access/serve_auth_config_test.ts
@@ -57,9 +57,9 @@ Deno.test("buildServeAuthConfig: mode token with admins succeeds", () => {
 Deno.test("buildServeAuthConfig: mode token with multiple admins succeeds", () => {
   const config = buildServeAuthConfig({
     authMode: "token",
-    admins: "user:oauth|user-123, worker:agent-456",
+    admins: "user:oauth|user-123, user:agent-456",
   });
-  assertEquals(config.admins, ["user:oauth|user-123", "worker:agent-456"]);
+  assertEquals(config.admins, ["user:oauth|user-123", "user:agent-456"]);
 });
 
 Deno.test("buildServeAuthConfig: mode oauth without admins refuses", () => {
@@ -149,6 +149,18 @@ Deno.test("buildServeAuthConfig: invalid principal kind in admins refuses", () =
   );
 });
 
+Deno.test("buildServeAuthConfig: worker principal kind in admins refuses", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "token",
+        admins: "worker:deploy-bot",
+      }),
+    UserError,
+    'Invalid --admins value "worker:deploy-bot"',
+  );
+});
+
 Deno.test("buildServeAuthConfig: admins with empty name after colon refuses", () => {
   assertThrows(
     () =>
@@ -182,9 +194,9 @@ Deno.test("buildServeAuthConfig: default groups-field is collectives", () => {
 Deno.test("buildServeAuthConfig: comma-separated admins trims whitespace", () => {
   const config = buildServeAuthConfig({
     authMode: "token",
-    admins: " user:alice , user:bob , worker:agent-1 ",
+    admins: " user:alice , user:bob , user:agent-1 ",
   });
-  assertEquals(config.admins, ["user:alice", "user:bob", "worker:agent-1"]);
+  assertEquals(config.admins, ["user:alice", "user:bob", "user:agent-1"]);
 });
 
 Deno.test("buildServeAuthConfig: empty strings in comma list are filtered", () => {


### PR DESCRIPTION
## Summary

- Add `admin_materializer.ts` domain service in `src/domain/access/` that reconciles `source: config` admin grants at `swamp serve` startup
- Four-state reconciliation: not-exists→create, active→no-op, revoked→re-activate, active+not-in-admins→revoke
- Deterministic instance names via `grant-config-<sha256-hash>` for idempotent reconciliation across restarts
- Wired into `serve.ts` **before** `PolicySnapshotLoader.load()` so the initial snapshot includes admin grants
- `createdBy: user:system`, `source: config`, skips entirely when `mode: none`

## Test Plan

- 12 unit tests in `admin_materializer_test.ts` covering:
  - Creates grants for new admins
  - Idempotent on second run with same admins (zero writes)
  - Revokes grants for removed admins
  - Idempotent after revocation
  - Re-activates grant after add→remove→re-add cycle
  - Runtime `source: method` grants are untouched
  - `mode: none` skips entirely
  - Multiple admins, oauth mode
  - Hash determinism and instance name format
- Full test suite: 7365 passed, 0 failed
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

Closes swamp-club#683