### PR TITLE
feat(models): add deleteResource to MethodContext

### DIFF
--- a/.claude/skills/swamp/references/extension/references/model/api.md
+++ b/.claude/skills/swamp/references/extension/references/model/api.md
@@ -7,6 +7,7 @@ Detailed API documentation for extension model development.
 - [Resource & File Specs](#resource--file-specs)
 - [Reading Bundled Assets](#reading-bundled-assets)
 - [writeResource API](#writeresource-api)
+- [deleteResource API](#deleteresource-api)
 - [createFileWriter API](#createfilewriter-api)
 - [DataWriter Methods](#datawriter-methods)
 - [DataHandle Structure](#datahandle-structure)
@@ -190,6 +191,39 @@ for (const item of items) {
 
 ---
 
+## deleteResource API
+
+Delete a previously stored resource by instance name:
+`context.deleteResource(instanceName)`.
+
+**Signature:**
+
+```typescript
+deleteResource(instanceName: string): Promise<void>
+```
+
+Removes all versions of the named resource. Use this to clean up stale data when
+a target recovers or a reconciliation loop detects orphaned entries.
+
+**Example — reconciliation cleanup:**
+
+```typescript
+const existing = await context.readResource!("target-status");
+if (existing && existing.state === "recovered") {
+  await context.deleteResource!("error-details");
+}
+```
+
+**Notes:**
+
+- Not available in pre-flight checks (same restriction as `writeResource`)
+- No-op if the named resource does not exist
+- For lower-level control (e.g., deleting a specific version), use
+  `context.dataRepository.delete(context.modelType, context.modelId, name, version?)`
+  directly
+
+---
+
 ## createFileWriter API
 
 Create a file writer:
@@ -332,11 +366,12 @@ const content = await context.dataRepository.getContent(
 
 **Key dataRepository methods for model authors:**
 
-| Method                                      | Returns              | Description                            |
-| ------------------------------------------- | -------------------- | -------------------------------------- |
-| `getContent(type, modelId, dataName, ver?)` | `Uint8Array \| null` | Get raw content bytes                  |
-| `findByName(type, modelId, dataName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc) |
-| `findAllForModel(type, modelId)`            | `Data[]`             | List all data for this model instance  |
+| Method                                      | Returns              | Description                               |
+| ------------------------------------------- | -------------------- | ----------------------------------------- |
+| `getContent(type, modelId, dataName, ver?)` | `Uint8Array \| null` | Get raw content bytes                     |
+| `findByName(type, modelId, dataName, ver?)` | `Data \| null`       | Get data metadata (tags, version, etc)    |
+| `findAllForModel(type, modelId)`            | `Data[]`             | List all data for this model instance     |
+| `delete(type, modelId, dataName, version?)` | `void`               | Delete data (all versions if unspecified) |
 
 ---
 

--- a/.claude/skills/swamp/references/extension/references/model/checks.md
+++ b/.claude/skills/swamp/references/extension/references/model/checks.md
@@ -15,7 +15,8 @@ checks: {
     execute: async (context) => {
       // context has: globalArgs, definition, methodName, repoDir, logger,
       //              dataRepository, modelType, modelId
-      // NOTE: writeResource and createFileWriter are NOT available in checks
+      // NOTE: writeResource, deleteResource, and createFileWriter are NOT
+      //       available in checks
       return { pass: true };
       // or: return { pass: false, errors: ["Reason check failed"] };
     },

--- a/.claude/skills/swamp/references/extension/references/model/examples.md
+++ b/.claude/skills/swamp/references/extension/references/model/examples.md
@@ -455,6 +455,34 @@ export const model = {
   detection
 - Always check for `null` content — the model may not have been created yet
 
+## Cleaning Up Stale Data with deleteResource
+
+When a reconciliation loop detects that a previously-errored target has
+recovered, use `deleteResource` to remove stale error data:
+
+```typescript
+sync: {
+  description: "Reconcile target state and clean up stale error records",
+  arguments: z.object({}),
+  execute: async (context) => {
+    const status = await context.readResource!("status");
+    if (!status) return {};
+
+    const errorData = await context.readResource!("last-error");
+    if (errorData && status.state === "healthy") {
+      await context.deleteResource!("last-error");
+    }
+
+    return {};
+  },
+},
+```
+
+`deleteResource` removes all versions of the named resource. It is a no-op if
+the resource does not exist. For version-specific deletion, use the lower-level
+`context.dataRepository.delete(context.modelType, context.modelId, name, version)`
+API directly.
+
 ## Polling to Completion
 
 When integrating with cloud providers or async APIs, the create/update response

--- a/.claude/skills/swamp/references/extension/references/model/testing.md
+++ b/.claude/skills/swamp/references/extension/references/model/testing.md
@@ -104,6 +104,24 @@ const result = await createVpc(mockClient, "10.0.0.0/16");
 assertEquals(result.vpcId, "vpc-123");
 ```
 
+## Testing deleteResource
+
+Use `getDeletedResources()` to verify which resources a method deletes:
+
+```typescript
+Deno.test("sync cleans up stale error data on recovery", async () => {
+  const { context, getDeletedResources } = createModelTestContext({
+    storedResources: {
+      "status": { state: "healthy" },
+      "last-error": { message: "connection refused" },
+    },
+  });
+
+  await model.methods.sync.execute({}, context);
+  assertEquals(getDeletedResources(), ["last-error"]);
+});
+```
+
 ## Other Testing Patterns
 
 **Logs**: Use `getLogs()` or `getLogsByLevel("info")` to assert on logged

--- a/.claude/skills/swamp/references/extension/references/model/typing.md
+++ b/.claude/skills/swamp/references/extension/references/model/typing.md
@@ -93,6 +93,7 @@ use:
 | `logger`               | `{ info(msg: string, ...args: unknown[]): void; ... }` (trace/debug/info/warning/error/fatal)  |
 | `writeResource`        | `(specName: string, name: string, data: Record<string, unknown>) => Promise<{ name: string }>` |
 | `readResource`         | `(instanceName: string, version?: number) => Promise<Record<string, unknown> \| null>`         |
+| `deleteResource`       | `(instanceName: string) => Promise<void>`                                                      |
 | `createFileWriter`     | `(specName: string, name: string) => DataWriter`                                               |
 | `createCelEnvironment` | `() => Environment`                                                                            |
 | `dataRepository`       | Low-level data API (for reading non-JSON content)                                              |

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -757,6 +757,24 @@ export function createResourceReader(
 }
 
 /**
+ * Creates a deleteResource function bound to a specific execution context.
+ *
+ * @param repo - The unified data repository
+ * @param modelType - The model type
+ * @param modelId - The model ID (definition ID)
+ * @returns A deleteResource function
+ */
+export function createResourceDeleter(
+  repo: UnifiedDataRepository,
+  modelType: ModelType,
+  modelId: string,
+): (instanceName: string) => Promise<void> {
+  return async (instanceName: string): Promise<void> => {
+    await repo.delete(modelType, modelId, instanceName);
+  };
+}
+
+/**
  * Creates a createFileWriter function bound to a specific execution context.
  *
  * The returned function creates DefaultDataWriter instances for writing

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
   createFileWriterFactory,
+  createResourceDeleter,
   createResourceReader,
   createResourceWriter,
   modelRequiresVault,
@@ -1464,4 +1465,45 @@ Deno.test("createFileWriterFactory: getHandles returns one handle per writeStrea
   } finally {
     await Deno.remove(tmpFile).catch(() => {});
   }
+});
+
+// --- createResourceDeleter tests ---
+
+Deno.test("createResourceDeleter: delegates to repo.delete with correct arguments", async () => {
+  let capturedType: ModelType | undefined;
+  let capturedModelId: string | undefined;
+  let capturedName: string | undefined;
+  const repo = {
+    ...createMockRepo(),
+    delete: (
+      type: ModelType,
+      id: string,
+      dataName: string,
+    ) => {
+      capturedType = type;
+      capturedModelId = id;
+      capturedName = dataName;
+      return Promise.resolve();
+    },
+  };
+
+  const deleteResource = createResourceDeleter(repo, modelType, modelId);
+  await deleteResource("stale-data");
+  assertEquals(capturedType, modelType);
+  assertEquals(capturedModelId, modelId);
+  assertEquals(capturedName, "stale-data");
+});
+
+Deno.test("createResourceDeleter: propagates repository errors", async () => {
+  const repo = {
+    ...createMockRepo(),
+    delete: () => Promise.reject(new Error("delete failed")),
+  };
+
+  const deleteResource = createResourceDeleter(repo, modelType, modelId);
+  await assertRejects(
+    () => deleteResource("some-data"),
+    Error,
+    "delete failed",
+  );
 });

--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -30,6 +30,7 @@ import type {
 } from "./model.ts";
 import {
   createFileWriterFactory,
+  createResourceDeleter,
   createResourceReader,
   createResourceWriter,
 } from "./data_writer.ts";
@@ -135,6 +136,12 @@ export class InProcessExecutor {
       this.context.redactor,
     );
 
+    const deleteResource = createResourceDeleter(
+      this.context.dataRepository,
+      this.context.modelType,
+      this.context.modelId,
+    );
+
     const dataAccessService = new DataAccessService(
       this.context.definitionRepository,
       this.context.dataRepository,
@@ -160,6 +167,7 @@ export class InProcessExecutor {
       methodName: this.methodName,
       writeResource,
       readResource,
+      deleteResource,
       readModelData,
       queryData,
       createFileWriter,

--- a/src/domain/models/in_process_executor_test.ts
+++ b/src/domain/models/in_process_executor_test.ts
@@ -510,3 +510,44 @@ Deno.test("InProcessExecutor: restores TRACEPARENT env var after execution error
   assertEquals(result.status, "error");
   assertEquals(Deno.env.get("TRACEPARENT"), originalTraceparent);
 });
+
+Deno.test("InProcessExecutor: wires deleteResource onto context", async () => {
+  let deletedName: string | undefined;
+  const mockDataRepo = {
+    ...createMockDataRepo(),
+    delete: (
+      _type: unknown,
+      _modelId: string,
+      dataName: string,
+    ) => {
+      deletedName = dataName;
+      return Promise.resolve();
+    },
+  } as unknown as UnifiedDataRepository;
+
+  const executor: MethodExecutor = {
+    execute: async (_def, _method, context) => {
+      await context.deleteResource!("stale-resource");
+      return {};
+    },
+  };
+
+  const context = {
+    ...createMockContext(),
+    dataRepository: mockDataRepo,
+  };
+
+  const inProcessExecutor = new InProcessExecutor(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  const result = await inProcessExecutor.execute(createMockRequest());
+
+  assertEquals(result.status, "success");
+  assertEquals(deletedName, "stale-resource");
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -237,6 +237,12 @@ export interface MethodContext {
   ) => Promise<Record<string, unknown> | null>;
 
   /**
+   * Delete a previously stored resource by instance name.
+   * Removes all versions of the named resource.
+   */
+  deleteResource?: (instanceName: string) => Promise<void>;
+
+  /**
    * Read data from another model by name.
    * Resolves the model name, reads all data (optionally filtered by spec name),
    * parses JSON content, and resolves vault references.

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -30,14 +30,15 @@
  * run uses, so declared-spec enforcement comes for free.
  *
  * Routes:
- *   GET  /data/{type}/{modelId}/{dataName}/{version}   read artifact bytes
- *   POST /data/resource                                write a resource (JSON)
- *   POST /data/writers                                 open a file writer
- *   POST /data/writers/{id}/line                       durable line append
- *   POST /data/writers/{id}/content                    stream bytes + finalize
- *   POST /data/writers/{id}/finalize                   finalize a line writer
- *   GET  /bundle/{fingerprint}                         fetch extension bundle
- *   GET  /bundle/{fingerprint}/file/{relPath}          fetch co-located asset
+ *   GET    /data/{type}/{modelId}/{dataName}/{version}   read artifact bytes
+ *   POST   /data/resource                                write a resource (JSON)
+ *   DELETE /data/resource                                delete a resource
+ *   POST   /data/writers                                 open a file writer
+ *   POST   /data/writers/{id}/line                       durable line append
+ *   POST   /data/writers/{id}/content                    stream bytes + finalize
+ *   POST   /data/writers/{id}/finalize                   finalize a line writer
+ *   GET    /bundle/{fingerprint}                         fetch extension bundle
+ *   GET    /bundle/{fingerprint}/file/{relPath}          fetch co-located asset
  */
 
 import { isAbsolute, join, normalize, resolve } from "@std/path";
@@ -224,6 +225,9 @@ export class DataPlane {
     if (req.method === "POST" && segments[1] === "resource") {
       return await this.#writeResource(req, workerName);
     }
+    if (req.method === "DELETE" && segments[1] === "resource") {
+      return await this.#deleteResource(req, workerName);
+    }
     if (req.method === "POST" && segments[1] === "writers") {
       if (segments.length === 2) {
         return await this.#openWriter(req, workerName);
@@ -323,6 +327,28 @@ export class DataPlane {
       );
     }
     return json(handleToJson(handle));
+  }
+
+  async #deleteResource(req: Request, workerName: string): Promise<Response> {
+    const dispatch = this.#activeDispatch(workerName);
+    const body = await req.json() as { name?: string };
+    if (!body.name) {
+      return errorResponse(400, "Expected { name }");
+    }
+
+    try {
+      await this.#options.repoContext.unifiedDataRepo.delete(
+        dispatch.modelType,
+        dispatch.modelId,
+        body.name,
+      );
+    } catch (error) {
+      throw new DataPlaneError(
+        400,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    return new Response(null, { status: 204 });
   }
 
   async #openWriter(req: Request, workerName: string): Promise<Response> {

--- a/src/serve/data_plane_test.ts
+++ b/src/serve/data_plane_test.ts
@@ -488,3 +488,46 @@ Deno.test("DataPlane: co-located assets serve from the bundle root only", async 
     assertEquals(missing?.status, 404);
   });
 });
+
+Deno.test("DataPlane: DELETE /data/resource deletes resource and returns 204", async () => {
+  await withHarness(async (h) => {
+    h.dispatches.register(activeDispatch());
+
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "DELETE",
+        body: JSON.stringify({ name: "stale-data" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    assertEquals(resp?.status, 204);
+  });
+});
+
+Deno.test("DataPlane: DELETE /data/resource rejects missing name", async () => {
+  await withHarness(async (h) => {
+    h.dispatches.register(activeDispatch());
+
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "DELETE",
+        body: JSON.stringify({}),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    assertEquals(resp?.status, 400);
+  });
+});
+
+Deno.test("DataPlane: DELETE /data/resource requires active dispatch", async () => {
+  await withHarness(async (h) => {
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "DELETE",
+        body: JSON.stringify({ name: "data" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    assertEquals(resp?.status, 400);
+  });
+});

--- a/src/worker/data_plane_client.ts
+++ b/src/worker/data_plane_client.ts
@@ -155,6 +155,17 @@ export class DataPlaneClient {
     return await response.json() as RemoteDataHandle;
   }
 
+  async deleteResource(
+    body: { name: string },
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.#request("DELETE", "/data/resource", {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+      signal,
+    });
+  }
+
   async openWriter(
     body: { specName: string; name: string },
     signal?: AbortSignal,

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -523,6 +523,10 @@ export function createRemoteMethodContext(
     >;
   };
 
+  const deleteResource = async (instanceName: string): Promise<void> => {
+    await options.client.deleteResource({ name: instanceName }, signal);
+  };
+
   const readModelData = async (modelName: string, specName?: string) => {
     const predicate = specName === undefined
       ? `modelName == ${JSON.stringify(modelName)}`
@@ -555,6 +559,7 @@ export function createRemoteMethodContext(
     dataQueryService,
     writeResource: writers.writeResource,
     readResource,
+    deleteResource,
     readModelData,
     queryData,
     createFileWriter: writers.createFileWriter,

--- a/src/worker/remote_method_context_test.ts
+++ b/src/worker/remote_method_context_test.ts
@@ -181,6 +181,10 @@ function harness(scratchDir: string, extensionFilesDir?: string) {
         size: lines.length,
         tags: {},
       }),
+    deleteResource: (body: { name: string }) => {
+      calls.push({ method: "deleteResource", params: body });
+      return Promise.resolve();
+    },
   } as unknown as DataPlaneClient;
 
   const { context, getHandles } = createRemoteMethodContext({
@@ -341,5 +345,16 @@ Deno.test("remote context: repoDir is the scratch directory", async () => {
     const h = harness(dir);
     assertEquals(h.context.repoDir, dir);
     return Promise.resolve();
+  });
+});
+
+Deno.test("remote context: deleteResource calls client.deleteResource", async () => {
+  await withScratch(async (dir) => {
+    const h = harness(dir);
+    await h.context.deleteResource!("stale-data");
+    assertEquals(
+      h.calls.filter((c) => c.method === "deleteResource"),
+      [{ method: "deleteResource", params: { name: "stale-data" } }],
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add `deleteResource` as a first-class method on `MethodContext`, completing the resource lifecycle (write/read/delete)
- Implement the full stack: interface, factory (`createResourceDeleter`), local executor wiring, remote execution path (worker `DataPlaneClient` + `DELETE /data/resource` endpoint), and skill documentation
- Previously model authors had to use the undiscoverable `dataRepository.delete()` API; the new wrapper mirrors `readResource` — takes an `instanceName` and removes all versions

## Test Plan

- Unit tests for `createResourceDeleter` (delegation + error propagation)
- `InProcessExecutor` test verifying `deleteResource` is wired onto method context
- Remote method context test verifying client delegation
- Data plane tests: successful delete (204), missing name (400), no active dispatch (400)
- Architecture enforcement test passes (no inline MethodContext construction)
- Full test suite passes (7632 tests)
- Binary compiles cleanly

Closes swamp-club#739