### PR TITLE
feat(serve-auth): wire AccessDecisionService into serve chokepoints for authorization enforcement (swamp-club#688)

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -55,9 +55,14 @@ import {
   GroupSchema,
 } from "../domain/models/access/group_model.ts";
 import type { DataRecord } from "../domain/data/data_record.ts";
-import { parsePrincipal, type Principal } from "../domain/access/principal.ts";
-import { ActionSchema } from "../domain/access/action.ts";
+import {
+  parsePrincipal,
+  type Principal,
+  principalToString,
+} from "../domain/access/principal.ts";
+import { type Action, ActionSchema } from "../domain/access/action.ts";
 import { parseResourceSelector } from "../domain/access/resource_selector.ts";
+import type { AccessResource } from "../domain/access/access_decision_service.ts";
 import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
 import { modelRegistry } from "../domain/models/model.ts";
 
@@ -180,7 +185,7 @@ export interface ConnectionContext {
 export function handleConnection(
   socket: WebSocket,
   ctx: ConnectionContext,
-  _principal: Principal | null,
+  principal: Principal | null,
 ): void {
   const activeRequests = new Map<string, AbortController>();
   const workerAttachment = ctx.workerGateway?.attachTransport({
@@ -198,7 +203,7 @@ export function handleConnection(
     ) {
       return;
     }
-    handleMessage(socket, ctx, activeRequests, event);
+    handleMessage(socket, ctx, activeRequests, event, principal);
   };
 
   socket.onclose = () => {
@@ -225,6 +230,7 @@ export function handleMessage(
   ctx: ConnectionContext,
   activeRequests: Map<string, AbortController>,
   event: MessageEvent,
+  principal: Principal | null = null,
 ): void {
   let parsed: unknown;
   try {
@@ -272,6 +278,7 @@ export function handleMessage(
         request.id,
         request.payload,
         controller,
+        principal,
       );
       break;
     case "model.method.run":
@@ -281,23 +288,117 @@ export function handleMessage(
         request.id,
         request.payload,
         controller,
+        principal,
       );
       break;
     case "access.grant.list":
-      task = handleAccessGrantList(socket, ctx, request.id, request.payload);
+      task = handleAccessGrantList(
+        socket,
+        ctx,
+        request.id,
+        principal,
+        request.payload,
+      );
       break;
     case "access.group.list":
-      task = handleAccessGroupList(socket, ctx, request.id, request.payload);
+      task = handleAccessGroupList(
+        socket,
+        ctx,
+        request.id,
+        principal,
+        request.payload,
+      );
       break;
     case "access.check":
-      task = handleAccessCheck(socket, ctx, request.id, request.payload);
+      task = handleAccessCheck(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        principal,
+      );
       break;
     case "access.reload":
-      task = handleAccessReload(socket, ctx, request.id);
+      task = handleAccessReload(socket, ctx, request.id, principal);
       break;
   }
 
   task.finally(() => activeRequests.delete(request.id));
+}
+
+function isAccessModelType(
+  typeArg: string | undefined,
+  resolvedType: string | undefined,
+): boolean {
+  const grantType = GRANT_MODEL_TYPE.normalized;
+  const groupType = GROUP_MODEL_TYPE.normalized;
+  if (typeArg) {
+    const stripped = typeArg.startsWith("@") ? typeArg.slice(1) : typeArg;
+    if (stripped === grantType || stripped === groupType) return true;
+  }
+  if (resolvedType) {
+    if (resolvedType === grantType || resolvedType === groupType) return true;
+  }
+  return false;
+}
+
+function authorizeOrReject(
+  socket: WebSocket,
+  requestId: string,
+  principal: Principal | null,
+  action: Action,
+  resource: AccessResource,
+  ctx: ConnectionContext,
+): boolean {
+  if (ctx.authConfig.mode === "none") return true;
+
+  if (!ctx.policySnapshotLoader) {
+    sendError(
+      socket,
+      requestId,
+      "access_not_configured",
+      "Authorization enforcement is enabled but no policy snapshot is available",
+    );
+    return false;
+  }
+
+  if (!principal) {
+    sendError(
+      socket,
+      requestId,
+      "unauthorized",
+      `Access denied: no authenticated principal for '${action}' on ${resource.kind}:${resource.name}`,
+    );
+    return false;
+  }
+
+  const snapshot = ctx.policySnapshotLoader.snapshot;
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  const decision = service.decide(
+    { principal, collectives: [] },
+    action,
+    resource,
+  );
+
+  if (decision && decision.effect === "allow") return true;
+
+  const principalStr = principalToString(principal);
+  if (decision && decision.effect === "deny") {
+    sendError(
+      socket,
+      requestId,
+      "unauthorized",
+      `Access denied: ${principalStr} is explicitly denied '${action}' on ${resource.kind}:${resource.name}`,
+    );
+  } else {
+    sendError(
+      socket,
+      requestId,
+      "unauthorized",
+      `Access denied: ${principalStr} does not have '${action}' on ${resource.kind}:${resource.name}`,
+    );
+  }
+  return false;
 }
 
 async function handleWorkflowRun(
@@ -306,7 +407,16 @@ async function handleWorkflowRun(
   requestId: string,
   payload: WorkflowRunPayload,
   controller: AbortController,
+  principal: Principal | null,
 ): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "run", {
+      kind: "workflow",
+      name: payload.workflowIdOrName,
+      fields: {},
+    }, ctx)
+  ) return;
+
   try {
     await executeWorkflowWithLocks(
       ctx.repoDir,
@@ -346,6 +456,7 @@ async function handleModelMethodRun(
   requestId: string,
   payload: ModelMethodRunPayload,
   controller: AbortController,
+  principal: Principal | null,
 ): Promise<void> {
   let flushLocks: (() => Promise<void>) | null = null;
 
@@ -355,6 +466,25 @@ async function handleModelMethodRun(
       ctx.repoContext.definitionRepo,
       payload.modelIdOrName,
     );
+
+    if (isAccessModelType(payload.typeArg, preResult?.type.normalized)) {
+      if (
+        !authorizeOrReject(socket, requestId, principal, "admin", {
+          kind: "access",
+          name: "*",
+          fields: {},
+        }, ctx)
+      ) return;
+    } else {
+      if (
+        !authorizeOrReject(socket, requestId, principal, "run", {
+          kind: "model",
+          name: payload.modelIdOrName,
+          fields: {},
+        }, ctx)
+      ) return;
+    }
+
     if (preResult) {
       const lockResult = await acquireModelLocks(
         ctx.datastoreConfig,
@@ -428,8 +558,17 @@ async function handleAccessGrantList(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  principal: Principal | null,
   payload?: AccessGrantListPayload,
 ): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "access",
+      name: "grant",
+      fields: {},
+    }, ctx)
+  ) return;
+
   try {
     await modelRegistry.ensureLoaded();
     const records = await ctx.repoContext.dataQueryService.query(
@@ -482,8 +621,17 @@ async function handleAccessGroupList(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  principal: Principal | null,
   payload?: AccessGroupListPayload,
 ): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "access",
+      name: "group",
+      fields: {},
+    }, ctx)
+  ) return;
+
   try {
     await modelRegistry.ensureLoaded();
     const records = await ctx.repoContext.dataQueryService.query(
@@ -523,7 +671,16 @@ function handleAccessCheck(
   ctx: ConnectionContext,
   requestId: string,
   payload: AccessCheckPayload,
+  principal: Principal | null,
 ): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return Promise.resolve();
+
   try {
     if (!ctx.policySnapshotLoader) {
       sendError(
@@ -581,7 +738,16 @@ async function handleAccessReload(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  principal: Principal | null,
 ): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
   try {
     if (!ctx.policySnapshotLoader) {
       sendError(

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -17,10 +17,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { handleMessage, validateServerRequest } from "./connection.ts";
 import type { ConnectionContext } from "./connection.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import type { Principal } from "../domain/access/principal.ts";
+import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
+import { PolicySnapshot } from "../domain/access/policy_snapshot.ts";
+import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
+import type { Grant } from "../domain/models/access/grant_model.ts";
 
 await initializeLogging({});
 
@@ -325,4 +330,386 @@ Deno.test("validateServerRequest rejects access.check without payload", () => {
   };
   const result = validateServerRequest(input);
   assertEquals(typeof result, "string");
+});
+
+// ── Authorization test helpers ────────────────────────────────────────────
+
+const modeNoneConfig: ServeAuthConfig = {
+  mode: "none",
+  admins: [],
+  allowedCollectives: [],
+  allowedUsers: [],
+  oauthProvider: "",
+  groupsField: "",
+};
+
+const modeTokenConfig: ServeAuthConfig = {
+  mode: "token",
+  admins: [],
+  allowedCollectives: [],
+  allowedUsers: [],
+  oauthProvider: "",
+  groupsField: "",
+};
+
+const testPrincipal: Principal = { kind: "user", id: "adam" };
+
+function makeGrant(
+  overrides: Partial<Grant> & {
+    subject: Grant["subject"];
+    resource: Grant["resource"];
+    actions: Grant["actions"];
+  },
+): Grant {
+  return {
+    id: overrides.id ?? "grant-1",
+    effect: overrides.effect ?? "allow",
+    state: overrides.state ?? "active",
+    source: overrides.source ?? "method",
+    condition: overrides.condition,
+    createdBy: overrides.createdBy ?? { kind: "user", id: "admin" },
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMockSnapshotLoader(
+  grants: Grant[],
+): PolicySnapshotLoader {
+  const snapshot = new PolicySnapshot(grants, []);
+  return {
+    snapshot,
+    load: () => Promise.resolve(snapshot),
+    loadWithCounts: () =>
+      Promise.resolve({ snapshot, grantCount: grants.length, groupCount: 0 }),
+    dispose: () => {},
+  } as unknown as PolicySnapshotLoader;
+}
+
+function makeCtx(
+  authConfig: ServeAuthConfig,
+  grants: Grant[] = [],
+): ConnectionContext {
+  const ctx: Partial<ConnectionContext> = {
+    authConfig,
+  };
+  if (authConfig.mode !== "none") {
+    (ctx as Record<string, unknown>).policySnapshotLoader =
+      makeMockSnapshotLoader(grants);
+  }
+  return ctx as ConnectionContext;
+}
+
+// ── Authorization: mode:none bypass ───────────────────────────────────────
+
+Deno.test("authorizeOrReject: mode:none allows all requests without principal", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeNoneConfig);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.reload",
+      id: "auth-1",
+    })),
+    null,
+  );
+
+  // mode:none should not send an error — the request proceeds to the handler
+  // (which will fail for other reasons in this stub, but not with "unauthorized")
+  for (const sent of mock.sent) {
+    const msg = JSON.parse(sent);
+    if (msg.type === "error") {
+      assertEquals(
+        (msg.error as Record<string, unknown>).code !== "unauthorized",
+        true,
+      );
+    }
+  }
+});
+
+// ── Authorization: null principal rejected in enforcing mode ──────────────
+
+Deno.test("authorizeOrReject: null principal rejected in token mode", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.reload",
+      id: "auth-2",
+    })),
+    null,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "no authenticated principal");
+  assertStringIncludes(errorMessage, "admin");
+  assertStringIncludes(errorMessage, "access:*");
+});
+
+// ── Authorization: authorized request succeeds ────────────────────────────
+
+Deno.test("authorizeOrReject: authorized workflow.run proceeds", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [grant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.run",
+      id: "auth-3",
+      payload: { workflowIdOrName: "@acme/deploy" },
+    })),
+    testPrincipal,
+  );
+
+  // Should not get an unauthorized error — the request proceeds to the handler
+  for (const sent of mock.sent) {
+    const msg = JSON.parse(sent);
+    if (msg.type === "error") {
+      assertEquals(
+        (msg.error as Record<string, unknown>).code !== "unauthorized",
+        true,
+      );
+    }
+  }
+});
+
+// ── Authorization: unauthorized request gets error frame ──────────────────
+
+Deno.test("authorizeOrReject: unauthorized workflow.run returns error frame", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.run",
+      id: "auth-4",
+      payload: { workflowIdOrName: "@acme/deploy" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "user:adam");
+  assertStringIncludes(errorMessage, "run");
+  assertStringIncludes(errorMessage, "workflow:@acme/deploy");
+});
+
+// ── Authorization: admin boundary ─────────────────────────────────────────
+
+Deno.test("authorizeOrReject: access.reload requires admin on access:*", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["read"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [grant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.reload",
+      id: "auth-5",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "admin");
+});
+
+Deno.test("authorizeOrReject: access.reload allowed with admin grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [grant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.reload",
+      id: "auth-6",
+    })),
+    testPrincipal,
+  );
+
+  // Should not get unauthorized — proceeds to handler (which may fail for other reasons)
+  for (const sent of mock.sent) {
+    const msg = JSON.parse(sent);
+    if (msg.type === "error") {
+      assertEquals(
+        (msg.error as Record<string, unknown>).code !== "unauthorized",
+        true,
+      );
+    }
+  }
+});
+
+// ── Authorization: grant list requires read on access:grant ───────────────
+
+Deno.test("authorizeOrReject: access.grant.list rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.grant.list",
+      id: "auth-7",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "read");
+  assertStringIncludes(errorMessage, "access:grant");
+});
+
+// ── Authorization: group list requires read on access:group ───────────────
+
+Deno.test("authorizeOrReject: access.group.list rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.group.list",
+      id: "auth-8",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "read");
+  assertStringIncludes(errorMessage, "access:group");
+});
+
+// ── Authorization: explicit deny ──────────────────────────────────────────
+
+Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const grants: Grant[] = [
+    makeGrant({
+      id: "deny-1",
+      subject: { kind: "user", name: "adam" },
+      effect: "deny",
+      actions: ["run"],
+      resource: { kind: "workflow", pattern: "*" },
+    }),
+    makeGrant({
+      id: "allow-1",
+      subject: { kind: "user", name: "adam" },
+      effect: "allow",
+      actions: ["run"],
+      resource: { kind: "workflow", pattern: "*" },
+    }),
+  ];
+  const ctx = makeCtx(modeTokenConfig, grants);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "workflow.run",
+      id: "auth-9",
+      payload: { workflowIdOrName: "@acme/deploy" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "explicitly denied");
+});
+
+// ── Authorization: missing policySnapshotLoader in enforcing mode ─────────
+
+Deno.test("authorizeOrReject: missing snapshot loader rejects in token mode", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = {
+    authConfig: modeTokenConfig,
+  } as ConnectionContext;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "access.reload",
+      id: "auth-10",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals(
+    (msg.error as Record<string, unknown>).code,
+    "access_not_configured",
+  );
 });


### PR DESCRIPTION
## Summary

- Thread the authenticated principal through all six WebSocket handler functions (`handleWorkflowRun`, `handleModelMethodRun`, `handleAccessGrantList`, `handleAccessGroupList`, `handleAccessCheck`, `handleAccessReload`)
- Build a single `authorizeOrReject` helper that checks `authConfig.mode`, calls `AccessDecisionService.decide()`, and sends actionable error frames when denied
- Insert authorization checks at each chokepoint: `run` on `workflow:*` / `model:*`, `read` on `access:grant` / `access:group`, `admin` on `access:*` for admin operations and grant/group mutations
- `mode: none` bypasses all checks (preserving existing behavior), `mode: token` uses empty collectives (phase 1)

Closes swamp-club/lab#688

## Test Plan

- 10 new unit tests covering: mode:none bypass, null principal rejection, authorized/unauthorized paths, admin boundary enforcement, grant/group list auth, explicit deny precedence, missing snapshot loader rejection
- All 7435 existing tests pass
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)