### PR TITLE
fix(security): WebSocket Origin/Host validation and auth-mode none deprecation

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -117,6 +117,54 @@ export function assertOffLoopbackSecurity(
   }
 }
 
+export function validateWebSocketOrigin(
+  origin: string | null,
+  hostHeader: string | null,
+  bindHost: string,
+  tlsEnabled: boolean,
+): { allowed: boolean; reason?: string } {
+  if (origin) {
+    const TRUSTED_ORIGINS = new Set([
+      "http://127.0.0.1",
+      "http://localhost",
+      "https://127.0.0.1",
+      "https://localhost",
+      "http://[::1]",
+      "https://[::1]",
+    ]);
+    if (tlsEnabled) {
+      TRUSTED_ORIGINS.add(`https://${bindHost.toLowerCase()}`);
+    }
+
+    let originBase: string;
+    try {
+      const originUrl = new URL(origin);
+      originBase = `${originUrl.protocol}//${originUrl.hostname}`;
+    } catch {
+      return { allowed: false, reason: `malformed origin: ${origin}` };
+    }
+
+    if (!TRUSTED_ORIGINS.has(originBase)) {
+      return { allowed: false, reason: `untrusted origin: ${origin}` };
+    }
+  }
+
+  if (hostHeader) {
+    const hostName = hostHeader.split(":")[0].toLowerCase();
+    const TRUSTED_HOSTS = new Set([
+      "127.0.0.1",
+      "localhost",
+      "::1",
+      bindHost.toLowerCase(),
+    ]);
+    if (!TRUSTED_HOSTS.has(hostName)) {
+      return { allowed: false, reason: `untrusted host: ${hostHeader}` };
+    }
+  }
+
+  return { allowed: true };
+}
+
 export const serveCommand = new Command()
   .name("serve")
   .description(
@@ -533,6 +581,29 @@ export const serveCommand = new Command()
         // WebSocket upgrade (check first — upgrade requests are also GETs)
         const upgrade = req.headers.get("upgrade") ?? "";
         if (upgrade.toLowerCase() === "websocket") {
+          const remoteAddr = trustProxy
+            ? (req.headers.get("x-forwarded-for")
+              ?.split(",")[0]?.trim() ??
+              info.remoteAddr.hostname)
+            : info.remoteAddr.hostname;
+
+          const originCheck = validateWebSocketOrigin(
+            req.headers.get("origin"),
+            req.headers.get("host"),
+            host,
+            tlsEnabled,
+          );
+          if (!originCheck.allowed) {
+            logger.warn(
+              "WebSocket upgrade rejected: {reason} from {ip}",
+              { reason: originCheck.reason, ip: remoteAddr },
+            );
+            return new Response(
+              `Forbidden: ${originCheck.reason}`,
+              { status: 403 },
+            );
+          }
+
           if (authConfig.mode !== "none") {
             if (authConfig.mode !== "token") {
               return new Response(
@@ -541,11 +612,6 @@ export const serveCommand = new Command()
               );
             }
 
-            const remoteAddr = trustProxy
-              ? (req.headers.get("x-forwarded-for")
-                ?.split(",")[0]?.trim() ??
-                info.remoteAddr.hostname)
-              : info.remoteAddr.hostname;
             if (!checkRateLimit(remoteAddr)) {
               logger.warn("WebSocket auth rate-limited from {ip}", {
                 ip: remoteAddr,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -212,7 +212,7 @@ export const serveCommand = new Command()
   )
   .option(
     "--auth-mode <mode:string>",
-    "Authentication mode: none (default), token, or oauth",
+    "Authentication mode: none (default, deprecated), token, or oauth",
     { default: "none" },
   )
   .option(
@@ -301,6 +301,14 @@ export const serveCommand = new Command()
       logger.warn(
         "--admins is set but --auth-mode is {mode} — admins will have no effect",
         { mode: authConfig.mode },
+      );
+    }
+
+    if (authConfig.mode === "none") {
+      logger.warn(
+        "auth-mode is 'none' — this mode is deprecated and will be removed in a future release. " +
+          "Use --auth-mode token for authenticated access. " +
+          "See https://swamp-club.com/manual/how-to/swamp-serve/set-up-token-auth",
       );
     }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -150,7 +150,13 @@ export function validateWebSocketOrigin(
   }
 
   if (hostHeader) {
-    const hostName = hostHeader.split(":")[0].toLowerCase();
+    let hostName: string;
+    try {
+      const parsed = new URL(`http://${hostHeader}`);
+      hostName = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    } catch {
+      return { allowed: false, reason: `malformed host: ${hostHeader}` };
+    }
     const TRUSTED_HOSTS = new Set([
       "127.0.0.1",
       "localhost",

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -19,7 +19,7 @@
 
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
-import { assertOffLoopbackSecurity } from "./serve.ts";
+import { assertOffLoopbackSecurity, validateWebSocketOrigin } from "./serve.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // Initialize logging for tests
@@ -117,4 +117,135 @@ Deno.test("assertOffLoopbackSecurity: loopback localhost with no TLS and no auth
 
 Deno.test("assertOffLoopbackSecurity: IPv6 loopback ::1 with no TLS and no auth passes", () => {
   assertOffLoopbackSecurity("::1", false, "none");
+});
+
+// --- WebSocket origin/host validation ---
+
+Deno.test("validateWebSocketOrigin: rejects cross-origin http://evil.com", () => {
+  const result = validateWebSocketOrigin(
+    "http://evil.com",
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted origin");
+});
+
+Deno.test("validateWebSocketOrigin: rejects attacker-controlled origin", () => {
+  const result = validateWebSocketOrigin(
+    "http://attacker.example.com",
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted origin");
+});
+
+Deno.test("validateWebSocketOrigin: accepts http://127.0.0.1", () => {
+  const result = validateWebSocketOrigin(
+    "http://127.0.0.1",
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: accepts http://127.0.0.1 with port", () => {
+  const result = validateWebSocketOrigin(
+    "http://127.0.0.1:9090",
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: accepts http://localhost", () => {
+  const result = validateWebSocketOrigin(
+    "http://localhost",
+    "localhost:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: accepts absent origin (non-browser client)", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: rejects DNS-rebinding host", () => {
+  const result = validateWebSocketOrigin(
+    "http://localhost",
+    "evil.com:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted host");
+});
+
+Deno.test("validateWebSocketOrigin: accepts host 127.0.0.1", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: accepts host localhost", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "localhost:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: accepts host matching --host flag", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "myhost.local:9090",
+    "myhost.local",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: TLS adds server domain to trusted origins", () => {
+  const result = validateWebSocketOrigin(
+    "https://myserver.example.com",
+    "myserver.example.com:443",
+    "myserver.example.com",
+    true,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: TLS server domain rejected without TLS", () => {
+  const result = validateWebSocketOrigin(
+    "https://myserver.example.com",
+    "myserver.example.com:443",
+    "myserver.example.com",
+    false,
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted origin");
+});
+
+Deno.test("validateWebSocketOrigin: absent host header passes", () => {
+  const result = validateWebSocketOrigin(null, null, "127.0.0.1", false);
+  assertEquals(result.allowed, true);
 });

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -249,3 +249,24 @@ Deno.test("validateWebSocketOrigin: absent host header passes", () => {
   const result = validateWebSocketOrigin(null, null, "127.0.0.1", false);
   assertEquals(result.allowed, true);
 });
+
+Deno.test("validateWebSocketOrigin: accepts IPv6 loopback host [::1]:9090", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "[::1]:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: rejects malformed origin", () => {
+  const result = validateWebSocketOrigin(
+    "not-a-url",
+    "127.0.0.1:9090",
+    "127.0.0.1",
+    false,
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "malformed origin");
+});


### PR DESCRIPTION
## Summary

- **Origin/Host validation on WebSocket upgrade**: Validates the `Origin` header against trusted loopback origins (and the server's own domain when TLS is enabled) to prevent Cross-Site WebSocket Hijacking (CSWSH). Validates the `Host` header against trusted hostnames to prevent DNS rebinding attacks. Applies to all auth modes as defence-in-depth. Non-browser clients (the swamp CLI) don't send Origin headers, so absent Origin passes through unchanged.
- **Deprecation warning for auth-mode none**: Emits a prominent warning when `swamp serve` starts with `--auth-mode none` (the current default), directing users to `--auth-mode token`. Updates CLI help text to mark `none` as deprecated. Does not remove the mode yet to avoid breaking existing users.
- **13 new unit tests** for `validateWebSocketOrigin` covering cross-origin rejection, DNS rebinding, loopback acceptance, absent headers, TLS domain trust, and `--host` flag matching.

## Test plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] All 27 tests in `serve_test.ts` pass (14 existing + 13 new)
- [ ] Manual verification with curl commands (cross-origin rejected 403, DNS rebinding rejected 403, legitimate local request accepted 101, no-Origin CLI request accepted 101)
- [ ] Verify existing `swamp` CLI commands still work unchanged against a server (CLI doesn't send Origin headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)