### PR TITLE
feat(serve-auth): server token authentication on WebSocket connections (swamp-club#685)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -147,9 +147,17 @@ When `--auth-mode token` is active, the server validates a `?token=name.secret`
 query parameter at WebSocket upgrade time via the `swamp/server-token` model's
 `redeem` method (timing-safe, vault-backed). Unauthenticated connections receive
 HTTP 401. The client resolves the token from (in precedence order) the
-`--token` flag, the `SWAMP_SERVER_TOKEN` env var, or stored credentials in
-`~/.config/swamp/servers.json` (managed by `swamp auth server-login`). Token
-management is through `swamp access token mint/list/revoke`.
+`--token` flag, the `SWAMP_SERVER_TOKEN` + `SWAMP_SERVER_URL` env vars, or
+stored credentials in `~/.config/swamp/servers.json` (managed by
+`swamp auth server-login`). Token management is through
+`swamp access token mint/list/revoke`.
+
+The token travels as a `?token=` query parameter on the WebSocket upgrade URL.
+This is the standard WebSocket auth pattern (the browser WebSocket API does not
+support custom headers on upgrade requests), but the plaintext will appear in
+any reverse proxy or load balancer access logs that capture the full request
+URL. Use TLS (`wss://`) for non-loopback deployments and configure access-log
+redaction on any intermediary that fronts the server.
 
 ## No execution drivers
 

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -141,10 +141,15 @@ run's event stream completes — so clients can distinguish "run ended" from
 `swamp workflow run --server <url>` / `swamp model ... method run --server`:
 repo-less, streaming the run's events through the same renderers as a local
 run (the wire codec is lossless for run events; `deserializeEvent` in
-`src/serve/serializer.ts` is the anti-corruption seam). Client
-authentication is still absent, matching serve's trust model; the intended
-evolution is a bearer credential presented at upgrade, reusing the
-session-credential machinery.
+`src/serve/serializer.ts` is the anti-corruption seam).
+
+When `--auth-mode token` is active, the server validates a `?token=name.secret`
+query parameter at WebSocket upgrade time via the `swamp/server-token` model's
+`redeem` method (timing-safe, vault-backed). Unauthenticated connections receive
+HTTP 401. The client resolves the token from (in precedence order) the
+`--token` flag, the `SWAMP_SERVER_TOKEN` env var, or stored credentials in
+`~/.config/swamp/servers.json` (managed by `swamp auth server-login`). Token
+management is through `swamp access token mint/list/revoke`.
 
 ## No execution drivers
 

--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -118,7 +118,7 @@ async function withServeRepo(
         const upgrade = req.headers.get("upgrade") ?? "";
         if (upgrade.toLowerCase() === "websocket") {
           const { socket, response } = Deno.upgradeWebSocket(req);
-          handleConnection(socket, connectionCtx);
+          handleConnection(socket, connectionCtx, null);
           return response;
         }
         return new Response("Not found", { status: 404 });

--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -23,13 +23,26 @@ import { accessGrantCommand } from "./access_grant.ts";
 import { accessGroupCommand } from "./access_group.ts";
 import { accessCheckCommand } from "./access_check.ts";
 import { accessReloadCommand } from "./access_reload.ts";
+import { accessTokenMintCommand } from "./access_token_mint.ts";
+import { accessTokenListCommand } from "./access_token_list.ts";
+import { accessTokenRevokeCommand } from "./access_token_revoke.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+
+export const accessTokenCommand = new Command()
+  .name("token")
+  .description("Manage server tokens for user authentication")
+  .error(unknownCommandErrorHandler)
+  .action(groupCommandAction)
+  .command("mint", accessTokenMintCommand)
+  .command("list", accessTokenListCommand)
+  .command("revoke", accessTokenRevokeCommand);
 
 export const accessCommand = new Command()
   .name("access")
   .description("Manage authorization grants, groups, and access checks")
   .error(unknownCommandErrorHandler)
   .action(groupCommandAction)
+  .command("token", accessTokenCommand)
   .command("grant", accessGrantCommand)
   .command("group", accessGroupCommand)
   .command("check", accessCheckCommand)

--- a/src/cli/commands/access_token_list.ts
+++ b/src/cli/commands/access_token_list.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenListDeps,
+  serverTokenList,
+  type ServerTokenListEvent,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { renderServerTokenList } from "../../presentation/output/access_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessTokenListCommand = new Command()
+  .name("list")
+  .description(
+    "List server tokens: state, principal, expiry, and last use",
+  )
+  .example("List all tokens", "swamp access token list")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "access",
+      "token",
+      "list",
+    ]);
+
+    const { repoContext } = await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createServerTokenListDeps(repoContext.dataQueryService);
+
+    await consumeStream(
+      serverTokenList(libCtx, deps),
+      withDefaults<ServerTokenListEvent>({
+        completed: (event) => {
+          renderServerTokenList(event.data, cliCtx.outputMode);
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+
+    cliCtx.logger.debug("Server token list command completed");
+  });

--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -1,0 +1,188 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenCreateDeps,
+  parseDuration,
+  serverTokenCreate,
+  type ServerTokenCreateData,
+  type ServerTokenCreateEvent,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { renderServerTokenCreate } from "../../presentation/output/access_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const DEFAULT_DURATION = "30d";
+
+export const accessTokenMintCommand = new Command()
+  .name("mint")
+  .description(
+    "Mint a server token for user authentication; the plaintext is shown once",
+  )
+  .example(
+    "Mint a token for a user",
+    "swamp access token mint adam-token --principal user:adam",
+  )
+  .example(
+    "Mint with custom duration",
+    "swamp access token mint adam-token --principal user:adam --duration 7d",
+  )
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--principal <principal:string>",
+    "Principal identity for the token (e.g. user:adam)",
+    { required: true },
+  )
+  .option(
+    "--email <email:string>",
+    "Display email for the token holder (defaults to principal)",
+  )
+  .option(
+    "--duration <duration:string>",
+    "Token lifetime (e.g. 30m, 1h, 24h, 7d, 30d)",
+    { default: DEFAULT_DURATION },
+  )
+  .option(
+    "--vault <vault:string>",
+    "Vault that stores the token plaintext (defaults to the sole configured vault)",
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "access",
+      "token",
+      "mint",
+    ]);
+
+    const principal = options.principal as string;
+    if (!principal.includes(":")) {
+      throw new UserError(
+        `Invalid --principal value "${principal}": expected format "user:<id>"`,
+      );
+    }
+
+    const durationMs = parseDuration(options.duration as string);
+    if (durationMs <= 0) {
+      throw new UserError(
+        `Invalid --duration value "${options.duration}": must be positive`,
+      );
+    }
+
+    const email = (options.email as string | undefined) ?? principal;
+
+    const { repoDir, repoContext, datastoreConfig, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+    cliCtx.logger.debug`Minting server token ${name}`;
+
+    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = await createServerTokenCreateDeps(
+      libCtx,
+      repoDir,
+      repoContext,
+    );
+
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      name,
+    );
+    let flushModelLocks: (() => Promise<void>) | null = null;
+    if (preResult) {
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+      flushModelLocks = lockResult.flush;
+    }
+
+    try {
+      let data: ServerTokenCreateData | undefined;
+      await consumeStream(
+        serverTokenCreate(libCtx, deps, {
+          name,
+          principalId: principal,
+          principalEmail: email,
+          durationMs,
+          vaultName: options.vault as string | undefined,
+        }),
+        withDefaults<ServerTokenCreateEvent>({
+          completed: (event) => {
+            data = event.data;
+          },
+          error: (event) => {
+            throw new UserError(event.error.message);
+          },
+        }),
+      );
+      if (data === undefined) {
+        throw new UserError(
+          `Minting token '${name}' ended without completing`,
+        );
+      }
+      renderServerTokenCreate(data, cliCtx.outputMode);
+    } finally {
+      if (flushModelLocks) {
+        try {
+          await flushModelLocks();
+        } catch (releaseError) {
+          cliCtx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
+    }
+
+    cliCtx.logger.debug("Server token mint command completed");
+  });

