### PR TITLE
fix(extensions): thread channel through download and checksum endpoints (swamp-club#743)

### DIFF
--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -77,8 +77,16 @@ function isBundleArtifactPath(relPath: string): boolean {
 
 interface InstallerAdapterConfig {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
-  downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
-  getChecksum: (name: string, version: string) => Promise<string | null>;
+  downloadArchive: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<Uint8Array>;
+  getChecksum: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<string | null>;
   /** Full path to the upstream_extensions.json lockfile. */
   lockfilePath: string;
   repoDir: string;

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -96,8 +96,16 @@ export interface PullContext {
     name: string,
     channel: string,
   ) => Promise<string | null>;
-  downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
-  getChecksum: (name: string, version: string) => Promise<string | null>;
+  downloadArchive: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<Uint8Array>;
+  getChecksum: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<string | null>;
   logger: Logger;
   /**
    * Lockfile repository owning read+write of upstream_extensions.json.

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -222,9 +222,10 @@ export const extensionSearchCommand = new Command()
       const lockfileRepository = await LockfileRepository.create(lockfilePath);
       const pullCtx: PullContext = {
         getExtension: (name) => client.getExtension(name),
-        downloadArchive: (name, version) =>
-          client.downloadArchive(name, version),
-        getChecksum: (name, version) => client.getChecksum(name, version),
+        downloadArchive: (name, version, channel) =>
+          client.downloadArchive(name, version, undefined, channel),
+        getChecksum: (name, version, channel) =>
+          client.getChecksum(name, version, channel),
         logger: ctx.logger,
         lockfileRepository,
         skillsDir: resolveSkillsDir(repoDir, resolvePrimaryTool(marker)),

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -77,8 +77,9 @@ export async function createExtensionInstallDeps(
     skillsDirRelative,
     createInstallContext: async (_name, _version) => ({
       getExtension: (n) => client.getExtension(n),
-      downloadArchive: (n, v) => client.downloadArchive(n, v),
-      getChecksum: (n, v) => client.getChecksum(n, v),
+      downloadArchive: (n, v, ch) =>
+        client.downloadArchive(n, v, undefined, ch),
+      getChecksum: (n, v, ch) => client.getChecksum(n, v, ch),
       logger,
       lockfileRepository: await LockfileRepository.create(lockfilePath),
       skillsDir: absoluteSkillsDir,

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -450,10 +450,10 @@ export function configureExtensionAutoResolver(
       extensionLookup: extensionClient,
       extensionInstaller: createAutoResolveInstallerAdapter({
         getExtension: (name) => extensionClient.getExtension(name),
-        downloadArchive: (name, version) =>
-          extensionClient.downloadArchive(name, version),
-        getChecksum: (name, version) =>
-          extensionClient.getChecksum(name, version),
+        downloadArchive: (name, version, channel) =>
+          extensionClient.downloadArchive(name, version, undefined, channel),
+        getChecksum: (name, version, channel) =>
+          extensionClient.getChecksum(name, version, channel),
         lockfilePath: join(
           resolve(repoDir, modelsDir),
           "upstream_extensions.json",

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -394,12 +394,14 @@ export class ExtensionApiClient {
     name: string,
     version: string,
     apiKey?: string,
+    channel?: string,
   ): Promise<string | null> {
     const encodedName = encodeURIComponent(name);
     const encodedVersion = encodeURIComponent(version);
     const headers = apiKey ? this.authHeaders(apiKey) : {};
+    const qs = channel ? `?channel=${encodeURIComponent(channel)}` : "";
     const res = await this.fetch(
-      `/api/v1/extensions/${encodedName}@${encodedVersion}/download`,
+      `/api/v1/extensions/${encodedName}@${encodedVersion}/download${qs}`,
       {
         method: "GET",
         redirect: "manual",
@@ -430,8 +432,14 @@ export class ExtensionApiClient {
     name: string,
     version: string,
     apiKey?: string,
+    channel?: string,
   ): Promise<Uint8Array> {
-    const downloadUrl = await this.getDownloadUrl(name, version, apiKey);
+    const downloadUrl = await this.getDownloadUrl(
+      name,
+      version,
+      apiKey,
+      channel,
+    );
     if (!downloadUrl) {
       throw new UserError(
         `Extension ${name}@${version} not found in the registry.`,
@@ -464,11 +472,13 @@ export class ExtensionApiClient {
   async getChecksum(
     name: string,
     version: string,
+    channel?: string,
   ): Promise<string | null> {
     const encodedName = encodeURIComponent(name);
     const encodedVersion = encodeURIComponent(version);
+    const qs = channel ? `?channel=${encodeURIComponent(channel)}` : "";
     const res = await this.fetch(
-      `/api/v1/extensions/${encodedName}@${encodedVersion}/checksum`,
+      `/api/v1/extensions/${encodedName}@${encodedVersion}/checksum${qs}`,
       {
         method: "GET",
       },

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -632,6 +632,16 @@ Deno.test("ExtensionApiClient version-scoped methods URL-encode version path seg
     const checksumUrl = new URL(captured.checksum);
     assertEquals(checksumUrl.pathname, `${expectedBase}/checksum`);
     assertEquals(checksumUrl.search, "");
+
+    await client.getDownloadUrl("@test/ext", hostileVersion, "key", "beta");
+    const downloadUrlCh = new URL(captured.download);
+    assertEquals(downloadUrlCh.pathname, `${expectedBase}/download`);
+    assertEquals(downloadUrlCh.searchParams.get("channel"), "beta");
+
+    await client.getChecksum("@test/ext", hostileVersion, "rc");
+    const checksumUrlCh = new URL(captured.checksum);
+    assertEquals(checksumUrlCh.pathname, `${expectedBase}/checksum`);
+    assertEquals(checksumUrlCh.searchParams.get("channel"), "rc");
   } finally {
     await server.shutdown();
   }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -123,10 +123,15 @@ export interface InstallResult {
  */
 export interface InstallContext {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
-  downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
+  downloadArchive: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<Uint8Array>;
   getChecksum: (
     name: string,
     version: string,
+    channel?: string,
   ) => Promise<string | null>;
   logger?: Logger;
   /**
@@ -209,8 +214,16 @@ export interface ExtensionPullDeps {
     name: string,
     channel: string,
   ) => Promise<string | null>;
-  downloadArchive: (name: string, version: string) => Promise<Uint8Array>;
-  getChecksum: (name: string, version: string) => Promise<string | null>;
+  downloadArchive: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<Uint8Array>;
+  getChecksum: (
+    name: string,
+    version: string,
+    channel?: string,
+  ) => Promise<string | null>;
   /**
    * Lockfile repository owning read+write of upstream_extensions.json.
    * See {@link InstallContext.lockfileRepository} for snapshot semantics
@@ -679,9 +692,10 @@ export async function installExtension(
   const archiveBytes = await ctx.downloadArchive(
     ref.name,
     version,
+    ctx.channel,
   );
 
-  const serverChecksum = await ctx.getChecksum(ref.name, version);
+  const serverChecksum = await ctx.getChecksum(ref.name, version, ctx.channel);
   const localChecksum = await computeChecksum(archiveBytes);
   let integrityStatus: "verified" | "unverified";
   if (serverChecksum !== null) {
@@ -1297,8 +1311,10 @@ export async function createExtensionPullDeps(
       const info = await client.getLatestVersion(name, undefined, channel);
       return info?.version ?? null;
     },
-    downloadArchive: (name, version) => client.downloadArchive(name, version),
-    getChecksum: (name, version) => client.getChecksum(name, version),
+    downloadArchive: (name, version, channel) =>
+      client.downloadArchive(name, version, undefined, channel),
+    getChecksum: (name, version, channel) =>
+      client.getChecksum(name, version, channel),
     lockfileRepository,
     skillsDir,
     repoDir,
@@ -1332,8 +1348,10 @@ export async function createInstallContext(
   const lockfileRepository = await LockfileRepository.create(opts.lockfilePath);
   return {
     getExtension: (name) => client.getExtension(name),
-    downloadArchive: (name, version) => client.downloadArchive(name, version),
-    getChecksum: (name, version) => client.getChecksum(name, version),
+    downloadArchive: (name, version, channel) =>
+      client.downloadArchive(name, version, undefined, channel),
+    getChecksum: (name, version, channel) =>
+      client.getChecksum(name, version, channel),
     logger: opts.logger,
     lockfileRepository,
     skillsDir: opts.skillsDir,


### PR DESCRIPTION
## Summary

- Thread the release channel query parameter through `getDownloadUrl` and `getChecksum` in `ExtensionApiClient`, matching the pattern already used by `getLatestVersion`
- Update all type signatures (`InstallContext`, `ExtensionPullDeps`, `PullContext`, `InstallerAdapterConfig`) and closure factories to forward the channel
- When channel is `undefined` (stable/default), URLs are byte-for-byte identical to before — only beta/rc pulls gain the `?channel=` param

Fixes swamp-club#743

## Test Plan

- [x] Extended URL-encoding test to verify `?channel=beta` and `?channel=rc` on download and checksum endpoints
- [x] All 7665 tests pass
- [x] Type check, lint, and format all clean
- [ ] E2E verification against swamp-club with a beta-channel extension (cannot be automated in unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)