### PR TITLE
fix(serve-auth): hard refusals for off-loopback without TLS or auth (swamp-club#689)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -71,12 +71,12 @@ export function assertOffLoopbackSecurity(
   if (LOOPBACK_HOSTS.has(host)) return;
 
   if (!tlsEnabled) {
-    throw new Error(
+    throw new UserError(
       "Off-loopback binding requires TLS — provide --cert-file and --key-file, or bind to 127.0.0.1",
     );
   }
   if (authMode === "none") {
-    throw new Error(
+    throw new UserError(
       "Off-loopback binding requires authentication — set --auth-mode token or --auth-mode oauth, or bind to 127.0.0.1",
     );
   }
@@ -97,8 +97,8 @@ export const serveCommand = new Command()
   .example("Start server", "swamp serve")
   .example("Custom port", "swamp serve --port 8080")
   .example(
-    "Bind to all interfaces",
-    "swamp serve --host 0.0.0.0 --port 3000",
+    "Bind to all interfaces (TLS + auth required)",
+    "swamp serve --host 0.0.0.0 --port 3000 --cert-file server.crt --key-file server.key --auth-mode token",
   )
   .option(
     "--repo-dir <dir:string>",
@@ -209,6 +209,8 @@ export const serveCommand = new Command()
       );
     }
 
+    assertOffLoopbackSecurity(host, tlsEnabled, authConfig.mode);
+
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
     const {
@@ -220,8 +222,6 @@ export const serveCommand = new Command()
       repoDir,
       outputMode: ctx.outputMode,
     });
-
-    assertOffLoopbackSecurity(host, tlsEnabled, authConfig.mode);
     // Remote-execution control plane: capability verbs, worker enrollment,
     // and the dispatch/lease registries shared with the HTTP data plane.
     // See design/remote-execution.md.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -61,6 +61,27 @@ type AnyOptions = any;
 
 const logger = getSwampLogger(["serve"]);
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+export function assertOffLoopbackSecurity(
+  host: string,
+  tlsEnabled: boolean,
+  authMode: string,
+): void {
+  if (LOOPBACK_HOSTS.has(host)) return;
+
+  if (!tlsEnabled) {
+    throw new Error(
+      "Off-loopback binding requires TLS — provide --cert-file and --key-file, or bind to 127.0.0.1",
+    );
+  }
+  if (authMode === "none") {
+    throw new Error(
+      "Off-loopback binding requires authentication — set --auth-mode token or --auth-mode oauth, or bind to 127.0.0.1",
+    );
+  }
+}
+
 export const serveCommand = new Command()
   .name("serve")
   .description(
@@ -200,15 +221,7 @@ export const serveCommand = new Command()
       outputMode: ctx.outputMode,
     });
 
-    if (
-      host !== "127.0.0.1" && host !== "localhost" &&
-      authConfig.mode === "none"
-    ) {
-      logger.warn(
-        "Binding to non-loopback address {host} — no authentication is enforced on WebSocket connections",
-        { host },
-      );
-    }
+    assertOffLoopbackSecurity(host, tlsEnabled, authConfig.mode);
     // Remote-execution control plane: capability verbs, worker enrollment,
     // and the dispatch/lease registries shared with the HTTP data plane.
     // See design/remote-execution.md.

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -17,8 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { assertOffLoopbackSecurity } from "./serve.ts";
 
 // Initialize logging for tests
 await initializeLogging({});
