### PR TITLE
feat(workflows): extract webhook payload into workflow inputs (#717)

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -203,6 +203,24 @@ every caller. `trigger.inputs` is a values map (the data to inject), not the
 `inputs` schema block. It applies to trigger-fired runs (scheduled and webhook);
 a manual `swamp workflow run` is unaffected.
 
+For webhook runs, `trigger.inputs` values may be CEL expressions that read the
+request payload through the `webhook` namespace, mapping payload fields onto
+named inputs:
+
+```yaml
+trigger:
+  inputs:
+    identifier: "${{ webhook.body.data.issue.identifier }}"
+    eventType: '${{ webhook.headers["x-linear-event"] }}'
+```
+
+`webhook.body` is the JSON-parsed body (raw string if not JSON),
+`webhook.headers` is a lowercased-name map (signature header excluded), and
+`webhook.route` is the matched route. Expressions resolve against the verified
+payload before input validation, so a payload field can satisfy a `required`
+input. swamp's CEL has no `??` — guard optional fields with `has(x) ? x : y`.
+See `design/workflow.md` for full semantics and the security caveat on headers.
+
 ## Edit a Workflow
 
 **Recommended:** Use `swamp workflow get <name> --json` to get the file path,

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -148,6 +148,31 @@ in workflow-level fields like `description`).
 The flat `workflowRunId` variable is also available (equivalent to `run.id`)
 for backward compatibility with `data.query()` predicates.
 
+## Webhook Payload Context
+
+For webhook-triggered runs, the `webhook` namespace exposes the verified request
+payload. It is available **only inside a workflow's `trigger.inputs`**, where
+expressions are evaluated against the payload at fire time (before input
+validation) to map payload fields onto named inputs.
+
+| Field             | Type                    | Description                          |
+| ----------------- | ----------------------- | ------------------------------------ |
+| `webhook.body`    | unknown                 | JSON-parsed body; raw string if not JSON |
+| `webhook.headers` | `Record<string,string>` | Lowercased header names (signature header excluded) |
+| `webhook.route`   | string                  | Matched webhook route (e.g. `/hooks/linear`) |
+
+```yaml
+trigger:
+  inputs:
+    identifier: "${{ webhook.body.data.issue.identifier }}"
+```
+
+swamp's CEL has no `??` operator — guard optional payload fields with the
+`has()` macro and a ternary: `has(x.y) ? x.y : fallback`. A hard reference to a
+missing field surfaces an error and the run does not start. Header values are
+not redacted (the same caveat as `env`). See `design/workflow.md` for the full
+walkthrough.
+
 **Run-scoped resource keys** — use `run.id` to prevent collisions when the
 same workflow runs concurrently:
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -328,15 +328,67 @@ description of allowed inputs.
 **Precedence:** the values are merged exactly like `--input` on
 `swamp workflow run`, layered as `caller inputs > trigger.inputs > schema
 defaults`. For a scheduled run there is no caller, so `trigger.inputs` becomes
-the baseline; for a webhook run any inputs the payload supplies (today none —
-the body is used only for signature verification) would override the trigger
-values. The merged inputs flow through the same coercion, default-application,
-and validation pipeline as every other run, so a `required` input satisfied
-only by `trigger.inputs` validates successfully.
+the baseline. The merged inputs flow through the same coercion,
+default-application, and validation pipeline as every other run, so a `required`
+input satisfied only by `trigger.inputs` validates successfully.
 
 Trigger inputs apply only to trigger-fired runs (scheduled, webhook). A manual
 `swamp workflow run` invokes the workflow directly and is unaffected by
 `trigger.inputs` — the operator supplies inputs explicitly.
