### PR TITLE
fix(serve): remove dead verifySignature superseded by verifier abstraction

### DIFF
--- a/src/serve/mod.ts
+++ b/src/serve/mod.ts
@@ -34,7 +34,6 @@ export {
 } from "./deps.ts";
 export {
   parseWebhookFlag,
-  verifySignature,
   type WebhookEndpoint,
   type WebhookEndpointInfo,
   type WebhookEvent,

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -31,9 +31,7 @@ import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import {
-  constantTimeEqualHex,
   createVerifier,
-  hmacSha256Hex,
   isWebhookScheme,
   type VerifierConfig,
 } from "./webhook_verifiers.ts";
@@ -157,29 +155,6 @@ export function parseWebhookFlag(flag: string): WebhookEndpoint {
   }
 
   return { route, workflowIdOrName, secret, verifier };
-}
-
-// ── HMAC Signature Verification ────────────────────────────────────────
-
-/**
- * Verify a GitHub-style HMAC-SHA256 signature.
- *
- * @param body - Raw request body bytes
- * @param signatureHeader - The X-Hub-Signature-256 header value (sha256=<hex>)
- * @param secret - The shared secret string
- * @returns true if the signature is valid
- */
-export async function verifySignature(
-  body: Uint8Array,
-  signatureHeader: string,
-  secret: string,
-): Promise<boolean> {
-  if (!signatureHeader.startsWith("sha256=")) {
-    return false;
-  }
-  const receivedHex = signatureHeader.slice("sha256=".length);
-  const expectedHex = await hmacSha256Hex(body, secret);
-  return constantTimeEqualHex(receivedHex, expectedHex);
 }
 
 // ── Body Size Limit ────────────────────────────────────────────────────

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -18,11 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import {
-  buildWebhookPayload,
-  parseWebhookFlag,
-  verifySignature,
-} from "./webhook.ts";
+import { buildWebhookPayload, parseWebhookFlag } from "./webhook.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
 await initializeLogging({});
@@ -212,108 +208,4 @@ Deno.test("parseWebhookFlag: rejects route without leading slash", () => {
     Error,
     "must start with '/'",
   );
-});
-
-// ── verifySignature ────────────────────────────────────────────────────
-
-async function computeSignature(
-  body: string,
-  secret: string,
-): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(body),
-  );
-  const hex = Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return `sha256=${hex}`;
-}
-
-Deno.test("verifySignature: accepts valid signature", async () => {
-  const body = '{"ref":"refs/heads/main"}';
-  const secret = "test-secret";
-  const sig = await computeSignature(body, secret);
-
-  const result = await verifySignature(
-    new TextEncoder().encode(body),
-    sig,
-    secret,
-  );
-  assertEquals(result, true);
-});
-
-Deno.test("verifySignature: rejects invalid signature", async () => {
-  const body = '{"ref":"refs/heads/main"}';
-  const secret = "test-secret";
-
-  const result = await verifySignature(
-    new TextEncoder().encode(body),
-    "sha256=0000000000000000000000000000000000000000000000000000000000000000",
-    secret,
-  );
-  assertEquals(result, false);
-});
-
-Deno.test("verifySignature: rejects wrong secret", async () => {
-  const body = '{"ref":"refs/heads/main"}';
-  const sig = await computeSignature(body, "correct-secret");
-
-  const result = await verifySignature(
-    new TextEncoder().encode(body),
-    sig,
-    "wrong-secret",
-  );
-  assertEquals(result, false);
-});
-
-Deno.test("verifySignature: rejects missing sha256= prefix", async () => {
-  const result = await verifySignature(
-    new TextEncoder().encode("body"),
-    "not-a-valid-header",
-    "secret",
-  );
-  assertEquals(result, false);
-});
-
-Deno.test("verifySignature: rejects empty signature header", async () => {
-  const result = await verifySignature(
-    new TextEncoder().encode("body"),
-    "",
-    "secret",
-  );
-  assertEquals(result, false);
-});
-
-Deno.test("verifySignature: works with empty body", async () => {
-  const body = "";
-  const secret = "test-secret";
-  const sig = await computeSignature(body, secret);
-
-  const result = await verifySignature(
-    new TextEncoder().encode(body),
-    sig,
-    secret,
-  );
-  assertEquals(result, true);
-});
-
-Deno.test("verifySignature: rejects tampered body", async () => {
-  const secret = "test-secret";
-  const sig = await computeSignature("original body", secret);
-
-  const result = await verifySignature(
-    new TextEncoder().encode("tampered body"),
-    sig,
-    secret,
-  );
-  assertEquals(result, false);
 });


### PR DESCRIPTION
## Summary

- Remove the dead `verifySignature` function from `src/serve/webhook.ts` — it had zero internal callers after the pluggable webhook verifier refactor (#1630), which replaced it with `createVerifier(endpoint.verifier).verify()`
- Remove its re-export from `src/serve/mod.ts` and orphaned `hmacSha256Hex`/`constantTimeEqualHex` imports from `webhook.ts`
- Remove 8 dedicated `verifySignature` tests and the `computeSignature` helper from `webhook_test.ts`

Closes swamp-club/swamp#725

## Test Plan

- All 7625 tests pass (`deno run test`)
- `deno check`, `deno lint`, `deno fmt` all clean
- `deno run compile` succeeds
- Verified `hmacSha256Hex`/`constantTimeEqualHex` helpers remain in `webhook_verifiers.ts` where the verifier abstraction uses them

🤖 Generated with [Claude Code](https://claude.com/claude-code)