@@ -73,4 +74,46 @@ Deno.test("serveCommand has --key-file option", async () => {
   const options = serveCommand.getOptions();
   const keyOpt = options.find((o) => o.name === "key-file");
   assertEquals(keyOpt !== undefined, true);
+});
+
+// --- Off-loopback security validation ---
+
+Deno.test("assertOffLoopbackSecurity: off-loopback without TLS refuses", () => {
+  assertThrows(
+    () => assertOffLoopbackSecurity("0.0.0.0", false, "none"),
+    Error,
+    "Off-loopback binding requires TLS",
+  );
+});
+
+Deno.test("assertOffLoopbackSecurity: off-loopback with TLS but no auth refuses", () => {
+  assertThrows(
+    () => assertOffLoopbackSecurity("0.0.0.0", true, "none"),
+    Error,
+    "Off-loopback binding requires authentication",
+  );
+});
+
+Deno.test("assertOffLoopbackSecurity: off-loopback without TLS but with auth refuses", () => {
+  assertThrows(
+    () => assertOffLoopbackSecurity("0.0.0.0", false, "token"),
+    Error,
+    "Off-loopback binding requires TLS",
+  );
+});
+
+Deno.test("assertOffLoopbackSecurity: off-loopback with TLS and auth passes", () => {
+  assertOffLoopbackSecurity("0.0.0.0", true, "token");
+});
+
+Deno.test("assertOffLoopbackSecurity: loopback 127.0.0.1 with no TLS and no auth passes", () => {
+  assertOffLoopbackSecurity("127.0.0.1", false, "none");
+});
+
+Deno.test("assertOffLoopbackSecurity: loopback localhost with no TLS and no auth passes", () => {
+  assertOffLoopbackSecurity("localhost", false, "none");
+});
+
+Deno.test("assertOffLoopbackSecurity: IPv6 loopback ::1 with no TLS and no auth passes", () => {
+  assertOffLoopbackSecurity("::1", false, "none");
 });

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import { assertOffLoopbackSecurity } from "./serve.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // Initialize logging for tests
 await initializeLogging({});
@@ -81,7 +82,7 @@ Deno.test("serveCommand has --key-file option", async () => {
 Deno.test("assertOffLoopbackSecurity: off-loopback without TLS refuses", () => {
   assertThrows(
     () => assertOffLoopbackSecurity("0.0.0.0", false, "none"),
-    Error,
+    UserError,
     "Off-loopback binding requires TLS",
   );
 });
@@ -89,7 +90,7 @@ Deno.test("assertOffLoopbackSecurity: off-loopback without TLS refuses", () => {
 Deno.test("assertOffLoopbackSecurity: off-loopback with TLS but no auth refuses", () => {
   assertThrows(
     () => assertOffLoopbackSecurity("0.0.0.0", true, "none"),
-    Error,
+    UserError,
     "Off-loopback binding requires authentication",
   );
 });
@@ -97,7 +98,7 @@ Deno.test("assertOffLoopbackSecurity: off-loopback with TLS but no auth refuses"
 Deno.test("assertOffLoopbackSecurity: off-loopback without TLS but with auth refuses", () => {
   assertThrows(
     () => assertOffLoopbackSecurity("0.0.0.0", false, "token"),
-    Error,
+    UserError,
     "Off-loopback binding requires TLS",
   );
 });


### PR DESCRIPTION
## Summary

- Replace the existing `logger.warn` for non-loopback binding with hard `throw new Error()` startup refusals — an unauthenticated, unencrypted control plane reachable from the network is arbitrary remote execution
- Server refuses to start when binding off-loopback without TLS (`--cert-file`/`--key-file`) or without authentication (`--auth-mode none`)
- Loopback addresses (`127.0.0.1`, `localhost`, `::1`) continue to work with no TLS and no auth for local development
- Extracted validation into a testable `assertOffLoopbackSecurity` function with 7 tests covering the full refusal matrix

Closes swamp-club#689

## Test Plan

- 7 new unit tests in `serve_test.ts` covering:
  - Off-loopback without TLS → refuses (TLS error)
  - Off-loopback with TLS but no auth → refuses (auth error)
  - Off-loopback without TLS but with auth → refuses (TLS error fires first)
  - Off-loopback with TLS and auth → passes
  - Loopback `127.0.0.1` with no TLS/auth → passes
  - Loopback `localhost` with no TLS/auth → passes
  - IPv6 loopback `::1` with no TLS/auth → passes
- `deno fmt --check`, `deno lint`, `deno run test` all pass