--- a/src/cli/commands/access_token_revoke.ts
+++ b/src/cli/commands/access_token_revoke.ts
@@ -1,0 +1,136 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenRevokeDeps,
+  serverTokenRevoke,
+  type ServerTokenRevokeData,
+  type ServerTokenRevokeEvent,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { renderServerTokenRevoke } from "../../presentation/output/access_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessTokenRevokeCommand = new Command()
+  .name("revoke")
+  .description("Invalidate a server token before it expires")
+  .example("Revoke a token", "swamp access token revoke adam-token")
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "access",
+      "token",
+      "revoke",
+    ]);
+
+    const { repoDir, repoContext, datastoreConfig, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+    cliCtx.logger.debug`Revoking server token ${name}`;
+
+    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = await createServerTokenRevokeDeps(
+      libCtx,
+      repoDir,
+      repoContext,
+    );
+
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      name,
+    );
+    let flushModelLocks: (() => Promise<void>) | null = null;
+    if (preResult) {
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+      flushModelLocks = lockResult.flush;
+    }
+
+    try {
+      let data: ServerTokenRevokeData | undefined;
+      await consumeStream(
+        serverTokenRevoke(libCtx, deps, { name }),
+        withDefaults<ServerTokenRevokeEvent>({
+          completed: (event) => {
+            data = event.data;
+          },
+          error: (event) => {
+            throw new UserError(event.error.message);
+          },
+        }),
+      );
+      if (data === undefined) {
+        throw new UserError(
+          `Revoking token '${name}' ended without completing`,
+        );
+      }
+      renderServerTokenRevoke(data, cliCtx.outputMode);
+    } finally {
+      if (flushModelLocks) {
+        try {
+          await flushModelLocks();
+        } catch (releaseError) {
+          cliCtx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
+    }
+
+    cliCtx.logger.debug("Server token revoke command completed");
+  });

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -22,6 +22,7 @@ import { groupCommandAction } from "../group_action.ts";
 import { authLoginCommand } from "./auth_login.ts";
 import { authLogoutCommand } from "./auth_logout.ts";
 import { authWhoamiCommand } from "./auth_whoami.ts";
+import { authServerLoginCommand } from "./auth_server_login.ts";
 
 export const authCommand = new Command()
   .name("auth")
@@ -29,4 +30,5 @@ export const authCommand = new Command()
   .action(groupCommandAction)
   .command("login", authLoginCommand)
   .command("logout", authLogoutCommand)
-  .command("whoami", authWhoamiCommand);
+  .command("whoami", authWhoamiCommand)
+  .command("server-login", authServerLoginCommand);

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { FileServerCredentialRepository } from "../../infrastructure/persistence/server_credential_repository.ts";
+import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
+import { splitServerToken } from "../../serve/token_auth.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { bold, green } from "@std/fmt/colors";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const authServerLoginCommand = new Command()
+  .name("server-login")
+  .description(
+    "Store a server token for a swamp serve instance — subsequent " +
+      "--server commands use it automatically",
+  )
+  .example(
+    "Save a token",
+    "swamp auth server-login --server wss://swamp.acme.internal:9090 --token adam-token.a1b2c3...",
+  )
+  .option(
+    "--server <url:string>",
+    "Server URL to associate the token with",
+    { required: true },
+  )
+  .option(
+    "--token <token:string>",
+    "Server token in <name>.<secret> format",
+    { required: true },
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "auth",
+      "server-login",
+    ]);
+
+    const token = options.token as string;
+    const split = splitServerToken(token);
+    if (split === null) {
+      throw new UserError(
+        `Invalid --token value: expected <name>.<secret> format`,
+      );
+    }
+
+    let serverUrl: string;
+    try {
+      serverUrl = normalizeServerUrl(options.server as string);
+    } catch {
+      throw new UserError(
+        `Invalid --server URL "${options.server}": expected http:// or https:// URL`,
+      );
+    }
+
+    const repo = new FileServerCredentialRepository();
+    await repo.save({
+      serverUrl,
+      tokenName: split.name,
+      token,
+      principalId: "",
+      obtainedAt: new Date().toISOString(),
+    });
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({
+        serverUrl,
+        tokenName: split.name,
+        stored: true,
+      }));
+    } else {
+      writeOutput(
+        `${green("✓")} Token ${bold(split.name)} stored for ${bold(serverUrl)}`,
+      );
+    }
+
+    cliCtx.logger.debug("Server login command completed");
+  });

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -63,12 +63,23 @@ export const authServerLoginCommand = new Command()
       );
     }
 
-    let serverUrl: string;
+    let rawUrl = options.server as string;
     try {
-      serverUrl = normalizeServerUrl(options.server as string);
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === "ws:") parsed.protocol = "http:";
+      else if (parsed.protocol === "wss:") parsed.protocol = "https:";
+      rawUrl = parsed.href;
     } catch {
       throw new UserError(
-        `Invalid --server URL "${options.server}": expected http:// or https:// URL`,
+        `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+      );
+    }
+    let serverUrl: string;
+    try {
+      serverUrl = normalizeServerUrl(rawUrl);
+    } catch {
+      throw new UserError(
+        `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
       );
     }
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -62,7 +62,7 @@ import {
   type ModelMethodRunEvent,
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
-import { runModelMethodOverServer } from "../remote_run.ts";
+import { resolveServerToken, runModelMethodOverServer } from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
 
@@ -163,6 +163,10 @@ export const modelMethodRunCommand = new Command()
   .option(
     "--server <url:string>",
     "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required.",
+  )
+  .option(
+    "--token <token:string>",
+    "Server token for authentication (overrides stored credentials)",
   )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
@@ -501,6 +505,11 @@ async function runMethodViaServer(
     )
     : [cliInputs];
 
+  const token = await resolveServerToken(
+    options.server as string,
+    options.token as string | undefined,
+  );
+
   try {
     for (let i = 0; i < inputSets.length; i++) {
       if (inputSets.length > 1) {
@@ -516,6 +525,7 @@ async function runMethodViaServer(
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           signal: abort.signal,
           payload: {
             modelIdOrName,
@@ -524,8 +534,6 @@ async function runMethodViaServer(
             lastEvaluated: options.lastEvaluated as boolean,
             runtimeTags,
           },
-          // The wire codec is lossless for run events; see
-          // deserializeEvent in src/serve/serializer.ts.
         }) as AsyncIterable<ModelMethodRunEvent>,
         renderer.handlers(),
       );

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -166,7 +166,7 @@ export const modelMethodRunCommand = new Command()
   )
   .option(
     "--token <token:string>",
-    "Server token for authentication (overrides stored credentials)",
+    "Server token in <name>.<secret> format (overrides stored credentials and SWAMP_SERVER_TOKEN)",
   )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -166,7 +166,7 @@ export const modelMethodRunCommand = new Command()
   )
   .option(
     "--token <token:string>",
-    "Server token in <name>.<secret> format (overrides stored credentials and SWAMP_SERVER_TOKEN)",
+    "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
   )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -27,6 +27,8 @@ import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
 import { handleConnection } from "../../serve/connection.ts";
+import { authenticateServerToken } from "../../serve/token_auth.ts";
+import { parsePrincipal } from "../../domain/access/principal.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
 import { CapabilityService } from "../../serve/capability_service.ts";
 import { WorkerGateway } from "../../serve/worker_gateway.ts";
@@ -198,7 +200,10 @@ export const serveCommand = new Command()
       outputMode: ctx.outputMode,
     });
 
