### PR TITLE
fix(serve): authorize typeArg execution target in model.method.run

### DIFF
--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -888,6 +888,24 @@ async function handleModelMethodRun(
           fields: {},
         }, ctx)
       ) return;
+
+      // SECURITY: When typeArg is present, the execution path resolves the model
+      // from typeArg, not modelIdOrName. Authorize the execution target separately
+      // to prevent a mismatch bypass where a user authorized for one model supplies
+      // a different typeArg (e.g. command/shell) to execute an unauthorized model.
+      if (payload.typeArg) {
+        const stripped = payload.typeArg.startsWith("@")
+          ? payload.typeArg.slice(1)
+          : payload.typeArg;
+        const executionTarget = ModelType.create(stripped).normalized;
+        if (
+          !authorizeOrReject(socket, requestId, principal, "run", {
+            kind: "model",
+            name: executionTarget,
+            fields: {},
+          }, ctx)
+        ) return;
+      }
     }
 
     if (preResult) {

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -1596,3 +1596,279 @@ Deno.test("authorizeOrReject: admin on access:* grants data.get (superuser)", ()
     "admin superuser should not be denied data.get",
   );
 });
+
+// ── Authorization: typeArg execution-target mismatch (SWAMP-003) ────────────
+// Regression tests: authorization must check the execution target (typeArg),
+// not just the claimed model (modelIdOrName).
+
+const narrowModelGrant = makeGrant({
+  subject: { kind: "user", name: "adam" },
+  actions: ["run"],
+  resource: { kind: "model", pattern: "@acme/my-model" },
+});
+
+Deno.test("typeArg authz: narrow grant + mismatched typeArg is denied", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, [narrowModelGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-mismatch",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "attack-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+  const errorMessage = String((msg.error as Record<string, unknown>).message);
+  assertStringIncludes(errorMessage, "run");
+  assertStringIncludes(errorMessage, "model:command/shell");
+});
+
+Deno.test("typeArg authz: direct command/shell without grant is denied", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, [narrowModelGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-direct",
+      payload: {
+        modelIdOrName: "command/shell",
+        methodName: "run",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  assertEquals(mock.sent.length, 1);
+  const msg = parseSent(mock);
+  assertEquals(msg.type, "error");
+  assertEquals((msg.error as Record<string, unknown>).code, "unauthorized");
+});
+
+Deno.test("typeArg authz: model:* grant + typeArg still works (no regression)", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, [lowPrivGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-wildcard",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "model:* grant should authorize any typeArg",
+  );
+});
+
+Deno.test("typeArg authz: matching modelIdOrName and typeArg with narrow grant works", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const matchingGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "command/shell" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [narrowModelGrant, matchingGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-matching",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "user with grants for both modelIdOrName and typeArg should be authorized",
+  );
+});
+
+Deno.test("typeArg authz: admin superuser bypasses typeArg check", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const adminGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["admin"],
+    resource: { kind: "access", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [adminGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-admin",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "admin superuser should bypass typeArg authorization",
+  );
+});
+
+Deno.test("typeArg authz: prefix wildcard grant covers matching typeArg", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const prefixGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "command/*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [narrowModelGrant, prefixGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-prefix",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "prefix wildcard grant command/* should cover command/shell typeArg",
+  );
+});
+
+Deno.test("typeArg authz: @ prefix on typeArg is stripped before authorization", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const shellGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "command/shell" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [narrowModelGrant, shellGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "model.method.run",
+      id: "swamp003-at-prefix",
+      payload: {
+        modelIdOrName: "@acme/my-model",
+        methodName: "run",
+        typeArg: "@command/shell",
+        definitionName: "my-shell",
+      },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const unauthorizedErrors = mock.sent
+    .map((s) => JSON.parse(s))
+    .filter((m) =>
+      m.type === "error" &&
+      (m.error as Record<string, unknown>).code === "unauthorized"
+    );
+  assertEquals(
+    unauthorizedErrors.length,
+    0,
+    "@ prefix on typeArg should be stripped — grant for command/shell should match @command/shell",
+  );
+});


### PR DESCRIPTION
## Summary

- When `typeArg` is present in a `model.method.run` request, the execution path
  resolves the model from `typeArg` rather than `modelIdOrName`. The
  authorization gate now checks both the claimed model and the normalized
  execution target, preventing a principal with a narrow per-model grant from
  supplying a mismatched `typeArg` to run a model they are not authorized for.
- Added 7 regression tests covering: mismatched typeArg denied, direct
  unauthorized denied, `model:*` wildcard no regression, matching grants pass,
  admin superuser bypass, prefix wildcard grants, and `@` prefix stripping.

## Test Plan

- `deno run test src/serve/connection_test.ts` — all 99 tests pass (92 existing + 7 new)
- `deno check` — type check passes
- `deno lint` — no lint issues
- `deno fmt --check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)