+
+#### Webhook Payload Extraction
+
+For webhook runs, `trigger.inputs` values may be CEL expressions that read the
+inbound request through the `webhook` namespace, mapping payload fields onto
+named workflow inputs:
+
+```yaml
+trigger:
+  inputs:
+    identifier: "${{ webhook.body.data.issue.identifier }}"
+    eventType: '${{ webhook.headers["x-linear-event"] }}'
+inputs:
+  type: object
+  properties:
+    identifier: { type: string }
+  required: [identifier]
+jobs:
+  # ... runs with identifier populated from the webhook body
+```
+
+The `webhook` namespace exposes:
+
+- `webhook.body` — the request body, parsed as JSON when the payload is valid
+  JSON, otherwise the raw string.
+- `webhook.headers` — request headers as a map of lowercased names to values.
+  The signature header (`x-hub-signature-256`) is excluded.
+- `webhook.route` — the matched webhook route (e.g. `/hooks/linear`).
+
+These expressions are evaluated against the verified payload **at fire time,
+before input validation**, so a payload field can satisfy a `required` input.
+A whole-value expression preserves the field's native type (object, number,
+boolean); an expression embedded in a larger string is interpolated.
+
+swamp's CEL has no `??` operator — guard optional payload fields with the
+`has()` macro and a ternary instead:
+
+```yaml
+trigger:
+  inputs:
+    identifier: >-
+      ${{ has(webhook.body.data.issue) ?
+        webhook.body.data.issue.identifier : webhook.body.data.identifier }}
+```
+
+A hard reference to a missing field (without a `has()` guard) surfaces an error
+and the run does not start. The `webhook` namespace is available only inside
+`trigger.inputs`; the rest of the workflow reads the extracted values as normal
+inputs (`${{ inputs.identifier }}`).
+
+**Security:** `webhook.headers` values are not redacted (the same caveat as the
+`env` namespace). If a workflow maps one into a model attribute it is stored in
+`.swamp/data/` and visible in `swamp data get` output — avoid forwarding
+sensitive headers.
 
 ## Jobs
 

