### PR TITLE
feat(workflows): support trigger.inputs for scheduled and webhook runs

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -184,6 +184,25 @@ modifying, or removing a schedule takes effect without restart.
 - Use `--no-schedule` on `swamp serve` to disable scheduled execution
 - Health endpoint (`/health`) reports scheduled workflows and next fire times
 
+### Trigger inputs
+
+Scheduled runs have no `--input` flag, so add `trigger.inputs` to supply
+baseline input values at fire time:
+
+```yaml
+trigger:
+  schedule: "0 3 * * *"
+  inputs:
+    projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e"
+```
+
+These are merged just like `--input` on `swamp workflow run`, with precedence
+`caller inputs > trigger.inputs > schema defaults`. This lets a workflow keep
+`required` inputs instead of setting a schema `default` that would apply to
+every caller. `trigger.inputs` is a values map (the data to inject), not the
+`inputs` schema block. It applies to trigger-fired runs (scheduled and webhook);
+a manual `swamp workflow run` is unaffected.
+
 ## Edit a Workflow
 
 **Recommended:** Use `swamp workflow get <name> --json` to get the file path,

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -305,6 +305,39 @@ jobs:
 The `ScheduledExecutionService` lives in libswamp, so any consumer (serve, a
 future daemon, or programmatic use) can use the same scheduling infrastructure.
 
+#### Trigger Inputs
+
+Scheduled (and webhook) runs have no `--input` flag, so a `trigger.inputs` map
+supplies baseline input values at fire time:
+
+```yaml
+trigger:
+  schedule: "* * * * *"
+  inputs:
+    projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e"
+jobs:
+  # ... runs with projectId already populated
+```
+
+This lets a workflow declare `required` inputs without abusing the input
+schema's `default` (which would apply to every caller, not just trigger-fired
+runs). `trigger.inputs` is a free values map — the runtime values to inject —
+distinct from the workflow's `inputs` block, which is the JSON-Schema
+description of allowed inputs.
+
+**Precedence:** the values are merged exactly like `--input` on
+`swamp workflow run`, layered as `caller inputs > trigger.inputs > schema
+defaults`. For a scheduled run there is no caller, so `trigger.inputs` becomes
+the baseline; for a webhook run any inputs the payload supplies (today none —
+the body is used only for signature verification) would override the trigger
+values. The merged inputs flow through the same coercion, default-application,
+and validation pipeline as every other run, so a `required` input satisfied
+only by `trigger.inputs` validates successfully.
+
+Trigger inputs apply only to trigger-fired runs (scheduled, webhook). A manual
+`swamp workflow run` invokes the workflow directly and is unaffected by
+`trigger.inputs` — the operator supplies inputs explicitly.
+
 ## Jobs
 
 Each job has a name, a description, a series of steps, and an array of objects

