### PR TITLE
feat(cli): accept positional name on history/output parent commands (swamp-club#780)

### DIFF
--- a/src/cli/commands/model_method_history.ts
+++ b/src/cli/commands/model_method_history.ts
@@ -18,8 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { groupCommandAction } from "../group_action.ts";
-import { modelMethodHistoryGetCommand } from "./model_method_history_get.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+import {
+  modelMethodHistoryGetAction,
+  modelMethodHistoryGetCommand,
+} from "./model_method_history_get.ts";
 import {
   modelMethodHistorySearchAction,
   modelMethodHistorySearchCommand,
@@ -29,7 +32,17 @@ import { modelMethodHistoryLogsCommand } from "./model_method_history_logs.ts";
 export const modelMethodHistoryCommand = new Command()
   .name("history")
   .description("Model method run history commands")
-  .action(groupCommandAction)
+  .error(unknownCommandErrorHandler)
+  .example(
+    "Show latest run (shorthand)",
+    "swamp model method history my-server",
+  )
+  .arguments("<output_id_or_model_name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(modelMethodHistoryGetAction)
   .command("get", modelMethodHistoryGetCommand)
   .command("search", modelMethodHistorySearchCommand)
   .command("logs", modelMethodHistoryLogsCommand)

--- a/src/cli/commands/model_method_history_get.ts
+++ b/src/cli/commands/model_method_history_get.ts
@@ -35,6 +35,37 @@ import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+export async function modelMethodHistoryGetAction(
+  options: AnyOptions,
+  outputIdOrModelName: string,
+): Promise<void> {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "model",
+    "method",
+    "history",
+    "get",
+  ]);
+  cliCtx.logger.debug`Getting method run: ${outputIdOrModelName}`;
+
+  const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+    {
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    },
+  );
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createModelOutputGetDeps(repoDir, datastoreResolver);
+
+  const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
+  await consumeStream(
+    modelOutputGet(ctx, deps, outputIdOrModelName),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Model method history get command completed");
+}
+
 export const modelMethodHistoryGetCommand = new Command()
   .name("get")
   .description("Show details of a model method run")
@@ -48,30 +79,4 @@ export const modelMethodHistoryGetCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async function (options: AnyOptions, outputIdOrModelName: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "model",
-      "method",
-      "history",
-      "get",
-    ]);
-    cliCtx.logger.debug`Getting method run: ${outputIdOrModelName}`;
-
-    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
-      {
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      },
-    );
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createModelOutputGetDeps(repoDir, datastoreResolver);
-
-    const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
-    await consumeStream(
-      modelOutputGet(ctx, deps, outputIdOrModelName),
-      renderer.handlers(),
-    );
-
-    cliCtx.logger.debug("Model method history get command completed");
-  });
+  .action(modelMethodHistoryGetAction);

--- a/src/cli/commands/model_output.ts
+++ b/src/cli/commands/model_output.ts
@@ -18,8 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { groupCommandAction } from "../group_action.ts";
-import { modelOutputGetCommand } from "./model_output_get.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+import {
+  modelOutputGetAction,
+  modelOutputGetCommand,
+} from "./model_output_get.ts";
 import {
   modelOutputSearchAction,
   modelOutputSearchCommand,
@@ -30,7 +33,14 @@ import { modelOutputDataCommand } from "./model_output_data.ts";
 export const modelOutputCommand = new Command()
   .name("output")
   .description("Manage model outputs")
-  .action(groupCommandAction)
+  .error(unknownCommandErrorHandler)
+  .example("Show latest output (shorthand)", "swamp model output my-server")
+  .arguments("<output_id_or_model_name:string>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(modelOutputGetAction)
   .command("get", modelOutputGetCommand)
   .command("search", modelOutputSearchCommand)
   .command("logs", modelOutputLogsCommand)

--- a/src/cli/commands/model_output_get.ts
+++ b/src/cli/commands/model_output_get.ts
@@ -35,6 +35,36 @@ import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+export async function modelOutputGetAction(
+  options: AnyOptions,
+  outputIdOrModelName: string,
+): Promise<void> {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "model",
+    "output",
+    "get",
+  ]);
+  cliCtx.logger.debug`Getting output: ${outputIdOrModelName}`;
+
+  const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
+    {
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    },
+  );
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createModelOutputGetDeps(repoDir, datastoreResolver);
+
+  const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
+  await consumeStream(
+    modelOutputGet(ctx, deps, outputIdOrModelName),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Model output get command completed");
+}
+
 export const modelOutputGetCommand = new Command()
   .name("get")
   .description("Show details of a model output")
@@ -45,29 +75,4 @@ export const modelOutputGetCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .action(async function (options: AnyOptions, outputIdOrModelName: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "model",
-      "output",
-      "get",
-    ]);
-    cliCtx.logger.debug`Getting output: ${outputIdOrModelName}`;
-
-    const { repoDir, datastoreResolver } = await requireInitializedRepoReadOnly(
-      {
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      },
-    );
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createModelOutputGetDeps(repoDir, datastoreResolver);
-
-    const renderer = createModelOutputGetRenderer(cliCtx.outputMode);
-    await consumeStream(
-      modelOutputGet(ctx, deps, outputIdOrModelName),
-      renderer.handlers(),
-    );
-
-    cliCtx.logger.debug("Model output get command completed");
-  });
+  .action(modelOutputGetAction);

