### PR TITLE
fix(security): strengthen adversarial review with trust boundary and data flow dimensions

### DIFF
--- a/.github/actions/adversarial-review/action.yml
+++ b/.github/actions/adversarial-review/action.yml
@@ -76,13 +76,69 @@ runs:
           - Are try/catch blocks too broad, catching errors they shouldn't?
           - Is cleanup code (finally blocks, resource disposal) actually correct?
 
-          ## 3. Security
+          ## 3. Security — Implementation Patterns
           - Command injection via string interpolation in shell commands or subprocess calls
-          - Path traversal — can user input escape intended directories?
+          - Path traversal — can user input escape intended directories? Are `..` components, absolute
+            paths, and symlink targets validated? Does the code use the codebase's existing primitives
+            (`assertSafePath`, `assertContainedPath`, `validateNoSymlinkEscape`) for untrusted paths?
+            New file-handling code that skips these is CRITICAL.
+          - Symlink escape — are symlinks from untrusted sources (extension dirs, archives, copied
+            skill directories) detected with lstat and validated to stay within the expected root?
+          - Path containment on external data — if file operations (copy, delete, read) use paths
+            from lockfiles, manifests, extension metadata, or repo-controlled JSON, are paths validated
+            to stay within the expected boundary before any filesystem operation?
           - Sensitive data exposure in logs, error messages, or stack traces
           - Prototype pollution, ReDoS, or other JS/TS-specific vulnerabilities
           - Are secrets, tokens, or credentials ever hardcoded or logged?
           - TOCTOU (time-of-check-time-of-use) race conditions on file operations
+
+          ## 3b. Security — Trust Boundary & Authorization Design
+          These checks catch design-level security flaws that code-pattern matching misses.
+          For every trust boundary crossing in the diff, apply ALL of the following:
+          - Authorization/execution identity consistency — when code authorizes an operation using
+            one value and then executes using a different value (different payload fields, raw vs.
+            normalized forms), that is a CRITICAL authorization bypass. The identity used for the
+            security decision must be the exact same canonical value used for execution. Example:
+            authorizing on `payload.modelIdOrName` but executing from `payload.typeArg` lets an
+            attacker authorize a harmless model and execute a dangerous one.
+          - Canonicalization before security decisions — any input that can be represented in multiple
+            forms (`.` vs `/` separators, `::` vs `/`, case variants, whitespace, URL encoding) MUST
+            be normalized to a single canonical form BEFORE authorization or access-control checks.
+            If a raw string passes the security gate but the normalized form resolves to a different
+            (privileged) resource, that is a bypass.
+          - Defense-in-depth at sensitive execution sinks — built-in operations that execute commands,
+            modify access control, or delete resources must independently verify authorization at the
+            point of execution, not rely solely on an upstream routing gate that may use a different
+            code path, payload field, or identity representation.
+          - Confused deputy / privilege delegation — when code acts on behalf of a caller (serve
+            executing a model for a WebSocket client, extension install acting on lockfile data), does
+            the callee operate with the caller's authority? Can the caller influence which authority is
+            used, which code path runs, or which capabilities are exercised beyond what was authorized?
+          - Untrusted data round-trip through persistence — if external or repo-controlled data is
+            written to a file (lockfile, config, manifest) and later read back and acted upon, the
+            read-back path must validate data shape AND path/identity containment. A hand-edited or
+            malicious committed file bypasses write-time checks.
+
+          ## 3c. Security — Data Flow & Reachability
+          - Trace untrusted data ingress-to-sink — for each piece of untrusted data in the diff
+            (WebSocket message fields, extension manifest entries, lockfile arrays, CLI arguments),
+            trace where it enters and where it acts (file operation, command execution, authorization
+            decision, database write). Every step must validate or be proven safe by its caller. If
+            any step assumes "the caller already validated this," verify the assumption for ALL callers.
+          - Reachability from unvalidated paths — if a function receives data that was validated at
+            one call site, can the same function be reached from a different path that skips validation?
+            Internal functions callable from both validated and unvalidated contexts must validate
+            defensively. This is CRITICAL when the function performs file operations, command execution,
+            or authorization decisions.
+          - Resource exhaustion — can a client-controlled value (array length, string size, nesting
+            depth, query predicate, CEL condition) cause unbounded memory allocation, CPU consumption,
+            or recursive processing? Operations driven by untrusted input must have explicit limits.
+          - Error information leakage — do error messages or WebSocket error frames returned to clients
+            leak internal paths, token fragments, configuration details, or other attacker-useful info?
+            Errors crossing trust boundaries should be generic; diagnostics belong in server-side logs.
+          - Stale authorization — for long-lived connections (WebSocket), are permissions re-evaluated
+            on each request? If grants are revoked or tokens expire mid-session, when does revocation
+            take effect? New authorized operations must consider the authorization lifecycle.
 
           ## 4. Concurrency & State
           - Can concurrent operations corrupt shared state?

--- a/agent-constraints/adversarial-dimensions.md
+++ b/agent-constraints/adversarial-dimensions.md
@@ -38,6 +38,91 @@ should be filed in `swamp-club/swamp-uat`?
 Is this over-engineered? Could it be simpler? Are there unnecessary abstractions
 or indirections?
 
