### PR TITLE
feat(serve-auth): swamp access can-i — user self-service permission check (swamp-club#690)

### DIFF
--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -21,6 +21,7 @@ import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import { accessGrantCommand } from "./access_grant.ts";
 import { accessGroupCommand } from "./access_group.ts";
+import { accessCanICommand } from "./access_can_i.ts";
 import { accessCheckCommand } from "./access_check.ts";
 import { accessReloadCommand } from "./access_reload.ts";
 import { accessTokenMintCommand } from "./access_token_mint.ts";
@@ -45,5 +46,6 @@ export const accessCommand = new Command()
   .command("token", accessTokenCommand)
   .command("grant", accessGrantCommand)
   .command("group", accessGroupCommand)
+  .command("can-i", accessCanICommand)
   .command("check", accessCheckCommand)
   .command("reload", accessReloadCommand);

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -62,9 +62,9 @@ export const accessCanICommand = new Command()
     "Comma-separated IdP group memberships to simulate",
   )
   .action(async function (options: AnyOptions) {
-    if (!options.server) {
+    if (!!options.action !== !!options.on) {
       throw new UserError(
-        "--server is required: can-i only works against a server where you have an authenticated identity",
+        "--action and --on must be used together; omit both to list all permissions",
       );
     }
 

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -1,0 +1,104 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { requestServerResponse } from "../../cli/remote_run.ts";
+import type { AccessCanIResponse } from "../../serve/protocol.ts";
+import { createAccessCanIRenderer } from "../../presentation/renderers/access_can_i.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const accessCanICommand = new Command()
+  .name("can-i")
+  .description(
+    "Check your own permissions against the server's grants",
+  )
+  .example(
+    "Check a specific permission",
+    "swamp access can-i --action run --on workflow:@acme/deploy --server wss://swamp.acme.internal:9090",
+  )
+  .example(
+    "List everything you can do",
+    "swamp access can-i --server wss://swamp.acme.internal:9090",
+  )
+  .option(
+    "--server <url:string>",
+    "Server to check permissions against (required)",
+    { required: true },
+  )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
+  .option(
+    "--action <action:string>",
+    "Action to check (run, read, write, admin)",
+  )
+  .option(
+    "--on <resource:string>",
+    "Resource to check (e.g. workflow:@acme/deploy)",
+  )
+  .option(
+    "--collectives <collectives:string>",
+    "Comma-separated IdP group memberships to simulate",
+  )
+  .action(async function (options: AnyOptions) {
+    if (!options.server) {
+      throw new UserError(
+        "--server is required: can-i only works against a server where you have an authenticated identity",
+      );
+    }
+
+    const ctx = createContext(options as GlobalOptions, [
+      "access",
+      "can-i",
+    ]);
+
+    const collectives = options.collectives
+      ? (options.collectives as string).split(",").map((c: string) => c.trim())
+        .filter((c: string) => c.length > 0)
+      : undefined;
+
+    const response = await requestServerResponse<AccessCanIResponse>(
+      {
+        server: options.server as string,
+        ...(options.token ? { token: options.token as string } : {}),
+      },
+      {
+        type: "access.can-i",
+        payload: {
+          ...(options.action ? { action: options.action as string } : {}),
+          ...(options.on ? { resource: options.on as string } : {}),
+          ...(collectives ? { collectives } : {}),
+        },
+      },
+    );
+
+    const renderer = createAccessCanIRenderer(ctx.outputMode);
+    renderer.render(response);
+
+    if (options.action && options.on) {
+      const isDenied = response.decisions.length === 0 ||
+        response.decisions[0].effect !== "allow";
+      if (isDenied) Deno.exitCode = 1;
+    }
+  });

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -22,7 +22,10 @@ import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { requestServerResponse } from "../../cli/remote_run.ts";
 import type { AccessCanIResponse } from "../../serve/protocol.ts";
-import { createAccessCanIRenderer } from "../../presentation/renderers/access_can_i.ts";
+import {
+  type AccessCanIResult,
+  createAccessCanIRenderer,
+} from "../../presentation/renderers/access_can_i.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -93,12 +96,24 @@ export const accessCanICommand = new Command()
       },
     );
 
-    const renderer = createAccessCanIRenderer(ctx.outputMode);
-    renderer.render(response);
+    const result: AccessCanIResult = {
+      ...response,
+      ...(options.action && options.on
+        ? {
+          query: {
+            action: options.action as string,
+            resource: options.on as string,
+          },
+        }
+        : {}),
+    };
 
-    if (options.action && options.on) {
-      const isDenied = response.decisions.length === 0 ||
-        response.decisions[0].effect !== "allow";
+    const renderer = createAccessCanIRenderer(ctx.outputMode);
+    renderer.render(result);
+
+    if (result.query) {
+      const isDenied = result.decisions.length === 0 ||
+        result.decisions[0].effect === "deny";
       if (isDenied) Deno.exitCode = 1;
     }
   });

