### PR TITLE
feat(audit): add Copilot audit hook support

### DIFF
--- a/design/audit-doctor.md
+++ b/design/audit-doctor.md
@@ -96,8 +96,8 @@ prefix is the only identifier available for all four tools.
 - Without `--tool`, reads `.swamp.yaml`'s `tool` field.
 - If both are absent, throws `NoToolConfiguredError` — a usage error,
   not a check fail, exits non-zero from the CLI.
-- `codex`, `copilot`, and `none` short-circuit to a single skip result
-  (those tools don't emit audit hooks).
+- `codex` and `none` short-circuit to a single skip result (those tools
+  don't emit audit hooks).
 
 ## Platform
 

--- a/src/cli/commands/doctor_audit_test.ts
+++ b/src/cli/commands/doctor_audit_test.ts
@@ -100,14 +100,21 @@ Deno.test(
 );
 
 Deno.test(
-  "resolveTargetTool: accepts the audit-skip tools (codex/copilot/none) as valid overrides",
+  "resolveTargetTool: accepts the audit-skip tools (codex/none) as valid overrides",
   async () => {
     const { resolveTargetTool } = await import("./doctor_audit.ts");
     // The service short-circuits these to skip; the CLI must still accept them
     // as valid --tool values so the user can explicitly check them.
     assertEquals(resolveTargetTool("codex", undefined), "codex");
-    assertEquals(resolveTargetTool("copilot", undefined), "copilot");
     assertEquals(resolveTargetTool("none", undefined), "none");
+  },
+);
+
+Deno.test(
+  "resolveTargetTool: accepts copilot as a valid audit-enabled tool override",
+  async () => {
+    const { resolveTargetTool } = await import("./doctor_audit.ts");
+    assertEquals(resolveTargetTool("copilot", undefined), "copilot");
   },
 );
 

--- a/src/domain/audit/doctor/checks/agent_config_loadable.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable.ts
@@ -31,6 +31,7 @@ const CONFIG_FILES: Record<string, string[]> = {
   claude: [".claude/settings.local.json"],
   cursor: [".cursor/hooks.json"],
   opencode: [".opencode/plugins/swamp-audit.ts"],
+  copilot: [".github/hooks/swamp-audit.json"],
 };
 
 async function readJsonFile(path: string): Promise<unknown> {
@@ -234,6 +235,59 @@ async function checkOpenCode(ctx: CheckContext): Promise<CheckResult> {
   };
 }
 
+async function checkCopilot(ctx: CheckContext): Promise<CheckResult> {
+  const configPath = join(ctx.repoPath, ".github/hooks/swamp-audit.json");
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = (await readJsonFile(configPath)) as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {
+        name: "agent-config-loadable",
+        status: "fail",
+        message: `${configPath} is missing`,
+        hint: "Run `swamp init --tool copilot --force` to regenerate.",
+      };
+    }
+    return {
+      name: "agent-config-loadable",
+      status: "fail",
+      message: `${configPath} could not be parsed as JSON`,
+      hint: "The file is corrupt; run `swamp init --tool copilot --force`.",
+      details: { error: String(error) },
+    };
+  }
+  const hooks = parsed.hooks as
+    | { postToolUse?: unknown[]; postToolUseFailure?: unknown[] }
+    | undefined;
+  if (!hooks?.postToolUse || !hooks.postToolUseFailure) {
+    return {
+      name: "agent-config-loadable",
+      status: "fail",
+      message:
+        "Copilot hooks (postToolUse/postToolUseFailure) are not configured",
+      hint: "Run `swamp init --tool copilot --force` to install the hooks.",
+    };
+  }
+  if (
+    !JSON.stringify(hooks).includes(
+      "swamp audit record --from-hook --tool copilot",
+    )
+  ) {
+    return {
+      name: "agent-config-loadable",
+      status: "fail",
+      message: "Copilot hooks do not reference `swamp audit record`",
+      hint: "Run `swamp init --tool copilot --force` to rewrite the hooks.",
+    };
+  }
+  return {
+    name: "agent-config-loadable",
+    status: "pass",
+    message: `${configPath} is present with both hooks wired`,
+  };
+}
+
 function appliesTo(tool: string): boolean {
   return tool in CONFIG_FILES;
 }
