### PR TITLE
feat(sbom): add CycloneDX SBOM generator for license compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ plans/
 # Generated/runtime data (ignored)
 .swamp/
 
+# Generated SBOM artifact (scripts/jsr_license_cache.json IS committed)
+sbom.cdx.json
+
 # Claude Code git worktrees (nested checkouts, not part of main working tree)
 .claude/worktrees/
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ deno fmt              # Format
 deno run compile      # Compile the binary
 ```
 
+### License Compliance
+
+`deno run sbom` generates a [CycloneDX](https://cyclonedx.org/) SBOM of every
+npm and JSR dependency for license-compliance scanning. See
+[design/license-compliance.md](design/license-compliance.md) for details on the
+generator, license resolution, and scanning with FOSSA.
+
 ### Contributing
 
 Swamp uses an **issue-driven contribution model**. We don't accept pull requests

--- a/deno.json
+++ b/deno.json
@@ -13,6 +13,7 @@
     "compile": "deno run -A scripts/compile.ts",
     "license-headers": "deno run --allow-read --allow-write scripts/add_license_headers.ts",
     "audit": "deno run --allow-read --allow-net=api.osv.dev --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/audit_deps.ts",
+    "sbom": "deno run --allow-read --allow-run --allow-net=api.jsr.io,registry.npmjs.org --allow-write=sbom.cdx.json,scripts/jsr_license_cache.json scripts/generate_sbom.ts",
     "audit-actions": "deno run --allow-read --allow-net=api.github.com --allow-env=GITHUB_STEP_SUMMARY,GITHUB_TOKEN --allow-write scripts/audit_actions.ts",
     "review-skills": "deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/review_skills.ts",
     "eval-skill-triggers": "deno run --allow-read --allow-run --allow-env --allow-write --allow-net scripts/eval_skill_triggers_promptfoo.ts"

--- a/design/license-compliance.md
+++ b/design/license-compliance.md
@@ -1,0 +1,85 @@
+# License Compliance
+
+Swamp generates a [CycloneDX](https://cyclonedx.org/) Software Bill of Materials
+(SBOM) describing every third-party dependency it ships, with an SPDX license
+for each. The SBOM is the input to license-compliance scanning — verifying that
+the licenses of bundled dependencies are compatible with how swamp is
+distributed.
+
+The generator lives in `scripts/generate_sbom.ts` and runs via `deno run sbom`.
+
+## Why a custom generator
+
+Swamp is a Deno project: its dependency graph spans both npm and JSR packages,
+recorded in `deno.json`/`deno.lock`. Off-the-shelf SBOM and SCA tools (FOSSA,
+Trivy, Syft) have no native Deno analyzer — pointed at the repo they discover
+nothing, or only an unrelated npm sub-project. The authoritative graph comes
+from `deno info --json main.ts`, so the generator reads that and emits a
+standard CycloneDX document any tool can consume.
+
+## SBOM generation
+
+```bash
+deno run sbom                 # write sbom.cdx.json (the default)
+deno run sbom --output -      # write to stdout instead
+deno run sbom --offline       # use cached license data only, no network
+```
+
+Discovery uses `deno info --json main.ts` — the resolved graph of npm packages
+(with their local cache paths) and every jsr.io module specifier. The output is
+CycloneDX 1.6 JSON, sorted deterministically, with one `library` component per
+dependency plus the dependency relationship graph.
+
+`sbom.cdx.json` is git-ignored (it is a build artifact). The JSR license cache
+(`scripts/jsr_license_cache.json`) **is** committed, so CI and offline runs are
+deterministic.
+
+## License resolution
+
+A license is resolved for every component:
+
+- **npm** — read from the package's cached `package.json` (`license`, the
+  deprecated `licenses` array, or an object form), entirely offline. Falls back
+  to the npm registry if a package isn't cached locally.
+- **JSR** — fetched from the JSR per-version API
+  (`api.jsr.io/scopes/{scope}/packages/{name}/versions/{version}`) and persisted
+  to `scripts/jsr_license_cache.json`. Repeat runs and CI read from the cache and
+  never hit the network for already-seen versions. `@std/*` packages that
+  declare no license resolve to MIT (the Deno standard library license).
+
+A component with no resolvable license is emitted as `NOASSERTION`, and the
+generator exits non-zero — a built-in signal that a dependency needs manual
+review.
+
+## CycloneDX required fields
+
+The SBOM populates the fields downstream tools (e.g. FOSSA's required-field
+check) expect for every component:
+
+- **Supplier** — npm packages use the `author` name; JSR packages use the scope
+  (e.g. `@std`).
+- **PURL** — `pkg:npm/...` for npm and `pkg:jsr/@scope/name@version` for JSR.
+- **Relationship data** — every component has a `dependsOn` entry (leaves carry
+  an explicit empty list); npm and jsr→jsr edges are included.
+- **BOM author** and **creation timestamp** are set in `metadata`.
+
+## Scanning with FOSSA
+
+[FOSSA](https://fossa.com/) ingests the CycloneDX SBOM directly. Set
+`FOSSA_API_KEY`, then:
+
+```bash
+deno run sbom                       # regenerate the SBOM
+fossa sbom analyze sbom.cdx.json    # upload and analyze
+fossa sbom test sbom.cdx.json       # check for license-policy violations
+```
+
+`fossa sbom test` exits non-zero when the analyzed SBOM violates the
+organization's license policy. A push-only `FOSSA_API_KEY` can upload and
+trigger scans but cannot read issue details back — use a full-access key, or
+view the report in the FOSSA web app, to inspect violations.
+
+## Related
+
+- [audit.md](audit.md) — the separate OSV-based vulnerability audit
+  (`deno run audit`), which scans the same dependency set for known CVEs.

--- a/scripts/generate_sbom.ts
+++ b/scripts/generate_sbom.ts
@@ -1,0 +1,619 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * CycloneDX SBOM generator for the swamp CLI.
+ *
+ * Produces a CycloneDX 1.6 JSON Software Bill of Materials describing every
+ * npm and JSR dependency resolved for `main.ts`, with an SPDX license for each
+ * component. Intended for license-compliance scanning (Trivy, FOSSA, etc.).
+ *
+ * Dependency discovery uses `deno info --json main.ts` — the authoritative
+ * resolved graph (npm packages with their local cache paths, plus every
+ * jsr.io module specifier).
+ *
+ * License resolution:
+ *   - npm  → read `license` from the package's cached `package.json` (offline);
+ *            fall back to the npm registry if the package isn't cached.
+ *   - jsr  → the JSR per-version API (`api.jsr.io`), persisted to an on-disk
+ *            cache (`scripts/jsr_license_cache.json`) so repeat runs and CI are
+ *            offline and deterministic. `@std/*` packages that declare no
+ *            license resolve to MIT (the Deno standard library license).
+ *
+ * Usage:
+ *   deno run sbom                 # writes sbom.cdx.json
+ *   deno run sbom --output -      # writes to stdout
+ *   deno run sbom --offline       # cache only, never hit the network
+ *
+ * Exit codes:
+ *   0 - SBOM generated (every component has a resolved license)
+ *   1 - SBOM generated but one or more components have no resolvable license
+ */
+
+import { parseArgs } from "@std/cli";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const CYCLONEDX_SPEC_VERSION = "1.6";
+const JSR_API = "https://api.jsr.io";
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const FETCH_TIMEOUT_MS = 15_000;
+const NOASSERTION = "NOASSERTION";
+/** Author recorded as the BOM creator (CycloneDX metadata.authors). */
+const SBOM_AUTHOR = "Elder Swamp Club, Inc.";
+
+const JSR_LICENSE_CACHE_PATH = join(
+  dirname(fromFileUrl(import.meta.url)),
+  "jsr_license_cache.json",
+);
+
+// --- deno info --json shapes (only the fields we read) ---------------------
+
+interface DenoInfoNpmPackage {
+  name: string;
+  version: string;
+  dependencies?: string[];
+  registryUrl?: string;
+  localPath?: string;
+}
+
+interface DenoInfoModuleDep {
+  specifier?: string;
+}
+
+interface DenoInfoModule {
+  specifier?: string;
+  dependencies?: DenoInfoModuleDep[];
+}
+
+interface DenoInfo {
+  npmPackages?: Record<string, DenoInfoNpmPackage>;
+  modules?: DenoInfoModule[];
+  /** Resolution map from a jsr range specifier to a concrete name@version. */
+  packages?: Record<string, string>;
+}
+
+// --- internal component model ----------------------------------------------
+
+interface Component {
+  ecosystem: "npm" | "jsr";
+  name: string;
+  version: string;
+  /** name@version key used to wire dependency edges. */
+  key: string;
+  /** Stable CycloneDX bom-ref. */
+  bomRef: string;
+  /** Package URL (pkg:npm/… or pkg:jsr/…). */
+  purl: string;
+  /** Resolved SPDX expression/id, or NOASSERTION. */
+  license: string;
+  /** Supplier/publisher name (npm author or jsr scope). */
+  supplier: string;
+  /** Dependency keys (name@version) for the dependency graph. */
+  dependsOn: string[];
+}
+
+// --- CycloneDX shapes ------------------------------------------------------
+
+type CdxLicenseChoice =
+  | { license: { id: string } }
+  | { license: { name: string } }
+  | { expression: string };
+
+interface CdxComponent {
+  type: "library";
+  "bom-ref": string;
+  name: string;
+  version: string;
+  purl: string;
+  supplier: { name: string };
+  licenses: CdxLicenseChoice[];
+  externalReferences?: Array<{ type: string; url: string }>;
+}
+
+interface CdxBom {
+  bomFormat: "CycloneDX";
+  specVersion: string;
+  serialNumber: string;
+  version: number;
+  metadata: {
+    timestamp: string;
+    authors: Array<{ name: string }>;
+    tools: { components: Array<{ type: string; name: string }> };
+    component: {
+      type: "application";
+      "bom-ref": string;
+      name: string;
+      version: string;
+      licenses: CdxLicenseChoice[];
+    };
+  };
+  components: CdxComponent[];
+  dependencies: Array<{ ref: string; dependsOn: string[] }>;
+}
+
+// --- license helpers -------------------------------------------------------
+
+/** Map an SPDX string (or null) to CycloneDX license choices. */
+export function licenseToCdx(spdx: string | null): CdxLicenseChoice[] {
+  if (!spdx || spdx === NOASSERTION) {
+    return [{ license: { name: NOASSERTION } }];
+  }
+  // Compound SPDX expressions (AND/OR/WITH or parenthesised) use `expression`;
+  // a bare identifier uses `license.id`.
+  if (/\s|\(/.test(spdx)) {
+    return [{ expression: spdx }];
+  }
+  return [{ license: { id: spdx } }];
+}
+
+/**
+ * Normalize the many shapes of an npm `license`/`licenses` field to a single
+ * SPDX string. Returns null when no license is declared.
+ */
+export function normalizeNpmLicense(
+  pkg: { license?: unknown; licenses?: unknown },
+): string | null {
+  const { license, licenses } = pkg;
+  if (typeof license === "string" && license.trim() !== "") {
+    return license.trim();
+  }
+  // Deprecated object form: { type: "MIT", url: "..." }.
+  if (
+    license && typeof license === "object" &&
+    typeof (license as { type?: unknown }).type === "string"
+  ) {
+    return (license as { type: string }).type;
+  }
+  // Deprecated array form: [{ type: "MIT" }, { type: "Apache-2.0" }].
+  if (Array.isArray(licenses)) {
+    const types = licenses
+      .map((
+        l,
+      ) => (l && typeof l === "object"
+        ? (l as { type?: string }).type
+        : undefined)
+      )
+      .filter((t): t is string => typeof t === "string" && t.trim() !== "");
+    if (types.length === 1) return types[0];
+    if (types.length > 1) return `(${types.join(" OR ")})`;
+  }
+  return null;
+}
+
+// --- fetch helper ----------------------------------------------------------
+
+async function fetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${url} → ${res.status}`);
+  }
+  return await res.json();
+}
+
+// --- JSR license cache -----------------------------------------------------
+
+export class JsrLicenseCache {
+  #entries: Record<string, string>;
+  #dirty = false;
+
+  private constructor(entries: Record<string, string>) {
+    this.#entries = entries;
+  }
+
+  static async load(path: string): Promise<JsrLicenseCache> {
+    try {
+      const text = await Deno.readTextFile(path);
+      return new JsrLicenseCache(JSON.parse(text) as Record<string, string>);
+    } catch {
+      return new JsrLicenseCache({});
+    }
+  }
+
+  get(key: string): string | undefined {
+    return this.#entries[key];
+  }
+
+  set(key: string, license: string): void {
+    if (this.#entries[key] !== license) {
+      this.#entries[key] = license;
+      this.#dirty = true;
+    }
+  }
+
+  async save(path: string): Promise<void> {
+    if (!this.#dirty) return;
+    const sorted = Object.fromEntries(
+      Object.entries(this.#entries).sort(([a], [b]) => a.localeCompare(b)),
+    );
+    await Deno.writeTextFile(path, JSON.stringify(sorted, null, 2) + "\n");
+    this.#dirty = false;
+  }
+}
+
+/**
+ * Resolve a JSR package's license, consulting the cache first. `@std/*`
+ * packages with no declared license resolve to MIT (the Deno std license).
+ */
+export async function resolveJsrLicense(
+  scope: string,
+  name: string,
+  version: string,
+  cache: JsrLicenseCache,
+  offline: boolean,
+): Promise<string> {
+  const key = `@${scope}/${name}@${version}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  let license: string | null = null;
+  if (!offline) {
+    try {
+      const meta = await fetchJson(
+        `${JSR_API}/scopes/${scope}/packages/${name}/versions/${version}`,
+      ) as { license?: string | null };
+      license = meta.license ?? null;
+    } catch (err) {
+      console.error(`  warning: JSR lookup failed for ${key}: ${errMsg(err)}`);
+    }
+  }
+  // The Deno standard library is uniformly MIT even when an older published
+  // version didn't declare a license field.
+  if (!license && scope === "std") license = "MIT";
+
+  const resolved = license ?? NOASSERTION;
+  if (resolved !== NOASSERTION) cache.set(key, resolved);
+  return resolved;
+}
+
+/** Extract a supplier name from an npm `author` field (string or object). */
+export function parseNpmAuthor(author: unknown): string | null {
+  if (typeof author === "string") {
+    // "Name <email> (url)" → "Name"
+    const name = author.split(/[<(]/)[0].trim();
+    return name || null;
+  }
+  if (
+    author && typeof author === "object" &&
+    typeof (author as { name?: unknown }).name === "string"
+  ) {
+    const name = (author as { name: string }).name.trim();
+    return name || null;
+  }
+  return null;
+}
+
+/** Supplier fallback when no author is declared: the scope, else "npm". */
+function npmSupplierFallback(name: string): string {
+  return name.startsWith("@") ? name.slice(0, name.indexOf("/")) : "npm";
+}
+
+interface NpmResolution {
+  license: string;
+  supplier: string;
+}
+
+async function resolveNpm(
+  pkg: DenoInfoNpmPackage,
+  offline: boolean,
+): Promise<NpmResolution> {
+  let license: string | null = null;
+  let supplier: string | null = null;
+
+  // Prefer the offline cached package.json.
+  if (pkg.localPath) {
+    try {
+      const text = await Deno.readTextFile(join(pkg.localPath, "package.json"));
+      const json = JSON.parse(text) as {
+        license?: unknown;
+        licenses?: unknown;
+        author?: unknown;
+      };
+      license = normalizeNpmLicense(json);
+      supplier = parseNpmAuthor(json.author);
+    } catch {
+      // fall through to registry
+    }
+  }
+  if ((!license || !supplier) && !offline) {
+    try {
+      const registry = pkg.registryUrl ?? NPM_REGISTRY;
+      const meta = await fetchJson(
+        `${registry.replace(/\/$/, "")}/${pkg.name}/${pkg.version}`,
+      ) as { author?: unknown };
+      license ??= normalizeNpmLicense(meta as Record<string, unknown>);
+      supplier ??= parseNpmAuthor(meta.author);
+    } catch (err) {
+      console.error(
+        `  warning: npm lookup failed for ${pkg.name}@${pkg.version}: ${
+          errMsg(err)
+        }`,
+      );
+    }
+  }
+  return {
+    license: license ?? NOASSERTION,
+    supplier: supplier ?? npmSupplierFallback(pkg.name),
+  };
+}
+
+// --- component extraction --------------------------------------------------
+
+/** percent-encode the leading @ of a scoped npm name for a purl. */
+function npmPurl(name: string, version: string): string {
+  const encoded = name.startsWith("@") ? `%40${name.slice(1)}` : name;
+  return `pkg:npm/${encoded}@${version}`;
+}
+
+export function extractNpmComponents(info: DenoInfo): Component[] {
+  const components: Component[] = [];
+  for (const pkg of Object.values(info.npmPackages ?? {})) {
+    const key = `${pkg.name}@${pkg.version}`;
+    components.push({
+      ecosystem: "npm",
+      name: pkg.name,
+      version: pkg.version,
+      key,
+      bomRef: npmPurl(pkg.name, pkg.version),
+      purl: npmPurl(pkg.name, pkg.version),
+      license: NOASSERTION,
+      // Supplier is resolved later from the package's author field.
+      supplier: "",
+      dependsOn: pkg.dependencies ?? [],
+    });
+  }
+  return components;
+}
+
+const JSR_SPECIFIER = /^https:\/\/jsr\.io\/(@[^/]+\/[^/]+)\/([^/]+)\//;
+
+export function extractJsrComponents(info: DenoInfo): Component[] {
+  const resolve = info.packages ?? {};
+  const seen = new Map<string, Component>();
+  // First pass: discover every jsr package from its module specifiers.
+  for (const mod of info.modules ?? []) {
+    const match = mod.specifier?.match(JSR_SPECIFIER);
+    if (!match) continue;
+    const [, nameWithScope, version] = match;
+    const key = `${nameWithScope}@${version}`;
+    if (seen.has(key)) continue;
+    seen.set(key, {
+      ecosystem: "jsr",
+      name: nameWithScope,
+      version,
+      key,
+      bomRef: `jsr:${key}`,
+      // pkg:jsr is the de-facto purl type for jsr.io packages.
+      purl: `pkg:jsr/${nameWithScope}@${version}`,
+      license: NOASSERTION,
+      // The jsr scope (e.g. "@std") is the package's publisher/supplier.
+      supplier: nameWithScope.slice(0, nameWithScope.indexOf("/")),
+      dependsOn: [],
+    });
+  }
+  // Second pass: jsr→jsr edges. Module deps appear as `jsr:@scope/name@range`
+  // and resolve to a concrete version via the `packages` map.
+  const edges = new Map<string, Set<string>>();
+  for (const mod of info.modules ?? []) {
+    const match = mod.specifier?.match(JSR_SPECIFIER);
+    if (!match) continue;
+    const srcKey = `${match[1]}@${match[2]}`;
+    for (const dep of mod.dependencies ?? []) {
+      const spec = dep.specifier ?? "";
+      if (!spec.startsWith("jsr:")) continue;
+      const target = resolve[spec.slice(4)];
+      if (!target || target === srcKey || !seen.has(target)) continue;
+      let targets = edges.get(srcKey);
+      if (!targets) {
+        targets = new Set();
+        edges.set(srcKey, targets);
+      }
+      targets.add(target);
+    }
+  }
+  for (const [key, component] of seen) {
+    const targets = edges.get(key);
+    if (targets) component.dependsOn = [...targets];
+  }
+  return [...seen.values()];
+}
+
+// --- SBOM assembly ---------------------------------------------------------
+
+interface RootMeta {
+  name: string;
+  version: string;
+  license: string;
+}
+
+export function buildSbom(
+  root: RootMeta,
+  components: Component[],
+  timestamp: string,
+  serialNumber: string,
+): CdxBom {
+  const sorted = [...components].sort((a, b) =>
+    `${a.ecosystem}:${a.key}`.localeCompare(`${b.ecosystem}:${b.key}`)
+  );
+  const refByKey = new Map(sorted.map((c) => [c.key, c.bomRef]));
+  const rootRef = `${root.name}@${root.version}`;
+
+  const cdxComponents: CdxComponent[] = sorted.map((c) => {
+    const component: CdxComponent = {
+      type: "library",
+      "bom-ref": c.bomRef,
+      name: c.name,
+      version: c.version,
+      purl: c.purl,
+      supplier: { name: c.supplier },
+      licenses: licenseToCdx(c.license),
+    };
+    if (c.ecosystem === "jsr") {
+      component.externalReferences = [{
+        type: "distribution",
+        url: `https://jsr.io/${c.name}@${c.version}`,
+      }];
+    }
+    return component;
+  });
+
+  // Emit a relationship entry for every component (leaves get an empty
+  // `dependsOn`, which asserts "analyzed, no dependencies") so the graph
+  // covers the full component set.
+  const dependencies = sorted.map((c) => ({
+    ref: c.bomRef,
+    dependsOn: c.dependsOn
+      .map((k) => refByKey.get(k))
+      .filter((ref): ref is string => ref !== undefined),
+  }));
+
+  return {
+    bomFormat: "CycloneDX",
+    specVersion: CYCLONEDX_SPEC_VERSION,
+    serialNumber,
+    version: 1,
+    metadata: {
+      timestamp,
+      authors: [{ name: SBOM_AUTHOR }],
+      tools: {
+        components: [{ type: "application", name: "swamp-sbom-generator" }],
+      },
+      component: {
+        type: "application",
+        "bom-ref": rootRef,
+        name: root.name,
+        version: root.version,
+        licenses: licenseToCdx(root.license),
+      },
+    },
+    components: cdxComponents,
+    dependencies,
+  };
+}
+
+// --- driver ----------------------------------------------------------------
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function readRootMeta(): Promise<RootMeta> {
+  const text = await Deno.readTextFile("deno.json");
+  const json = JSON.parse(text) as {
+    name?: string;
+    version?: string;
+    license?: string;
+  };
+  return {
+    name: json.name ?? "swamp",
+    version: json.version ?? "0.0.0",
+    license: json.license ?? NOASSERTION,
+  };
+}
+
+async function runDenoInfo(): Promise<DenoInfo> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json", "main.ts"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await command.output();
+  if (code !== 0) {
+    throw new Error(`deno info failed: ${new TextDecoder().decode(stderr)}`);
+  }
+  return JSON.parse(new TextDecoder().decode(stdout)) as DenoInfo;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(Deno.args, {
+    string: ["output"],
+    boolean: ["offline"],
+    default: { output: "sbom.cdx.json", offline: false },
+  });
+  const offline = args.offline;
+
+  const [root, info] = await Promise.all([readRootMeta(), runDenoInfo()]);
+
+  const components = [
+    ...extractNpmComponents(info),
+    ...extractJsrComponents(info),
+  ];
+  console.error(
+    `Resolving licenses for ${components.length} components ` +
+      `(${components.filter((c) => c.ecosystem === "npm").length} npm, ` +
+      `${components.filter((c) => c.ecosystem === "jsr").length} jsr)…`,
+  );
+
+  const cache = await JsrLicenseCache.load(JSR_LICENSE_CACHE_PATH);
+  for (const component of components) {
+    if (component.ecosystem === "npm") {
+      const pkg = info.npmPackages?.[component.key] ??
+        Object.values(info.npmPackages ?? {}).find(
+          (p) => `${p.name}@${p.version}` === component.key,
+        );
+      if (pkg) {
+        const { license, supplier } = await resolveNpm(pkg, offline);
+        component.license = license;
+        component.supplier = supplier;
+      } else {
+        component.supplier = npmSupplierFallback(component.name);
+      }
+    } else {
+      const at = component.name.indexOf("/");
+      const scope = component.name.slice(1, at); // strip leading @
+      const name = component.name.slice(at + 1);
+      component.license = await resolveJsrLicense(
+        scope,
+        name,
+        component.version,
+        cache,
+        offline,
+      );
+    }
+  }
+  await cache.save(JSR_LICENSE_CACHE_PATH);
+
+  const timestamp = new Date().toISOString();
+  const serialNumber = `urn:uuid:${crypto.randomUUID()}`;
+  const bom = buildSbom(root, components, timestamp, serialNumber);
+  const json = JSON.stringify(bom, null, 2) + "\n";
+
+  if (args.output === "-") {
+    console.log(json.trimEnd());
+  } else {
+    await Deno.writeTextFile(args.output, json);
+    console.error(`Wrote ${components.length} components to ${args.output}`);
+  }
+
+  const unlicensed = components.filter((c) => c.license === NOASSERTION);
+  if (unlicensed.length > 0) {
+    console.error(
+      `\n${unlicensed.length} component(s) with no resolvable license:`,
+    );
+    for (const c of unlicensed) {
+      console.error(`  ${c.ecosystem}: ${c.key}`);
+    }
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/generate_sbom_test.ts
+++ b/scripts/generate_sbom_test.ts
@@ -1,0 +1,239 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  buildSbom,
+  extractJsrComponents,
+  extractNpmComponents,
+  JsrLicenseCache,
+  licenseToCdx,
+  normalizeNpmLicense,
+  parseNpmAuthor,
+} from "./generate_sbom.ts";
+
+Deno.test("licenseToCdx: bare identifier becomes license.id", () => {
+  assertEquals(licenseToCdx("MIT"), [{ license: { id: "MIT" } }]);
+});
+
+Deno.test("licenseToCdx: compound expression becomes expression", () => {
+  assertEquals(licenseToCdx("(MIT OR CC0-1.0)"), [
+    { expression: "(MIT OR CC0-1.0)" },
+  ]);
+  assertEquals(licenseToCdx("Apache-2.0 WITH LLVM-exception"), [
+    { expression: "Apache-2.0 WITH LLVM-exception" },
+  ]);
+});
+
+Deno.test("licenseToCdx: null and NOASSERTION become license.name", () => {
+  assertEquals(licenseToCdx(null), [{ license: { name: "NOASSERTION" } }]);
+  assertEquals(licenseToCdx("NOASSERTION"), [
+    { license: { name: "NOASSERTION" } },
+  ]);
+});
+
+Deno.test("normalizeNpmLicense: handles string, object, and array shapes", () => {
+  assertEquals(normalizeNpmLicense({ license: "MIT" }), "MIT");
+  assertEquals(normalizeNpmLicense({ license: { type: "ISC" } }), "ISC");
+  assertEquals(
+    normalizeNpmLicense({
+      licenses: [{ type: "MIT" }, { type: "Apache-2.0" }],
+    }),
+    "(MIT OR Apache-2.0)",
+  );
+  assertEquals(normalizeNpmLicense({}), null);
+  assertEquals(normalizeNpmLicense({ license: "   " }), null);
+});
+
+Deno.test("parseNpmAuthor: extracts name from string and object forms", () => {
+  assertEquals(
+    parseNpmAuthor("Colin McDonnell <zod@colinhacks.com>"),
+    "Colin McDonnell",
+  );
+  assertEquals(parseNpmAuthor("Hexagon (github.com/hexagon)"), "Hexagon");
+  assertEquals(
+    parseNpmAuthor({ name: "Christopher Jeffrey" }),
+    "Christopher Jeffrey",
+  );
+  assertEquals(parseNpmAuthor({ email: "x@y.z" }), null);
+  assertEquals(parseNpmAuthor(undefined), null);
+});
+
+Deno.test("extractNpmComponents: builds purl and dependency keys", () => {
+  const components = extractNpmComponents({
+    npmPackages: {
+      "zod@4.4.3": { name: "zod", version: "4.4.3", dependencies: [] },
+      "@scope/pkg@1.0.0": {
+        name: "@scope/pkg",
+        version: "1.0.0",
+        dependencies: ["zod@4.4.3"],
+      },
+    },
+  });
+  const zod = components.find((c) => c.name === "zod");
+  const scoped = components.find((c) => c.name === "@scope/pkg");
+  assertEquals(zod?.purl, "pkg:npm/zod@4.4.3");
+  assertEquals(scoped?.purl, "pkg:npm/%40scope/pkg@1.0.0");
+  assertEquals(scoped?.dependsOn, ["zod@4.4.3"]);
+});
+
+Deno.test("extractJsrComponents: dedupes packages and sets purl + supplier", () => {
+  const components = extractJsrComponents({
+    modules: [
+      { specifier: "https://jsr.io/@cliffy/command/1.0.1/mod.ts" },
+      { specifier: "https://jsr.io/@cliffy/command/1.0.1/types.ts" },
+      { specifier: "https://jsr.io/@std/path/1.1.4/mod.ts" },
+      { specifier: "file:///home/x/main.ts" },
+      { specifier: "https://registry.npmjs.org/zod" },
+    ],
+  });
+  assertEquals(components.length, 2);
+  const command = components.find((c) => c.name === "@cliffy/command");
+  assertEquals(command?.version, "1.0.1");
+  assertEquals(command?.bomRef, "jsr:@cliffy/command@1.0.1");
+  assertEquals(command?.purl, "pkg:jsr/@cliffy/command@1.0.1");
+  assertEquals(command?.supplier, "@cliffy");
+});
+
+Deno.test("extractJsrComponents: resolves jsr->jsr edges via packages map", () => {
+  const components = extractJsrComponents({
+    modules: [
+      {
+        specifier: "https://jsr.io/@logtape/pretty/2.0.7/mod.ts",
+        dependencies: [{ specifier: "jsr:@logtape/logtape@^2.0.7" }],
+      },
+      { specifier: "https://jsr.io/@logtape/logtape/2.0.7/mod.ts" },
+    ],
+    packages: { "@logtape/logtape@^2.0.7": "@logtape/logtape@2.0.7" },
+  });
+  const pretty = components.find((c) => c.name === "@logtape/pretty");
+  assertEquals(pretty?.dependsOn, ["@logtape/logtape@2.0.7"]);
+});
+
+Deno.test("buildSbom: assembles a deterministic CycloneDX 1.6 document", () => {
+  const bom = buildSbom(
+    { name: "@swamp/cli", version: "0.1.0", license: "AGPL-3.0-only" },
+    [
+      {
+        ecosystem: "npm",
+        name: "zod",
+        version: "4.4.3",
+        key: "zod@4.4.3",
+        bomRef: "pkg:npm/zod@4.4.3",
+        purl: "pkg:npm/zod@4.4.3",
+        license: "MIT",
+        supplier: "Colin McDonnell",
+        dependsOn: [],
+      },
+      {
+        ecosystem: "jsr",
+        name: "@cliffy/command",
+        version: "1.0.1",
+        key: "@cliffy/command@1.0.1",
+        bomRef: "jsr:@cliffy/command@1.0.1",
+        purl: "pkg:jsr/@cliffy/command@1.0.1",
+        license: "MIT",
+        supplier: "@cliffy",
+        dependsOn: [],
+      },
+    ],
+    "2026-06-23T00:00:00.000Z",
+    "urn:uuid:00000000-0000-0000-0000-000000000000",
+  );
+
+  assertEquals(bom.bomFormat, "CycloneDX");
+  assertEquals(bom.specVersion, "1.6");
+  assertEquals(bom.metadata.authors, [{ name: "Elder Swamp Club, Inc." }]);
+  assertEquals(bom.metadata.component.name, "@swamp/cli");
+  assertEquals(bom.metadata.component.licenses, [{
+    license: { id: "AGPL-3.0-only" },
+  }]);
+  assertEquals(bom.components.length, 2);
+  // jsr sorts before npm
+  assertEquals(bom.components[0].name, "@cliffy/command");
+  assertEquals(bom.components[0].purl, "pkg:jsr/@cliffy/command@1.0.1");
+  assertEquals(bom.components[0].supplier, { name: "@cliffy" });
+  assertEquals(
+    bom.components[0].externalReferences?.[0].url,
+    "https://jsr.io/@cliffy/command@1.0.1",
+  );
+  assertEquals(bom.components[1].purl, "pkg:npm/zod@4.4.3");
+  assertEquals(bom.components[1].supplier, { name: "Colin McDonnell" });
+  // every component has a relationship entry (211/211-style coverage)
+  assertEquals(bom.dependencies.length, 2);
+});
+
+Deno.test("buildSbom: every component gets a relationship entry; bad refs dropped", () => {
+  const bom = buildSbom(
+    { name: "root", version: "1.0.0", license: "MIT" },
+    [
+      {
+        ecosystem: "npm",
+        name: "a",
+        version: "1.0.0",
+        key: "a@1.0.0",
+        bomRef: "pkg:npm/a@1.0.0",
+        purl: "pkg:npm/a@1.0.0",
+        license: "MIT",
+        supplier: "npm",
+        dependsOn: ["b@1.0.0", "missing@9.9.9"],
+      },
+      {
+        ecosystem: "npm",
+        name: "b",
+        version: "1.0.0",
+        key: "b@1.0.0",
+        bomRef: "pkg:npm/b@1.0.0",
+        purl: "pkg:npm/b@1.0.0",
+        license: "MIT",
+        supplier: "npm",
+        dependsOn: [],
+      },
+    ],
+    "2026-06-23T00:00:00.000Z",
+    "urn:uuid:00000000-0000-0000-0000-000000000000",
+  );
+  // Both components present; unresolvable "missing@9.9.9" edge is dropped,
+  // leaf "b" keeps an explicit empty dependsOn.
+  assertEquals(bom.dependencies, [
+    { ref: "pkg:npm/a@1.0.0", dependsOn: ["pkg:npm/b@1.0.0"] },
+    { ref: "pkg:npm/b@1.0.0", dependsOn: [] },
+  ]);
+});
+
+Deno.test("JsrLicenseCache: round-trips and only writes when dirty", async () => {
+  const dir = await Deno.makeTempDir();
+  const path = join(dir, "cache.json");
+  try {
+    const cache = await JsrLicenseCache.load(path);
+    assertEquals(cache.get("@std/path@1.1.4"), undefined);
+    cache.set("@std/path@1.1.4", "MIT");
+    await cache.save(path);
+
+    const reloaded = await JsrLicenseCache.load(path);
+    assertEquals(reloaded.get("@std/path@1.1.4"), "MIT");
+
+    // Missing file load yields an empty cache rather than throwing.
+    const empty = await JsrLicenseCache.load(join(dir, "absent.json"));
+    assertEquals(empty.get("anything"), undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/scripts/jsr_license_cache.json
+++ b/scripts/jsr_license_cache.json
@@ -1,0 +1,17 @@
+{
+  "@cliffy/command@1.0.1": "MIT",
+  "@cliffy/flags@1.0.1": "MIT",
+  "@cliffy/internal@1.0.1": "MIT",
+  "@cliffy/table@1.0.1": "MIT",
+  "@logtape/logtape@2.0.7": "MIT",
+  "@logtape/pretty@2.0.7": "MIT",
+  "@std/assert@1.0.19": "MIT",
+  "@std/fmt@1.0.10": "MIT",
+  "@std/fs@1.0.23": "MIT",
+  "@std/internal@1.0.13": "MIT",
+  "@std/path@1.1.4": "MIT",
+  "@std/streams@1.1.0": "MIT",
+  "@std/tar@0.1.10": "MIT",
+  "@std/text@1.0.18": "MIT",
+  "@std/yaml@1.1.0": "MIT"
+}


### PR DESCRIPTION
## Summary

Adds `deno run sbom`, a CycloneDX 1.6 SBOM generator covering every npm **and**
JSR dependency resolved for the CLI, with an SPDX license per component — the
input for license-compliance scanning (FOSSA, Trivy, etc.).

No off-the-shelf SCA tool understands Deno's combined npm + JSR dependency
graph, so the generator (`scripts/generate_sbom.ts`) reads `deno info --json`
and resolves licenses itself:

- **npm** — from each package's cached `package.json` (offline), falling back to
  the npm registry.
- **JSR** — from the per-version JSR API, cached to
  `scripts/jsr_license_cache.json` (committed) so CI and offline runs are
  deterministic. `@std/*` packages with no declared license resolve to MIT.

The SBOM populates the fields downstream tools require for every component:
supplier, PURL (`pkg:npm` / `pkg:jsr`), relationship/dependency data, and a BOM
author. Verified end-to-end against FOSSA's SBOM ingestion (`fossa sbom analyze`
/ `fossa sbom test`) — all required-field checks pass at 211/211.

Docs live in `design/license-compliance.md`, referenced from the README
Developer Guide.

## Changes

- `scripts/generate_sbom.ts` — the generator (`deno run sbom`, with `--output`
  and `--offline` flags)
- `scripts/generate_sbom_test.ts` — 11 unit tests
- `scripts/jsr_license_cache.json` — committed JSR license cache
- `deno.json` — new `sbom` task
- `design/license-compliance.md` + `README.md` — documentation
- `.gitignore` — ignore the generated `sbom.cdx.json` artifact

## Test Plan

- `deno run sbom` produces a valid CycloneDX 1.6 `sbom.cdx.json` (211 components,
  every one licensed)
- 11/11 unit tests pass; `deno fmt --check` and `deno lint` clean
- `fossa sbom analyze` / `fossa sbom test` accept the SBOM with all required
  fields satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)