### PR TITLE
fix(logging): key RunFileSink writers by handle to fix concurrent "Bad resource ID"

### DIFF
--- a/integration/workflow_foreach_concurrency_test.ts
+++ b/integration/workflow_foreach_concurrency_test.ts
@@ -1,0 +1,253 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Cross-component regression guard for issue #718.
+ *
+ * A forEach step with concurrency > 1 that fans out child workflow runs
+ * (`task.type: workflow`) used to intermittently fail children with
+ * "Bad resource ID": every concurrent run registered its log writer under the
+ * same catch-all `[]` prefix, so one child's registration closed a sibling's
+ * still-open file descriptor before any step executed. This test drives the
+ * real `swamp workflow run` path (the same code used in production) and asserts
+ * every fanned-out child succeeds and no run reports "Bad resource ID".
+ *
+ * The deterministic unit tests in
+ * src/infrastructure/logging/run_file_sink_test.ts are the authoritative
+ * regression guard; this exercises the end-to-end concurrent child-dispatch
+ * path that the bug actually manifested on.
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-foreach-conc-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native handles yet.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function initializeTestRepo(repoDir: string): Promise<void> {
+  const subdirs = [
+    "models",
+    ".swamp/outputs",
+    ".swamp/data",
+    ".swamp/logs",
+    "workflows",
+    ".swamp/workflow-runs",
+    ".swamp/workflows-evaluated",
+  ];
+  for (const subdir of subdirs) {
+    await ensureDir(join(repoDir, subdir));
+  }
+  await Deno.writeTextFile(
+    join(repoDir, ".swamp.yaml"),
+    stringifyYaml(
+      {
+        swampVersion: "0.0.0",
+        initializedAt: new Date().toISOString(),
+      } as Record<string, unknown>,
+    ),
+  );
+}
+
+async function createShellModel(repoDir: string, name: string): Promise<void> {
+  const modelData = {
+    type: "command/shell",
+    typeVersion: 1,
+    id: crypto.randomUUID(),
+    name,
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: { execute: { arguments: { run: "echo 'child ran'" } } },
+  };
+  const modelDir = join(repoDir, "models/command/shell");
+  await ensureDir(modelDir);
+  await Deno.writeTextFile(
+    join(modelDir, `${modelData.id}.yaml`),
+    stringifyYaml(modelData as Record<string, unknown>),
+  );
+}
+
+async function writeWorkflow(
+  repoDir: string,
+  workflow: Record<string, unknown>,
+): Promise<void> {
+  const workflowDir = join(repoDir, "workflows");
+  await ensureDir(workflowDir);
+  await Deno.writeTextFile(
+    join(workflowDir, `workflow-${workflow.id}.yaml`),
+    stringifyYaml(workflow),
+  );
+}
+
+async function runCliCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: Deno.cwd(),
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test("CLI: forEach concurrency>1 fanning out child workflows does not fail with Bad resource ID", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModel(repoDir, "child-model");
+
+    // Child workflow: one model_method step. Fanned out once per parent item.
+    await writeWorkflow(repoDir, {
+      id: crypto.randomUUID(),
+      name: "issue-718-child",
+      version: 1,
+      inputs: {
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+      jobs: [
+        {
+          name: "work",
+          steps: [
+            {
+              name: "run-child",
+              task: {
+                type: "model_method",
+                modelIdOrName: "child-model",
+                methodName: "execute",
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    });
+
+    // Parent workflow: forEach with concurrency 3 over 6 items, each item
+    // triggering the child workflow concurrently — the exact shape from #718.
+    const parentId = crypto.randomUUID();
+    await writeWorkflow(repoDir, {
+      id: parentId,
+      name: "issue-718-parent",
+      version: 1,
+      inputs: {
+        properties: {
+          items: { type: "array", items: { type: "string" }, minItems: 1 },
+        },
+        required: ["items"],
+      },
+      jobs: [
+        {
+          name: "fan-out",
+          steps: [
+            {
+              name: "child-${{self.item}}",
+              forEach: {
+                item: "item",
+                in: "${{ inputs.items }}",
+              },
+              concurrency: 3,
+              task: {
+                type: "workflow",
+                workflowIdOrName: "issue-718-child",
+                inputs: { id: "${{ self.item }}" },
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    });
+
+    const items = ["a", "b", "c", "d", "e", "f"];
+    const result = await runCliCommand([
+      "workflow",
+      "run",
+      "issue-718-parent",
+      "--repo-dir",
+      repoDir,
+      "--input",
+      JSON.stringify({ items }),
+      "--json",
+    ]);
+
+    // The previously-failing race surfaced as "Bad resource ID" in a failed
+    // child step; assert it never appears.
+    assertEquals(
+      (result.stdout + result.stderr).includes("Bad resource ID"),
+      false,
+      `Child run failed with "Bad resource ID":\n${result.stderr}\n${result.stdout}`,
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow should succeed. stderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    const job = output.jobs?.find(
+      (j: { name: string }) => j.name === "fan-out",
+    );
+    const steps = (job?.steps ?? []) as { name: string; status: string }[];
+
+    // Every fanned-out child step must have run and succeeded — none left
+    // failed/pending by a dispatch-time crash.
+    const expanded = steps.filter((s) => !s.name.includes("${{"));
+    assertEquals(
+      expanded.length,
+      items.length,
+      `Expected ${items.length} expanded child steps, got ${expanded.length}: ${
+        JSON.stringify(expanded.map((s) => s.name))
+      }`,
+    );
+    for (const step of expanded) {
+      assertEquals(
+        step.status,
+        "succeeded",
+        `Expected ${step.name} to succeed but got ${step.status}`,
+      );
+    }
+  });
+});

--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -178,9 +178,8 @@ export function buildModelMethodRunDeps(
         method,
         `${definitionId}-${timestamp}.log`,
       );
-      const logCategory: string[] = [];
-      await runFileSink.register(
-        logCategory,
+      const logHandle = await runFileSink.register(
+        [],
         logFilePath,
         redactor,
         swampPath(repoDir),
@@ -188,7 +187,7 @@ export function buildModelMethodRunDeps(
       return {
         logFilePath,
         redactor,
-        cleanup: () => runFileSink.unregister(logCategory),
+        cleanup: () => runFileSink.unregister(logHandle),
       };
     },
     createAndSaveDefinition: isDirectExecution

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -290,9 +290,8 @@ export const modelMethodRunCommand = new Command()
             method,
             `${definitionId}-${timestamp}.log`,
           );
-          const logCategory: string[] = [];
-          await runFileSink.register(
-            logCategory,
+          const logHandle = await runFileSink.register(
+            [],
             logFilePath,
             redactor,
             swampPath(repoDir),
@@ -300,7 +299,7 @@ export const modelMethodRunCommand = new Command()
           return {
             logFilePath,
             redactor,
-            cleanup: () => runFileSink.unregister(logCategory),
+            cleanup: () => runFileSink.unregister(logHandle),
           };
         },
         createAndSaveDefinition: isDirectExecution

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1298,7 +1298,7 @@ export class WorkflowExecutionService {
     });
 
     let workflowRun: WorkflowRun | undefined;
-    let workflowLogCategory: string[] | undefined;
+    let workflowLogHandle: string | undefined;
     try {
       const wfSetupSpan = tracer.startSpan("swamp.workflow.setup");
       let workflow: Workflow;
@@ -1384,10 +1384,9 @@ export class WorkflowExecutionService {
           workflow.id,
           `workflow-run-${run.id}.log`,
         );
-        workflowLogCategory = [];
         const workflowLogBoundary = swampPath(this.repoDir);
-        await runFileSink.register(
-          workflowLogCategory,
+        workflowLogHandle = await runFileSink.register(
+          [],
           workflowLogPath,
           secretRedactor,
           workflowLogBoundary,
@@ -1582,16 +1581,14 @@ export class WorkflowExecutionService {
         }
 
         // Unregister workflow log file sink
-        runFileSink.unregister(workflowLogCategory);
+        runFileSink.unregister(workflowLogHandle);
       } finally {
         wfTeardownSpan.end();
       }
       runSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
       if (error instanceof WorkflowSuspendedError && workflowRun) {
-        if (workflowLogCategory) {
-          runFileSink.unregister(workflowLogCategory);
-        }
+        runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
           run: workflowRun,
@@ -1611,9 +1608,7 @@ export class WorkflowExecutionService {
         );
         yield { kind: "completed" as const, run: workflowRun };
       }
-      if (workflowLogCategory) {
-        runFileSink.unregister(workflowLogCategory);
-      }
+      runFileSink.unregister(workflowLogHandle);
       runSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),
@@ -1728,9 +1723,8 @@ export class WorkflowExecutionService {
         workflow.id,
         `workflow-run-${existingRun.id}.log`,
       );
-    const workflowLogCategory: string[] = [];
-    await runFileSink.register(
-      workflowLogCategory,
+    const workflowLogHandle = await runFileSink.register(
+      [],
       workflowLogPath,
       secretRedactor,
       swampPath(this.repoDir),
@@ -1866,10 +1860,10 @@ export class WorkflowExecutionService {
 
       yield { kind: "completed", run: existingRun };
       await this.saveRun(workflow.id, existingRun);
-      runFileSink.unregister(workflowLogCategory);
+      runFileSink.unregister(workflowLogHandle);
     } catch (error) {
       if (error instanceof WorkflowSuspendedError) {
-        runFileSink.unregister(workflowLogCategory);
+        runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
           run: existingRun,
@@ -1883,7 +1877,7 @@ export class WorkflowExecutionService {
       existingRun.complete();
       await this.saveRun(workflow.id, existingRun);
       yield { kind: "completed" as const, run: existingRun };
-      runFileSink.unregister(workflowLogCategory);
+      runFileSink.unregister(workflowLogHandle);
       throw error;
     }
   }

--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -28,13 +28,6 @@ import { assertSafePath } from "../persistence/safe_path.ts";
 const formatRecord = getTextFormatter();
 
 /**
- * Converts a category prefix array to a string key for map lookups.
- */
-function prefixKey(prefix: string[]): string {
-  return prefix.join("\x00");
-}
-
-/**
  * Checks whether `category` starts with `prefix`.
  */
 function categoryMatchesPrefix(
@@ -59,27 +52,34 @@ interface FileWriter {
  * A LogTape sink that routes log records to per-run log files.
  * Registered once at startup. File targets are added/removed dynamically
  * as runs start and complete.
+ *
+ * Each {@link register} call is keyed by a unique opaque handle rather than by
+ * its category prefix. Concurrent runs (forEach children, parent+child) share
+ * the same catch-all `[]` prefix, so keying by the prefix would collide on a
+ * single map entry and let one run's register/unregister close a sibling run's
+ * still-open file descriptor — surfacing as Deno's "Bad resource ID". The
+ * handle decouples a registration's identity from its routing rule (the prefix
+ * is retained only for record matching).
  */
 export class RunFileSink {
   private writers = new Map<string, FileWriter>();
 
   /**
-   * Register a log file for a category prefix.
-   * All log records matching this prefix will be written to the file.
+   * Register a log file for a category prefix and return an opaque handle that
+   * identifies this registration. All log records matching the prefix while the
+   * registration is active are written to the file. Pass the returned handle to
+   * {@link unregister} to close the file.
+   *
+   * Failure-atomic: all fallible I/O (path validation, directory creation, file
+   * open) completes before the writer is recorded, so a throw leaves the writer
+   * map and every open descriptor untouched and requires no caller cleanup.
    */
   async register(
     categoryPrefix: string[],
     filePath: string,
     redactor?: SecretRedactor,
     boundary?: string,
-  ): Promise<void> {
-    const key = prefixKey(categoryPrefix);
-    // Close existing writer if any
-    const existing = this.writers.get(key);
-    if (existing) {
-      existing.fd.close();
-    }
-
+  ): Promise<string> {
     // Validate the file path stays within the expected boundary
     if (boundary) {
       await assertSafePath(filePath, boundary);
@@ -96,23 +96,33 @@ export class RunFileSink {
       create: true,
       truncate: true,
     });
-    this.writers.set(key, {
+
+    // Only mutate the map once all fallible I/O has succeeded.
+    const handle = crypto.randomUUID();
+    this.writers.set(handle, {
       fd,
       encoder: new TextEncoder(),
       prefix: categoryPrefix,
       redactor,
     });
+    return handle;
   }
 
   /**
-   * Unregister and close the file writer for a category prefix.
+   * Unregister and close the file writer for a registration handle. No-ops if
+   * the handle is unknown or undefined (e.g. when a `register` call threw before
+   * returning a handle), so callers can unregister unconditionally on cleanup.
    */
-  unregister(categoryPrefix: string[]): void {
-    const key = prefixKey(categoryPrefix);
-    const writer = this.writers.get(key);
+  unregister(handle: string | undefined): void {
+    if (handle === undefined) return;
+    const writer = this.writers.get(handle);
     if (writer) {
-      writer.fd.close();
-      this.writers.delete(key);
+      try {
+        writer.fd.close();
+      } catch {
+        // Already closed — closing twice must never throw "Bad resource ID".
+      }
+      this.writers.delete(handle);
     }
   }
 

--- a/src/infrastructure/logging/run_file_sink_test.ts
+++ b/src/infrastructure/logging/run_file_sink_test.ts
@@ -17,8 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { RunFileSink } from "./run_file_sink.ts";
+import { SecretRedactor } from "../../domain/secrets/mod.ts";
 import { join } from "@std/path";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -56,7 +61,10 @@ Deno.test("RunFileSink writes log records to registered file", async () => {
     const sink = new RunFileSink();
     const logPath = join(dir, "test.log");
 
-    await sink.register(["model", "method", "run", "my-model"], logPath);
+    const handle = await sink.register(
+      ["model", "method", "run", "my-model"],
+      logPath,
+    );
 
     const sinkFn = sink.sink;
     sinkFn(
@@ -69,7 +77,7 @@ Deno.test("RunFileSink writes log records to registered file", async () => {
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "hello world");
 
-    sink.unregister(["model", "method", "run", "my-model"]);
+    sink.unregister(handle);
   });
 });
 
@@ -78,7 +86,10 @@ Deno.test("RunFileSink ignores records that don't match any prefix", async () =>
     const sink = new RunFileSink();
     const logPath = join(dir, "test.log");
 
-    await sink.register(["model", "method", "run", "my-model"], logPath);
+    const handle = await sink.register(
+      ["model", "method", "run", "my-model"],
+      logPath,
+    );
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["workflow", "run", "wf1"], "should not appear"));
@@ -86,7 +97,7 @@ Deno.test("RunFileSink ignores records that don't match any prefix", async () =>
     const content = await Deno.readTextFile(logPath);
     assertEquals(content, "");
 
-    sink.unregister(["model", "method", "run", "my-model"]);
+    sink.unregister(handle);
   });
 });
 
@@ -96,8 +107,14 @@ Deno.test("RunFileSink writes to all matching prefixes", async () => {
     const broadPath = join(dir, "broad.log");
     const specificPath = join(dir, "specific.log");
 
-    await sink.register(["model", "method", "run"], broadPath);
-    await sink.register(["model", "method", "run", "my-model"], specificPath);
+    const broadHandle = await sink.register(
+      ["model", "method", "run"],
+      broadPath,
+    );
+    const specificHandle = await sink.register(
+      ["model", "method", "run", "my-model"],
+      specificPath,
+    );
 
     const sinkFn = sink.sink;
     sinkFn(
@@ -113,8 +130,8 @@ Deno.test("RunFileSink writes to all matching prefixes", async () => {
     assertStringIncludes(broadContent, "broad");
     assertStringIncludes(broadContent, "specific");
 
-    sink.unregister(["model", "method", "run"]);
-    sink.unregister(["model", "method", "run", "my-model"]);
+    sink.unregister(broadHandle);
+    sink.unregister(specificHandle);
   });
 });
 
@@ -123,12 +140,15 @@ Deno.test("RunFileSink unregister closes file and stops writing", async () => {
     const sink = new RunFileSink();
     const logPath = join(dir, "test.log");
 
-    await sink.register(["model", "method", "run", "my-model"], logPath);
+    const handle = await sink.register(
+      ["model", "method", "run", "my-model"],
+      logPath,
+    );
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["model", "method", "run", "my-model"], "before"));
 
-    sink.unregister(["model", "method", "run", "my-model"]);
+    sink.unregister(handle);
 
     // After unregister, records should not be written
     sinkFn(makeRecord(["model", "method", "run", "my-model"], "after"));
@@ -144,7 +164,7 @@ Deno.test("RunFileSink creates parent directories", async () => {
     const sink = new RunFileSink();
     const logPath = join(dir, "nested", "deep", "test.log");
 
-    await sink.register(["workflow", "run"], logPath);
+    const handle = await sink.register(["workflow", "run"], logPath);
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["workflow", "run", "wf1"], "nested dir test"));
@@ -152,7 +172,7 @@ Deno.test("RunFileSink creates parent directories", async () => {
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "nested dir test");
 
-    sink.unregister(["workflow", "run"]);
+    sink.unregister(handle);
   });
 });
 
@@ -161,7 +181,7 @@ Deno.test("RunFileSink empty prefix matches all categories", async () => {
     const sink = new RunFileSink();
     const logPath = join(dir, "all.log");
 
-    await sink.register([], logPath);
+    const handle = await sink.register([], logPath);
 
     const sinkFn = sink.sink;
     sinkFn(makeRecord(["workflow", "run", "wf1"], "workflow log"));
@@ -178,7 +198,7 @@ Deno.test("RunFileSink empty prefix matches all categories", async () => {
     assertStringIncludes(content, "model log");
     assertStringIncludes(content, "other log");
 
-    sink.unregister([]);
+    sink.unregister(handle);
   });
 });
 
@@ -198,5 +218,134 @@ Deno.test("RunFileSink dispose closes all writers", async () => {
     // Files should be empty since no records matched after dispose
     const contentA = await Deno.readTextFile(join(dir, "a.log"));
     assertEquals(contentA, "");
+  });
+});
+
+// Regression: issue #718. Concurrent runs (forEach children, parent+child) all
+// register under the same catch-all `[]` prefix. Each registration must get its
+// own writer keyed by a unique handle so one run can never close another run's
+// open file descriptor ("Bad resource ID").
+
+Deno.test("RunFileSink: concurrent same-prefix registrations get independent writers", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const pathA = join(dir, "run-a.log");
+    const pathB = join(dir, "run-b.log");
+
+    // Two "runs" register under the identical `[]` prefix — the exact collision
+    // that previously clobbered a shared map entry.
+    const handleA = await sink.register([], pathA);
+    const handleB = await sink.register([], pathB);
+    assertNotEquals(handleA, handleB);
+
+    const sinkFn = sink.sink;
+    sinkFn(makeRecord(["workflow", "run", "wf1"], "shared record"));
+
+    // Both writers survive and capture the record; neither close throws.
+    assertStringIncludes(await Deno.readTextFile(pathA), "shared record");
+    assertStringIncludes(await Deno.readTextFile(pathB), "shared record");
+
+    sink.unregister(handleA);
+    sink.unregister(handleB);
+  });
+});
+
+Deno.test("RunFileSink: unregistering one writer leaves a same-prefix sibling working", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const pathA = join(dir, "run-a.log");
+    const pathB = join(dir, "run-b.log");
+
+    const handleA = await sink.register([], pathA);
+    const handleB = await sink.register([], pathB);
+
+    const sinkFn = sink.sink;
+
+    // Run A finishes first. Under the old shared-key design this evicted/closed
+    // the sibling's fd; now it must only affect A.
+    sink.unregister(handleA);
+    sinkFn(makeRecord(["workflow", "run", "wf1"], "after-a-unregister"));
+
+    // B is still open and still writing — no "Bad resource ID".
+    assertStringIncludes(
+      await Deno.readTextFile(pathB),
+      "after-a-unregister",
+    );
+    assertEquals(
+      (await Deno.readTextFile(pathA)).includes("after-a-unregister"),
+      false,
+    );
+
+    sink.unregister(handleB);
+  });
+});
+
+Deno.test("RunFileSink: unregister is a safe no-op for unknown, undefined, and double calls", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const handle = await sink.register([], join(dir, "run.log"));
+
+    // None of these may throw "Bad resource ID".
+    sink.unregister(undefined);
+    sink.unregister("not-a-real-handle");
+    sink.unregister(handle);
+    sink.unregister(handle); // double close of the same handle
+
+    // Sink still works for surviving registrations.
+    const pathB = join(dir, "run-b.log");
+    const handleB = await sink.register([], pathB);
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "still works"));
+    assertStringIncludes(await Deno.readTextFile(pathB), "still works");
+    sink.unregister(handleB);
+  });
+});
+
+Deno.test("RunFileSink: register is failure-atomic and leaves no state on a rejected path", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+
+    // A healthy registration that must remain intact after the failure below.
+    const goodPath = join(dir, "good.log");
+    const goodHandle = await sink.register([], goodPath);
+
+    // A path that escapes the boundary fails in assertSafePath, before any fd
+    // is opened or the writer map is mutated.
+    const escapingPath = join(dir, "..", "escape.log");
+    let threw = false;
+    let badHandle: string | undefined;
+    try {
+      badHandle = await sink.register([], escapingPath, undefined, dir);
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+
+    // No handle was returned; unregistering the undefined handle is a no-op.
+    sink.unregister(badHandle);
+
+    // The good writer is untouched and still works.
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "survived"));
+    assertStringIncludes(await Deno.readTextFile(goodPath), "survived");
+
+    sink.unregister(goodHandle);
+  });
+});
+
+Deno.test("RunFileSink: applies the per-writer secret redactor", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const logPath = join(dir, "redacted.log");
+
+    const redactor = new SecretRedactor();
+    redactor.addSecret("supersecret");
+    const handle = await sink.register([], logPath, redactor);
+
+    sink.sink(makeRecord(["workflow", "run", "wf1"], "token=supersecret"));
+
+    const content = await Deno.readTextFile(logPath);
+    assertStringIncludes(content, "***");
+    assertEquals(content.includes("supersecret"), false);
+
+    sink.unregister(handle);
   });
 });

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -93,9 +93,8 @@ export async function createServerTokenRunDeps(
         method,
         `${definitionId}-${timestamp}.log`,
       );
