### PR TITLE
fix(runtime): demote deno extraction logs from info to debug

### DIFF
--- a/src/infrastructure/runtime/embedded_deno_runtime.ts
+++ b/src/infrastructure/runtime/embedded_deno_runtime.ts
@@ -107,7 +107,7 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
       // Version marker missing or binary missing — need to extract
     }
 
-    logger.info`Extracting embedded deno ${embeddedVersion} to ${swampDir}`;
+    logger.debug`Extracting embedded deno ${embeddedVersion} to ${swampDir}`;
 
     // Ensure target directory exists
     await Deno.mkdir(swampDir, { recursive: true });
@@ -131,7 +131,7 @@ export class EmbeddedDenoRuntime implements DenoRuntime {
     await Deno.writeTextFile(versionMarker, embeddedVersion.value);
 
     logger
-      .info`Extracted deno ${embeddedVersion} (${embeddedBinary.length} bytes)`;
+      .debug`Extracted deno ${embeddedVersion} (${embeddedBinary.length} bytes)`;
 
     if (await this.healthCheck(targetBinary)) {
       return targetBinary;


### PR DESCRIPTION
## Summary

- Demote the two deno-extraction log lines (lines 110, 134) in `embedded_deno_runtime.ts` from `info` to `debug` so they no longer clutter routine command output on every swamp upgrade.
- The `warn` on health-check failure (line 104) is unchanged.

## Test Plan

- All 7387 tests pass (`deno run test`)
- `deno check`, `deno lint`, `deno fmt` all clean