### PR TITLE
fix(data): wire markDirty hook into GC so S3 datastores propagate deletes

### DIFF
--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -79,12 +79,16 @@ export const dataGcCommand = new Command()
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     };
-    const { repoDir, datastoreResolver } = options.dryRun
+    const { repoDir, repoContext, datastoreResolver } = options.dryRun
       ? await requireInitializedRepoReadOnly(repoOpts)
       : await requireInitializedRepo(repoOpts);
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDataGcDeps(repoDir, datastoreResolver);
+    const deps = createDataGcDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.markDirty,
+    );
 
     // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
     if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1345,10 +1345,6 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     let versionsRemoved = 0;
     let bytesReclaimed = 0;
 
-    // Dry-run does not touch the cache; live runs remove version directories
-    // and rewrite the latest marker, both of which are cache writes.
-    if (!dryRun) await this.notifyDirty();
-
     const allData = await this.findAllForModel(type, modelId);
 
     for (const data of allData) {
@@ -1406,6 +1402,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
               // Ignore stat errors
             }
             if (!dryRun) {
+              await this.notifyDirty(versionDir);
               try {
                 await Deno.remove(versionDir, { recursive: true });
               } catch (error) {
@@ -1463,6 +1460,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
           }
         } else {
           const dataNameDir = this.getDataNameDir(type, modelId, data.name);
+          await this.notifyDirty(dataNameDir);
           await Deno.remove(dataNameDir, { recursive: true }).catch(() => {});
           this.catalogRemove(type, modelId, data.name);
         }

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -627,7 +627,8 @@ Deno.test("findAllForModelSync returns empty for missing model", () => {
 // allocateVersion) pass the data-name directory because the version directory
 // doesn't exist yet; finalizeVersion passes the version directory; delete
 // passes the version dir or data-name dir based on whether a version was
-// supplied; rename and collectGarbage pass undefined (bulk).
+// supplied; rename passes undefined (bulk); collectGarbage passes each version
+// directory being removed (per-path, so the sync service can detect deletions).
 //
 // Regression coverage for the datastore fast-path contract violation that
 // silently lost writes when the sidecar stayed clean.
@@ -746,13 +747,12 @@ Deno.test("mutations call markDirty before writing", async () => {
       repo.getDataNameDir(testType, "model-1", "mark-dirty-ren"),
     );
 
-    // collectGarbage (live) → bulk (undefined)
+    // collectGarbage (live) with nothing to GC → no markDirty calls
     await repo.collectGarbage(testType, "model-1");
-    assertEquals(calls.length, afterRename + 3);
     assertEquals(
-      calls[afterRename + 2],
-      undefined,
-      "collectGarbage must use bulk relPath",
+      calls.length,
+      afterRename + 2,
+      "collectGarbage with no excess versions must not call markDirty",
     );
 
     // collectGarbage (dry-run) must not notify — it does not touch the cache
@@ -763,6 +763,61 @@ Deno.test("mutations call markDirty before writing", async () => {
     if (Deno.build.os === "windows") {
       // Best-effort: EBUSY can fire when V8 hasn't GC'd native
       // sqlite handles yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("collectGarbage: emits per-path markDirty for each removed version", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const calls: Array<string | undefined> = [];
+    const markDirty = (relPath?: string) => {
+      calls.push(relPath);
+      return Promise.resolve();
+    };
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      markDirty,
+    );
+
+    const gc1 = Data.create({
+      name: "gc-dirty",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 1,
+      streaming: false,
+      tags: { type: "resource" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+
+    // Save 3 versions (gc threshold is 1, so 2 will be removed)
+    for (let i = 0; i < 3; i++) {
+      await repo.save(
+        testType,
+        "gc-model",
+        gc1,
+        new TextEncoder().encode(`v${i}`),
+      );
+    }
+    calls.length = 0;
+
+    const result = await repo.collectGarbage(testType, "gc-model");
+    assertEquals(result.versionsRemoved, 2);
+
+    // Each removed version directory should have its own markDirty call
+    assertEquals(calls.length, 2);
+    const v1Dir = repo.getPath(testType, "gc-model", "gc-dirty", 1);
+    const v2Dir = repo.getPath(testType, "gc-model", "gc-dirty", 2);
+    assertEquals(calls[0], v1Dir);
+    assertEquals(calls[1], v2Dir);
+  } finally {
+    if (Deno.build.os === "windows") {
       await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
     } else {
       await Deno.remove(tmpDir, { recursive: true });

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -31,6 +31,7 @@ import {
   namespaceFromResolver,
 } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
@@ -101,6 +102,7 @@ export interface DataGcDeps {
 export function createDataGcDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  markDirty?: MarkDirtyHook,
 ): DataGcDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -109,7 +111,7 @@ export function createDataGcDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,
-    undefined,
+    markDirty,
     undefined,
     namespaceFromResolver(datastoreResolver),
   );


### PR DESCRIPTION
## Summary

Fixes swamp-club#788.

- **Wire `markDirty` into `createDataGcDeps`** — the GC construction site was the only write-path that omitted the sync hook, so `notifyDirty` was a no-op and `pushChanged` fast-pathed past the deletions with "no changes"
- **Change `collectGarbage` from bulk to per-path `notifyDirty`** — each version directory being removed gets its own dirty signal (matching the `delete` method's pattern), so the sync service can apply the absence-on-disk = delete rule from the `markDirty` contract
- **Signal data-name directory removal** when all versions of a data item are GC'd

This is the core half of the fix. The extension half (`@swamp/s3-datastore` deletion handling in `pushChanged`) will ship separately — without it, the core correctly signals but the extension doesn't yet act on absent dirty paths.

For filesystem datastores, this fix is immediately effective: the per-path `notifyDirty` calls ensure the local filesystem deletions are visible to any sync service that implements rule #2 of the `markDirty` contract.

## Test Plan

- Updated contract test (`mutations call markDirty before writing`) to expect 0 calls when nothing to GC (was 1 bulk call)
- Added new test (`collectGarbage: emits per-path markDirty for each removed version`) verifying per-path signals with GC threshold=1 and 3 versions → 2 removed, 2 dirty calls with correct version directory paths
- Full test suite passes (7742 passed, 0 failed)
- End-to-end verified against MinIO: before fix, GC reports "push complete, no changes" with S3 objects unchanged; after fix (with extension change), GC deletes 60 objects from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)