### PR TITLE
fix(serve): surface webhook scheme in startup event, health endpoint, and log line

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -449,11 +449,16 @@ export const serveCommand = new Command()
             kind: "webhook_registered",
             route: ep.route,
             workflow: ep.workflowIdOrName,
+            scheme: ep.verifier.scheme,
           }));
         } else {
           logger.info(
-            "Webhook registered: {route} → {workflow}",
-            { route: ep.route, workflow: ep.workflowIdOrName },
+            "Webhook registered: {route} → {workflow} (scheme: {scheme})",
+            {
+              route: ep.route,
+              workflow: ep.workflowIdOrName,
+              scheme: ep.verifier.scheme,
+            },
           );
         }
       }
@@ -542,6 +547,7 @@ export const serveCommand = new Command()
               ? webhookService.listEndpoints().map((ep) => ({
                 route: ep.route,
                 workflow: ep.workflowIdOrName,
+                scheme: ep.scheme,
               }))
               : [];
 

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -255,6 +255,7 @@ const MAX_QUEUE_DEPTH = 100;
 export interface WebhookEndpointInfo {
   readonly route: string;
   readonly workflowIdOrName: string;
+  readonly scheme: string;
 }
 
 export class WebhookService {
@@ -281,6 +282,7 @@ export class WebhookService {
     return this.deps.endpoints.map((e) => ({
       route: e.route,
       workflowIdOrName: e.workflowIdOrName,
+      scheme: e.verifier.scheme,
     }));
   }
 

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { buildWebhookPayload, parseWebhookFlag } from "./webhook.ts";
+import {
+  buildWebhookPayload,
+  parseWebhookFlag,
+  WebhookService,
+} from "./webhook.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 
 await initializeLogging({});
@@ -208,4 +212,27 @@ Deno.test("parseWebhookFlag: rejects route without leading slash", () => {
     Error,
     "must start with '/'",
   );
+});
+
+// ── listEndpoints ─────────────────────────────────────────────────────
+
+Deno.test("listEndpoints: includes scheme from each endpoint verifier", () => {
+  const service = new WebhookService({
+    repoDir: "/tmp/fake",
+    // deno-lint-ignore no-explicit-any
+    repoContext: {} as any,
+    // deno-lint-ignore no-explicit-any
+    datastoreConfig: {} as any,
+    endpoints: [
+      parseWebhookFlag("/hooks/gh:deploy:secret"),
+      parseWebhookFlag("/hooks/stripe:billing:secret:stripe"),
+      parseWebhookFlag("/hooks/custom:wf:secret:generic:X-Sig:sha256="),
+    ],
+  });
+
+  const infos = service.listEndpoints();
+  assertEquals(infos.length, 3);
+  assertEquals(infos[0].scheme, "github");
+  assertEquals(infos[1].scheme, "stripe");
+  assertEquals(infos[2].scheme, "generic");
 });


### PR DESCRIPTION
Closes swamp-club/lab#728

## Summary

- Add `scheme` field to the `webhook_registered` JSON startup event, `/health` endpoint webhook entries, and log-mode registration line so users can confirm which verification scheme was applied to each webhook endpoint
- Add `scheme` to `WebhookEndpointInfo` interface and `listEndpoints()` return values
- Add unit test for `listEndpoints()` verifying scheme is surfaced for github, stripe, and generic endpoints

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt --check` — passes
- [x] `deno run test src/serve/webhook_test.ts` — 21 tests pass (including new `listEndpoints` test)
- [x] `deno run test src/cli/commands/serve_test.ts` — 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)