### PR TITLE
feat(extension-source): install skills from source-path extensions (swamp-club#724)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -397,6 +397,25 @@ dev/prod parity gap where published bundles loaded all declared
 components but local source loading only discovered components matching
 their kind directory.
 
+### Source-Path Skill Installation
+
+Source-path extensions (configured via `.swamp-sources.yaml`) can provide
+skills just like registry-pulled extensions. When `extension source add`
+records a new source, it reads the source's `manifest.yaml` and — if
+the manifest declares a `skills` field — resolves and copies those skill
+directories into the repo's tool-specific skills directory (e.g.
+`.claude/skills/`). Skill resolution uses the same `paths.base` strategy
+as `extension push` and `extension quality`: under
+`paths.base: manifest`, skills are found relative to the manifest
+directory; otherwise they are found under the source root's tool-specific
+skill directories.
+
+The installed skill names are tracked in the `installedSkills` field on
+the source entry in `.swamp-sources.yaml`. When `extension source rm`
+removes a source, it reads this field and deletes the corresponding
+skill directories from the repo. This ensures cleanup does not depend
+on the source directory still being accessible at removal time.
+
 The on-wire manifest in the archive preserves the field strings
 verbatim — no path rewriting, no normalization. WYSIWYG between what
 the author pushes and what the registry stores. The archive layout

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -33,6 +33,10 @@ import {
 import { createSourceModifyRenderer } from "../../presentation/renderers/extension_source_modify.ts";
 import type { ExtensionKind } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
+import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -76,7 +80,13 @@ export const extensionSourceAddCommand = new Command()
     cliCtx.logger.debug`Adding extension source: ${path}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceAddDeps(resolveRepoDir(options.repoDir));
+    const repoDir = resolveRepoDir(options.repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const primaryTool = resolvePrimaryTool(marker);
+    const skillsDir = resolveSkillsDir(repoDir, primaryTool);
+    const deps = createSourceAddDeps(repoDir, tools, skillsDir);
 
     let only: ExtensionKind[] | undefined;
     if (options.only) {

--- a/src/cli/commands/extension_source_rm.ts
+++ b/src/cli/commands/extension_source_rm.ts
@@ -30,6 +30,10 @@ import {
   sourceRemove,
 } from "../../libswamp/mod.ts";
 import { createSourceModifyRenderer } from "../../presentation/renderers/extension_source_modify.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
+import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -55,7 +59,12 @@ export const extensionSourceRmCommand = new Command()
     cliCtx.logger.debug`Removing extension source: ${path}`;
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceRemoveDeps(resolveRepoDir(options.repoDir));
+    const repoDir = resolveRepoDir(options.repoDir);
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const primaryTool = resolvePrimaryTool(marker);
+    const skillsDir = resolveSkillsDir(repoDir, primaryTool);
+    const deps = createSourceRemoveDeps(repoDir, skillsDir);
 
     const renderer = createSourceModifyRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/domain/repo/swamp_sources.ts
+++ b/src/domain/repo/swamp_sources.ts
@@ -49,6 +49,8 @@ export interface SwampSource {
   path: string;
   /** Optional filter — only load these extension kinds from this source. */
   only?: ExtensionKind[];
+  /** Skill directory names installed from this source's manifest. */
+  installedSkills?: string[];
 }
 
 /**
@@ -86,6 +88,7 @@ const ExtensionKindSchema = z.enum([
 const SwampSourceSchema = z.object({
   path: z.string().min(1, "Source path must not be empty"),
   only: z.array(ExtensionKindSchema).optional(),
+  installedSkills: z.array(z.string()).optional(),
 });
 
 const SwampSourcesConfigSchema = z.object({

--- a/src/domain/repo/swamp_sources.ts
+++ b/src/domain/repo/swamp_sources.ts
@@ -85,10 +85,17 @@ const ExtensionKindSchema = z.enum([
   "workflows",
 ]);
 
+const safeSkillName = z.string().refine(
+  (name) =>
+    name.length > 0 && !name.includes("/") && !name.includes("\\") &&
+    !name.includes(".."),
+  { message: "Skill name must not contain path separators or '..' components" },
+);
+
 const SwampSourceSchema = z.object({
   path: z.string().min(1, "Source path must not be empty"),
   only: z.array(ExtensionKindSchema).optional(),
-  installedSkills: z.array(z.string()).optional(),
+  installedSkills: z.array(safeSkillName).optional(),
 });
 
 const SwampSourcesConfigSchema = z.object({

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -461,6 +461,7 @@ export {
   sourceAdd,
   type SourceAddDeps,
 } from "./sources/add.ts";
+export { type ResolvedSkill } from "./sources/source_skills.ts";
 export {
   createSourceRemoveDeps,
   sourceRemove,

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -35,6 +35,7 @@ import {
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
 import {
   copySourceSkills,
+  removeSourceSkills,
   type ResolvedSkill,
   resolveSourceSkills,
 } from "./source_skills.ts";
@@ -53,6 +54,8 @@ export interface SourceAddDeps {
   resolveSkills: (sourcePath: string) => Promise<ResolvedSkill[]>;
   /** Copies resolved skills to the repo's skill directory. */
   copySkills: (skills: ResolvedSkill[]) => Promise<string[]>;
+  /** Removes named skill directories (used for cleanup on partial failure). */
+  cleanupSkills: (skillNames: string[]) => Promise<void>;
 }
 
 /** Wires real infrastructure into SourceAddDeps. */
@@ -71,6 +74,8 @@ export function createSourceAddDeps(
       resolveSourceSkills(sourcePath, resolvedTools),
     copySkills: (skills) =>
       skillsDir ? copySourceSkills(skills, skillsDir) : Promise.resolve([]),
+    cleanupSkills: (skillNames) =>
+      skillsDir ? removeSourceSkills(skillNames, skillsDir) : Promise.resolve(),
   };
 }
 
@@ -108,17 +113,18 @@ export async function* sourceAdd(
   // can configure sources before the target dirs exist (pre-population).
   const tentative: SwampSource = only ? { path, only } : { path };
   const isGlob = isGlobPattern(path);
+  let cachedExpansions: SwampSource[] | undefined;
   const resolvedKinds = await deps.resolveKinds(tentative);
   if (resolvedKinds.length === 0) {
     if (isGlob) {
-      const expansions = await deps.expandSource(tentative);
-      if (expansions.length > 0) {
+      cachedExpansions = await deps.expandSource(tentative);
+      if (cachedExpansions.length > 0) {
         // Glob expanded to concrete dirs but none contributed kinds.
         yield {
           kind: "error",
           error: validationFailed(
             `No extensions found under glob '${path}'. ` +
-              `All ${expansions.length} matched path(s) lack either ` +
+              `All ${cachedExpansions.length} matched path(s) lack either ` +
               `'extensions/<kind>/' subdirectories or files declaring ` +
               `extension exports (model, vault, driver, datastore, ` +
               `report, or workflow). Check the target paths or remove ` +
@@ -147,18 +153,25 @@ export async function* sourceAdd(
   const newEntry: SwampSource = only ? { path, only } : { path };
 
   // Resolve and copy skills from the source's manifest.
-  // For glob sources, expand to concrete paths and resolve skills from each.
+  // For glob sources, reuse the cached expansion from validation.
   const sourcesToProbe = isGlob
-    ? await deps.expandSource(newEntry)
+    ? (cachedExpansions ?? await deps.expandSource(newEntry))
     : [newEntry];
 
   const allInstalledSkills: string[] = [];
-  for (const source of sourcesToProbe) {
-    const skills = await deps.resolveSkills(source.path);
-    if (skills.length > 0) {
-      const copied = await deps.copySkills(skills);
-      allInstalledSkills.push(...copied);
+  try {
+    for (const source of sourcesToProbe) {
+      const skills = await deps.resolveSkills(source.path);
+      if (skills.length > 0) {
+        const copied = await deps.copySkills(skills);
+        allInstalledSkills.push(...copied);
+      }
     }
+  } catch (error) {
+    if (allInstalledSkills.length > 0) {
+      await deps.cleanupSkills(allInstalledSkills);
+    }
+    throw error;
   }
 
   if (allInstalledSkills.length > 0) {
@@ -175,6 +188,9 @@ export async function* sourceAdd(
       path,
       only,
       totalSources: updated.length,
+      ...(allInstalledSkills.length > 0
+        ? { installedSkills: allInstalledSkills }
+        : {}),
     },
   };
 }

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -33,6 +33,11 @@ import {
   resolveExtensionKindsForSource,
   writeSwampSources,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import {
+  copySourceSkills,
+  type ResolvedSkill,
+  resolveSourceSkills,
+} from "./source_skills.ts";
 
 /** Dependencies for the source add operation. */
 export interface SourceAddDeps {
@@ -44,15 +49,28 @@ export interface SourceAddDeps {
   /** Expands globs to concrete paths. Injected alongside resolveKinds so
    * the glob-vs-concrete validation split is fully testable. */
   expandSource: (source: SwampSource) => Promise<SwampSource[]>;
+  /** Resolves skill directories from a source extension's manifest. */
+  resolveSkills: (sourcePath: string) => Promise<ResolvedSkill[]>;
+  /** Copies resolved skills to the repo's skill directory. */
+  copySkills: (skills: ResolvedSkill[]) => Promise<string[]>;
 }
 
 /** Wires real infrastructure into SourceAddDeps. */
-export function createSourceAddDeps(repoDir: string): SourceAddDeps {
+export function createSourceAddDeps(
+  repoDir: string,
+  tools?: string[],
+  skillsDir?: string,
+): SourceAddDeps {
+  const resolvedTools = tools?.length ? tools : ["claude"];
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
     resolveKinds: (source) => resolveExtensionKindsForSource(source, repoDir),
     expandSource: (source) => expandSourcePaths({ sources: [source] }, repoDir),
+    resolveSkills: (sourcePath) =>
+      resolveSourceSkills(sourcePath, resolvedTools),
+    copySkills: (skills) =>
+      skillsDir ? copySourceSkills(skills, skillsDir) : Promise.resolve([]),
   };
 }
 
@@ -89,9 +107,9 @@ export async function* sourceAdd(
   // paths must resolve to ≥1 kind; unexpanded globs are allowed so users
   // can configure sources before the target dirs exist (pre-population).
   const tentative: SwampSource = only ? { path, only } : { path };
+  const isGlob = isGlobPattern(path);
   const resolvedKinds = await deps.resolveKinds(tentative);
   if (resolvedKinds.length === 0) {
-    const isGlob = isGlobPattern(path);
     if (isGlob) {
       const expansions = await deps.expandSource(tentative);
       if (expansions.length > 0) {
@@ -126,9 +144,28 @@ export async function* sourceAdd(
     }
   }
 
-  const newEntry = only ? { path, only } : { path };
-  const updated = [...sources, newEntry];
+  const newEntry: SwampSource = only ? { path, only } : { path };
 
+  // Resolve and copy skills from the source's manifest.
+  // For glob sources, expand to concrete paths and resolve skills from each.
+  const sourcesToProbe = isGlob
+    ? await deps.expandSource(newEntry)
+    : [newEntry];
+
+  const allInstalledSkills: string[] = [];
+  for (const source of sourcesToProbe) {
+    const skills = await deps.resolveSkills(source.path);
+    if (skills.length > 0) {
+      const copied = await deps.copySkills(skills);
+      allInstalledSkills.push(...copied);
+    }
+  }
+
+  if (allInstalledSkills.length > 0) {
+    newEntry.installedSkills = allInstalledSkills;
+  }
+
+  const updated = [...sources, newEntry];
   await deps.writeSources({ sources: updated });
 
   yield {

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -53,6 +53,8 @@ function createTestDeps(
       Promise.resolve(options.resolveKinds?.(source) ?? ["models"]),
     expandSource: (source) =>
       Promise.resolve(options.expandSource?.(source) ?? [source]),
+    resolveSkills: () => Promise.resolve([]),
+    copySkills: () => Promise.resolve([]),
     get written() {
       return state.written;
     },

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -55,6 +55,7 @@ function createTestDeps(
       Promise.resolve(options.expandSource?.(source) ?? [source]),
     resolveSkills: () => Promise.resolve([]),
     copySkills: () => Promise.resolve([]),
+    cleanupSkills: () => Promise.resolve(),
     get written() {
       return state.written;
     },
@@ -375,4 +376,38 @@ Deno.test("sourceAdd e2e: mixed layout — standard wins, loose files ignored", 
     // Should succeed — standard layout has content; loose file ignored.
     assertEquals(findCompleted(events)?.kind, "completed");
   });
+});
+
+Deno.test("sourceAdd: copies skills and records installedSkills on source entry", async () => {
+  const deps = createTestDeps({
+    resolveKinds: () => ["models"],
+  });
+  (deps as unknown as Record<string, unknown>).resolveSkills = () =>
+    Promise.resolve([{ name: "my-skill", absolutePath: "/src/my-skill" }]);
+  (deps as unknown as Record<string, unknown>).copySkills = () =>
+    Promise.resolve(["my-skill"]);
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/some/path"),
+  );
+  const completed = findCompleted(events);
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.installedSkills, ["my-skill"]);
+  }
+  assertEquals(deps.written?.sources[0].installedSkills, ["my-skill"]);
+});
+
+Deno.test("sourceAdd: does not set installedSkills when no skills resolved", async () => {
+  const deps = createTestDeps({
+    resolveKinds: () => ["models"],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/some/path"),
+  );
+  const completed = findCompleted(events);
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.installedSkills, undefined);
+  }
+  assertEquals(deps.written?.sources[0].installedSkills, undefined);
 });

--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -122,6 +122,7 @@ export async function* sourceRemove(
     deps.purgeCatalogByPrefix(expandedPath);
   }
 
+  const removedSkills = removed.installedSkills;
   yield {
     kind: "completed",
     data: {
@@ -129,6 +130,7 @@ export async function* sourceRemove(
       path,
       only: removed.only,
       totalSources: updated.length,
+      ...(removedSkills?.length ? { installedSkills: removedSkills } : {}),
     },
   };
 }

--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -30,6 +30,7 @@ import {
 import { existsSync } from "@std/fs/exists";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { removeSourceSkills } from "./source_skills.ts";
 
 /** Dependencies for the source remove operation. */
 export interface SourceRemoveDeps {
@@ -38,10 +39,15 @@ export interface SourceRemoveDeps {
   removeSources: () => Promise<void>;
   purgeCatalogByPrefix: (prefix: string) => number;
   expandPath: (path: string) => Promise<string[]>;
+  /** Removes named skill directories from the repo's skills dir. */
+  removeSkills: (skillNames: string[]) => Promise<void>;
 }
 
 /** Wires real infrastructure into SourceRemoveDeps. */
-export function createSourceRemoveDeps(repoDir: string): SourceRemoveDeps {
+export function createSourceRemoveDeps(
+  repoDir: string,
+  skillsDir?: string,
+): SourceRemoveDeps {
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
@@ -63,6 +69,8 @@ export function createSourceRemoveDeps(repoDir: string): SourceRemoveDeps {
       );
       return expanded.map((s) => s.path);
     },
+    removeSkills: (skillNames) =>
+      skillsDir ? removeSourceSkills(skillNames, skillsDir) : Promise.resolve(),
   };
 }
 
@@ -96,6 +104,11 @@ export async function* sourceRemove(
 
   const removed = existing.sources[idx];
   const updated = existing.sources.filter((_, i) => i !== idx);
+
+  // Remove skills that were installed from this source.
+  if (removed.installedSkills && removed.installedSkills.length > 0) {
+    await deps.removeSkills(removed.installedSkills);
+  }
 
   if (updated.length === 0) {
     await deps.removeSources();

--- a/src/libswamp/sources/remove_test.ts
+++ b/src/libswamp/sources/remove_test.ts
@@ -73,6 +73,10 @@ async function collectEvents(
   return events;
 }
 
+function findCompleted(events: SourceModifyEvent[]) {
+  return events.find((e) => e.kind === "completed");
+}
+
 const ctx = createLibSwampContext({});
 
 Deno.test("sourceRemove: removes an existing source", async () => {
@@ -206,4 +210,39 @@ Deno.test("sourceRemove: purges multiple expanded paths from glob source", async
   await collectEvents(sourceRemove(ctx, deps, "~/code/ext-*"));
 
   assertEquals(deps.purgedPrefixes, ["/expanded/ext-one", "/expanded/ext-two"]);
+});
+
+Deno.test("sourceRemove: calls removeSkills with installed skill names", async () => {
+  const removedSkills: string[] = [];
+  const deps = createTestDeps({
+    sources: [
+      { path: "/some/ext", installedSkills: ["skill-a", "skill-b"] },
+    ],
+  });
+  deps.removeSkills = (names: string[]) => {
+    removedSkills.push(...names);
+    return Promise.resolve();
+  };
+  const events = await collectEvents(
+    sourceRemove(ctx, deps, "/some/ext"),
+  );
+  const completed = findCompleted(events);
+  assertEquals(completed?.kind, "completed");
+  assertEquals(removedSkills, ["skill-a", "skill-b"]);
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.installedSkills, ["skill-a", "skill-b"]);
+  }
+});
+
+Deno.test("sourceRemove: does not call removeSkills when no skills installed", async () => {
+  let removeSkillsCalled = false;
+  const deps = createTestDeps({
+    sources: [{ path: "/some/ext" }],
+  });
+  deps.removeSkills = () => {
+    removeSkillsCalled = true;
+    return Promise.resolve();
+  };
+  await collectEvents(sourceRemove(ctx, deps, "/some/ext"));
+  assertEquals(removeSkillsCalled, false);
 });

--- a/src/libswamp/sources/remove_test.ts
+++ b/src/libswamp/sources/remove_test.ts
@@ -50,6 +50,7 @@ function createTestDeps(
       return 1;
     },
     expandPath: (path: string) => Promise.resolve([path]),
+    removeSkills: () => Promise.resolve(),
     get written() {
       return state.written;
     },
@@ -190,6 +191,7 @@ Deno.test("sourceRemove: purges multiple expanded paths from glob source", async
     },
     expandPath: () =>
       Promise.resolve(["/expanded/ext-one", "/expanded/ext-two"]),
+    removeSkills: () => Promise.resolve(),
     get written() {
       return state.written;
     },

--- a/src/libswamp/sources/source_events.ts
+++ b/src/libswamp/sources/source_events.ts
@@ -26,6 +26,8 @@ export interface SourceModifyData {
   path: string;
   only?: ExtensionKind[];
   totalSources: number;
+  /** Skill directory names installed or removed by this operation. */
+  installedSkills?: string[];
 }
 
 /** Events emitted by source add/remove operations. */

--- a/src/libswamp/sources/source_skills.ts
+++ b/src/libswamp/sources/source_skills.ts
@@ -18,8 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { dirname, join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
 import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
 import { SKILL_DIRS } from "../../domain/repo/skill_dirs.ts";
+
+const logger = getLogger(["swamp", "sources", "skills"]);
 
 export interface ResolvedSkill {
   name: string;
@@ -97,7 +100,9 @@ export async function resolveSourceSkills(
 
 /**
  * Copies resolved skill directories to the target skills directory.
- * Returns the list of skill names that were copied.
+ * Skips skills whose target directory already exists (from another source
+ * or user-authored) and logs a warning. Returns the list of skill names
+ * that were actually copied.
  */
 export async function copySourceSkills(
   skills: ResolvedSkill[],
@@ -110,6 +115,13 @@ export async function copySourceSkills(
   const copied: string[] = [];
   for (const skill of skills) {
     const destDir = join(targetSkillsDir, skill.name);
+    try {
+      const stat = await Deno.stat(destDir);
+      if (stat.isDirectory) {
+        logger.warn`Skill ${skill.name} already exists at ${destDir}, skipping`;
+        continue;
+      }
+    } catch { /* not found — safe to copy */ }
     await Deno.mkdir(destDir, { recursive: true });
     await copyDir(skill.absolutePath, destDir);
     copied.push(skill.name);
@@ -127,6 +139,9 @@ export async function removeSourceSkills(
   targetSkillsDir: string,
 ): Promise<void> {
   for (const name of skillNames) {
+    if (name.includes("/") || name.includes("\\") || name.includes("..")) {
+      continue;
+    }
     const skillDir = join(targetSkillsDir, name);
     try {
       await Deno.remove(skillDir, { recursive: true });
@@ -151,7 +166,10 @@ async function copyDir(srcDir: string, destDir: string): Promise<void> {
   for await (const entry of Deno.readDir(srcDir)) {
     const srcPath = join(srcDir, entry.name);
     const destPath = join(destDir, entry.name);
-    if (entry.isDirectory) {
+    if (entry.isSymlink) {
+      const target = await Deno.readLink(srcPath);
+      await Deno.symlink(target, destPath, { type: "file" });
+    } else if (entry.isDirectory) {
       await Deno.mkdir(destPath, { recursive: true });
       await copyDir(srcPath, destPath);
     } else if (entry.isFile) {

--- a/src/libswamp/sources/source_skills.ts
+++ b/src/libswamp/sources/source_skills.ts
@@ -1,0 +1,161 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import { parseExtensionManifest } from "../../domain/extensions/extension_manifest.ts";
+import { SKILL_DIRS } from "../../domain/repo/skill_dirs.ts";
+
+export interface ResolvedSkill {
+  name: string;
+  absolutePath: string;
+}
+
+/**
+ * Reads a source extension's manifest.yaml and resolves skill directories
+ * relative to the source. Only searches within the source itself — does not
+ * search project-local or global skill directories.
+ */
+export async function resolveSourceSkills(
+  sourcePath: string,
+  tools: string[],
+): Promise<ResolvedSkill[]> {
+  const manifestPath = await findManifest(sourcePath);
+  if (!manifestPath) return [];
+
+  let content: string;
+  try {
+    content = await Deno.readTextFile(manifestPath);
+  } catch {
+    return [];
+  }
+
+  let manifest;
+  try {
+    manifest = parseExtensionManifest(content);
+  } catch {
+    return [];
+  }
+
+  if (manifest.skills.length === 0) return [];
+
+  const manifestDir = dirname(manifestPath);
+  const useManifestBase = manifest.paths.base === "manifest";
+
+  const candidateBases: string[] = [];
+  const seen = new Set<string>();
+  const addCandidate = (dir: string) => {
+    if (!seen.has(dir)) {
+      seen.add(dir);
+      candidateBases.push(dir);
+    }
+  };
+
+  // Only search within the source — manifest-relative tool dirs
+  for (const tool of tools) {
+    const rel = SKILL_DIRS[tool];
+    if (!rel) continue;
+    if (useManifestBase) {
+      addCandidate(join(manifestDir, rel));
+    }
+    addCandidate(join(sourcePath, rel));
+  }
+
+  if (candidateBases.length === 0) return [];
+
+  const resolved: ResolvedSkill[] = [];
+  for (const skillName of manifest.skills) {
+    for (const base of candidateBases) {
+      const candidate = join(base, skillName);
+      try {
+        const stat = await Deno.stat(candidate);
+        if (stat.isDirectory) {
+          resolved.push({ name: skillName, absolutePath: candidate });
+          break;
+        }
+      } catch { /* not found here */ }
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Copies resolved skill directories to the target skills directory.
+ * Returns the list of skill names that were copied.
+ */
+export async function copySourceSkills(
+  skills: ResolvedSkill[],
+  targetSkillsDir: string,
+): Promise<string[]> {
+  if (skills.length === 0) return [];
+
+  await Deno.mkdir(targetSkillsDir, { recursive: true });
+
+  const copied: string[] = [];
+  for (const skill of skills) {
+    const destDir = join(targetSkillsDir, skill.name);
+    await Deno.mkdir(destDir, { recursive: true });
+    await copyDir(skill.absolutePath, destDir);
+    copied.push(skill.name);
+  }
+
+  return copied;
+}
+
+/**
+ * Removes named skill directories from the target skills directory.
+ * Silently skips directories that don't exist.
+ */
+export async function removeSourceSkills(
+  skillNames: string[],
+  targetSkillsDir: string,
+): Promise<void> {
+  for (const name of skillNames) {
+    const skillDir = join(targetSkillsDir, name);
+    try {
+      await Deno.remove(skillDir, { recursive: true });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+}
+
+async function findManifest(sourcePath: string): Promise<string | null> {
+  const candidate = join(sourcePath, "manifest.yaml");
+  try {
+    const stat = await Deno.stat(candidate);
+    if (stat.isFile) return candidate;
+  } catch { /* not found */ }
+  return null;
+}
+
+async function copyDir(srcDir: string, destDir: string): Promise<void> {
+  for await (const entry of Deno.readDir(srcDir)) {
+    const srcPath = join(srcDir, entry.name);
+    const destPath = join(destDir, entry.name);
+    if (entry.isDirectory) {
+      await Deno.mkdir(destPath, { recursive: true });
+      await copyDir(srcPath, destPath);
+    } else if (entry.isFile) {
+      await Deno.copyFile(srcPath, destPath);
+    }
+  }
+}

--- a/src/libswamp/sources/source_skills_test.ts
+++ b/src/libswamp/sources/source_skills_test.ts
@@ -1,0 +1,219 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  copySourceSkills,
+  removeSourceSkills,
+  resolveSourceSkills,
+} from "./source_skills.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function writeFile(path: string, content: string): Promise<void> {
+  await Deno.mkdir(join(path, ".."), { recursive: true }).catch(() => {});
+  await Deno.writeTextFile(path, content);
+}
+
+Deno.test("resolveSourceSkills: returns empty when no manifest exists", async () => {
+  await withTempDir(async (dir) => {
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills, []);
+  });
+});
+
+Deno.test("resolveSourceSkills: returns empty when manifest has no skills", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      join(dir, "manifest.yaml"),
+      `manifestVersion: 1
+name: "@test/no-skills"
+version: "2026.01.01.1"
+models:
+  - my-model.ts
+`,
+    );
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills, []);
+  });
+});
+
+Deno.test("resolveSourceSkills: resolves skills from manifest with paths.base=manifest", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      join(dir, "manifest.yaml"),
+      `manifestVersion: 1
+name: "@test/with-skills"
+version: "2026.01.01.1"
+paths:
+  base: manifest
+skills:
+  - my-skill
+`,
+    );
+    const skillDir = join(dir, ".claude", "skills", "my-skill");
+    await Deno.mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# My Skill");
+
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills.length, 1);
+    assertEquals(skills[0].name, "my-skill");
+    assertEquals(skills[0].absolutePath, skillDir);
+  });
+});
+
+Deno.test("resolveSourceSkills: resolves skills from source root without paths.base", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      join(dir, "manifest.yaml"),
+      `manifestVersion: 1
+name: "@test/root-skills"
+version: "2026.01.01.1"
+skills:
+  - root-skill
+`,
+    );
+    const skillDir = join(dir, ".claude", "skills", "root-skill");
+    await Deno.mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Root Skill");
+
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills.length, 1);
+    assertEquals(skills[0].name, "root-skill");
+    assertEquals(skills[0].absolutePath, skillDir);
+  });
+});
+
+Deno.test("resolveSourceSkills: resolves multiple skills", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      join(dir, "manifest.yaml"),
+      `manifestVersion: 1
+name: "@test/multi-skills"
+version: "2026.01.01.1"
+paths:
+  base: manifest
+skills:
+  - skill-a
+  - skill-b
+`,
+    );
+    for (const name of ["skill-a", "skill-b"]) {
+      const skillDir = join(dir, ".claude", "skills", name);
+      await Deno.mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, "SKILL.md"), `# ${name}`);
+    }
+
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills.length, 2);
+    assertEquals(skills[0].name, "skill-a");
+    assertEquals(skills[1].name, "skill-b");
+  });
+});
+
+Deno.test("resolveSourceSkills: skips skills not found in any candidate dir", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      join(dir, "manifest.yaml"),
+      `manifestVersion: 1
+name: "@test/missing-skill"
+version: "2026.01.01.1"
+paths:
+  base: manifest
+skills:
+  - exists
+  - missing
+`,
+    );
+    const skillDir = join(dir, ".claude", "skills", "exists");
+    await Deno.mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Exists");
+
+    const skills = await resolveSourceSkills(dir, ["claude"]);
+    assertEquals(skills.length, 1);
+    assertEquals(skills[0].name, "exists");
+  });
+});
+
+Deno.test("copySourceSkills: copies skill directories to target", async () => {
+  await withTempDir(async (dir) => {
+    const srcSkill = join(dir, "src-skills", "my-skill");
+    await Deno.mkdir(srcSkill, { recursive: true });
+    await writeFile(join(srcSkill, "SKILL.md"), "# My Skill");
+    await Deno.mkdir(join(srcSkill, "references"), { recursive: true });
+    await writeFile(join(srcSkill, "references", "guide.md"), "guide content");
+
+    const targetDir = join(dir, "target-skills");
+    const copied = await copySourceSkills(
+      [{ name: "my-skill", absolutePath: srcSkill }],
+      targetDir,
+    );
+
+    assertEquals(copied, ["my-skill"]);
+
+    const content = await Deno.readTextFile(
+      join(targetDir, "my-skill", "SKILL.md"),
+    );
+    assertEquals(content, "# My Skill");
+
+    const refContent = await Deno.readTextFile(
+      join(targetDir, "my-skill", "references", "guide.md"),
+    );
+    assertEquals(refContent, "guide content");
+  });
+});
+
+Deno.test("copySourceSkills: returns empty when no skills provided", async () => {
+  const copied = await copySourceSkills([], "/nonexistent");
+  assertEquals(copied, []);
+});
+
+Deno.test("removeSourceSkills: removes named skill directories", async () => {
+  await withTempDir(async (dir) => {
+    const skillDir = join(dir, "my-skill");
+    await Deno.mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# My Skill");
+
+    await removeSourceSkills(["my-skill"], dir);
+
+    let exists = true;
+    try {
+      await Deno.stat(skillDir);
+    } catch {
+      exists = false;
+    }
+    assertEquals(exists, false);
+  });
+});
+
+Deno.test("removeSourceSkills: silently skips missing directories", async () => {
+  await withTempDir(async (dir) => {
+    await removeSourceSkills(["nonexistent"], dir);
+  });
+});