--- a/src/cli/commands/workflow_history.ts
+++ b/src/cli/commands/workflow_history.ts
@@ -18,8 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { groupCommandAction } from "../group_action.ts";
-import { workflowHistoryGetCommand } from "./workflow_history_get.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
+import {
+  workflowHistoryGetAction,
+  workflowHistoryGetCommand,
+} from "./workflow_history_get.ts";
 import {
   workflowHistorySearchAction,
   workflowHistorySearchCommand,
@@ -29,7 +32,18 @@ import { workflowHistoryLogsCommand } from "./workflow_history_logs.ts";
 export const workflowHistoryCommand = new Command()
   .name("history")
   .description("Workflow run history commands")
-  .action(groupCommandAction)
+  .error(unknownCommandErrorHandler)
+  .example(
+    "Show latest run (shorthand)",
+    "swamp workflow history deploy-pipeline",
+  )
+  .arguments("<workflow_id_or_name:workflow_name>")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
+  .action(workflowHistoryGetAction)
   .command("get", workflowHistoryGetCommand)
   .command("search", workflowHistorySearchCommand)
   .command("logs", workflowHistoryLogsCommand)

--- a/src/cli/commands/workflow_history_get.ts
+++ b/src/cli/commands/workflow_history_get.ts
@@ -35,6 +35,41 @@ import { requireInitializedRepoReadOnly } from "../repo_context.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+export async function workflowHistoryGetAction(
+  options: AnyOptions,
+  workflowIdOrName: string,
+): Promise<void> {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "history",
+    "get",
+  ]);
+  cliCtx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
+
+  const { repoDir, repoContext, datastoreResolver } =
+    await requireInitializedRepoReadOnly(
+      {
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      },
+    );
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createWorkflowHistoryGetDeps(
+    repoDir,
+    datastoreResolver,
+    repoContext.workflowRepo,
+  );
+
+  const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
+  await consumeStream(
+    workflowHistoryGet(ctx, deps, workflowIdOrName),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Workflow history get command completed");
+}
+
 export const workflowHistoryGetCommand = new Command()
   .name("get")
   .description("Show the latest run for a workflow")
@@ -45,34 +80,4 @@ export const workflowHistoryGetCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  .action(async function (options: AnyOptions, workflowIdOrName: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "workflow",
-      "history",
-      "get",
-    ]);
-    cliCtx.logger.debug`Getting latest run for workflow: ${workflowIdOrName}`;
-
-    const { repoDir, repoContext, datastoreResolver } =
-      await requireInitializedRepoReadOnly(
-        {
-          repoDir: resolveRepoDir(options.repoDir),
-          outputMode: cliCtx.outputMode,
-        },
-      );
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowHistoryGetDeps(
-      repoDir,
-      datastoreResolver,
-      repoContext.workflowRepo,
-    );
-
-    const renderer = createWorkflowHistoryGetRenderer(cliCtx.outputMode);
-    await consumeStream(
-      workflowHistoryGet(ctx, deps, workflowIdOrName),
-      renderer.handlers(),
-    );
-
-    cliCtx.logger.debug("Workflow history get command completed");
-  });
+  .action(workflowHistoryGetAction);

--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -129,6 +129,26 @@ function buildContextSuggestions(
     suggestions.push(
       `swamp vault list-keys ${unknownName}`,
     );
+  } else if (parentName === "history") {
+    suggestions.push(
+      `swamp ... history get ${unknownName}`,
+    );
+    suggestions.push(
+      `swamp ... history logs ${unknownName}`,
+    );
+    suggestions.push(
+      `swamp ... history search`,
+    );
+  } else if (parentName === "output") {
+    suggestions.push(
+      `swamp model output get ${unknownName}`,
+    );
+    suggestions.push(
+      `swamp model output search`,
+    );
+    suggestions.push(
+      `swamp model output logs ${unknownName}`,
+    );
   } else if (parentName === "extension") {
     suggestions.push(
       `swamp extension push ${unknownName}`,

--- a/src/cli/unknown_command_handler_test.ts
+++ b/src/cli/unknown_command_handler_test.ts
@@ -151,3 +151,19 @@ Deno.test("buildUnknownCommandMessage - repo typo suggests upgrade", () => {
   const msg = buildUnknownCommandMessage("update", cmd);
   assertStringIncludes(msg, 'Did you mean "upgrade"');
 });
+
+Deno.test("buildUnknownCommandMessage - history context suggestions", () => {
+  const cmd = buildCommand("history", ["get", "search", "logs"]);
+  const msg = buildUnknownCommandMessage("deploy-pipeline", cmd);
+  assertStringIncludes(msg, "history get deploy-pipeline");
+  assertStringIncludes(msg, "history logs deploy-pipeline");
+  assertStringIncludes(msg, "history search");
+});
+
+Deno.test("buildUnknownCommandMessage - output context suggestions", () => {
+  const cmd = buildCommand("output", ["get", "search", "logs", "data"]);
+  const msg = buildUnknownCommandMessage("my-server", cmd);
+  assertStringIncludes(msg, "swamp model output get my-server");
+  assertStringIncludes(msg, "swamp model output search");
+  assertStringIncludes(msg, "swamp model output logs my-server");
+});


### PR DESCRIPTION
## Summary

- `swamp workflow history <name>` now works as shorthand for `swamp workflow history get <name>`, following the existing `workflow run` pattern where a parent command accepts both a positional arg and subcommands
- Same shorthand added for `swamp model method history <name>` and `swamp model output <name>`
- Added context-aware error suggestions for the `history` and `output` command groups via `unknownCommandErrorHandler`

Closes swamp-club#780

## Test Plan

- Compiled binary and verified all three shorthand commands route to the correct get action
- Verified existing subcommands (`search`, `logs`, `get`) still route correctly
- Verified `--help` shows the new usage and example
- All 7756 tests pass (including 2 new tests for error handler context suggestions)
- `deno check`, `deno lint`, `deno fmt` all pass