-    if (host !== "127.0.0.1" && host !== "localhost") {
+    if (
+      host !== "127.0.0.1" && host !== "localhost" &&
+      authConfig.mode === "none"
+    ) {
       logger.warn(
         "Binding to non-loopback address {host} — no authentication is enforced on WebSocket connections",
         { host },
@@ -462,8 +467,35 @@ export const serveCommand = new Command()
         // WebSocket upgrade (check first — upgrade requests are also GETs)
         const upgrade = req.headers.get("upgrade") ?? "";
         if (upgrade.toLowerCase() === "websocket") {
+          if (authConfig.mode === "token") {
+            const url = new URL(req.url);
+            const tokenParam = url.searchParams.get("token");
+            if (!tokenParam) {
+              return new Response("Unauthorized: token required", {
+                status: 401,
+              });
+            }
+            const result = await authenticateServerToken(
+              tokenParam,
+              resolvedRepoDir,
+              repoContext,
+            );
+            if (!result.ok) {
+              logger.warn(
+                "WebSocket auth rejected: {error}",
+                { error: result.error },
+              );
+              return new Response(`Unauthorized: ${result.error}`, {
+                status: 401,
+              });
+            }
+            const principal = parsePrincipal(result.principalId);
+            const { socket, response } = Deno.upgradeWebSocket(req);
+            handleConnection(socket, connectionCtx, principal);
+            return response;
+          }
           const { socket, response } = Deno.upgradeWebSocket(req);
-          handleConnection(socket, connectionCtx);
+          handleConnection(socket, connectionCtx, null);
           return response;
         }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -485,9 +485,7 @@ export const serveCommand = new Command()
                 "WebSocket auth rejected: {error}",
                 { error: result.error },
               );
-              return new Response(`Unauthorized: ${result.error}`, {
-                status: 401,
-              });
+              return new Response("Unauthorized", { status: 401 });
             }
             const principal = parsePrincipal(result.principalId);
             const { socket, response } = Deno.upgradeWebSocket(req);

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -165,7 +165,7 @@ export const workflowRunCommand = new Command()
   )
   .option(
     "--token <token:string>",
-    "Server token in <name>.<secret> format (overrides stored credentials and SWAMP_SERVER_TOKEN)",
+    "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
   )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -165,7 +165,7 @@ export const workflowRunCommand = new Command()
   )
   .option(
     "--token <token:string>",
-    "Server token for authentication (overrides stored credentials)",
+    "Server token in <name>.<secret> format (overrides stored credentials and SWAMP_SERVER_TOKEN)",
   )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -69,7 +69,7 @@ import {
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
 import { getActiveTelemetryService } from "../telemetry_integration.ts";
-import { runWorkflowOverServer } from "../remote_run.ts";
+import { resolveServerToken, runWorkflowOverServer } from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -162,6 +162,10 @@ export const workflowRunCommand = new Command()
   .option(
     "--server <url:string>",
     "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required. Required for steps with worker placement.",
+  )
+  .option(
+    "--token <token:string>",
+    "Server token for authentication (overrides stored credentials)",
   )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
@@ -547,6 +551,11 @@ async function runWorkflowViaServer(
     )
     : [cliInputs];
 
+  const token = await resolveServerToken(
+    options.server as string,
+    options.token as string | undefined,
+  );
+
   try {
     for (let i = 0; i < inputSets.length; i++) {
       if (inputSets.length > 1) {
@@ -562,6 +571,7 @@ async function runWorkflowViaServer(
       await consumeStream(
         runWorkflowOverServer({
           server: options.server as string,
+          token,
           signal: abort.signal,
           payload: {
             workflowIdOrName,
@@ -570,8 +580,6 @@ async function runWorkflowViaServer(
             verbose: ctx.verbosity === "verbose",
             runtimeTags,
           },
-          // The wire codec is lossless for run events; see
-          // deserializeEvent in src/serve/serializer.ts.
         }) as AsyncIterable<WorkflowRunEvent>,
         renderer.handlers(),
       );

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -157,10 +157,8 @@ export function requestServerResponse<T>(
   options: RequestResponseOptions,
   request: { type: string; id?: string; payload?: unknown },
 ): Promise<T> {
-  const url = appendTokenToUrl(
-    normalizeServerUrl(options.server),
-    options.token,
-  );
+  const baseUrl = normalizeServerUrl(options.server);
+  const url = appendTokenToUrl(baseUrl, options.token);
   const requestId = request.id ?? crypto.randomUUID();
   const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
@@ -204,7 +202,7 @@ export function requestServerResponse<T>(
         settled = true;
         cleanup();
         reject(
-          new UserError(`Could not connect to ${url}`),
+          new UserError(`Could not connect to ${baseUrl}`),
         );
       }
     };
@@ -277,10 +275,8 @@ async function* streamServerRun(
   options: ServerRunOptions,
   request: OutboundRequest,
 ): AsyncIterable<{ kind: string; [key: string]: unknown }> {
-  const url = appendTokenToUrl(
-    normalizeServerUrl(options.server),
-    options.token,
-  );
+  const baseUrl = normalizeServerUrl(options.server);
+  const url = appendTokenToUrl(baseUrl, options.token);
   const requestId = crypto.randomUUID();
   const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
 
@@ -316,7 +312,7 @@ async function* streamServerRun(
     notify();
   };
   socket.onerror = () => {
-    connectError = `Could not connect to ${url}`;
+    connectError = `Could not connect to ${baseUrl}`;
     notify();
   };
 
@@ -324,7 +320,7 @@ async function* streamServerRun(
     const timer = setTimeout(() => {
       reject(
         new UserError(
-          `Timed out connecting to ${url} after ${CONNECT_TIMEOUT_MS}ms — is 'swamp serve' running?`,
+          `Timed out connecting to ${baseUrl} after ${CONNECT_TIMEOUT_MS}ms — is 'swamp serve' running?`,
         ),
       );
     }, CONNECT_TIMEOUT_MS);
@@ -336,7 +332,7 @@ async function* streamServerRun(
       clearTimeout(timer);
       reject(
         new UserError(
-          connectError ?? `Connection to ${url} closed before it opened`,
+          connectError ?? `Connection to ${baseUrl} closed before it opened`,
         ),
       );
     };

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -25,10 +25,11 @@
  * server's terminal `done` frame. Ctrl-C (signal abort) sends `cancel` and
  * drains until the server confirms.
  *
- * Authentication: none yet — this matches `swamp serve`'s current model
- * (it warns on non-loopback binds). The intended evolution is a bearer
- * credential presented at upgrade, reusing the session-credential machinery
- * from remote execution.
+ * Authentication: when `--auth-mode token` is active on the server, the
+ * client appends `?token=<name>.<secret>` to the WebSocket URL. The token
+ * comes from (in precedence order): the `--token` flag, the
+ * `SWAMP_SERVER_TOKEN` env var, or the `~/.config/swamp/servers.json` file
+ * via `ServerCredentialRepository`.
  */
 
 import { UserError } from "../domain/errors.ts";
@@ -38,6 +39,8 @@ import type {
   WorkflowRunPayload,
 } from "../serve/protocol.ts";
 import { deserializeEvent } from "../serve/serializer.ts";
+import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
+import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
 
 /** How long to keep draining after sending `cancel` before giving up. */
 const CANCEL_DRAIN_MS = 10_000;
@@ -48,9 +51,55 @@ const CONNECT_TIMEOUT_MS = 15_000;
 export interface ServerRunOptions {
   /** Server URL: ws://, wss://, http://, or https://. */
   server: string;
+  /** Server token (`<name>.<secret>`) for authentication. */
+  token?: string;
   signal?: AbortSignal;
   /** Test seam: WebSocket factory. */
   createSocket?: (url: string) => WebSocket;
+}
+
+/**
+ * Appends a `?token=` query parameter to a WebSocket URL for server token
+ * authentication. Returns the original URL unmodified when no token is
+ * provided.
+ */
+export function appendTokenToUrl(url: string, token?: string): string {
+  if (!token) return url;
+  const parsed = new URL(url);
+  parsed.searchParams.set("token", token);
+  return parsed.href;
+}
+
+/**
+ * Converts ws(s) URLs to http(s) for credential lookup — stored credentials
+ * are keyed by http(s) URL, but `--server` flags often use ws(s).
+ */
+function toHttpUrl(serverUrl: string): string {
+  try {
+    const parsed = new URL(serverUrl);
+    if (parsed.protocol === "ws:") parsed.protocol = "http:";
+    else if (parsed.protocol === "wss:") parsed.protocol = "https:";
+    return parsed.href;
+  } catch {
+    return serverUrl;
+  }
+}
+
+/**
+ * Resolves the server token for authentication. Precedence:
+ * 1. Explicit `--token` flag value
+ * 2. `SWAMP_SERVER_TOKEN` env var (via ServerCredentialRepository)
+ * 3. Stored credential in `~/.config/swamp/servers.json`
+ */
+export async function resolveServerToken(
+  serverUrl: string,
+  explicitToken?: string,
+  credentialRepo?: ServerCredentialRepository,
+): Promise<string | undefined> {
+  if (explicitToken) return explicitToken;
+  const repo = credentialRepo ?? new FileServerCredentialRepository();
+  const credential = await repo.get(toHttpUrl(serverUrl));
+  return credential?.token;
 }
 
 /** Normalizes http(s) URLs to ws(s) so `--server http://host:4000` works. */
@@ -98,6 +147,7 @@ const REQUEST_RESPONSE_TIMEOUT_MS = 30_000;
 
 export interface RequestResponseOptions {
   server: string;
+  token?: string;
   signal?: AbortSignal;
   createSocket?: (url: string) => WebSocket;
   timeoutMs?: number;
@@ -107,7 +157,10 @@ export function requestServerResponse<T>(
   options: RequestResponseOptions,
   request: { type: string; id?: string; payload?: unknown },
 ): Promise<T> {
-  const url = normalizeServerUrl(options.server);
+  const url = appendTokenToUrl(
+    normalizeServerUrl(options.server),
+    options.token,
+  );
   const requestId = request.id ?? crypto.randomUUID();
   const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
@@ -224,7 +277,10 @@ async function* streamServerRun(
   options: ServerRunOptions,
   request: OutboundRequest,
 ): AsyncIterable<{ kind: string; [key: string]: unknown }> {
-  const url = normalizeServerUrl(options.server);
+  const url = appendTokenToUrl(
+    normalizeServerUrl(options.server),
+    options.token,
+  );
   const requestId = crypto.randomUUID();
   const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
 

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -25,11 +25,15 @@ import {
 } from "@std/assert";
 import { UserError } from "../domain/errors.ts";
 import {
+  appendTokenToUrl,
   normalizeServerUrl,
   requestServerResponse,
+  resolveServerToken,
   runModelMethodOverServer,
   runWorkflowOverServer,
 } from "./remote_run.ts";
+import type { ServerCredential } from "../domain/auth/server_credential.ts";
+import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
 
 /**
  * In-process scripted serve endpoint: the script receives each parsed client
@@ -352,4 +356,108 @@ Deno.test({
       await server.shutdown();
     }
   },
+});
+
+// ── appendTokenToUrl tests ──────────────────────────────────────────────
+
+Deno.test("appendTokenToUrl: appends token as query param", () => {
+  const result = appendTokenToUrl(
+    "ws://localhost:9090/",
+    "adam-token.secret123",
+  );
+  assertEquals(result, "ws://localhost:9090/?token=adam-token.secret123");
+});
+
+Deno.test("appendTokenToUrl: returns unchanged URL when no token", () => {
+  const url = "ws://localhost:9090/";
+  assertEquals(appendTokenToUrl(url), url);
+  assertEquals(appendTokenToUrl(url, undefined), url);
+});
+
+Deno.test("appendTokenToUrl: preserves existing path", () => {
+  const result = appendTokenToUrl(
+    "wss://swamp.acme.internal:9090/api",
+    "tok.sec",
+  );
+  assertEquals(result, "wss://swamp.acme.internal:9090/api?token=tok.sec");
+});
+
+// ── resolveServerToken tests ────────────────────────────────────────────
+
+Deno.test("resolveServerToken: explicit token takes precedence", async () => {
+  const result = await resolveServerToken(
+    "http://localhost:9090",
+    "explicit.token",
+  );
+  assertEquals(result, "explicit.token");
+});
+
+Deno.test("resolveServerToken: falls back to credential repo", async () => {
+  const mockRepo: ServerCredentialRepository = {
+    get: (url: string): Promise<ServerCredential | null> => {
+      if (url.includes("localhost")) {
+        return Promise.resolve({
+          serverUrl: url,
+          tokenName: "stored",
+          token: "stored.credential",
+          principalId: "user:test",
+          obtainedAt: "2026-06-18T00:00:00Z",
+        });
+      }
+      return Promise.resolve(null);
+    },
+    save: () => Promise.resolve(),
+    remove: () => Promise.resolve(),
+    list: () => Promise.resolve([]),
+  };
+
+  const result = await resolveServerToken(
+    "http://localhost:9090",
+    undefined,
+    mockRepo,
+  );
+  assertEquals(result, "stored.credential");
+});
+
+Deno.test("resolveServerToken: converts ws URL to http for credential lookup", async () => {
+  const mockRepo: ServerCredentialRepository = {
+    get: (url: string): Promise<ServerCredential | null> => {
+      if (url === "http://localhost:9090/") {
+        return Promise.resolve({
+          serverUrl: url,
+          tokenName: "stored",
+          token: "stored.ws-lookup",
+          principalId: "user:test",
+          obtainedAt: "2026-06-18T00:00:00Z",
+        });
+      }
+      return Promise.resolve(null);
+    },
+    save: () => Promise.resolve(),
+    remove: () => Promise.resolve(),
+    list: () => Promise.resolve([]),
+  };
+
+  const result = await resolveServerToken(
+    "ws://localhost:9090",
+    undefined,
+    mockRepo,
+  );
+  assertEquals(result, "stored.ws-lookup");
+});
+
+Deno.test("resolveServerToken: returns undefined when no credential", async () => {
+  const emptyRepo: ServerCredentialRepository = {
+    get: () => Promise.resolve(null),
+    save: () => Promise.resolve(),
+    remove: () => Promise.resolve(),
+    list: () => Promise.resolve([]),
+  };
+
+  const result = await resolveServerToken(
+    "http://unknown:9090",
+    undefined,
+    emptyRepo,
+  );
+  assertEquals(result, undefined);
 });

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -1,0 +1,126 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import type { ModelMethodRunDeps } from "../models/run.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
+import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { runFileSink } from "../../infrastructure/logging/logger.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { SecretRedactor } from "../../domain/secrets/mod.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
+import { reportRegistry } from "../../domain/reports/report_registry.ts";
+
+/**
+ * Builds the full ModelMethodRunDeps needed to run methods on the built-in
+ * server token model, with direct type execution enabled.
+ */
+export async function createServerTokenRunDeps(
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<ModelMethodRunDeps> {
+  await Promise.all([
+    modelRegistry.ensureLoaded(),
+    vaultTypeRegistry.ensureLoaded(),
+    reportRegistry.ensureLoaded(),
+  ]);
+
+  return {
+    repoDir,
+    lookupDefinition: (idOrName) =>
+      findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+    getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+    createEvaluationService: () => {
+      const dqs = new DataQueryService(
+        repoContext.catalogStore,
+        repoContext.unifiedDataRepo,
+      );
+      return new ExpressionEvaluationService(
+        repoContext.definitionRepo,
+        repoDir,
+        {
+          dataRepo: repoContext.unifiedDataRepo,
+          dataQueryService: dqs,
+        },
+      );
+    },
+    loadEvaluatedDefinition: (type, name) =>
+      repoContext.evaluatedDefinitionRepo.findByName(type, name),
+    saveEvaluatedDefinition: (type, definition) =>
+      repoContext.evaluatedDefinitionRepo.save(type, definition),
+    createExecutionService: () => new DefaultMethodExecutionService(),
+    createVaultService: () => VaultService.fromRepository(repoDir),
+    dataRepo: repoContext.unifiedDataRepo,
+    definitionRepo: repoContext.definitionRepo,
+    outputRepo: repoContext.outputRepo,
+    dataQueryService: new DataQueryService(
+      repoContext.catalogStore,
+      repoContext.unifiedDataRepo,
+    ),
+    createRunLog: async (modelType, method, definitionId) => {
+      const redactor = new SecretRedactor();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const logFilePath = join(
+        swampPath(repoDir, SWAMP_SUBDIRS.outputs),
+        modelType.normalized,
+        method,
+        `${definitionId}-${timestamp}.log`,
+      );
+      const logCategory: string[] = [];
+      await runFileSink.register(
+        logCategory,
+        logFilePath,
+        redactor,
+        swampPath(repoDir),
+      );
+      return {
+        logFilePath,
+        redactor,
+        cleanup: () => runFileSink.unregister(logCategory),
+      };
+    },
+    createAndSaveDefinition: async (type, definition) => {
+      const autoDefRepo = new YamlDefinitionRepository(
+        repoDir,
+        undefined,
+        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        false,
+      );
+      await autoDefRepo.save(type, definition);
+    },
+    getDefinitionPath: (type, id) => {
+      return join(
+        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        type.toDirectoryPath(),
+        `${id}.yaml`,
+      );
+    },
+  };
+}

--- a/src/libswamp/access/token_create.ts
+++ b/src/libswamp/access/token_create.ts
@@ -1,0 +1,211 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Mint a server token for user authentication on `swamp serve`.
+ *
+ * Runs the `mint` method on the built-in `swamp/server-token` model via
+ * direct type execution — auto-creating the model instance named after the
+ * token — then reads the plaintext back from the vault so the CLI can show
+ * it exactly once.
+ */
+
+import type { LibSwampContext } from "../context.ts";
+import { type SwampError, validationFailed } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { SERVER_TOKEN_MODEL_TYPE } from "../../domain/models/access/server_token_model.ts";
+import { createServerTokenRunDeps } from "./run_deps.ts";
+
+export interface ServerTokenCreateData {
+  name: string;
+  token: string;
+  principalId: string;
+  expiresAt: string;
+  vaultRef: { vaultName: string; secretKey: string };
+}
+
+export type ServerTokenCreateEvent =
+  | { kind: "minting"; name: string; vaultName: string }
+  | { kind: "completed"; data: ServerTokenCreateData }
+  | { kind: "error"; error: SwampError };
+
+export interface ServerTokenCreateInput {
+  name: string;
+  principalId: string;
+  principalEmail: string;
+  durationMs: number;
+  vaultName?: string;
+}
+
+export interface ServerTokenCreateDeps {
+  listVaultNames: () => Promise<string[]>;
+  runMint: (
+    input: {
+      name: string;
+      principalId: string;
+      principalEmail: string;
+      durationMs: number;
+      vaultName: string;
+    },
+  ) => AsyncIterable<ModelMethodRunEvent>;
+  readSecret: (vaultName: string, secretKey: string) => Promise<string>;
+}
+
+export async function createServerTokenCreateDeps(
+  ctx: LibSwampContext,
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<ServerTokenCreateDeps> {
+  const runDeps = await createServerTokenRunDeps(repoDir, repoContext);
+  const vaultService = await VaultService.fromRepository(repoDir);
+  return {
+    listVaultNames: () => Promise.resolve(vaultService.getVaultNames()),
+    runMint: (input) =>
+      modelMethodRun(ctx, runDeps, {
+        modelIdOrName: input.name,
+        methodName: "mint",
+        inputs: {
+          principalId: input.principalId,
+          principalEmail: input.principalEmail,
+          durationMs: input.durationMs,
+          vaultName: input.vaultName,
+        },
+        lastEvaluated: false,
+        typeArg: SERVER_TOKEN_MODEL_TYPE.normalized,
+        definitionName: input.name,
+      }),
+    readSecret: (vaultName, secretKey) =>
+      vaultService.get(vaultName, secretKey),
+  };
+}
+
+async function resolveVaultName(
+  deps: ServerTokenCreateDeps,
+  requested: string | undefined,
+): Promise<{ ok: true; vaultName: string } | { ok: false; message: string }> {
+  const available = await deps.listVaultNames();
+  if (requested !== undefined) {
+    if (!available.includes(requested)) {
+      const hint = available.length > 0
+        ? `Available vaults: ${available.join(", ")}`
+        : "No vaults are configured. Create one with: swamp vault create <type> <name>";
+      return {
+        ok: false,
+        message: `Vault '${requested}' is not configured. ${hint}`,
+      };
+    }
+    return { ok: true, vaultName: requested };
+  }
+  if (available.length === 0) {
+    return {
+      ok: false,
+      message: "No vaults are configured — the token plaintext must be " +
+        "stored in a vault. Create one with: swamp vault create <type> <name>",
+    };
+  }
+  if (available.length > 1) {
+    return {
+      ok: false,
+      message: `Multiple vaults are configured (${
+        available.join(", ")
+      }). Pass --vault <name> to choose one.`,
+    };
+  }
+  return { ok: true, vaultName: available[0] };
+}
+
+const TOKEN_DATA_NAME = "token-main";
+
+export async function* serverTokenCreate(
+  _ctx: LibSwampContext,
+  deps: ServerTokenCreateDeps,
+  input: ServerTokenCreateInput,
+): AsyncGenerator<ServerTokenCreateEvent> {
+  yield* withGeneratorSpan(
+    "swamp.access.token.create",
+    { "token.name": input.name },
+    (async function* () {
+      const resolved = await resolveVaultName(deps, input.vaultName);
+      if (!resolved.ok) {
+        yield {
+          kind: "error" as const,
+          error: validationFailed(resolved.message),
+        };
+        return;
+      }
+      const vaultName = resolved.vaultName;
+
+      yield { kind: "minting" as const, name: input.name, vaultName };
+
+      let tokenRecord: Record<string, unknown> | undefined;
+      for await (
+        const event of deps.runMint({
+          name: input.name,
+          principalId: input.principalId,
+          principalEmail: input.principalEmail,
+          durationMs: input.durationMs,
+          vaultName,
+        })
+      ) {
+        if (event.kind === "error") {
+          yield { kind: "error" as const, error: event.error };
+          return;
+        }
+        if (event.kind === "completed") {
+          tokenRecord = event.run.dataArtifacts.find(
+            (artifact) => artifact.name === TOKEN_DATA_NAME,
+          )?.attributes;
+        }
+      }
+
+      if (
+        tokenRecord === undefined ||
+        typeof tokenRecord.expiresAt !== "string" ||
+        typeof tokenRecord.secretKey !== "string"
+      ) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_record_missing",
+            message: `Mint completed but the '${TOKEN_DATA_NAME}' record ` +
+              `for token '${input.name}' was not produced`,
+          },
+        };
+        return;
+      }
+
+      const secretKey = tokenRecord.secretKey;
+      const plaintext = await deps.readSecret(vaultName, secretKey);
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          name: input.name,
+          token: `${input.name}.${plaintext}`,
+          principalId: input.principalId,
+          expiresAt: tokenRecord.expiresAt as string,
+          vaultRef: { vaultName, secretKey },
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/access/token_create_test.ts
+++ b/src/libswamp/access/token_create_test.ts
@@ -1,0 +1,260 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { ModelMethodRunEvent } from "../models/run.ts";
+import {
+  serverTokenCreate,
+  type ServerTokenCreateDeps,
+  type ServerTokenCreateEvent,
+} from "./token_create.ts";
+
+const EXPIRES_AT = "2026-07-18T00:00:00.000Z";
+
+function mintEvents(
+  name: string,
+  attributes?: Record<string, unknown>,
+): ModelMethodRunEvent[] {
+  return [
+    { kind: "validating_inputs" },
+    {
+      kind: "completed",
+      run: {
+        modelId: name,
+        modelName: name,
+        modelType: "swamp/server-token",
+        methodName: "mint",
+        status: "succeeded",
+        outputId: "output-1",
+        dataArtifacts: [
+          {
+            id: "data-1",
+            name: "token-main",
+            path: `/data/${name}/token-main`,
+            attributes: attributes ?? {
+              name,
+              state: "active",
+              principalId: "user:adam",
+              principalEmail: "adam@example.com",
+              createdAt: "2026-06-18T00:00:00.000Z",
+              expiresAt: EXPIRES_AT,
+              vaultName: "main-vault",
+              secretKey: `server-token-${name}`,
+            },
+          },
+        ],
+      },
+    },
+  ];
+}
+
+function makeDeps(
+  overrides?: Partial<ServerTokenCreateDeps>,
+): ServerTokenCreateDeps {
+  return {
+    listVaultNames: () => Promise.resolve(["main-vault"]),
+    runMint: async function* (input) {
+      for (const event of mintEvents(input.name)) {
+        yield await Promise.resolve(event);
+      }
+    },
+    readSecret: () => Promise.resolve("plaintext-secret"),
+    ...overrides,
+  };
+}
+
+Deno.test("serverTokenCreate: mints and yields the plaintext once", async () => {
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), makeDeps(), {
+      name: "adam-token",
+      principalId: "user:adam",
+      principalEmail: "adam@example.com",
+      durationMs: 30 * 24 * 60 * 60 * 1000,
+    }),
+  );
+
+  assertEquals(events[0], {
+    kind: "minting",
+    name: "adam-token",
+    vaultName: "main-vault",
+  });
+  const completed = events[1] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data, {
+    name: "adam-token",
+    token: "adam-token.plaintext-secret",
+    principalId: "user:adam",
+    expiresAt: EXPIRES_AT,
+    vaultRef: {
+      vaultName: "main-vault",
+      secretKey: "server-token-adam-token",
+    },
+  });
+});
+
+Deno.test("serverTokenCreate: defaults to the sole configured vault", async () => {
+  let mintedVault: string | undefined;
+  const deps = makeDeps({
+    listVaultNames: () => Promise.resolve(["only-vault"]),
+    runMint: async function* (input) {
+      mintedVault = input.vaultName;
+      for (const event of mintEvents(input.name)) {
+        yield await Promise.resolve(event);
+      }
+    },
+  });
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), deps, {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+    }),
+  );
+  assertEquals(mintedVault, "only-vault");
+  assertEquals(events[1].kind, "completed");
+});
+
+Deno.test("serverTokenCreate: errors when no vaults are configured", async () => {
+  const deps = makeDeps({ listVaultNames: () => Promise.resolve([]) });
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), deps, {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+    }),
+  );
+  assertEquals(events.length, 1);
+  const error = events[0] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "No vaults are configured");
+});
+
+Deno.test("serverTokenCreate: errors when multiple vaults and no --vault", async () => {
+  const deps = makeDeps({
+    listVaultNames: () => Promise.resolve(["a", "b"]),
+  });
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), deps, {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+    }),
+  );
+  const error = events[0] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "Multiple vaults are configured");
+  assertStringIncludes(error.error.message, "--vault");
+});
+
+Deno.test("serverTokenCreate: errors when the requested vault is unknown", async () => {
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), makeDeps(), {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+      vaultName: "missing",
+    }),
+  );
+  const error = events[0] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "Vault 'missing'");
+  assertStringIncludes(error.error.message, "main-vault");
+});
+
+Deno.test("serverTokenCreate: forwards mint errors", async () => {
+  const deps = makeDeps({
+    runMint: async function* () {
+      await Promise.resolve();
+      yield {
+        kind: "error",
+        error: {
+          code: "method_execution_failed",
+          message: "Server token 'tok' already exists",
+        },
+      } as ModelMethodRunEvent;
+    },
+  });
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), deps, {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+    }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "already exists");
+});
+
+Deno.test("serverTokenCreate: errors when the token record is missing", async () => {
+  const deps = makeDeps({
+    runMint: async function* (input) {
+      yield await Promise.resolve(
+        {
+          kind: "completed",
+          run: {
+            modelId: input.name,
+            modelName: input.name,
+            modelType: "swamp/server-token",
+            methodName: "mint",
+            status: "succeeded",
+            outputId: "output-1",
+            dataArtifacts: [],
+          },
+        } satisfies ModelMethodRunEvent,
+      );
+    },
+  });
+  const events = await collect<ServerTokenCreateEvent>(
+    serverTokenCreate(createLibSwampContext(), deps, {
+      name: "tok",
+      principalId: "user:bob",
+      principalEmail: "bob@example.com",
+      durationMs: 1000,
+    }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "token-main");
+});

--- a/src/libswamp/access/token_list.ts
+++ b/src/libswamp/access/token_list.ts
@@ -1,0 +1,138 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * List server tokens for the `swamp access token list` command.
+ */
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  ServerTokenSchema,
+  type ServerTokenState,
+} from "../../domain/models/access/server_token_model.ts";
+
+const TOKEN_DATA_NAME = "token-main";
+
+export interface ServerTokenListItem {
+  name: string;
+  state: ServerTokenState;
+  effectiveState: ServerTokenState;
+  principalId: string;
+  principalEmail: string;
+  createdAt: string;
+  expiresAt: string;
+  lastUsedAt?: string;
+}
+
+export interface ServerTokenListData {
+  tokens: ServerTokenListItem[];
+  count: number;
+}
+
+export type ServerTokenListEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: ServerTokenListData }
+  | { kind: "error"; error: SwampError };
+
+export interface ServerTokenListDeps {
+  query: (predicate: string) => Promise<DataRecord[]>;
+  now?: () => number;
+}
+
+export function createServerTokenListDeps(
+  dataQueryService: DataQueryService,
+): ServerTokenListDeps {
+  return {
+    query: async (predicate) => {
+      const results = await dataQueryService.query(predicate, {
+        loadAttributes: true,
+      });
+      return results as DataRecord[];
+    },
+  };
+}
+
+function effectiveTokenState(
+  state: ServerTokenState,
+  expiresAt: string,
+  nowMs: number,
+): ServerTokenState {
+  if (state === "active" && Date.parse(expiresAt) <= nowMs) {
+    return "expired";
+  }
+  return state;
+}
+
+export async function* serverTokenList(
+  _ctx: LibSwampContext,
+  deps: ServerTokenListDeps,
+): AsyncGenerator<ServerTokenListEvent> {
+  yield* withGeneratorSpan(
+    "swamp.access.token.list",
+    {},
+    (async function* () {
+      yield { kind: "resolving" as const };
+      try {
+        const records = await deps.query(
+          `modelType == "${SERVER_TOKEN_MODEL_TYPE.normalized}" && ` +
+            `name == "${TOKEN_DATA_NAME}"`,
+        );
+        const nowMs = (deps.now ?? Date.now)();
+        const tokens: ServerTokenListItem[] = [];
+        for (const record of records) {
+          const parsed = ServerTokenSchema.safeParse(record.attributes);
+          if (!parsed.success) continue;
+          const token = parsed.data;
+          tokens.push({
+            name: token.name,
+            state: token.state,
+            effectiveState: effectiveTokenState(
+              token.state,
+              token.expiresAt,
+              nowMs,
+            ),
+            principalId: token.principalId,
+            principalEmail: token.principalEmail,
+            createdAt: token.createdAt,
+            expiresAt: token.expiresAt,
+            lastUsedAt: token.lastUsedAt,
+          });
+        }
+        tokens.sort((a, b) => a.name.localeCompare(b.name));
+        yield {
+          kind: "completed" as const,
+          data: { tokens, count: tokens.length },
+        };
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "server_token_list_failed",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    })(),
+  );
+}

--- a/src/libswamp/access/token_list_test.ts
+++ b/src/libswamp/access/token_list_test.ts
@@ -1,0 +1,204 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { DataRecord } from "../../domain/data/data_record.ts";
+import {
+  serverTokenList,
+  type ServerTokenListDeps,
+  type ServerTokenListEvent,
+} from "./token_list.ts";
+
+function makeRecord(
+  modelName: string,
+  dataName: string,
+  attributes: Record<string, unknown>,
+): DataRecord {
+  return {
+    id: `${modelName}-${dataName}`,
+    name: dataName,
+    version: 1,
+    isLatest: true,
+    createdAt: "2026-06-18T00:00:00.000Z",
+    namespace: "",
+    attributes,
+    tags: {},
+    modelName,
+    modelId: modelName,
+    modelType: "swamp/server-token",
+    specName: "token",
+    dataType: "resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    ownerType: "model",
+    streaming: false,
+    size: 0,
+    content: "",
+    ownerRef: "",
+    workflowRunId: "",
+    workflowName: "",
+    jobName: "",
+    stepName: "",
+    source: "",
+  };
+}
+
+function tokenAttributes(
+  name: string,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    name,
+    state: "active",
+    principalId: "user:adam",
+    principalEmail: "adam@example.com",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    expiresAt: "2026-07-18T00:00:00.000Z",
+    vaultName: "main-vault",
+    secretKey: `server-token-${name}`,
+    ...overrides,
+  };
+}
+
+const NOW = Date.parse("2026-06-20T00:00:00.000Z");
+
+function makeDeps(records: DataRecord[]): ServerTokenListDeps {
+  return {
+    query: () => Promise.resolve(records),
+    now: () => NOW,
+  };
+}
+
+Deno.test("serverTokenList: yields resolving then completed with mapped tokens", async () => {
+  const deps = makeDeps([
+    makeRecord("adam-token", "token-main", tokenAttributes("adam-token")),
+  ]);
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.count, 1);
+  assertEquals(completed.data.tokens[0].name, "adam-token");
+  assertEquals(completed.data.tokens[0].state, "active");
+  assertEquals(completed.data.tokens[0].effectiveState, "active");
+  assertEquals(completed.data.tokens[0].principalId, "user:adam");
+  assertEquals(completed.data.tokens[0].principalEmail, "adam@example.com");
+});
+
+Deno.test("serverTokenList: overlays expired display state on stale active tokens", async () => {
+  const deps = makeDeps([
+    makeRecord(
+      "stale",
+      "token-main",
+      tokenAttributes("stale", {
+        state: "active",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+        lastUsedAt: "2026-06-18T12:00:00.000Z",
+      }),
+    ),
+  ]);
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.tokens[0].state, "active");
+  assertEquals(completed.data.tokens[0].effectiveState, "expired");
+  assertEquals(completed.data.tokens[0].lastUsedAt, "2026-06-18T12:00:00.000Z");
+});
+
+Deno.test("serverTokenList: revoked tokens keep their state regardless of expiry", async () => {
+  const deps = makeDeps([
+    makeRecord(
+      "revoked-tok",
+      "token-main",
+      tokenAttributes("revoked-tok", {
+        state: "revoked",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      }),
+    ),
+  ]);
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.tokens[0].effectiveState, "revoked");
+});
+
+Deno.test("serverTokenList: skips malformed records and sorts by name", async () => {
+  const deps = makeDeps([
+    makeRecord("zeta", "token-main", tokenAttributes("zeta")),
+    makeRecord("broken", "token-main", { nonsense: true }),
+    makeRecord("alpha", "token-main", tokenAttributes("alpha")),
+  ]);
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.count, 2);
+  assertEquals(
+    completed.data.tokens.map((t) => t.name),
+    ["alpha", "zeta"],
+  );
+});
+
+Deno.test("serverTokenList: yields error when the query fails", async () => {
+  const deps: ServerTokenListDeps = {
+    query: () => Promise.reject(new Error("catalog unavailable")),
+  };
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+  const error = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "catalog unavailable");
+});
+
+Deno.test("serverTokenList: empty list yields zero-count completed", async () => {
+  const deps = makeDeps([]);
+  const events = await collect<ServerTokenListEvent>(
+    serverTokenList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    ServerTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.count, 0);
+  assertEquals(completed.data.tokens, []);
+});