--- a/integration/webhook_payload_inputs_test.ts
+++ b/integration/webhook_payload_inputs_test.ts
@@ -1,0 +1,230 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for webhook payload extraction into workflow inputs (#717).
+ *
+ * Webhook runs flow through `executeWorkflowWithLocks` carrying a `webhook`
+ * payload. The workflow's `trigger.inputs` CEL expressions are evaluated against
+ * that payload BEFORE input validation, so a payload field can satisfy a
+ * required input. These tests drive `executeWorkflowWithLocks` directly with a
+ * payload (rather than standing up an HTTP server) and assert that the extracted
+ * value reaches the workflow as a validated input.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createRepoInitDeps,
+  repoInit,
+  withDefaults,
+} from "../src/libswamp/mod.ts";
+import type { WorkflowRunEvent } from "../src/libswamp/mod.ts";
+import type { WebhookPayload } from "../src/domain/expressions/model_resolver.ts";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { YamlEvaluatedWorkflowRepository } from "../src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
+import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
+import { executeWorkflowWithLocks } from "../src/serve/deps.ts";
+
+// Import models barrel to trigger built-in registration.
+import "../src/domain/models/models.ts";
+import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+const requiredInputSchema = {
+  type: "object" as const,
+  properties: { identifier: { type: "string" as const } },
+  required: ["identifier"],
+};
+
+/**
+ * A workflow that requires `identifier` and maps it from the webhook payload via
+ * trigger.inputs. The step echoes the resolved input so the evaluated workflow
+ * carries the extracted value where we can assert on it.
+ */
+function webhookWorkflow(
+  name: string,
+  triggerInputs: Record<string, unknown>,
+): Workflow {
+  return Workflow.create({
+    name,
+    trigger: { inputs: triggerInputs },
+    inputs: requiredInputSchema,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "echo",
+            task: StepTask.directExecution(
+              "command/shell",
+              `${name}-shell`,
+              "execute",
+              { run: "echo ok", identifier: "${{ inputs.identifier }}" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
+async function runWebhook(
+  repoDir: string,
+  workflowName: string,
+  webhook: WebhookPayload,
+): Promise<WorkflowRunEvent[]> {
+  const {
+    repoDir: resolvedRepoDir,
+    repoContext,
+    datastoreConfig,
+    syncService,
+  } = await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+
+  const events: WorkflowRunEvent[] = [];
+  await executeWorkflowWithLocks(
+    resolvedRepoDir,
+    repoContext,
+    datastoreConfig,
+    { workflowIdOrName: workflowName, webhook },
+    new AbortController().signal,
+    (event) => events.push(event),
+    syncService,
+  );
+  return events;
+}
+
+async function withRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp-webhook-inputs-" });
+  try {
+    await consumeStream(
+      repoInit(
+        createLibSwampContext({}),
+        createRepoInitDeps("20260101.120000.0"),
+        { path: repoDir, force: false, version: "20260101.120000.0" },
+      ),
+      withDefaults({
+        error: (event) => {
+          throw new Error(String(event.error?.message ?? "repo init failed"));
+        },
+      }),
+    );
+    await fn(repoDir);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+function stepIdentifier(workflow: Workflow): unknown {
+  const data = workflow.jobs[0].steps[0].task.data;
+  return "inputs" in data ? data.inputs?.identifier : undefined;
+}
+
+Deno.test({
+  name:
+    "webhook run: a required input mapped from the payload resolves, validates, and reaches the step",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = webhookWorkflow("webhook-required-input", {
+        identifier: "${{ webhook.body.data.issue.identifier }}",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      const events = await runWebhook(repoDir, workflow.name, {
+        body: { data: { issue: { identifier: "PLT-1057" } } },
+        headers: { "x-linear-event": "Issue" },
+        route: "/hooks/linear",
+      });
+      const kinds = events.map((e) => e.kind);
+
+      assertEquals(
+        kinds.some((k) => k === "error"),
+        false,
+        `unexpected error event: ${JSON.stringify(events)}`,
+      );
+      assertEquals(kinds.at(-1), "completed");
+
+      const evaluated = await new YamlEvaluatedWorkflowRepository(repoDir)
+        .findByName(workflow.name);
+      assertEquals(stepIdentifier(evaluated!), "PLT-1057");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "webhook run: has()/ternary fallback selects an alternate payload field",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = webhookWorkflow("webhook-fallback-input", {
+        identifier:
+          "${{ has(webhook.body.data.issue) ? webhook.body.data.issue.identifier : webhook.body.data.identifier }}",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      const events = await runWebhook(repoDir, workflow.name, {
+        body: { data: { identifier: "FALLBACK-9" } },
+        headers: {},
+        route: "/hooks/linear",
+      });
+
+      assertEquals(events.map((e) => e.kind).at(-1), "completed");
+
+      const evaluated = await new YamlEvaluatedWorkflowRepository(repoDir)
+        .findByName(workflow.name);
+      assertEquals(stepIdentifier(evaluated!), "FALLBACK-9");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "webhook run: a hard reference to a missing payload field surfaces an error",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withRepo(async (repoDir) => {
+      const workflow = webhookWorkflow("webhook-missing-field", {
+        identifier: "${{ webhook.body.data.issue.identifier }}",
+      });
+      await new YamlWorkflowRepository(repoDir).save(workflow);
+
+      // Payload has no data.issue — the strict resolver propagates the error.
+      await assertRejects(() =>
+        runWebhook(repoDir, workflow.name, {
+          body: { data: {} },
+          headers: {},
+          route: "/hooks/linear",
+        })
+      );
+    });
+  },
+});

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -221,6 +221,24 @@ export function isTaskInputsPath(path: string): boolean {
 }
 
 /**
+ * Checks if an expression path is within a workflow's `trigger.inputs`.
+ *
+ * These values are resolved at fire time by the trigger machinery — webhook
+ * runs CEL-evaluate them against the request payload (see TriggerInputResolver),
+ * scheduled runs use them as static literals — so workflow-body evaluation must
+ * leave them raw rather than evaluate `webhook.*` against a context that lacks
+ * the payload.
+ *
+ * @param path - The expression path (e.g., "trigger.inputs.identifier")
+ * @returns True if the path is within the trigger's inputs map
+ */
+export function isTriggerInputsPath(path: string): boolean {
+  return path === "trigger.inputs" ||
+    path.startsWith("trigger.inputs.") ||
+    path.startsWith("trigger.inputs[");
+}
+
+/**
  * Pattern to match `inputs.fieldName` (dot notation) in CEL expressions.
  * Uses negative lookbehind to exclude cross-model references like `model.foo.input.bar`.
  */

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -25,6 +25,7 @@ import {
   extractInputReferences,
   extractInputReferencesFromCel,
   isTaskInputsPath,
+  isTriggerInputsPath,
   replaceExpressions,
 } from "./expression_parser.ts";
 
@@ -306,6 +307,28 @@ Deno.test("isTaskInputsPath returns false for model definition attribute", () =>
     isTaskInputsPath("attributes.vpc_id"),
     false,
   );
+});
+
+// Tests for isTriggerInputsPath
+
+Deno.test("isTriggerInputsPath returns true for a trigger.inputs dot path", () => {
+  assertEquals(isTriggerInputsPath("trigger.inputs.identifier"), true);
+});
+
+Deno.test("isTriggerInputsPath returns true for a trigger.inputs bracket path", () => {
+  assertEquals(isTriggerInputsPath("trigger.inputs[0]"), true);
+});
+
+Deno.test("isTriggerInputsPath returns true for the trigger.inputs root", () => {
+  assertEquals(isTriggerInputsPath("trigger.inputs"), true);
+});
+
+Deno.test("isTriggerInputsPath returns false for trigger.schedule", () => {
+  assertEquals(isTriggerInputsPath("trigger.schedule"), false);
+});
+
+Deno.test("isTriggerInputsPath returns false for the top-level inputs schema", () => {
+  assertEquals(isTriggerInputsPath("inputs.identifier"), false);
 });
 
 // Tests for extractInputReferences

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -268,6 +268,25 @@ export interface RunContext {
 }
 
 /**
+ * The verified payload of an inbound webhook request, exposed to a workflow's
+ * `trigger.inputs` CEL expressions as the `webhook` namespace
+ * (`webhook.body`, `webhook.headers`, `webhook.route`).
+ *
+ * `body` is the JSON-parsed request body when the payload is valid JSON, or the
+ * raw UTF-8 string otherwise. `headers` is a map of lowercased header names to
+ * values; the signature header is intentionally excluded.
+ *
+ * **Security note:** header values are not redacted. If a workflow maps one into
+ * a model attribute it is stored in `.swamp/data/` and visible in
+ * `swamp data get` output. Treat sensitive headers accordingly.
+ */
+export interface WebhookPayload {
+  body: unknown;
+  headers: Record<string, string>;
+  route: string;
+}
+
+/**
  * Context for evaluating CEL expressions.
  */
 export interface ExpressionContext {
@@ -314,6 +333,11 @@ export interface ExpressionContext {
   workflowRunId?: string;
   /** Structured workflow run context, available as `run.*` in CEL expressions. */
   run?: RunContext;
+  /**
+   * Verified inbound webhook payload, available as `webhook.*` in a workflow's
+   * `trigger.inputs` CEL expressions. Set only for webhook-triggered runs.
+   */
+  webhook?: WebhookPayload;
   /** Index signature for CEL evaluator compatibility */
   [key: string]: unknown;
 }

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -23,6 +23,7 @@ import { Workflow as WorkflowClass } from "./workflow.ts";
 import {
   extractExpressions,
   isTaskInputsPath,
+  isTriggerInputsPath,
   replaceExpressions,
 } from "../expressions/expression_parser.ts";
 import { containsRuntimeExpression } from "../expressions/expression_evaluation_service.ts";
@@ -104,6 +105,13 @@ export class WorkflowExpressionEvaluator {
       }
       // forEach.in expressions must remain as strings for expansion.
       if (forEachInExpressions.has(expr.raw)) {
+        continue;
+      }
+      // trigger.inputs are resolved at fire time (TriggerInputResolver for
+      // webhook runs; static literals for scheduled runs), not during
+      // workflow-body evaluation — leave them raw so a `webhook.*` reference
+      // doesn't evaluate against a context that lacks the payload.
+      if (isTriggerInputsPath(expr.path)) {
         continue;
       }
       // task.inputs that depend on step outputs are evaluated at step

--- a/src/domain/workflows/trigger_input_resolver.ts
+++ b/src/domain/workflows/trigger_input_resolver.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ExpressionContext } from "../expressions/model_resolver.ts";
+import type { CelExpressionEvaluator } from "../expressions/cel_runtime.ts";
+
+const WHOLE_EXPRESSION = /^\$\{\{\s*(.+?)\s*\}\}$/;
+const EMBEDDED_EXPRESSION = /\$\{\{\s*(.+?)\s*\}\}/g;
+
+/**
+ * Resolves a trigger's `inputs` value map by evaluating its CEL expressions
+ * against an {@link ExpressionContext}. Used for webhook-triggered runs where
+ * `trigger.inputs` maps fields of the request payload onto workflow inputs,
+ * e.g. `identifier: "${{ webhook.body.data.issue.identifier }}"`.
+ *
+ * A value that is exactly a single `${{ ... }}` expression resolves to the
+ * evaluated result with its native type preserved (object, number, boolean).
+ * Expressions embedded in a larger string are interpolated and stringified.
+ * Nested objects and arrays are resolved recursively; non-expression values
+ * (the static literals scheduled runs rely on) pass through unchanged.
+ *
+ * **Strict**: a CEL evaluation error propagates, surfacing a misconfigured
+ * mapping to the caller rather than silently dropping the input. Optional
+ * payload fields should be guarded with `??` in the expression itself.
+ */
+export class TriggerInputResolver {
+  constructor(private readonly celEvaluator: CelExpressionEvaluator) {}
+
+  async resolve(
+    triggerInputs: Record<string, unknown>,
+    context: ExpressionContext,
+  ): Promise<Record<string, unknown>> {
+    const resolved = await this.resolveValue(triggerInputs, context);
+    return resolved as Record<string, unknown>;
+  }
+
+  private async resolveValue(
+    value: unknown,
+    context: ExpressionContext,
+  ): Promise<unknown> {
+    if (typeof value === "string") {
+      return await this.resolveString(value, context);
+    }
+    if (Array.isArray(value)) {
+      const out: unknown[] = [];
+      for (const item of value) {
+        out.push(await this.resolveValue(item, context));
+      }
+      return out;
+    }
+    if (value !== null && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) {
+        out[key] = await this.resolveValue(item, context);
+      }
+      return out;
+    }
+    return value;
+  }
+
+  private async resolveString(
+    value: string,
+    context: ExpressionContext,
+  ): Promise<unknown> {
+    const whole = value.match(WHOLE_EXPRESSION);
+    if (whole) {
+      return await this.celEvaluator.evaluateAsync(whole[1].trim(), context);
+    }
+
+    const matches = [...value.matchAll(EMBEDDED_EXPRESSION)];
+    if (matches.length === 0) {
+      return value;
+    }
+
+    let result = value;
+    for (const match of matches) {
+      const evaluated = await this.celEvaluator.evaluateAsync(
+        match[1].trim(),
+        context,
+      );
+      result = result.split(match[0]).join(String(evaluated));
+    }
+    return result;
+  }
+}

--- a/src/domain/workflows/trigger_input_resolver_test.ts
+++ b/src/domain/workflows/trigger_input_resolver_test.ts
@@ -1,0 +1,128 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { TriggerInputResolver } from "./trigger_input_resolver.ts";
+import type { ExpressionContext } from "../expressions/model_resolver.ts";
+import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
+
+function contextWith(webhook: ExpressionContext["webhook"]): ExpressionContext {
+  return { model: {}, env: {}, webhook };
+}
+
+const linearContext = contextWith({
+  body: { data: { issue: { identifier: "PLT-1057" } } },
+  headers: { "x-linear-event": "Issue" },
+  route: "/hooks/linear",
+});
+
+Deno.test("TriggerInputResolver: passes static literals through unchanged", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const result = await resolver.resolve(
+    { projectId: "a6b254a2", count: 3, enabled: true },
+    contextWith(undefined),
+  );
+  assertEquals(result, { projectId: "a6b254a2", count: 3, enabled: true });
+});
+
+Deno.test("TriggerInputResolver: resolves a whole-value webhook expression", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const result = await resolver.resolve(
+    { identifier: "${{ webhook.body.data.issue.identifier }}" },
+    linearContext,
+  );
+  assertEquals(result, { identifier: "PLT-1057" });
+});
+
+Deno.test("TriggerInputResolver: reads a header via webhook.headers", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const result = await resolver.resolve(
+    { eventType: '${{ webhook.headers["x-linear-event"] }}' },
+    linearContext,
+  );
+  assertEquals(result, { eventType: "Issue" });
+});
+
+Deno.test("TriggerInputResolver: preserves the native type of a whole-value expression", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const ctx = contextWith({
+    body: { count: 42, nested: { ok: true } },
+    headers: {},
+    route: "/hooks/x",
+  });
+  const result = await resolver.resolve(
+    {
+      count: "${{ webhook.body.count }}",
+      nested: "${{ webhook.body.nested }}",
+    },
+    ctx,
+  );
+  assertEquals(result, { count: 42, nested: { ok: true } });
+});
+
+Deno.test("TriggerInputResolver: interpolates an expression embedded in a string", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const result = await resolver.resolve(
+    { ref: "issue-${{ webhook.body.data.issue.identifier }}" },
+    linearContext,
+  );
+  assertEquals(result, { ref: "issue-PLT-1057" });
+});
+
+Deno.test("TriggerInputResolver: resolves nested object and array values", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const result = await resolver.resolve(
+    {
+      meta: { id: "${{ webhook.body.data.issue.identifier }}", static: "x" },
+      tags: ["${{ webhook.body.data.issue.identifier }}", "literal"],
+    },
+    linearContext,
+  );
+  assertEquals(result, {
+    meta: { id: "PLT-1057", static: "x" },
+    tags: ["PLT-1057", "literal"],
+  });
+});
+
+Deno.test("TriggerInputResolver: supports has()/ternary fallback for a missing field", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const ctx = contextWith({
+    body: { data: { identifier: "FALLBACK-1" } },
+    headers: {},
+    route: "/hooks/x",
+  });
+  const result = await resolver.resolve(
+    {
+      identifier:
+        "${{ has(webhook.body.data.issue) ? webhook.body.data.issue.identifier : webhook.body.data.identifier }}",
+    },
+    ctx,
+  );
+  assertEquals(result, { identifier: "FALLBACK-1" });
+});
+
+Deno.test("TriggerInputResolver: propagates a hard reference error", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  await assertRejects(() =>
+    resolver.resolve(
+      { broken: "${{ webhook.body.does.not.exist.deeply }}" },
+      contextWith({ body: {}, headers: {}, route: "/hooks/x" }),
+    )
+  );
+});

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -224,11 +224,20 @@ export class Workflow {
    * win on conflict (e.g. a webhook payload overrides a trigger default).
    * Schema defaults are applied later, downstream, for any keys still missing —
    * yielding precedence: caller inputs > trigger.inputs > schema defaults.
+   *
+   * `resolvedTriggerInputs`, when supplied, replaces the raw `trigger.inputs`
+   * as the baseline layer. Webhook-triggered runs CEL-evaluate `trigger.inputs`
+   * against the request payload first (see TriggerInputResolver) and pass the
+   * resolved values here, so the precedence rule stays in the aggregate.
    */
   baselineInputs(
     callerInputs: Record<string, unknown>,
+    resolvedTriggerInputs?: Record<string, unknown>,
   ): Record<string, unknown> {
-    return deepMerge(this.trigger?.inputs ?? {}, callerInputs);
+    return deepMerge(
+      resolvedTriggerInputs ?? this.trigger?.inputs ?? {},
+      callerInputs,
+    );
   }
 
   /**

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -806,6 +806,38 @@ Deno.test("Workflow.baselineInputs preserves non-string trigger input types", ()
   assertEquals(result.items, ["a", "b"]);
 });
 
+Deno.test("Workflow.baselineInputs uses resolvedTriggerInputs over raw trigger inputs", () => {
+  const workflow = Workflow.create({
+    name: "resolved-trigger-inputs",
+    trigger: {
+      inputs: { identifier: "${{ webhook.body.id }}" },
+    },
+    jobs: [createTestJob("job1")],
+  });
+
+  // The webhook path resolves trigger.inputs against the payload first and
+  // passes the resolved values as the baseline layer.
+  assertEquals(
+    workflow.baselineInputs({}, { identifier: "PLT-1057" }),
+    { identifier: "PLT-1057" },
+  );
+});
+
+Deno.test("Workflow.baselineInputs lets caller override resolvedTriggerInputs", () => {
+  const workflow = Workflow.create({
+    name: "resolved-trigger-inputs-override",
+    trigger: { inputs: { identifier: "${{ webhook.body.id }}" } },
+    jobs: [createTestJob("job1")],
+  });
+
+  assertEquals(
+    workflow.baselineInputs({ identifier: "OVERRIDE" }, {
+      identifier: "PLT-1057",
+    }),
+    { identifier: "OVERRIDE" },
+  );
+});
+
 Deno.test("Workflow.fromData handles missing tags (backward compat)", () => {
   // Simulate legacy data without tags field — Zod .default({}) fills it in
   const data = {

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -28,6 +28,7 @@ import type { EnvVarUsageDetail } from "../../domain/models/validation_service.t
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { StepRun } from "../../domain/workflows/workflow_run.ts";
+import type { WebhookPayload } from "../../domain/expressions/model_resolver.ts";
 import type {
   StepArtifactsData,
   StepRunView,
@@ -243,6 +244,12 @@ export interface WorkflowRunInput {
   workflowIdOrName: string;
   lastEvaluated?: boolean;
   inputs?: Record<string, unknown>;
+  /**
+   * Verified webhook request payload, set only for webhook-triggered runs.
+   * `executeWorkflowWithLocks` CEL-evaluates the workflow's `trigger.inputs`
+   * against this payload to produce baseline inputs before validation.
+   */
+  webhook?: WebhookPayload;
   runtimeTags?: Record<string, string>;
   verbose?: boolean;
   skipAllReports?: boolean;

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -37,6 +37,9 @@ import {
   WorkflowExecutionService,
 } from "../domain/workflows/execution_service.ts";
 import { createWorkflowId } from "../domain/workflows/workflow_id.ts";
+import { TriggerInputResolver } from "../domain/workflows/trigger_input_resolver.ts";
+import { buildEnvContext } from "../domain/expressions/model_resolver.ts";
+import { CelEvaluator } from "../infrastructure/cel/cel_evaluator.ts";
 import { ModelType } from "../domain/models/model_type.ts";
 import { resolveOrCreateDefinition } from "../libswamp/mod.ts";
 import { YamlDefinitionRepository } from "../infrastructure/persistence/yaml_definition_repository.ts";
@@ -323,8 +326,30 @@ export async function executeWorkflowWithLocks(
     // scheduled and webhook trigger-fired runs get baseline values at fire
     // time. Downstream workflowRun applies schema defaults and validates,
     // yielding precedence: caller inputs > trigger.inputs > schema defaults.
+    //
+    // For webhook runs, trigger.inputs may reference the request payload via the
+    // `webhook` CEL namespace (e.g. "${{ webhook.body.data.issue.identifier }}").
+    // Resolve those against the payload here — before workflowRun's coercion and
+    // validation — so a required input mapped from the payload satisfies the
+    // schema.
+    let resolvedTriggerInputs: Record<string, unknown> | undefined;
+    if (workflow && input.webhook && workflow.triggerInputs) {
+      const resolver = new TriggerInputResolver(new CelEvaluator());
+      resolvedTriggerInputs = await resolver.resolve(workflow.triggerInputs, {
+        model: {},
+        env: buildEnvContext(),
+        webhook: input.webhook,
+      });
+    }
+
     const effectiveInput = workflow
-      ? { ...input, inputs: workflow.baselineInputs(input.inputs ?? {}) }
+      ? {
+        ...input,
+        inputs: workflow.baselineInputs(
+          input.inputs ?? {},
+          resolvedTriggerInputs,
+        ),
+      }
       : input;
 
     for await (const event of workflowRun(libCtx, deps, effectiveInput)) {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -26,11 +26,45 @@
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import type { WebhookPayload } from "../domain/expressions/model_resolver.ts";
 import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
 const logger = getSwampLogger(["serve", "webhook"]);
+
+/** Header carrying the HMAC signature — excluded from the exposed payload. */
+const SIGNATURE_HEADER = "x-hub-signature-256";
+
+/**
+ * Builds the {@link WebhookPayload} exposed to a workflow's `trigger.inputs`
+ * CEL expressions from a verified request. The body is JSON-parsed when
+ * possible, falling back to the raw UTF-8 string for non-JSON payloads. Header
+ * names are lowercased and the signature header is dropped so it can never leak
+ * into workflow inputs.
+ */
+export function buildWebhookPayload(
+  body: Uint8Array,
+  headers: Headers,
+  route: string,
+): WebhookPayload {
+  const text = new TextDecoder().decode(body);
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Non-JSON payload — expose the raw string.
+  }
+
+  const exposedHeaders: Record<string, string> = {};
+  for (const [name, value] of headers) {
+    const lower = name.toLowerCase();
+    if (lower === SIGNATURE_HEADER) continue;
+    exposedHeaders[lower] = value;
+  }
+
+  return { body: parsed, headers: exposedHeaders, route };
+}
 
 // ── Value Objects ──────────────────────────────────────────────────────
 
@@ -241,6 +275,7 @@ export class WebhookService {
   private readonly runQueue: Array<{
     workflowIdOrName: string;
     route: string;
+    payload: WebhookPayload;
   }> = [];
   private processing = false;
   private processingPromise: Promise<void> = Promise.resolve();
@@ -342,6 +377,7 @@ export class WebhookService {
     this.runQueue.push({
       workflowIdOrName: endpoint.workflowIdOrName,
       route: endpoint.route,
+      payload: buildWebhookPayload(body, req.headers, endpoint.route),
     });
 
     this.emit({
@@ -383,8 +419,8 @@ export class WebhookService {
 
     try {
       while (this.runQueue.length > 0) {
-        const { workflowIdOrName, route } = this.runQueue.shift()!;
-        await this.executeWorkflow(workflowIdOrName, route);
+        const { workflowIdOrName, route, payload } = this.runQueue.shift()!;
+        await this.executeWorkflow(workflowIdOrName, route, payload);
       }
     } finally {
       this.processing = false;
@@ -394,6 +430,7 @@ export class WebhookService {
   private async executeWorkflow(
     workflowIdOrName: string,
     route: string,
+    payload: WebhookPayload,
   ): Promise<void> {
     const controller = new AbortController();
     this.running.set(workflowIdOrName, controller);
@@ -405,7 +442,7 @@ export class WebhookService {
         this.deps.repoDir,
         this.deps.repoContext,
         this.deps.datastoreConfig,
-        { workflowIdOrName },
+        { workflowIdOrName, webhook: payload },
         controller.signal,
         (event) => {
           if (event.kind === "started") {

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -18,10 +18,57 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { parseWebhookFlag, verifySignature } from "./webhook.ts";
+import {
+  buildWebhookPayload,
+  parseWebhookFlag,
+  verifySignature,
+} from "./webhook.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
 await initializeLogging({});
+
+// ── buildWebhookPayload ────────────────────────────────────────────────
+
+Deno.test("buildWebhookPayload: parses a JSON body into webhook.body", () => {
+  const body = new TextEncoder().encode(
+    '{"data":{"issue":{"identifier":"PLT-1057"}}}',
+  );
+  const payload = buildWebhookPayload(body, new Headers(), "/hooks/linear");
+  assertEquals(payload.body, {
+    data: { issue: { identifier: "PLT-1057" } },
+  });
+  assertEquals(payload.route, "/hooks/linear");
+});
+
+Deno.test("buildWebhookPayload: falls back to the raw string for non-JSON", () => {
+  const body = new TextEncoder().encode("not json at all");
+  const payload = buildWebhookPayload(body, new Headers(), "/hooks/x");
+  assertEquals(payload.body, "not json at all");
+});
+
+Deno.test("buildWebhookPayload: lowercases header names", () => {
+  const headers = new Headers({ "X-Linear-Event": "Issue" });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/hooks/x",
+  );
+  assertEquals(payload.headers["x-linear-event"], "Issue");
+});
+
+Deno.test("buildWebhookPayload: drops the signature header", () => {
+  const headers = new Headers({
+    "X-Hub-Signature-256": "sha256=deadbeef",
+    "X-Other": "keep",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/hooks/x",
+  );
+  assertEquals("x-hub-signature-256" in payload.headers, false);
+  assertEquals(payload.headers["x-other"], "keep");
+});
 
 // ── parseWebhookFlag ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Lab #717 — webhook-triggered runs can now map fields of the verified request payload onto workflow inputs. A workflow's `trigger.inputs` values may be CEL expressions that read the request through a new `webhook` namespace (`webhook.body`, `webhook.headers`, `webhook.route`):

```yaml
trigger:
  inputs:
    identifier: "${{ webhook.body.data.issue.identifier }}"
    eventType: '${{ webhook.headers["x-linear-event"] }}'
inputs:
  type: object
  properties:
    identifier: { type: string }
  required: [identifier]
```

These resolve against the payload **at fire time, before input validation**, so a payload field can satisfy a `required` input. Builds directly on #700 (`trigger.inputs`): the resolved values feed the existing `caller > trigger.inputs > schema defaults` precedence via `baselineInputs`.

Before this, `swamp serve --webhook` read the body only for HMAC verification and discarded it, so any workflow requiring inputs could not be webhook-triggered.

## Design

- **`WebhookPayload`** value object + a `webhook` namespace on `ExpressionContext` (`src/domain/expressions/model_resolver.ts`).
- **`TriggerInputResolver`** domain service CEL-evaluates the `trigger.inputs` map against the payload — whole-value expressions preserve native type, embedded expressions interpolate, nested objects/arrays recurse, hard reference errors propagate. CEL evaluation stays out of the `Workflow` aggregate; `baselineInputs` remains a pure merge that now accepts the pre-resolved map.
- **`WebhookService.handleRequest`** captures the verified body (JSON-parsed, raw-string fallback) and lowercased headers, **excluding the signature header**; threaded through `executeWorkflowWithLocks` (the shared scheduled/webhook entry point) before validation.
- **`WorkflowExpressionEvaluator`** skips `trigger.inputs` paths so workflow-body evaluation leaves them raw for fire-time resolution (otherwise the strict evaluator throws `Unknown variable: webhook`).

Scheduled/WebSocket runs are unchanged — `webhook` is optional throughout.

## Notes

- swamp's CEL engine has **no `??` operator** — guard optional payload fields with the `has()` macro and a ternary: `has(x.y) ? x.y : fallback`. Documented in `design/workflow.md`, `design/expressions.md`, and the swamp skill.
- Security: `webhook.headers` values are not redacted (same caveat as `env`); the `x-hub-signature-256` header is dropped from the exposed map.

## Test Plan

- **Unit**: `TriggerInputResolver` (literal pass-through, whole-value/type preservation, header access, interpolation, nested, `has()` fallback, strict error), `baselineInputs` precedence with resolved inputs, `isTriggerInputsPath`, `buildWebhookPayload` (JSON parse, raw fallback, lowercased headers, signature dropped).
- **Integration** (`integration/webhook_payload_inputs_test.ts`): required input mapped from payload resolves + validates + reaches the step; `has()`/ternary fallback; hard-missing-field surfaces an error.
- **Live**: real `swamp serve --webhook` + signed POST verified end-to-end — `identifier=PLT-1057`, `event=Issue` reached the step; invalid signature → 401; missing field → `webhook_failed`.
- Full suite: 7539 passed; `deno check` / `lint` / `fmt` / `compile` clean.
- UAT gap filed: swamp-club/swamp-uat#276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)