### PR TITLE
fix(serve-auth): canonicalize typeArg before access-model authorization check

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -109,6 +109,8 @@ import {
   GROUP_MODEL_TYPE,
   GroupSchema,
 } from "../domain/models/access/group_model.ts";
+import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
+import { ModelType } from "../domain/models/model_type.ts";
 import type { DataRecord } from "../domain/data/data_record.ts";
 import {
   parsePrincipal,
@@ -687,18 +689,30 @@ export function handleMessage(
   task.finally(() => activeRequests.delete(request.id));
 }
 
+// SECURITY: Authorization must operate on canonical (normalized) model types,
+// never raw client input. ModelType.normalize() applies lowercasing, separator
+// canonicalization (:: . whitespace → /), and deduplication. Any raw typeArg
+// that normalizes to an access-control model type must require admin authority.
 function isAccessModelType(
   typeArg: string | undefined,
   resolvedType: string | undefined,
 ): boolean {
   const grantType = GRANT_MODEL_TYPE.normalized;
   const groupType = GROUP_MODEL_TYPE.normalized;
+  const serverTokenType = SERVER_TOKEN_MODEL_TYPE.normalized;
   if (typeArg) {
     const stripped = typeArg.startsWith("@") ? typeArg.slice(1) : typeArg;
-    if (stripped === grantType || stripped === groupType) return true;
+    const normalized = ModelType.create(stripped).normalized;
+    if (
+      normalized === grantType || normalized === groupType ||
+      normalized === serverTokenType
+    ) return true;
   }
   if (resolvedType) {
-    if (resolvedType === grantType || resolvedType === groupType) return true;
+    if (
+      resolvedType === grantType || resolvedType === groupType ||
+      resolvedType === serverTokenType
+    ) return true;
   }
   return false;
 }

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -459,6 +459,8 @@ const stubRepoContext = {
   },
 } as unknown as ConnectionContext["repoContext"];
 
