### PR TITLE
feat(serve-auth): add token rotate command and hide internal model types

### DIFF
--- a/src/cli/commands/access.ts
+++ b/src/cli/commands/access.ts
@@ -27,6 +27,7 @@ import { accessReloadCommand } from "./access_reload.ts";
 import { accessTokenMintCommand } from "./access_token_mint.ts";
 import { accessTokenListCommand } from "./access_token_list.ts";
 import { accessTokenRevokeCommand } from "./access_token_revoke.ts";
+import { accessTokenRotateCommand } from "./access_token_rotate.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const accessTokenCommand = new Command()
@@ -36,7 +37,8 @@ export const accessTokenCommand = new Command()
   .action(groupCommandAction)
   .command("mint", accessTokenMintCommand)
   .command("list", accessTokenListCommand)
-  .command("revoke", accessTokenRevokeCommand);
+  .command("revoke", accessTokenRevokeCommand)
+  .command("rotate", accessTokenRotateCommand);
 
 export const accessCommand = new Command()
   .name("access")

--- a/src/cli/commands/access_token_rotate.ts
+++ b/src/cli/commands/access_token_rotate.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createServerTokenRotateDeps,
+  parseDuration,
+  serverTokenRotate,
+  type ServerTokenRotateData,
+  type ServerTokenRotateEvent,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { renderServerTokenRotate } from "../../presentation/output/access_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const DEFAULT_DURATION = "30d";
+
+export const accessTokenRotateCommand = new Command()
+  .name("rotate")
+  .description(
+    "Revoke an existing token and mint a replacement with the same name and principal",
+  )
+  .example(
+    "Rotate a compromised token",
+    "swamp access token rotate sarah-token",
+  )
+  .example(
+    "Rotate with custom duration",
+    "swamp access token rotate sarah-token --duration 7d",
+  )
+  .arguments("<name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--duration <duration:string>",
+    "Lifetime for the new token (e.g. 30m, 1h, 24h, 7d, 30d)",
+    { default: DEFAULT_DURATION },
+  )
+  .action(async function (options: AnyOptions, name: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "access",
+      "token",
+      "rotate",
+    ]);
+
+    const durationMs = parseDuration(options.duration as string);
+    if (durationMs <= 0) {
+      throw new UserError(
+        `Invalid --duration value "${options.duration}": must be positive`,
+      );
+    }
+
+    const { repoDir, repoContext, datastoreConfig, syncService } =
+      await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+    cliCtx.logger.debug`Rotating server token ${name}`;
+
+    const libCtx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = await createServerTokenRotateDeps(
+      libCtx,
+      repoDir,
+      repoContext,
+    );
+
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      name,
+    );
+    if (!preResult) {
+      throw new UserError(
+        `Server token '${name}' not found. ` +
+          "Use 'swamp access token list' to see existing tokens.",
+      );
+    }
+
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
+      repoDir,
+      syncService,
+      repoContext.catalogStore,
+    );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+    const flushModelLocks = lockResult.flush;
+
+    try {
+      let data: ServerTokenRotateData | undefined;
+      await consumeStream(
+        serverTokenRotate(libCtx, deps, {
+          name,
+          durationMs,
+        }),
+        withDefaults<ServerTokenRotateEvent>({
+          completed: (event) => {
+            data = event.data;
+          },
+          error: (event) => {
+            throw new UserError(event.error.message);
+          },
+        }),
+      );
+      if (data === undefined) {
+        throw new UserError(
+          `Rotating token '${name}' ended without completing`,
+        );
+      }
+      renderServerTokenRotate(data, cliCtx.outputMode);
+    } finally {
+      try {
+        await flushModelLocks();
+      } catch (releaseError) {
+        cliCtx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
+          },
+        );
+      }
+    }
+
+    cliCtx.logger.debug("Server token rotate command completed");
+  });