--- a/src/cli/commands/access_can_i_test.ts
+++ b/src/cli/commands/access_can_i_test.ts
@@ -1,0 +1,82 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("accessCanICommand: module loads", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  assertEquals(accessCanICommand.getName(), "can-i");
+});
+
+Deno.test("accessCanICommand: has correct description", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  assertEquals(
+    accessCanICommand.getDescription(),
+    "Check your own permissions against the server's grants",
+  );
+});
+
+Deno.test("accessCanICommand: has --server option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "server");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCanICommand: has --action option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "action");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCanICommand: has --on option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "on");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCanICommand: has --collectives option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "collectives");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCanICommand: has --token option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "token");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("accessCanICommand: does not have --subject option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "subject");
+  assertEquals(opt, undefined);
+});

--- a/src/presentation/renderers/access_can_i.ts
+++ b/src/presentation/renderers/access_can_i.ts
@@ -37,6 +37,7 @@ class LogAccessCanIRenderer implements AccessCanIRenderer {
       return;
     }
 
+    writeOutput(`Permissions for ${result.principal}:`);
     for (const decision of result.decisions) {
       const marker = decision.effect === "allow" ? "✓" : "✗";
       const via = `(via ${decision.via})`;

--- a/src/presentation/renderers/access_can_i.ts
+++ b/src/presentation/renderers/access_can_i.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "../output/output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { AccessCanIDecision } from "../../serve/protocol.ts";
+
+export interface AccessCanIResult {
+  principal: string;
+  decisions: AccessCanIDecision[];
+}
+
+export interface AccessCanIRenderer {
+  render(result: AccessCanIResult): void;
+}
+
+class LogAccessCanIRenderer implements AccessCanIRenderer {
+  render(result: AccessCanIResult): void {
+    if (result.decisions.length === 0) {
+      writeOutput(`No matching grants for ${result.principal}`);
+      return;
+    }
+
+    for (const decision of result.decisions) {
+      const marker = decision.effect === "allow" ? "✓" : "✗";
+      const via = `(via ${decision.via})`;
+      const cond = decision.condition ? ` [when: ${decision.condition}]` : "";
+      writeOutput(
+        `${decision.resource.padEnd(30)} ${
+          decision.action.padEnd(6)
+        } ${marker} ${via}${cond}`,
+      );
+    }
+  }
+}
+
+class JsonAccessCanIRenderer implements AccessCanIRenderer {
+  render(result: AccessCanIResult): void {
+    writeOutput(JSON.stringify(result, null, 2));
+  }
+}
+
+export function createAccessCanIRenderer(
+  mode: OutputMode,
+): AccessCanIRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonAccessCanIRenderer();
+    case "log":
+      return new LogAccessCanIRenderer();
+  }
+}

--- a/src/presentation/renderers/access_can_i.ts
+++ b/src/presentation/renderers/access_can_i.ts
@@ -19,11 +19,20 @@
 
 import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import type { AccessCanIDecision } from "../../serve/protocol.ts";
