### PR TITLE
fix(serve-auth): security, correctness, and performance hardening for auth subsystem

### DIFF
--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -219,6 +219,6 @@ export const accessCheckCommand = new Command()
         decisions[0].effect === "deny";
       if (isDenied) Deno.exitCode = 1;
     } finally {
-      loader.dispose();
+      await loader.dispose();
     }
   });

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -122,6 +122,6 @@ export const accessReloadCommand = new Command()
         groupCount: result.groupCount,
       });
     } finally {
-      loader.dispose();
+      await loader.dispose();
     }
   });

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -66,11 +66,24 @@ const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const authAttempts = new Map<string, { count: number; resetAt: number }>();
 const MAX_AUTH_ATTEMPTS = 5;
 const AUTH_WINDOW_MS = 60_000;
+const MAX_RATE_LIMIT_ENTRIES = 10_000;
+
+function sweepExpiredEntries(): void {
+  const now = Date.now();
+  for (const [ip, entry] of authAttempts) {
+    if (now > entry.resetAt) authAttempts.delete(ip);
+  }
+}
 
 function checkRateLimit(ip: string): boolean {
   const now = Date.now();
   const entry = authAttempts.get(ip);
   if (!entry || now > entry.resetAt) {
+    if (authAttempts.size >= MAX_RATE_LIMIT_ENTRIES) sweepExpiredEntries();
+    if (authAttempts.size >= MAX_RATE_LIMIT_ENTRIES) {
+      const oldest = authAttempts.keys().next().value!;
+      authAttempts.delete(oldest);
+    }
     authAttempts.set(ip, { count: 1, resetAt: now + AUTH_WINDOW_MS });
     return true;
   }
@@ -79,7 +92,10 @@ function checkRateLimit(ip: string): boolean {
 }
 
 function clearRateLimit(ip: string): void {
-  authAttempts.delete(ip);
+  const entry = authAttempts.get(ip);
+  if (entry) {
+    entry.count = 0;
+  }
 }
 
 export function assertOffLoopbackSecurity(
@@ -175,6 +191,10 @@ export const serveCommand = new Command()
     "--groups-field <field:string>",
     "Userinfo field name for group/collective memberships (default: collectives)",
   )
+  .option(
+    "--trust-proxy",
+    "Trust X-Forwarded-For header for client IP (enable when behind a reverse proxy)",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
@@ -217,6 +237,7 @@ export const serveCommand = new Command()
       key = await Deno.readTextFile(keyFile);
     }
     const tlsEnabled = cert !== undefined;
+    const trustProxy = options.trustProxy === true;
 
     const authConfig = buildServeAuthConfig({
       authMode: options.authMode as string | undefined,
@@ -514,9 +535,11 @@ export const serveCommand = new Command()
               );
             }
 
-            const remoteAddr = req.headers.get("x-forwarded-for")
-              ?.split(",")[0]?.trim() ??
-              info.remoteAddr.hostname;
+            const remoteAddr = trustProxy
+              ? (req.headers.get("x-forwarded-for")
+                ?.split(",")[0]?.trim() ??
+                info.remoteAddr.hostname)
+              : info.remoteAddr.hostname;
             if (!checkRateLimit(remoteAddr)) {
               logger.warn("WebSocket auth rate-limited from {ip}", {
                 ip: remoteAddr,
@@ -617,7 +640,7 @@ export const serveCommand = new Command()
       if (scheduledExecution) {
         await scheduledExecution.stop();
       }
-      policySnapshotLoader.dispose();
+      await policySnapshotLoader.dispose();
       setRemoteStepDispatcher(null);
       ac.abort();
       if (isJson) {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -63,6 +63,25 @@ const logger = getSwampLogger(["serve"]);
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 
+const authAttempts = new Map<string, { count: number; resetAt: number }>();
+const MAX_AUTH_ATTEMPTS = 5;
+const AUTH_WINDOW_MS = 60_000;
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = authAttempts.get(ip);
+  if (!entry || now > entry.resetAt) {
+    authAttempts.set(ip, { count: 1, resetAt: now + AUTH_WINDOW_MS });
+    return true;
+  }
+  entry.count++;
+  return entry.count <= MAX_AUTH_ATTEMPTS;
+}
+
+function clearRateLimit(ip: string): void {
+  authAttempts.delete(ip);
+}
+
 export function assertOffLoopbackSecurity(
   host: string,
   tlsEnabled: boolean,
@@ -483,14 +502,35 @@ export const serveCommand = new Command()
           }
         },
       },
-      async (req) => {
+      async (req, info) => {
         // WebSocket upgrade (check first — upgrade requests are also GETs)
         const upgrade = req.headers.get("upgrade") ?? "";
         if (upgrade.toLowerCase() === "websocket") {
-          if (authConfig.mode === "token") {
+          if (authConfig.mode !== "none") {
+            if (authConfig.mode !== "token") {
+              return new Response(
+                `Auth mode '${authConfig.mode}' is not yet supported for WebSocket`,
+                { status: 501 },
+              );
+            }
+
+            const remoteAddr = req.headers.get("x-forwarded-for")
+              ?.split(",")[0]?.trim() ??
+              info.remoteAddr.hostname;
+            if (!checkRateLimit(remoteAddr)) {
+              logger.warn("WebSocket auth rate-limited from {ip}", {
+                ip: remoteAddr,
+              });
+              return new Response("Too Many Requests", { status: 429 });
+            }
+
             const url = new URL(req.url);
             const tokenParam = url.searchParams.get("token");
             if (!tokenParam) {
+              logger.warn(
+                "WebSocket auth rejected: no token provided from {ip}",
+                { ip: remoteAddr },
+              );
               return new Response("Unauthorized: token required", {
                 status: 401,
               });
@@ -502,11 +542,12 @@ export const serveCommand = new Command()
             );
             if (!result.ok) {
               logger.warn(
-                "WebSocket auth rejected: {error}",
-                { error: result.error },
+                "WebSocket auth rejected from {ip}: {error}",
+                { ip: remoteAddr, error: result.error },
               );
               return new Response("Unauthorized", { status: 401 });
             }
+            clearRateLimit(remoteAddr);
             const principal = parsePrincipal(result.principalId);
             const { socket, response } = Deno.upgradeWebSocket(req);
             handleConnection(socket, connectionCtx, principal);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -193,7 +193,7 @@ export const serveCommand = new Command()
   )
   .option(
     "--trust-proxy",
-    "Trust X-Forwarded-For header for client IP (enable when behind a reverse proxy)",
+    "Trust X-Forwarded-For header for client IP in token auth rate limiting (enable when behind a reverse proxy)",
   )
   .example(
     "Enable TLS",
@@ -530,7 +530,7 @@ export const serveCommand = new Command()
           if (authConfig.mode !== "none") {
             if (authConfig.mode !== "token") {
               return new Response(
-                `Auth mode '${authConfig.mode}' is not yet supported for WebSocket`,
+                "WebSocket authentication is not supported for this server configuration",
                 { status: 501 },
               );
             }

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -47,12 +47,16 @@ import {
 } from "../../infrastructure/io/stdin_reader.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import {
+  normalizeServerUrl,
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { VaultPutResponse } from "../../serve/protocol.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const vaultLogger = getSwampLogger(["vault", "put"]);
 
 /**
  * Parses a KEY=VALUE string into key and value parts.
@@ -240,6 +244,16 @@ When using --server, the value must be passed as a positional argument or KEY=VA
     let refreshTtlMs: number | undefined;
     if (options.refreshTtl) {
       refreshTtlMs = parseTimeout(options.refreshTtl);
+    }
+
+    const wsUrl = normalizeServerUrl(server);
+    if (
+      wsUrl.startsWith("ws://") &&
+      !wsUrl.includes("127.0.0.1") && !wsUrl.includes("localhost")
+    ) {
+      vaultLogger.warn(
+        "Sending secrets over unencrypted connection — use wss:// for security",
+      );
     }
 
     const token = await resolveServerToken(

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -247,15 +247,15 @@ When using --server, the value must be passed as a positional argument or KEY=VA
     }
 
     const wsUrl = normalizeServerUrl(server);
-    if (
-      wsUrl.startsWith("ws://") &&
-      !wsUrl.includes("127.0.0.1") && !wsUrl.includes("localhost") &&
-      !wsUrl.includes("[::1]")
-    ) {
-      vaultLogger.warn(
-        "Sending secrets over unencrypted connection — use wss:// for security",
-      );
-    }
+    const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+    try {
+      const parsed = new URL(wsUrl);
+      if (parsed.protocol === "ws:" && !LOOPBACK_HOSTS.has(parsed.hostname)) {
+        vaultLogger.warn(
+          "Sending secrets over unencrypted connection — use wss:// for security",
+        );
+      }
+    } catch { /* invalid URL handled by normalizeServerUrl */ }
 
     const token = await resolveServerToken(
       server,

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -249,7 +249,8 @@ When using --server, the value must be passed as a positional argument or KEY=VA
     const wsUrl = normalizeServerUrl(server);
     if (
       wsUrl.startsWith("ws://") &&
-      !wsUrl.includes("127.0.0.1") && !wsUrl.includes("localhost")
+      !wsUrl.includes("127.0.0.1") && !wsUrl.includes("localhost") &&
+      !wsUrl.includes("[::1]")
     ) {
       vaultLogger.warn(
         "Sending secrets over unencrypted connection — use wss:// for security",

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -239,9 +239,10 @@ export function requestServerResponse<T>(
     socket.onmessage = (event) => {
       if (typeof event.data !== "string") return;
       try {
-        const message = JSON.parse(event.data) as ServerMessage;
+        const message = JSON.parse(event.data);
         if (
           typeof message !== "object" || message === null ||
+          !("type" in message) || typeof message.type !== "string" ||
           !("id" in message) || message.id !== requestId
         ) {
           return;

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -32,7 +32,7 @@ import { resourceSelectorMatches } from "./resource_selector.ts";
 
 function resolveSubjects(
   accessPrincipal: AccessPrincipal,
-  snapshot: PolicySnapshot,
+  localGroups: readonly string[],
 ): string[] {
   const subjects: string[] = [];
 
@@ -40,8 +40,6 @@ function resolveSubjects(
     `${accessPrincipal.principal.kind}:${accessPrincipal.principal.id}`,
   );
 
-  const principalKey = principalToString(accessPrincipal.principal);
-  const localGroups = snapshot.groupsForPrincipal(principalKey);
   for (const groupName of localGroups) {
     subjects.push(`group:${groupName}`);
   }
@@ -66,10 +64,8 @@ function grantMatchesAction(grant: Grant, action: Action): boolean {
 
 function buildPrincipalContext(
   accessPrincipal: AccessPrincipal,
-  snapshot: PolicySnapshot,
+  localGroups: readonly string[],
 ): PrincipalContext {
-  const principalKey = principalToString(accessPrincipal.principal);
-  const localGroups = snapshot.groupsForPrincipal(principalKey);
   return {
     sub: accessPrincipal.principal.id,
     groups: [...localGroups],
@@ -124,9 +120,11 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     resource: AccessResource,
   ): AccessDecision | null {
     const snapshot = this.#snapshot;
-    const subjects = resolveSubjects(principal, snapshot);
+    const principalKey = principalToString(principal.principal);
+    const localGroups = snapshot.groupsForPrincipal(principalKey);
+    const subjects = resolveSubjects(principal, localGroups);
     const candidates = snapshot.grantsForSubjects(subjects);
-    const principalContext = buildPrincipalContext(principal, snapshot);
+    const principalContext = buildPrincipalContext(principal, localGroups);
 
     const denies: Grant[] = [];
     const allows: Grant[] = [];
@@ -161,9 +159,11 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     resource: AccessResource,
   ): AccessDecision[] {
     const snapshot = this.#snapshot;
-    const subjects = resolveSubjects(principal, snapshot);
+    const principalKey = principalToString(principal.principal);
+    const localGroups = snapshot.groupsForPrincipal(principalKey);
+    const subjects = resolveSubjects(principal, localGroups);
     const candidates = snapshot.grantsForSubjects(subjects);
-    const principalContext = buildPrincipalContext(principal, snapshot);
+    const principalContext = buildPrincipalContext(principal, localGroups);
 
     const decisions: AccessDecision[] = [];
     for (const grant of candidates) {

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -47,7 +47,7 @@ const GROUP_MODEL_TYPE_STR = GROUP_MODEL_TYPE.normalized;
 
 const RESOURCE_FIELDS: Record<ResourceKind, string[]> = {
   workflow: ["name", "tags", "collective"],
-  model: ["modelType", "collective"],
+  model: ["name", "modelType", "tags", "collective"],
   data: ["name", "ns", "tags", "owner"],
   access: ["name"],
 };
@@ -166,7 +166,7 @@ export class PolicySnapshotLoader {
     return result;
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this.#rebuildTimer) {
       clearTimeout(this.#rebuildTimer);
       this.#rebuildTimer = null;
@@ -175,6 +175,7 @@ export class PolicySnapshotLoader {
       unsub();
     }
     this.#unsubscribers.length = 0;
+    await this.#pendingRebuild;
   }
 
   #isAccessModel(modelType: string): boolean {

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -38,6 +38,7 @@ import type { PrincipalContext } from "./principal_context.ts";
 import type { ConditionEvaluator } from "./policy_snapshot.ts";
 import { PolicySnapshot } from "./policy_snapshot.ts";
 import type { ResourceKind } from "./resource_selector.ts";
+import { GrantBasedAccessDecisionService } from "./grant_based_access_decision_service.ts";
 
 const logger = getLogger(["swamp", "domain", "access", "policy-snapshot"]);
 
@@ -100,6 +101,9 @@ export class PolicySnapshotLoader {
   readonly #unsubscribers: (() => void)[] = [];
   readonly #conditionEvaluator: ConditionEvaluator;
   #snapshot: PolicySnapshot = PolicySnapshot.empty();
+  #pendingRebuild: Promise<void> = Promise.resolve();
+  #rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  #cachedDecisionService: GrantBasedAccessDecisionService | null = null;
 
   constructor(
     dataQueryService: DataQueryService,
@@ -113,7 +117,7 @@ export class PolicySnapshotLoader {
       this.#unsubscribers.push(
         eventBus.subscribe<ModelCreated>("ModelCreated", (event) => {
           if (this.#isAccessModel(event.modelType)) {
-            this.#rebuild();
+            this.#scheduleRebuild();
           }
         }),
       );
@@ -121,7 +125,7 @@ export class PolicySnapshotLoader {
       this.#unsubscribers.push(
         eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
           if (this.#isAccessModel(event.modelType)) {
-            this.#rebuild();
+            this.#scheduleRebuild();
           }
         }),
       );
@@ -132,9 +136,22 @@ export class PolicySnapshotLoader {
     return this.#snapshot;
   }
 
+  get decisionService(): GrantBasedAccessDecisionService {
+    if (
+      !this.#cachedDecisionService ||
+      this.#cachedDecisionService.snapshot !== this.#snapshot
+    ) {
+      this.#cachedDecisionService = new GrantBasedAccessDecisionService(
+        this.#snapshot,
+      );
+    }
+    return this.#cachedDecisionService;
+  }
+
   async load(): Promise<PolicySnapshot> {
     const result = await this.#buildSnapshotWithCounts();
     this.#snapshot = result.snapshot;
+    this.#cachedDecisionService = null;
     return this.#snapshot;
   }
 
@@ -145,10 +162,15 @@ export class PolicySnapshotLoader {
   }> {
     const result = await this.#buildSnapshotWithCounts();
     this.#snapshot = result.snapshot;
+    this.#cachedDecisionService = null;
     return result;
   }
 
   dispose(): void {
+    if (this.#rebuildTimer) {
+      clearTimeout(this.#rebuildTimer);
+      this.#rebuildTimer = null;
+    }
     for (const unsub of this.#unsubscribers) {
       unsub();
     }
@@ -203,10 +225,19 @@ export class PolicySnapshotLoader {
     };
   }
 
+  #scheduleRebuild(): void {
+    if (this.#rebuildTimer) clearTimeout(this.#rebuildTimer);
+    this.#rebuildTimer = setTimeout(() => {
+      this.#rebuildTimer = null;
+      this.#pendingRebuild = this.#pendingRebuild.then(() => this.#rebuild());
+    }, 500);
+  }
+
   async #rebuild(): Promise<void> {
     try {
       const result = await this.#buildSnapshotWithCounts();
       this.#snapshot = result.snapshot;
+      this.#cachedDecisionService = null;
     } catch (error) {
       logger.error`Failed to rebuild policy snapshot: ${error}`;
     }

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -147,7 +147,7 @@ Deno.test("PolicySnapshotLoader.load: builds snapshot from DataQueryService", as
   assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 1);
   assertEquals([...snapshot.groupsForPrincipal("user:adam")], ["devs"]);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader.load: filters out revoked grants", async () => {
@@ -163,7 +163,7 @@ Deno.test("PolicySnapshotLoader.load: filters out revoked grants", async () => {
   const snapshot = await loader.load();
   assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 1);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant model", async () => {
@@ -195,7 +195,7 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant mod
   await delay(700);
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group model", async () => {
@@ -227,7 +227,7 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group mod
   await delay(700);
   assertEquals([...loader.snapshot.groupsForPrincipal("user:adam")], ["devs"]);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader: ignores events for non-access models", async () => {
@@ -251,7 +251,7 @@ Deno.test("PolicySnapshotLoader: ignores events for non-access models", async ()
 
   assertEquals(queryCallCount, initialCount);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () => {
@@ -269,7 +269,7 @@ Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () =
   await loader.load();
   const initialCount = queryCallCount;
 
-  loader.dispose();
+  await loader.dispose();
 
   await eventBus.publish(
     createModelCreated("swamp/grant", "123", "my-grant"),
@@ -299,7 +299,7 @@ Deno.test("PolicySnapshotLoader: manual mode does not subscribe to EventBus", as
 
   assertEquals(queryCallCount, initialCount);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => {
@@ -331,7 +331,7 @@ Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => 
   await delay(700);
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
 
-  loader.dispose();
+  await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader.loadWithCounts: returns counts", async () => {
@@ -349,5 +349,5 @@ Deno.test("PolicySnapshotLoader.loadWithCounts: returns counts", async () => {
   assertEquals(result.grantCount, 1);
   assertEquals(result.groupCount, 1);
 
-  loader.dispose();
+  await loader.dispose();
 });

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -29,6 +29,8 @@ import { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
 
 await initializeLogging({});
 
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 function makeGrantRecord(grant: Grant): DataRecord {
   return {
     id: crypto.randomUUID(),
@@ -190,6 +192,7 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant mod
     createModelCreated("swamp/grant", "123", "my-grant"),
   );
 
+  await delay(700);
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
 
   loader.dispose();
@@ -221,6 +224,7 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group mod
     createModelUpdated("swamp/group", "456", "devs"),
   );
 
+  await delay(700);
   assertEquals([...loader.snapshot.groupsForPrincipal("user:adam")], ["devs"]);
 
   loader.dispose();
@@ -324,6 +328,7 @@ Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => 
     createModelCreated("swamp/grant", "123", "my-grant"),
   );
 
+  await delay(700);
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
 
   loader.dispose();

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -120,8 +120,9 @@ import {
 import { type Action, ActionSchema } from "../domain/access/action.ts";
 import { parseResourceSelector } from "../domain/access/resource_selector.ts";
 import type { AccessResource } from "../domain/access/access_decision_service.ts";
-import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
 import { modelRegistry } from "../domain/models/model.ts";
+
+const MAX_ACTIVE_REQUESTS = 100;
 
 // ── Zod schemas for incoming WebSocket messages ─────────────────────────
 
@@ -484,6 +485,16 @@ export function handleMessage(
     return;
   }
 
+  if (activeRequests.size >= MAX_ACTIVE_REQUESTS) {
+    sendError(
+      socket,
+      request.id,
+      "too_many_requests",
+      "Too many concurrent requests",
+    );
+    return;
+  }
+
   if (activeRequests.has(request.id)) {
     sendError(
       socket,
@@ -768,8 +779,7 @@ function authorizeOrReject(
     return false;
   }
 
-  const snapshot = ctx.policySnapshotLoader.snapshot;
-  const service = new GrantBasedAccessDecisionService(snapshot);
+  const service = ctx.policySnapshotLoader.decisionService;
   const decision = service.decide(
     { principal, collectives: [] },
     action,
@@ -818,7 +828,7 @@ async function handleWorkflowRun(
     !authorizeOrReject(socket, requestId, principal, "run", {
       kind: "workflow",
       name: payload.workflowIdOrName,
-      fields: {},
+      fields: { name: payload.workflowIdOrName },
     }, ctx)
   ) return;
 
@@ -872,12 +882,20 @@ async function handleModelMethodRun(
       payload.modelIdOrName,
     );
 
+    const modelFields: Record<string, unknown> = {};
+    if (preResult) {
+      modelFields.modelType = preResult.type.normalized;
+      modelFields.name = preResult.definition.name;
+      const tags = preResult.definition.tags;
+      if (tags && Object.keys(tags).length > 0) modelFields.tags = tags;
+    }
+
     if (isAccessModelType(payload.typeArg, preResult?.type.normalized)) {
       if (
         !authorizeOrReject(socket, requestId, principal, "admin", {
           kind: "access",
           name: "*",
-          fields: {},
+          fields: modelFields,
         }, ctx)
       ) return;
     } else {
@@ -885,7 +903,7 @@ async function handleModelMethodRun(
         !authorizeOrReject(socket, requestId, principal, "run", {
           kind: "model",
           name: payload.modelIdOrName,
-          fields: {},
+          fields: modelFields,
         }, ctx)
       ) return;
     }
@@ -1112,8 +1130,7 @@ function handleAccessCheck(
     const resource = parseResourceSelector(payload.resource);
     const collectives = payload.collectives ?? [];
 
-    const snapshot = ctx.policySnapshotLoader.snapshot;
-    const service = new GrantBasedAccessDecisionService(snapshot);
+    const service = ctx.policySnapshotLoader.decisionService;
     const decisions = service.explain(
       { principal, collectives },
       actionResult.data,
@@ -1185,7 +1202,7 @@ function handleAccessCanI(
       }
 
       const resource = parseResourceSelector(payload.resource);
-      const service = new GrantBasedAccessDecisionService(snapshot);
+      const service = ctx.policySnapshotLoader.decisionService;
       const decisions = service.explain(
         accessPrincipal,
         actionResult.data,
@@ -1297,11 +1314,13 @@ async function handleDataGet(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
+  const dataFields: Record<string, unknown> = {};
+  if (payload.modelIdOrName) dataFields.name = payload.modelIdOrName;
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
       name: resourceName,
-      fields: {},
+      fields: dataFields,
     }, ctx)
   ) return;
 
@@ -1425,11 +1444,13 @@ async function handleDataList(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
+  const listFields: Record<string, unknown> = {};
+  if (payload.modelIdOrName) listFields.name = payload.modelIdOrName;
   if (
     !authorizeOrReject(socket, requestId, principal, "read", {
       kind: "data",
       name: resourceName,
-      fields: {},
+      fields: listFields,
     }, ctx)
   ) return;
 

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -490,7 +490,7 @@ export function handleMessage(
       socket,
       request.id,
       "too_many_requests",
-      "Too many concurrent requests",
+      `Too many concurrent requests (limit: ${MAX_ACTIVE_REQUESTS}); wait for active requests to complete`,
     );
     return;
   }

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -449,7 +449,7 @@ function makeMockSnapshotLoader(
     load: () => Promise.resolve(snapshot),
     loadWithCounts: () =>
       Promise.resolve({ snapshot, grantCount: grants.length, groupCount: 0 }),
-    dispose: () => {},
+    dispose: () => Promise.resolve(),
   } as unknown as PolicySnapshotLoader;
 }
 

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -26,6 +26,7 @@ import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
 import { PolicySnapshot } from "../domain/access/policy_snapshot.ts";
 import type { PolicySnapshotLoader } from "../domain/access/policy_snapshot_loader.ts";
 import type { Grant } from "../domain/models/access/grant_model.ts";
+import { GrantBasedAccessDecisionService } from "../domain/access/grant_based_access_decision_service.ts";
 
 await initializeLogging({});
 
@@ -441,8 +442,10 @@ function makeMockSnapshotLoader(
   grants: Grant[],
 ): PolicySnapshotLoader {
   const snapshot = new PolicySnapshot(grants, []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
   return {
     snapshot,
+    decisionService: service,
     load: () => Promise.resolve(snapshot),
     loadWithCounts: () =>
       Promise.resolve({ snapshot, grantCount: grants.length, groupCount: 0 }),

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -51,11 +51,17 @@ export type ServerTokenAuthResult =
  * ServerToken model's `redeem` method. Returns the authenticated
  * principal ID on success, or an error message on failure.
  */
+const MAX_TOKEN_LENGTH = 512;
+
 export async function authenticateServerToken(
   presented: string,
   repoDir: string,
   repoContext: RepositoryContext,
 ): Promise<ServerTokenAuthResult> {
+  if (presented.length > MAX_TOKEN_LENGTH) {
+    return { ok: false, error: "Token exceeds maximum length" };
+  }
+
   const split = splitServerToken(presented);
   if (split === null) {
     return {
@@ -86,7 +92,7 @@ export async function authenticateServerToken(
         name: split.name,
         error: event.error.message,
       });
-      return { ok: false, error: event.error.message };
+      return { ok: false, error: "Authentication failed" };
     }
     if (event.kind === "completed") {
       const tokenRecord = event.run.dataArtifacts.find(

--- a/src/serve/token_auth_test.ts
+++ b/src/serve/token_auth_test.ts
@@ -18,7 +18,8 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { splitServerToken } from "./token_auth.ts";
+import { authenticateServerToken, splitServerToken } from "./token_auth.ts";
+import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 
 // ── splitServerToken ────────────────────────────────────────────────────
 
@@ -47,4 +48,19 @@ Deno.test("splitServerToken: handles dots in secret", () => {
 Deno.test("splitServerToken: single-char name and secret", () => {
   const result = splitServerToken("a.b");
   assertEquals(result, { name: "a", secret: "b" });
+});
+
+// ── authenticateServerToken ─────────────────────────────────────────────
+
+Deno.test("authenticateServerToken: rejects token exceeding MAX_TOKEN_LENGTH", async () => {
+  const longToken = "name." + "a".repeat(513);
+  const result = await authenticateServerToken(
+    longToken,
+    "/tmp/nonexistent",
+    {} as RepositoryContext,
+  );
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error, "Token exceeds maximum length");
+  }
 });


### PR DESCRIPTION
## Summary

12 fixes for the serve auth subsystem, found during pre-publication review of the serve user guide. All verified against `wss://demo.swamp-club.ai` with live token auth.

**Security (critical):**
- Reject WebSocket upgrades for non-token auth modes (oauth fallthrough → 501 instead of unauthenticated)
- Cap presented token length at 512 chars to prevent expensive processing
- Generic "Authentication failed" errors instead of state-specific messages that enable token enumeration
- Per-IP rate limiting on auth failures (5 attempts / 60s, then 429)
- Cap concurrent requests per connection at 100

**Correctness:**
- Populate resource fields (modelType, name, tags) in `authorizeOrReject` so CEL grant conditions evaluate against real values
- Replace fire-and-forget `#rebuild()` with serialized promise chain + 500ms debounce

**Hardening:**
- Warn on vault put over unencrypted `ws://` to non-loopback hosts
- Validate `type`/`id` fields on server response frames in remote_run client
- Warn-level logging before every 401/429 for operator visibility

**Performance:**
- Cache `GrantBasedAccessDecisionService` on `PolicySnapshotLoader` (invalidated on snapshot change)
- Deduplicate `groupsForPrincipal` calls in `decide()`/`explain()`

## Test Plan

- `deno run test` — 7630 passed, 0 failed
- Live verification against `wss://demo.swamp-club.ai`:
  - Paul (admin) — grant list, can-i, data get/query, model run all work
  - Fake/oversized/wrong-secret/nonexistent tokens all rejected with generic errors
  - Rate limiting kicks in after 5 failures, recovers after 60s window
  - Sarah (conditional CEL grant `modelType == "command/shell"`) — allowed for `hello`, denied for `swamp/grant` models
  - Sarah denied admin ops (grant list)
  - Adam explicit deny confirmed
  - Server logs verified: correct warn messages, no enumeration leakage, rate-limit entries visible
  - All operations under 0.8s (no performance regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)