### PR TITLE
feat(serve-auth): SWAMP_SERVE_URL env var as default for --server flag

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -141,7 +141,11 @@ run's event stream completes — so clients can distinguish "run ended" from
 `swamp workflow run --server <url>` / `swamp model ... method run --server`:
 repo-less, streaming the run's events through the same renderers as a local
 run (the wire codec is lossless for run events; `deserializeEvent` in
-`src/serve/serializer.ts` is the anti-corruption seam).
+`src/serve/serializer.ts` is the anti-corruption seam). The `--server` flag
+on all remote commands falls back to the `SWAMP_SERVE_URL` env var when not
+provided, so `export SWAMP_SERVE_URL=wss://demo.swamp-club.ai` avoids
+repeating the URL on every invocation. The explicit flag takes precedence when
+both are set.
 
 When `--auth-mode token` is active, the server validates a `?token=name.secret`
 query parameter at WebSocket upgrade time via the `swamp/server-token` model's

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -23,6 +23,7 @@ import { UserError } from "../../domain/errors.ts";
 import {
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
 } from "../../cli/remote_run.ts";
 import type { AccessCanIResponse } from "../../serve/protocol.ts";
 import {
@@ -48,8 +49,7 @@ export const accessCanICommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Server to check permissions against (required)",
-    { required: true },
+    "Server to check permissions against (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
@@ -68,6 +68,13 @@ export const accessCanICommand = new Command()
     "Comma-separated IdP group memberships to simulate",
   )
   .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (!server) {
+      throw new UserError(
+        "--server is required (or set SWAMP_SERVE_URL)",
+      );
+    }
+
     if (!!options.action !== !!options.on) {
       throw new UserError(
         "--action and --on must be used together; omit both to list all permissions",
@@ -85,13 +92,13 @@ export const accessCanICommand = new Command()
       : undefined;
 
     const token = await resolveServerToken(
-      options.server as string,
+      server,
       options.token as string | undefined,
     );
 
     const response = await requestServerResponse<AccessCanIResponse>(
       {
-        server: options.server as string,
+        server,
         ...(token ? { token } : {}),
       },
       {

--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -40,6 +40,7 @@ import { createAccessCheckRenderer } from "../../presentation/renderers/access_c
 import {
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
 } from "../../cli/remote_run.ts";
 import type { AccessCheckResponse } from "../../serve/protocol.ts";
 import type { AccessCheckResult } from "../../presentation/renderers/access_check.ts";
@@ -94,19 +95,21 @@ export const accessCheckCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Check access on a 'swamp serve' server instead of locally",
+    "Check access on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       if (options.field && (options.field as string[]).length > 0) {
         throw new UserError(
           "--field is not supported with --server: the server evaluates conditions against its own resource context",
@@ -124,12 +127,12 @@ export const accessCheckCommand = new Command()
         : [];
 
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
 
       const response = await requestServerResponse<AccessCheckResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         {
           type: "access.check",
           payload: {

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -60,6 +60,7 @@ import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
 import {
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
   runModelMethodOverServer,
 } from "../../cli/remote_run.ts";
 import type { AccessGrantListResponse } from "../../serve/protocol.ts";
@@ -119,7 +120,7 @@ const accessGrantCreateCommand = new Command()
   .option("--when <condition:string>", "Optional CEL condition")
   .option(
     "--server <url:string>",
-    "Run through a 'swamp serve' server instead of locally",
+    "Run through a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
@@ -133,8 +134,10 @@ const accessGrantCreateCommand = new Command()
       throw new UserError("Cannot specify both --allow and --deny");
     }
 
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
@@ -146,14 +149,14 @@ const accessGrantCreateCommand = new Command()
 
     const instanceName = `grant-${crypto.randomUUID().slice(0, 8)}`;
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "grant",
         "create",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
@@ -162,7 +165,7 @@ const accessGrantCreateCommand = new Command()
       });
       await consumeStream(
         runModelMethodOverServer({
-          server: options.server as string,
+          server,
           token,
           payload: {
             modelIdOrName: `@${GRANT_MODEL_TYPE.normalized}`,
@@ -304,30 +307,32 @@ const accessGrantListCommand = new Command()
   .option("--on <resource:string>", "Filter by resource selector (exact match)")
   .option(
     "--server <url:string>",
-    "List grants on a 'swamp serve' server instead of locally",
+    "List grants on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "grant",
         "list",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const response = await requestServerResponse<AccessGrantListResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         {
           type: "access.grant.list",
           payload: {
@@ -396,30 +401,32 @@ const accessGrantRevokeCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Revoke a grant on a 'swamp serve' server instead of locally",
+    "Revoke a grant on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions, grantId: string) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "grant",
         "revoke",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const response = await requestServerResponse<AccessGrantListResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         { type: "access.grant.list" },
       );
       const allGrants: { grant: Grant; instanceName: string }[] = [];
@@ -453,7 +460,7 @@ const accessGrantRevokeCommand = new Command()
       });
       await consumeStream(
         runModelMethodOverServer({
-          server: options.server as string,
+          server,
           token,
           payload: {
             modelIdOrName: match.instanceName,

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -58,6 +58,7 @@ import type { ModelMethodRunEvent } from "../../libswamp/mod.ts";
 import {
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
   runModelMethodOverServer,
 } from "../../cli/remote_run.ts";
 import type { AccessGroupListResponse } from "../../serve/protocol.ts";
@@ -195,26 +196,28 @@ const accessGroupCreateCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Create a group on a 'swamp serve' server instead of locally",
+    "Create a group on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions, name: string) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "group",
         "create",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
@@ -223,7 +226,7 @@ const accessGroupCreateCommand = new Command()
       });
       await consumeStream(
         runModelMethodOverServer({
-          server: options.server as string,
+          server,
           token,
           payload: {
             modelIdOrName: `@${GROUP_MODEL_TYPE.normalized}`,
@@ -265,7 +268,7 @@ const accessGroupAddMemberCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Add a member on a 'swamp serve' server instead of locally",
+    "Add a member on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
@@ -276,19 +279,21 @@ const accessGroupAddMemberCommand = new Command()
     group: string,
     principal: string,
   ) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "group",
         "add-member",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
@@ -297,7 +302,7 @@ const accessGroupAddMemberCommand = new Command()
       });
       await consumeStream(
         runModelMethodOverServer({
-          server: options.server as string,
+          server,
           token,
           payload: {
             modelIdOrName: group,
@@ -337,7 +342,7 @@ const accessGroupRemoveMemberCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Remove a member on a 'swamp serve' server instead of locally",
+    "Remove a member on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
@@ -348,19 +353,21 @@ const accessGroupRemoveMemberCommand = new Command()
     group: string,
     principal: string,
   ) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "group",
         "remove-member",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
@@ -369,7 +376,7 @@ const accessGroupRemoveMemberCommand = new Command()
       });
       await consumeStream(
         runModelMethodOverServer({
-          server: options.server as string,
+          server,
           token,
           payload: {
             modelIdOrName: group,
@@ -405,30 +412,32 @@ const accessGroupListCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "List groups on a 'swamp serve' server instead of locally",
+    "List groups on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "group",
         "list",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const response = await requestServerResponse<AccessGroupListResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         { type: "access.group.list" },
       );
       const groups: Group[] = [];
@@ -472,30 +481,32 @@ const accessGroupMembersCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "List members on a 'swamp serve' server instead of locally",
+    "List members on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions, name: string) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
-    if (options.server) {
+    if (server) {
       const ctx = createContext(options as GlobalOptions, [
         "access",
         "group",
         "members",
       ]);
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
       const response = await requestServerResponse<AccessGroupListResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         { type: "access.group.list", payload: { name } },
       );
       const groups: Group[] = [];

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -32,6 +32,7 @@ import { validateServerRepoExclusivity } from "./access_helpers.ts";
 import {
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
 } from "../../cli/remote_run.ts";
 import type { AccessReloadResponse } from "../../serve/protocol.ts";
 import { createAccessReloadRenderer } from "../../presentation/renderers/access_reload.ts";
@@ -55,15 +56,17 @@ export const accessReloadCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Reload access policy on a 'swamp serve' server instead of locally",
+    "Reload access policy on a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
     "Server token (falls back to stored credential)",
   )
   .action(async function (options: AnyOptions) {
+    const server = resolveServeUrl(options.server as string | undefined);
+
     validateServerRepoExclusivity(
-      options.server as string | undefined,
+      server,
       options.repoDir as string | undefined,
     );
 
@@ -74,14 +77,14 @@ export const accessReloadCommand = new Command()
 
     const renderer = createAccessReloadRenderer(ctx.outputMode);
 
-    if (options.server) {
+    if (server) {
       const token = await resolveServerToken(
-        options.server as string,
+        server,
         options.token as string | undefined,
       );
 
       const response = await requestServerResponse<AccessReloadResponse>(
-        { server: options.server as string, ...(token ? { token } : {}) },
+        { server, ...(token ? { token } : {}) },
         { type: "access.reload" },
       );
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -62,7 +62,11 @@ import {
   type ModelMethodRunEvent,
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
-import { resolveServerToken, runModelMethodOverServer } from "../remote_run.ts";
+import {
+  resolveServerToken,
+  resolveServeUrl,
+  runModelMethodOverServer,
+} from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
 
@@ -162,7 +166,7 @@ export const modelMethodRunCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required.",
+    "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required (env: SWAMP_SERVE_URL).",
   )
   .option(
     "--token <token:string>",
@@ -176,10 +180,14 @@ export const modelMethodRunCommand = new Command()
       methodName: string,
       definitionNameArg?: string,
     ) {
-      if (options.server) {
-        await runMethodViaServer(options, modelOrType, methodName, {
-          isDirectExecution: modelOrType.startsWith("@"),
-        });
+      const server = resolveServeUrl(options.server as string | undefined);
+      if (server) {
+        await runMethodViaServer(
+          { ...options, server },
+          modelOrType,
+          methodName,
+          { isDirectExecution: modelOrType.startsWith("@") },
+        );
         return;
       }
       const isDirectExecution = modelOrType.startsWith("@");

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -69,7 +69,11 @@ import {
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
 import { getActiveTelemetryService } from "../telemetry_integration.ts";
-import { resolveServerToken, runWorkflowOverServer } from "../remote_run.ts";
+import {
+  resolveServerToken,
+  resolveServeUrl,
+  runWorkflowOverServer,
+} from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -161,7 +165,7 @@ export const workflowRunCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required. Required for steps with worker placement.",
+    "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required. Required for steps with worker placement (env: SWAMP_SERVE_URL).",
   )
   .option(
     "--token <token:string>",
@@ -172,8 +176,9 @@ export const workflowRunCommand = new Command()
     const ctx = createContext(options as GlobalOptions, ["workflow", "run"]);
     ctx.logger.debug`Running workflow: ${workflowIdOrName}`;
 
-    if (options.server) {
-      await runWorkflowViaServer(ctx, options, workflowIdOrName);
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      await runWorkflowViaServer(ctx, { ...options, server }, workflowIdOrName);
       return;
     }
 

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -42,6 +42,16 @@ import { deserializeEvent } from "../serve/serializer.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
 import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
 
+/**
+ * Resolves the server URL from the `--server` flag with `SWAMP_SERVE_URL`
+ * env var as fallback. Flag takes precedence when both are provided.
+ */
+export function resolveServeUrl(
+  flagValue: string | undefined,
+): string | undefined {
+  return flagValue ?? Deno.env.get("SWAMP_SERVE_URL");
+}
+
 /** How long to keep draining after sending `cancel` before giving up. */
 const CANCEL_DRAIN_MS = 10_000;
 

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -29,6 +29,7 @@ import {
   normalizeServerUrl,
   requestServerResponse,
   resolveServerToken,
+  resolveServeUrl,
   runModelMethodOverServer,
   runWorkflowOverServer,
 } from "./remote_run.ts";
@@ -73,6 +74,43 @@ function scriptedServer(
     received,
   };
 }
+
+// ── resolveServeUrl tests ──────────────────────────────────────────────
+
+Deno.test("resolveServeUrl: flag value takes precedence over env var", () => {
+  const prev = Deno.env.get("SWAMP_SERVE_URL");
+  try {
+    Deno.env.set("SWAMP_SERVE_URL", "wss://env.example.com");
+    assertEquals(
+      resolveServeUrl("wss://flag.example.com"),
+      "wss://flag.example.com",
+    );
+  } finally {
+    if (prev !== undefined) Deno.env.set("SWAMP_SERVE_URL", prev);
+    else Deno.env.delete("SWAMP_SERVE_URL");
+  }
+});
+
+Deno.test("resolveServeUrl: falls back to SWAMP_SERVE_URL env var", () => {
+  const prev = Deno.env.get("SWAMP_SERVE_URL");
+  try {
+    Deno.env.set("SWAMP_SERVE_URL", "wss://env.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://env.example.com");
+  } finally {
+    if (prev !== undefined) Deno.env.set("SWAMP_SERVE_URL", prev);
+    else Deno.env.delete("SWAMP_SERVE_URL");
+  }
+});
+
+Deno.test("resolveServeUrl: returns undefined when neither flag nor env var set", () => {
+  const prev = Deno.env.get("SWAMP_SERVE_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    assertEquals(resolveServeUrl(undefined), undefined);
+  } finally {
+    if (prev !== undefined) Deno.env.set("SWAMP_SERVE_URL", prev);
+  }
+});
 
 Deno.test("normalizeServerUrl: accepts ws/wss and maps http/https", () => {
   assertEquals(normalizeServerUrl("ws://h:1"), "ws://h:1/");


### PR DESCRIPTION
## Summary

- Add `SWAMP_SERVE_URL` env var as a default for the `--server` flag on all remote commands, so users working against a single server can `export SWAMP_SERVE_URL=wss://...` instead of repeating `--server` on every invocation
- Add `resolveServeUrl()` helper in `src/cli/remote_run.ts` — flag takes precedence over env var
- Update all 7 command files: `model method run`, `workflow run`, `access grant create/list/revoke`, `access group create/add-member/remove-member/list/members`, `access check`, `access reload`, `access can-i`

Closes swamp-club#702

## Test Plan

- 3 new unit tests for `resolveServeUrl()`: flag precedence, env fallback, undefined when neither set
- All 20 `remote_run_test.ts` tests pass
- `deno check`, `deno lint`, `deno fmt` all clean