@@ -252,6 +306,8 @@ export const agentConfigLoadableCheck: PreflightCheck = {
         return await checkCursor(ctx);
       case "opencode":
         return await checkOpenCode(ctx);
+      case "copilot":
+        return await checkCopilot(ctx);
       default:
         return {
           name: "agent-config-loadable",

--- a/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
@@ -188,3 +188,83 @@ Deno.test("agentConfigLoadable: opencode fails when plugin does not reference sw
     assertEquals(result.status, "fail");
   });
 });
+
+Deno.test("agentConfigLoadable: copilot passes for a well-formed config", async () => {
+  await withTempRepo(async (repo) => {
+    await writeJson(join(repo, ".github/hooks/swamp-audit.json"), {
+      version: 1,
+      hooks: {
+        postToolUse: [
+          {
+            type: "command",
+            command: "swamp audit record --from-hook --tool copilot",
+          },
+        ],
+        postToolUseFailure: [
+          {
+            type: "command",
+            command: "swamp audit record --from-hook --tool copilot",
+          },
+        ],
+      },
+    });
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "copilot"),
+    );
+    assertEquals(result.status, "pass");
+  });
+});
+
+Deno.test("agentConfigLoadable: copilot fails when file is missing", async () => {
+  await withTempRepo(async (repo) => {
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "copilot"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "missing");
+  });
+});
+
+Deno.test("agentConfigLoadable: copilot fails on malformed JSON", async () => {
+  await withTempRepo(async (repo) => {
+    const path = join(repo, ".github/hooks/swamp-audit.json");
+    await ensureDir(join(path, ".."));
+    await Deno.writeTextFile(path, "{ not json");
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "copilot"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "could not be parsed");
+  });
+});
+
+Deno.test("agentConfigLoadable: copilot fails when hooks are missing", async () => {
+  await withTempRepo(async (repo) => {
+    await writeJson(join(repo, ".github/hooks/swamp-audit.json"), {
+      version: 1,
+      hooks: {},
+    });
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "copilot"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "postToolUse/postToolUseFailure");
+  });
+});
+
+Deno.test("agentConfigLoadable: copilot fails when hooks do not reference swamp audit record", async () => {
+  await withTempRepo(async (repo) => {
+    await writeJson(join(repo, ".github/hooks/swamp-audit.json"), {
+      version: 1,
+      hooks: {
+        postToolUse: [{ type: "command", command: "echo hello" }],
+        postToolUseFailure: [{ type: "command", command: "echo fail" }],
+      },
+    });
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "copilot"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "swamp audit record");
+  });
+});

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -27,7 +27,7 @@ const INSTALL_HINTS: Record<string, string> = {
   kiro: "Install Kiro CLI: https://docs.kiro.ai/cli",
   opencode: "Install OpenCode: https://opencode.ai",
   copilot:
-    "Install Copilot CLI: npm install -g @github/copilot or brew install copilot-cli",
+    "Install GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli",
 };
 
 function appliesTo(tool: string): boolean {

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -26,11 +26,13 @@ const INSTALL_HINTS: Record<string, string> = {
   cursor: "Install Cursor: https://cursor.com",
   kiro: "Install Kiro CLI: https://docs.kiro.ai/cli",
   opencode: "Install OpenCode: https://opencode.ai",
+  copilot:
+    "Install Copilot CLI: npm install -g @github/copilot or brew install copilot-cli",
 };
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode";
+    tool === "opencode" || tool === "copilot";
 }
 
 /**

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -65,7 +65,8 @@ Deno.test("binaryOnPath: uses tool-specific binary name", async () => {
   await check.run(makeCtx("claude"));
   await check.run(makeCtx("cursor"));
   await check.run(makeCtx("opencode"));
-  assertEquals(seen, ["kiro-cli", "claude", "cursor", "opencode"]);
+  await check.run(makeCtx("copilot"));
+  assertEquals(seen, ["kiro-cli", "claude", "cursor", "opencode", "copilot"]);
 });
 
 Deno.test("binaryOnPath: appliesTo returns true for all five audit tools, false otherwise", () => {

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -68,7 +68,7 @@ Deno.test("binaryOnPath: uses tool-specific binary name", async () => {
   assertEquals(seen, ["kiro-cli", "claude", "cursor", "opencode"]);
 });
 
-Deno.test("binaryOnPath: appliesTo returns true for all four audit tools, false otherwise", () => {
+Deno.test("binaryOnPath: appliesTo returns true for all five audit tools, false otherwise", () => {
   const check = makeBinaryOnPathCheck({
     resolveBinary: () => Promise.resolve(null),
   });
@@ -76,7 +76,7 @@ Deno.test("binaryOnPath: appliesTo returns true for all four audit tools, false 
   assertEquals(check.appliesTo("cursor"), true);
   assertEquals(check.appliesTo("kiro"), true);
   assertEquals(check.appliesTo("opencode"), true);
+  assertEquals(check.appliesTo("copilot"), true);
   assertEquals(check.appliesTo("codex"), false);
-  assertEquals(check.appliesTo("copilot"), false);
   assertEquals(check.appliesTo("none"), false);
 });

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -36,7 +36,7 @@ import { syntheticPayloadFor } from "../synthetic_payloads.ts";
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode";
+    tool === "opencode" || tool === "copilot";
 }
 
 function randomNonce(): string {

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -128,8 +128,8 @@ Deno.test("recordingSmokeTest: fails cleanly when spawn throws", async () => {
 Deno.test("recordingSmokeTest: appliesTo returns true only for audit-hook tools", () => {
   assertEquals(recordingSmokeTestCheck.appliesTo("claude"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("kiro"), true);
+  assertEquals(recordingSmokeTestCheck.appliesTo("copilot"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("codex"), false);
-  assertEquals(recordingSmokeTestCheck.appliesTo("copilot"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("none"), false);
 });
 

--- a/src/domain/audit/doctor/checks/resolve_binary.ts
+++ b/src/domain/audit/doctor/checks/resolve_binary.ts
@@ -37,6 +37,8 @@ export function binaryNameFor(tool: string): string {
       return "kiro-cli";
     case "opencode":
       return "opencode";
+    case "copilot":
+      return "copilot";
     default:
       return tool;
   }

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -35,7 +35,7 @@ import type { ResolveBinary } from "./resolve_binary.ts";
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode";
+    tool === "opencode" || tool === "copilot";
 }
 
 async function checkKiroBakedPath(ctx: CheckContext): Promise<{

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
@@ -77,7 +77,7 @@ Deno.test("swampBinaryOnPath: passes for non-kiro when PATH resolves", async () 
     resolveBinary: () => Promise.resolve("/usr/local/bin/swamp"),
   });
   await withTempRepo(async (repo) => {
-    for (const tool of ["claude", "cursor", "opencode"] as const) {
+    for (const tool of ["claude", "cursor", "opencode", "copilot"] as const) {
       const result = await check.run(makeCtx(repo, tool));
       assertEquals(result.status, "pass", `failed for tool ${tool}`);
     }

--- a/src/domain/audit/doctor/doctor_service.ts
+++ b/src/domain/audit/doctor/doctor_service.ts
@@ -105,7 +105,7 @@ function buildDefaultChecks(deps: AuditDoctorDeps): readonly PreflightCheck[] {
 /**
  * Runs preflight checks against the audit integration for the given tool.
  *
- * For tools without audit hooks (codex, copilot, none), emits a single
+ * For tools without audit hooks (codex, none), emits a single
  * skip result and returns a `warn` report.
  */
 export async function* auditDoctor(
@@ -116,8 +116,7 @@ export async function* auditDoctor(
   // Tools without audit hook integration: short-circuit cleanly.
   // Custom tools (non-built-in) also skip — they have no audit hooks.
   if (
-    !isBuiltInTool(tool) || tool === "codex" || tool === "copilot" ||
-    tool === "none"
+    !isBuiltInTool(tool) || tool === "codex" || tool === "none"
   ) {
     const skipResult: CheckResult = {
       name: "recording-smoke-test",

--- a/src/domain/audit/doctor/doctor_service_test.ts
+++ b/src/domain/audit/doctor/doctor_service_test.ts
@@ -149,7 +149,7 @@ Deno.test(
 Deno.test(
   "auditDoctor: short-circuits to a single skip for tools without audit hooks",
   async () => {
-    for (const tool of ["codex", "copilot", "none"] as const) {
+    for (const tool of ["codex", "none"] as const) {
       const events = await collect(auditDoctor(makeDeps(tool)));
       assertEquals(events.length, 2);
       assertEquals(events[0].kind, "check-completed");

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -42,6 +42,8 @@
  *   https://docs.kiro.ai/ide/hooks (Kiro IDE emits camelCase via USER_PROMPT)
  * - OpenCode:
  *   https://opencode.ai/docs/plugins (plugin emits normalized JSON on stdin)
+ * - Copilot:
+ *   https://docs.github.com/en/copilot/reference/hooks-reference
  */
 
 import { DIAGNOSTIC_COMMAND_PREFIX } from "../audit_service.ts";
@@ -124,8 +126,16 @@ export function syntheticPayloadFor(
       };
       return { stdin: JSON.stringify(raw), env: {}, expectedCommand };
     }
+    case "copilot": {
+      const raw = {
+        sessionId: DOCTOR_SMOKE_TEST_SESSION_ID,
+        cwd,
+        toolName: "bash",
+        toolArgs: { command: expectedCommand },
+      };
+      return { stdin: JSON.stringify(raw), env: {}, expectedCommand };
+    }
     case "codex":
-    case "copilot":
     case "none":
     default:
       return null;

--- a/src/domain/audit/doctor/synthetic_payloads_test.ts
+++ b/src/domain/audit/doctor/synthetic_payloads_test.ts
@@ -31,7 +31,13 @@ import {
  * tests break, surfacing the drift at CI time rather than silently at
  * runtime.
  */
-const SUPPORTED_TOOLS: HookTool[] = ["claude", "cursor", "kiro", "opencode"];
+const SUPPORTED_TOOLS: HookTool[] = [
+  "claude",
+  "cursor",
+  "kiro",
+  "opencode",
+  "copilot",
+];
 
 for (const tool of SUPPORTED_TOOLS) {
   Deno.test(
@@ -74,6 +80,20 @@ Deno.test("syntheticPayloadFor: sets USER_PROMPT env var for kiro only", () => {
 
 Deno.test("syntheticPayloadFor: returns null for tools without audit hooks", () => {
   assertEquals(syntheticPayloadFor("codex", "nonce"), null);
-  assertEquals(syntheticPayloadFor("copilot", "nonce"), null);
   assertEquals(syntheticPayloadFor("none", "nonce"), null);
+});
+
+Deno.test("syntheticPayloadFor(copilot): snake_case format also normalizes", () => {
+  const nonce = "snake-test";
+  const expectedCommand = `${DOCTOR_SMOKE_TEST_COMMAND_PREFIX} ${nonce}`;
+  const raw = {
+    session_id: "doctor-session",
+    cwd: ".",
+    hook_event_name: "PostToolUse",
+    tool_name: "bash",
+    tool_input: { command: expectedCommand },
+  };
+  const normalized = normalizeHookInput("copilot", raw);
+  assertNotEquals(normalized, null, "snake_case copilot payload rejected");
+  assertEquals(normalized?.command, expectedCommand);
 });

--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -250,7 +250,8 @@ function normalizeCopilot(
   if (!command) return null;
 
   const errorStr = raw.error as string | undefined;
-  const isFailure = raw.hook_event_name === "PostToolUseFailure" || !!errorStr;
+  const isFailure = raw.hook_event_name === "PostToolUseFailure" ||
+    raw.hookEventName === "PostToolUseFailure" || !!errorStr;
 
   return {
     command,

--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -20,7 +20,7 @@
 /**
  * Supported AI coding tools that can provide hook input.
  */
-export type HookTool = "claude" | "cursor" | "kiro" | "opencode";
+export type HookTool = "claude" | "cursor" | "kiro" | "opencode" | "copilot";
 
 /**
  * Normalized hook input from any supported tool.
@@ -80,6 +80,8 @@ export function normalizeHookInput(
       return normalizeKiro(raw);
     case "opencode":
       return normalizeOpenCode(raw);
+    case "copilot":
+      return normalizeCopilot(raw);
   }
 }
 
@@ -218,6 +220,42 @@ function normalizeOpenCode(
     command,
     cwd: (raw.cwd as string) || ".",
     sessionId: raw.session_id as string | undefined,
+    isFailure,
+    ...(isFailure && errorStr ? { errorMessage: errorStr } : {}),
+  };
+}
+
+/**
+ * Copilot: postToolUse / postToolUseFailure hooks.
+ * Upstream contract: https://docs.github.com/en/copilot/reference/hooks-reference
+ *
+ * Supports two input formats:
+ * - camelCase (CLI): toolName, toolArgs, sessionId, timestamp (number)
+ * - snake_case (VS Code compatible): tool_name, tool_input, session_id,
+ *   hook_event_name, timestamp (ISO string)
+ *
+ * toolName/tool_name is "bash" for shell commands. Failure when
+ * hook_event_name === "PostToolUseFailure" or error field is present.
+ */
+function normalizeCopilot(
+  raw: Record<string, unknown>,
+): NormalizedHookInput | null {
+  const toolName = (raw.toolName ?? raw.tool_name) as string | undefined;
+  if (toolName !== "bash") return null;
+
+  const toolInput = (raw.toolArgs ?? raw.tool_input) as
+    | { command?: string }
+    | undefined;
+  const command = toolInput?.command;
+  if (!command) return null;
+
+  const errorStr = raw.error as string | undefined;
+  const isFailure = raw.hook_event_name === "PostToolUseFailure" || !!errorStr;
+
+  return {
+    command,
+    cwd: (raw.cwd as string) || ".",
+    sessionId: (raw.sessionId ?? raw.session_id) as string | undefined,
     isFailure,
     ...(isFailure && errorStr ? { errorMessage: errorStr } : {}),
   };

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -319,3 +319,116 @@ Deno.test("normalizeHookInput opencode: skips non-bash tools", () => {
 
   assertEquals(result, null);
 });
+
+// ---- Copilot normalization (camelCase format) ----
+
+Deno.test("normalizeHookInput copilot: normalizes successful bash (camelCase)", () => {
+  const result = normalizeHookInput("copilot", {
+    sessionId: "cp-session-1",
+    cwd: "/repo",
+    toolName: "bash",
+    toolArgs: { command: "npm test" },
+    toolResult: { resultType: "success", textResultForLlm: "all tests passed" },
+  });
+
+  assertEquals(result, {
+    command: "npm test",
+    cwd: "/repo",
+    sessionId: "cp-session-1",
+    isFailure: false,
+  });
+});
+
+Deno.test("normalizeHookInput copilot: normalizes failed bash (camelCase)", () => {
+  const result = normalizeHookInput("copilot", {
+    sessionId: "cp-session-1",
+    cwd: "/repo",
+    toolName: "bash",
+    toolArgs: { command: "npm build" },
+    error: "build failed",
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, "build failed");
+});
+
+Deno.test("normalizeHookInput copilot: skips non-bash tools (camelCase)", () => {
+  const result = normalizeHookInput("copilot", {
+    sessionId: "cp-session-1",
+    cwd: "/repo",
+    toolName: "edit",
+    toolArgs: { file: "foo.ts" },
+  });
+
+  assertEquals(result, null);
+});
+
+Deno.test("normalizeHookInput copilot: returns null for missing command (camelCase)", () => {
+  const result = normalizeHookInput("copilot", {
+    sessionId: "cp-session-1",
+    cwd: "/repo",
+    toolName: "bash",
+    toolArgs: {},
+  });
+
+  assertEquals(result, null);
+});
+
+// ---- Copilot normalization (snake_case format) ----
+
+Deno.test("normalizeHookInput copilot: normalizes successful bash (snake_case)", () => {
+  const result = normalizeHookInput("copilot", {
+    session_id: "cp-session-2",
+    cwd: "/project",
+    hook_event_name: "PostToolUse",
+    tool_name: "bash",
+    tool_input: { command: "deno test" },
+    tool_result: { result_type: "success", text_result_for_llm: "ok" },
+  });
+
+  assertEquals(result, {
+    command: "deno test",
+    cwd: "/project",
+    sessionId: "cp-session-2",
+    isFailure: false,
+  });
+});
+
+Deno.test("normalizeHookInput copilot: normalizes failed bash (snake_case)", () => {
+  const result = normalizeHookInput("copilot", {
+    session_id: "cp-session-2",
+    cwd: "/project",
+    hook_event_name: "PostToolUseFailure",
+    tool_name: "bash",
+    tool_input: { command: "deno check" },
+    error: "type check failed",
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, "type check failed");
+});
+
+Deno.test("normalizeHookInput copilot: detects failure from hook_event_name without error field", () => {
+  const result = normalizeHookInput("copilot", {
+    session_id: "cp-session-2",
+    cwd: "/project",
+    hook_event_name: "PostToolUseFailure",
+    tool_name: "bash",
+    tool_input: { command: "exit 1" },
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, undefined);
+});
+
+Deno.test("normalizeHookInput copilot: skips non-bash tools (snake_case)", () => {
+  const result = normalizeHookInput("copilot", {
+    session_id: "cp-session-2",
+    cwd: "/project",
+    hook_event_name: "PostToolUse",
+    tool_name: "view",
+    tool_input: { path: "/etc/hosts" },
+  });
+
+  assertEquals(result, null);
+});

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -421,6 +421,19 @@ Deno.test("normalizeHookInput copilot: detects failure from hook_event_name with
   assertEquals(result?.errorMessage, undefined);
 });
 
+Deno.test("normalizeHookInput copilot: detects failure from hookEventName (camelCase) without error field", () => {
+  const result = normalizeHookInput("copilot", {
+    sessionId: "cp-session-3",
+    cwd: "/project",
+    hookEventName: "PostToolUseFailure",
+    toolName: "bash",
+    toolArgs: { command: "exit 1" },
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, undefined);
+});
+
 Deno.test("normalizeHookInput copilot: skips non-bash tools (snake_case)", () => {
   const result = normalizeHookInput("copilot", {
     session_id: "cp-session-2",

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -539,8 +539,12 @@ export class RepoService {
             ? await this.updateOpenCodePlugin(repoPath)
             : await this.createOpenCodePluginIfNotExists(repoPath);
           break;
-        case "codex":
         case "copilot":
+          settingsChanged = alreadyExists
+            ? await this.updateCopilotHooks(repoPath)
+            : await this.createCopilotHooksIfNotExists(repoPath);
+          break;
+        case "codex":
         case "none":
           break;
         default:
@@ -1524,6 +1528,113 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
       hookPath,
       await this.generateKiroHookContent(),
     );
+  }
+
+  /**
+   * Generates the content for Copilot's .github/hooks/swamp-audit.json.
+   * Upstream contract: https://docs.github.com/en/copilot/reference/hooks-configuration
+   */
+  private generateCopilotHooksContent(): string {
+    const hooks = {
+      version: 1,
+      hooks: {
+        postToolUse: [
+          {
+            type: "command",
+            command: "swamp audit record --from-hook --tool copilot",
+          },
+        ],
+        postToolUseFailure: [
+          {
+            type: "command",
+            command: "swamp audit record --from-hook --tool copilot",
+          },
+        ],
+      },
+    };
+    return JSON.stringify(hooks, null, 2) + "\n";
+  }
+
+  /**
+   * Creates .github/hooks/swamp-audit.json if it doesn't already exist.
+   */
+  private createCopilotHooksIfNotExists(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const hooksPath = join(
+      repoPath.value,
+      ".github",
+      "hooks",
+      "swamp-audit.json",
+    );
+    return this.createFileIfNotExists(
+      hooksPath,
+      this.generateCopilotHooksContent(),
+    );
+  }
+
+  /**
+   * Updates .github/hooks/swamp-audit.json, merging new hook entries with
+   * existing ones.
+   */
+  private async updateCopilotHooks(repoPath: RepoPath): Promise<boolean> {
+    const githubDir = join(repoPath.value, ".github", "hooks");
+    const hooksPath = join(githubDir, "swamp-audit.json");
+
+    await ensureDir(githubDir);
+
+    let existingHooks: {
+      version?: number;
+      hooks?: Record<string, unknown[]>;
+    } = {};
+    let hooksExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(hooksPath);
+      existingHooks = JSON.parse(content);
+      hooksExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    const ourHooks: Record<string, unknown[]> = {
+      postToolUse: [
+        {
+          type: "command",
+          command: "swamp audit record --from-hook --tool copilot",
+        },
+      ],
+      postToolUseFailure: [
+        {
+          type: "command",
+          command: "swamp audit record --from-hook --tool copilot",
+        },
+      ],
+    };
+
+    const mergedHooks = this.mergeHooks(
+      existingHooks.hooks ?? {},
+      ourHooks,
+    );
+
+    const hooksChanged = JSON.stringify(existingHooks.hooks ?? {}) !==
+      JSON.stringify(mergedHooks);
+
+    if (!hooksChanged && hooksExisted) {
+      return false;
+    }
+
+    const newContent = {
+      version: existingHooks.version ?? 1,
+      hooks: mergedHooks,
+    };
+    await atomicWriteTextFile(
+      hooksPath,
+      JSON.stringify(newContent, null, 2) + "\n",
+    );
+    return true;
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -661,7 +661,7 @@ Deno.test("RepoService.init with codex creates .agents/skills/ and AGENTS.md", a
   });
 });
 
-Deno.test("RepoService.init with copilot creates .agents/skills/ and AGENTS.md", async () => {
+Deno.test("RepoService.init with copilot creates .agents/skills/, AGENTS.md, and .github/hooks/", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -670,7 +670,7 @@ Deno.test("RepoService.init with copilot creates .agents/skills/ and AGENTS.md",
 
     assertEquals(result.tools[0], "copilot");
     assertEquals(result.instructionsFileCreated, true);
-    assertEquals(result.settingsCreated, false);
+    assertEquals(result.settingsCreated, true);
     assertEquals(result.gitignoreAction, "created");
 
     // Check skills copied to .agents/skills/
@@ -683,6 +683,16 @@ Deno.test("RepoService.init with copilot creates .agents/skills/ and AGENTS.md",
     const content = await Deno.readTextFile(agentsMdPath);
     assertStringIncludes(content, "swamp");
     assertStringIncludes(content, "## Skills");
+
+    // Check .github/hooks/swamp-audit.json created
+    const hooksPath = join(tempDir, ".github", "hooks", "swamp-audit.json");
+    const hooksContent = await Deno.readTextFile(hooksPath);
+    const hooks = JSON.parse(hooksContent);
+    assertEquals(hooks.version, 1);
+    assertStringIncludes(
+      JSON.stringify(hooks),
+      "swamp audit record --from-hook --tool copilot",
+    );
 
     // Check no .claude/ settings created
     const claudeSettingsPath = join(

--- a/src/libswamp/audit/timeline.ts
+++ b/src/libswamp/audit/timeline.ts
@@ -76,7 +76,7 @@ export async function* auditTimeline(
       ctx.logger.debug`Fetching audit timeline`;
 
       // Check if the configured tool supports audit hooks
-      if (input.tool === "codex" || input.tool === "copilot") {
+      if (input.tool === "codex") {
         yield {
           kind: "completed",
           data: { status: "tool_not_supported", tool: input.tool },

--- a/src/libswamp/audit/timeline_test.ts
+++ b/src/libswamp/audit/timeline_test.ts
@@ -114,7 +114,7 @@ Deno.test("auditTimeline: yields completed with tool_not_supported for codex", a
   assertEquals(completed.data.status, "tool_not_supported");
 });
 
-Deno.test("auditTimeline: copilot is not tool_not_supported", async () => {
+Deno.test("auditTimeline: copilot proceeds to normal timeline (not tool_not_supported)", async () => {
   const deps = makeDeps();
 
   const events = await collect<AuditTimelineEvent>(
@@ -130,5 +130,5 @@ Deno.test("auditTimeline: copilot is not tool_not_supported", async () => {
     { kind: "completed" }
   >;
   assertEquals(completed.kind, "completed");
-  assertEquals(completed.data.status !== "tool_not_supported", true);
+  assertEquals(completed.data.status, "timeline");
 });

--- a/src/libswamp/audit/timeline_test.ts
+++ b/src/libswamp/audit/timeline_test.ts
@@ -114,7 +114,7 @@ Deno.test("auditTimeline: yields completed with tool_not_supported for codex", a
   assertEquals(completed.data.status, "tool_not_supported");
 });
 
-Deno.test("auditTimeline: yields completed with tool_not_supported for copilot", async () => {
+Deno.test("auditTimeline: copilot is not tool_not_supported", async () => {
   const deps = makeDeps();
 
   const events = await collect<AuditTimelineEvent>(
@@ -125,11 +125,10 @@ Deno.test("auditTimeline: yields completed with tool_not_supported for copilot",
     }),
   );
 
-  assertEquals(events.length, 1);
-  const completed = events[0] as Extract<
+  const completed = events[events.length - 1] as Extract<
     AuditTimelineEvent,
     { kind: "completed" }
   >;
   assertEquals(completed.kind, "completed");
-  assertEquals(completed.data.status, "tool_not_supported");
+  assertEquals(completed.data.status !== "tool_not_supported", true);
 });

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -64,7 +64,7 @@ const TOOL_CLEANUP_PATHS: Partial<Record<string, readonly string[]>> = {
   kiro: [".kiro/", ".vscode/settings.local.json"],
   opencode: [".opencode/", ".agents/skills/"],
   codex: [".agents/skills/"],
-  copilot: [".agents/skills/"],
+  copilot: [".agents/skills/", ".github/hooks/"],
 };
 
 /**


### PR DESCRIPTION
## Summary

Copilot v1.0.x now supports hooks via `.github/hooks/*.json`. This updates the
integration from minimal (no hooks, `tool_not_supported`) to full audit recording
parity with Claude, Cursor, Kiro, and OpenCode.

- Add `copilot` to `HookTool` union and implement `normalizeCopilot()` with
  dual-format support (camelCase CLI + snake_case VS Code payloads)
- Generate `.github/hooks/swamp-audit.json` during `swamp repo init/upgrade`
  with `postToolUse` and `postToolUseFailure` hooks
- Remove copilot from `tool_not_supported` short-circuits in audit timeline and
  doctor service
- Add copilot synthetic payload and update all five doctor preflight checks
- Update cleanup paths and design docs
- Filed #1621 for manual documentation update

Closes #705

## Test Plan

- All 7486 tests pass (unit + integration)
- `normalizeCopilot()` tested with both camelCase and snake_case payload formats
- Synthetic payload round-trips through normalizer (contract test)
- `repo_service` init test verifies `.github/hooks/swamp-audit.json` is created
- Doctor check `appliesTo` coverage updated for copilot
- Type check, lint, and format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: g2rant <g2rant@users.noreply.github.com>