### PR TITLE
fix(skill): correct model create syntax in swamp SKILL.md

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -49,7 +49,7 @@ Route to the right guide based on what the user needs.
 
 ```bash
 # Models
-swamp model @<type> create <name>              # create a model definition
+swamp model create <type> <name>               # create a model definition
 swamp model @<type> method run <method> <name> # run a method on a model
 swamp model get <name> --json                  # inspect current model state
 swamp model type search [query]                # find available model types


### PR DESCRIPTION
## Summary

Fixes swamp-club#778.

- The Common Commands section of `.claude/skills/swamp/SKILL.md` showed `swamp model @<type> create <name>`, but `model create` takes positional args `<type> <name>` without the `@` prefix. The `@<type>` syntax is only valid for `method run` (direct type execution).

## Test Plan

- [x] `deno fmt --check` passes
- [x] Verified correct syntax matches `swamp model create --help` output