### PR TITLE
fix(extensions): enforce local > pulled origin precedence in catalog (swamp-club#793)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -693,6 +693,26 @@ claims the entire `extensions/` tree — per-subdirectory manifests are
 ignored. Per-subdirectory discovery only activates when no top-level
 manifest is present.
 
+### Origin Precedence Enforcement
+
+When both a local source and a pulled extension provide the same
+`(kind, type)`, the local source wins. The pulled row's `type_normalized`
+is cleared to empty in the catalog so it no longer occupies the type
+namespace — the same treatment as `ValidationFailed` or
+`EntryPointUnreadable` states. The pulled files remain on disk for
+reference (diffing, version comparison) but are not registered as active
+types.
+
+This applies to the push/pull development loop: when editing a local
+extension source that is also pulled from the registry, `extension pull`
+succeeds and the local source's types take precedence. The in-memory
+registry has always respected this ordering (`load()` processes local
+directories first and deduplicates via `hasType()`); the catalog now
+matches.
+
+To re-activate pulled types after removing a local source, run
+`swamp doctor extensions` or any command that triggers a catalog rescan.
+
 ## Split Extensions Directory (`--extensions-dir`)
 
 By default, swamp discovers local extension sources from `extensions/<kind>/`

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -193,8 +193,14 @@ export const doctorExtensionsCommand = new Command()
         });
         const result = await reconciler.execute();
         reconcileTransitions = result.transitions;
-      } catch {
-        // Best-effort — the loader will bootstrap a fresh catalog if this fails.
+      } catch (reconcileError) {
+        // Best-effort — the loader will bootstrap a fresh catalog if
+        // most failures. DuplicateTypeError from same-origin conflicts
+        // should still surface so the user sees it.
+        const { DuplicateTypeError } = await import(
+          "../../infrastructure/persistence/duplicate_type_error.ts"
+        );
+        if (reconcileError instanceof DuplicateTypeError) throw reconcileError;
       }
 
       const registries: ReadonlyArray<DoctorRegistryDeps> = [

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -194,13 +194,26 @@ export const doctorExtensionsCommand = new Command()
         const result = await reconciler.execute();
         reconcileTransitions = result.transitions;
       } catch (reconcileError) {
-        // Best-effort — the loader will bootstrap a fresh catalog if
+        // Best-effort — the loader will bootstrap a fresh catalog for
         // most failures. DuplicateTypeError from same-origin conflicts
         // should still surface so the user sees it.
         const { DuplicateTypeError } = await import(
           "../../infrastructure/persistence/duplicate_type_error.ts"
         );
-        if (reconcileError instanceof DuplicateTypeError) throw reconcileError;
+        if (reconcileError instanceof DuplicateTypeError) {
+          const { UserError } = await import("../../domain/errors.ts");
+          const e = reconcileError;
+          throw new UserError(
+            `Type "${e.typeNormalized}" (kind=${e.kind}) is claimed by two ` +
+              `installed extensions:\n` +
+              `  • ${e.firstSource.extensionName}@${e.firstSource.extensionVersion}` +
+              `  at ${e.firstSource.canonicalPath}\n` +
+              `  • ${e.secondSource.extensionName}@${e.secondSource.extensionVersion}` +
+              `  at ${e.secondSource.canonicalPath}\n` +
+              `Remove one with \`swamp extension rm <name>\` to resolve ` +
+              `the conflict, then run \`swamp doctor extensions\` again.`,
+          );
+        }
       }
 
       const registries: ReadonlyArray<DoctorRegistryDeps> = [

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -379,6 +379,10 @@ export class ExtensionLoader {
         }
       }
 