+
+export interface CanIDecision {
+  action: string;
+  resource: string;
+  effect: string;
+  grantId: string;
+  via: string;
+  condition?: string;
+}
 
 export interface AccessCanIResult {
   principal: string;
-  decisions: AccessCanIDecision[];
+  decisions: CanIDecision[];
+  query?: { action: string; resource: string };
 }
 
 export interface AccessCanIRenderer {
@@ -32,10 +41,53 @@ export interface AccessCanIRenderer {
 
 class LogAccessCanIRenderer implements AccessCanIRenderer {
   render(result: AccessCanIResult): void {
+    if (result.query) {
+      this.#renderSpecificCheck(result);
+    } else {
+      this.#renderEnumeration(result);
+    }
+  }
+
+  #renderSpecificCheck(result: AccessCanIResult): void {
+    if (result.decisions.length === 0) {
+      writeOutput(
+        `DENY (implicit) — no matching grants for ${result.principal} ${
+          result.query!.action
+        } ${result.query!.resource}`,
+      );
+      return;
+    }
+
+    const first = result.decisions[0];
+    const effect = first.effect.toUpperCase();
+    const via = `grant ${first.grantId.slice(0, 8)}…`;
+    writeOutput(
+      `${effect} via ${via} (${first.via} → ${result.query!.action} → ${
+        result.query!.resource
+      })`,
+    );
+
+    if (result.decisions.length > 1) {
+      writeOutput("");
+      writeOutput("All matching grants:");
+      for (const d of result.decisions) {
+        const e = d.effect.toUpperCase().padEnd(5);
+        const g = d.grantId.slice(0, 8);
+        const cond = d.condition ? ` [when: ${d.condition}]` : "";
+        writeOutput(`  ${e}  ${g}…  via ${d.via}${cond}`);
+      }
+    }
+  }
+
+  #renderEnumeration(result: AccessCanIResult): void {
     if (result.decisions.length === 0) {
       writeOutput(`No matching grants for ${result.principal}`);
       return;
     }
+
+    const resourceWidth = Math.max(
+      ...result.decisions.map((d) => d.resource.length),
+    );
 
     writeOutput(`Permissions for ${result.principal}:`);
     for (const decision of result.decisions) {
@@ -43,7 +95,7 @@ class LogAccessCanIRenderer implements AccessCanIRenderer {
       const via = `(via ${decision.via})`;
       const cond = decision.condition ? ` [when: ${decision.condition}]` : "";
       writeOutput(
-        `${decision.resource.padEnd(30)} ${
+        `${decision.resource.padEnd(resourceWidth + 2)} ${
           decision.action.padEnd(6)
         } ${marker} ${via}${cond}`,
       );
@@ -53,7 +105,32 @@ class LogAccessCanIRenderer implements AccessCanIRenderer {
 
 class JsonAccessCanIRenderer implements AccessCanIRenderer {
   render(result: AccessCanIResult): void {
-    writeOutput(JSON.stringify(result, null, 2));
+    if (result.query) {
+      const effect = result.decisions.length > 0
+        ? result.decisions[0].effect
+        : "deny";
+      writeOutput(
+        JSON.stringify(
+          {
+            principal: result.principal,
+            action: result.query.action,
+            resource: result.query.resource,
+            effect,
+            decisions: result.decisions,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      writeOutput(
+        JSON.stringify(
+          { principal: result.principal, decisions: result.decisions },
+          null,
+          2,
+        ),
+      );
+    }
   }
 }
 

--- a/src/presentation/renderers/access_can_i_test.ts
+++ b/src/presentation/renderers/access_can_i_test.ts
@@ -1,0 +1,31 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createAccessCanIRenderer } from "./access_can_i.ts";
+
+Deno.test("createAccessCanIRenderer: returns renderer for log mode", () => {
+  const renderer = createAccessCanIRenderer("log");
+  assertEquals(typeof renderer.render, "function");
+});
+
+Deno.test("createAccessCanIRenderer: returns renderer for json mode", () => {
+  const renderer = createAccessCanIRenderer("json");
+  assertEquals(typeof renderer.render, "function");
+});

--- a/src/presentation/renderers/access_can_i_test.ts
+++ b/src/presentation/renderers/access_can_i_test.ts
@@ -18,7 +18,43 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { createAccessCanIRenderer } from "./access_can_i.ts";
+import { assertStringIncludes } from "@std/assert";
+import {
+  type AccessCanIResult,
+  type CanIDecision,
+  createAccessCanIRenderer,
+} from "./access_can_i.ts";
+
+function makeDecision(
+  overrides: Partial<CanIDecision> = {},
+): CanIDecision {
+  return {
+    action: "run",
+    resource: "workflow:@acme/deploy",
+    effect: "allow",
+    grantId: "7f3a1234-5678-abcd-ef01-234567890abc",
+    via: "idp-group:platform-eng",
+    ...overrides,
+  };
+}
+
+function captureRender(
+  mode: "log" | "json",
+  result: AccessCanIResult,
+): string[] {
+  const renderer = createAccessCanIRenderer(mode);
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render(result);
+  } finally {
+    console.log = origLog;
+  }
+  return output;
+}
+
+// ── Factory ─────────────────────────────────────────────────────────────
 
 Deno.test("createAccessCanIRenderer: returns renderer for log mode", () => {
   const renderer = createAccessCanIRenderer("log");
@@ -28,4 +64,143 @@ Deno.test("createAccessCanIRenderer: returns renderer for log mode", () => {
 Deno.test("createAccessCanIRenderer: returns renderer for json mode", () => {
   const renderer = createAccessCanIRenderer("json");
   assertEquals(typeof renderer.render, "function");
+});
+
+// ── Log mode: specific check ────────────────────────────────────────────
+
+Deno.test("accessCanIRenderer log: specific check shows ALLOW with grant provenance", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [makeDecision()],
+    query: { action: "run", resource: "workflow:@acme/deploy" },
+  });
+  assertStringIncludes(output[0], "ALLOW");
+  assertStringIncludes(output[0], "7f3a1234");
+  assertStringIncludes(output[0], "run");
+  assertStringIncludes(output[0], "workflow:@acme/deploy");
+});
+
+Deno.test("accessCanIRenderer log: specific check shows DENY with action and resource on implicit deny", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [],
+    query: { action: "admin", resource: "access:*" },
+  });
+  assertStringIncludes(output[0], "DENY");
+  assertStringIncludes(output[0], "admin");
+  assertStringIncludes(output[0], "access:*");
+  assertStringIncludes(output[0], "user:adam");
+});
+
+Deno.test("accessCanIRenderer log: specific check lists all grants when multiple match", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision(),
+      makeDecision({
+        grantId: "abc12345-0000-0000-0000-000000000000",
+        via: "group:admins",
+        effect: "deny",
+      }),
+    ],
+    query: { action: "run", resource: "workflow:@acme/deploy" },
+  });
+  assertStringIncludes(output[0], "ALLOW");
+  assertStringIncludes(output[2], "All matching grants:");
+  assertStringIncludes(output[3], "ALLOW");
+  assertStringIncludes(output[3], "7f3a1234");
+  assertStringIncludes(output[4], "DENY");
+  assertStringIncludes(output[4], "abc12345");
+});
+
+// ── Log mode: enumeration ───────────────────────────────────────────────
+
+Deno.test("accessCanIRenderer log: enumeration shows no grants message", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [],
+  });
+  assertStringIncludes(output[0], "No matching grants");
+  assertStringIncludes(output[0], "user:adam");
+});
+
+Deno.test("accessCanIRenderer log: enumeration shows permissions header and decision rows", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision(),
+      makeDecision({
+        action: "read",
+        resource: "data:@acme/dev-*",
+        via: "group:development",
+      }),
+    ],
+  });
+  assertStringIncludes(output[0], "Permissions for user:adam:");
+  assertStringIncludes(output[1], "workflow:@acme/deploy");
+  assertStringIncludes(output[1], "run");
+  assertStringIncludes(output[1], "✓");
+  assertStringIncludes(output[2], "data:@acme/dev-*");
+  assertStringIncludes(output[2], "read");
+});
+
+Deno.test("accessCanIRenderer log: enumeration shows condition text", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision({ condition: "resource.tags.env == 'staging'" }),
+    ],
+  });
+  assertStringIncludes(output[1], "[when: resource.tags.env == 'staging']");
+});
+
+Deno.test("accessCanIRenderer log: enumeration shows deny marker for deny effect", () => {
+  const output = captureRender("log", {
+    principal: "user:adam",
+    decisions: [
+      makeDecision({ effect: "deny" }),
+    ],
+  });
+  assertStringIncludes(output[1], "✗");
+});
+
+// ── JSON mode: specific check ───────────────────────────────────────────
+
+Deno.test("accessCanIRenderer json: specific check includes top-level effect", () => {
+  const output = captureRender("json", {
+    principal: "user:adam",
+    decisions: [makeDecision()],
+    query: { action: "run", resource: "workflow:@acme/deploy" },
+  });
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.effect, "allow");
+  assertEquals(parsed.action, "run");
+  assertEquals(parsed.resource, "workflow:@acme/deploy");
+  assertEquals(parsed.principal, "user:adam");
+  assertEquals(parsed.decisions.length, 1);
+});
+
+Deno.test("accessCanIRenderer json: specific check implicit deny sets effect to deny", () => {
+  const output = captureRender("json", {
+    principal: "user:adam",
+    decisions: [],
+    query: { action: "admin", resource: "access:*" },
+  });
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.effect, "deny");
+  assertEquals(parsed.action, "admin");
+  assertEquals(parsed.resource, "access:*");
+});
+
+// ── JSON mode: enumeration ──────────────────────────────────────────────
+
+Deno.test("accessCanIRenderer json: enumeration outputs principal and decisions", () => {
+  const output = captureRender("json", {
+    principal: "user:adam",
+    decisions: [makeDecision(), makeDecision({ action: "read" })],
+  });
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed.principal, "user:adam");
+  assertEquals(parsed.decisions.length, 2);
+  assertEquals(parsed.effect, undefined);
 });

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -30,6 +30,7 @@ import { createLibSwampContext, modelMethodRun } from "../libswamp/mod.ts";
 import { createModelMethodRunDeps, executeWorkflowWithLocks } from "./deps.ts";
 import { serializeEvent } from "./serializer.ts";
 import type {
+  AccessCanIPayload,
   AccessCheckPayload,
   AccessGrantListPayload,
   AccessGroupListPayload,
@@ -122,6 +123,16 @@ const AccessCheckRequestSchema = z.object({
   }),
 });
 
+const AccessCanIRequestSchema = z.object({
+  type: z.literal("access.can-i"),
+  id: z.string().min(1),
+  payload: z.object({
+    action: z.string().optional(),
+    resource: z.string().optional(),
+    collectives: z.array(z.string()).optional(),
+  }),
+});
+
 const AccessReloadRequestSchema = z.object({
   type: z.literal("access.reload"),
   id: z.string().min(1),
@@ -138,6 +149,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   AccessGrantListRequestSchema,
   AccessGroupListRequestSchema,
   AccessCheckRequestSchema,
+  AccessCanIRequestSchema,
   AccessReloadRequestSchema,
   CancelRequestSchema,
 ]);
@@ -311,6 +323,15 @@ export function handleMessage(
       break;
     case "access.check":
       task = handleAccessCheck(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        principal,
+      );
+      break;
+    case "access.can-i":
+      task = handleAccessCanI(
         socket,
         ctx,
         request.id,
@@ -730,6 +751,109 @@ function handleAccessCheck(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     sendError(socket, requestId, "access_check_failed", message);
+    return Promise.resolve();
+  }
+}
+
+function handleAccessCanI(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: AccessCanIPayload,
+  principal: Principal | null,
+): Promise<void> {
+  if (!principal) {
+    sendError(
+      socket,
+      requestId,
+      "unauthorized",
+      "can-i requires an authenticated connection — use --token or swamp auth server-login",
+    );
+    return Promise.resolve();
+  }
+
+  try {
+    if (!ctx.policySnapshotLoader) {
+      sendError(
+        socket,
+        requestId,
+        "access_not_configured",
+        "Access control is not configured on this server",
+      );
+      return Promise.resolve();
+    }
+
+    const snapshot = ctx.policySnapshotLoader.snapshot;
+    const collectives = payload.collectives ?? [];
+    const accessPrincipal = { principal, collectives };
+    const principalStr = principalToString(principal);
+
+    if (payload.action && payload.resource) {
+      const actionResult = ActionSchema.safeParse(payload.action);
+      if (!actionResult.success) {
+        sendError(
+          socket,
+          requestId,
+          "invalid_action",
+          `Invalid action "${payload.action}": must be one of run, read, write, admin`,
+        );
+        return Promise.resolve();
+      }
+
+      const resource = parseResourceSelector(payload.resource);
+      const service = new GrantBasedAccessDecisionService(snapshot);
+      const decisions = service.explain(
+        accessPrincipal,
+        actionResult.data,
+        { kind: resource.kind, name: resource.pattern, fields: {} },
+      );
+
+      send(socket, {
+        type: "access.can-i",
+        id: requestId,
+        payload: {
+          principal: principalStr,
+          decisions: decisions.map((d) => ({
+            action: payload.action!,
+            resource: payload.resource!,
+            effect: d.effect,
+            grantId: d.grantId,
+            via: `${d.subject.kind}:${d.subject.name}`,
+            ...(d.condition ? { condition: d.condition } : {}),
+          })),
+        },
+      });
+    } else {
+      const subjects: string[] = [principalStr];
+      const localGroups = snapshot.groupsForPrincipal(principalStr);
+      for (const groupName of localGroups) {
+        subjects.push(`group:${groupName}`);
+      }
+      for (const collective of collectives) {
+        subjects.push(`idp-group:${collective}`);
+      }
+
+      const grants = snapshot.grantsForSubjects(subjects);
+      send(socket, {
+        type: "access.can-i",
+        id: requestId,
+        payload: {
+          principal: principalStr,
+          decisions: grants.map((g) => ({
+            action: g.actions.join(","),
+            resource: `${g.resource.kind}:${g.resource.pattern}`,
+            effect: g.effect,
+            grantId: g.id,
+            via: `${g.subject.kind}:${g.subject.name}`,
+            ...(g.condition ? { condition: g.condition } : {}),
+          })),
+        },
+      });
+    }
+    return Promise.resolve();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "access_can_i_failed", message);
     return Promise.resolve();
   }
 }

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -839,14 +839,16 @@ function handleAccessCanI(
         id: requestId,
         payload: {
           principal: principalStr,
-          decisions: grants.map((g) => ({
-            action: g.actions.join(","),
-            resource: `${g.resource.kind}:${g.resource.pattern}`,
-            effect: g.effect,
-            grantId: g.id,
-            via: `${g.subject.kind}:${g.subject.name}`,
-            ...(g.condition ? { condition: g.condition } : {}),
-          })),
+          decisions: grants.flatMap((g) =>
+            g.actions.map((a) => ({
+              action: a,
+              resource: `${g.resource.kind}:${g.resource.pattern}`,
+              effect: g.effect,
+              grantId: g.id,
+              via: `${g.subject.kind}:${g.subject.name}`,
+              ...(g.condition ? { condition: g.condition } : {}),
+            }))
+          ),
         },
       });
     }

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -130,7 +130,10 @@ const AccessCanIRequestSchema = z.object({
     action: z.string().optional(),
     resource: z.string().optional(),
     collectives: z.array(z.string()).optional(),
-  }),
+  }).refine(
+    (p) => !!p.action === !!p.resource,
+    "action and resource must both be present or both absent",
+  ),
 });
 
 const AccessReloadRequestSchema = z.object({

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -376,6 +376,26 @@ Deno.test("validateServerRequest rejects access.can-i without id", () => {
   assertEquals(typeof result, "string");
 });
 
+Deno.test("validateServerRequest rejects access.can-i with action but no resource", () => {
+  const input = {
+    type: "access.can-i",
+    id: "req-1",
+    payload: { action: "run" },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "string");
+});
+
+Deno.test("validateServerRequest rejects access.can-i with resource but no action", () => {
+  const input = {
+    type: "access.can-i",
+    id: "req-1",
+    payload: { resource: "workflow:@acme/deploy" },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "string");
+});
+
 // ── Authorization test helpers ────────────────────────────────────────────
 
 const modeNoneConfig: ServeAuthConfig = {

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -332,6 +332,50 @@ Deno.test("validateServerRequest rejects access.check without payload", () => {
   assertEquals(typeof result, "string");
 });
 
+Deno.test("validateServerRequest accepts access.can-i with action and resource", () => {
+  const input = {
+    type: "access.can-i",
+    id: "req-1",
+    payload: {
+      action: "run",
+      resource: "workflow:@acme/deploy",
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.can-i without action/resource for enumeration", () => {
+  const input = {
+    type: "access.can-i",
+    id: "req-1",
+    payload: {},
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest accepts access.can-i with collectives", () => {
+  const input = {
+    type: "access.can-i",
+    id: "req-1",
+    payload: {
+      collectives: ["platform-eng", "ops"],
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest rejects access.can-i without id", () => {
+  const input = {
+    type: "access.can-i",
+    payload: {},
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "string");
+});
+
 // ── Authorization test helpers ────────────────────────────────────────────
 
 const modeNoneConfig: ServeAuthConfig = {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -61,12 +61,19 @@ export interface AccessCheckPayload {
   collectives?: string[];
 }
 
+export interface AccessCanIPayload {
+  action?: string;
+  resource?: string;
+  collectives?: string[];
+}
+
 export type ServerRequest =
   | { type: "workflow.run"; id: string; payload: WorkflowRunPayload }
   | { type: "model.method.run"; id: string; payload: ModelMethodRunPayload }
   | { type: "access.grant.list"; id: string; payload?: AccessGrantListPayload }
   | { type: "access.group.list"; id: string; payload?: AccessGroupListPayload }
   | { type: "access.check"; id: string; payload: AccessCheckPayload }
+  | { type: "access.can-i"; id: string; payload: AccessCanIPayload }
   | { type: "access.reload"; id: string }
   | { type: "cancel"; id: string };
 
@@ -101,6 +108,20 @@ export interface AccessCheckResponse {
   decisions: Record<string, unknown>[];
 }
 
+export interface AccessCanIDecision {
+  action: string;
+  resource: string;
+  effect: string;
+  grantId: string;
+  via: string;
+  condition?: string;
+}
+
+export interface AccessCanIResponse {
+  principal: string;
+  decisions: AccessCanIDecision[];
+}
+
 export interface AccessReloadResponse {
   success: boolean;
   grantCount: number;
@@ -124,4 +145,5 @@ export type ServerMessage =
     payload: AccessGroupListResponse;
   }
   | { type: "access.check"; id: string; payload: AccessCheckResponse }
+  | { type: "access.can-i"; id: string; payload: AccessCanIResponse }
   | { type: "access.reload"; id: string; payload: AccessReloadResponse };


### PR DESCRIPTION
## Summary

- Add `swamp access can-i` CLI command for user self-service permission checks against a server's grants
- New `access.can-i` protocol frame type with server-side handler that uses the connection's authenticated principal directly (no `--subject`, no admin authorization)
- Two modes: specific check (`--action` + `--on`) via `explain()`, and enumeration (no flags) via `grantsForSubjects()` to list everything the user can do
- Dual-mode renderer: log mode shows table with ✓/✗ markers, resource, action, via grant; JSON mode outputs raw result

Closes swamp-club/lab#690

## Test Plan

- `deno check` — type checking passes
- `deno lint` — no lint issues
- `deno fmt` — formatting clean
- `deno run test` — 7451 passed, 1 pre-existing failure (unrelated `workflow_test.ts`)
- `deno run compile` — binary compiles successfully
- Unit tests verify: command loads, correct description, all expected flags present (`--server`, `--action`, `--on`, `--token`, `--collectives`), no `--subject` flag, renderer factory works for both output modes