### PR TITLE
fix(audit): add copilot to VALID_HOOK_TOOLS allowlist

### DIFF
--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -73,7 +73,13 @@ function readHookInput(tool: HookTool): Promise<string> {
 }
 
 /** Valid values for the --tool option */
-const VALID_HOOK_TOOLS: HookTool[] = ["claude", "cursor", "kiro", "opencode"];
+const VALID_HOOK_TOOLS: HookTool[] = [
+  "claude",
+  "cursor",
+  "kiro",
+  "opencode",
+  "copilot",
+];
 
 /**
  * `swamp audit record --from-hook`


### PR DESCRIPTION
## Summary

- PR #1623 added the copilot normalizer and synthetic payload but missed adding `"copilot"` to the `VALID_HOOK_TOOLS` guard in the `audit record` command
- The command silently rejected `--tool copilot` before the normalizer ever ran, causing the `recording-smoke-test` doctor check to fail

## Test Plan

- `deno run test src/domain/audit/` — all 129 audit tests pass
- `deno check src/cli/commands/audit.ts` — type-checks clean
- `deno fmt --check` / `deno lint` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)