### PR TITLE
fix(workflow): use per-step locking to prevent subprocess deadlock (swamp-club#744)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -800,17 +800,30 @@ lifecycle as a global singleton:
 - `registerDatastoreSync({ service?, lock? })` — acquire lock, pull if S3
 - `flushDatastoreSync()` — push if S3, release lock
 
-Per-model commands (`model method run`, `workflow run`) acquire only
-per-model locks via `acquireModelLocks`; they do not acquire the global
-lock but do `inspect()` it to wait out any in-flight structural command.
-The `inspect()` must target the **same** namespaced global-lock key the
-structural command acquires (`datastoreGlobalLockOptions`); otherwise the
-drain coordination would inspect a different lock than the one held and
-silently become a no-op in namespaced mode. When a stale global lock is
-observed during this wait, `acquireModelLocks` calls
-`forceRelease(expectedNonce)` to clear it — without this, the post-acquire
-TOCTOU re-check would re-detect the same stale lock on every iteration and
-recurse indefinitely.
+Per-model commands (`model method run`) acquire only per-model locks via
+`acquireModelLocks`; they do not acquire the global lock but do `inspect()`
+it to wait out any in-flight structural command. The `inspect()` must
+target the **same** namespaced global-lock key the structural command
+acquires (`datastoreGlobalLockOptions`); otherwise the drain coordination
+would inspect a different lock than the one held and silently become a
+no-op in namespaced mode. When a stale global lock is observed during this
+wait, `acquireModelLocks` calls `forceRelease(expectedNonce)` to clear
+it — without this, the post-acquire TOCTOU re-check would re-detect the
+same stale lock on every iteration and recurse indefinitely.
+
+Workflow commands (`workflow run`, `workflow resume`) and serve-hosted
+workflow execution do **not** acquire locks upfront. Instead, per-model
+locks are acquired per-step via a `StepLockHook` callback injected into
+the workflow execution engine. Each model method step acquires its own
+per-model lock before execution and releases it in a finally block after
+the method completes. This per-step locking prevents deadlocks when a
+model method spawns a subprocess `swamp model method run` targeting a
+model that would otherwise be locked by the parent workflow. Parallel
+workflow steps on different models lock independently; parallel steps on
+the same model serialize at the lock (correct — concurrent writes to the
+same model are unsafe). The coordinator uses unique keys per lock
+acquisition (suffixed with a random ID) so parallel steps on the same
+model get separate entries and do not overwrite each other.
 
 Because per-model lock keys are not namespaced, `waitForPerModelLocks`
 (which walks the datastore root) drains in-flight per-model writers across

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -25,16 +25,14 @@ import {
 } from "../context.ts";
 import {
   acquireModelLocks,
-  requireInitializedRepo,
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
-import { extractModelReferencesFromWorkflow } from "../../domain/workflows/model_reference_extractor.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import {
   type DirectTypeResolver,
+  type StepLockHook,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import {
@@ -143,12 +141,12 @@ export const workflowResumeCommand = new Command()
       // workflow-runs path the run was written to. Constructing
       // YamlWorkflowRunRepository(repoDir) directly would bind to repo-local
       // .swamp/workflow-runs/ and miss runs stored in a configured datastore.
-      let repoDir = unlocked.repoDir;
-      let repoContext = unlocked.repoContext;
+      const repoDir = unlocked.repoDir;
+      const repoContext = unlocked.repoContext;
       const workflowRepo = repoContext.workflowRepo;
       const runRepo = repoContext.workflowRunRepo;
 
-      const { run, workflow, workflowName } = await resolveSuspendedRun(
+      const { run, workflowName } = await resolveSuspendedRun(
         workflowRepo,
         runRepo,
         workflowIdOrName,
@@ -163,195 +161,135 @@ export const workflowResumeCommand = new Command()
         );
       }
 
-      // Acquire per-model locks instead of the global lock so that steps
-      // which perform datastore operations (e.g. shelling out to
-      // `swamp model method run` on another model) don't deadlock.
-      let flushModelLocks: (() => Promise<void>) | null = null;
+      const stepLockHook: StepLockHook = async (modelType, modelId) => {
+        const result = await acquireModelLocks(
+          unlocked.datastoreConfig,
+          [{ modelType, modelId }],
+          repoDir,
+          unlocked.syncService,
+          repoContext.catalogStore,
+        );
+        if (result.synced) repoContext.catalogStore.invalidate();
+        return result;
+      };
 
-      const modelRefs = await extractModelReferencesFromWorkflow(
-        workflow,
-        workflowRepo,
-      );
+      await Promise.all([
+        modelRegistry.ensureLoaded(),
+        vaultTypeRegistry.ensureLoaded(),
+        reportRegistry.ensureLoaded(),
+      ]);
 
-      if (modelRefs !== null && modelRefs.length > 0) {
-        const resolvedModels: Array<
-          { modelType: string; modelId: string }
-        > = [];
-
-        for (const ref of modelRefs) {
-          const lookupResult = await findDefinitionByIdOrName(
-            unlocked.repoContext.definitionRepo,
-            ref,
-          );
-          if (lookupResult) {
-            resolvedModels.push({
-              modelType: lookupResult.type.normalized,
-              modelId: lookupResult.definition.id,
-            });
-          }
+      // Surface what the resume inputs do to the run's inputs. Key names only —
+      // values may be secrets and are never logged. Overrides (a resume key
+      // that collides with an existing input) are warned; purely-additive keys
+      // are info.
+      const resumeKeys = Object.keys(resumeInputs);
+      if (resumeKeys.length > 0) {
+        const overridden = resumeKeys.filter((key) => key in run.inputs);
+        const added = resumeKeys.filter((key) => !(key in run.inputs));
+        if (overridden.length > 0) {
+          cliCtx.logger
+            .warn`Resume overriding existing input(s): ${
+            overridden.join(", ")
+          }`;
         }
-
-        if (resolvedModels.length > 0) {
-          const lockResult = await acquireModelLocks(
-            unlocked.datastoreConfig,
-            resolvedModels,
-            unlocked.repoDir,
-            unlocked.syncService,
-            unlocked.repoContext.catalogStore,
-          );
-          if (lockResult.synced) {
-            unlocked.repoContext.catalogStore.invalidate();
-          }
-          flushModelLocks = lockResult.flush;
+        if (added.length > 0) {
+          cliCtx.logger.info`Resume adding input(s): ${added.join(", ")}`;
         }
-      } else if (modelRefs === null) {
-        const logger = getSwampLogger(["workflow", "resume"]);
-        logger
-          .info`Workflow contains dynamic model references — using global lock`;
-        const globalResult = await requireInitializedRepo({
-          repoDir: resolveRepoDir(options.repoDir),
-          outputMode: cliCtx.outputMode,
-        });
-        repoDir = globalResult.repoDir;
-        repoContext = globalResult.repoContext;
       }
 
-      try {
-        await Promise.all([
-          modelRegistry.ensureLoaded(),
-          vaultTypeRegistry.ensureLoaded(),
-          reportRegistry.ensureLoaded(),
-        ]);
-
-        // Surface what the resume inputs do to the run's inputs. Key names only —
-        // values may be secrets and are never logged. Overrides (a resume key
-        // that collides with an existing input) are warned; purely-additive keys
-        // are info.
-        const resumeKeys = Object.keys(resumeInputs);
-        if (resumeKeys.length > 0) {
-          const overridden = resumeKeys.filter((key) => key in run.inputs);
-          const added = resumeKeys.filter((key) => !(key in run.inputs));
-          if (overridden.length > 0) {
-            cliCtx.logger
-              .warn`Resume overriding existing input(s): ${
-              overridden.join(", ")
-            }`;
-          }
-          if (added.length > 0) {
-            cliCtx.logger.info`Resume adding input(s): ${added.join(", ")}`;
+      const directResolver: DirectTypeResolver = async (
+        typeArg,
+        defName,
+        methodName,
+        inputs,
+      ) => {
+        let resolvedType = ModelType.create(typeArg);
+        let modelDef = await resolveModelType(
+          resolvedType,
+          getAutoResolver(),
+        );
+        if (!modelDef && typeArg.startsWith("@")) {
+          const strippedType = ModelType.create(typeArg.slice(1));
+          const strippedDef = await resolveModelType(
+            strippedType,
+            getAutoResolver(),
+          );
+          if (strippedDef) {
+            resolvedType = strippedType;
+            modelDef = strippedDef;
           }
         }
-
-        const directResolver: DirectTypeResolver = async (
+        if (!modelDef) {
+          throw new Error(`Unknown model type: ${resolvedType.normalized}`);
+        }
+        const autoDefRepo = new YamlDefinitionRepository(
+          repoDir,
+          undefined,
+          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          false,
+        );
+        const result = await resolveOrCreateDefinition(
+          {
+            lookupDefinition: (name) =>
+              findDefinitionByIdOrName(repoContext.definitionRepo, name),
+            getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+            saveDefinition: (type, def) => autoDefRepo.save(type, def),
+            getDefinitionPath: (type, id) =>
+              autoDefRepo.getPath(type, id as DefinitionId),
+          },
           typeArg,
           defName,
           methodName,
           inputs,
-        ) => {
-          let resolvedType = ModelType.create(typeArg);
-          let modelDef = await resolveModelType(
-            resolvedType,
-            getAutoResolver(),
-          );
-          if (!modelDef && typeArg.startsWith("@")) {
-            const strippedType = ModelType.create(typeArg.slice(1));
-            const strippedDef = await resolveModelType(
-              strippedType,
-              getAutoResolver(),
-            );
-            if (strippedDef) {
-              resolvedType = strippedType;
-              modelDef = strippedDef;
-            }
-          }
-          if (!modelDef) {
-            throw new Error(`Unknown model type: ${resolvedType.normalized}`);
-          }
-          const autoDefRepo = new YamlDefinitionRepository(
-            repoDir,
-            undefined,
-            swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
-            false,
-          );
-          const result = await resolveOrCreateDefinition(
-            {
-              lookupDefinition: (name) =>
-                findDefinitionByIdOrName(repoContext.definitionRepo, name),
-              getModelDef: (type) => resolveModelType(type, getAutoResolver()),
-              saveDefinition: (type, def) => autoDefRepo.save(type, def),
-              getDefinitionPath: (type, id) =>
-                autoDefRepo.getPath(type, id as DefinitionId),
-            },
-            typeArg,
-            defName,
-            methodName,
-            inputs,
-            resolvedType,
-            modelDef,
-          );
-          if (!result.ok) throw new Error(result.error.message);
-          return {
-            definition: result.definition,
-            modelType: result.modelType,
-            created: result.created,
-            routedMethodInputs: result.routedInputs.methodArguments,
-          };
-        };
-
-        const service = new WorkflowExecutionService(
-          workflowRepo,
-          runRepo,
-          repoDir,
-          undefined,
-          unlocked.datastoreResolver.resolvePath(SWAMP_SUBDIRS.data),
-          repoContext.catalogStore,
-          directResolver,
-          repoContext.markDirty,
-          repoContext.unifiedDataRepo.namespace,
+          resolvedType,
+          modelDef,
         );
-
-        const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
-          workflowName,
-        });
-
-        const resumeGenerator = async function* (): AsyncGenerator<
-          WorkflowRunEvent
-        > {
-          for await (
-            const event of service.resume(workflowName, run.id, {
-              signal: AbortSignal.timeout(600_000),
-              swampSha: GIT_SHA,
-              inputs: resumeInputs,
-            })
-          ) {
-            yield mapWorkflowExecutionEvent(event, runRepo);
-          }
+        if (!result.ok) throw new Error(result.error.message);
+        return {
+          definition: result.definition,
+          modelType: result.modelType,
+          created: result.created,
+          routedMethodInputs: result.routedInputs.methodArguments,
         };
+      };
 
-        await consumeStream(resumeGenerator(), renderer.handlers());
+      const service = new WorkflowExecutionService(
+        workflowRepo,
+        runRepo,
+        repoDir,
+        undefined,
+        unlocked.datastoreResolver.resolvePath(SWAMP_SUBDIRS.data),
+        repoContext.catalogStore,
+        directResolver,
+        repoContext.markDirty,
+        repoContext.unifiedDataRepo.namespace,
+        stepLockHook,
+      );
 
-        if (renderer.workflowFailed()) {
-          if (flushModelLocks) await flushModelLocks();
-          Deno.exitCode = 1;
-          return;
+      const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
+        workflowName,
+      });
+
+      const resumeGenerator = async function* (): AsyncGenerator<
+        WorkflowRunEvent
+      > {
+        for await (
+          const event of service.resume(workflowName, run.id, {
+            signal: AbortSignal.timeout(600_000),
+            swampSha: GIT_SHA,
+            inputs: resumeInputs,
+          })
+        ) {
+          yield mapWorkflowExecutionEvent(event, runRepo);
         }
+      };
 
-        if (flushModelLocks) await flushModelLocks();
-      } catch (error) {
-        try {
-          if (flushModelLocks) await flushModelLocks();
-        } catch (releaseError) {
-          const logger = getSwampLogger(["workflow", "resume"]);
-          logger.warn(
-            "Failed to release locks during error cleanup: {error}",
-            {
-              error: releaseError instanceof Error
-                ? releaseError.message
-                : String(releaseError),
-            },
-          );
-        }
-        throw error;
+      await consumeStream(resumeGenerator(), renderer.handlers());
+
+      if (renderer.workflowFailed()) {
+        Deno.exitCode = 1;
+        return;
       }
     },
   );

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -25,15 +25,13 @@ import {
 } from "../context.ts";
 import {
   acquireModelLocks,
-  requireInitializedRepo,
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
-import { extractModelReferencesFromWorkflow } from "../../domain/workflows/model_reference_extractor.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import {
   type DirectTypeResolver,
+  type StepLockHook,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
 import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
@@ -187,8 +185,6 @@ export const workflowRunCommand = new Command()
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: ctx.outputMode,
     });
-    const workflowRepo = unlocked.repoContext.workflowRepo;
-
     const lastEvaluated = options.lastEvaluated as boolean;
 
     const stdinContent = options.stdin ? await readStdin() : null;
@@ -215,77 +211,22 @@ export const workflowRunCommand = new Command()
       ? parseTags(options.tag as string[])
       : undefined;
 
-    let flushModelLocks: (() => Promise<void>) | null = null;
-    let repoDir: string;
-    let repoContext: typeof unlocked.repoContext;
+    const repoDir = unlocked.repoDir;
+    const repoContext = unlocked.repoContext;
+
+    const stepLockHook: StepLockHook = async (modelType, modelId) => {
+      const result = await acquireModelLocks(
+        unlocked.datastoreConfig,
+        [{ modelType, modelId }],
+        repoDir,
+        unlocked.syncService,
+        repoContext.catalogStore,
+      );
+      if (result.synced) repoContext.catalogStore.invalidate();
+      return result;
+    };
 
     try {
-      // Pre-lookup workflow for per-model lock acquisition
-      const preWorkflow = await workflowRepo.findByName(workflowIdOrName) ??
-        await workflowRepo.findById(createWorkflowId(workflowIdOrName));
-
-      if (preWorkflow) {
-        // Try to extract model references for per-model locking
-        const modelRefs = await extractModelReferencesFromWorkflow(
-          preWorkflow,
-          workflowRepo,
-        );
-
-        if (modelRefs !== null && modelRefs.length > 0) {
-          const definitionRepo = unlocked.repoContext.definitionRepo;
-          const resolvedModels: Array<
-            { modelType: string; modelId: string }
-          > = [];
-
-          for (const ref of modelRefs) {
-            const lookupResult = await findDefinitionByIdOrName(
-              definitionRepo,
-              ref,
-            );
-            if (lookupResult) {
-              resolvedModels.push({
-                modelType: lookupResult.type.normalized,
-                modelId: lookupResult.definition.id,
-              });
-            }
-          }
-
-          if (resolvedModels.length > 0) {
-            const lockResult = await acquireModelLocks(
-              unlocked.datastoreConfig,
-              resolvedModels,
-              unlocked.repoDir,
-              unlocked.syncService,
-              unlocked.repoContext.catalogStore,
-            );
-            if (lockResult.synced) {
-              unlocked.repoContext.catalogStore.invalidate();
-            }
-            flushModelLocks = lockResult.flush;
-          }
-
-          repoDir = unlocked.repoDir;
-          repoContext = unlocked.repoContext;
-        } else if (modelRefs === null) {
-          // Dynamic references — fall back to global lock
-          const logger = getSwampLogger(["workflow", "run"]);
-          logger
-            .info`Workflow contains dynamic model references — using global lock`;
-          const globalResult = await requireInitializedRepo({
-            repoDir: resolveRepoDir(options.repoDir),
-            outputMode: ctx.outputMode,
-          });
-          repoDir = globalResult.repoDir;
-          repoContext = globalResult.repoContext;
-        } else {
-          repoDir = unlocked.repoDir;
-          repoContext = unlocked.repoContext;
-        }
-      } else {
-        repoDir = unlocked.repoDir;
-        repoContext = unlocked.repoContext;
-      }
-
       const runRepo = repoContext.workflowRunRepo;
 
       // Load all extension registries needed for workflow execution in parallel
@@ -394,6 +335,7 @@ export const workflowRunCommand = new Command()
             directResolver,
             repoContext.markDirty,
             repoContext.unifiedDataRepo.namespace,
+            stepLockHook,
           );
         },
         catalogStore: repoContext.catalogStore,
@@ -451,27 +393,11 @@ export const workflowRunCommand = new Command()
         );
 
         if (renderer.workflowFailed()) {
-          if (flushModelLocks) await flushModelLocks();
           Deno.exitCode = 1;
           return;
         }
       }
-
-      // Release per-model locks on success
-      if (flushModelLocks) await flushModelLocks();
     } catch (error) {
-      // Release per-model locks on error (best-effort — don't lose original error)
-      try {
-        if (flushModelLocks) await flushModelLocks();
-      } catch (releaseError) {
-        const logger = getSwampLogger(["workflow", "run"]);
-        logger.warn("Failed to release locks during error cleanup: {error}", {
-          error: releaseError instanceof Error
-            ? releaseError.message
-            : String(releaseError),
-        });
-      }
-
       if (error instanceof UserError) {
         throw error;
       }

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1069,14 +1069,19 @@ export async function acquireModelLocks(
   }
 
   for (const { modelType, modelId } of unique) {
-    const key = `data/${modelType}/${modelId}/.lock`;
+    const lockFileKey = `data/${modelType}/${modelId}/.lock`;
     // Use cached provider for custom types to avoid repeated registry lookups
     const lock = customProvider && isCustomDatastoreConfig(config)
-      ? customProvider.createLock(config.datastorePath, { lockKey: key })
+      ? customProvider.createLock(config.datastorePath, {
+        lockKey: lockFileKey,
+      })
       : await createModelLock(config, modelType, modelId);
-    // Register lock only (no sync service — we handle S3 pull/push manually)
-    await registerDatastoreSyncNamed(key, { lock });
-    lockKeys.push(key);
+    // Unique coordinator key so parallel steps on the same model get
+    // separate entries — prevents the second registration from
+    // overwriting the first (which would orphan the first lock).
+    const coordinatorKey = `${lockFileKey}#${crypto.randomUUID().slice(0, 8)}`;
+    await registerDatastoreSyncNamed(coordinatorKey, { lock });
+    lockKeys.push(coordinatorKey);
 
     // Re-check global lock after acquiring each per-model lock to close TOCTOU race.
     // If a structural command acquired the global lock between our initial check
@@ -1168,8 +1173,6 @@ export async function acquireModelLocks(
     }
   }
 
-  Deno.env.set(SWAMP_LOCK_HOLDER_PID, String(Deno.pid));
-
   const flush = async () => {
     try {
       // For custom sync-capable datastores: push under global lock
@@ -1255,7 +1258,6 @@ export async function acquireModelLocks(
       for (const key of lockKeys) {
         await flushDatastoreSyncNamed(key);
       }
-      Deno.env.delete(SWAMP_LOCK_HOLDER_PID);
     }
   };
 

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -126,17 +126,6 @@ async function executeCommand(
       }
     }
 
-    // When explicit env vars are present, Deno.Command replaces the entire
-    // inherited environment. Propagate the lock-holder PID so nested swamp
-    // commands can skip the parent's per-model locks (prevents deadlock).
-    // Only inject when shellEnv already has entries — when it's empty, env
-    // is passed as undefined and the child inherits the full parent env
-    // (including SWAMP_LOCK_HOLDER_PID) naturally.
-    const lockHolderPid = Deno.env.get("SWAMP_LOCK_HOLDER_PID");
-    if (lockHolderPid && Object.keys(shellEnv).length > 0) {
-      shellEnv = { ...shellEnv, SWAMP_LOCK_HOLDER_PID: lockHolderPid };
-    }
-
     const invocation = shellStrategy.buildInvocation(shellCommand);
     const result = await executeProcess({
       command: invocation.command,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -252,6 +252,15 @@ export type DirectTypeResolver = (
   globalArgs?: Record<string, unknown>,
 ) => Promise<DirectTypeResolveResult>;
 
+export interface StepLockResult {
+  flush: () => Promise<void>;
+}
+
+export type StepLockHook = (
+  modelType: string,
+  modelId: string,
+) => Promise<StepLockResult>;
+
 export interface StepExecutorDeps {
   definitionRepo: DefinitionRepository;
   unifiedDataRepo: UnifiedDataRepository;
@@ -276,6 +285,7 @@ export class DefaultStepExecutor implements StepExecutor {
     private readonly injectedDeps?: StepExecutorDeps,
     directTypeResolver?: DirectTypeResolver,
     private readonly markDirty?: MarkDirtyHook,
+    private readonly stepLockHook?: StepLockHook,
   ) {
     this._directTypeResolver = directTypeResolver;
   }
@@ -842,72 +852,86 @@ export class DefaultStepExecutor implements StepExecutor {
       }
     }
 
-    // Execute the method with the EVALUATED definition. The logger
-    // handles both console and file persistence via RunFileSink. Data
-    // is persisted by DataWriter during execution — no double-save.
-    return await executionService.executeWorkflow(
-      evaluatedDefinition,
-      modelDef,
-      task.methodName,
-      buildMethodContext(
-        {
-          dataRepository: unifiedDataRepo,
-          definitionRepository: definitionRepo,
-          vaultService,
-          redactor: ctx.secretRedactor,
-          dataQueryService,
-          createCelEnvironment: createExtensionCelEnvironment,
-        },
-        {
-          signal: ctx.signal,
-          repoDir: ctx.repoDir,
-          modelType,
-          modelId: evaluatedDefinition.id,
-          globalArgs: evaluatedDefinition.globalArguments,
-          definition: {
-            id: evaluatedDefinition.id,
-            name: evaluatedDefinition.name,
-            version: evaluatedDefinition.version,
-            tags: evaluatedDefinition.tags,
+    // Acquire per-step lock if a lock hook is provided. The lock covers
+    // the method execution (which writes data) and is released in the
+    // finally block — even on failure — so the lock is never orphaned.
+    let flushLock: (() => Promise<void>) | null = null;
+    if (this.stepLockHook) {
+      const lockResult = await this.stepLockHook(
+        modelType.normalized,
+        originalDefinition.id,
+      );
+      flushLock = lockResult.flush;
+    }
+    try {
+      return await executionService.executeWorkflow(
+        evaluatedDefinition,
+        modelDef,
+        task.methodName,
+        buildMethodContext(
+          {
+            dataRepository: unifiedDataRepo,
+            definitionRepository: definitionRepo,
+            vaultService,
+            redactor: ctx.secretRedactor,
+            dataQueryService,
+            createCelEnvironment: createExtensionCelEnvironment,
           },
-          methodName: task.methodName,
-          logger: runLogger,
-          tagOverrides: workflowTagOverrides,
-          runtimeTags: ctx.runtimeTags,
-          dataOutputOverrides: stepDataOutputOverrides,
-          vaultSecrets: secretBag,
-          placement: ctx.step?.placement,
-          skipCheckNames: ctx.skipCheckNames,
-          skipCheckLabels: ctx.skipCheckLabels,
-          skipAllChecks: ctx.skipAllChecks,
-          extensionFilesRoot: modelDef.extensionFilesRoot,
-          onEvent: ctx.emitEvent
-            ? (event: MethodExecutionEvent) => {
-              if (event.type === "output") {
-                ctx.emitEvent!({
-                  kind: "method_output",
-                  jobId: ctx.jobName,
-                  stepId: ctx.stepName,
-                  modelName: originalDefinition.name,
-                  methodName: task.methodName,
-                  stream: event.stream,
-                  line: event.line,
-                });
-              } else {
-                ctx.emitEvent!({
-                  kind: "method_event",
-                  jobId: ctx.jobName,
-                  stepId: ctx.stepName,
-                  modelName: originalDefinition.name,
-                  methodName: task.methodName,
-                  event,
-                });
+          {
+            signal: ctx.signal,
+            repoDir: ctx.repoDir,
+            modelType,
+            modelId: evaluatedDefinition.id,
+            globalArgs: evaluatedDefinition.globalArguments,
+            definition: {
+              id: evaluatedDefinition.id,
+              name: evaluatedDefinition.name,
+              version: evaluatedDefinition.version,
+              tags: evaluatedDefinition.tags,
+            },
+            methodName: task.methodName,
+            logger: runLogger,
+            tagOverrides: workflowTagOverrides,
+            runtimeTags: ctx.runtimeTags,
+            dataOutputOverrides: stepDataOutputOverrides,
+            vaultSecrets: secretBag,
+            placement: ctx.step?.placement,
+            skipCheckNames: ctx.skipCheckNames,
+            skipCheckLabels: ctx.skipCheckLabels,
+            skipAllChecks: ctx.skipAllChecks,
+            extensionFilesRoot: modelDef.extensionFilesRoot,
+            onEvent: ctx.emitEvent
+              ? (event: MethodExecutionEvent) => {
+                if (event.type === "output") {
+                  ctx.emitEvent!({
+                    kind: "method_output",
+                    jobId: ctx.jobName,
+                    stepId: ctx.stepName,
+                    modelName: originalDefinition.name,
+                    methodName: task.methodName,
+                    stream: event.stream,
+                    line: event.line,
+                  });
+                } else {
+                  ctx.emitEvent!({
+                    kind: "method_event",
+                    jobId: ctx.jobName,
+                    stepId: ctx.stepName,
+                    modelName: originalDefinition.name,
+                    methodName: task.methodName,
+                    event,
+                  });
+                }
               }
-            }
-            : undefined,
-        },
-      ),
-    );
+              : undefined,
+          },
+        ),
+      );
+    } finally {
+      if (flushLock) {
+        await flushLock();
+      }
+    }
   }
 
   /**
@@ -1237,9 +1261,15 @@ export class WorkflowExecutionService {
     private readonly directTypeResolver?: DirectTypeResolver,
     private readonly markDirty?: MarkDirtyHook,
     private readonly namespace: Namespace = SOLO_NAMESPACE,
+    stepLockHook?: StepLockHook,
   ) {
     this.executor = executor ??
-      new DefaultStepExecutor(undefined, directTypeResolver, markDirty);
+      new DefaultStepExecutor(
+        undefined,
+        directTypeResolver,
+        markDirty,
+        stepLockHook,
+      );
     this.dataBaseDir = dataBaseDir;
     this.catalogStore = catalogStore;
     this.definitionRepo = new YamlDefinitionRepository(repoDir);

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -34,6 +34,7 @@ import type {
 import { createLibSwampContext, workflowRun } from "../libswamp/mod.ts";
 import {
   type DirectTypeResolver,
+  type StepLockHook,
   WorkflowExecutionService,
 } from "../domain/workflows/execution_service.ts";
 import { createWorkflowId } from "../domain/workflows/workflow_id.ts";
@@ -45,7 +46,6 @@ import { resolveOrCreateDefinition } from "../libswamp/mod.ts";
 import { YamlDefinitionRepository } from "../infrastructure/persistence/yaml_definition_repository.ts";
 import type { DefinitionId } from "../domain/definitions/definition.ts";
 import { findDefinitionByIdOrName } from "../domain/models/model_lookup.ts";
-import { extractModelReferencesFromWorkflow } from "../domain/workflows/model_reference_extractor.ts";
 import { resolveModelType } from "../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
 import { DefaultMethodExecutionService } from "../domain/models/method_execution_service.ts";
@@ -64,11 +64,11 @@ import { reportRegistry } from "../domain/reports/report_registry.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
-import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
 export async function createWorkflowRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
+  stepLockHook?: StepLockHook,
 ): Promise<WorkflowRunDeps> {
   await Promise.all([
     modelRegistry.ensureLoaded(),
@@ -152,6 +152,7 @@ export async function createWorkflowRunDeps(
         directResolver,
         repoContext.markDirty,
         repoContext.unifiedDataRepo.namespace,
+        stepLockHook,
       );
     },
     catalogStore: repoContext.catalogStore,
@@ -249,13 +250,13 @@ export async function createModelMethodRunDeps(
   };
 }
 
-const depsLogger = getSwampLogger(["serve", "deps"]);
-
 /**
- * Executes a workflow run with model lock acquisition — the single code path
- * for both WebSocket-triggered and scheduled workflow execution.
+ * Executes a workflow run with per-step model lock acquisition — the single
+ * code path for both WebSocket-triggered and scheduled workflow execution.
  *
- * Handles: pre-lookup → lock acquisition → workflowRun → lock release.
+ * Handles: pre-lookup → stepLockHook creation → workflowRun.
+ * Locks are acquired and released per-step by the execution service rather
+ * than held for the entire workflow duration.
  * The caller provides a callback to consume the event stream.
  */
 export async function executeWorkflowWithLocks(
@@ -273,98 +274,60 @@ export async function executeWorkflowWithLocks(
    */
   syncService?: DatastoreSyncService,
 ): Promise<void> {
-  let flushLocks: (() => Promise<void>) | null = null;
+  // Pre-lookup workflow for trigger.inputs resolution
+  const workflowRepo = repoContext.workflowRepo;
+  const workflow = await workflowRepo.findByName(
+    input.workflowIdOrName,
+  ) ?? await workflowRepo.findById(
+    createWorkflowId(input.workflowIdOrName),
+  );
 
-  try {
-    // Pre-lookup workflow for per-model lock acquisition
-    const workflowRepo = repoContext.workflowRepo;
-    const workflow = await workflowRepo.findByName(
-      input.workflowIdOrName,
-    ) ?? await workflowRepo.findById(
-      createWorkflowId(input.workflowIdOrName),
+  const stepLockHook: StepLockHook = async (modelType, modelId) => {
+    const result = await acquireModelLocks(
+      datastoreConfig,
+      [{ modelType, modelId }],
+      repoDir,
+      syncService,
+      repoContext.catalogStore,
     );
+    if (result.synced) repoContext.catalogStore.invalidate();
+    return result;
+  };
 
-    if (workflow) {
-      const modelRefs = await extractModelReferencesFromWorkflow(
-        workflow,
-        workflowRepo,
-      );
-      if (modelRefs !== null && modelRefs.length > 0) {
-        const resolvedModels: Array<{ modelType: string; modelId: string }> =
-          [];
-        for (const ref of modelRefs) {
-          const result = await findDefinitionByIdOrName(
-            repoContext.definitionRepo,
-            ref,
-          );
-          if (result) {
-            resolvedModels.push({
-              modelType: result.type.normalized,
-              modelId: result.definition.id,
-            });
-          }
-        }
-        if (resolvedModels.length > 0) {
-          const lockResult = await acquireModelLocks(
-            datastoreConfig,
-            resolvedModels,
-            repoDir,
-            syncService,
-            repoContext.catalogStore,
-          );
-          if (lockResult.synced) repoContext.catalogStore.invalidate();
-          flushLocks = lockResult.flush;
-        }
-      }
+  const deps = await createWorkflowRunDeps(repoDir, repoContext, stepLockHook);
+  const libCtx = createLibSwampContext({ signal });
+
+  // Layer the workflow's trigger.inputs under any caller-supplied inputs so
+  // scheduled and webhook trigger-fired runs get baseline values at fire
+  // time. Downstream workflowRun applies schema defaults and validates,
+  // yielding precedence: caller inputs > trigger.inputs > schema defaults.
+  //
+  // For webhook runs, trigger.inputs may reference the request payload via the
+  // `webhook` CEL namespace (e.g. "${{ webhook.body.data.issue.identifier }}").
+  // Resolve those against the payload here — before workflowRun's coercion and
+  // validation — so a required input mapped from the payload satisfies the
+  // schema.
+  let resolvedTriggerInputs: Record<string, unknown> | undefined;
+  if (workflow && input.webhook && workflow.triggerInputs) {
+    const resolver = new TriggerInputResolver(new CelEvaluator());
+    resolvedTriggerInputs = await resolver.resolve(workflow.triggerInputs, {
+      model: {},
+      env: buildEnvContext(),
+      webhook: input.webhook,
+    });
+  }
+
+  const effectiveInput = workflow
+    ? {
+      ...input,
+      inputs: workflow.baselineInputs(
+        input.inputs ?? {},
+        resolvedTriggerInputs,
+      ),
     }
+    : input;
 
-    const deps = await createWorkflowRunDeps(repoDir, repoContext);
-    const libCtx = createLibSwampContext({ signal });
-
-    // Layer the workflow's trigger.inputs under any caller-supplied inputs so
-    // scheduled and webhook trigger-fired runs get baseline values at fire
-    // time. Downstream workflowRun applies schema defaults and validates,
-    // yielding precedence: caller inputs > trigger.inputs > schema defaults.
-    //
-    // For webhook runs, trigger.inputs may reference the request payload via the
-    // `webhook` CEL namespace (e.g. "${{ webhook.body.data.issue.identifier }}").
-    // Resolve those against the payload here — before workflowRun's coercion and
-    // validation — so a required input mapped from the payload satisfies the
-    // schema.
-    let resolvedTriggerInputs: Record<string, unknown> | undefined;
-    if (workflow && input.webhook && workflow.triggerInputs) {
-      const resolver = new TriggerInputResolver(new CelEvaluator());
-      resolvedTriggerInputs = await resolver.resolve(workflow.triggerInputs, {
-        model: {},
-        env: buildEnvContext(),
-        webhook: input.webhook,
-      });
-    }
-
-    const effectiveInput = workflow
-      ? {
-        ...input,
-        inputs: workflow.baselineInputs(
-          input.inputs ?? {},
-          resolvedTriggerInputs,
-        ),
-      }
-      : input;
-
-    for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
-      onEvent(event);
-    }
-  } finally {
-    if (flushLocks) {
-      try {
-        await flushLocks();
-      } catch (releaseError) {
-        depsLogger.warn("Failed to release locks: {error}", {
-          error: releaseError instanceof Error
-            ? releaseError.message
-            : String(releaseError),
-        });
-      }
-    }
+  for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
+    onEvent(event);
   }
 }


### PR DESCRIPTION
## Summary

- Workflows previously acquired per-model locks on **all** referenced models upfront, holding them for the entire execution. When a model method spawned a subprocess (`swamp model method run`) targeting one of those locked models, the subprocess timed out after 60s waiting for the parent's lock — deadlock.
- Moved lock acquisition from workflow entry points (`workflow_run`, `workflow_resume`, `executeWorkflowWithLocks`) into the execution engine at the step level via a `StepLockHook` callback. Each model method step acquires its own per-model lock before execution and releases it after. Subprocesses acquire their own locks independently.
- Removed the `SWAMP_LOCK_HOLDER_PID` env var mechanism — no longer needed since the parent workflow no longer holds locks that children contend on.
- Used unique coordinator keys per lock acquisition so parallel steps (e.g. `forEach`) on the same model get separate entries in the sync coordinator map.

## Test Plan

- [x] All 7700 existing tests pass (including ENOTEMPTY race regression test #234)
- [x] Verified with filesystem datastore: workflow with model A shelling out to model B via subprocess completes without deadlock
- [x] Verified with S3 datastore (MinIO): full per-step lock → pull → execute → push → release cycle works correctly
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Fixes swamp-club#744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>