### PR TITLE
fix(cli): replace misleading 'submit' in issue group description (swamp-club#796)

### DIFF
--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -30,7 +30,7 @@ import { issueSecurityCommand } from "./issue_security.ts";
 export const issueCommand = new Command()
   .name("issue")
   .description(
-    "Search, fetch, submit, and comment on swamp-club Lab issues",
+    "Search, fetch, report, and comment on swamp-club Lab issues",
   )
   .action(groupCommandAction)
   .command("search", issueSearchCommand)


### PR DESCRIPTION
## Summary

- The `swamp issue` group description said "Search, fetch, **submit**, and
  comment" but there is no `submit` subcommand — submission is done via `bug`,
  `feature`, and `security`. This leads agents (and humans) to try
  `swamp issue submit` and get an unhelpful error.
- Replaces "submit" with "report" which accurately describes what those
  subcommands do without implying a nonexistent subcommand name.

Closes swamp-club/lab#796

## Test Plan

- Verified `swamp issue --help` now shows "Search, fetch, report, and comment
  on swamp-club Lab issues"
- `deno check`, `deno lint`, `deno fmt --check` all pass
- Full test suite (7756 tests) passes