### PR TITLE
fix(workflow): surface step errors in workflow failure log lines

### DIFF
--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -84,6 +84,7 @@ export {
 export type { MethodExecutionEvent } from "../domain/models/method_events.ts";
 export {
   type DataArtifactRefData,
+  extractFirstStepError,
   type JobRunView,
   type StepArtifactsData,
   type StepRunView,

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -36,6 +36,10 @@ import { workflowsDir, WorkflowWatcher } from "./watcher.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import type { WorkflowRunEvent, WorkflowRunInput } from "./run.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  extractFirstStepError,
+  type WorkflowRunView,
+} from "./workflow_run_view.ts";
 
 const logger = getSwampLogger(["scheduled-execution"]);
 
@@ -286,6 +290,7 @@ export class ScheduledExecutionService {
 
     try {
       let runId = "";
+      let completedRun: WorkflowRunView | undefined;
 
       await this.deps.executeWorkflow(
         { workflowIdOrName: workflowName },
@@ -294,19 +299,36 @@ export class ScheduledExecutionService {
           if (event.kind === "started") {
             runId = event.runId;
           }
+          if (event.kind === "completed") {
+            completedRun = event.run;
+          }
         },
       );
 
-      this.emit({
-        kind: "schedule_completed",
-        workflowId,
-        workflowName,
-        runId,
-      });
-      logger.info(
-        "Scheduled run completed for workflow {name} (run: {runId})",
-        { name: workflowName, runId },
-      );
+      if (completedRun?.status === "failed") {
+        const message = extractFirstStepError(completedRun);
+        this.emit({
+          kind: "schedule_failed",
+          workflowId,
+          workflowName,
+          error: message,
+        });
+        logger.error(
+          "Scheduled run failed for workflow {name}: {error}",
+          { name: workflowName, error: message },
+        );
+      } else {
+        this.emit({
+          kind: "schedule_completed",
+          workflowId,
+          workflowName,
+          runId,
+        });
+        logger.info(
+          "Scheduled run completed for workflow {name} (run: {runId})",
+          { name: workflowName, runId },
+        );
+      }
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         logger.info("Scheduled run aborted for workflow {name}", {

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -27,6 +27,7 @@ import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRunEvent } from "./run.ts";
 
 function createTestWorkflow(
   name: string,
@@ -114,6 +115,64 @@ Deno.test("ScheduledExecutionService: ignores workflows without schedules", asyn
   assertEquals(events.length, 0);
 
   await service.stop();
+});
+
+Deno.test("ScheduledExecutionService: emits schedule_failed when workflow run has failed status", async () => {
+  const wf = createTestWorkflow("fail-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: (
+      _input,
+      _signal,
+      onEvent: (event: WorkflowRunEvent) => void,
+    ) => {
+      onEvent({
+        kind: "started",
+        runId: "run-1",
+        workflowName: "fail-wf",
+        jobs: [],
+      });
+      onEvent({
+        kind: "completed",
+        run: {
+          id: "run-1",
+          workflowId: wf.id,
+          workflowName: "fail-wf",
+          status: "failed",
+          jobs: [{
+            name: "job1",
+            status: "failed",
+            steps: [{
+              name: "step1",
+              status: "failed",
+              error: "CEL type mismatch",
+            }],
+          }],
+        },
+      });
+      return Promise.resolve();
+    },
+  });
+
+  await service.start((e) => events.push(e));
+
+  // Wait for the cron to fire (every second)
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const failed = events.filter((e) => e.kind === "schedule_failed");
+  assertEquals(failed.length >= 1, true);
+  assertEquals(
+    (failed[0] as { kind: "schedule_failed"; error: string }).error,
+    "CEL type mismatch",
+  );
+
+  const completed = events.filter((e) => e.kind === "schedule_completed");
+  assertEquals(completed.length, 0);
 });
 
 Deno.test("ScheduledExecutionService: stop clears schedules", async () => {

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -166,10 +166,12 @@ Deno.test("ScheduledExecutionService: emits schedule_failed when workflow run ha
 
   const failed = events.filter((e) => e.kind === "schedule_failed");
   assertEquals(failed.length >= 1, true);
-  assertEquals(
-    (failed[0] as { kind: "schedule_failed"; error: string }).error,
-    "CEL type mismatch",
-  );
+  for (const event of failed) {
+    assertEquals(
+      (event as { kind: "schedule_failed"; error: string }).error,
+      "CEL type mismatch",
+    );
+  }
 
   const completed = events.filter((e) => e.kind === "schedule_completed");
   assertEquals(completed.length, 0);

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -91,3 +91,14 @@ export interface WorkflowRunView {
   /** Data artifacts produced at workflow scope (e.g. workflow-scope reports). */
   workflowDataArtifacts?: DataArtifactRefData[];
 }
+
+export function extractFirstStepError(run: WorkflowRunView): string {
+  for (const job of run.jobs) {
+    for (const step of job.steps) {
+      if (step.status === "failed" && !step.allowedFailure && step.error) {
+        return step.error;
+      }
+    }
+  }
+  return "unknown error";
+}

--- a/src/libswamp/workflows/workflow_run_view_test.ts
+++ b/src/libswamp/workflows/workflow_run_view_test.ts
@@ -1,0 +1,115 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  extractFirstStepError,
+  type WorkflowRunView,
+} from "./workflow_run_view.ts";
+
+function makeRun(
+  jobs: WorkflowRunView["jobs"],
+): WorkflowRunView {
+  return {
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "test-workflow",
+    status: "failed",
+    jobs,
+  };
+}
+
+Deno.test("extractFirstStepError: returns error from first failed step", () => {
+  const run = makeRun([{
+    name: "job1",
+    status: "failed",
+    steps: [
+      { name: "step1", status: "succeeded" },
+      { name: "step2", status: "failed", error: "CEL type mismatch" },
+    ],
+  }]);
+  assertEquals(extractFirstStepError(run), "CEL type mismatch");
+});
+
+Deno.test("extractFirstStepError: skips allowed failures", () => {
+  const run = makeRun([{
+    name: "job1",
+    status: "failed",
+    steps: [
+      {
+        name: "step1",
+        status: "failed",
+        error: "allowed error",
+        allowedFailure: true,
+      },
+      { name: "step2", status: "failed", error: "real error" },
+    ],
+  }]);
+  assertEquals(extractFirstStepError(run), "real error");
+});
+
+Deno.test("extractFirstStepError: searches across jobs", () => {
+  const run = makeRun([
+    {
+      name: "job1",
+      status: "succeeded",
+      steps: [{ name: "step1", status: "succeeded" }],
+    },
+    {
+      name: "job2",
+      status: "failed",
+      steps: [
+        { name: "step1", status: "failed", error: "second job error" },
+      ],
+    },
+  ]);
+  assertEquals(extractFirstStepError(run), "second job error");
+});
+
+Deno.test("extractFirstStepError: returns unknown error when no failed steps", () => {
+  const run = makeRun([{
+    name: "job1",
+    status: "failed",
+    steps: [{ name: "step1", status: "succeeded" }],
+  }]);
+  assertEquals(extractFirstStepError(run), "unknown error");
+});
+
+Deno.test("extractFirstStepError: returns unknown error when failed step has no error string", () => {
+  const run = makeRun([{
+    name: "job1",
+    status: "failed",
+    steps: [{ name: "step1", status: "failed" }],
+  }]);
+  assertEquals(extractFirstStepError(run), "unknown error");
+});
+
+Deno.test("extractFirstStepError: returns unknown error when all failures are allowed", () => {
+  const run = makeRun([{
+    name: "job1",
+    status: "failed",
+    steps: [{
+      name: "step1",
+      status: "failed",
+      error: "allowed",
+      allowedFailure: true,
+    }],
+  }]);
+  assertEquals(extractFirstStepError(run), "unknown error");
+});

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -17,10 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type {
-  EventHandlers,
-  WorkflowRunEvent,
-  WorkflowRunView,
+import {
+  type EventHandlers,
+  extractFirstStepError,
+  type WorkflowRunEvent,
+  type WorkflowRunView,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
@@ -70,7 +71,12 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
         getWorkflowRunLogger(this.workflowName, e.jobId).info("Job started");
       },
       job_completed: (e) => {
-        getWorkflowRunLogger(this.workflowName, e.jobId).info("Job completed");
+        const jobLogger = getWorkflowRunLogger(this.workflowName, e.jobId);
+        if (e.status === "failed") {
+          jobLogger.error("Job failed");
+        } else {
+          jobLogger.info("Job completed");
+        }
       },
       job_skipped: (e) => {
         getWorkflowRunLogger(this.workflowName, e.jobId).info("Job skipped");
@@ -199,7 +205,8 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
         const wfLogger = getWorkflowRunLogger(this.workflowName);
         if (e.run.status === "failed") {
           this._failed = true;
-          wfLogger.error("Workflow {status}", { status: e.run.status });
+          const stepError = extractFirstStepError(e.run);
+          wfLogger.error("Workflow failed: {error}", { error: stepError });
         } else {
           wfLogger.with({ summary: true }).info("Workflow {status}", {
             status: e.run.status,

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -33,7 +33,7 @@ import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import {
   extractFirstStepError,
   type WorkflowRunView,
-} from "../libswamp/workflows/workflow_run_view.ts";
+} from "../libswamp/mod.ts";
 import {
   createVerifier,
   isWebhookScheme,

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -31,6 +31,10 @@ import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import {
+  extractFirstStepError,
+  type WorkflowRunView,
+} from "../libswamp/workflows/workflow_run_view.ts";
+import {
   createVerifier,
   isWebhookScheme,
   type VerifierConfig,
@@ -440,6 +444,7 @@ export class WebhookService {
 
     try {
       let runId = "";
+      let completedRun: WorkflowRunView | undefined;
 
       await executeWorkflowWithLocks(
         this.deps.repoDir,
@@ -451,20 +456,37 @@ export class WebhookService {
           if (event.kind === "started") {
             runId = event.runId;
           }
+          if (event.kind === "completed") {
+            completedRun = event.run;
+          }
         },
         this.deps.syncService,
       );
 
-      this.emit({
-        kind: "webhook_completed",
-        route,
-        workflowName: workflowIdOrName,
-        runId,
-      });
-      logger.info(
-        "Webhook workflow {workflow} completed (run: {runId})",
-        { workflow: workflowIdOrName, runId },
-      );
+      if (completedRun?.status === "failed") {
+        const message = extractFirstStepError(completedRun);
+        this.emit({
+          kind: "webhook_failed",
+          route,
+          workflowName: workflowIdOrName,
+          error: message,
+        });
+        logger.error(
+          "Webhook workflow {workflow} failed: {error}",
+          { workflow: workflowIdOrName, error: message },
+        );
+      } else {
+        this.emit({
+          kind: "webhook_completed",
+          route,
+          workflowName: workflowIdOrName,
+          runId,
+        });
+        logger.info(
+          "Webhook workflow {workflow} completed (run: {runId})",
+          { workflow: workflowIdOrName, runId },
+        );
+      }
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         logger.info("Webhook workflow {workflow} aborted", {


### PR DESCRIPTION
## Summary

Fixes swamp-club#782.

- Add `extractFirstStepError` helper that walks `WorkflowRunView.jobs[*].steps[*]` for the first non-allowed-failure step error, falling back to `"unknown error"`
- Fix `ScheduledExecutionService` and `WebhookService` to detect workflow step failures (which complete normally with `run.status=failed`, not via exceptions) and emit `schedule_failed`/`webhook_failed` events with the actual error message
- Fix `LogWorkflowRunRenderer` to log `"Workflow failed: <step error>"` instead of just `"Workflow failed"`
- Fix `job_completed` handler to log `"Job failed"` at error level when the job status is `"failed"` instead of always logging `"Job completed"` at info level

**Before:**
```
[INF] workflow·run·fail-test·main: Job completed
[ERR] workflow·run·fail-test: Workflow "failed"
```

**After:**
```
[ERR] workflow·run·fail-test·main: Job failed
[ERR] workflow·run·fail-test: Workflow failed: "Command exited with code 1"
```

## Test Plan

- Added 6 unit tests for `extractFirstStepError` covering: first failed step, allowed failures skipped, cross-job search, no failed steps, missing error string, all-allowed failures
- Added integration test for `ScheduledExecutionService` verifying step failures emit `schedule_failed` events with the extracted error
- Verified fix against reproduction scenario in `/tmp/swamp-repro-issue-782` using locally compiled binary
- Full test suite passes (7737 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)