### PR TITLE
fix(telemetry): revert 200ms flush timeout and guard cleanup against unflushed data loss

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1282,21 +1282,22 @@ export async function runCli(args: string[]): Promise<void> {
       if (telemetryCtx) {
         await telemetryCtx.service.recordSuccess(commandInfo, startTime);
 
-        // Flush telemetry to remote endpoint with a 200ms timeout — fast/local
-        // endpoints flush within the window; slow endpoints rely on the
-        // next-invocation retry (data is already persisted to the spool).
         const sender = new HttpTelemetrySender(
           telemetryCtx.telemetryEndpoint,
           USER_AGENT,
         );
-        await telemetryCtx.service.flushTelemetry({
+        const flushed = await telemetryCtx.service.flushTelemetry({
           sender,
           distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
           repoId: telemetryCtx.repoId,
           authToken: telemetryCtx.authToken ?? undefined,
           keepFlushed: telemetryCtx.keepFlushed,
-          signal: AbortSignal.timeout(200),
+          signal: AbortSignal.timeout(2000),
         });
+        if (!flushed) {
+          logger
+            .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+        }
 
         // Trigger cleanup asynchronously (fire-and-forget)
         telemetryCtx.service.cleanupOldTelemetry();
@@ -1426,7 +1427,7 @@ export async function runCli(args: string[]): Promise<void> {
         repoId: telemetryCtx.repoId,
         authToken: telemetryCtx.authToken ?? undefined,
         keepFlushed: telemetryCtx.keepFlushed,
-        signal: AbortSignal.timeout(200),
+        signal: AbortSignal.timeout(2000),
       });
     }
     throw error;

--- a/src/domain/telemetry/repositories.ts
+++ b/src/domain/telemetry/repositories.ts
@@ -50,12 +50,22 @@ export interface TelemetryRepository {
   findByDateRange(startDate: Date, endDate: Date): Promise<TelemetryEntry[]>;
 
   /**
-   * Deletes all telemetry entries older than the given date.
+   * Deletes flushed telemetry entries older than the given date.
+   * Unflushed entries are preserved for retry.
    *
-   * @param date - Delete entries older than this date
+   * @param date - Delete flushed entries older than this date
    * @returns The number of entries deleted
    */
   deleteOlderThan(date: Date): Promise<number>;
+
+  /**
+   * Deletes ALL telemetry entries older than the given date,
+   * regardless of flush status. Hard retention cap.
+   *
+   * @param date - Delete all entries older than this date
+   * @returns The number of entries deleted
+   */
+  deleteAllOlderThan(date: Date): Promise<number>;
 
   /**
    * Finds unflushed telemetry entries, sorted oldest first.

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -75,8 +75,11 @@ export interface TelemetryStats {
   daysAnalyzed: number;
 }
 
-/** Default retention period in days */
+/** Default retention period for flushed entries in days */
 const DEFAULT_RETENTION_DAYS = 2;
+
+/** Hard retention cap for all entries (including unflushed) in days */
+const HARD_RETENTION_DAYS = 7;
 
 /**
  * Service for recording and analyzing CLI telemetry.
@@ -218,16 +221,26 @@ export class TelemetryService {
 
   /**
    * Cleans up telemetry entries older than the retention period.
+   * Flushed entries are cleaned after `retentionDays` (default 2).
+   * Unflushed entries survive until the hard cap (`HARD_RETENTION_DAYS`,
+   * 7 days) to allow retry, then are deleted to prevent unbounded growth.
+   *
    * This method is fire-and-forget and does not block.
    *
-   * @param retentionDays - Number of days to retain (default: 2)
+   * @param retentionDays - Number of days to retain flushed entries (default: 2)
    */
   cleanupOldTelemetry(retentionDays: number = DEFAULT_RETENTION_DAYS): void {
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+    const flushedCutoff = new Date();
+    flushedCutoff.setDate(flushedCutoff.getDate() - retentionDays);
+
+    const hardCutoff = new Date();
+    hardCutoff.setDate(hardCutoff.getDate() - HARD_RETENTION_DAYS);
 
     // Fire-and-forget: don't await, don't let errors propagate
-    this.repository.deleteOlderThan(cutoffDate).catch((error) => {
+    Promise.all([
+      this.repository.deleteOlderThan(flushedCutoff),
+      this.repository.deleteAllOlderThan(hardCutoff),
+    ]).catch((error) => {
       if (Deno.env.get("SWAMP_DEBUG")) {
         console.error("[Telemetry] Cleanup failed:", error);
       }
@@ -236,31 +249,28 @@ export class TelemetryService {
 
   /**
    * Flushes unflushed telemetry entries to a remote endpoint.
-   * Returns a promise that resolves when the flush completes (or fails silently).
-   * Callers should await this before process exit to ensure data is sent.
+   * Returns true if the flush succeeded (or there was nothing to flush),
+   * false if the send failed. Never throws.
    *
    * @param config - Flush configuration with sender and distinctId
    */
-  flushTelemetry(config: TelemetryFlushConfig): Promise<void> {
+  async flushTelemetry(config: TelemetryFlushConfig): Promise<boolean> {
     const batchSize = config.batchSize ?? DEFAULT_FLUSH_BATCH_SIZE;
     const keepFlushed = config.keepFlushed ?? false;
 
-    return this.doFlush(
-      config.sender,
-      config.distinctId,
-      batchSize,
-      keepFlushed,
-      config.repoId,
-      config.authToken,
-      config.signal,
-    )
-      .catch(
-        (error) => {
-          if (Deno.env.get("SWAMP_DEBUG")) {
-            console.error("[Telemetry] Flush failed:", error);
-          }
-        },
+    try {
+      return await this.doFlush(
+        config.sender,
+        config.distinctId,
+        batchSize,
+        keepFlushed,
+        config.repoId,
+        config.authToken,
+        config.signal,
       );
+    } catch {
+      return false;
+    }
   }
 
   private async doFlush(
@@ -271,9 +281,9 @@ export class TelemetryService {
     repoId?: string,
     authToken?: string,
     signal?: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const entries = await this.repository.findUnflushed(batchSize);
-    if (entries.length === 0) return;
+    if (entries.length === 0) return true;
 
     const success = await sender.sendBatch(
       entries,
@@ -287,6 +297,7 @@ export class TelemetryService {
         await this.repository.markFlushed(entry, keepFlushed);
       }
     }
+    return success;
   }
 
   /**

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -30,6 +30,7 @@ class MockTelemetryRepository implements TelemetryRepository {
   mockUnflushedEntries: TelemetryEntry[] = [];
   flushedEntries: TelemetryEntry[] = [];
   deletedBefore: Date | null = null;
+  deleteAllBefore: Date | null = null;
 
   save(entry: TelemetryEntry): Promise<void> {
     this.savedEntries.push(entry);
@@ -49,7 +50,12 @@ class MockTelemetryRepository implements TelemetryRepository {
 
   deleteOlderThan(date: Date): Promise<number> {
     this.deletedBefore = date;
-    return Promise.resolve(5); // Mock deleted count
+    return Promise.resolve(5);
+  }
+
+  deleteAllOlderThan(date: Date): Promise<number> {
+    this.deleteAllBefore = date;
+    return Promise.resolve(3);
   }
 
   findUnflushed(_limit: number): Promise<TelemetryEntry[]> {
@@ -272,15 +278,19 @@ Deno.test("TelemetryService.flushTelemetry sends unflushed entries and marks the
   );
   repo.mockUnflushedEntries = [entry1, entry2];
 
-  await service.flushTelemetry({ sender, distinctId: "repo-uuid" });
+  const result = await service.flushTelemetry({
+    sender,
+    distinctId: "repo-uuid",
+  });
 
+  assertEquals(result, true);
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(sender.sentBatches[0].entries.length, 2);
   assertEquals(sender.sentBatches[0].distinctId, "repo-uuid");
   assertEquals(repo.flushedEntries.length, 2);
 });
 
-Deno.test("TelemetryService.flushTelemetry does not mark flushed on send failure", async () => {
+Deno.test("TelemetryService.flushTelemetry returns false on send failure", async () => {
   const repo = new MockTelemetryRepository();
   const sender = new MockTelemetrySender();
   sender.shouldSucceed = false;
@@ -292,21 +302,29 @@ Deno.test("TelemetryService.flushTelemetry does not mark flushed on send failure
   );
   repo.mockUnflushedEntries = [entry];
 
-  await service.flushTelemetry({ sender, distinctId: "repo-uuid" });
+  const result = await service.flushTelemetry({
+    sender,
+    distinctId: "repo-uuid",
+  });
 
+  assertEquals(result, false);
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(repo.flushedEntries.length, 0);
 });
 
-Deno.test("TelemetryService.flushTelemetry is a no-op when no unflushed entries", async () => {
+Deno.test("TelemetryService.flushTelemetry returns true when no unflushed entries", async () => {
   const repo = new MockTelemetryRepository();
   const sender = new MockTelemetrySender();
   const service = new TelemetryService(repo, "1.0.0");
 
   repo.mockUnflushedEntries = [];
 
-  await service.flushTelemetry({ sender, distinctId: "repo-uuid" });
+  const result = await service.flushTelemetry({
+    sender,
+    distinctId: "repo-uuid",
+  });
 
+  assertEquals(result, true);
   assertEquals(sender.sentBatches.length, 0);
   assertEquals(repo.flushedEntries.length, 0);
 });

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -132,9 +132,27 @@ export class JsonTelemetryRepository implements TelemetryRepository {
   }
 
   /**
-   * Deletes all telemetry entries older than the given date.
+   * Deletes flushed telemetry entries older than the given date.
+   * Only removes `.flushed.json` files — unflushed entries are preserved
+   * so they can still be retried on the next invocation.
    */
-  async deleteOlderThan(date: Date): Promise<number> {
+  deleteOlderThan(date: Date): Promise<number> {
+    return this.deleteByDate(date, true);
+  }
+
+  /**
+   * Deletes ALL telemetry entries older than the given date, regardless
+   * of flush status. Used as a hard retention cap to prevent unbounded
+   * disk growth when the remote endpoint is permanently unreachable.
+   */
+  deleteAllOlderThan(date: Date): Promise<number> {
+    return this.deleteByDate(date, false);
+  }
+
+  private async deleteByDate(
+    date: Date,
+    flushedOnly: boolean,
+  ): Promise<number> {
     let deletedCount = 0;
     const cutoffDateStr = date.toISOString().split("T")[0];
 
@@ -147,7 +165,10 @@ export class JsonTelemetryRepository implements TelemetryRepository {
           entry.name.startsWith("telemetry-") &&
           entry.name.endsWith(".json")
         ) {
-          // Extract date from filename: telemetry-YYYY-MM-DD-uuid.json
+          if (flushedOnly && !entry.name.endsWith(".flushed.json")) {
+            continue;
+          }
+
           const dateMatch = entry.name.match(/^telemetry-(\d{4}-\d{2}-\d{2})-/);
           if (dateMatch) {
             const fileDate = dateMatch[1];
@@ -167,7 +188,6 @@ export class JsonTelemetryRepository implements TelemetryRepository {
       if (error instanceof Deno.errors.NotFound) {
         return 0;
       }
-      // Log but don't throw for cleanup operations
       if (Deno.env.get("SWAMP_DEBUG")) {
         console.error("[Telemetry] Cleanup error:", error);
       }

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -233,11 +233,11 @@ Deno.test("JsonTelemetryRepository.findByDateRange includes both boundary dates"
   });
 });
 
-Deno.test("JsonTelemetryRepository.deleteOlderThan deletes files older than cutoff", async () => {
+Deno.test("JsonTelemetryRepository.deleteOlderThan deletes flushed files older than cutoff", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonTelemetryRepository(dir);
 
-    // Create an old entry and a recent entry
+    // Create an old flushed entry and a recent entry
     const oldEntry = createTestEntry({
       id: "old-entry-uuid",
       date: new Date("2024-01-01T10:00:00Z"),
@@ -249,15 +249,13 @@ Deno.test("JsonTelemetryRepository.deleteOlderThan deletes files older than cuto
 
     await repo.save(oldEntry);
     await repo.save(recentEntry);
+    await repo.markFlushed(oldEntry, true);
 
-    // Delete entries older than June 1st
+    // Delete flushed entries older than June 1st
     const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
     assertEquals(deletedCount, 1);
 
-    // Verify only recent entry remains
-    const oldEntries = await repo.findByDate(new Date("2024-01-01"));
-    assertEquals(oldEntries.length, 0);
-
+    // Verify recent entry remains
     const recentEntries = await repo.findByDate(new Date("2024-06-15"));
     assertEquals(recentEntries.length, 1);
   });
@@ -294,30 +292,25 @@ Deno.test("JsonTelemetryRepository.deleteOlderThan keeps files on/after cutoff d
   });
 });
 
-Deno.test("JsonTelemetryRepository.deleteOlderThan returns correct deletion count", async () => {
+Deno.test("JsonTelemetryRepository.deleteOlderThan skips unflushed entries", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonTelemetryRepository(dir);
 
-    // Create multiple old entries
-    const oldEntry1 = createTestEntry({
-      id: "old-entry-1-uuid",
+    const oldUnflushed = createTestEntry({
+      id: "old-unflushed-uuid",
       date: new Date("2024-01-10T10:00:00Z"),
     });
-    const oldEntry2 = createTestEntry({
-      id: "old-entry-2-uuid",
-      date: new Date("2024-01-15T10:00:00Z"),
-    });
-    const oldEntry3 = createTestEntry({
-      id: "old-entry-3-uuid",
-      date: new Date("2024-01-20T10:00:00Z"),
-    });
 
-    await repo.save(oldEntry1);
-    await repo.save(oldEntry2);
-    await repo.save(oldEntry3);
+    await repo.save(oldUnflushed);
 
+    // deleteOlderThan should skip unflushed entries
     const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
-    assertEquals(deletedCount, 3);
+    assertEquals(deletedCount, 0);
+
+    // Unflushed entry should still exist
+    const remaining = await repo.findUnflushed(25);
+    assertEquals(remaining.length, 1);
+    assertEquals(remaining[0].id, "old-unflushed-uuid");
   });
 });
 
@@ -461,7 +454,7 @@ Deno.test("JsonTelemetryRepository.markFlushed does not throw on non-existent fi
   });
 });
 
-Deno.test("JsonTelemetryRepository.deleteOlderThan cleans up both flushed and unflushed files", async () => {
+Deno.test("JsonTelemetryRepository.deleteOlderThan preserves unflushed entries while removing flushed", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonTelemetryRepository(dir);
 
@@ -485,8 +478,47 @@ Deno.test("JsonTelemetryRepository.deleteOlderThan cleans up both flushed and un
     // Mark one as flushed with keepFlushed to create .flushed.json
     await repo.markFlushed(flushedEntry, true);
 
-    // Delete entries older than June 1st
+    // deleteOlderThan only removes flushed entries
     const deletedCount = await repo.deleteOlderThan(new Date("2024-06-01"));
+    assertEquals(deletedCount, 1);
+
+    // Unflushed old entry and recent entry should remain
+    const telemetryDir = join(dir, ".swamp", "telemetry");
+    const files: string[] = [];
+    for await (const f of Deno.readDir(telemetryDir)) {
+      files.push(f.name);
+    }
+    assertEquals(files.length, 2);
+    const sorted = files.sort();
+    assertEquals(sorted[0], "telemetry-2024-01-01-unflushed-old-uuid.json");
+    assertEquals(sorted[1], "telemetry-2024-06-15-recent-uuid.json");
+  });
+});
+
+Deno.test("JsonTelemetryRepository.deleteAllOlderThan removes both flushed and unflushed entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    const unflushedEntry = createTestEntry({
+      id: "unflushed-old-uuid",
+      date: new Date("2024-01-01T10:00:00Z"),
+    });
+    const flushedEntry = createTestEntry({
+      id: "flushed-old-uuid",
+      date: new Date("2024-01-02T10:00:00Z"),
+    });
+    const recentEntry = createTestEntry({
+      id: "recent-uuid",
+      date: new Date("2024-06-15T10:00:00Z"),
+    });
+
+    await repo.save(unflushedEntry);
+    await repo.save(flushedEntry);
+    await repo.save(recentEntry);
+    await repo.markFlushed(flushedEntry, true);
+
+    // deleteAllOlderThan removes everything regardless of flush status
+    const deletedCount = await repo.deleteAllOlderThan(new Date("2024-06-01"));
     assertEquals(deletedCount, 2);
 
     // Only recent entry should remain
@@ -496,10 +528,7 @@ Deno.test("JsonTelemetryRepository.deleteOlderThan cleans up both flushed and un
       files.push(f.name);
     }
     assertEquals(files.length, 1);
-    assertEquals(
-      files[0],
-      "telemetry-2024-06-15-recent-uuid.json",
-    );
+    assertEquals(files[0], "telemetry-2024-06-15-recent-uuid.json");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes swamp-club#731 — telemetry files accumulate locally but are never synced to swamp-club, then silently deleted after the 2-day retention window.

**Root cause:** Commit 9dda1cb6 (PR #1594, fixing #671) reduced the telemetry flush timeout from 2s to 200ms. The production endpoint `telemetry.swamp-club.com` consistently exceeds 200ms, so `sendBatch` returns `false`, entries are never marked flushed, and `cleanupOldTelemetry()` permanently deletes them after 2 days — silent data loss.

**This PR:**
- Reverts flush timeout from 200ms → 2s (re-introduces #671 CLI exit latency; a background daemon is the proper long-term fix)
- Guards `deleteOlderThan` to only remove `.flushed.json` files — unflushed entries survive for retry
- Adds 7-day hard retention cap (`deleteAllOlderThan`) to prevent unbounded disk growth if the endpoint is permanently unreachable
- Changes `flushTelemetry` to return `boolean` so callers can observe failure
- Logs a warning via LogTape when flush fails on the success path

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint errors
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test` — all 7580 tests pass (0 failures)
- [x] Updated 3 existing tests for new `deleteOlderThan` behavior (flushed-only)
- [x] Added 2 new tests: unflushed entry preservation, `deleteAllOlderThan` hard cap
- [x] Updated 3 flush tests to verify new boolean return value

Co-authored-by: Magistr <umag@users.noreply.github.com>