### PR TITLE
fix(skills): use bundled deno path in extension dev docs

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -260,14 +260,15 @@ export const datastore = {
 All extension types follow the same lifecycle:
 
 1. **Confirm nothing covers it** — search built-in and community first.
-2. **Author the extension file** — use the Quick Start above; `deno check`.
+2. **Author the extension file** — use the Quick Start above;
+   `~/.swamp/deno/deno check`.
 3. **Verify registration** — `swamp model type search --json` (models/drivers)
    or `swamp vault status --json` / `swamp datastore status --json`.
 4. **Adversarial review** — see
    [Adversarial Review Gate](#adversarial-review-gate) below.
 5. **Smoke test** (models) — see
    [references/model/smoke_testing.md](references/model/smoke_testing.md).
-6. **Unit tests** — colocate `*_test.ts`; `deno test` passes.
+6. **Unit tests** — colocate `*_test.ts`; `~/.swamp/deno/deno test` passes.
 7. **Version + manifest** — `swamp extension version`,
    `swamp extension fmt manifest.yaml --check`.
 8. **Quality check** (optional) — `swamp extension quality manifest.yaml`.

--- a/.claude/skills/swamp/references/extension/references/quality/templates.md
+++ b/.claude/skills/swamp/references/extension/references/quality/templates.md
@@ -196,15 +196,15 @@ Run from the extension's directory before invoking `swamp extension push`:
 
 ```sh
 # Verify types and catch slow-type issues.
-deno doc --lint models/my-model.ts
+~/.swamp/deno/deno doc --lint models/my-model.ts
 # Exit status 0 + no output means clean.
 
 # See extracted doc structure — confirms exports are well-shaped.
-deno doc --json models/my-model.ts | jq '.nodes | keys'
+~/.swamp/deno/deno doc --json models/my-model.ts | jq '.nodes | keys'
 
 # Verify formatting and standard lint.
-deno fmt --check
-deno lint
+~/.swamp/deno/deno fmt --check
+~/.swamp/deno/deno lint
 ```
 
 Any diagnostic from `deno doc --lint` costs the `fast-check` point. Fix each one

--- a/.claude/skills/swamp/references/troubleshooting/references/error-inspection.md
+++ b/.claude/skills/swamp/references/troubleshooting/references/error-inspection.md
@@ -96,10 +96,9 @@ Symptom: a model file at `extensions/models/<name>.ts` doesn't appear in
 2. **If doctor passes**, the model is loading but isn't visible. Re-run
    `swamp model type search --json` and check stderr for late warnings (some
    issues only surface when the catalog is queried, not when registries load).
-3. **Verify `deno check` passes** on the file — type errors that pass
-   `deno
-   check` may still be rejected by swamp's stricter validation (e.g.
-   missing `version`).
+3. **Verify `~/.swamp/deno/deno check` passes** on the file — type errors that
+   pass `~/.swamp/deno/deno check` may still be rejected by swamp's stricter
+   validation (e.g. missing `version`).
 4. **Do NOT run `swamp extension source add extensions/models`** — that path is
    auto-discovered by default. Registering it as a source is a no-op that adds
    confusion. Source-add is for directories _outside_ the repo.

--- a/.claude/skills/swamp/references/troubleshooting/references/health-checks.md
+++ b/.claude/skills/swamp/references/troubleshooting/references/health-checks.md
@@ -205,7 +205,7 @@ The error string identifies the cause. Most failures fall into these buckets:
 | `Missing version field` / `not CalVer` | Add `version: "YYYY.MM.DD.MICRO"` to the extension export                                                                 |
 | `type` field not a string literal      | Replace the variable with a literal — the catalog regex requires it                                                       |
 | `Import "<dep>" not a dependency`      | Add the dep to the source's `deno.json` `imports` map                                                                     |
-| Syntax / unresolvable import           | Fix the file so `deno check` passes                                                                                       |
+| Syntax / unresolvable import           | Fix the file so `~/.swamp/deno/deno check` passes                                                                         |
 | `<registry> loader>: …`                | The loader itself threw — read the message; usually a config issue in the source's `deno.json` or a missing native binary |
 
 For the deeper "extension not in type search" walkthrough (stderr inspection,


### PR DESCRIPTION
## Summary

Closes swamp-club#695.

- Updated extension guide, troubleshooting docs, and quality templates to use `~/.swamp/deno/deno` instead of bare `deno` commands
- The bundled Deno binary is always available after installing swamp and is version-matched to avoid false positives from version skew
- Affected files: `guide.md` (steps 2 & 6), `health-checks.md`, `error-inspection.md`, `quality/templates.md`

## Test Plan

- [x] Verified `~/.swamp/deno/deno check extensions/models/*.ts` works against this repo
- [x] `deno fmt --check` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)