### PR TITLE
feat(serve): pluggable webhook signature verification schemes

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -215,11 +215,17 @@ trigger:
 ```
 
 `webhook.body` is the JSON-parsed body (raw string if not JSON),
-`webhook.headers` is a lowercased-name map (signature header excluded), and
-`webhook.route` is the matched route. Expressions resolve against the verified
-payload before input validation, so a payload field can satisfy a `required`
-input. swamp's CEL has no `??` — guard optional fields with `has(x) ? x : y`.
-See `design/workflow.md` for full semantics and the security caveat on headers.
+`webhook.headers` is a lowercased-name map (the active scheme's signature header
+excluded), and `webhook.route` is the matched route. Expressions resolve against
+the verified payload before input validation, so a payload field can satisfy a
+`required` input. swamp's CEL has no `??` — guard optional fields with
+`has(x) ? x : y`. See `design/workflow.md` for full semantics and the security
+caveat on headers.
+
+The signature scheme is set per endpoint on `swamp serve`'s `--webhook` flag:
+`<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`, where `scheme`
+is `github` (default), `linear`, `stripe`, `slack`, or `generic` (header +
+optional prefix). Omitting the scheme preserves the original behavior.
 
 ## Edit a Workflow
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -361,8 +361,17 @@ The `webhook` namespace exposes:
 - `webhook.body` — the request body, parsed as JSON when the payload is valid
   JSON, otherwise the raw string.
 - `webhook.headers` — request headers as a map of lowercased names to values.
-  The signature header (`x-hub-signature-256`) is excluded.
+  The active scheme's signature header is excluded (e.g. `x-hub-signature-256`
+  for github, `stripe-signature` for stripe — see schemes below).
 - `webhook.route` — the matched webhook route (e.g. `/hooks/linear`).
+
+The signature scheme is selected per endpoint on the `--webhook` flag:
+`<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`. `scheme` is one
+of `github` (the default, `X-Hub-Signature-256`), `linear`, `stripe`, `slack`,
+or `generic` (which takes a header name and optional value prefix). When no
+scheme is given the flag behaves exactly as before, so the secret may still
+contain colons; a scheme is recognized only when the fourth field is a known
+scheme keyword.
 
 These expressions are evaluated against the verified payload **at fire time,
 before input validation**, so a payload field can satisfy a `required` input.

--- a/integration/webhook_signature_schemes_test.ts
+++ b/integration/webhook_signature_schemes_test.ts
@@ -1,0 +1,229 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for pluggable webhook signature verification (#716).
+ *
+ * These drive WebhookService.handleRequest with real signed HTTP requests for
+ * non-github schemes, asserting that a correctly-signed request is accepted
+ * (queued) and a forged one is rejected (401). Timestamps for the timestamped
+ * schemes are generated at request time so they fall inside the tolerance
+ * window. The actual workflow execution is exercised by #717's tests; here we
+ * focus on the verification gate, so the queued workflow can be a trivial echo.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createRepoInitDeps,
+  repoInit,
+  withDefaults,
+} from "../src/libswamp/mod.ts";
+import { Workflow } from "../src/domain/workflows/workflow.ts";
+import { Job } from "../src/domain/workflows/job.ts";
+import { Step } from "../src/domain/workflows/step.ts";
+import { StepTask } from "../src/domain/workflows/step_task.ts";
+import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
+import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
+import { parseWebhookFlag, WebhookService } from "../src/serve/webhook.ts";
+import { hmacSha256Hex } from "../src/serve/webhook_verifiers.ts";
+
+import "../src/domain/models/models.ts";
+import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+const SECRET = "shhh";
+
+function echoWorkflow(name: string): Workflow {
+  return Workflow.create({
+    name,
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "echo",
+            task: StepTask.directExecution(
+              "command/shell",
+              `${name}-shell`,
+              "execute",
+              { run: "echo ok" },
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
+async function withService(
+  flag: string,
+  workflowName: string,
+  fn: (service: WebhookService) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp-webhook-schemes-" });
+  try {
+    await consumeStream(
+      repoInit(
+        createLibSwampContext({}),
+        createRepoInitDeps("20260101.120000.0"),
+        { path: repoDir, force: false, version: "20260101.120000.0" },
+      ),
+      withDefaults({
+        error: (event) => {
+          throw new Error(String(event.error?.message ?? "repo init failed"));
+        },
+      }),
+    );
+
+    await new YamlWorkflowRepository(repoDir).save(echoWorkflow(workflowName));
+
+    const {
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      syncService,
+    } = await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+
+    const service = new WebhookService({
+      repoDir: resolvedRepoDir,
+      repoContext,
+      datastoreConfig,
+      endpoints: [parseWebhookFlag(flag)],
+      syncService,
+    });
+
+    try {
+      await fn(service);
+    } finally {
+      await service.stop();
+    }
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+function post(route: string, headers: HeadersInit, body: string): Request {
+  return new Request(`http://localhost${route}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+Deno.test({
+  name: "webhook scheme: a valid linear signature is accepted",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/linear:linear-wf:shhh:linear",
+      "linear-wf",
+      async (service) => {
+        const body = '{"action":"create"}';
+        const sig = await hmacSha256Hex(new TextEncoder().encode(body), SECRET);
+        const res = await service.handleRequest(
+          post("/hooks/linear", { "linear-signature": sig }, body),
+        );
+        assertEquals(res?.status, 200);
+        assertEquals((await res!.json()).status, "queued");
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "webhook scheme: a forged linear signature is rejected with 401",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/linear:linear-wf:shhh:linear",
+      "linear-wf",
+      async (service) => {
+        const res = await service.handleRequest(
+          post(
+            "/hooks/linear",
+            { "linear-signature": "00".repeat(32) },
+            '{"action":"create"}',
+          ),
+        );
+        assertEquals(res?.status, 401);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "webhook scheme: a fresh valid stripe signature is accepted",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/stripe:stripe-wf:shhh:stripe",
+      "stripe-wf",
+      async (service) => {
+        const body = '{"id":"evt_1"}';
+        const t = Math.floor(Date.now() / 1000);
+        const v1 = await hmacSha256Hex(
+          new TextEncoder().encode(`${t}.${body}`),
+          SECRET,
+        );
+        const res = await service.handleRequest(
+          post(
+            "/hooks/stripe",
+            { "stripe-signature": `t=${t},v1=${v1}` },
+            body,
+          ),
+        );
+        assertEquals(res?.status, 200);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "webhook scheme: a stale stripe timestamp is rejected with 401",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withService(
+      "/hooks/stripe:stripe-wf:shhh:stripe",
+      "stripe-wf",
+      async (service) => {
+        const body = '{"id":"evt_1"}';
+        const t = Math.floor(Date.now() / 1000) - 3600;
+        const v1 = await hmacSha256Hex(
+          new TextEncoder().encode(`${t}.${body}`),
+          SECRET,
+        );
+        const res = await service.handleRequest(
+          post(
+            "/hooks/stripe",
+            { "stripe-signature": `t=${t},v1=${v1}` },
+            body,
+          ),
+        );
+        assertEquals(res?.status, 401);
+      },
+    );
+  },
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -122,7 +122,9 @@ export const serveCommand = new Command()
   )
   .option(
     "--webhook <spec:string>",
-    "Register a webhook endpoint: <route>:<workflow>:<secret>",
+    "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
+      "scheme is one of github (default), linear, stripe, slack, generic; " +
+      "generic takes a header name and optional value prefix",
     { collect: true },
   )
   .option(
@@ -165,6 +167,11 @@ export const serveCommand = new Command()
   .example(
     "Webhook trigger",
     "swamp serve --webhook '/hooks/github:my-workflow:$WEBHOOK_SECRET'",
+  )
+  .example(
+    "Webhook with a provider scheme",
+    "swamp serve --webhook '/hooks/linear:my-workflow:$SECRET:linear' " +
+      "--webhook '/hooks/custom:my-workflow:$SECRET:generic:X-Signature:sha256='",
   )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["serve"]);

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -30,10 +30,17 @@ import type { WebhookPayload } from "../domain/expressions/model_resolver.ts";
 import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import {
+  constantTimeEqualHex,
+  createVerifier,
+  hmacSha256Hex,
+  isWebhookScheme,
+  type VerifierConfig,
+} from "./webhook_verifiers.ts";
 
 const logger = getSwampLogger(["serve", "webhook"]);
 
-/** Header carrying the HMAC signature — excluded from the exposed payload. */
+/** Default signature header — used by the github scheme. */
 const SIGNATURE_HEADER = "x-hub-signature-256";
 
 /**
@@ -47,6 +54,7 @@ export function buildWebhookPayload(
   body: Uint8Array,
   headers: Headers,
   route: string,
+  signatureHeader: string = SIGNATURE_HEADER,
 ): WebhookPayload {
   const text = new TextDecoder().decode(body);
   let parsed: unknown = text;
@@ -56,10 +64,11 @@ export function buildWebhookPayload(
     // Non-JSON payload — expose the raw string.
   }
 
+  const excluded = signatureHeader.toLowerCase();
   const exposedHeaders: Record<string, string> = {};
   for (const [name, value] of headers) {
     const lower = name.toLowerCase();
-    if (lower === SIGNATURE_HEADER) continue;
+    if (lower === excluded) continue;
     exposedHeaders[lower] = value;
   }
 
@@ -76,32 +85,64 @@ export interface WebhookEndpoint {
   readonly route: string;
   readonly workflowIdOrName: string;
   readonly secret: string;
+  readonly verifier: VerifierConfig;
 }
 
 /**
  * Parse a --webhook flag value into a WebhookEndpoint.
- * Format: <route>:<workflow>:<secret>
  *
- * The secret is everything after the second colon, allowing colons
- * within the secret itself.
+ * Format: `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`
+ *
+ * The scheme is recognized only when the fourth field is a known scheme
+ * keyword; otherwise the flag is parsed the legacy way — the secret is
+ * everything after the second colon (so it may still contain colons) and the
+ * scheme defaults to github. This keeps every existing flag working. The
+ * consequence (a colon-bearing secret cannot be combined with an explicit
+ * scheme, and a secret whose colon-tail begins with a reserved keyword would be
+ * reinterpreted) is the accepted limitation tracked in #723. When a scheme is
+ * given, the remaining fields are positional: `generic` additionally takes a
+ * header name (fifth, required) and a value prefix (sixth, optional).
  */
 export function parseWebhookFlag(flag: string): WebhookEndpoint {
-  const firstColon = flag.indexOf(":");
-  if (firstColon === -1) {
-    throw new UserError(
-      `Invalid --webhook format: expected '<route>:<workflow>:<secret>', got '${flag}'`,
-    );
-  }
-  const secondColon = flag.indexOf(":", firstColon + 1);
-  if (secondColon === -1) {
-    throw new UserError(
-      `Invalid --webhook format: expected '<route>:<workflow>:<secret>', got '${flag}'`,
-    );
+  const fields = flag.split(":");
+  const usage =
+    "expected '<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]'";
+
+  if (fields.length < 3) {
+    throw new UserError(`Invalid --webhook format: ${usage}, got '${flag}'`);
   }
 
-  const route = flag.slice(0, firstColon);
-  const workflowIdOrName = flag.slice(firstColon + 1, secondColon);
-  const secret = flag.slice(secondColon + 1);
+  const route = fields[0];
+  const workflowIdOrName = fields[1];
+
+  let secret: string;
+  let verifier: VerifierConfig;
+
+  if (fields.length >= 4 && isWebhookScheme(fields[3])) {
+    // Scheme-qualified form: fields are positional, so the secret cannot
+    // contain a colon here.
+    secret = fields[2];
+    const scheme = fields[3];
+    if (scheme === "generic") {
+      const header = fields[4];
+      if (!header) {
+        throw new UserError(
+          "Invalid --webhook format: the 'generic' scheme requires a header " +
+            `name (<route>:<workflow>:<secret>:generic:<header>[:<prefix>]), got '${flag}'`,
+        );
+      }
+      verifier = { scheme, header, prefix: fields[5] ?? "" };
+    } else {
+      verifier = { scheme };
+    }
+  } else {
+    // Legacy form: secret is everything after the second colon (may contain
+    // colons); scheme defaults to github.
+    const firstColon = flag.indexOf(":");
+    const secondColon = flag.indexOf(":", firstColon + 1);
+    secret = flag.slice(secondColon + 1);
+    verifier = { scheme: "github" };
+  }
 
   if (!route || !workflowIdOrName || !secret) {
     throw new UserError(
@@ -115,7 +156,7 @@ export function parseWebhookFlag(flag: string): WebhookEndpoint {
     );
   }
 
-  return { route, workflowIdOrName, secret };
+  return { route, workflowIdOrName, secret, verifier };
 }
 
 // ── HMAC Signature Verification ────────────────────────────────────────
@@ -136,39 +177,9 @@ export async function verifySignature(
   if (!signatureHeader.startsWith("sha256=")) {
     return false;
   }
-
   const receivedHex = signatureHeader.slice("sha256=".length);
-
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-
-  // body is always a freshly-allocated Uint8Array from readBodyWithLimit
-  // or TextEncoder, so .buffer is a plain ArrayBuffer (not SharedArrayBuffer)
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    body.buffer as ArrayBuffer,
-  );
-  const expectedHex = Array.from(new Uint8Array(signature))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // Constant-time comparison: always compare all characters
-  if (receivedHex.length !== expectedHex.length) {
-    return false;
-  }
-
-  let mismatch = 0;
-  for (let i = 0; i < expectedHex.length; i++) {
-    mismatch |= receivedHex.charCodeAt(i) ^ expectedHex.charCodeAt(i);
-  }
-
-  return mismatch === 0;
+  const expectedHex = await hmacSha256Hex(body, secret);
+  return constantTimeEqualHex(receivedHex, expectedHex);
 }
 
 // ── Body Size Limit ────────────────────────────────────────────────────
@@ -319,17 +330,18 @@ export class WebhookService {
       workflowName: endpoint.workflowIdOrName,
     });
 
-    // Reject missing signature before reading the body to avoid
-    // unauthenticated resource consumption
-    const signatureHeader = req.headers.get("x-hub-signature-256") ?? "";
-    if (!signatureHeader) {
+    const verifier = createVerifier(endpoint.verifier);
+
+    // Reject a missing signature before reading the body to avoid
+    // unauthenticated resource consumption.
+    if (!req.headers.get(verifier.signatureHeader)) {
       this.emit({
         kind: "webhook_rejected",
         route: endpoint.route,
-        reason: "Missing X-Hub-Signature-256 header",
+        reason: `Missing ${verifier.signatureHeader} header`,
       });
       return Response.json(
-        { error: "Missing X-Hub-Signature-256 header" },
+        { error: `Missing ${verifier.signatureHeader} header` },
         { status: 401 },
       );
     }
@@ -348,7 +360,9 @@ export class WebhookService {
       );
     }
 
-    const valid = await verifySignature(body, signatureHeader, endpoint.secret);
+    // Any verification failure (malformed value, stale timestamp, mismatch)
+    // returns a uniform 401 so the response cannot be used as an oracle.
+    const valid = await verifier.verify(body, req.headers, endpoint.secret);
     if (!valid) {
       this.emit({
         kind: "webhook_rejected",
@@ -377,7 +391,12 @@ export class WebhookService {
     this.runQueue.push({
       workflowIdOrName: endpoint.workflowIdOrName,
       route: endpoint.route,
-      payload: buildWebhookPayload(body, req.headers, endpoint.route),
+      payload: buildWebhookPayload(
+        body,
+        req.headers,
+        endpoint.route,
+        verifier.signatureHeader,
+      ),
     });
 
     this.emit({

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -70,6 +70,22 @@ Deno.test("buildWebhookPayload: drops the signature header", () => {
   assertEquals(payload.headers["x-other"], "keep");
 });
 
+Deno.test("buildWebhookPayload: drops the scheme-specific signature header", () => {
+  const headers = new Headers({
+    "Stripe-Signature": "t=1,v1=deadbeef",
+    "X-Hub-Signature-256": "sha256=keep-me",
+  });
+  const payload = buildWebhookPayload(
+    new TextEncoder().encode("{}"),
+    headers,
+    "/hooks/stripe",
+    "stripe-signature",
+  );
+  // Only the active scheme's header is excluded; others pass through.
+  assertEquals("stripe-signature" in payload.headers, false);
+  assertEquals(payload.headers["x-hub-signature-256"], "sha256=keep-me");
+});
+
 // ── parseWebhookFlag ───────────────────────────────────────────────────
 
 Deno.test("parseWebhookFlag: parses valid flag", () => {
@@ -78,16 +94,76 @@ Deno.test("parseWebhookFlag: parses valid flag", () => {
     route: "/hooks/github",
     workflowIdOrName: "my-workflow",
     secret: "mysecret",
+    verifier: { scheme: "github" },
   });
 });
 
-Deno.test("parseWebhookFlag: secret can contain colons", () => {
+Deno.test("parseWebhookFlag: three-field form defaults to github", () => {
+  const result = parseWebhookFlag("/hooks/gh:deploy:mysecret");
+  assertEquals(result.verifier, { scheme: "github" });
+});
+
+Deno.test("parseWebhookFlag: secret can contain colons (legacy 3-field form)", () => {
   const result = parseWebhookFlag(
     "/hooks/gh:deploy:secret:with:colons",
   );
   assertEquals(result.route, "/hooks/gh");
   assertEquals(result.workflowIdOrName, "deploy");
   assertEquals(result.secret, "secret:with:colons");
+  assertEquals(result.verifier, { scheme: "github" });
+});
+
+Deno.test("parseWebhookFlag: parses an explicit linear scheme", () => {
+  const result = parseWebhookFlag("/hooks/linear:wf:mysecret:linear");
+  assertEquals(result.secret, "mysecret");
+  assertEquals(result.verifier, { scheme: "linear" });
+});
+
+Deno.test("parseWebhookFlag: parses stripe and slack schemes", () => {
+  assertEquals(
+    parseWebhookFlag("/hooks/s:wf:sec:stripe").verifier,
+    { scheme: "stripe" },
+  );
+  assertEquals(
+    parseWebhookFlag("/hooks/s:wf:sec:slack").verifier,
+    { scheme: "slack" },
+  );
+});
+
+Deno.test("parseWebhookFlag: parses generic scheme with header and prefix", () => {
+  const result = parseWebhookFlag(
+    "/hooks/x:wf:sec:generic:X-Signature:sha256=",
+  );
+  assertEquals(result.verifier, {
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "sha256=",
+  });
+});
+
+Deno.test("parseWebhookFlag: generic prefix defaults to empty", () => {
+  const result = parseWebhookFlag("/hooks/x:wf:sec:generic:X-Signature");
+  assertEquals(result.verifier, {
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "",
+  });
+});
+
+Deno.test("parseWebhookFlag: a non-scheme 4th field stays part of a colon-secret", () => {
+  // 'nope' is not a known scheme, so the legacy interpretation wins: the secret
+  // is everything after the 2nd colon and the scheme defaults to github.
+  const result = parseWebhookFlag("/hooks/x:wf:sec:nope");
+  assertEquals(result.secret, "sec:nope");
+  assertEquals(result.verifier, { scheme: "github" });
+});
+
+Deno.test("parseWebhookFlag: rejects generic without a header", () => {
+  assertThrows(
+    () => parseWebhookFlag("/hooks/x:wf:sec:generic"),
+    Error,
+    "'generic' scheme requires a header",
+  );
 });
 
 Deno.test("parseWebhookFlag: rejects missing first colon", () => {

--- a/src/serve/webhook_verifiers.ts
+++ b/src/serve/webhook_verifiers.ts
@@ -1,0 +1,268 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Pluggable webhook signature verification schemes (#716).
+ *
+ * Every supported provider authenticates with the same primitive — an
+ * HMAC-SHA256 digest of a provider-specific message — and differs only in the
+ * header it uses, how the digest is encoded in that header, and what bytes are
+ * signed. This module hosts a closed, hardcoded set of schemes (github, linear,
+ * stripe, slack, generic) over shared HMAC and constant-time-comparison
+ * primitives. Each verifier is a stateless function of (body, headers, secret).
+ *
+ * Generalizing this into a data-driven/templated engine so new providers need
+ * no swamp release is intentionally out of scope here and tracked in #723.
+ */
+
+/** Replay window for timestamped schemes (stripe, slack). */
+const TIMESTAMP_TOLERANCE_SECONDS = 300;
+
+/** The closed set of supported verification schemes. */
+export type WebhookScheme =
+  | "github"
+  | "linear"
+  | "stripe"
+  | "slack"
+  | "generic";
+
+/** Schemes selectable on the --webhook flag, in stable order. */
+export const WEBHOOK_SCHEMES: readonly WebhookScheme[] = [
+  "github",
+  "linear",
+  "stripe",
+  "slack",
+  "generic",
+];
+
+/**
+ * Immutable verification config for a single endpoint. Only the `generic`
+ * scheme carries extra parameters (the header to read and the value prefix to
+ * strip); the named schemes are fully determined by their scheme tag.
+ */
+export type VerifierConfig =
+  | { readonly scheme: "github" | "linear" | "stripe" | "slack" }
+  | {
+    readonly scheme: "generic";
+    readonly header: string;
+    readonly prefix: string;
+  };
+
+/**
+ * A stateless signature verifier. `signatureHeader` is always lowercased so it
+ * can be used both for the pre-body presence check and for exclusion from the
+ * exposed webhook payload without a case mismatch.
+ */
+export interface WebhookVerifier {
+  readonly signatureHeader: string;
+  verify(
+    body: Uint8Array,
+    headers: Headers,
+    secret: string,
+  ): Promise<boolean>;
+}
+
+// ── Shared primitives ──────────────────────────────────────────────────
+
+/**
+ * Compute the lowercase hex HMAC-SHA256 of `message` keyed by `secret`.
+ */
+export async function hmacSha256Hex(
+  message: Uint8Array,
+  secret: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  // message is always a freshly-allocated Uint8Array, so .buffer is a plain
+  // ArrayBuffer (not SharedArrayBuffer).
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    message.buffer as ArrayBuffer,
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Constant-time comparison of two hex strings. Always compares every character
+ * so timing does not leak how much of the digest matched.
+ */
+export function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+/** Concatenate a leading UTF-8 string with the raw body bytes. */
+function prefixedMessage(prefix: string, body: Uint8Array): Uint8Array {
+  const head = new TextEncoder().encode(prefix);
+  const out = new Uint8Array(head.length + body.length);
+  out.set(head, 0);
+  out.set(body, head.length);
+  return out;
+}
+
+/** True when `timestamp` (unix seconds) is within the replay tolerance. */
+function timestampFresh(timestamp: number): boolean {
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return Math.abs(nowSeconds - timestamp) <= TIMESTAMP_TOLERANCE_SECONDS;
+}
+
+// ── Per-scheme verifiers ────────────────────────────────────────────────
+
+/**
+ * HMAC-over-body schemes that read a single header and strip a fixed prefix.
+ * Covers github (`sha256=`), linear (bare), and generic (configurable).
+ */
+function prefixedBodyVerifier(
+  signatureHeader: string,
+  prefix: string,
+): WebhookVerifier {
+  return {
+    signatureHeader,
+    async verify(body, headers, secret) {
+      const value = headers.get(signatureHeader);
+      if (value === null || !value.startsWith(prefix)) {
+        return false;
+      }
+      const received = value.slice(prefix.length);
+      const expected = await hmacSha256Hex(body, secret);
+      return constantTimeEqualHex(received, expected);
+    },
+  };
+}
+
+/**
+ * Stripe: header `Stripe-Signature` carries `t=<unix>,v1=<hex>[,v1=<hex>...]`.
+ * The signed message is `<t>.<body>`. Multiple v1 values appear during secret
+ * rotation — the request is valid if any v1 matches.
+ */
+function stripeVerifier(): WebhookVerifier {
+  const signatureHeader = "stripe-signature";
+  return {
+    signatureHeader,
+    async verify(body, headers, secret) {
+      const value = headers.get(signatureHeader);
+      if (value === null) {
+        return false;
+      }
+
+      let timestamp: string | undefined;
+      const candidates: string[] = [];
+      for (const part of value.split(",")) {
+        const eq = part.indexOf("=");
+        if (eq === -1) continue;
+        const k = part.slice(0, eq).trim();
+        const v = part.slice(eq + 1).trim();
+        if (k === "t") timestamp = v;
+        else if (k === "v1") candidates.push(v);
+      }
+
+      if (timestamp === undefined || candidates.length === 0) {
+        return false;
+      }
+      if (!timestampFresh(Number(timestamp))) {
+        return false;
+      }
+
+      const expected = await hmacSha256Hex(
+        prefixedMessage(`${timestamp}.`, body),
+        secret,
+      );
+      // Compare against every candidate so timing does not reveal which (or
+      // how many) signatures were present.
+      let matched = false;
+      for (const candidate of candidates) {
+        if (constantTimeEqualHex(candidate, expected)) {
+          matched = true;
+        }
+      }
+      return matched;
+    },
+  };
+}
+
+/**
+ * Slack: header `X-Slack-Signature` carries `v0=<hex>`, with the timestamp in
+ * `X-Slack-Request-Timestamp`. The signed message is `v0:<timestamp>:<body>`.
+ */
+function slackVerifier(): WebhookVerifier {
+  const signatureHeader = "x-slack-signature";
+  return {
+    signatureHeader,
+    async verify(body, headers, secret) {
+      const value = headers.get(signatureHeader);
+      const timestamp = headers.get("x-slack-request-timestamp");
+      if (value === null || !value.startsWith("v0=") || timestamp === null) {
+        return false;
+      }
+      if (!timestampFresh(Number(timestamp))) {
+        return false;
+      }
+      const received = value.slice("v0=".length);
+      const expected = await hmacSha256Hex(
+        prefixedMessage(`v0:${timestamp}:`, body),
+        secret,
+      );
+      return constantTimeEqualHex(received, expected);
+    },
+  };
+}
+
+/**
+ * Build a verifier for the given config. The returned verifier's
+ * `signatureHeader` is lowercased.
+ */
+export function createVerifier(config: VerifierConfig): WebhookVerifier {
+  switch (config.scheme) {
+    case "github":
+      return prefixedBodyVerifier("x-hub-signature-256", "sha256=");
+    case "linear":
+      return prefixedBodyVerifier("linear-signature", "");
+    case "stripe":
+      return stripeVerifier();
+    case "slack":
+      return slackVerifier();
+    case "generic":
+      return prefixedBodyVerifier(
+        config.header.toLowerCase(),
+        config.prefix,
+      );
+  }
+}
+
+/** Type guard: is `value` one of the known scheme keywords? */
+export function isWebhookScheme(value: string): value is WebhookScheme {
+  return (WEBHOOK_SCHEMES as readonly string[]).includes(value);
+}

--- a/src/serve/webhook_verifiers_test.ts
+++ b/src/serve/webhook_verifiers_test.ts
@@ -1,0 +1,230 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  createVerifier,
+  hmacSha256Hex,
+  isWebhookScheme,
+} from "./webhook_verifiers.ts";
+
+const SECRET = "test-secret";
+const enc = (s: string) => new TextEncoder().encode(s);
+
+/** Lowercase hex HMAC-SHA256 of a UTF-8 message — the reference computation. */
+async function sign(message: string, secret = SECRET): Promise<string> {
+  return await hmacSha256Hex(enc(message), secret);
+}
+
+/** Current unix time in seconds (inside the 300s tolerance window). */
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+// ── github ──────────────────────────────────────────────────────────────
+
+Deno.test("github verifier: accepts a valid signature", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  const body = '{"ref":"refs/heads/main"}';
+  const headers = new Headers({
+    "x-hub-signature-256": `sha256=${await sign(body)}`,
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("github verifier: rejects a wrong secret", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  const body = "payload";
+  const headers = new Headers({
+    "x-hub-signature-256": `sha256=${await sign(body, "other")}`,
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+Deno.test("github verifier: rejects a missing header", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  assertEquals(await verifier.verify(enc("x"), new Headers(), SECRET), false);
+});
+
+Deno.test("github verifier: rejects a tampered body", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  const headers = new Headers({
+    "x-hub-signature-256": `sha256=${await sign("original")}`,
+  });
+  assertEquals(await verifier.verify(enc("tampered"), headers, SECRET), false);
+});
+
+Deno.test("github verifier: rejects a missing sha256= prefix", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  const headers = new Headers({
+    "x-hub-signature-256": await sign("body"),
+  });
+  assertEquals(await verifier.verify(enc("body"), headers, SECRET), false);
+});
+
+Deno.test("github verifier: accepts an empty body", async () => {
+  const verifier = createVerifier({ scheme: "github" });
+  const headers = new Headers({
+    "x-hub-signature-256": `sha256=${await sign("")}`,
+  });
+  assertEquals(await verifier.verify(enc(""), headers, SECRET), true);
+});
+
+// ── linear ──────────────────────────────────────────────────────────────
+
+Deno.test("linear verifier: accepts a valid bare-hex signature", async () => {
+  const verifier = createVerifier({ scheme: "linear" });
+  assertEquals(verifier.signatureHeader, "linear-signature");
+  const body = '{"action":"create"}';
+  const headers = new Headers({ "linear-signature": await sign(body) });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("linear verifier: rejects an invalid signature", async () => {
+  const verifier = createVerifier({ scheme: "linear" });
+  const headers = new Headers({ "linear-signature": "00".repeat(32) });
+  assertEquals(await verifier.verify(enc("body"), headers, SECRET), false);
+});
+
+// ── generic ─────────────────────────────────────────────────────────────
+
+Deno.test("generic verifier: lowercases the configured header", () => {
+  const verifier = createVerifier({
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "sha256=",
+  });
+  assertEquals(verifier.signatureHeader, "x-signature");
+});
+
+Deno.test("generic verifier: accepts a valid prefixed signature regardless of header case", async () => {
+  const verifier = createVerifier({
+    scheme: "generic",
+    header: "X-Signature",
+    prefix: "sha256=",
+  });
+  const body = "payload";
+  // Request supplies the header in a different case — Headers is case-insensitive.
+  const headers = new Headers({ "X-SIGNATURE": `sha256=${await sign(body)}` });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("generic verifier: rejects a missing prefix", async () => {
+  const verifier = createVerifier({
+    scheme: "generic",
+    header: "x-signature",
+    prefix: "sha256=",
+  });
+  // Correct digest but no prefix present.
+  const headers = new Headers({ "x-signature": await sign("payload") });
+  assertEquals(await verifier.verify(enc("payload"), headers, SECRET), false);
+});
+
+Deno.test("generic verifier: empty prefix accepts a bare digest", async () => {
+  const verifier = createVerifier({
+    scheme: "generic",
+    header: "x-signature",
+    prefix: "",
+  });
+  const headers = new Headers({ "x-signature": await sign("payload") });
+  assertEquals(await verifier.verify(enc("payload"), headers, SECRET), true);
+});
+
+// ── stripe ──────────────────────────────────────────────────────────────
+
+Deno.test("stripe verifier: accepts a fresh valid signature", async () => {
+  const verifier = createVerifier({ scheme: "stripe" });
+  const body = '{"id":"evt_1"}';
+  const t = nowSeconds();
+  const v1 = await sign(`${t}.${body}`);
+  const headers = new Headers({ "stripe-signature": `t=${t},v1=${v1}` });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("stripe verifier: accepts when any v1 matches (key rotation)", async () => {
+  const verifier = createVerifier({ scheme: "stripe" });
+  const body = "payload";
+  const t = nowSeconds();
+  const good = await sign(`${t}.${body}`);
+  const headers = new Headers({
+    "stripe-signature": `t=${t},v1=${"00".repeat(32)},v1=${good}`,
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("stripe verifier: rejects a stale timestamp (replay)", async () => {
+  const verifier = createVerifier({ scheme: "stripe" });
+  const body = "payload";
+  const t = nowSeconds() - 3600; // an hour old, well outside tolerance
+  const v1 = await sign(`${t}.${body}`);
+  const headers = new Headers({ "stripe-signature": `t=${t},v1=${v1}` });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+Deno.test("stripe verifier: rejects a missing timestamp", async () => {
+  const verifier = createVerifier({ scheme: "stripe" });
+  const headers = new Headers({ "stripe-signature": `v1=${"ab".repeat(32)}` });
+  assertEquals(await verifier.verify(enc("payload"), headers, SECRET), false);
+});
+
+// ── slack ───────────────────────────────────────────────────────────────
+
+Deno.test("slack verifier: accepts a fresh valid signature", async () => {
+  const verifier = createVerifier({ scheme: "slack" });
+  const body = "token=abc&team_id=T1";
+  const ts = nowSeconds();
+  const v0 = await sign(`v0:${ts}:${body}`);
+  const headers = new Headers({
+    "x-slack-signature": `v0=${v0}`,
+    "x-slack-request-timestamp": String(ts),
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), true);
+});
+
+Deno.test("slack verifier: rejects a stale timestamp", async () => {
+  const verifier = createVerifier({ scheme: "slack" });
+  const body = "payload";
+  const ts = nowSeconds() - 3600;
+  const v0 = await sign(`v0:${ts}:${body}`);
+  const headers = new Headers({
+    "x-slack-signature": `v0=${v0}`,
+    "x-slack-request-timestamp": String(ts),
+  });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+Deno.test("slack verifier: rejects a missing timestamp header", async () => {
+  const verifier = createVerifier({ scheme: "slack" });
+  const body = "payload";
+  const v0 = await sign(`v0:${nowSeconds()}:${body}`);
+  const headers = new Headers({ "x-slack-signature": `v0=${v0}` });
+  assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+// ── isWebhookScheme ─────────────────────────────────────────────────────
+
+Deno.test("isWebhookScheme: recognizes known schemes", () => {
+  assertEquals(isWebhookScheme("github"), true);
+  assertEquals(isWebhookScheme("generic"), true);
+});
+
+Deno.test("isWebhookScheme: rejects unknown schemes", () => {
+  assertEquals(isWebhookScheme("service_butthole"), false);
+  assertEquals(isWebhookScheme(""), false);
+});


### PR DESCRIPTION
## Summary

`swamp serve --webhook` previously only verified GitHub-style `X-Hub-Signature-256` HMACs, blocking integration with any other provider. This adds a closed set of verification schemes — **github** (default), **linear**, **stripe**, **slack**, and **generic** — selected via an optional positional field on the flag:

```
<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]
```

A scheme is recognized **only when the fourth field is a known keyword**, so every existing flag (including colon-bearing secrets) keeps working unchanged. The default stays github.

### Design notes
- Verifiers live in `src/serve/webhook_verifiers.ts`, sharing one HMAC-SHA256 + constant-time-compare primitive; each is a pure function of `(body, headers, secret)`.
- **Stripe/slack** reject stale timestamps (300s tolerance → replay protection); **stripe** accepts any matching `v1` for secret rotation.
- All verification failures return a **uniform 401** to avoid a verification-stage oracle.
- `buildWebhookPayload` now excludes the **active scheme's** signature header (not just github's) from the payload exposed to `trigger.inputs` (builds on #717).

### Scope / follow-ups
- A data-driven/templated engine so a new provider needs no swamp release is intentionally **out of scope** here and tracked in **#723**.
- The colon-secret backward-compat limitation (a secret whose colon-tail equals a reserved keyword would be reinterpreted) is documented and also folded into #723.
- UAT gap filed in swamp-uat #278; manual docs gap filed in #1629.

Implements swamp-club lab issue **#716**.

## Test Plan

- **Unit** — `src/serve/webhook_verifiers_test.ts` (per-scheme valid/invalid/wrong-secret/missing-header/tampered/empty; stripe multi-v1 + stale; slack v0 + stale + missing timestamp; generic prefix match/mismatch + header case) and extended `webhook_test.ts` (new grammar incl. legacy colon-secret, scheme-specific header exclusion).
- **Integration** — `integration/webhook_signature_schemes_test.ts` drives `WebhookService.handleRequest` with real signed requests (linear + stripe), runtime timestamps.
- **Full gate** — `deno check` / `deno lint` / `deno fmt` clean; `deno run test` → 7578 passed, 0 failed; `deno run compile` succeeds.
- **End-to-end harness** — real `swamp serve` over HTTP with openssl-computed signatures: all 5 schemes accept correctly-signed requests (200, 5 unique workflow runs triggered) and reject forged / missing-header / replayed / wrong-prefix / wrong-secret requests (401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)