### PR TITLE
fix(skill): correct model type search command in swamp SKILL.md

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -52,7 +52,7 @@ Route to the right guide based on what the user needs.
 swamp model @<type> create <name>              # create a model definition
 swamp model @<type> method run <method> <name> # run a method on a model
 swamp model get <name> --json                  # inspect current model state
-swamp model search @<type>                     # find available model types
+swamp model type search [query]                # find available model types
 swamp model list                               # list all models in the repo
 
 # Data


### PR DESCRIPTION
## Summary

- Fixes the Common Commands section of `.claude/skills/swamp/SKILL.md` (line 55): replaced incorrect `swamp model search @<type>` with the correct `swamp model type search [query]`
- `swamp model search` searches model definitions, not model types, and `@<type>` is not valid query syntax for it

Closes swamp-club#779

## Test Plan

- [x] Verified `swamp model type search` is the correct command via `swamp model type search --help`
- [x] Confirmed no other files reference the incorrect pattern
- [x] `deno fmt --check` passes
- [x] `deno lint` passes