### PR TITLE
feat(serve-auth): alias 'swamp access policy' as alternative to 'grant'

### DIFF
--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -40,7 +40,9 @@ export const accessTokenCommand = new Command()
 
 export const accessCommand = new Command()
   .name("access")
-  .description("Manage authorization grants, groups, and access checks")
+  .description(
+    "Manage authorization policies (grants), groups, and access checks",
+  )
   .error(unknownCommandErrorHandler)
   .action(groupCommandAction)
   .command("token", accessTokenCommand)

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -578,6 +578,7 @@ const accessGrantRevokeCommand = new Command()
 
 export const accessGrantCommand = new Command()
   .name("grant")
+  .alias("policy")
   .description("Manage authorization grants")
   .action(groupCommandAction)
   .command("create", accessGrantCreateCommand)

--- a/src/cli/commands/access_grant_test.ts
+++ b/src/cli/commands/access_grant_test.ts
@@ -31,6 +31,11 @@ Deno.test("accessGrantCommand: module loads", async () => {
   assertEquals(accessGrantCommand.getName(), "grant");
 });
 
+Deno.test("accessGrantCommand: has policy alias", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  assertEquals(accessGrantCommand.getAliases().includes("policy"), true);
+});
+
 Deno.test("accessGrantCommand: has correct description", async () => {
   const { accessGrantCommand } = await import("./access_grant.ts");
   assertEquals(


### PR DESCRIPTION
## Summary

- Add `policy` as a Cliffy `.alias()` for the `grant` subcommand under `swamp access`, so `swamp access policy create/list/revoke` works identically to `swamp access grant create/list/revoke`
- `grant` remains the canonical name (data store, internal types); `policy` is a user-facing alias
- Updated `accessCommand` description to mention "policies (grants)"

Closes swamp-club/lab#704

## Test Plan

- [x] Unit test verifying `getAliases()` includes `"policy"` on the grant command
- [x] All existing access grant tests pass (15/15)
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] Binary compiled and manually verified: `swamp access policy --help` and `swamp access policy create --help` resolve correctly through the alias