### PR TITLE
fix(validation): allow model-type-specific self extras in CEL expressions (swamp-club#733)

### DIFF
--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -976,11 +976,7 @@ export class DefaultModelValidationService implements ModelValidationService {
     }
 
     if (firstSegment !== "globalArguments") {
-      return {
-        expression: ref.rawExpression,
-        error:
-          `Invalid self reference segment "${firstSegment}". Valid segments: name, version, tags, globalArguments`,
-      };
+      return null;
     }
 
     if (remainingPath.length === 0) {

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -365,11 +365,32 @@ Deno.test("validateModel with expression paths fails for invalid self attribute"
   assertStringIncludes(exprResult?.error ?? "", "nonExistent");
 });
 
-Deno.test("validateModel with expression paths fails for invalid self segment", async () => {
+Deno.test("validateModel with expression paths allows unknown self segments for extension extras", async () => {
   const service = new DefaultModelValidationService();
   const definition = Definition.create({
     name: "test-definition",
-    globalArguments: { message: "${{ self.wrongSegment }}" },
+    globalArguments: { message: "${{ self.workItem }}" },
+  });
+
+  const mockRepo = createMockDefinitionRepo([
+    { name: "test-definition", type: "test/expr-validation", definition },
+  ]);
+
+  const { results } = await service.validateModel(
+    definition,
+    testExprModel,
+    mockRepo,
+  );
+
+  const exprResult = results.find((r) => r.name === "Expression paths");
+  assertEquals(exprResult?.passed, true);
+});
+
+Deno.test("validateModel with expression paths still validates globalArguments paths", async () => {
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { message: "${{ self.globalArguments.nonExistent }}" },
   });
 
   const mockRepo = createMockDefinitionRepo([
@@ -384,7 +405,7 @@ Deno.test("validateModel with expression paths fails for invalid self segment", 
 
   const exprResult = results.find((r) => r.name === "Expression paths");
   assertEquals(exprResult?.passed, false);
-  assertStringIncludes(exprResult?.error ?? "", "wrongSegment");
+  assertStringIncludes(exprResult?.error ?? "", "nonExistent");
 });
 
 Deno.test("validateModel with expression paths provides typo suggestion", async () => {


### PR DESCRIPTION
## Summary

- The structural CEL validator (`validateSelfPathReference`) rejected any `self.*` segment beyond the four hardcoded builtins (`name`, `version`, `tags`, `globalArguments`). Model types that inject runtime self extras (e.g. `@swamp/software-factory` with `self.workItem`) could not reference those extras in CEL expressions — static validation blocked them even though the runtime resolver handled them correctly.
- Fix: keep strict deep-path validation on `self.globalArguments.*` (schema-backed) and allow unknown first-level self segments to pass through. Unknown segments resolve to `null` at runtime if unpopulated, with no crash.
- No extension changes needed — existing extensions like `@swamp/software-factory` work immediately.

Closes swamp-club/lab#733

## Test Plan

- Added unit test confirming unknown self segments (e.g. `self.workItem`) now pass expression path validation
- Added unit test confirming `self.globalArguments.*` deep-path validation still catches invalid nested keys
- Existing tests for `self.name`, `self.version`, `self.tags`, `self.globalArguments` continue to pass
- Verified end-to-end: pulled `@swamp/software-factory` extension, created a factory with `${{ self.workItem }}` in stage inputs, `swamp model validate` now passes (previously failed with `Invalid self reference segment "workItem"`)
- Full test suite: 7652 passed, 1 pre-existing failure (unrelated `xattr` environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)