### PR TITLE
fix(serve): clarify that --webhook generic scheme requires <header> (swamp-club#729)

### DIFF
--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -224,8 +224,8 @@ caveat on headers.
 
 The signature scheme is set per endpoint on `swamp serve`'s `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`, where `scheme`
-is `github` (default), `linear`, `stripe`, `slack`, or `generic` (header +
-optional prefix). Omitting the scheme preserves the original behavior.
+is `github` (default), `linear`, `stripe`, `slack`, or `generic` (requires
+header; optional prefix). Omitting the scheme preserves the original behavior.
 
 ## Edit a Workflow
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -368,7 +368,7 @@ The `webhook` namespace exposes:
 The signature scheme is selected per endpoint on the `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`. `scheme` is one
 of `github` (the default, `X-Hub-Signature-256`), `linear`, `stripe`, `slack`,
-or `generic` (which takes a header name and optional value prefix). When no
+or `generic` (which requires a header name and accepts an optional value prefix). When no
 scheme is given the flag behaves exactly as before, so the secret may still
 contain colons; a scheme is recognized only when the fourth field is a known
 scheme keyword.

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -213,7 +213,7 @@ export const serveCommand = new Command()
     "--webhook <spec:string>",
     "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
       "scheme is one of github (default), linear, stripe, slack, generic; " +
-      "generic takes a header name and optional value prefix",
+      "generic requires a header name and accepts an optional value prefix",
     { collect: true },
   )
   .option(

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -98,13 +98,14 @@ export interface WebhookEndpoint {
  * consequence (a colon-bearing secret cannot be combined with an explicit
  * scheme, and a secret whose colon-tail begins with a reserved keyword would be
  * reinterpreted) is the accepted limitation tracked in #723. When a scheme is
- * given, the remaining fields are positional: `generic` additionally takes a
- * header name (fifth, required) and a value prefix (sixth, optional).
+ * given, the remaining fields are positional: `generic` requires a header name
+ * (fifth field) and accepts an optional value prefix (sixth field).
  */
 export function parseWebhookFlag(flag: string): WebhookEndpoint {
   const fields = flag.split(":");
   const usage =
-    "expected '<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]'";
+    "expected '<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]' " +
+    "(note: generic scheme requires <header>)";
 
   if (fields.length < 3) {
     throw new UserError(`Invalid --webhook format: ${usage}, got '${flag}'`);


### PR DESCRIPTION
## Summary

- Updated the `--webhook` flag description across CLI help text, JSDoc, error message, design doc, and skill reference to clarify that the `generic` scheme **requires** a header name (not optional)
- The nested-bracket format `[:<scheme>[:<header>[:<prefix>]]]` implied `<header>` was always optional, but `generic` errors without it — the wording now says "requires" instead of "takes"/"accepts"

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test` — 7741 passed, 0 failed
- [x] Existing `parseWebhookFlag: rejects generic without a header` test confirms runtime validation is unchanged

Closes swamp-club#729