+const stubRepoDir = await Deno.makeTempDir({ prefix: "swamp_conn_test_" });
+
 function makeCtx(
   authConfig: ServeAuthConfig,
   grants: Grant[] = [],
@@ -466,6 +468,7 @@ function makeCtx(
   const ctx: Partial<ConnectionContext> = {
     authConfig,
     repoContext: stubRepoContext,
+    repoDir: stubRepoDir,
   };
   if (authConfig.mode !== "none") {
     (ctx as Record<string, unknown>).policySnapshotLoader =

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -450,12 +450,22 @@ function makeMockSnapshotLoader(
   } as unknown as PolicySnapshotLoader;
 }
 
+const stubRepoContext = {
+  definitionRepo: {
+    findByNameGlobal: () => Promise.resolve(null),
+    findById: () => Promise.resolve(null),
+    listTypes: () => Promise.resolve([]),
+    listByType: () => Promise.resolve([]),
+  },
+} as unknown as ConnectionContext["repoContext"];
+
 function makeCtx(
   authConfig: ServeAuthConfig,
   grants: Grant[] = [],
 ): ConnectionContext {
   const ctx: Partial<ConnectionContext> = {
     authConfig,
+    repoContext: stubRepoContext,
   };
   if (authConfig.mode !== "none") {
     (ctx as Record<string, unknown>).policySnapshotLoader =
@@ -878,6 +888,170 @@ Deno.test("authorizeOrReject: explicit deny returns denied error frame", () => {
   assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
   const errorMessage = String((msg.error as Record<string, unknown>).message);
   assertStringIncludes(errorMessage, "explicitly denied");
+});
+
+// ── Authorization: missing policySnapshotLoader in enforcing mode ─────────
+
+// ── Authorization: denormalized access model typeArgs require admin ──────────
+// Regression tests for CVE: canonicalization mismatch between authorization
+// gate (raw typeArg) and executor (normalized ModelType). Every separator
+// variant that normalizes to an access-control model must require admin.
+
+const lowPrivGrant = makeGrant({
+  subject: { kind: "user", name: "adam" },
+  actions: ["run"],
+  resource: { kind: "model", pattern: "*" },
+});
+
+function assertDenormDenied(
+  typeArg: string,
+  label: string,
+): void {
+  Deno.test(`isAccessModelType: denormalized ${label} "${typeArg}" requires admin`, async () => {
+    const mock = createMockSocket();
+    const active = new Map<string, AbortController>();
+    const ctx = makeCtx(modeTokenConfig, [lowPrivGrant]);
+
+    handleMessage(
+      mock as unknown as WebSocket,
+      ctx,
+      active,
+      makeEvent(JSON.stringify({
+        type: "model.method.run",
+        id: `denorm-${label}`,
+        payload: {
+          modelIdOrName: "attack-def",
+          methodName: "create",
+          typeArg,
+          definitionName: "attack-def",
+        },
+      })),
+      testPrincipal,
+    );
+
+    // handleModelMethodRun is async — wait for the task to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    assertEquals(mock.sent.length, 1);
+    const msg = parseSent(mock);
+    assertEquals(msg.type, "error");
+    assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+    const errorMessage = String(
+      (msg.error as Record<string, unknown>).message,
+    );
+    assertStringIncludes(errorMessage, "admin");
+    assertStringIncludes(errorMessage, "access:*");
+  });
+}
+
+// grant: dot separator
+assertDenormDenied("swamp.grant", "grant-dot");
+// grant: double-colon separator
+assertDenormDenied("swamp::grant", "grant-doublecolon");
+// grant: uppercase
+assertDenormDenied("SWAMP/GRANT", "grant-uppercase");
+// grant: double-slash
+assertDenormDenied("swamp//grant", "grant-doubleslash");
+// grant: whitespace separator
+assertDenormDenied("swamp grant", "grant-space");
+// grant: canonical with @ prefix
+assertDenormDenied("@swamp/grant", "grant-at-prefix");
+// grant: canonical without @
+assertDenormDenied("swamp/grant", "grant-canonical");
+
+// group: dot separator
+assertDenormDenied("swamp.group", "group-dot");
+// group: double-colon separator
+assertDenormDenied("swamp::group", "group-doublecolon");
+// group: uppercase
+assertDenormDenied("SWAMP/GROUP", "group-uppercase");
+// group: whitespace separator
+assertDenormDenied("swamp group", "group-space");
+// group: canonical
+assertDenormDenied("swamp/group", "group-canonical");
+
+// server-token: dot separator (swamp.server-token normalizes to swamp/server-token)
+assertDenormDenied("swamp.server-token", "server-token-dot");
+// server-token: double-colon separator
+assertDenormDenied("swamp::server-token", "server-token-doublecolon");
+// server-token: uppercase
+assertDenormDenied("SWAMP/SERVER-TOKEN", "server-token-uppercase");
+// server-token: canonical
+assertDenormDenied("swamp/server-token", "server-token-canonical");
+
+Deno.test("isAccessModelType: normal model typeArg still uses model:* run, not admin", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, [lowPrivGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "normal-model",
+      payload: {
+        modelIdOrName: "my-shell",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  // Should NOT get an unauthorized error — the request proceeds past authz
+  for (const sent of mock.sent) {
+    const msg = JSON.parse(sent);
+    if (msg.type === "error") {
+      assertEquals(
+        (msg.error as Record<string, unknown>).code !== "unauthorized",
+        true,
+      );
+    }
+  }
+});
+
+Deno.test("isAccessModelType: admin user can still run canonical swamp/grant", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const adminGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [adminGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "admin-grant",
+      payload: {
+        modelIdOrName: "grant-def",
+        methodName: "create",
+        typeArg: "@swamp/grant",
+        definitionName: "grant-def",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  // Should not get unauthorized — admin on access:* is sufficient
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(unauthorizedErrors.length, 0);
 });
 
 // ── Authorization: missing policySnapshotLoader in enforcing mode ─────────


### PR DESCRIPTION
## Summary

Fixes a high-severity authorization bypass (CVSS 8.1) in `swamp serve` where denormalized `typeArg` values could bypass the access-control model gate.

- **Root cause:** `isAccessModelType()` compared raw client-supplied `typeArg` against normalized constants. `ModelType.normalize()` maps `.`, `::`, whitespace, `//`, and case variants to `/`, so `"swamp.grant"` bypassed the check but resolved to the built-in grant model at execution time.
- **Impact:** An authenticated low-privilege user with `model:* run` could execute `swamp/grant` to persist elevated permissions for themselves.
- **Fix:** Normalize `typeArg` via `ModelType.create()` before comparing. Also extends the check to cover `swamp/server-token` (same elevated privilege semantics as grant/group).
- **Not introduced by #1630** — the bug originates in #1613 (commit `5eb83e40`) which wired access control into the serve chokepoints.

## Test Plan

- 16 regression tests for denormalized variants across grant (7), group (5), and server-token (4) — all verify low-privilege user gets `unauthorized` requiring `admin` on `access:*`
- 1 positive test: normal model `typeArg` (`command/shell`) still authorized under `model:* run`
- 1 positive test: admin user can still create grants via canonical `@swamp/grant`
- All 59 tests pass (`deno run test src/serve/connection_test.ts`)
- `deno check`, `deno lint`, `deno fmt` all clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>