--- a/src/libswamp/access/token_revoke.ts
+++ b/src/libswamp/access/token_revoke.ts
@@ -1,0 +1,145 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Revoke a server token before its lifetime expires.
+ *
+ * Runs the `revoke` method on the existing `swamp/server-token` model
+ * instance named by the token. Revoking an already-revoked token is a
+ * no-op, reported via `alreadyRevoked`.
+ */
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { createServerTokenRunDeps } from "./run_deps.ts";
+
+export interface ServerTokenRevokeData {
+  name: string;
+  state: string;
+  revokedAt?: string;
+  alreadyRevoked: boolean;
+}
+
+export type ServerTokenRevokeEvent =
+  | { kind: "revoking"; name: string }
+  | { kind: "completed"; data: ServerTokenRevokeData }
+  | { kind: "error"; error: SwampError };
+
+export interface ServerTokenRevokeInput {
+  name: string;
+}
+
+export interface ServerTokenRevokeDeps {
+  runRevoke: (name: string) => AsyncIterable<ModelMethodRunEvent>;
+}
+
+export async function createServerTokenRevokeDeps(
+  ctx: LibSwampContext,
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<ServerTokenRevokeDeps> {
+  const runDeps = await createServerTokenRunDeps(repoDir, repoContext);
+  return {
+    runRevoke: (name) =>
+      modelMethodRun(ctx, runDeps, {
+        modelIdOrName: name,
+        methodName: "revoke",
+        inputs: {},
+        lastEvaluated: false,
+      }),
+  };
+}
+
+const TOKEN_DATA_NAME = "token-main";
+
+export async function* serverTokenRevoke(
+  _ctx: LibSwampContext,
+  deps: ServerTokenRevokeDeps,
+  input: ServerTokenRevokeInput,
+): AsyncGenerator<ServerTokenRevokeEvent> {
+  yield* withGeneratorSpan(
+    "swamp.access.token.revoke",
+    { "token.name": input.name },
+    (async function* () {
+      yield { kind: "revoking" as const, name: input.name };
+
+      let tokenRecord: Record<string, unknown> | undefined;
+      let completed = false;
+      for await (const event of deps.runRevoke(input.name)) {
+        if (event.kind === "error") {
+          const error = event.error.code === "model_not_found"
+            ? {
+              code: event.error.code,
+              message: `Server token '${input.name}' not found. ` +
+                "Use 'swamp access token list' to see existing tokens.",
+            }
+            : event.error;
+          yield { kind: "error" as const, error };
+          return;
+        }
+        if (event.kind === "completed") {
+          completed = true;
+          tokenRecord = event.run.dataArtifacts.find(
+            (artifact) => artifact.name === TOKEN_DATA_NAME,
+          )?.attributes;
+        }
+      }
+
+      if (!completed) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "revoke_incomplete",
+            message: `Revoke of token '${input.name}' ended without completing`,
+          },
+        };
+        return;
+      }
+
+      if (tokenRecord === undefined) {
+        yield {
+          kind: "completed" as const,
+          data: {
+            name: input.name,
+            state: "revoked",
+            alreadyRevoked: true,
+          },
+        };
+        return;
+      }
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          name: input.name,
+          state: typeof tokenRecord.state === "string"
+            ? tokenRecord.state
+            : "revoked",
+          revokedAt: typeof tokenRecord.revokedAt === "string"
+            ? tokenRecord.revokedAt
+            : undefined,
+          alreadyRevoked: false,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/access/token_revoke_test.ts
+++ b/src/libswamp/access/token_revoke_test.ts
@@ -1,0 +1,170 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { ModelMethodRunEvent } from "../models/run.ts";
+import {
+  serverTokenRevoke,
+  type ServerTokenRevokeDeps,
+  type ServerTokenRevokeEvent,
+} from "./token_revoke.ts";
+
+const REVOKED_AT = "2026-06-20T12:00:00.000Z";
+
+function completedEvent(
+  name: string,
+  artifacts: Array<{ name: string; attributes?: Record<string, unknown> }>,
+): ModelMethodRunEvent {
+  return {
+    kind: "completed",
+    run: {
+      modelId: name,
+      modelName: name,
+      modelType: "swamp/server-token",
+      methodName: "revoke",
+      status: "succeeded",
+      outputId: "output-1",
+      dataArtifacts: artifacts.map((artifact, index) => ({
+        id: `data-${index}`,
+        name: artifact.name,
+        path: `/data/${name}/${artifact.name}`,
+        attributes: artifact.attributes,
+      })),
+    },
+  };
+}
+
+Deno.test("serverTokenRevoke: yields revoking then completed with state", async () => {
+  const deps: ServerTokenRevokeDeps = {
+    runRevoke: async function* (name) {
+      yield await Promise.resolve(
+        completedEvent(name, [
+          {
+            name: "token-main",
+            attributes: { state: "revoked", revokedAt: REVOKED_AT },
+          },
+        ]),
+      );
+    },
+  };
+  const events = await collect<ServerTokenRevokeEvent>(
+    serverTokenRevoke(createLibSwampContext(), deps, { name: "adam-token" }),
+  );
+
+  assertEquals(events[0], { kind: "revoking", name: "adam-token" });
+  const completed = events[1] as Extract<
+    ServerTokenRevokeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data, {
+    name: "adam-token",
+    state: "revoked",
+    revokedAt: REVOKED_AT,
+    alreadyRevoked: false,
+  });
+});
+
+Deno.test("serverTokenRevoke: reports already-revoked tokens as a no-op", async () => {
+  const deps: ServerTokenRevokeDeps = {
+    runRevoke: async function* (name) {
+      yield await Promise.resolve(completedEvent(name, []));
+    },
+  };
+  const events = await collect<ServerTokenRevokeEvent>(
+    serverTokenRevoke(createLibSwampContext(), deps, { name: "old-token" }),
+  );
+  const completed = events[1] as Extract<
+    ServerTokenRevokeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.alreadyRevoked, true);
+  assertEquals(completed.data.state, "revoked");
+});
+
+Deno.test("serverTokenRevoke: rewrites model_not_found as token-specific error", async () => {
+  const deps: ServerTokenRevokeDeps = {
+    runRevoke: async function* () {
+      yield await Promise.resolve(
+        {
+          kind: "error",
+          error: {
+            code: "model_not_found",
+            message: "Model 'missing' not found",
+          },
+        } satisfies ModelMethodRunEvent,
+      );
+    },
+  };
+  const events = await collect<ServerTokenRevokeEvent>(
+    serverTokenRevoke(createLibSwampContext(), deps, { name: "missing" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevokeEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertEquals(error.error.code, "model_not_found");
+  assertStringIncludes(error.error.message, "Server token 'missing' not found");
+  assertStringIncludes(error.error.message, "swamp access token list");
+});
+
+Deno.test("serverTokenRevoke: forwards non-model_not_found errors unchanged", async () => {
+  const deps: ServerTokenRevokeDeps = {
+    runRevoke: async function* () {
+      yield await Promise.resolve(
+        {
+          kind: "error",
+          error: {
+            code: "method_execution_failed",
+            message: "vault unavailable",
+          },
+        } satisfies ModelMethodRunEvent,
+      );
+    },
+  };
+  const events = await collect<ServerTokenRevokeEvent>(
+    serverTokenRevoke(createLibSwampContext(), deps, { name: "tok" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevokeEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.error.code, "method_execution_failed");
+  assertStringIncludes(error.error.message, "vault unavailable");
+});
+
+Deno.test("serverTokenRevoke: errors when the stream ends without completing", async () => {
+  const deps: ServerTokenRevokeDeps = {
+    // deno-lint-ignore require-yield
+    runRevoke: async function* () {
+      await Promise.resolve();
+    },
+  };
+  const events = await collect<ServerTokenRevokeEvent>(
+    serverTokenRevoke(createLibSwampContext(), deps, { name: "tok" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRevokeEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "without completing");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -364,6 +364,34 @@ export {
   type WorkerTokenRevokeInput,
 } from "./worker/token_revoke.ts";
 export { createWorkerModelRunDeps } from "./worker/run_deps.ts";
+
+// Server token operations (user authentication for swamp serve)
+export {
+  createServerTokenCreateDeps,
+  serverTokenCreate,
+  type ServerTokenCreateData,
+  type ServerTokenCreateDeps,
+  type ServerTokenCreateEvent,
+  type ServerTokenCreateInput,
+} from "./access/token_create.ts";
+export {
+  createServerTokenListDeps,
+  serverTokenList,
+  type ServerTokenListData,
+  type ServerTokenListDeps,
+  type ServerTokenListEvent,
+  type ServerTokenListItem,
+} from "./access/token_list.ts";
+export {
+  createServerTokenRevokeDeps,
+  serverTokenRevoke,
+  type ServerTokenRevokeData,
+  type ServerTokenRevokeDeps,
+  type ServerTokenRevokeEvent,
+  type ServerTokenRevokeInput,
+} from "./access/token_revoke.ts";
+export { createServerTokenRunDeps } from "./access/run_deps.ts";
+
 export {
   createNamespace,
   formatNamespacedModelName,

--- a/src/presentation/output/access_token_output.ts
+++ b/src/presentation/output/access_token_output.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Render functions for the `swamp access token` command group. Each supports
+ * both "log" (human-readable) and "json" (structured) output modes per the
+ * terminal-output design system.
+ */
+
+import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type {
+  ServerTokenCreateData,
+  ServerTokenListData,
+  ServerTokenRevokeData,
+} from "../../libswamp/mod.ts";
+import type { OutputMode } from "./output.ts";
+
+const checkmark = "✓";
+
+function tableLines(
+  headers: string[],
+  rows: string[][],
+  colorCell?: (columnIndex: number, value: string) => string,
+): string[] {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length))
+  );
+  const lines: string[] = [
+    dim(headers.map((header, i) => header.padEnd(widths[i])).join("  ")),
+  ];
+  for (const row of rows) {
+    lines.push(
+      row
+        .map((cell, i) => {
+          const padded = cell.padEnd(widths[i]);
+          return colorCell ? colorCell(i, padded) : padded;
+        })
+        .join("  ")
+        .trimEnd(),
+    );
+  }
+  return lines;
+}
+
+function colorTokenState(state: string): string {
+  const trimmed = state.trim();
+  switch (trimmed) {
+    case "active":
+      return state.replace(trimmed, green(trimmed));
+    case "expired":
+    case "revoked":
+      return state.replace(trimmed, red(trimmed));
+    default:
+      return state;
+  }
+}
+
+export function renderServerTokenCreate(
+  data: ServerTokenCreateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  const lines = [
+    `${bold(cyan("Token:"))} ${bold(data.name)}`,
+    `${bold(cyan("Principal:"))} ${data.principalId}`,
+    `${bold(cyan("Expires:"))} ${data.expiresAt}`,
+    `${bold(cyan("Vault:"))} ${data.vaultRef.vaultName} ${
+      dim(`(key ${data.vaultRef.secretKey})`)
+    }`,
+    "",
+    `  ${bold(data.token)}`,
+    "",
+    yellow(
+      "This token is shown once and will not be displayed again — store it now.",
+    ),
+  ];
+  writeOutput(lines.join("\n"));
+}
+
+export function renderServerTokenList(
+  data: ServerTokenListData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data.tokens, null, 2));
+    return;
+  }
+  if (data.tokens.length === 0) {
+    writeOutput(
+      [
+        "No server tokens found.",
+        dim(
+          "Mint one with: swamp access token mint <name> --principal user:<id>",
+        ),
+      ].join("\n"),
+    );
+    return;
+  }
+  const rows = data.tokens.map((token) => [
+    token.name,
+    token.effectiveState,
+    token.principalId,
+    token.expiresAt,
+    token.lastUsedAt ?? "-",
+  ]);
+  const lines = tableLines(
+    ["NAME", "STATE", "PRINCIPAL", "EXPIRES", "LAST USED"],
+    rows,
+    (column, value) => (column === 1 ? colorTokenState(value) : value),
+  );
+  writeOutput(lines.join("\n"));
+}
+
+export function renderServerTokenRevoke(
+  data: ServerTokenRevokeData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  if (data.alreadyRevoked) {
+    writeOutput(`Token ${bold(data.name)} was already revoked.`);
+    return;
+  }
+  const lines = [`${green(checkmark)} Token ${bold(data.name)} revoked.`];
+  if (data.revokedAt) {
+    lines.push(`${bold(cyan("Revoked at:"))} ${data.revokedAt}`);
+  }
+  writeOutput(lines.join("\n"));
+}

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -55,7 +55,7 @@ import {
   GroupSchema,
 } from "../domain/models/access/group_model.ts";
 import type { DataRecord } from "../domain/data/data_record.ts";
-import { parsePrincipal } from "../domain/access/principal.ts";
+import { parsePrincipal, type Principal } from "../domain/access/principal.ts";
 import { ActionSchema } from "../domain/access/action.ts";
 import { parseResourceSelector } from "../domain/access/resource_selector.ts";
 import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
@@ -180,6 +180,7 @@ export interface ConnectionContext {
 export function handleConnection(
   socket: WebSocket,
   ctx: ConnectionContext,
+  _principal: Principal | null,
 ): void {
   const activeRequests = new Map<string, AbortController>();
   const workerAttachment = ctx.workerGateway?.attachTransport({

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -1,0 +1,113 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+import { createLibSwampContext, modelMethodRun } from "../libswamp/mod.ts";
+import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
+import { createModelMethodRunDeps } from "./deps.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "token-auth"]);
+
+const TOKEN_DATA_NAME = "token-main";
+
+/**
+ * Splits a presented server token of the form `<name>.<secret>`.
+ * The name half addresses the token aggregate; the secret half is compared
+ * against the vault-stored plaintext.
+ */
+export function splitServerToken(
+  presented: string,
+): { name: string; secret: string } | null {
+  const dot = presented.indexOf(".");
+  if (dot <= 0 || dot === presented.length - 1) {
+    return null;
+  }
+  return { name: presented.slice(0, dot), secret: presented.slice(dot + 1) };
+}
+
+export type ServerTokenAuthResult =
+  | { ok: true; principalId: string }
+  | { ok: false; error: string };
+
+/**
+ * Validates a presented `<name>.<secret>` server token by running the
+ * ServerToken model's `redeem` method. Returns the authenticated
+ * principal ID on success, or an error message on failure.
+ */
+export async function authenticateServerToken(
+  presented: string,
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<ServerTokenAuthResult> {
+  const split = splitServerToken(presented);
+  if (split === null) {
+    return {
+      ok: false,
+      error: "Invalid token format: expected <name>.<secret>",
+    };
+  }
+
+  const deps = await createModelMethodRunDeps(repoDir, repoContext, {
+    directExecution: true,
+  });
+  const libCtx = createLibSwampContext({});
+
+  let principalId: string | undefined;
+  for await (
+    const event of modelMethodRun(libCtx, deps, {
+      modelIdOrName: split.name,
+      methodName: "redeem",
+      inputs: { presentedToken: presented },
+      lastEvaluated: false,
+      typeArg: SERVER_TOKEN_MODEL_TYPE.normalized,
+      definitionName: split.name,
+      skipAllReports: true,
+    })
+  ) {
+    if (event.kind === "error") {
+      logger.debug("Token authentication failed for {name}: {error}", {
+        name: split.name,
+        error: event.error.message,
+      });
+      return { ok: false, error: event.error.message };
+    }
+    if (event.kind === "completed") {
+      const tokenRecord = event.run.dataArtifacts.find(
+        (artifact) => artifact.name === TOKEN_DATA_NAME,
+      )?.attributes;
+      if (tokenRecord && typeof tokenRecord.principalId === "string") {
+        principalId = tokenRecord.principalId;
+      }
+    }
+  }
+
+  if (principalId === undefined) {
+    return {
+      ok: false,
+      error: "Token validation completed but principal could not be resolved",
+    };
+  }
+
+  logger.info("Authenticated token {name} as {principal}", {
+    name: split.name,
+    principal: principalId,
+  });
+  return { ok: true, principalId };
+}

--- a/src/serve/token_auth_test.ts
+++ b/src/serve/token_auth_test.ts
@@ -1,0 +1,50 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { splitServerToken } from "./token_auth.ts";
+
+// ── splitServerToken ────────────────────────────────────────────────────
+
+Deno.test("splitServerToken: splits valid name.secret", () => {
+  const result = splitServerToken("adam-token.abc123def456");
+  assertEquals(result, { name: "adam-token", secret: "abc123def456" });
+});
+
+Deno.test("splitServerToken: returns null for no dot", () => {
+  assertEquals(splitServerToken("no-dot-here"), null);
+});
+
+Deno.test("splitServerToken: returns null for leading dot", () => {
+  assertEquals(splitServerToken(".leading-dot"), null);
+});
+
+Deno.test("splitServerToken: returns null for trailing dot", () => {
+  assertEquals(splitServerToken("trailing-dot."), null);
+});
+
+Deno.test("splitServerToken: handles dots in secret", () => {
+  const result = splitServerToken("my-token.secret.with.dots");
+  assertEquals(result, { name: "my-token", secret: "secret.with.dots" });
+});
+
+Deno.test("splitServerToken: single-char name and secret", () => {
+  const result = splitServerToken("a.b");
+  assertEquals(result, { name: "a", secret: "b" });
+});


### PR DESCRIPTION
## Summary

- Implements server token authentication on WebSocket connections when `swamp serve` runs with `--auth-mode token`. Tokens are validated via the ServerToken model's `redeem` method at HTTP upgrade time; unauthenticated connections receive HTTP 401.
- Adds `swamp access token mint/list/revoke` CLI commands for admin token management, following the existing worker token command patterns.
- Adds `swamp auth server-login` for storing server credentials and `--token` flag on `--server` commands with automatic credential lookup fallback (`--token` flag > `SWAMP_SERVER_TOKEN` env var > `~/.config/swamp/servers.json`).

Closes swamp-club#685

## Test Plan

- [x] `splitServerToken` unit tests: valid tokens, edge cases (no dot, leading/trailing dot, dots in secret)
- [x] `appendTokenToUrl` unit tests: token appending, no-token passthrough, path preservation
- [x] `resolveServerToken` unit tests: explicit precedence, credential repo fallback, ws→http URL conversion, missing credential
- [x] Existing `handleMessage` and `remote_run` tests still pass with signature changes
- [x] `deno check` — full type check passes
- [x] `deno lint` — no issues
- [x] `deno fmt` — all formatted
- [x] `deno run test` — 7407 tests pass, 0 failures
- [x] `deno run compile` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)