### PR TITLE
fix(telemetry): use requireRepoMarker for telemetry stats (swamp-club#741)

### DIFF
--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -24,7 +24,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import { requireRepoMarker } from "../repo_context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -51,10 +51,9 @@ export const telemetryStatsCommand = new Command()
     ]);
     cliCtx.logger.debug`Fetching telemetry stats`;
 
-    const { repoDir } = await requireInitializedRepoReadOnly({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir } = await requireRepoMarker(
+      resolveRepoDir(options.repoDir),
+    );
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = createTelemetryStatsDeps(repoDir, VERSION);


### PR DESCRIPTION
## Summary

- `telemetry stats` fatally crashed with `Unknown datastore type` for repos using custom datastore extensions, while all other commands loaded the same extension fine
- Root cause: `telemetry` is in `NON_REPO_COMMANDS` so extension loaders are never configured, but the command called `requireInitializedRepoReadOnly()` which eagerly resolves custom datastores
- Fix: switch to `requireRepoMarker()` — the command only reads local JSON telemetry files and never needs the datastore

Fixes swamp-club#741

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 415 CLI command tests pass
- [ ] Manual verification with a custom datastore extension repo (requires external setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)