### PR TITLE
feat(vault): add `swamp vault delete` command (swamp-club#785)

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -98,6 +98,27 @@ interface VaultRefreshHookProvider {
 Detection is via runtime type guard (`isVaultRefreshHookProvider()`), mirroring
 the annotation pattern.
 
+## Vault Delete Provider Interface
+
+Vault providers can optionally support deleting secrets. Delete support is
+opt-in: providers that implement `VaultDeleteProvider` alongside `VaultProvider`
+gain delete capabilities. Providers that don't implement it will report
+"unsupported" when a user tries `swamp vault delete`.
+
+```typescript
+interface VaultDeleteProvider {
+  delete(secretKey: string): Promise<void>;
+}
+```
+
+Detection is via runtime type guard (`isVaultDeleteProvider()`), mirroring the
+annotation and refresh hook patterns. When a secret is deleted, its associated
+annotation and refresh hook are also removed.
+
+Built-in providers (`local_encryption`, `mock`) implement this interface.
+Extension providers (e.g. `@swamp/1password`, `@swamp/aws-sm`) may opt in by
+having their `createProvider` return an object that implements both interfaces.
+
 ### Refresh Hook Value Object
 
 `RefreshHook` is an immutable value object:

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -29,6 +29,7 @@ import { vaultGetCommand } from "./vault_get.ts";
 import { vaultDescribeCommand } from "./vault_describe.ts";
 import { vaultEditCommand } from "./vault_edit.ts";
 import { vaultPutCommand } from "./vault_put.ts";
+import { vaultDeleteCommand } from "./vault_delete.ts";
 import { vaultAnnotateCommand } from "./vault_annotate.ts";
 import { vaultInspectCommand } from "./vault_inspect.ts";
 import { vaultListKeysCommand } from "./vault_list_keys.ts";
@@ -68,6 +69,7 @@ export const vaultCommand = new Command()
   .command("describe", vaultDescribeCommand)
   .command("edit", vaultEditCommand)
   .command("put", vaultPutCommand)
+  .command("delete", vaultDeleteCommand)
   .command("annotate", vaultAnnotateCommand)
   .command("inspect", vaultInspectCommand)
   .command("migrate", vaultMigrateCommand)

--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -1,0 +1,200 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createVaultDeleteDeps,
+  vaultDelete,
+  type VaultDeleteData,
+  vaultDeletePreview,
+} from "../../libswamp/mod.ts";
+import {
+  createVaultDeleteRenderer,
+  renderVaultDeleteCancelled,
+} from "../../presentation/renderers/vault_delete.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  acquireVaultSync,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import {
+  normalizeServerUrl,
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultDeleteResponse } from "../../serve/protocol.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return false;
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
+
+export const vaultDeleteCommand = withRemoteOptions(
+  new Command()
+    .name("delete")
+    .description(
+      `Delete a secret from a vault.
+
+Removes the secret and any associated metadata (annotations, refresh hooks).
+Use --force to skip the confirmation prompt and to treat non-existent keys as a no-op.`,
+    )
+    .arguments("<vault_name:string> <key:string>")
+    .example(
+      "Delete a secret (with confirmation)",
+      "swamp vault delete my-vault OLD_API_KEY",
+    )
+    .example(
+      "Delete without confirmation (for scripts/CI)",
+      "swamp vault delete my-vault OLD_API_KEY --force",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("-f, --force", "Skip confirmation prompt and ignore missing keys"),
+).action(async function (
+  options: AnyOptions,
+  vaultName: string,
+  key: string,
+) {
+  const cliCtx = createContext(options as GlobalOptions, ["vault", "delete"]);
+  cliCtx.logger.debug`Deleting secret from vault: ${vaultName}`;
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const wsUrl = normalizeServerUrl(server);
+    const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+    try {
+      const parsed = new URL(wsUrl);
+      if (parsed.protocol === "ws:" && !LOOPBACK_HOSTS.has(parsed.hostname)) {
+        cliCtx.logger.warn(
+          "Sending request over unencrypted connection — use wss:// for security",
+        );
+      }
+    } catch { /* invalid URL handled by normalizeServerUrl */ }
+
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<VaultDeleteResponse>(
+      { server, token },
+      {
+        type: "vault.delete",
+        payload: {
+          vaultName,
+          key,
+          force: options.force as boolean | undefined,
+        },
+      },
+    );
+    const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
+    renderer.handlers().completed({
+      kind: "completed",
+      data: response.data as unknown as VaultDeleteData,
+    });
+    return;
+  }
+
+  const { repoDir, repoContext, datastoreConfig, syncService } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+  const { flush } = await acquireVaultSync(
+    datastoreConfig,
+    syncService,
+    repoDir,
+  );
+
+  try {
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createVaultDeleteDeps(repoDir, repoContext.eventBus);
+
+    let preview;
+    try {
+      preview = await vaultDeletePreview(ctx, deps, vaultName, key);
+    } catch (error) {
+      if ("code" in (error as Record<string, unknown>)) {
+        throw new UserError((error as { message: string }).message);
+      }
+      throw error;
+    }
+
+    if (!preview.supportsDelete) {
+      throw new UserError(
+        `Vault '${vaultName}' (type: ${preview.vaultType}) does not support deleting secrets`,
+      );
+    }
+
+    if (!preview.secretExists) {
+      if (options.force) {
+        cliCtx.logger.debug`Secret does not exist, --force specified, no-op`;
+        return;
+      }
+      throw new UserError(
+        `Secret '${key}' not found in vault '${vaultName}'`,
+      );
+    }
+
+    if (cliCtx.outputMode === "log" && !options.force) {
+      const confirmed = await promptConfirmation(
+        `Delete secret '${key}' from vault '${vaultName}'?`,
+      );
+      if (!confirmed) {
+        renderVaultDeleteCancelled(cliCtx.outputMode);
+        return;
+      }
+    }
+
+    const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
+    await consumeStream(
+      vaultDelete(ctx, deps, {
+        vaultName,
+        key,
+      }),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("Vault delete command completed");
+  } finally {
+    await flush();
+  }
+});

--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -73,7 +73,9 @@ export const vaultDeleteCommand = withRemoteOptions(
       `Delete a secret from a vault.
 
 Removes the secret and any associated metadata (annotations, refresh hooks).
-Use --force to skip the confirmation prompt and to treat non-existent keys as a no-op.`,
+Use --force to skip the confirmation prompt and to treat non-existent keys as a no-op.
+
+When using --server, the confirmation prompt is not available — use --force to suppress the error on missing keys.`,
     )
     .arguments("<vault_name:string> <key:string>")
     .example(
@@ -166,7 +168,17 @@ Use --force to skip the confirmation prompt and to treat non-existent keys as a 
 
     if (!preview.secretExists) {
       if (options.force) {
-        cliCtx.logger.debug`Secret does not exist, --force specified, no-op`;
+        const renderer = createVaultDeleteRenderer(cliCtx.outputMode);
+        renderer.handlers().completed({
+          kind: "completed",
+          data: {
+            vaultName,
+            secretKey: key,
+            vaultType: preview.vaultType,
+            timestamp: new Date().toISOString(),
+            noOp: true,
+          },
+        });
         return;
       }
       throw new UserError(

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -189,6 +189,7 @@ export type RepositoryEvent =
   | VaultUpdated
   | VaultDeleted
   | VaultSecretUpdated
+  | VaultSecretDeleted
   | VaultSecretRead
   | VaultSecretAnnotated;
 
@@ -491,6 +492,36 @@ export function createVaultDeleted(
     vaultId,
     vaultType,
     vaultName,
+    timestamp: new Date(),
+  };
+}
+
+/**
+ * Emitted when a secret is deleted from a vault.
+ */
+export interface VaultSecretDeleted extends DomainEvent {
+  readonly type: "VaultSecretDeleted";
+  readonly vaultId: string;
+  readonly vaultType: string;
+  readonly vaultName: string;
+  readonly secretKey: string;
+}
+
+/**
+ * Creates a VaultSecretDeleted event.
+ */
+export function createVaultSecretDeleted(
+  vaultId: string,
+  vaultType: string,
+  vaultName: string,
+  secretKey: string,
+): VaultSecretDeleted {
+  return {
+    type: "VaultSecretDeleted",
+    vaultId,
+    vaultType,
+    vaultName,
+    secretKey,
     timestamp: new Date(),
   };
 }

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -184,33 +184,22 @@ export class LocalEncryptionVaultProvider
       );
     }
 
-    // Clean up associated annotation and refresh hook
-    const annotationPath = this.annotationPath(secretKey);
-    await assertSafePath(annotationPath, this.secretsBoundary);
+    // Best-effort cleanup of associated annotation and refresh hook.
+    // The primary secret is already gone — don't throw if cleanup fails.
     try {
+      const annotationPath = this.annotationPath(secretKey);
+      await assertSafePath(annotationPath, this.secretsBoundary);
       await Deno.remove(annotationPath);
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw new Error(
-          `Failed to delete annotation for '${secretKey}': ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
+    } catch {
+      // NotFound or permission error — either way, best-effort
     }
 
-    const hookPath = this.refreshPath(secretKey);
-    await assertSafePath(hookPath, this.secretsBoundary);
     try {
+      const hookPath = this.refreshPath(secretKey);
+      await assertSafePath(hookPath, this.secretsBoundary);
       await Deno.remove(hookPath);
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw new Error(
-          `Failed to delete refresh hook for '${secretKey}': ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
+    } catch {
+      // NotFound or permission error — either way, best-effort
     }
   }
 

--- a/src/domain/vaults/local_encryption_vault_provider.ts
+++ b/src/domain/vaults/local_encryption_vault_provider.ts
@@ -19,7 +19,7 @@
 
 import { join } from "@std/path";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
-import type { VaultProvider } from "./vault_provider.ts";
+import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
 import type { VaultAnnotationProvider } from "./vault_annotation.ts";
 import { VaultAnnotation } from "./vault_annotation.ts";
 import type { VaultRefreshHookProvider } from "./refresh_hook.ts";
@@ -65,7 +65,11 @@ interface EncryptedData {
  * Supports both SSH private key files and auto-generated encryption keys.
  */
 export class LocalEncryptionVaultProvider
-  implements VaultProvider, VaultAnnotationProvider, VaultRefreshHookProvider {
+  implements
+    VaultProvider,
+    VaultAnnotationProvider,
+    VaultRefreshHookProvider,
+    VaultDeleteProvider {
   private readonly name: string;
   private readonly config: LocalEncryptionConfig;
   private readonly vaultDir: string;
@@ -158,6 +162,56 @@ export class LocalEncryptionVaultProvider
     }
 
     return secretKeys.sort();
+  }
+
+  async delete(secretKey: string): Promise<void> {
+    this.validateSecretKey(secretKey);
+    const encryptedFilePath = join(this.vaultDir, `${secretKey}.enc`);
+    await assertSafePath(encryptedFilePath, this.secretsBoundary);
+
+    try {
+      await Deno.remove(encryptedFilePath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        throw new Error(
+          `Secret '${secretKey}' not found in local vault '${this.name}'`,
+        );
+      }
+      throw new Error(
+        `Failed to delete secret '${secretKey}': ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    // Clean up associated annotation and refresh hook
+    const annotationPath = this.annotationPath(secretKey);
+    await assertSafePath(annotationPath, this.secretsBoundary);
+    try {
+      await Deno.remove(annotationPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw new Error(
+          `Failed to delete annotation for '${secretKey}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
+    const hookPath = this.refreshPath(secretKey);
+    await assertSafePath(hookPath, this.secretsBoundary);
+    try {
+      await Deno.remove(hookPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw new Error(
+          `Failed to delete refresh hook for '${secretKey}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
   }
 
   private get annotationsDir(): string {

--- a/src/domain/vaults/local_encryption_vault_provider_test.ts
+++ b/src/domain/vaults/local_encryption_vault_provider_test.ts
@@ -787,6 +787,150 @@ Deno.test("LocalEncryptionVaultProvider - list secrets", async (t) => {
   });
 });
 
+Deno.test("LocalEncryptionVaultProvider - delete secrets", async (t) => {
+  await t.step("should delete an existing secret", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider("delete-vault", config);
+
+      await vault.put("to-delete", "secret-value");
+      const before = await vault.list();
+      assertEquals(before.includes("to-delete"), true);
+
+      await vault.delete("to-delete");
+      const after = await vault.list();
+      assertEquals(after.includes("to-delete"), false);
+    });
+  });
+
+  await t.step("should throw for non-existent secret", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider(
+        "delete-missing-vault",
+        config,
+      );
+
+      const error = await assertRejects(
+        () => vault.delete("nonexistent-key"),
+        Error,
+      );
+      assertStringIncludes(
+        error.message,
+        "Secret 'nonexistent-key' not found",
+      );
+    });
+  });
+
+  await t.step(
+    "should clean up annotation when deleting a secret",
+    async () => {
+      await withTempDir(async (dir) => {
+        const config: LocalEncryptionConfig = {
+          auto_generate: true,
+          base_dir: dir,
+        };
+        const vault = new LocalEncryptionVaultProvider(
+          "delete-annot-vault",
+          config,
+        );
+
+        await vault.put("annotated", "value");
+        const { VaultAnnotation } = await import("./vault_annotation.ts");
+        const annotation = VaultAnnotation.create({
+          notes: "test note",
+        });
+        await vault.putAnnotation("annotated", annotation);
+
+        const annotBefore = await vault.getAnnotation("annotated");
+        assertEquals(annotBefore !== null, true);
+
+        await vault.delete("annotated");
+
+        const annotAfter = await vault.getAnnotation("annotated");
+        assertEquals(annotAfter, null);
+      });
+    },
+  );
+
+  await t.step(
+    "should clean up refresh hook when deleting a secret",
+    async () => {
+      await withTempDir(async (dir) => {
+        const config: LocalEncryptionConfig = {
+          auto_generate: true,
+          base_dir: dir,
+        };
+        const vault = new LocalEncryptionVaultProvider(
+          "delete-hook-vault",
+          config,
+        );
+
+        await vault.put("hooked", "value");
+        const { RefreshHook } = await import("./refresh_hook.ts");
+        const hook = RefreshHook.create("echo hi", 60000);
+        await vault.putRefreshHook("hooked", hook);
+
+        const hookBefore = await vault.getRefreshHook("hooked");
+        assertEquals(hookBefore !== null, true);
+
+        await vault.delete("hooked");
+
+        const hookAfter = await vault.getRefreshHook("hooked");
+        assertEquals(hookAfter, null);
+      });
+    },
+  );
+
+  await t.step("should not affect other secrets", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider(
+        "delete-other-vault",
+        config,
+      );
+
+      await vault.put("keep", "keep-value");
+      await vault.put("remove", "remove-value");
+
+      await vault.delete("remove");
+
+      const value = await vault.get("keep");
+      assertEquals(value, "keep-value");
+      const keys = await vault.list();
+      assertEquals(keys, ["keep"]);
+    });
+  });
+
+  await t.step("should reject path traversal in delete", async () => {
+    await withTempDir(async (dir) => {
+      const config: LocalEncryptionConfig = {
+        auto_generate: true,
+        base_dir: dir,
+      };
+      const vault = new LocalEncryptionVaultProvider(
+        "delete-traversal-vault",
+        config,
+      );
+
+      await assertRejects(
+        () => vault.delete("../../../etc/passwd"),
+        Error,
+        "must not contain",
+      );
+    });
+  });
+});
+
 Deno.test("LocalEncryptionVaultProvider - path traversal prevention", async (t) => {
   await t.step("should reject key with ../ in put()", async () => {
     await withTempDir(async (dir) => {

--- a/src/domain/vaults/mock_vault_provider.ts
+++ b/src/domain/vaults/mock_vault_provider.ts
@@ -17,13 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { VaultProvider } from "./vault_provider.ts";
+import type { VaultDeleteProvider, VaultProvider } from "./vault_provider.ts";
 
 /**
  * Mock vault provider for testing and demonstrations.
  * Returns predefined values for known secret keys.
  */
-export class MockVaultProvider implements VaultProvider {
+export class MockVaultProvider implements VaultProvider, VaultDeleteProvider {
   private readonly secrets = new Map<string, string>();
   private readonly name: string;
 
@@ -62,6 +62,16 @@ export class MockVaultProvider implements VaultProvider {
 
   list(): Promise<string[]> {
     return Promise.resolve(Array.from(this.secrets.keys()).sort());
+  }
+
+  delete(secretKey: string): Promise<void> {
+    if (!this.secrets.has(secretKey)) {
+      throw new Error(
+        `Secret '${secretKey}' not found in mock vault '${this.name}'`,
+      );
+    }
+    this.secrets.delete(secretKey);
+    return Promise.resolve();
   }
 
   /**

--- a/src/domain/vaults/mock_vault_provider_test.ts
+++ b/src/domain/vaults/mock_vault_provider_test.ts
@@ -96,6 +96,37 @@ Deno.test("MockVaultProvider - addSecret", async (t) => {
   });
 });
 
+Deno.test("MockVaultProvider - delete", async (t) => {
+  await t.step("should delete an existing secret", async () => {
+    const provider = new MockVaultProvider("test-vault", {
+      "to-delete": "value",
+    });
+    await provider.delete("to-delete");
+    const keys = await provider.list();
+    assertEquals(keys.includes("to-delete"), false);
+  });
+
+  await t.step("should throw for non-existent secret", () => {
+    const provider = new MockVaultProvider("test-vault");
+    const error = assertThrows(
+      () => provider.delete("nonexistent-key"),
+      Error,
+    );
+    assertStringIncludes(error.message, "Secret 'nonexistent-key' not found");
+    assertStringIncludes(error.message, "mock vault 'test-vault'");
+  });
+
+  await t.step("should not affect other secrets", async () => {
+    const provider = new MockVaultProvider("test-vault", {
+      "keep-me": "keep-value",
+      "delete-me": "delete-value",
+    });
+    await provider.delete("delete-me");
+    const value = await provider.get("keep-me");
+    assertEquals(value, "keep-value");
+  });
+});
+
 Deno.test("MockVaultProvider - listSecrets", async (t) => {
   await t.step("should list all secret keys", () => {
     const provider = new MockVaultProvider("test-vault", {

--- a/src/domain/vaults/vault_provider.ts
+++ b/src/domain/vaults/vault_provider.ts
@@ -54,6 +54,25 @@ export interface VaultProvider {
 }
 
 /**
+ * Optional interface for vault providers that support deleting secrets.
+ * Separate from VaultProvider — providers opt in by implementing both.
+ */
+export interface VaultDeleteProvider {
+  delete(secretKey: string): Promise<void>;
+}
+
+/**
+ * Type guard to check if a vault provider supports secret deletion.
+ */
+export function isVaultDeleteProvider(
+  provider: unknown,
+): provider is VaultDeleteProvider {
+  if (typeof provider !== "object" || provider === null) return false;
+  const obj = provider as Record<string, unknown>;
+  return typeof obj.delete === "function";
+}
+
+/**
  * Configuration for vault providers.
  */
 export interface VaultConfiguration {

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
-import type { VaultConfiguration, VaultProvider } from "./vault_provider.ts";
+import {
+  isVaultDeleteProvider,
+  type VaultConfiguration,
+  type VaultProvider,
+} from "./vault_provider.ts";
 import {
   isVaultAnnotationProvider,
   type VaultAnnotation,
@@ -228,6 +232,40 @@ export class VaultService {
   ): Promise<void> {
     const provider = this.requireProvider(vaultName);
     await provider.put(secretKey, secretValue);
+  }
+
+  async delete(vaultName: string, secretKey: string): Promise<void> {
+    const provider = this.requireDeleteProvider(vaultName);
+    await provider.delete(secretKey);
+  }
+
+  supportsDelete(vaultName: string): boolean {
+    const provider = this.providers.get(vaultName);
+    if (!provider) return false;
+    return isVaultDeleteProvider(provider);
+  }
+
+  private requireDeleteProvider(vaultName: string) {
+    const provider = this.providers.get(vaultName);
+    if (!provider) {
+      const availableVaults = Array.from(this.providers.keys());
+      if (availableVaults.length === 0) {
+        throw new Error(
+          `Vault '${vaultName}' not found. No vaults are configured.`,
+        );
+      }
+      throw new Error(
+        `Vault '${vaultName}' not found. Available vaults: ${
+          availableVaults.join(", ")
+        }`,
+      );
+    }
+    if (!isVaultDeleteProvider(provider)) {
+      throw new Error(
+        `Vault '${vaultName}' (type: ${provider.getName()}) does not support deleting secrets`,
+      );
+    }
+    return provider;
   }
 
   /**

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -576,3 +576,83 @@ Deno.test("VaultService - fromRepository auto-remaps renamed vault types", async
     },
   );
 });
+
+Deno.test("VaultService - delete", async (t) => {
+  await t.step("should delete a secret from a mock vault", async () => {
+    const vaultService = new VaultService();
+    vaultService.registerVault({
+      name: "test-vault",
+      type: "mock",
+      config: {},
+    });
+
+    await vaultService.put("test-vault", "to-delete", "value");
+    const keys = await vaultService.list("test-vault");
+    assertEquals(keys.includes("to-delete"), true);
+
+    await vaultService.delete("test-vault", "to-delete");
+    const keysAfter = await vaultService.list("test-vault");
+    assertEquals(keysAfter.includes("to-delete"), false);
+  });
+
+  await t.step(
+    "should throw when vault not found (no vaults configured)",
+    async () => {
+      const vaultService = new VaultService();
+      const error = await assertRejects(
+        () => vaultService.delete("nonexistent", "key"),
+        Error,
+      );
+      assertStringIncludes(error.message, "No vaults are configured");
+    },
+  );
+
+  await t.step(
+    "should throw when vault not found (other vaults exist)",
+    async () => {
+      const vaultService = new VaultService();
+      vaultService.registerVault({
+        name: "existing",
+        type: "mock",
+        config: {},
+      });
+      const error = await assertRejects(
+        () => vaultService.delete("missing", "key"),
+        Error,
+      );
+      assertStringIncludes(error.message, "Available vaults: existing");
+    },
+  );
+
+  await t.step("should throw when secret does not exist", async () => {
+    const vaultService = new VaultService();
+    vaultService.registerVault({
+      name: "test-vault",
+      type: "mock",
+      config: {},
+    });
+
+    await assertRejects(
+      () => vaultService.delete("test-vault", "nonexistent-key"),
+      Error,
+      "not found",
+    );
+  });
+});
+
+Deno.test("VaultService - supportsDelete", async (t) => {
+  await t.step("should return true for mock vault", () => {
+    const vaultService = new VaultService();
+    vaultService.registerVault({
+      name: "test-vault",
+      type: "mock",
+      config: {},
+    });
+    assertEquals(vaultService.supportsDelete("test-vault"), true);
+  });
+
+  await t.step("should return false for non-existent vault", () => {
+    const vaultService = new VaultService();
+    assertEquals(vaultService.supportsDelete("nonexistent"), false);
+  });
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1012,6 +1012,19 @@ export {
   vaultPutPreview,
 } from "./vaults/put.ts";
 
+// Vault delete operations
+export {
+  createVaultDeleteDeps,
+  vaultDelete,
+  type VaultDeleteConfigInfo,
+  type VaultDeleteData,
+  type VaultDeleteDeps,
+  type VaultDeleteEvent,
+  type VaultDeleteInput,
+  type VaultDeletePreview,
+  vaultDeletePreview,
+} from "./vaults/delete.ts";
+
 // Vault annotate operations
 export {
   createVaultAnnotateDeps,

--- a/src/libswamp/vaults/delete.ts
+++ b/src/libswamp/vaults/delete.ts
@@ -46,6 +46,7 @@ export interface VaultDeleteData {
   secretKey: string;
   vaultType: string;
   timestamp: string;
+  noOp?: boolean;
 }
 
 export type VaultDeleteEvent =

--- a/src/libswamp/vaults/delete.ts
+++ b/src/libswamp/vaults/delete.ts
@@ -1,0 +1,197 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { VaultService } from "../../domain/vaults/vault_service.ts";
+import { createVaultSecretDeleted } from "../../domain/events/types.ts";
+import type { EventBus } from "../../domain/events/event_bus.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { notFound } from "../errors.ts";
+
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface VaultDeleteConfigInfo {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface VaultDeletePreview {
+  vaultName: string;
+  vaultType: string;
+  secretKey: string;
+  secretExists: boolean;
+  supportsDelete: boolean;
+}
+
+export interface VaultDeleteData {
+  vaultName: string;
+  secretKey: string;
+  vaultType: string;
+  timestamp: string;
+}
+
+export type VaultDeleteEvent =
+  | { kind: "deleting" }
+  | { kind: "completed"; data: VaultDeleteData }
+  | { kind: "error"; error: SwampError };
+
+export interface VaultDeleteInput {
+  vaultName: string;
+  key: string;
+}
+
+export interface VaultDeleteDeps {
+  findVault: (name: string) => Promise<VaultDeleteConfigInfo | null>;
+  listVaultNames: () => Promise<string[]>;
+  secretExists: (vaultName: string, key: string) => Promise<boolean>;
+  supportsDelete: (vaultName: string) => Promise<boolean>;
+  deleteSecret: (vaultName: string, key: string) => Promise<void>;
+  publishSecretDeleted: (
+    vaultId: string,
+    vaultType: string,
+    vaultName: string,
+    key: string,
+  ) => Promise<void>;
+}
+
+export function createVaultDeleteDeps(
+  repoDir: string,
+  eventBus: EventBus,
+): VaultDeleteDeps {
+  const vaultConfigRepo = new YamlVaultConfigRepository(repoDir);
+  let vaultServicePromise: Promise<VaultService> | null = null;
+
+  const getVaultService = () => {
+    if (!vaultServicePromise) {
+      vaultServicePromise = VaultService.fromRepository(repoDir);
+    }
+    return vaultServicePromise;
+  };
+
+  return {
+    findVault: (name) => vaultConfigRepo.findByName(name),
+    listVaultNames: async () => {
+      const all = await vaultConfigRepo.findAll();
+      return all.map((v) => v.name);
+    },
+    secretExists: async (vaultName, key) => {
+      const svc = await getVaultService();
+      const keys = await svc.list(vaultName);
+      return keys.includes(key);
+    },
+    supportsDelete: async (vaultName) => {
+      const svc = await getVaultService();
+      return svc.supportsDelete(vaultName);
+    },
+    deleteSecret: async (vaultName, key) => {
+      const svc = await getVaultService();
+      await svc.delete(vaultName, key);
+    },
+    publishSecretDeleted: async (vaultId, vaultType, vaultName, key) => {
+      const event = createVaultSecretDeleted(
+        vaultId,
+        vaultType,
+        vaultName,
+        key,
+      );
+      await eventBus.publish(event);
+    },
+  };
+}
+
+export async function vaultDeletePreview(
+  ctx: LibSwampContext,
+  deps: VaultDeleteDeps,
+  vaultName: string,
+  key: string,
+): Promise<VaultDeletePreview> {
+  ctx.logger.debug`Checking vault: ${vaultName}`;
+  const config = await deps.findVault(vaultName);
+  if (!config) {
+    const names = await deps.listVaultNames();
+    if (names.length === 0) {
+      throw notFound(
+        "Vault",
+        `${vaultName}. No vaults are configured. Create a vault using: swamp vault create <type> ${vaultName}`,
+      );
+    }
+    throw notFound(
+      "Vault",
+      `${vaultName}. Available vaults: ${names.join(", ")}`,
+    );
+  }
+
+  const supports = await deps.supportsDelete(vaultName);
+  const exists = supports ? await deps.secretExists(vaultName, key) : false;
+  ctx.logger.debug`Secret exists: ${exists}, supports delete: ${supports}`;
+
+  return {
+    vaultName: config.name,
+    vaultType: config.type,
+    secretKey: key,
+    secretExists: exists,
+    supportsDelete: supports,
+  };
+}
+
+export async function* vaultDelete(
+  ctx: LibSwampContext,
+  deps: VaultDeleteDeps,
+  input: VaultDeleteInput,
+): AsyncIterable<VaultDeleteEvent> {
+  yield* withGeneratorSpan(
+    "swamp.vault.delete",
+    {},
+    (async function* () {
+      yield { kind: "deleting" };
+
+      const config = await deps.findVault(input.vaultName);
+      if (!config) {
+        yield {
+          kind: "error",
+          error: notFound("Vault", input.vaultName),
+        };
+        return;
+      }
+
+      await deps.deleteSecret(input.vaultName, input.key);
+      ctx.logger.debug`Secret deleted successfully`;
+
+      await deps.publishSecretDeleted(
+        config.id,
+        config.type,
+        config.name,
+        input.key,
+      );
+      ctx.logger.debug`Emitted VaultSecretDeleted event`;
+
+      yield {
+        kind: "completed",
+        data: {
+          vaultName: input.vaultName,
+          secretKey: input.key,
+          vaultType: config.type,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/vaults/delete_test.ts
+++ b/src/libswamp/vaults/delete_test.ts
@@ -1,0 +1,178 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  vaultDelete,
+  type VaultDeleteDeps,
+  type VaultDeleteEvent,
+  vaultDeletePreview,
+} from "./delete.ts";
+
+function makeDeps(overrides: Partial<VaultDeleteDeps> = {}): VaultDeleteDeps {
+  return {
+    findVault: () =>
+      Promise.resolve({ id: "v1", name: "my-vault", type: "local_encryption" }),
+    listVaultNames: () => Promise.resolve(["my-vault"]),
+    secretExists: () => Promise.resolve(true),
+    supportsDelete: () => Promise.resolve(true),
+    deleteSecret: () => Promise.resolve(),
+    publishSecretDeleted: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+Deno.test("vaultDeletePreview: returns preview with secret existence check", async () => {
+  const deps = makeDeps();
+
+  const preview = await vaultDeletePreview(
+    createLibSwampContext(),
+    deps,
+    "my-vault",
+    "API_KEY",
+  );
+
+  assertEquals(preview.vaultName, "my-vault");
+  assertEquals(preview.vaultType, "local_encryption");
+  assertEquals(preview.secretKey, "API_KEY");
+  assertEquals(preview.secretExists, true);
+  assertEquals(preview.supportsDelete, true);
+});
+
+Deno.test("vaultDeletePreview: throws not_found for missing vault", async () => {
+  const deps = makeDeps({
+    findVault: () => Promise.resolve(null),
+    listVaultNames: () => Promise.resolve(["other-vault"]),
+  });
+
+  try {
+    await vaultDeletePreview(
+      createLibSwampContext(),
+      deps,
+      "missing-vault",
+      "KEY",
+    );
+    throw new Error("Expected to throw");
+  } catch (error) {
+    assertEquals((error as { code: string }).code, "not_found");
+  }
+});
+
+Deno.test("vaultDeletePreview: reports unsupported when provider lacks delete", async () => {
+  const deps = makeDeps({
+    supportsDelete: () => Promise.resolve(false),
+  });
+
+  const preview = await vaultDeletePreview(
+    createLibSwampContext(),
+    deps,
+    "my-vault",
+    "KEY",
+  );
+
+  assertEquals(preview.supportsDelete, false);
+  assertEquals(preview.secretExists, false);
+});
+
+Deno.test("vaultDeletePreview: reports non-existent secret", async () => {
+  const deps = makeDeps({
+    secretExists: () => Promise.resolve(false),
+  });
+
+  const preview = await vaultDeletePreview(
+    createLibSwampContext(),
+    deps,
+    "my-vault",
+    "MISSING_KEY",
+  );
+
+  assertEquals(preview.secretExists, false);
+});
+
+Deno.test("vaultDelete: yields completed after deleting secret", async () => {
+  let deletedKey = "";
+  const deps = makeDeps({
+    deleteSecret: (_vault, key) => {
+      deletedKey = key;
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<VaultDeleteEvent>(
+    vaultDelete(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "API_KEY",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "deleting");
+  const completed = events[1] as Extract<
+    VaultDeleteEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.vaultName, "my-vault");
+  assertEquals(completed.data.secretKey, "API_KEY");
+  assertEquals(completed.data.vaultType, "local_encryption");
+  assertEquals(deletedKey, "API_KEY");
+});
+
+Deno.test("vaultDelete: yields error when vault not found", async () => {
+  const deps = makeDeps({
+    findVault: () => Promise.resolve(null),
+  });
+
+  const events = await collect<VaultDeleteEvent>(
+    vaultDelete(createLibSwampContext(), deps, {
+      vaultName: "missing",
+      key: "KEY",
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultDeleteEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
+});
+
+Deno.test("vaultDelete: publishes VaultSecretDeleted event", async () => {
+  let publishedKey = "";
+  let publishedVaultName = "";
+  const deps = makeDeps({
+    publishSecretDeleted: (_id, _type, vaultName, key) => {
+      publishedKey = key;
+      publishedVaultName = vaultName;
+      return Promise.resolve();
+    },
+  });
+
+  await collect<VaultDeleteEvent>(
+    vaultDelete(createLibSwampContext(), deps, {
+      vaultName: "my-vault",
+      key: "SECRET",
+    }),
+  );
+
+  assertEquals(publishedKey, "SECRET");
+  assertEquals(publishedVaultName, "my-vault");
+});

--- a/src/presentation/renderers/vault_delete.ts
+++ b/src/presentation/renderers/vault_delete.ts
@@ -29,8 +29,13 @@ class LogVaultDeleteRenderer implements Renderer<VaultDeleteEvent> {
     return {
       deleting: () => {},
       completed: (e) => {
-        logger
-          .info`Deleted secret ${e.data.secretKey} from vault ${e.data.vaultName}`;
+        if (e.data.noOp) {
+          logger
+            .info`Secret ${e.data.secretKey} does not exist in vault ${e.data.vaultName}, skipping`;
+        } else {
+          logger
+            .info`Deleted secret ${e.data.secretKey} from vault ${e.data.vaultName}`;
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/vault_delete.ts
+++ b/src/presentation/renderers/vault_delete.ts
@@ -1,0 +1,74 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, VaultDeleteEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogVaultDeleteRenderer implements Renderer<VaultDeleteEvent> {
+  handlers(): EventHandlers<VaultDeleteEvent> {
+    const logger = getSwampLogger(["vault", "delete"]);
+    return {
+      deleting: () => {},
+      completed: (e) => {
+        logger
+          .info`Deleted secret ${e.data.secretKey} from vault ${e.data.vaultName}`;
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonVaultDeleteRenderer implements Renderer<VaultDeleteEvent> {
+  handlers(): EventHandlers<VaultDeleteEvent> {
+    return {
+      deleting: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createVaultDeleteRenderer(
+  mode: OutputMode,
+): Renderer<VaultDeleteEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonVaultDeleteRenderer();
+    case "log":
+      return new LogVaultDeleteRenderer();
+  }
+}
+
+export function renderVaultDeleteCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ cancelled: true }, null, 2));
+  } else {
+    const logger = getSwampLogger(["vault", "delete"]);
+    logger.info("Operation cancelled.");
+  }
+}

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -35,6 +35,7 @@ import {
   createLibSwampContext,
   createModelMethodDescribeDeps,
   createSummariseDeps,
+  createVaultDeleteDeps,
   createVaultGetDeps,
   createVaultPutDeps,
   dataGet,
@@ -55,6 +56,8 @@ import {
   reportTypeSearch,
   type ReportTypeSearchDeps,
   summarise,
+  vaultDelete,
+  vaultDeletePreview,
   vaultGet,
   vaultPut,
   vaultPutPreview,
@@ -82,6 +85,7 @@ import type {
   ServerMessage,
   ServerRequest,
   SummarisePayload,
+  VaultDeletePayload,
   VaultGetPayload,
   VaultPutPayload,
   WorkflowRunPayload,
@@ -312,6 +316,16 @@ const VaultPutRequestSchema = z.object({
   }),
 });
 
+const VaultDeleteRequestSchema = z.object({
+  type: z.literal("vault.delete"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultName: z.string(),
+    key: z.string(),
+    force: z.boolean().optional(),
+  }),
+});
+
 const AuditTimelineRequestSchema = z.object({
   type: z.literal("audit.timeline"),
   id: z.string().min(1).max(256),
@@ -389,6 +403,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkflowSearchRequestSchema,
   VaultGetRequestSchema,
   VaultPutRequestSchema,
+  VaultDeleteRequestSchema,
   AuditTimelineRequestSchema,
   SummariseRequestSchema,
   ReportGetRequestSchema,
@@ -678,6 +693,16 @@ export function handleMessage(
       break;
     case "vault.put":
       task = handleVaultPut(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.delete":
+      task = handleVaultDelete(
         socket,
         ctx,
         request.id,
@@ -1894,6 +1919,127 @@ async function handleVaultPut(
     } else {
       const message = sanitizeErrorForClient(error);
       sendError(socket, requestId, "vault_put_failed", message);
+    }
+  } finally {
+    if (flush) await flush();
+  }
+}
+
+async function handleVaultDelete(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultDeletePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "write", {
+      kind: "data",
+      name: "vault",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  let flush: (() => Promise<void>) | undefined;
+  try {
+    ({ flush } = await acquireVaultSync(
+      ctx.datastoreConfig,
+      ctx.syncService,
+      ctx.repoDir,
+    ));
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "vault_delete_failed", message);
+    return;
+  }
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createVaultDeleteDeps(ctx.repoDir, ctx.repoContext.eventBus);
+
+    const preview = await vaultDeletePreview(
+      libCtx,
+      deps,
+      payload.vaultName,
+      payload.key,
+    );
+
+    if (!preview.supportsDelete) {
+      sendError(
+        socket,
+        requestId,
+        "unsupported",
+        `Vault '${payload.vaultName}' (type: ${preview.vaultType}) does not support deleting secrets`,
+      );
+      return;
+    }
+
+    if (!preview.secretExists && !payload.force) {
+      sendError(
+        socket,
+        requestId,
+        "not_found",
+        `Secret '${payload.key}' not found in vault '${payload.vaultName}'`,
+      );
+      return;
+    }
+
+    if (!preview.secretExists && payload.force) {
+      send(socket, {
+        type: "vault.delete",
+        id: requestId,
+        payload: {
+          data: {
+            vaultName: payload.vaultName,
+            secretKey: payload.key,
+            vaultType: preview.vaultType,
+            noOp: true,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+      return;
+    }
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultDelete(libCtx, deps, {
+        vaultName: payload.vaultName,
+        key: payload.key,
+      }),
+      {
+        deleting: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.delete",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+    } else {
+      const message = sanitizeErrorForClient(error);
+      sendError(socket, requestId, "vault_delete_failed", message);
     }
   } finally {
     if (flush) await flush();

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -117,6 +117,12 @@ export interface VaultPutPayload {
   clearRefresh?: boolean;
 }
 
+export interface VaultDeletePayload {
+  vaultName: string;
+  key: string;
+  force?: boolean;
+}
+
 export interface AuditTimelinePayload {
   hours?: number;
   showAll?: boolean;
@@ -174,6 +180,7 @@ export type ServerRequest =
   | { type: "workflow.search"; id: string; payload?: WorkflowSearchPayload }
   | { type: "vault.get"; id: string; payload: VaultGetPayload }
   | { type: "vault.put"; id: string; payload: VaultPutPayload }
+  | { type: "vault.delete"; id: string; payload: VaultDeletePayload }
   | { type: "audit.timeline"; id: string; payload?: AuditTimelinePayload }
   | { type: "summarise"; id: string; payload?: SummarisePayload }
   | { type: "report.get"; id: string; payload: ReportGetPayload }
@@ -269,6 +276,10 @@ export interface VaultPutResponse {
   data: Record<string, unknown>;
 }
 
+export interface VaultDeleteResponse {
+  data: Record<string, unknown>;
+}
+
 export interface AuditTimelineResponse {
   data: Record<string, unknown>;
 }
@@ -324,6 +335,7 @@ export type ServerMessage =
   | { type: "workflow.search"; id: string; payload: WorkflowSearchResponse }
   | { type: "vault.get"; id: string; payload: VaultGetResponse }
   | { type: "vault.put"; id: string; payload: VaultPutResponse }
+  | { type: "vault.delete"; id: string; payload: VaultDeleteResponse }
   | { type: "audit.timeline"; id: string; payload: AuditTimelineResponse }
   | { type: "summarise"; id: string; payload: SummariseResponse }
   | { type: "report.get"; id: string; payload: ReportGetResponse }


### PR DESCRIPTION
## Summary

- Adds `swamp vault delete <vault> <key>` command to remove individual secrets from vaults, closing the CRUD gap in the vault subsystem
- Uses an opt-in `VaultDeleteProvider` interface (following `VaultAnnotationProvider`/`VaultRefreshHookProvider` pattern) so existing extension providers are unaffected
- Deleting a secret also cleans up its associated annotation and refresh hook
- `--force` / `-f` skips confirmation and treats missing keys as a no-op (like `rm -f`)
- `--server` support for remote execution via `swamp serve`
- `--json` structured output

Closes swamp-club#785

## Test Plan

- [x] `deno check` — zero type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 7700 tests pass
- [x] `deno run compile` — binary compiles
- [x] `swamp vault delete --help` — correct usage, flags, examples
- [x] E2E: put → list-keys → delete --force → list-keys shows 0
- [x] E2E: delete non-existent key → error exit 1
- [x] E2E: delete non-existent key --force → silent no-op exit 0
- [x] E2E: delete --json → structured output
- [x] E2E: put + annotate → delete → no orphaned annotation files on disk