--- a/src/cli/commands/type_search.ts
+++ b/src/cli/commands/type_search.ts
@@ -82,7 +82,7 @@ export async function typeSearchAction(
 
   await modelRegistry.ensureLoaded();
   const deps: TypeSearchDeps = {
-    getRegisteredTypes: () => modelRegistry.types(),
+    getRegisteredTypes: () => modelRegistry.publicTypes(),
   };
 
   const fetchPreview = effectiveMode === "log"

--- a/src/cli/completion_types.ts
+++ b/src/cli/completion_types.ts
@@ -132,6 +132,6 @@ export class ModelTypeType extends Type<string> {
 
   override async complete(): Promise<string[]> {
     await modelRegistry.ensureLoaded();
-    return modelRegistry.types().map((t) => t.normalized);
+    return modelRegistry.publicTypes().map((t) => t.normalized);
   }
 }

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -174,6 +174,39 @@ async function redeem(
   return { dataHandles: [handle] };
 }
 
+const RotateArgsSchema = z.object({
+  durationMs: z.number().int().positive().optional(),
+});
+
+async function rotate(
+  args: z.infer<typeof RotateArgsSchema>,
+  context: MethodContext,
+): Promise<MethodResult> {
+  if (!context.vaultService) {
+    throw new Error("Rotating a server token requires a vault service");
+  }
+  const existing = await readToken(context);
+  const name = context.definition.name;
+  const secretKey = serverTokenSecretKey(name);
+  const plaintext = generateOpaqueToken();
+  await context.vaultService.put(existing.vaultName, secretKey, plaintext);
+
+  const now = Date.now();
+  const durationMs = args.durationMs ?? DEFAULT_DURATION_MS;
+  const token: ServerToken = {
+    name,
+    state: "active",
+    principalId: existing.principalId,
+    principalEmail: existing.principalEmail,
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + durationMs).toISOString(),
+    vaultName: existing.vaultName,
+    secretKey,
+  };
+  const handle = await context.writeResource!("token", TOKEN_DATA_NAME, token);
+  return { dataHandles: [handle] };
+}
+
 const EmptyArgsSchema = z.object({});
 
 async function revoke(
@@ -239,6 +272,13 @@ export const serverTokenModel: ModelDefinition = defineModel({
       kind: "action",
       arguments: RedeemArgsSchema,
       execute: redeem,
+    },
+    rotate: {
+      description:
+        "Atomically revoke the current token and mint a replacement with the same name and principal",
+      kind: "action",
+      arguments: RotateArgsSchema,
+      execute: rotate,
     },
     revoke: {
       description: "Revoke the token — takes effect immediately, idempotent",

--- a/src/domain/models/access/server_token_model_test.ts
+++ b/src/domain/models/access/server_token_model_test.ts
@@ -284,3 +284,107 @@ Deno.test("serverTokenModel: redeem without vault service throws", async () => {
   );
   assertStringIncludes(error.message, "requires a vault service");
 });
+
+Deno.test("serverTokenModel: rotate active token produces new credentials", async () => {
+  const { context, store, vault, plaintext } = await mintToken();
+  const oldSecretKey = store.get("token-main")!.secretKey as string;
+  await serverTokenModel.methods.rotate.execute({}, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "active");
+  assertEquals(token.principalId, "oauth|user-123");
+  assertEquals(token.principalEmail, "user@example.com");
+  const newPlaintext = vault.get(`local/${oldSecretKey}`)!;
+  assertNotEquals(newPlaintext, plaintext);
+});
+
+Deno.test("serverTokenModel: rotate preserves principal from original token", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.rotate.execute({}, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.principalId, "oauth|user-123");
+  assertEquals(token.principalEmail, "user@example.com");
+});
+
+Deno.test("serverTokenModel: rotate respects custom durationMs", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.rotate.execute(
+    { durationMs: 120_000 },
+    context,
+  );
+  const token = store.get("token-main")!;
+  const createdAt = Date.parse(token.createdAt as string);
+  const expiresAt = Date.parse(token.expiresAt as string);
+  assertEquals(expiresAt - createdAt, 120_000);
+});
+
+Deno.test("serverTokenModel: rotate expired token succeeds", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.expire.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "expired");
+  await serverTokenModel.methods.rotate.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "active");
+});
+
+Deno.test("serverTokenModel: rotate revoked token succeeds", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "revoked");
+  await serverTokenModel.methods.rotate.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "active");
+});
+
+Deno.test("serverTokenModel: rotate nonexistent token throws", async () => {
+  const harness = createInMemoryWorkerContext(
+    SERVER_TOKEN_MODEL_TYPE,
+    "missing-token",
+  );
+  await assertRejects(
+    () => serverTokenModel.methods.rotate.execute({}, harness.context),
+    Error,
+    "does not exist",
+  );
+});
+
+Deno.test("serverTokenModel: rotate without vault service throws", async () => {
+  const { context } = await mintToken();
+  const ctx = { ...context, vaultService: undefined };
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.rotate.execute(
+        {},
+        ctx as typeof context,
+      ),
+    Error,
+    "requires a vault service",
+  );
+});
+
+Deno.test("serverTokenModel: rotated token is redeemable with new credentials", async () => {
+  const { context, store } = await mintToken();
+  await serverTokenModel.methods.rotate.execute({}, context);
+  const token = store.get("token-main")!;
+  const newPlaintext = (context as unknown as {
+    vaultService: { get: (v: string, k: string) => Promise<string> };
+  })
+    .vaultService.get(token.vaultName as string, token.secretKey as string);
+  const plaintext = await newPlaintext;
+  await serverTokenModel.methods.redeem.execute(
+    { presentedToken: `user-token-1.${plaintext}` },
+    context,
+  );
+  assertEquals(store.get("token-main")!.lastUsedAt !== undefined, true);
+});
+
+Deno.test("serverTokenModel: old credentials fail after rotate", async () => {
+  const { context, fullToken } = await mintToken();
+  await serverTokenModel.methods.rotate.execute({}, context);
+  await assertRejects(
+    () =>
+      serverTokenModel.methods.redeem.execute(
+        { presentedToken: fullToken },
+        context,
+      ),
+    Error,
+    "does not match",
+  );
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -735,6 +735,7 @@ export interface LazyModelEntry {
 export class ModelRegistry {
   private models = new Map<string, ModelDefinition>();
   private lazyTypes = new Map<string, LazyModelEntry>();
+  private internalTypes = new Set<string>();
   private extensionLoader: (() => Promise<void>) | null = null;
   private extensionLoadPromise: Promise<void> | null = null;
   private extensionsLoaded = false;
@@ -1050,6 +1051,27 @@ export class ModelRegistry {
       .filter((entry) => !this.models.has(entry.type.normalized))
       .map((entry) => entry.type);
     return [...loaded, ...lazy];
+  }
+
+  /**
+   * Returns model types visible to users — excludes types registered
+   * via {@link markInternal}.
+   */
+  publicTypes(): ModelType[] {
+    return this.types().filter((t) => !this.internalTypes.has(t.normalized));
+  }
+
+  /**
+   * Marks a model type as internal infrastructure. Internal types are
+   * hidden from user-facing discovery commands (`swamp type search`,
+   * shell completions, `swamp model create` type suggestions) but
+   * remain fully functional.
+   */
+  markInternal(type: ModelType | string): void {
+    const normalized = typeof type === "string"
+      ? ModelType.create(type).normalized
+      : type.normalized;
+    this.internalTypes.add(normalized);
   }
 }
 

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -406,6 +406,18 @@ Deno.test("ModelRegistry.types returns empty array when no models", () => {
   assertEquals(registry.types(), []);
 });
 
+Deno.test("ModelRegistry.publicTypes excludes internal models", () => {
+  const registry = new ModelRegistry();
+  registry.register(createTestModel("swamp/echo"));
+  registry.register(createTestModel("swamp/internal"));
+  registry.markInternal("swamp/internal");
+
+  assertEquals(registry.types().length, 2);
+  const publicTypes = registry.publicTypes();
+  assertEquals(publicTypes.length, 1);
+  assertEquals(publicTypes[0].normalized, "swamp/echo");
+});
+
 Deno.test("ModelDefinition method can execute", async () => {
   const model = createTestModel("swamp/echo");
 

--- a/src/domain/models/models.ts
+++ b/src/domain/models/models.ts
@@ -50,3 +50,19 @@ import "./aws/aws_models.ts";
 
 // Re-export the registry for convenient access
 export { modelRegistry } from "./model.ts";
+
+// Built-in infrastructure types are hidden from user-facing discovery
+// commands (swamp type search, shell completions, model create suggestions).
+import { modelRegistry } from "./model.ts";
+for (
+  const type of [
+    "swamp/enrollment-token",
+    "swamp/worker",
+    "swamp/step-lease",
+    "swamp/server-token",
+    "swamp/grant",
+    "swamp/group",
+  ]
+) {
+  modelRegistry.markInternal(type);
+}

--- a/src/libswamp/access/token_rotate.ts
+++ b/src/libswamp/access/token_rotate.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
+import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { createServerTokenRunDeps } from "./run_deps.ts";
+
+export interface ServerTokenRotateData {
+  name: string;
+  token: string;
+  principalId: string;
+  expiresAt: string;
+  vaultRef: { vaultName: string; secretKey: string };
+}
+
+export type ServerTokenRotateEvent =
+  | { kind: "rotating"; name: string }
+  | { kind: "completed"; data: ServerTokenRotateData }
+  | { kind: "error"; error: SwampError };
+
+export interface ServerTokenRotateInput {
+  name: string;
+  durationMs?: number;
+}
+
+export interface ServerTokenRotateDeps {
+  runRotate: (
+    input: { name: string; durationMs?: number },
+  ) => AsyncIterable<ModelMethodRunEvent>;
+  readSecret: (vaultName: string, secretKey: string) => Promise<string>;
+}
+
+export async function createServerTokenRotateDeps(
+  ctx: LibSwampContext,
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<ServerTokenRotateDeps> {
+  const runDeps = await createServerTokenRunDeps(repoDir, repoContext);
+  const vaultService = await VaultService.fromRepository(repoDir);
+  return {
+    runRotate: (input) =>
+      modelMethodRun(ctx, runDeps, {
+        modelIdOrName: input.name,
+        methodName: "rotate",
+        inputs: input.durationMs !== undefined
+          ? { durationMs: input.durationMs }
+          : {},
+        lastEvaluated: false,
+      }),
+    readSecret: (vaultName, secretKey) =>
+      vaultService.get(vaultName, secretKey),
+  };
+}
+
+const TOKEN_DATA_NAME = "token-main";
+
+export async function* serverTokenRotate(
+  _ctx: LibSwampContext,
+  deps: ServerTokenRotateDeps,
+  input: ServerTokenRotateInput,
+): AsyncGenerator<ServerTokenRotateEvent> {
+  yield* withGeneratorSpan(
+    "swamp.access.token.rotate",
+    { "token.name": input.name },
+    (async function* () {
+      yield { kind: "rotating" as const, name: input.name };
+
+      let tokenRecord: Record<string, unknown> | undefined;
+      for await (
+        const event of deps.runRotate({
+          name: input.name,
+          durationMs: input.durationMs,
+        })
+      ) {
+        if (event.kind === "error") {
+          const error = event.error.code === "model_not_found"
+            ? {
+              code: event.error.code,
+              message: `Server token '${input.name}' not found. ` +
+                "Use 'swamp access token list' to see existing tokens.",
+            }
+            : event.error;
+          yield { kind: "error" as const, error };
+          return;
+        }
+        if (event.kind === "completed") {
+          tokenRecord = event.run.dataArtifacts.find(
+            (artifact) => artifact.name === TOKEN_DATA_NAME,
+          )?.attributes;
+        }
+      }
+
+      if (
+        tokenRecord === undefined ||
+        typeof tokenRecord.expiresAt !== "string" ||
+        typeof tokenRecord.secretKey !== "string" ||
+        typeof tokenRecord.vaultName !== "string"
+      ) {
+        yield {
+          kind: "error" as const,
+          error: {
+            code: "token_record_missing",
+            message: `Rotate completed but the '${TOKEN_DATA_NAME}' record ` +
+              `for token '${input.name}' was not produced`,
+          },
+        };
+        return;
+      }
+
+      const plaintext = await deps.readSecret(
+        tokenRecord.vaultName,
+        tokenRecord.secretKey,
+      );
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          name: input.name,
+          token: `${input.name}.${plaintext}`,
+          principalId: typeof tokenRecord.principalId === "string"
+            ? tokenRecord.principalId
+            : "",
+          expiresAt: tokenRecord.expiresAt,
+          vaultRef: {
+            vaultName: tokenRecord.vaultName,
+            secretKey: tokenRecord.secretKey,
+          },
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/access/token_rotate_test.ts
+++ b/src/libswamp/access/token_rotate_test.ts
@@ -1,0 +1,204 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { ModelMethodRunEvent } from "../models/run.ts";
+import {
+  serverTokenRotate,
+  type ServerTokenRotateDeps,
+  type ServerTokenRotateEvent,
+} from "./token_rotate.ts";
+
+const EXPIRES_AT = "2026-07-18T00:00:00.000Z";
+
+function rotateEvents(
+  name: string,
+  attributes?: Record<string, unknown>,
+): ModelMethodRunEvent[] {
+  return [
+    { kind: "validating_inputs" },
+    {
+      kind: "completed",
+      run: {
+        modelId: name,
+        modelName: name,
+        modelType: "swamp/server-token",
+        methodName: "rotate",
+        status: "succeeded",
+        outputId: "output-1",
+        dataArtifacts: [
+          {
+            id: "data-1",
+            name: "token-main",
+            path: `/data/${name}/token-main`,
+            attributes: attributes ?? {
+              name,
+              state: "active",
+              principalId: "user:sarah",
+              principalEmail: "sarah@example.com",
+              createdAt: "2026-06-19T00:00:00.000Z",
+              expiresAt: EXPIRES_AT,
+              vaultName: "main-vault",
+              secretKey: `server-token-${name}`,
+            },
+          },
+        ],
+      },
+    },
+  ];
+}
+
+function makeDeps(
+  overrides?: Partial<ServerTokenRotateDeps>,
+): ServerTokenRotateDeps {
+  return {
+    runRotate: async function* (input) {
+      for (const event of rotateEvents(input.name)) {
+        yield await Promise.resolve(event);
+      }
+    },
+    readSecret: () => Promise.resolve("new-plaintext-secret"),
+    ...overrides,
+  };
+}
+
+Deno.test("serverTokenRotate: rotates and yields the new plaintext", async () => {
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), makeDeps(), {
+      name: "sarah-token",
+    }),
+  );
+
+  assertEquals(events[0], { kind: "rotating", name: "sarah-token" });
+  const completed = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data, {
+    name: "sarah-token",
+    token: "sarah-token.new-plaintext-secret",
+    principalId: "user:sarah",
+    expiresAt: EXPIRES_AT,
+    vaultRef: {
+      vaultName: "main-vault",
+      secretKey: "server-token-sarah-token",
+    },
+  });
+});
+
+Deno.test("serverTokenRotate: passes durationMs to the model method", async () => {
+  let receivedDuration: number | undefined;
+  const deps = makeDeps({
+    runRotate: async function* (input) {
+      receivedDuration = input.durationMs;
+      for (const event of rotateEvents(input.name)) {
+        yield await Promise.resolve(event);
+      }
+    },
+  });
+  await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, {
+      name: "tok",
+      durationMs: 60_000,
+    }),
+  );
+  assertEquals(receivedDuration, 60_000);
+});
+
+Deno.test("serverTokenRotate: enriches model_not_found error", async () => {
+  const deps = makeDeps({
+    runRotate: async function* () {
+      await Promise.resolve();
+      yield {
+        kind: "error",
+        error: {
+          code: "model_not_found",
+          message: "Model not found",
+        },
+      } as ModelMethodRunEvent;
+    },
+  });
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, { name: "missing" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "Server token 'missing' not found");
+  assertStringIncludes(error.error.message, "swamp access token list");
+});
+
+Deno.test("serverTokenRotate: forwards other method errors", async () => {
+  const deps = makeDeps({
+    runRotate: async function* () {
+      await Promise.resolve();
+      yield {
+        kind: "error",
+        error: {
+          code: "method_execution_failed",
+          message: "does not exist",
+        },
+      } as ModelMethodRunEvent;
+    },
+  });
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, { name: "tok" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "does not exist");
+});
+
+Deno.test("serverTokenRotate: errors when token record is missing from result", async () => {
+  const deps = makeDeps({
+    runRotate: async function* (input) {
+      yield await Promise.resolve(
+        {
+          kind: "completed",
+          run: {
+            modelId: input.name,
+            modelName: input.name,
+            modelType: "swamp/server-token",
+            methodName: "rotate",
+            status: "succeeded",
+            outputId: "output-1",
+            dataArtifacts: [],
+          },
+        } satisfies ModelMethodRunEvent,
+      );
+    },
+  });
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, { name: "tok" }),
+  );
+  const error = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "token-main");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -390,6 +390,14 @@ export {
   type ServerTokenRevokeEvent,
   type ServerTokenRevokeInput,
 } from "./access/token_revoke.ts";
+export {
+  createServerTokenRotateDeps,
+  serverTokenRotate,
+  type ServerTokenRotateData,
+  type ServerTokenRotateDeps,
+  type ServerTokenRotateEvent,
+  type ServerTokenRotateInput,
+} from "./access/token_rotate.ts";
 export { createServerTokenRunDeps } from "./access/run_deps.ts";
 
 export {

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -113,7 +113,8 @@ export async function createModelCreateDeps(
       return definition;
     },
     getPath: (type, id) => definitionRepo.getPath(type, id),
-    listAvailableTypes: () => modelRegistry.types().map((t) => t.normalized),
+    listAvailableTypes: () =>
+      modelRegistry.publicTypes().map((t) => t.normalized),
   };
 }
 

--- a/src/presentation/output/access_token_output.ts
+++ b/src/presentation/output/access_token_output.ts
@@ -29,6 +29,7 @@ import type {
   ServerTokenCreateData,
   ServerTokenListData,
   ServerTokenRevokeData,
+  ServerTokenRotateData,
 } from "../../libswamp/mod.ts";
 import type { OutputMode } from "./output.ts";
 
@@ -147,5 +148,30 @@ export function renderServerTokenRevoke(
   if (data.revokedAt) {
     lines.push(`${bold(cyan("Revoked at:"))} ${data.revokedAt}`);
   }
+  writeOutput(lines.join("\n"));
+}
+
+export function renderServerTokenRotate(
+  data: ServerTokenRotateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+  const lines = [
+    `${green(checkmark)} Token ${bold(data.name)} rotated.`,
+    `${bold(cyan("Principal:"))} ${data.principalId}`,
+    `${bold(cyan("Expires:"))} ${data.expiresAt}`,
+    `${bold(cyan("Vault:"))} ${data.vaultRef.vaultName} ${
+      dim(`(key ${data.vaultRef.secretKey})`)
+    }`,
+    "",
+    `  ${bold(data.token)}`,
+    "",
+    yellow(
+      "Previous token has been revoked. Store the new token now — it will not be shown again.",
+    ),
+  ];
   writeOutput(lines.join("\n"));
 }


### PR DESCRIPTION
## Summary

- Add `swamp access token rotate <name>` command that atomically revokes an existing server token and mints a replacement with the same name and principal — simplifies the token compromise workflow from two manual steps to one
- Add `ModelRegistry.markInternal()` / `publicTypes()` to hide built-in infrastructure model types (`swamp/server-token`, `swamp/grant`, `swamp/group`, `swamp/enrollment-token`, `swamp/worker`, `swamp/step-lease`) from `swamp type search`, shell completions, and `swamp model create` type suggestions while keeping them fully functional
- The `internal` flag is registry-level only — not on the `ModelDefinition` interface — so extension authors cannot set it

## Test Plan

- [x] 9 model-layer unit tests for rotate (active, expired, revoked, nonexistent, custom duration, vault requirement, credential reuse, old credential rejection)
- [x] 5 application-service tests for `serverTokenRotate` (happy path, durationMs passthrough, model_not_found enrichment, error forwarding, missing token record)
- [x] 1 registry test for `publicTypes()` filtering
- [x] All 136 related tests pass (model + access + types)
- [x] Full test suite passes (7489 passed, 1 pre-existing macOS xattr failure)
- [x] Binary compiles and runs: `swamp access token rotate` verified end-to-end in scratch repo
- [x] `swamp model type search --json` confirms internal types are hidden

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)