+      if (this.repoDir) {
+        catalog.resolveOriginConflicts(this.repoDir);
+      }
+
       if (this.adapter.attachPendingExtensionsForType) {
         for (const type of typesNeedingExtensionAttach) {
           await this.adapter.attachPendingExtensionsForType(
@@ -475,6 +479,9 @@ export class ExtensionLoader {
       dir,
       options?.additionalDirs,
     );
+    if (this.repoDir) {
+      catalog.resolveOriginConflicts(this.repoDir);
+    }
     catalog.markPopulated(this.adapter.kind);
     catalog.setLayoutVersion(BUNDLE_LAYOUT_VERSION);
     catalog.setDatastoreBasePath(currentBasePath, this.adapter.kind);

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1106,6 +1106,72 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Enforces the `local > source-mounted > pulled` origin precedence
+   * rule at the catalog level. Scans all non-Tombstoned rows with
+   * non-empty type_normalized and kind !== "extension". When two rows
+   * from different origins claim the same (kind, type_normalized),
+   * clears the pulled row's type_normalized to empty so it no longer
+   * occupies the type namespace. Precedence is determined by
+   * source_path prefix: paths under `<repoRoot>/.swamp/pulled-extensions/`
+   * are pulled; everything else is local or source-mounted and wins.
+   *
+   * Mirrors {@link ExtensionRepository}'s `assertIRepo1` exclusions
+   * exactly — same Tombstoned skip, same empty-type skip, same
+   * extension-kind skip — but resolves instead of throwing.
+   *
+   * Idempotent: running twice produces the same result.
+   */
+  resolveOriginConflicts(canonicalRepoRoot: string): void {
+    const pulledPrefix = canonicalRepoRoot.endsWith("/")
+      ? `${canonicalRepoRoot}.swamp/pulled-extensions/`
+      : `${canonicalRepoRoot}/.swamp/pulled-extensions/`;
+
+    const rows = this.findAll();
+
+    let hasPulled = false;
+    for (const row of rows) {
+      if (row.source_path.startsWith(pulledPrefix)) {
+        hasPulled = true;
+        break;
+      }
+    }
+    if (!hasPulled) return;
+
+    const occupants = new Map<
+      string,
+      { sourcePath: string; isPulled: boolean }
+    >();
+
+    for (const row of rows) {
+      if ((row.state ?? "Indexed") === "Tombstoned") continue;
+      if (row.type_normalized.length === 0) continue;
+      if (row.kind === "extension") continue;
+
+      const key = `${row.kind}::${row.type_normalized}`;
+      const isPulled = row.source_path.startsWith(pulledPrefix);
+      const prior = occupants.get(key);
+
+      if (prior) {
+        if (prior.isPulled && !isPulled) {
+          this.clearTypeNormalized(prior.sourcePath);
+          occupants.set(key, { sourcePath: row.source_path, isPulled });
+        } else if (!prior.isPulled && isPulled) {
+          this.clearTypeNormalized(row.source_path);
+        }
+      } else {
+        occupants.set(key, { sourcePath: row.source_path, isPulled });
+      }
+    }
+  }
+
+  private clearTypeNormalized(sourcePath: string): void {
+    const stmt = this.db.prepare(
+      "UPDATE bundle_types SET type_normalized = '' WHERE source_path = ?",
+    );
+    stmt.run(sourcePath);
+  }
+
+  /**
    * Returns every row in `bundle_types`, ordered by source_path so the
    * output is stable across runs. Used by ExtensionRepository.loadAll
    * (which groups by extension identity) and by I-Repo-1 verification

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1121,16 +1121,17 @@ export class ExtensionCatalogStore {
    *
    * Idempotent: running twice produces the same result.
    */
-  resolveOriginConflicts(canonicalRepoRoot: string): void {
-    const pulledPrefix = canonicalRepoRoot.endsWith("/")
-      ? `${canonicalRepoRoot}.swamp/pulled-extensions/`
-      : `${canonicalRepoRoot}/.swamp/pulled-extensions/`;
+  resolveOriginConflicts(repoRoot: string): void {
+    const canonical = canonicalizePath(repoRoot);
+    const pulledPrefix = canonical.endsWith("/")
+      ? `${canonical}.swamp/pulled-extensions/`
+      : `${canonical}/.swamp/pulled-extensions/`;
 
     const rows = this.findAll();
 
     let hasPulled = false;
     for (const row of rows) {
-      if (row.source_path.startsWith(pulledPrefix)) {
+      if (canonicalizePath(row.source_path).startsWith(pulledPrefix)) {
         hasPulled = true;
         break;
       }
@@ -1148,7 +1149,9 @@ export class ExtensionCatalogStore {
       if (row.kind === "extension") continue;
 
       const key = `${row.kind}::${row.type_normalized}`;
-      const isPulled = row.source_path.startsWith(pulledPrefix);
+      const isPulled = canonicalizePath(row.source_path).startsWith(
+        pulledPrefix,
+      );
       const prior = occupants.get(key);
 
       if (prior) {

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -1881,3 +1881,217 @@ Deno.test("pruneUnreachableSources: preserves all rows under the repo root", () 
 
   store.close();
 });
+
+// ── resolveOriginConflicts ──────────────────────────────────────────
+
+Deno.test("resolveOriginConflicts: no-op when no pulled rows exist", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(
+    makeRow({
+      source_path: canonicalizePath(join(repoRoot, "extensions/models/a.ts")),
+      type_normalized: "@ns/a",
+    }),
+  );
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const rows = store.findAll();
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].type_normalized, "@ns/a");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: clears pulled type when local claims same type", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const localPath = canonicalizePath(
+    join(repoRoot, "extensions/models/foo.ts"),
+  );
+  const pulledPath = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/foo/models/foo.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: localPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+  store.upsert(makeRow({
+    source_path: pulledPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const local = store.findBySourcePath(localPath);
+  const pulled = store.findBySourcePath(pulledPath);
+  assertEquals(local?.type_normalized, "@ns/foo");
+  assertEquals(pulled?.type_normalized, "");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: same-origin conflict is untouched", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const pulled1 = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/a/models/x.ts"),
+  );
+  const pulled2 = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/b/models/x.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: pulled1,
+    type_normalized: "@ns/conflict",
+    kind: "model",
+  }));
+  store.upsert(makeRow({
+    source_path: pulled2,
+    type_normalized: "@ns/conflict",
+    kind: "model",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const r1 = store.findBySourcePath(pulled1);
+  const r2 = store.findBySourcePath(pulled2);
+  assertEquals(r1?.type_normalized, "@ns/conflict");
+  assertEquals(r2?.type_normalized, "@ns/conflict");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: skips extension-kind rows", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const localPath = canonicalizePath(
+    join(repoRoot, "extensions/models/ext.ts"),
+  );
+  const pulledPath = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/ext/models/ext.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: localPath,
+    type_normalized: "@ns/target",
+    kind: "extension",
+  }));
+  store.upsert(makeRow({
+    source_path: pulledPath,
+    type_normalized: "@ns/target",
+    kind: "extension",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const local = store.findBySourcePath(localPath);
+  const pulled = store.findBySourcePath(pulledPath);
+  assertEquals(local?.type_normalized, "@ns/target");
+  assertEquals(pulled?.type_normalized, "@ns/target");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: skips Tombstoned rows", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const localPath = canonicalizePath(
+    join(repoRoot, "extensions/models/foo.ts"),
+  );
+  const pulledPath = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/foo/models/foo.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: localPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+    state: "Tombstoned",
+  }));
+  store.upsert(makeRow({
+    source_path: pulledPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const pulled = store.findBySourcePath(pulledPath);
+  assertEquals(pulled?.type_normalized, "@ns/foo");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: idempotent", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const localPath = canonicalizePath(
+    join(repoRoot, "extensions/models/foo.ts"),
+  );
+  const pulledPath = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/foo/models/foo.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: localPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+  store.upsert(makeRow({
+    source_path: pulledPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+  store.resolveOriginConflicts(repoRoot);
+
+  const local = store.findBySourcePath(localPath);
+  const pulled = store.findBySourcePath(pulledPath);
+  assertEquals(local?.type_normalized, "@ns/foo");
+  assertEquals(pulled?.type_normalized, "");
+  store.close();
+});
+
+Deno.test("resolveOriginConflicts: different kinds do not conflict", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = dirname(dirname(dbPath));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const localPath = canonicalizePath(
+    join(repoRoot, "extensions/models/foo.ts"),
+  );
+  const pulledPath = canonicalizePath(
+    join(repoRoot, ".swamp/pulled-extensions/@ns/foo/reports/foo.ts"),
+  );
+
+  store.upsert(makeRow({
+    source_path: localPath,
+    type_normalized: "@ns/foo",
+    kind: "model",
+  }));
+  store.upsert(makeRow({
+    source_path: pulledPath,
+    type_normalized: "@ns/foo",
+    kind: "report",
+  }));
+
+  store.resolveOriginConflicts(repoRoot);
+
+  const local = store.findBySourcePath(localPath);
+  const pulled = store.findBySourcePath(pulledPath);
+  assertEquals(local?.type_normalized, "@ns/foo");
+  assertEquals(pulled?.type_normalized, "@ns/foo");
+  store.close();
+});

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -228,6 +228,7 @@ export class ExtensionRepository {
         logger
           .info`Pruned ${pruned.length} catalog row(s) with unreachable source path(s)`;
       }
+      this.catalog.resolveOriginConflicts(this.repoRoot);
       this.assertIRepo1();
     });
   }


### PR DESCRIPTION
## Summary

- Add `resolveOriginConflicts()` to `ExtensionCatalogStore` — clears `type_normalized` on pulled catalog rows when a local/source-mounted source claims the same `(kind, type)`. Mirrors `assertIRepo1`'s exclusions exactly (Tombstoned, empty type, extension kind) but resolves instead of throwing.
- Call it from three sites covering all catalog write paths: inside `saveAll` (before `assertIRepo1`), after the loader's full-rebuild `populateCatalogFromRegistry`, and after the loader's incremental stale-file processing.
- Narrow doctor's bare `catch {}` around the reconciler to re-throw `DuplicateTypeError` for genuine same-origin conflicts.
- Document origin precedence enforcement in `design/extension.md`.

Fixes swamp-club#793.

## Test Plan

- 7 new unit tests for `resolveOriginConflicts`: no-op when no pulled rows, local-vs-pulled resolution, same-origin untouched, extension-kind skipped, Tombstoned skipped, idempotent, different-kinds don't conflict
- Full test suite: 7763 passed, 0 failed
- Verified against scratch reproduction at `/tmp/swamp-repro-issue-793/`: `extension pull` succeeds where it previously crashed with `DuplicateTypeError`; local type takes precedence; recovery path (remove local → doctor --repair → doctor) fully restores pulled type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>