-      const logCategory: string[] = [];
-      await runFileSink.register(
-        logCategory,
+      const logHandle = await runFileSink.register(
+        [],
         logFilePath,
         redactor,
         swampPath(repoDir),
@@ -103,7 +102,7 @@ export async function createServerTokenRunDeps(
       return {
         logFilePath,
         redactor,
-        cleanup: () => runFileSink.unregister(logCategory),
+        cleanup: () => runFileSink.unregister(logHandle),
       };
     },
     createAndSaveDefinition: async (type, definition) => {

--- a/src/libswamp/worker/run_deps.ts
+++ b/src/libswamp/worker/run_deps.ts
@@ -102,9 +102,8 @@ export async function createWorkerModelRunDeps(
         method,
         `${definitionId}-${timestamp}.log`,
       );
-      const logCategory: string[] = [];
-      await runFileSink.register(
-        logCategory,
+      const logHandle = await runFileSink.register(
+        [],
         logFilePath,
         redactor,
         swampPath(repoDir),
@@ -112,7 +111,7 @@ export async function createWorkerModelRunDeps(
       return {
         logFilePath,
         redactor,
-        cleanup: () => runFileSink.unregister(logCategory),
+        cleanup: () => runFileSink.unregister(logHandle),
       };
     },
     createAndSaveDefinition: async (type, definition) => {

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -211,9 +211,8 @@ export async function createModelMethodRunDeps(
         method,
         `${definitionId}-${timestamp}.log`,
       );
-      const logCategory: string[] = [];
-      await runFileSink.register(
-        logCategory,
+      const logHandle = await runFileSink.register(
+        [],
         logFilePath,
         redactor,
         swampPath(repoDir),
@@ -221,7 +220,7 @@ export async function createModelMethodRunDeps(
       return {
         logFilePath,
         redactor,
-        cleanup: () => runFileSink.unregister(logCategory),
+        cleanup: () => runFileSink.unregister(logHandle),
       };
     },
     createAndSaveDefinition: isDirectExecution


### PR DESCRIPTION
## Summary

`forEach` steps with `concurrency > 1` that fan out child workflow runs (`task.type: workflow`) intermittently failed children with `error: Bad resource ID` before any step executed, silently skipping items on a cron cycle.

**Root cause:** the global `RunFileSink` keys its writer `Map` by the LogTape match-prefix. Every workflow/model run registers under the catch-all category prefix `[]`, whose key is the constant `""`. Concurrent runs (forEach children, parent+child) therefore collided on a single `Map` entry, and `register()`'s unguarded `existing.fd.close()` closed a sibling run's still-open `Deno.FsFile`. The throw landed during child setup *before* `run.start()`, so the child run was persisted as `status: failed` with no `startedAt` and all steps `pending` — exactly the reported symptom. The error never reached the daemon log because the sink's write path is guarded but the `close()` path was not.

**Fix:** decouple a registration's identity from its routing rule.

- `register()` now returns a unique opaque handle (`crypto.randomUUID()`) used as the `Map` key; the category prefix is kept solely for record matching, so `[]` still captures the run's own logs plus child model-method-run logs.
- `register()` is failure-atomic — all fallible I/O (`assertSafePath` → `mkdir` → `Deno.open`) completes before the writer map is mutated, and the now-dead close-existing branch is removed.
- `unregister()` takes the handle, no-ops on unknown/`undefined` handles (so a `register()` throw needs no caller cleanup), and guards `fd.close()`.
- All seven registration sites (2 workflow + 5 `createRunLog`) are migrated. The five `createRunLog` sites shared the identical latent bug for concurrent model runs.

The per-writer `SecretRedactor` behavior is preserved. This change is internal to the logging layer; no user-facing CLI behavior changes and no design/skill docs describe the keying contract.

Note: per-run log *interleaving* under concurrency (multiple writers matching the catch-all `[]` prefix) is a pre-existing limitation of the catch-all design, not introduced here. True per-run isolation would require async-context routing (LogTape `withContext`) and is left as a separate issue.

## Test Plan

- **Unit** (`run_file_sink_test.ts`): new deterministic tests for the same-prefix concurrency collision, sibling survival after one unregister, no-op unregister (unknown/undefined/double), `register()` failure-atomicity, and secret redaction. Existing tests migrated to the handle API.
- **Integration** (`workflow_foreach_concurrency_test.ts`): drives the real `swamp workflow run` path with a `forEach` step (concurrency 3) fanning out 6 child workflows; asserts no `Bad resource ID` and every child succeeds.
- **End-to-end**: ran the exact #718 scenario (concurrency 3, 8 child workflows) with the compiled binary across many cycles — 0 `Bad resource ID`, all children `succeeded`.
- `deno check`, `deno lint`, `deno fmt --check`, `deno run test` (7523 passed), `deno run compile` all green.

Fixes swamp-club#718

🤖 Generated with [Claude Code](https://claude.com/claude-code)