--- a/integration/scheduled_trigger_inputs_test.ts
+++ b/integration/scheduled_trigger_inputs_test.ts
@@ -1,0 +1,181 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for `trigger.inputs` on scheduled/webhook workflows.
+ *
+ * Scheduled and webhook runs both flow through `executeWorkflowWithLocks` with
+ * no caller-supplied inputs. These tests drive that function directly (rather
+ * than waiting on a real cron tick) to verify that a workflow's declared
+ * `trigger.inputs` are injected as baseline inputs at fire time.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createRepoInitDeps,
+  repoInit,
+  withDefaults,
+} from "../src/libswamp/mod.ts";
+import type { WorkflowRunEvent } from "../src/libswamp/mod.ts";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
+import { executeWorkflowWithLocks } from "../src/serve/deps.ts";
+
+// Import models barrel to trigger built-in registration.
+import "../src/domain/models/models.ts";
+import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+const requiredInputSchema = {
+  type: "object" as const,
+  properties: { projectId: { type: "string" as const } },
+  required: ["projectId"],
+};
+
+function shellWorkflow(
+  name: string,
+  trigger: { schedule?: string; inputs?: Record<string, unknown> } | undefined,
+): Workflow {
+  return Workflow.create({
+    name,
+    trigger,
+    inputs: requiredInputSchema,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "echo",
+            task: StepTask.directExecution(
+              "command/shell",
+              `${name}-shell`,
+              "execute",
+              { run: "echo trigger-inputs-ok" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
+async function runViaLocks(
+  repoDir: string,
+  workflowName: string,
+): Promise<WorkflowRunEvent[]> {
+  const {
+    repoDir: resolvedRepoDir,
+    repoContext,
+    datastoreConfig,
+    syncService,
+  } = await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+
+  const events: WorkflowRunEvent[] = [];
+  await executeWorkflowWithLocks(
+    resolvedRepoDir,
+    repoContext,
+    datastoreConfig,
+    { workflowIdOrName: workflowName },
+    new AbortController().signal,
+    (event) => events.push(event),
+    syncService,
+  );
+  return events;
+}
+
+async function withRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp-trigger-inputs-",
+  });
+  try {
+    await consumeStream(
+      repoInit(
+        createLibSwampContext({}),
+        createRepoInitDeps("20260101.120000.0"),
+        { path: repoDir, force: false, version: "20260101.120000.0" },
+      ),
+      withDefaults({
+        error: (event) => {
+          throw new Error(String(event.error?.message ?? "repo init failed"));
+        },
+      }),
+    );
+    await fn(repoDir);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test({
+  name:
+    "scheduled run: a required input supplied only via trigger.inputs resolves and the run completes",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = shellWorkflow("scheduled-with-trigger-inputs", {
+        schedule: "0 3 * * *",
+        inputs: { projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e" },
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      const events = await runViaLocks(repoDir, workflow.name);
+      const kinds = events.map((e) => e.kind);
+
+      assertEquals(
+        kinds.some((k) => k === "error"),
+        false,
+        `unexpected error event: ${JSON.stringify(events)}`,
+      );
+      assertEquals(kinds.at(-1), "completed");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "scheduled run: a required input with no trigger.inputs still fails validation with a clear error",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = shellWorkflow("scheduled-missing-input", {
+        schedule: "0 3 * * *",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      const events = await runViaLocks(repoDir, workflow.name);
+      const errorEvent = events.find(
+        (e): e is Extract<WorkflowRunEvent, { kind: "error" }> =>
+          e.kind === "error",
+      );
+
+      assertEquals(errorEvent?.error.code, "input_validation_failed");
+    });
+  },
+});

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -25,6 +25,7 @@ import {
   InputsSchemaSchema,
 } from "../definitions/definition.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
+import { deepMerge } from "../inputs/input_merge.ts";
 import {
   type ReportSelection,
   ReportSelectionSchema,
@@ -63,6 +64,7 @@ const WorkflowObjectSchema = z.object({
       },
       { message: "Invalid cron expression" },
     ).optional(),
+    inputs: z.record(z.string(), z.unknown()).optional(),
   }).optional(),
   tags: z.record(z.string(), z.string()).default({}),
   inputs: InputsSchemaSchema,
@@ -99,7 +101,7 @@ export interface CreateWorkflowProps {
   id?: string;
   name: string;
   description?: string;
-  trigger?: { schedule?: string };
+  trigger?: { schedule?: string; inputs?: Record<string, unknown> };
   tags?: Record<string, string>;
   inputs?: InputsSchema;
   jobs?: Job[];
@@ -123,7 +125,9 @@ export class Workflow {
     readonly id: WorkflowId,
     readonly name: string,
     readonly description: string | undefined,
-    readonly trigger: { schedule?: string } | undefined,
+    readonly trigger:
+      | { schedule?: string; inputs?: Record<string, unknown> }
+      | undefined,
     readonly tags: Record<string, string>,
     readonly inputs: InputsSchema | undefined,
     private _jobs: Job[],
@@ -203,6 +207,28 @@ export class Workflow {
    */
   get schedule(): string | undefined {
     return this.trigger?.schedule;
+  }
+
+  /**
+   * Returns the baseline input values declared on the trigger, if any.
+   * These are supplied by the trigger (e.g. scheduled or webhook runs), not
+   * by an operator invoking the workflow manually.
+   */
+  get triggerInputs(): Record<string, unknown> | undefined {
+    return this.trigger?.inputs;
+  }
+
+  /**
+   * Computes the baseline inputs for a trigger-initiated run by layering
+   * caller-supplied inputs over the trigger's declared inputs. Caller values
+   * win on conflict (e.g. a webhook payload overrides a trigger default).
+   * Schema defaults are applied later, downstream, for any keys still missing —
+   * yielding precedence: caller inputs > trigger.inputs > schema defaults.
+   */
+  baselineInputs(
+    callerInputs: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return deepMerge(this.trigger?.inputs ?? {}, callerInputs);
   }
 
   /**

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -699,6 +699,113 @@ Deno.test("Workflow.fromData rejects invalid cron expression", () => {
   );
 });
 
+// trigger.inputs field tests
+
+Deno.test("Workflow.create creates workflow with trigger.inputs", () => {
+  const workflow = Workflow.create({
+    name: "scheduled-with-inputs",
+    trigger: {
+      schedule: "0 3 * * *",
+      inputs: { projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e" },
+    },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(workflow.triggerInputs, {
+    projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e",
+  });
+});
+
+Deno.test("Workflow.triggerInputs is undefined when no trigger inputs", () => {
+  const workflow = Workflow.create({
+    name: "scheduled-no-inputs",
+    trigger: { schedule: "0 3 * * *" },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(workflow.triggerInputs, undefined);
+});
+
+Deno.test("Workflow.toData and fromData roundtrip with trigger.inputs", () => {
+  const original = Workflow.create({
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "roundtrip-trigger-inputs",
+    trigger: {
+      schedule: "0 * * * *",
+      inputs: { count: 5, dryRun: true, nested: { region: "us" } },
+    },
+    jobs: [createTestJob("job1")],
+  });
+
+  const data = original.toData();
+  assertEquals(data.trigger?.inputs, {
+    count: 5,
+    dryRun: true,
+    nested: { region: "us" },
+  });
+
+  const restored = Workflow.fromData(data);
+  assertEquals(restored.triggerInputs, {
+    count: 5,
+    dryRun: true,
+    nested: { region: "us" },
+  });
+});
+
+Deno.test("Workflow.baselineInputs returns caller inputs when no trigger inputs", () => {
+  const workflow = Workflow.create({
+    name: "no-trigger-inputs",
+    trigger: { schedule: "0 3 * * *" },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(workflow.baselineInputs({ foo: "bar" }), { foo: "bar" });
+});
+
+Deno.test("Workflow.baselineInputs returns trigger inputs when caller is empty", () => {
+  const workflow = Workflow.create({
+    name: "trigger-inputs-only",
+    trigger: { schedule: "0 3 * * *", inputs: { projectId: "p1", count: 3 } },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(workflow.baselineInputs({}), { projectId: "p1", count: 3 });
+});
+
+Deno.test("Workflow.baselineInputs lets caller inputs override trigger inputs", () => {
+  const workflow = Workflow.create({
+    name: "caller-overrides-trigger",
+    trigger: {
+      schedule: "0 3 * * *",
+      inputs: { projectId: "p1", region: "us" },
+    },
+    jobs: [createTestJob("job1")],
+  });
+
+  // Caller value wins on conflict; non-conflicting trigger values are kept.
+  assertEquals(workflow.baselineInputs({ projectId: "p2" }), {
+    projectId: "p2",
+    region: "us",
+  });
+});
+
+Deno.test("Workflow.baselineInputs preserves non-string trigger input types", () => {
+  const workflow = Workflow.create({
+    name: "typed-trigger-inputs",
+    trigger: {
+      schedule: "0 3 * * *",
+      inputs: { count: 5, enabled: false, ratio: 1.5, items: ["a", "b"] },
+    },
+    jobs: [createTestJob("job1")],
+  });
+
+  const result = workflow.baselineInputs({});
+  assertEquals(result.count, 5);
+  assertEquals(result.enabled, false);
+  assertEquals(result.ratio, 1.5);
+  assertEquals(result.items, ["a", "b"]);
+});
+
 Deno.test("Workflow.fromData handles missing tags (backward compat)", () => {
   // Simulate legacy data without tags field — Zod .default({}) fills it in
   const data = {

--- a/src/libswamp/workflows/schema_test.ts
+++ b/src/libswamp/workflows/schema_test.ts
@@ -39,3 +39,30 @@ Deno.test("workflowSchema yields completed with schema data", async () => {
   assert(typeof completed.data.stepTask === "object");
   assert(typeof completed.data.triggerCondition === "object");
 });
+
+Deno.test("workflowSchema exposes trigger.inputs in the workflow schema", async () => {
+  const ctx = createLibSwampContext();
+  const events = await collect<WorkflowSchemaEvent>(workflowSchema(ctx));
+  const completed = events[0] as Extract<
+    WorkflowSchemaEvent,
+    { kind: "completed" }
+  >;
+
+  const asRecord = (value: unknown): Record<string, unknown> => {
+    assert(
+      typeof value === "object" && value !== null,
+      "expected an object node in the generated schema",
+    );
+    return value as Record<string, unknown>;
+  };
+
+  const workflow = asRecord(completed.data.workflow);
+  const properties = asRecord(workflow.properties);
+  const trigger = asRecord(properties.trigger);
+  const triggerProperties = asRecord(trigger.properties);
+
+  assert(
+    "inputs" in triggerProperties,
+    "workflow schema trigger should expose an 'inputs' property",
+  );
+});

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -319,7 +319,15 @@ export async function executeWorkflowWithLocks(
     const deps = await createWorkflowRunDeps(repoDir, repoContext);
     const libCtx = createLibSwampContext({ signal });
 
-    for await (const event of workflowRun(libCtx, deps, input)) {
+    // Layer the workflow's trigger.inputs under any caller-supplied inputs so
+    // scheduled and webhook trigger-fired runs get baseline values at fire
+    // time. Downstream workflowRun applies schema defaults and validates,
+    // yielding precedence: caller inputs > trigger.inputs > schema defaults.
+    const effectiveInput = workflow
+      ? { ...input, inputs: workflow.baselineInputs(input.inputs ?? {}) }
+      : input;
+
+    for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
       onEvent(event);
     }
   } finally {


### PR DESCRIPTION
## Summary

Scheduled (`trigger.schedule`) workflows had no mechanism to supply input values at fire time — the only workaround was setting schema `default` values, which conflates "the value I want for cron runs" with "the schema default for all callers."

This adds an optional **`trigger.inputs`** values map to the workflow trigger schema:

```yaml
trigger:
  schedule: "0 3 * * *"
  inputs:
    projectId: "a6b254a2-0b57-4d0f-bf8b-fef767ab119e"
```

These are merged as baseline inputs for trigger-fired runs, exactly like `--input` on `swamp workflow run`.

### Design

- New `Workflow.baselineInputs(callerInputs)` domain method layers caller inputs over the trigger's declared inputs (`deepMerge`, override-wins). Keeps the precedence rule in the aggregate and unit-testable without serve.
- Applied in `executeWorkflowWithLocks` — the shared entry point for **scheduled and webhook** runs — before `workflowRun`, which keeps ownership of coercion, default-application, and validation against the input schema.
- **Precedence:** caller inputs > `trigger.inputs` > schema defaults. A `required` input can now be satisfied by `trigger.inputs` alone.
- CLI `swamp workflow run` invokes `workflowRun` directly and is intentionally unaffected — trigger inputs are supplied by the trigger, not the operator.
- Webhooks currently forward no inputs (the body is used only for HMAC verification), so `trigger.inputs` flows naturally as the baseline; override-wins is future-proofing for any later payload forwarding.
- The workflow JSON Schema picks up `trigger.inputs` automatically via `zodToJsonSchema`.

Resolves swamp-club issue #700.

## Test Plan

- **Unit** (`workflow_test.ts`): create + `triggerInputs` getter, `toData`/`fromData` round-trip, backward-compat (no trigger inputs / no trigger), and `baselineInputs` precedence including a non-string (number/bool/array) trigger-input case.
- **Schema** (`schema_test.ts`): asserts the generated workflow JSON Schema exposes `trigger.inputs`.
- **Integration** (`scheduled_trigger_inputs_test.ts`): drives `executeWorkflowWithLocks` directly — a `required` input satisfied only via `trigger.inputs` resolves and the run completes; the still-missing case yields a clear `input_validation_failed` error.
- Full suite: `deno check`, `deno lint`, `deno fmt`, `deno run test` (7517 passed), `deno run compile` — all green.
- **Live end-to-end**: `swamp serve --webhook '/greet:greeter:mysecret'` over a real repo with a `required` input supplied only by `trigger.inputs`. A signed webhook POST and the cron tick both ran the workflow and resolved the input — neither supplied `name` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)