### PR TITLE
fix(serve): check all required headers in webhook pre-body gate

### DIFF
--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -307,18 +307,18 @@ export class WebhookService {
 
     const verifier = createVerifier(endpoint.verifier);
 
-    // Reject a missing signature before reading the body to avoid
-    // unauthenticated resource consumption.
-    if (!req.headers.get(verifier.signatureHeader)) {
-      this.emit({
-        kind: "webhook_rejected",
-        route: endpoint.route,
-        reason: `Missing ${verifier.signatureHeader} header`,
-      });
-      return Response.json(
-        { error: `Missing ${verifier.signatureHeader} header` },
-        { status: 401 },
-      );
+    for (const header of verifier.requiredHeaders) {
+      if (!req.headers.get(header)) {
+        this.emit({
+          kind: "webhook_rejected",
+          route: endpoint.route,
+          reason: `Missing ${header} header`,
+        });
+        return Response.json(
+          { error: `Missing ${header} header` },
+          { status: 401 },
+        );
+      }
     }
 
     // Read body with size limit — streams to avoid unbounded allocation

--- a/src/serve/webhook_verifiers.ts
+++ b/src/serve/webhook_verifiers.ts
@@ -71,6 +71,7 @@ export type VerifierConfig =
  */
 export interface WebhookVerifier {
   readonly signatureHeader: string;
+  readonly requiredHeaders: readonly string[];
   verify(
     body: Uint8Array,
     headers: Headers,
@@ -149,6 +150,7 @@ function prefixedBodyVerifier(
 ): WebhookVerifier {
   return {
     signatureHeader,
+    requiredHeaders: [signatureHeader],
     async verify(body, headers, secret) {
       const value = headers.get(signatureHeader);
       if (value === null || !value.startsWith(prefix)) {
@@ -170,6 +172,7 @@ function stripeVerifier(): WebhookVerifier {
   const signatureHeader = "stripe-signature";
   return {
     signatureHeader,
+    requiredHeaders: [signatureHeader],
     async verify(body, headers, secret) {
       const value = headers.get(signatureHeader);
       if (value === null) {
@@ -217,11 +220,13 @@ function stripeVerifier(): WebhookVerifier {
  */
 function slackVerifier(): WebhookVerifier {
   const signatureHeader = "x-slack-signature";
+  const timestampHeader = "x-slack-request-timestamp";
   return {
     signatureHeader,
+    requiredHeaders: [signatureHeader, timestampHeader],
     async verify(body, headers, secret) {
       const value = headers.get(signatureHeader);
-      const timestamp = headers.get("x-slack-request-timestamp");
+      const timestamp = headers.get(timestampHeader);
       if (value === null || !value.startsWith("v0=") || timestamp === null) {
         return false;
       }

--- a/src/serve/webhook_verifiers_test.ts
+++ b/src/serve/webhook_verifiers_test.ts
@@ -86,6 +86,11 @@ Deno.test("github verifier: accepts an empty body", async () => {
   assertEquals(await verifier.verify(enc(""), headers, SECRET), true);
 });
 
+Deno.test("github verifier: requiredHeaders contains only the signature header", () => {
+  const verifier = createVerifier({ scheme: "github" });
+  assertEquals(verifier.requiredHeaders, ["x-hub-signature-256"]);
+});
+
 // ── linear ──────────────────────────────────────────────────────────────
 
 Deno.test("linear verifier: accepts a valid bare-hex signature", async () => {
@@ -100,6 +105,11 @@ Deno.test("linear verifier: rejects an invalid signature", async () => {
   const verifier = createVerifier({ scheme: "linear" });
   const headers = new Headers({ "linear-signature": "00".repeat(32) });
   assertEquals(await verifier.verify(enc("body"), headers, SECRET), false);
+});
+
+Deno.test("linear verifier: requiredHeaders contains only the signature header", () => {
+  const verifier = createVerifier({ scheme: "linear" });
+  assertEquals(verifier.requiredHeaders, ["linear-signature"]);
 });
 
 // ── generic ─────────────────────────────────────────────────────────────
@@ -146,6 +156,15 @@ Deno.test("generic verifier: empty prefix accepts a bare digest", async () => {
   assertEquals(await verifier.verify(enc("payload"), headers, SECRET), true);
 });
 
+Deno.test("generic verifier: requiredHeaders contains only the configured header", () => {
+  const verifier = createVerifier({
+    scheme: "generic",
+    header: "X-My-Sig",
+    prefix: "",
+  });
+  assertEquals(verifier.requiredHeaders, ["x-my-sig"]);
+});
+
 // ── stripe ──────────────────────────────────────────────────────────────
 
 Deno.test("stripe verifier: accepts a fresh valid signature", async () => {
@@ -183,6 +202,11 @@ Deno.test("stripe verifier: rejects a missing timestamp", async () => {
   assertEquals(await verifier.verify(enc("payload"), headers, SECRET), false);
 });
 
+Deno.test("stripe verifier: requiredHeaders contains only the signature header", () => {
+  const verifier = createVerifier({ scheme: "stripe" });
+  assertEquals(verifier.requiredHeaders, ["stripe-signature"]);
+});
+
 // ── slack ───────────────────────────────────────────────────────────────
 
 Deno.test("slack verifier: accepts a fresh valid signature", async () => {
@@ -215,6 +239,14 @@ Deno.test("slack verifier: rejects a missing timestamp header", async () => {
   const v0 = await sign(`v0:${nowSeconds()}:${body}`);
   const headers = new Headers({ "x-slack-signature": `v0=${v0}` });
   assertEquals(await verifier.verify(enc(body), headers, SECRET), false);
+});
+
+Deno.test("slack verifier: requiredHeaders includes both signature and timestamp", () => {
+  const verifier = createVerifier({ scheme: "slack" });
+  assertEquals(verifier.requiredHeaders, [
+    "x-slack-signature",
+    "x-slack-request-timestamp",
+  ]);
 });
 
 // ── isWebhookScheme ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `requiredHeaders` to the `WebhookVerifier` interface so each scheme declares every header needed for verification
- Update the pre-body gate in `webhook.ts` to iterate `verifier.requiredHeaders` instead of checking only `verifier.signatureHeader`
- Slack's verifier now declares both `x-slack-signature` and `x-slack-request-timestamp`, so requests missing the timestamp are rejected before body consumption

Fixes swamp-club#726

## Test Plan

- [x] `requiredHeaders` tests for all 5 schemes (github, linear, generic, stripe, slack)
- [x] Existing verifier and webhook tests pass (46 total)
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)