### PR TITLE
fix(http): improve timeout error for issue submission (swamp-club#742)

### DIFF
--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -296,8 +296,18 @@ export async function submitIssue(
       body: input.body,
     };
 
-  await consumeStream(
-    issueCreate(libCtx, deps, labInput),
-    renderer.handlers(),
-  );
+  try {
+    await consumeStream(
+      issueCreate(libCtx, deps, labInput),
+      renderer.handlers(),
+    );
+  } catch (error) {
+    if (error instanceof UserError && error.code === "timeout") {
+      throw new UserError(
+        `${error.message} Your report has not been lost — retry, or use --email to send it via email instead.`,
+        "timeout",
+      );
+    }
+    throw error;
+  }
 }

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -208,30 +208,63 @@ export class SwampClubClient {
       title: string;
       body: string;
     },
+    signal?: AbortSignal,
   ): Promise<{ number: number; id: string }> {
-    const res = await this.fetch("/api/v1/lab/issues", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-      },
-      body: JSON.stringify({
-        source: "swamp",
-        type: input.type,
-        title: input.title,
-        body: input.body,
-      }),
-    });
+    const maxAttempts = 3;
+    const backoffMs = [2_000, 4_000];
 
-    if (!res.ok) {
-      const body = await res.text();
-      throw new UserError(
-        `Failed to submit issue (HTTP ${res.status}): ${body}`,
-      );
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const res = await this.fetch(
+          "/api/v1/lab/issues",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-api-key": apiKey,
+            },
+            body: JSON.stringify({
+              source: "swamp",
+              type: input.type,
+              title: input.title,
+              body: input.body,
+            }),
+          },
+          signal,
+          60_000,
+        );
+
+        if (!res.ok) {
+          const body = await res.text();
+          throw new UserError(
+            `Failed to submit issue (HTTP ${res.status}): ${body}`,
+          );
+        }
+
+        const data = await res.json();
+        return { number: data.issue.number, id: data.issue.id };
+      } catch (error) {
+        const isTimeout = error instanceof UserError &&
+          error.code === "timeout";
+        const isLastAttempt = attempt === maxAttempts - 1;
+        if (!isTimeout || isLastAttempt) throw error;
+
+        const delay = backoffMs[attempt] ?? backoffMs[backoffMs.length - 1];
+        await new Promise<void>((resolve, reject) => {
+          if (signal?.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          const timer = setTimeout(resolve, delay);
+          signal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(signal.reason);
+          }, { once: true });
+        });
+      }
     }
 
-    const data = await res.json();
-    return { number: data.issue.number, id: data.issue.id };
+    throw new Error("unreachable");
   }
 
   /**
@@ -491,9 +524,10 @@ export class SwampClubClient {
     path: string,
     init: RequestInit,
     callerSignal?: AbortSignal,
+    timeoutMs = 15_000,
   ): Promise<Response> {
     const url = `${this.serverUrl}${path}`;
-    const timeoutSignal = AbortSignal.timeout(15000);
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
     const signal = callerSignal
       ? AbortSignal.any([callerSignal, timeoutSignal])
       : timeoutSignal;
@@ -520,8 +554,10 @@ export class SwampClubClient {
         throw error;
       }
       if (error instanceof DOMException && error.name === "TimeoutError") {
+        const seconds = Math.round(timeoutMs / 1000);
         throw new UserError(
-          `Request to ${this.serverUrl} timed out. Is the server running?`,
+          `Request to ${this.serverUrl}${path} timed out after ${seconds}s.`,
+          "timeout",
         );
       }
       const message = error instanceof Error ? error.message : String(error);

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -619,3 +619,86 @@ Deno.test("fetchIssue: commentCount is 0 when no comments array in response", as
     await mock.shutdown();
   }
 });
+
+// ── Timeout and retry ────────────────────────────────────────────────
+
+Deno.test("fetch: connection-refused error has no timeout code", async () => {
+  const client = new SwampClubClient("http://localhost:1");
+  const err = await assertRejects(
+    () => client.whoami("key"),
+    UserError,
+  );
+  assertEquals(err.code, undefined);
+  assertStringIncludes(err.message, "Could not connect to");
+});
+
+Deno.test("submitIssue: does not retry on non-timeout HTTP errors", async () => {
+  let attempts = 0;
+  const mock = startMockServer((_req) => {
+    attempts++;
+    return new Response("Server error", { status: 500 });
+  });
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    await assertRejects(
+      () =>
+        client.submitIssue("key", {
+          type: "bug",
+          title: "t",
+          body: "b",
+        }),
+      UserError,
+      "Failed to submit issue",
+    );
+    assertEquals(attempts, 1);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("submitIssue: does not retry on connection-refused errors", async () => {
+  let attempts = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (...args: Parameters<typeof fetch>) => {
+    attempts++;
+    return originalFetch(...args);
+  };
+  try {
+    const client = new SwampClubClient("http://localhost:1");
+    await assertRejects(
+      () =>
+        client.submitIssue("key", {
+          type: "bug",
+          title: "t",
+          body: "b",
+        }),
+      UserError,
+      "Could not connect to",
+    );
+    assertEquals(attempts, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("submitIssue: respects caller abort signal", async () => {
+  const mock = startMockServer(
+    (_req) => new Promise<Response>(() => {}),
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 50);
+    await assertRejects(
+      () =>
+        client.submitIssue(
+          "key",
+          { type: "bug", title: "t", body: "b" },
+          ac.signal,
+        ),
+      DOMException,
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- Improve timeout error message to include the endpoint path and timeout
  duration, replacing the misleading "Is the server running?" phrasing
- Raise `submitIssue` timeout from 15s to 60s (other calls keep the 15s
  default) and add bounded retry with exponential backoff (2 retries, 2s/4s)
  on timeout errors only
- Suggest `--email` fallback when Lab submission times out so the user's
  drafted report isn't lost
- Set `code: "timeout"` on the `UserError` for programmatic detection

Closes swamp-club/swamp-club#742

## Test Plan

- Existing 31 HTTP client tests pass unchanged
- Added 4 new tests: connection-refused has no timeout code, no retry on
  HTTP errors, no retry on connection-refused, respects caller abort signal
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)