+## Security
+
+Does this change handle untrusted input from a trust boundary (WebSocket
+messages, extension sources, lockfiles, user-supplied paths, repo-controlled
+JSON)? Challenge each trust boundary crossing:
+
+### Trust boundary & authorization design
+
+- **Authorization/execution identity consistency**: If the change authorizes an
+  operation using one value and executes using another (different payload fields,
+  raw vs. normalized forms), that is a critical finding. The identity used for
+  the security decision must be the exact same canonical value used for
+  execution.
+- **Canonicalization before security decisions**: If input can be represented in
+  multiple forms (case variants, separator substitution like `.` for `/`,
+  whitespace, `::`, `//`), is it normalized to a single canonical form _before_
+  any authorization or access-control check? Raw-vs-canonical mismatches are
+  bypass vectors.
+- **Defense-in-depth at execution sinks**: Sensitive operations (command
+  execution, access-control model execution, credential access, file deletion)
+  should independently verify authorization at the point of execution, not rely
+  solely on an upstream gate that may use a different code path or identity.
+- **Confused deputy / privilege delegation**: When code acts on behalf of a
+  caller (serve executing a model for a WebSocket client, extension install
+  acting on lockfile data), does the callee operate with the _caller's_
+  authority? Can the caller influence which authority is used, which code path
+  runs, or which capabilities are exercised beyond what they were authorized for?
+
+### Data flow & input validation
+
+- **Trace untrusted data from ingress to sink**: For every trust boundary
+  crossing in this change, trace the data from where it enters (WebSocket
+  message field, extension manifest entry, lockfile array, CLI argument) to
+  where it acts (file operation, command execution, authorization decision,
+  database write). Every step in that path must either validate/constrain the
+  data or be proven safe by the step before it. If a step assumes "the caller
+  already validated this," verify the assumption holds for _every_ caller.
+- **Reachability from unvalidated paths**: If a function receives data that was
+  validated at the call site, is the same function reachable from a different
+  path that skips validation? Internal functions called from both validated and
+  unvalidated contexts must validate defensively or the plan must ensure a
+  single validated entry point.
+- **Untrusted data in persisted artifacts**: If repo-controlled or
+  user-controlled data is written to a file that is later read back and acted
+  upon (lockfiles, config, manifests), verify the read-back path validates the
+  data shape and containment — not just the write path. A hand-edited or
+  malicious committed file bypasses write-time checks.
+
+### Filesystem safety
+
+- **Path and symlink containment**: If the change performs file operations
+  (copy, delete, read, stat) using paths from external data (lockfiles,
+  extension manifests, archive entries, user input), does it validate that
+  resolved paths stay within the expected root? Check for `..` traversal,
+  absolute paths, and symlinks that escape the boundary. Use existing primitives
+  (`assertSafePath`, `assertContainedPath`, `validateNoSymlinkEscape`) or
+  equivalent. New file-handling code that doesn't use these is a finding.
+
+### Resource exhaustion
+
+- **Unbounded operations from untrusted input**: Can a client-controlled value
+  (array length, string size, nesting depth, query predicate, CEL condition)
+  cause unbounded memory allocation, CPU consumption, or recursive processing?
+  Operations driven by untrusted input must have explicit size, depth, or
+  complexity limits.
+
+### Information disclosure
+
+- **Error leakage to callers**: Do error messages, stack traces, or WebSocket
+  error frames returned to clients leak internal paths, token fragments,
+  configuration details, or other information useful to an attacker? Errors
+  crossing trust boundaries should be generic; diagnostic detail belongs in
+  server-side logs only.
+
+### Stateful protocol safety
+
+- **Stale authorization on long-lived connections**: If a WebSocket connection
+  is long-lived, are permissions re-evaluated on each request? If grants are
+  revoked or tokens expire, when does the revocation take effect for existing
+  connections? Plans that add new authorized operations to serve must consider
+  the authorization lifecycle.
+- **Replay and ordering**: Can WebSocket messages be replayed to repeat
+  operations that should be one-shot? Can message ordering be manipulated to
+  bypass checks that assume a sequence?
+
 ## Correctness
 
 Will this actually solve the problem? Are there logical gaps? Does the approach


### PR DESCRIPTION
## Summary

Four security reports (SWAMP-001 through SWAMP-004) revealed systematic gaps in our adversarial review process. The vulnerabilities shared common patterns — authorization/execution identity mismatches, canonicalization bypasses, path/symlink containment gaps, and confused deputy patterns — that neither the plan-time nor code-time adversarial reviews were designed to catch.

**Root cause:** The issue-lifecycle adversarial review had no security dimension at all, and the CI adversarial review's security checks were implementation-focused (string interpolation injection, TOCTOU) rather than design-focused.

This PR adds comprehensive security dimensions to both review layers:

**`agent-constraints/adversarial-dimensions.md`** (plan-time) — new Security dimension with 6 subcategories:
- Trust boundary & authorization design (auth/exec identity, canonicalization, defense-in-depth, confused deputy)
- Data flow & input validation (ingress-to-sink tracing, reachability from unvalidated paths, persisted data trust)
- Filesystem safety (path/symlink containment, enforcing existing primitives)
- Resource exhaustion (unbounded ops from client-controlled input)
- Information disclosure (error leakage across trust boundaries)
- Stateful protocol safety (stale auth on long-lived connections, replay/ordering)

**`.github/actions/adversarial-review/action.yml`** (code-time) — expanded from 1 security section to 3:
- §3: Implementation patterns — original checks plus symlink escape and path containment with explicit reference to existing primitives (`assertSafePath`, `assertContainedPath`, `validateNoSymlinkEscape`)
- §3b: Trust boundary & authorization design
- §3c: Data flow & reachability

The key shift: the old reviews asked "does this code pattern look dangerous?" The new ones ask "trace the untrusted data from where it enters to where it acts — does every step in that path validate or constrain it?"

## Test Plan

- These are review dimension changes (markdown/YAML), not code changes — no runtime tests required
- Verified `deno fmt --check` and `deno lint` pass
- CI adversarial review and issue-lifecycle will pick up the new dimensions on the next PR/triage cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)