### PR TITLE
fix(serve): emit schedule_failed when scheduled workflow errors (swamp-club#693)

### DIFF
--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -810,12 +810,14 @@ Deno.test("collectGarbage: emits per-path markDirty for each removed version", a
     const result = await repo.collectGarbage(testType, "gc-model");
     assertEquals(result.versionsRemoved, 2);
 
-    // Each removed version directory should have its own markDirty call
+    // Each removed version directory should have its own markDirty call.
+    // GC runs removals in parallel so call order is non-deterministic.
     assertEquals(calls.length, 2);
     const v1Dir = repo.getPath(testType, "gc-model", "gc-dirty", 1);
     const v2Dir = repo.getPath(testType, "gc-model", "gc-dirty", 2);
-    assertEquals(calls[0], v1Dir);
-    assertEquals(calls[1], v2Dir);
+    const sorted = [...calls].sort();
+    const expected = [v1Dir, v2Dir].sort();
+    assertEquals(sorted, expected);
   } finally {
     if (Deno.build.os === "windows") {
       await Deno.remove(tmpDir, { recursive: true }).catch(() => {});

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -291,6 +291,7 @@ export class ScheduledExecutionService {
     try {
       let runId = "";
       let completedRun: WorkflowRunView | undefined;
+      let streamError: string | undefined;
 
       await this.deps.executeWorkflow(
         { workflowIdOrName: workflowName },
@@ -302,22 +303,13 @@ export class ScheduledExecutionService {
           if (event.kind === "completed") {
             completedRun = event.run;
           }
+          if (event.kind === "error") {
+            streamError = event.error.message;
+          }
         },
       );
 
-      if (completedRun?.status === "failed") {
-        const message = extractFirstStepError(completedRun);
-        this.emit({
-          kind: "schedule_failed",
-          workflowId,
-          workflowName,
-          error: message,
-        });
-        logger.error(
-          "Scheduled run failed for workflow {name}: {error}",
-          { name: workflowName, error: message },
-        );
-      } else {
+      if (completedRun?.status === "succeeded") {
         this.emit({
           kind: "schedule_completed",
           workflowId,
@@ -327,6 +319,20 @@ export class ScheduledExecutionService {
         logger.info(
           "Scheduled run completed for workflow {name} (run: {runId})",
           { name: workflowName, runId },
+        );
+      } else {
+        const message = completedRun
+          ? extractFirstStepError(completedRun)
+          : streamError ?? "workflow did not complete";
+        this.emit({
+          kind: "schedule_failed",
+          workflowId,
+          workflowName,
+          error: message,
+        });
+        logger.error(
+          "Scheduled run failed for workflow {name}: {error}",
+          { name: workflowName, error: message },
         );
       }
     } catch (error) {

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -177,6 +177,83 @@ Deno.test("ScheduledExecutionService: emits schedule_failed when workflow run ha
   assertEquals(completed.length, 0);
 });
 
+Deno.test("ScheduledExecutionService: emits schedule_failed when workflow yields error event without completed", async () => {
+  const wf = createTestWorkflow("error-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: (
+      _input,
+      _signal,
+      onEvent: (event: WorkflowRunEvent) => void,
+    ) => {
+      onEvent({
+        kind: "started",
+        runId: "run-1",
+        workflowName: "error-wf",
+        jobs: [],
+      });
+      onEvent({
+        kind: "error",
+        error: {
+          code: "workflow_execution_failed",
+          message: "Unknown model type: @acme/missing",
+        },
+      });
+      return Promise.resolve();
+    },
+  });
+
+  await service.start((e) => events.push(e));
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const failed = events.filter((e) => e.kind === "schedule_failed");
+  assertEquals(failed.length >= 1, true);
+  for (const event of failed) {
+    assertEquals(
+      (event as { kind: "schedule_failed"; error: string }).error,
+      "Unknown model type: @acme/missing",
+    );
+  }
+
+  const completed = events.filter((e) => e.kind === "schedule_completed");
+  assertEquals(completed.length, 0);
+});
+
+Deno.test("ScheduledExecutionService: emits schedule_failed when no terminal event is yielded", async () => {
+  const wf = createTestWorkflow("silent-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+  });
+
+  await service.start((e) => events.push(e));
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const failed = events.filter((e) => e.kind === "schedule_failed");
+  assertEquals(failed.length >= 1, true);
+  for (const event of failed) {
+    assertEquals(
+      (event as { kind: "schedule_failed"; error: string }).error,
+      "workflow did not complete",
+    );
+  }
+
+  const completed = events.filter((e) => e.kind === "schedule_completed");
+  assertEquals(completed.length, 0);
+});
+
 Deno.test("ScheduledExecutionService: stop clears schedules", async () => {
   const wf = createTestWorkflow("scheduled-wf", "0 * * * *");
 


### PR DESCRIPTION
## Summary

- Fixes misleading `schedule_completed` log when a scheduled workflow actually fails before producing a `completed` event (e.g. "Unknown model type" errors)
- Inverts the completion check to require explicit `succeeded` status — all other outcomes (explicit failure, error events, missing terminal events) now emit `schedule_failed` with a meaningful error message
- Captures `error` kind events from the workflow run stream so the error message is surfaced in the `schedule_failed` event

Closes swamp-club#693

## Test Plan

- Added unit test: workflow yields `error` event without `completed` → `schedule_failed` with error message
- Added unit test: workflow resolves without any terminal event → `schedule_failed` with fallback message
- Existing test for explicit `failed` status continues to pass
- Verified manually: `swamp serve` with a workflow referencing `@acme/does-not-exist` now logs `ERR Scheduled workflow "bad-model" failed: "Unknown model type: @acme/does-not-exist"` instead of `INF Scheduled workflow "bad-model" completed`
- All 7759 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)