### PR TITLE
fix(access): downgrade CEL unknown-variable warning to debug level

### DIFF
--- a/src/domain/access/policy_snapshot.ts
+++ b/src/domain/access/policy_snapshot.ts
@@ -104,7 +104,14 @@ export class PolicySnapshot {
         principalContext,
       );
     } catch (error) {
-      logger.warn`Condition evaluation failed for ${condition}: ${error}`;
+      if (
+        error instanceof Error &&
+        error.message.startsWith("Unknown variable:")
+      ) {
+        logger.debug`Condition evaluation skipped for ${condition}: ${error}`;
+      } else {
+        logger.warn`Condition evaluation failed for ${condition}: ${error}`;
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- When `access check` runs without `--field` flags, CEL conditions that reference missing fields throw expected "Unknown variable" errors. These were logged at `warn` level with a full stack trace, which is noisy for a normal operational case (condition simply can't be evaluated → treated as not satisfied).
- Downgraded "Unknown variable" errors to `debug` level. Unexpected evaluation failures (type errors, syntax issues) still log at `warn`.

## Test Plan

- Existing test `PolicySnapshot.evaluateCondition: returns false when evaluator throws` continues to pass — confirms unknown-variable errors still return `false`
- `deno check`, `deno lint`, `deno fmt --check` all pass
- Manual: `swamp access check --subject user:jake --action run --on 'workflow:@acme/deploy' --collectives platform-eng` should produce clean output with no warning stack trace