### PR TITLE
fix(datastore): surface namespace hint on lock contention (swamp-club#666)

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1184,7 +1184,21 @@ export async function acquireModelLocks(
           datastoreGlobalLockOptions(config),
         );
         try {
+          const lockStart = Date.now();
           await pushLock.acquire();
+          const lockMs = Date.now() - lockStart;
+          if (
+            lockMs > 5_000 && isCustomDatastoreConfig(config) &&
+            !config.namespace
+          ) {
+            logger.warn(
+              "Lock acquisition took {ms}ms — multiple repos sharing this " +
+                "datastore without namespaces serialize all writes behind a " +
+                "single global lock. Run 'swamp datastore namespace set " +
+                "<name>' to scope each repo to its own lock and index",
+              { ms: lockMs },
+            );
+          }
           logger.info`Pushing changes to datastore...`;
 
           const pushNs = isCustomDatastoreConfig(config)
@@ -1329,7 +1343,18 @@ export async function acquireVaultSync(
         datastoreGlobalLockOptions(config),
       );
       try {
+        const lockStart = Date.now();
         await pushLock.acquire();
+        const lockMs = Date.now() - lockStart;
+        if (lockMs > 5_000 && !config.namespace) {
+          logger.warn(
+            "Lock acquisition took {ms}ms — multiple repos sharing this " +
+              "datastore without namespaces serialize all writes behind a " +
+              "single global lock. Run 'swamp datastore namespace set " +
+              "<name>' to scope each repo to its own lock and index",
+            { ms: lockMs },
+          );
+        }
         logger.info`Pushing vault changes to datastore...`;
 
         const pushNs = config.namespace;

--- a/src/domain/datastore/distributed_lock.ts
+++ b/src/domain/datastore/distributed_lock.ts
@@ -25,6 +25,8 @@
  * mechanics (S3 conditional writes, file locks, blob leases, etc.).
  */
 
+import { UserError } from "../errors.ts";
+
 /** Procfile-style metadata stored in the lock. */
 export interface LockInfo {
   /** Who holds the lock, e.g. "user@hostname". */
@@ -88,8 +90,26 @@ export interface DistributedLock {
   forceRelease(expectedNonce: string): Promise<boolean>;
 }
 
-/** Thrown when a lock cannot be acquired within the configured timeout. */
-export class LockTimeoutError extends Error {
+/**
+ * Returns true when the lock key identifies the global (non-namespaced)
+ * datastore lock. Covers both the bare key (`".datastore.lock"` from
+ * S3/GCS locks) and the full filesystem path (`"/…/.datastore.lock"`
+ * from FileLock). Namespaced keys live under `.locks/` and won't match.
+ */
+function isGlobalDatastoreLock(lockKey: string): boolean {
+  return (lockKey === ".datastore.lock" ||
+    lockKey.endsWith("/.datastore.lock")) &&
+    !lockKey.includes("/.locks/");
+}
+
+/**
+ * Thrown when a lock cannot be acquired within the configured timeout.
+ *
+ * Extends `UserError` so the message renders clean (no stack trace) at
+ * the CLI error boundary — the message is already hand-crafted to be
+ * actionable, and a stack would bury the remedies.
+ */
+export class LockTimeoutError extends UserError {
   override readonly name = "LockTimeoutError";
 
   constructor(
@@ -97,10 +117,22 @@ export class LockTimeoutError extends Error {
     public readonly holder: LockInfo | null,
     public readonly waitedMs: number,
   ) {
-    const msg = holder
+    const base = holder
       ? `Lock "${lockKey}" held by ${holder.holder} (pid ${holder.pid}) — ` +
         `timed out after ${waitedMs}ms`
       : `Lock "${lockKey}" — timed out after ${waitedMs}ms`;
-    super(msg);
+
+    const hint = isGlobalDatastoreLock(lockKey)
+      ? `\n\nMultiple repos sharing this datastore serialize all writes ` +
+        `behind a single global lock. To scope each repo to its own lock ` +
+        `and index, run:\n` +
+        `  swamp datastore namespace set <name>\n` +
+        `  swamp datastore namespace migrate --confirm`
+      : "";
+
+    super(base + hint, "lock_timeout");
+    this.lockKey = lockKey;
+    this.holder = holder;
+    this.waitedMs = waitedMs;
   }
 }

--- a/src/domain/datastore/distributed_lock_test.ts
+++ b/src/domain/datastore/distributed_lock_test.ts
@@ -18,9 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { UserError } from "../errors.ts";
 import { LockTimeoutError } from "./distributed_lock.ts";
 
-Deno.test("LockTimeoutError - includes holder info when available", () => {
+Deno.test("LockTimeoutError: includes holder info when available", () => {
   const error = new LockTimeoutError(
     ".datastore.lock",
     {
@@ -42,7 +43,7 @@ Deno.test("LockTimeoutError - includes holder info when available", () => {
   assertEquals(error.holder?.pid, 12345);
 });
 
-Deno.test("LockTimeoutError - works without holder info", () => {
+Deno.test("LockTimeoutError: works without holder info", () => {
   const error = new LockTimeoutError(
     ".datastore.lock",
     null,
@@ -55,8 +56,38 @@ Deno.test("LockTimeoutError - works without holder info", () => {
   assertEquals(error.holder, null);
 });
 
-Deno.test("LockTimeoutError - is an instance of Error", () => {
+Deno.test("LockTimeoutError: is an instance of Error and UserError", () => {
   const error = new LockTimeoutError("key", null, 1000);
   assertEquals(error instanceof Error, true);
+  assertEquals(error instanceof UserError, true);
   assertEquals(error instanceof LockTimeoutError, true);
+});
+
+Deno.test("LockTimeoutError: global lock key includes namespace hint", () => {
+  const error = new LockTimeoutError(".datastore.lock", null, 5000);
+  assertStringIncludes(error.message, "swamp datastore namespace set");
+  assertStringIncludes(error.message, "swamp datastore namespace migrate");
+});
+
+Deno.test("LockTimeoutError: filesystem global lock path includes namespace hint", () => {
+  const error = new LockTimeoutError(
+    "/home/user/.swamp/.datastore.lock",
+    null,
+    5000,
+  );
+  assertStringIncludes(error.message, "swamp datastore namespace set");
+});
+
+Deno.test("LockTimeoutError: namespaced lock key omits namespace hint", () => {
+  const error = new LockTimeoutError(".locks/infra.lock", null, 5000);
+  assertEquals(error.message.includes("namespace set"), false);
+});
+
+Deno.test("LockTimeoutError: filesystem namespaced lock path omits namespace hint", () => {
+  const error = new LockTimeoutError(
+    "/home/user/.swamp/.locks/infra.lock",
+    null,
+    5000,
+  );
+  assertEquals(error.message.includes("namespace set"), false);
 });

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -282,7 +282,18 @@ export async function registerDatastoreSyncNamed(
       attributes: { "lock.key": key, "lock.label": label },
     });
     try {
+      const lockStart = Date.now();
       await lock.acquire();
+      const lockMs = Date.now() - lockStart;
+      if (lockMs > 5_000 && !namespace) {
+        logger.warn(
+          "Lock acquisition took {ms}ms — multiple repos sharing this " +
+            "datastore without namespaces serialize all writes behind a " +
+            "single global lock. Run 'swamp datastore namespace set " +
+            "<name>' to scope each repo to its own lock and index",
+          { ms: lockMs },
+        );
+      }
       lockAcquired = true;
       lockSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {


### PR DESCRIPTION
## Summary

- **LockTimeoutError** now extends `UserError` for clean CLI rendering (no stack trace) and includes an actionable namespace hint when the global lock (`.datastore.lock`) times out — suggests `swamp datastore namespace set <name>` + `migrate`
- **Slow-lock contention warning** (>5s threshold) added in three paths: `acquireVaultSync` push lock, `acquireModelLocks` flush push lock, and coordinator `registerDatastoreSyncNamed` — warns when lock acquisition is slow and no namespace is configured
- Both S3 and GCS extensions already implement `namespacedSync` — the issue is purely UX: users sharing a bucket don't know to configure namespaces

Verified via MinIO integration test: placed a stale lock with 8s TTL, ran vault put from a second repo sharing the same bucket — the warning fired at 7.3s with the namespace suggestion.

Closes swamp-club#666

## Test Plan

- [x] 7 unit tests for `LockTimeoutError` covering: holder info, no holder, `UserError` inheritance, global lock namespace hint, filesystem global lock hint, namespaced lock omits hint, filesystem namespaced lock omits hint
- [x] All 7761 existing tests pass
- [x] `deno fmt --check`, `deno lint` clean
- [x] Manual MinIO reproduction: slow-lock warning fires correctly at >5s acquisition time

🤖 Generated with [Claude Code](https://claude.com/claude-code)