--- a/src/libswamp/sources/source_skills_test.ts
+++ b/src/libswamp/sources/source_skills_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import {
   copySourceSkills,
   removeSourceSkills,
@@ -37,7 +37,7 @@ async function withTempDir(
 }
 
 async function writeFile(path: string, content: string): Promise<void> {
-  await Deno.mkdir(join(path, ".."), { recursive: true }).catch(() => {});
+  await Deno.mkdir(dirname(path), { recursive: true }).catch(() => {});
   await Deno.writeTextFile(path, content);
 }
 

--- a/src/presentation/renderers/extension_source_modify.ts
+++ b/src/presentation/renderers/extension_source_modify.ts
@@ -33,6 +33,12 @@ class LogSourceModifyRenderer implements Renderer<SourceModifyEvent> {
         if (e.data.only) {
           writeOutput(`  only: ${e.data.only.join(", ")}`);
         }
+        if (e.data.installedSkills && e.data.installedSkills.length > 0) {
+          const skillVerb = e.data.action === "added"
+            ? "skills installed"
+            : "skills removed";
+          writeOutput(`  ${skillVerb}: ${e.data.installedSkills.join(", ")}`);
+        }
         const count = e.data.totalSources;
         writeOutput(
           count === 1 ? "1 source configured" : `${count} sources configured`,


### PR DESCRIPTION
## Summary

- Source-path extensions (`extension source add`) now install skills declared in their `manifest.yaml` into the repo's tool-specific skills directory (`.claude/skills/`, etc.)
- `extension source rm` cleans up installed skills automatically
- Installed skill names are tracked via `installedSkills` in `.swamp-sources.yaml` so removal doesn't depend on the source directory still existing

Closes swamp-club#724

## How It Works

On `extension source add`:
1. After recording the source path, reads the source's `manifest.yaml`
2. If `skills` field is present, resolves skill directories using the same `paths.base` strategy as `extension push`/`extension quality`
3. Copies skill directories to the repo's tool-specific skills dir
4. Records installed skill names in `.swamp-sources.yaml`

On `extension source rm`:
1. Reads `installedSkills` from the source entry
2. Removes those skill directories from the repo
3. Proceeds with existing removal logic

## Test Plan

- 10 new unit tests for `resolveSourceSkills`, `copySourceSkills`, `removeSourceSkills`
- Existing 44 source add/remove tests pass with updated deps interfaces
- Full suite: 7642 tests pass
- Manual E2E: compiled binary, created fresh repo, ran `extension source add ~/code/swamp-club/swamp-extensions/issue-lifecycle`, verified skill copied to `.claude/skills/issue-lifecycle/`, verified `installedSkills` tracked in `.swamp-sources.yaml`, ran `extension source rm`, verified skill removed and bundled skills untouched

Co-authored-by: Joseph Anthony Pasquale Holsten <joseph@josephholsten.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)