### PR TITLE
fix(serve-auth): resolve stored credentials for access commands

### DIFF
--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -20,7 +20,10 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
-import { requestServerResponse } from "../../cli/remote_run.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+} from "../../cli/remote_run.ts";
 import type { AccessCanIResponse } from "../../serve/protocol.ts";
 import {
   type AccessCanIResult,
@@ -81,10 +84,15 @@ export const accessCanICommand = new Command()
         .filter((c: string) => c.length > 0)
       : undefined;
 
+    const token = await resolveServerToken(
+      options.server as string,
+      options.token as string | undefined,
+    );
+
     const response = await requestServerResponse<AccessCanIResponse>(
       {
         server: options.server as string,
-        ...(options.token ? { token: options.token as string } : {}),
+        ...(token ? { token } : {}),
       },
       {
         type: "access.can-i",

--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -37,7 +37,10 @@ import {
   validateServerRepoExclusivity,
 } from "./access_helpers.ts";
 import { createAccessCheckRenderer } from "../../presentation/renderers/access_check.ts";
-import { requestServerResponse } from "../../cli/remote_run.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+} from "../../cli/remote_run.ts";
 import type { AccessCheckResponse } from "../../serve/protocol.ts";
 import type { AccessCheckResult } from "../../presentation/renderers/access_check.ts";
 
@@ -93,6 +96,10 @@ export const accessCheckCommand = new Command()
     "--server <url:string>",
     "Check access on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -116,8 +123,13 @@ export const accessCheckCommand = new Command()
         ).filter((c: string) => c.length > 0)
         : [];
 
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
+
       const response = await requestServerResponse<AccessCheckResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         {
           type: "access.check",
           payload: {

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -59,6 +59,7 @@ import {
 import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
 import {
   requestServerResponse,
+  resolveServerToken,
   runModelMethodOverServer,
 } from "../../cli/remote_run.ts";
 import type { AccessGrantListResponse } from "../../serve/protocol.ts";
@@ -120,6 +121,10 @@ const accessGrantCreateCommand = new Command()
     "--server <url:string>",
     "Run through a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions) {
     if (!options.allow && !options.deny) {
       throw new UserError("Either --allow or --deny must be specified");
@@ -147,6 +152,10 @@ const accessGrantCreateCommand = new Command()
         "grant",
         "create",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: instanceName,
         methodName: "create",
@@ -154,6 +163,7 @@ const accessGrantCreateCommand = new Command()
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           payload: {
             modelIdOrName: `@${GRANT_MODEL_TYPE.normalized}`,
             methodName: "create",
@@ -296,6 +306,10 @@ const accessGrantListCommand = new Command()
     "--server <url:string>",
     "List grants on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -308,8 +322,12 @@ const accessGrantListCommand = new Command()
         "grant",
         "list",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const response = await requestServerResponse<AccessGrantListResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         {
           type: "access.grant.list",
           payload: {
@@ -380,6 +398,10 @@ const accessGrantRevokeCommand = new Command()
     "--server <url:string>",
     "Revoke a grant on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions, grantId: string) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -392,8 +414,12 @@ const accessGrantRevokeCommand = new Command()
         "grant",
         "revoke",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const response = await requestServerResponse<AccessGrantListResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         { type: "access.grant.list" },
       );
       const allGrants: { grant: Grant; instanceName: string }[] = [];
@@ -428,6 +454,7 @@ const accessGrantRevokeCommand = new Command()
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           payload: {
             modelIdOrName: match.instanceName,
             methodName: "revoke",

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -57,6 +57,7 @@ import {
 import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
 import {
   requestServerResponse,
+  resolveServerToken,
   runModelMethodOverServer,
 } from "../../cli/remote_run.ts";
 import type { AccessGroupListResponse } from "../../serve/protocol.ts";
@@ -196,6 +197,10 @@ const accessGroupCreateCommand = new Command()
     "--server <url:string>",
     "Create a group on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions, name: string) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -208,6 +213,10 @@ const accessGroupCreateCommand = new Command()
         "group",
         "create",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: name,
         methodName: "create",
@@ -215,6 +224,7 @@ const accessGroupCreateCommand = new Command()
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           payload: {
             modelIdOrName: `@${GROUP_MODEL_TYPE.normalized}`,
             methodName: "create",
@@ -257,6 +267,10 @@ const accessGroupAddMemberCommand = new Command()
     "--server <url:string>",
     "Add a member on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (
     options: AnyOptions,
     group: string,
@@ -273,6 +287,10 @@ const accessGroupAddMemberCommand = new Command()
         "group",
         "add-member",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: group,
         methodName: "add-member",
@@ -280,6 +298,7 @@ const accessGroupAddMemberCommand = new Command()
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           payload: {
             modelIdOrName: group,
             methodName: "add-member",
@@ -320,6 +339,10 @@ const accessGroupRemoveMemberCommand = new Command()
     "--server <url:string>",
     "Remove a member on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (
     options: AnyOptions,
     group: string,
@@ -336,6 +359,10 @@ const accessGroupRemoveMemberCommand = new Command()
         "group",
         "remove-member",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: group,
         methodName: "remove-member",
@@ -343,6 +370,7 @@ const accessGroupRemoveMemberCommand = new Command()
       await consumeStream(
         runModelMethodOverServer({
           server: options.server as string,
+          token,
           payload: {
             modelIdOrName: group,
             methodName: "remove-member",
@@ -379,6 +407,10 @@ const accessGroupListCommand = new Command()
     "--server <url:string>",
     "List groups on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -391,8 +423,12 @@ const accessGroupListCommand = new Command()
         "group",
         "list",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const response = await requestServerResponse<AccessGroupListResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         { type: "access.group.list" },
       );
       const groups: Group[] = [];
@@ -438,6 +474,10 @@ const accessGroupMembersCommand = new Command()
     "--server <url:string>",
     "List members on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions, name: string) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -450,8 +490,12 @@ const accessGroupMembersCommand = new Command()
         "group",
         "members",
       ]);
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
       const response = await requestServerResponse<AccessGroupListResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         { type: "access.group.list", payload: { name } },
       );
       const groups: Group[] = [];

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -29,7 +29,10 @@ import { modelRegistry } from "../../domain/models/model.ts";
 import { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
 import { EventBus } from "../../domain/events/event_bus.ts";
 import { validateServerRepoExclusivity } from "./access_helpers.ts";
-import { requestServerResponse } from "../../cli/remote_run.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+} from "../../cli/remote_run.ts";
 import type { AccessReloadResponse } from "../../serve/protocol.ts";
 import { createAccessReloadRenderer } from "../../presentation/renderers/access_reload.ts";
 
@@ -54,6 +57,10 @@ export const accessReloadCommand = new Command()
     "--server <url:string>",
     "Reload access policy on a 'swamp serve' server instead of locally",
   )
+  .option(
+    "--token <token:string>",
+    "Server token (falls back to stored credential)",
+  )
   .action(async function (options: AnyOptions) {
     validateServerRepoExclusivity(
       options.server as string | undefined,
@@ -68,8 +75,13 @@ export const accessReloadCommand = new Command()
     const renderer = createAccessReloadRenderer(ctx.outputMode);
 
     if (options.server) {
+      const token = await resolveServerToken(
+        options.server as string,
+        options.token as string | undefined,
+      );
+
       const response = await requestServerResponse<AccessReloadResponse>(
-        { server: options.server as string },
+        { server: options.server as string, ...(token ? { token } : {}) },
         { type: "access.reload" },
       );
 

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -79,7 +79,7 @@ function toHttpUrl(serverUrl: string): string {
     const parsed = new URL(serverUrl);
     if (parsed.protocol === "ws:") parsed.protocol = "http:";
     else if (parsed.protocol === "wss:") parsed.protocol = "https:";
-    return parsed.href;
+    return parsed.href.replace(/\/+$/, "");
   } catch {
     return serverUrl;
   }

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -422,7 +422,7 @@ Deno.test("resolveServerToken: falls back to credential repo", async () => {
 Deno.test("resolveServerToken: converts ws URL to http for credential lookup", async () => {
   const mockRepo: ServerCredentialRepository = {
     get: (url: string): Promise<ServerCredential | null> => {
-      if (url === "http://localhost:9090/") {
+      if (url === "http://localhost:9090") {
         return Promise.resolve({
           serverUrl: url,
           tokenName: "stored",


### PR DESCRIPTION
## Summary

- **Bug 1**: Access commands (`can-i`, `check`, `grant`, `group`, `reload`) passed `options.token` directly to server calls instead of calling `resolveServerToken()`, so stored credentials from `swamp auth server-login` were never looked up — users had to pass `--token` explicitly every time.
- **Bug 2**: `toHttpUrl()` in `remote_run.ts` returned URLs with a trailing slash (via `URL.href`), but `normalizeServerUrl()` in `server_url.ts` strips trailing slashes when storing credentials. The key mismatch caused credential lookups to always miss.
- Added `--token` option to access commands that were missing it (`check`, `grant create/list/revoke`, `group create/add-member/remove-member/list/members`, `reload`) for consistency with `can-i` and `model method run`.

## Test Plan

- All 7468 existing tests pass, including the updated `resolveServerToken` test that now expects no trailing slash in credential lookup URLs
- Manual verification sequence:
  ```
  swamp auth server-login --server wss://demo.swamp-club.ai --token 'paul-token.secret123'
  swamp access can-i --server wss://demo.swamp-club.ai
  swamp access grant list --server wss://demo.swamp-club.ai
  swamp access reload --server wss://demo.swamp-club.ai
  swamp access check --subject user:adam --action run --on workflow:test --server wss://demo.swamp-club.ai
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)