### PR TITLE
fix(models): let sensitive-arg guard recurse into record/array values (swamp-club#684)

### DIFF
--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -203,11 +203,13 @@ function isExpressionOnly(value: string): boolean {
  * - `undefined`/`null` and empty/whitespace-only strings carry no secret.
  * - A string that is composed solely of `${{ ... }}` expressions (e.g. a
  *   `vault.get(...)` reference) is resolved at runtime and is safe.
+ * - An array or plain object (record/map) is a literal secret iff any leaf
+ *   value is one — an all-`vault.get(...)` map carries no cleartext; an empty
+ *   container carries no secret.
  * - Any other present value — a non-expression string, a string mixing literal
- *   text with an expression, or any number/boolean/array/object — is treated as
- *   a literal secret. Non-string values cannot be expression references, so they
- *   are always literals; this fails closed rather than risk leaking a typed
- *   secret.
+ *   text with an expression, or a bare non-string scalar (number/boolean) — is
+ *   treated as a literal secret. Bare non-string scalars cannot be expression
+ *   references, so they fail closed.
  */
 function isLiteralSecret(value: unknown): boolean {
   if (value === undefined || value === null) {
@@ -218,6 +220,18 @@ function isLiteralSecret(value: unknown): boolean {
       return false;
     }
     return !isExpressionOnly(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(isLiteralSecret);
+  }
+  if (
+    typeof value === "object" &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  ) {
+    return Object.values(value as Record<string, unknown>).some(
+      isLiteralSecret,
+    );
   }
   return true;
 }
@@ -381,6 +395,35 @@ export function redactSensitiveValues(
 }
 
 /**
+ * Recursively collects all string values from a value tree into `out`.
+ * Handles strings, arrays, and plain objects (records/maps).
+ */
+function collectSecretStrings(value: unknown, out: string[]): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (typeof value === "string") {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const element of value) {
+      collectSecretStrings(element, out);
+    }
+    return;
+  }
+  if (
+    typeof value === "object" &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  ) {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      collectSecretStrings(v, out);
+    }
+  }
+}
+
+/**
  * Extracts the runtime secret values from a data object based on its Zod schema.
  *
  * For each field marked `{ sensitive: true }` in the schema:
@@ -404,20 +447,7 @@ export function extractSensitiveFieldValues(
   const secrets: string[] = [];
 
   for (const field of fields) {
-    const value = getNestedValue(data, field.path);
-    if (value === undefined || value === null) {
-      continue;
-    }
-    if (typeof value === "string") {
-      secrets.push(value);
-    } else if (Array.isArray(value)) {
-      for (const element of value) {
-        if (typeof element === "string") {
-          secrets.push(element);
-        }
-      }
-    }
-    // Object values are skipped — nested fields are found by extractSensitiveFields recursion
+    collectSecretStrings(getNestedValue(data, field.path), secrets);
   }
 
   return secrets;

--- a/src/domain/models/sensitive_field_extractor_test.ts
+++ b/src/domain/models/sensitive_field_extractor_test.ts
@@ -227,6 +227,17 @@ Deno.test("extractSensitiveFieldValues: array with non-string elements skips the
   assertEquals(extractSensitiveFieldValues(schema, data), ["str", "other"]);
 });
 
+Deno.test("extractSensitiveFieldValues: record field collects each string value", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.string()).meta({ sensitive: true }),
+  });
+  const data = { secrets: { KEY_A: "secret-a", KEY_B: "secret-b" } };
+  assertEquals(extractSensitiveFieldValues(schema, data).sort(), [
+    "secret-a",
+    "secret-b",
+  ]);
+});
+
 Deno.test("extractSensitiveFieldValues: empty schema returns empty", () => {
   const schema = z.object({});
   const data = {};
@@ -487,14 +498,101 @@ Deno.test("findLiteralSensitiveGlobalArgs: returns [] for undefined schema or ar
   assertEquals(findLiteralSensitiveGlobalArgs(schema, undefined), []);
 });
 
-Deno.test("findLiteralSensitiveGlobalArgs: returns [] for a non-object schema (documented residual)", () => {
-  // extractSensitiveFields only walks object shapes; a record schema is not
-  // inspected, so a sensitive value nested in it is not detected. This mirrors
-  // the redaction primitives' limitation and is an accepted best-effort gap.
+Deno.test("findLiteralSensitiveGlobalArgs: returns [] for a non-object schema (schema-level residual)", () => {
+  // extractSensitiveFields only walks object shapes; a standalone record schema
+  // has no sensitive metadata on individual keys, so nothing is detected.
   const schema = z.record(z.string(), z.string());
 
   assertEquals(
     findLiteralSensitiveGlobalArgs(schema, { apiKey: "SECRET" }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: accepts an all-vault.get() record", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.string()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      secrets: {
+        MY_KEY: "${{ vault.get('my-vault', 'my-key') }}",
+        OTHER: "${{ vault.get('my-vault', 'other') }}",
+      },
+    }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: accepts an all-vault.get() array", () => {
+  const schema = z.object({
+    tokens: z.array(z.string()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      tokens: [
+        "${{ vault.get('my-vault', 'token-a') }}",
+        "${{ vault.get('my-vault', 'token-b') }}",
+      ],
+    }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: accepts an empty record", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.string()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, { secrets: {} }),
+    [],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: rejects a record with one literal string", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.string()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      secrets: {
+        SAFE: "${{ vault.get('my-vault', 'safe') }}",
+        LEAKED: "cleartext-secret",
+      },
+    }),
+    ["secrets"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: rejects a record with a number value", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.unknown()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      secrets: { port: 5432 },
+    }),
+    ["secrets"],
+  );
+});
+
+Deno.test("findLiteralSensitiveGlobalArgs: accepts nested containers of vault.get() expressions", () => {
+  const schema = z.object({
+    secrets: z.record(z.string(), z.unknown()).meta({ sensitive: true }),
+  });
+
+  assertEquals(
+    findLiteralSensitiveGlobalArgs(schema, {
+      secrets: {
+        keys: ["${{ vault.get('v', 'a') }}", "${{ vault.get('v', 'b') }}"],
+        nested: { deep: "${{ vault.get('v', 'c') }}" },
+      },
+    }),
     [],
   );
 });


### PR DESCRIPTION
## Summary

- **`isLiteralSecret()`** now recurses into arrays and plain objects instead of rejecting any non-string value as a cleartext literal. An all-`vault.get()` record/map is accepted; a container with any literal leaf is still rejected. Bare non-string scalars (number, boolean) remain fail-closed.
- **`extractSensitiveFieldValues()`** now collects string values from record/map entries via a `collectSecretStrings()` helper, so sensitive record values are registered with the log redactor.
- 7 new unit tests + 1 updated test covering records, arrays, nested containers, mixed-literal rejection, and value collection.

Fixes swamp-club#684.

## Test Plan

- [x] All 55 `sensitive_field_extractor_test.ts` tests pass (48 existing + 7 new)
- [x] Full test suite passes (7371 passed, 2 pre-existing flaky failures unrelated to this change)
- [x] End-to-end reproduction of the exact issue path: model type with sensitive `z.record()` field, persisted instance pinned to old typeVersion, `method run` triggers migration re-save — old binary rejects with "literal value" error, fixed binary accepts and upgrades typeVersion successfully
- [x] Verified log file redaction: secret values from record fields show as `***` in the persisted run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)