### PR TITLE
fix(serve,worker): harden error handling, security, and resource management

### DIFF
--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -100,7 +100,10 @@ export class CapabilityService {
   }
 
   #vault(): Promise<VaultService> {
-    this.#vaultService ??= this.#createVaultService();
+    this.#vaultService ??= this.#createVaultService().catch((error) => {
+      this.#vaultService = null;
+      throw error;
+    });
     return this.#vaultService;
   }
 

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -700,7 +700,14 @@ export function handleMessage(
       break;
   }
 
-  task.finally(() => activeRequests.delete(request.id));
+  task
+    .catch((error: unknown) => {
+      logger.error("Unhandled request error for {requestId}: {error}", {
+        requestId: request.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    })
+    .finally(() => activeRequests.delete(request.id));
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -84,6 +84,15 @@ function errorResponse(status: number, message: string): Response {
   return json({ error: message }, status);
 }
 
+class DataPlaneError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "DataPlaneError";
+    this.status = status;
+  }
+}
+
 function handleToJson(handle: DataHandle): Record<string, unknown> {
   return {
     dataId: handle.dataId,
@@ -151,13 +160,16 @@ export class DataPlane {
       }
       return await this.#handleData(req, segments, workerName);
     } catch (error) {
+      if (error instanceof DataPlaneError) {
+        return errorResponse(error.status, error.message);
+      }
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn("Data-plane request failed: {method} {path}: {error}", {
+      logger.error("Data-plane request failed: {method} {path}: {error}", {
         method: req.method,
         path: url.pathname,
         error: message,
       });
-      return errorResponse(400, message);
+      return errorResponse(500, "Internal server error");
     }
   }
 
@@ -172,7 +184,8 @@ export class DataPlane {
   #activeDispatch(workerName: string): ActiveDispatch {
     const dispatch = this.#options.dispatches.forWorker(workerName);
     if (dispatch === null) {
-      throw new Error(
+      throw new DataPlaneError(
+        400,
         `Worker '${workerName}' has no active dispatch — writes are lease-scoped`,
       );
     }
@@ -295,7 +308,15 @@ export class DataPlane {
     // Mark the lease BEFORE persisting: a lease may over-report writes
     // (safe, conservative) but must never under-report them.
     await this.#recordWrite(dispatch);
-    const handle = await writeResource(body.specName, body.name, body.data);
+    let handle: DataHandle;
+    try {
+      handle = await writeResource(body.specName, body.name, body.data);
+    } catch (error) {
+      throw new DataPlaneError(
+        400,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
     return json(handleToJson(handle));
   }
 
@@ -346,9 +367,13 @@ export class DataPlane {
     switch (action) {
       case "line": {
         const text = await req.text();
-        // The request body may carry one line or a small batch; each request
-        // is durable once acknowledged — the live-log contract.
-        const lines = text.length === 0 ? [""] : text.split("\n");
+        const lines = text.split("\n");
+        if (lines.length > 0 && lines[lines.length - 1] === "") {
+          lines.pop();
+        }
+        if (lines.length === 0) {
+          return json({ ok: true });
+        }
         await this.#recordWrite(dispatch);
         for (const line of lines) {
           await session.writer.writeLine(line);
@@ -445,8 +470,11 @@ export class DataPlane {
     };
     try {
       walk(filesRoot, "");
-    } catch {
-      return json({ files: [] });
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return json({ files: [] });
+      }
+      throw error;
     }
     return json({ files });
   }
@@ -456,13 +484,13 @@ export class DataPlane {
     fingerprint: string,
     relPath: string,
   ): Response {
-    let file: Deno.FsFile;
+    let bytes: Uint8Array;
     try {
-      file = Deno.openSync(target, { read: true });
+      bytes = Deno.readFileSync(target);
     } catch {
       return errorResponse(404, `No asset '${relPath}' in bundle`);
     }
-    return new Response(file.readable, {
+    return new Response(bytes.buffer as ArrayBuffer, {
       headers: {
         "content-type": "application/octet-stream",
         etag: `"${fingerprint}-${relPath}"`,

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -203,11 +203,11 @@ export class DataPlane {
   #vault(): Promise<VaultService> {
     this.#vaultService ??= (this.#options.createVaultService ??
       (() => VaultService.fromRepository(this.#options.repoDir)))().catch(
-      (error) => {
-        this.#vaultService = null;
-        throw error;
-      },
-    );
+        (error) => {
+          this.#vaultService = null;
+          throw error;
+        },
+      );
     return this.#vaultService;
   }
 

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -202,7 +202,12 @@ export class DataPlane {
 
   #vault(): Promise<VaultService> {
     this.#vaultService ??= (this.#options.createVaultService ??
-      (() => VaultService.fromRepository(this.#options.repoDir)))();
+      (() => VaultService.fromRepository(this.#options.repoDir)))().catch(
+      (error) => {
+        this.#vaultService = null;
+        throw error;
+      },
+    );
     return this.#vaultService;
   }
 

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -329,7 +329,7 @@ export class DispatchService {
       }
       if (error instanceof ChannelClosedError) {
         const hadWrites = this.#writesByDispatch.has(dispatchId);
-        const fate = await this.#awaitWorkerFate(workerName);
+        const fate = await this.#awaitWorkerFate(workerName, request.signal);
         if (hadWrites) {
           await this.#leaseTransition("fail", {
             leaseId,
@@ -440,8 +440,10 @@ export class DispatchService {
    */
   async #awaitWorkerFate(
     workerName: string,
+    signal?: AbortSignal,
   ): Promise<"reconnected" | "expired"> {
     while (true) {
+      signal?.throwIfAborted();
       const current = this.#gateway!.worker(workerName);
       if (current === null) {
         return "expired";
@@ -449,7 +451,7 @@ export class DispatchService {
       if (current.connected) {
         return "reconnected";
       }
-      await this.#waitForPoolChange(60_000, undefined);
+      await this.#waitForPoolChange(60_000, signal);
     }
   }
 

--- a/src/serve/serializer.ts
+++ b/src/serve/serializer.ts
@@ -77,7 +77,7 @@ export function serializeSwampError(error: SwampError): SerializedError {
 export function jsonSafeClone(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (value instanceof Error) {
-    return { message: value.message, stack: value.stack };
+    return { message: value.message };
   }
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) return value.map(jsonSafeClone);

--- a/src/serve/serializer_test.ts
+++ b/src/serve/serializer_test.ts
@@ -143,7 +143,7 @@ Deno.test("serializeEvent - converts Error instances to plain objects", () => {
   assertEquals(nested.err !== null && typeof nested.err === "object", true);
   const errObj = nested.err as Record<string, unknown>;
   assertEquals(errObj.message, "something broke");
-  assertExists(errObj.stack);
+  assertEquals("stack" in errObj, false);
 });
 
 Deno.test("serializeEvent - handles arrays", () => {

--- a/src/serve/serializer_test.ts
+++ b/src/serve/serializer_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import {
   deserializeEvent,
   serializeEvent,

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -458,7 +458,8 @@ export class WebhookService {
     payload: WebhookPayload,
   ): Promise<void> {
     const controller = new AbortController();
-    this.running.set(workflowIdOrName, controller);
+    const execId = crypto.randomUUID();
+    this.running.set(execId, controller);
 
     try {
       let runId = "";
@@ -507,7 +508,7 @@ export class WebhookService {
         { workflow: workflowIdOrName, error: message },
       );
     } finally {
-      this.running.delete(workflowIdOrName);
+      this.running.delete(execId);
     }
   }
 

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -412,7 +412,13 @@ export class WebhookService {
 
     // Start processing the queue — only store when actually starting
     if (!this.processing) {
-      this.processingPromise = this.processQueue();
+      this.processingPromise = this.processQueue().catch(
+        (error: unknown) => {
+          logger.error("Webhook queue processing failed: {error}", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+      );
     }
 
     return Response.json({

--- a/src/serve/webhook_verifiers.ts
+++ b/src/serve/webhook_verifiers.ts
@@ -94,13 +94,11 @@ export async function hmacSha256Hex(
     false,
     ["sign"],
   );
-  // message is always a freshly-allocated Uint8Array, so .buffer is a plain
-  // ArrayBuffer (not SharedArrayBuffer).
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    message.buffer as ArrayBuffer,
-  );
+  const data = message.buffer.slice(
+    message.byteOffset,
+    message.byteOffset + message.byteLength,
+  ) as ArrayBuffer;
+  const signature = await crypto.subtle.sign("HMAC", key, data);
   return Array.from(new Uint8Array(signature))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");

--- a/src/worker/data_plane_client.ts
+++ b/src/worker/data_plane_client.ts
@@ -50,6 +50,8 @@ export interface DataPlaneClientOptions {
   /** Per-request timeout; bulk uploads get no upper bound. */
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
+  /** Maximum cached artifacts before oldest is evicted. Defaults to 1000. */
+  maxCacheEntries?: number;
 }
 
 function combineSignals(
@@ -73,6 +75,7 @@ export class DataPlaneClient {
   readonly #options: DataPlaneClientOptions;
   readonly #fetch: typeof fetch;
   readonly #timeoutMs: number;
+  readonly #maxCacheEntries: number;
   /** Immutable (contentPath) → bytes. Versioned handles never change. */
   readonly #artifactCache = new Map<string, Uint8Array>();
 
@@ -80,6 +83,7 @@ export class DataPlaneClient {
     this.#options = options;
     this.#fetch = options.fetchImpl ?? fetch;
     this.#timeoutMs = options.timeoutMs ?? DATA_PLANE_TIMEOUT_MS;
+    this.#maxCacheEntries = options.maxCacheEntries ?? 1_000;
   }
 
   get cachedArtifactCount(): number {
@@ -130,6 +134,12 @@ export class DataPlaneClient {
     const response = await this.#request("GET", contentPath, { signal });
     const bytes = new Uint8Array(await response.arrayBuffer());
     this.#artifactCache.set(contentPath, bytes);
+    if (this.#artifactCache.size > this.#maxCacheEntries) {
+      const oldest = this.#artifactCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.#artifactCache.delete(oldest);
+      }
+    }
     return bytes;
   }
 

--- a/src/worker/data_plane_client_test.ts
+++ b/src/worker/data_plane_client_test.ts
@@ -141,6 +141,35 @@ Deno.test("DataPlaneClient: bundle and asset fetch paths are fingerprint-keyed",
   ]);
 });
 
+Deno.test("DataPlaneClient: artifact cache evicts oldest entries at capacity", async () => {
+  let fetchCount = 0;
+  const client = new DataPlaneClient({
+    baseUrl: "http://test",
+    credential: () => "c",
+    maxCacheEntries: 2,
+    fetchImpl: (() => {
+      fetchCount++;
+      return Promise.resolve(
+        new Response(new Uint8Array([fetchCount])),
+      );
+    }) as unknown as typeof fetch,
+  });
+  await client.readArtifact("/a");
+  await client.readArtifact("/b");
+  assertEquals(client.cachedArtifactCount, 2);
+  assertEquals(fetchCount, 2);
+
+  await client.readArtifact("/c");
+  assertEquals(client.cachedArtifactCount, 2);
+  assertEquals(fetchCount, 3);
+
+  await client.readArtifact("/a");
+  assertEquals(fetchCount, 4);
+
+  await client.readArtifact("/c");
+  assertEquals(fetchCount, 4);
+});
+
 Deno.test("dataPlaneUrlFromConnectUrl: maps ws→http and wss→https", () => {
   assertEquals(
     dataPlaneUrlFromConnectUrl("ws://orch.internal:4000"),


### PR DESCRIPTION
## Summary

Fixes 10 issues identified by an adversarial code review of `src/serve/` and `src/worker/`. Each fix is a separate commit.

- **Fire-and-forget promises** — add `.catch()` guards to `handleMessage` task chain and webhook `processQueue` to prevent unhandled rejections (`connection.ts`, `webhook.ts`)
- **Stack trace leak** — `jsonSafeClone` was exposing `Error.stack` to remote WebSocket clients; now only sends `message` (`serializer.ts`)
- **HMAC buffer safety** — `hmacSha256Hex` used `message.buffer` which signs wrong bytes for `Uint8Array` subarrays; now slices to the exact byte range (`webhook_verifiers.ts`)
- **Webhook AbortController clobber** — `running` map was keyed by workflow name so concurrent runs could overwrite each other's controller; now keyed by unique execution ID (`webhook.ts`)
- **awaitWorkerFate infinite loop** — the dispatch loop waiting for a disconnected worker had no abort signal; now threads the request's `AbortSignal` through (`dispatch_service.ts`)
- **Data plane error masking** — outer catch returned all errors as 400; now distinguishes client errors from server errors via `DataPlaneError` class, returns 500 for unexpected failures (`data_plane.ts`)
- **Error swallowing in listAssetFiles** — catch block swallowed all errors as empty file list; now only swallows `NotFound`, re-throws permission errors (`data_plane.ts`)
- **Line splitting bug** — `split("\n")` on newline-terminated input produced a spurious trailing empty line; now strips it (`data_plane.ts`)
- **File handle leak** — `Deno.openSync` + `file.readable` for asset serving could leak handles on client disconnect; replaced with `Deno.readFileSync` since assets are small and immutable-cached (`data_plane.ts`)
- **Vault rejection caching** — lazy `#vault()` init permanently cached a rejected promise on transient failure; now clears the cache on rejection so subsequent calls retry (`capability_service.ts`, `data_plane.ts`)
- **Unbounded artifact cache** — `DataPlaneClient` cached every artifact forever; added configurable `maxCacheEntries` (default 1000) with FIFO eviction (`data_plane_client.ts`)

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno run test` — 7581 passed, 0 failed (run 3x: pre-change baseline, post-change, post-rebase)
- [x] `deno run compile` — binary compiles
- [x] Rebased on top of #1633 and #1634 (no conflicts)
- [x] New test: artifact cache eviction at capacity (`data_plane_client_test.ts`)