### PR TITLE
fix(lock): configurable timeout and jittered backoff (swamp-club#520)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -792,6 +792,39 @@ Co-locating the lock with the namespaced data would require namespace-scoping
 `data` as the first path segment), so it is deferred to the per-model lock
 namespacing work rather than expanding this phase's scope for a cosmetic issue.
 
+### Lock Timeout and Retry Behavior
+
+The default lock acquisition timeout is **60 seconds** (`DEFAULT_LOCK_TIMEOUT_MS`).
+This is sufficient for most workloads because per-step locking gives each model
+method step a fresh timeout budget.
+
+The timeout can be overridden via the `SWAMP_LOCK_TIMEOUT_MS` environment
+variable. Resolution order (first positive value wins):
+
+1. Per-invocation override (internal; no CLI flag currently exposes this)
+2. `SWAMP_LOCK_TIMEOUT_MS` env var (must parse as a positive integer)
+3. `DEFAULT_LOCK_TIMEOUT_MS` (60,000 ms)
+
+Invalid env values (non-numeric, zero, negative) are silently ignored.
+
+The resolved timeout is threaded into every lock creation site: per-model
+locks (`createModelLock`), global datastore locks (`createDatastoreLock`),
+and inline lock constructions in `requireInitializedRepo` and flush paths.
+Custom datastore providers receive `maxWaitMs` in `LockOptions` — whether
+they honor it depends on their implementation.
+
+**Retry backoff.** `FileLock.acquire` uses jittered exponential backoff:
+starting at `retryIntervalMs` (default 1 second), doubling each attempt,
+capped at 8 seconds, with ±25% random jitter. Each sleep is also clamped to
+the remaining timeout budget so the loop never overshoots `maxWaitMs`.
+
+**Contention logging.** When a lock is acquired after one or more retries,
+an info-level log line reports the retry count and total wait time:
+
+```
+INF datastore·lock Acquired lock "data/.../lock" after 3 retries (4521ms)
+```
+
 ### Lock Lifecycle
 
 The sync coordinator (`datastore_sync_coordinator.ts`) manages the lock

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -70,6 +70,7 @@ import {
   type CustomDatastoreConfig,
   type DatastoreConfig,
   isCustomDatastoreConfig,
+  resolveLockTimeoutMs,
   resolveSyncTimeoutMs,
 } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreProvider } from "../domain/datastore/datastore_provider.ts";
@@ -502,7 +503,10 @@ export function requireInitializedRepo(
       const provider = await resolveCustomProvider(datastoreConfig);
       const lock = provider.createLock(
         datastoreConfig.datastorePath,
-        datastoreGlobalLockOptions(datastoreConfig),
+        {
+          ...datastoreGlobalLockOptions(datastoreConfig),
+          maxWaitMs: resolveLockTimeoutMs(),
+        },
       );
 
       // If the custom provider supports sync, register sync service too
@@ -574,7 +578,10 @@ export function requireInitializedRepo(
       // race our structural work.
       const lock = new FileLock(
         datastoreConfig.path,
-        datastoreGlobalLockOptions(datastoreConfig),
+        {
+          ...datastoreGlobalLockOptions(datastoreConfig),
+          maxWaitMs: resolveLockTimeoutMs(),
+        },
       );
       await registerDatastoreSync({ lock });
 
@@ -814,11 +821,12 @@ export async function createModelLock(
   modelId: string,
 ): Promise<DistributedLock> {
   const lockKey = `data/${modelType}/${modelId}/.lock`;
+  const maxWaitMs = resolveLockTimeoutMs();
   if (isCustomDatastoreConfig(config)) {
     const provider = await resolveCustomProvider(config);
-    return provider.createLock(config.datastorePath, { lockKey });
+    return provider.createLock(config.datastorePath, { lockKey, maxWaitMs });
   }
-  return new FileLock(config.path, { lockKey });
+  return new FileLock(config.path, { lockKey, maxWaitMs });
 }
 
 /**
@@ -1000,7 +1008,10 @@ export async function acquireModelLocks(
   const globalLock = customProvider && isCustomDatastoreConfig(config)
     ? customProvider.createLock(
       config.datastorePath,
-      datastoreGlobalLockOptions(config),
+      {
+        ...datastoreGlobalLockOptions(config),
+        maxWaitMs: resolveLockTimeoutMs(),
+      },
     )
     : await createDatastoreLock(config);
   const globalInfo = await globalLock.inspect();
@@ -1181,7 +1192,10 @@ export async function acquireModelLocks(
       ) {
         const pushLock = customProvider.createLock(
           config.datastorePath,
-          datastoreGlobalLockOptions(config),
+          {
+            ...datastoreGlobalLockOptions(config),
+            maxWaitMs: resolveLockTimeoutMs(),
+          },
         );
         try {
           await pushLock.acquire();
@@ -1326,7 +1340,10 @@ export async function acquireVaultSync(
     ) {
       const pushLock = customProvider.createLock(
         config.datastorePath,
-        datastoreGlobalLockOptions(config),
+        {
+          ...datastoreGlobalLockOptions(config),
+          maxWaitMs: resolveLockTimeoutMs(),
+        },
       );
       try {
         await pushLock.acquire();
@@ -1403,10 +1420,12 @@ export function datastoreGlobalLockOptions(
 export async function createDatastoreLock(
   config: DatastoreConfig,
 ): Promise<DistributedLock> {
+  const maxWaitMs = resolveLockTimeoutMs();
   const options = datastoreGlobalLockOptions(config);
+  const merged = { ...options, maxWaitMs };
   if (isCustomDatastoreConfig(config)) {
     const provider = await resolveCustomProvider(config);
-    return provider.createLock(config.datastorePath, options);
+    return provider.createLock(config.datastorePath, merged);
   }
-  return new FileLock(config.path, options);
+  return new FileLock(config.path, merged);
 }

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -80,6 +80,19 @@ export const DEFAULT_SYNC_TIMEOUT_MS = 300_000;
 export const SYNC_TIMEOUT_ENV_VAR = "SWAMP_DATASTORE_SYNC_TIMEOUT_MS";
 
 /**
+ * Default timeout (milliseconds) for acquiring a distributed lock.
+ *
+ * Per-step locking means each model method step gets a fresh timeout
+ * budget. 60 seconds is sufficient for the vast majority of workloads;
+ * users running extreme concurrency (10+ parallel writers on the same
+ * model) can raise this via `SWAMP_LOCK_TIMEOUT_MS`.
+ */
+export const DEFAULT_LOCK_TIMEOUT_MS = 60_000;
+
+/** Env var that overrides `DEFAULT_LOCK_TIMEOUT_MS` at runtime. */
+export const LOCK_TIMEOUT_ENV_VAR = "SWAMP_LOCK_TIMEOUT_MS";
+
+/**
  * Filesystem-based datastore configuration.
  * Data is stored at a specified filesystem path.
  */
@@ -214,4 +227,25 @@ export function resolveSyncTimeoutMs(
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_SYNC_TIMEOUT_MS;
+}
+
+/**
+ * Resolve the effective lock acquisition timeout.
+ *
+ * Resolution order:
+ *   1. `overrideMs` (per-invocation override)
+ *   2. `SWAMP_LOCK_TIMEOUT_MS` env var (must parse as positive int)
+ *   3. `DEFAULT_LOCK_TIMEOUT_MS` (60 seconds)
+ *
+ * Invalid env values (non-numeric, zero, negative) are ignored with a silent
+ * fallback to the default.
+ */
+export function resolveLockTimeoutMs(overrideMs?: number): number {
+  if (overrideMs != null && overrideMs > 0) return overrideMs;
+  const envValue = Deno.env.get(LOCK_TIMEOUT_ENV_VAR);
+  if (envValue) {
+    const parsed = Number.parseInt(envValue, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_LOCK_TIMEOUT_MS;
 }

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -22,10 +22,13 @@ import {
   ALWAYS_LOCAL_SUBDIRS,
   type CustomDatastoreConfig,
   DEFAULT_DATASTORE_SUBDIRS,
+  DEFAULT_LOCK_TIMEOUT_MS,
   DEFAULT_SYNC_TIMEOUT_MS,
   type FilesystemDatastoreConfig,
   getDatastoreDirectories,
   isAlwaysLocal,
+  LOCK_TIMEOUT_ENV_VAR,
+  resolveLockTimeoutMs,
   resolveSyncTimeoutMs,
   SYNC_TIMEOUT_ENV_VAR,
 } from "./datastore_config.ts";
@@ -105,6 +108,51 @@ Deno.test("resolveSyncTimeoutMs: undefined override preserves existing precedenc
 Deno.test("resolveSyncTimeoutMs: no override, no config, no env returns default", () => {
   withEnv(SYNC_TIMEOUT_ENV_VAR, undefined, () => {
     assertEquals(resolveSyncTimeoutMs(customConfig), DEFAULT_SYNC_TIMEOUT_MS);
+  });
+});
+
+// --- resolveLockTimeoutMs ---
+
+Deno.test("resolveLockTimeoutMs: override wins over env and default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, "120000", () => {
+    assertEquals(resolveLockTimeoutMs(30_000), 30_000);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: env var wins over default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, "180000", () => {
+    assertEquals(resolveLockTimeoutMs(), 180_000);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: no override, no env returns default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(resolveLockTimeoutMs(), DEFAULT_LOCK_TIMEOUT_MS);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: non-positive override falls through", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, undefined, () => {
+    assertEquals(resolveLockTimeoutMs(0), DEFAULT_LOCK_TIMEOUT_MS);
+    assertEquals(resolveLockTimeoutMs(-1), DEFAULT_LOCK_TIMEOUT_MS);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: invalid env var falls through to default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, "not-a-number", () => {
+    assertEquals(resolveLockTimeoutMs(), DEFAULT_LOCK_TIMEOUT_MS);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: zero env var falls through to default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, "0", () => {
+    assertEquals(resolveLockTimeoutMs(), DEFAULT_LOCK_TIMEOUT_MS);
+  });
+});
+
+Deno.test("resolveLockTimeoutMs: negative env var falls through to default", () => {
+  withEnv(LOCK_TIMEOUT_ENV_VAR, "-5000", () => {
+    assertEquals(resolveLockTimeoutMs(), DEFAULT_LOCK_TIMEOUT_MS);
   });
 });
 

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -91,6 +91,8 @@ const DEFAULT_TTL_MS = 30_000;
 const DEFAULT_RETRY_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_WAIT_MS = 60_000;
 const DEFAULT_LOCK_PATH = ".datastore.lock";
+const MAX_BACKOFF_MS = 8_000;
+const JITTER_FACTOR = 0.25;
 
 /** Build a LockInfo for the current process. */
 function buildLockInfo(ttlMs: number, nonce: string): LockInfo {
@@ -142,6 +144,8 @@ export class FileLock implements DistributedLock {
     const nonce = crypto.randomUUID();
     const logger = getSwampLogger(["datastore", "lock"]);
     let contentionLogged = false;
+    let retryCount = 0;
+    let currentBackoff = this.retryIntervalMs;
 
     while (true) {
       // Check timeout on every iteration — including retries after stale lock cleanup
@@ -170,12 +174,22 @@ export class FileLock implements DistributedLock {
         this.nonce = nonce;
         this.held = true;
         this.startHeartbeat();
+
+        if (retryCount > 0) {
+          const waitMs = Date.now() - startTime;
+          logger.info(
+            "Acquired lock {path} after {retries} retries ({waitMs}ms)",
+            { path: this.lockPath, retries: retryCount, waitMs },
+          );
+        }
         return;
       } catch (error) {
         if (!(error instanceof Deno.errors.AlreadyExists)) {
           throw error;
         }
       }
+
+      retryCount++;
 
       // Lock file exists — check if stale.
       // Best-effort: if we accidentally delete a fresh lock, the nonce
@@ -208,8 +222,18 @@ export class FileLock implements DistributedLock {
         }
       }
 
-      // Wait and retry
-      await new Promise((resolve) => setTimeout(resolve, this.retryIntervalMs));
+      // Jittered exponential backoff, clamped to remaining budget
+      const jitter = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
+      const remaining = this.maxWaitMs - (Date.now() - startTime);
+      const sleepMs = Math.min(
+        currentBackoff * jitter,
+        remaining,
+        MAX_BACKOFF_MS,
+      );
+      if (sleepMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, sleepMs));
+      }
+      currentBackoff = Math.min(currentBackoff * 2, MAX_BACKOFF_MS);
     }
   }
 

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { FileLock } from "./file_lock.ts";
 import type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
@@ -321,5 +321,98 @@ Deno.test("FileLock - different namespaces acquire their locks concurrently", as
 
     await infra.release();
     await security.release();
+  });
+});
+
+Deno.test("FileLock - backoff does not exceed maxWaitMs budget", async () => {
+  await withTempDir(async (dir) => {
+    const holder = new FileLock(dir, { ttlMs: 60_000 });
+    await holder.acquire();
+
+    const maxWaitMs = 800;
+    const waiter = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 100,
+      maxWaitMs,
+    });
+
+    const start = Date.now();
+    await assertRejects(() => waiter.acquire(), LockTimeoutError);
+    const elapsed = Date.now() - start;
+
+    // Should not overshoot maxWaitMs by more than one retry interval + jitter
+    assert(
+      elapsed < maxWaitMs + 500,
+      `elapsed ${elapsed}ms should be close to maxWaitMs ${maxWaitMs}ms`,
+    );
+
+    await holder.release();
+  });
+});
+
+Deno.test("FileLock - acquire succeeds after holder releases (contention path)", async () => {
+  await withTempDir(async (dir) => {
+    const holder = new FileLock(dir, { ttlMs: 60_000 });
+    await holder.acquire();
+
+    const waiter = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 50,
+      maxWaitMs: 5000,
+    });
+
+    // Release the holder after a short delay
+    const releaseDelay = setTimeout(async () => {
+      await holder.release();
+    }, 200);
+
+    const start = Date.now();
+    await waiter.acquire();
+    const elapsed = Date.now() - start;
+
+    clearTimeout(releaseDelay);
+    assert(elapsed >= 100, `should have waited for release, took ${elapsed}ms`);
+    assert(
+      elapsed < 3000,
+      `should acquire quickly after release, took ${elapsed}ms`,
+    );
+
+    const info = await waiter.inspect();
+    assertEquals(info!.pid, Deno.pid);
+
+    await waiter.release();
+  });
+});
+
+Deno.test("FileLock - maxWaitMs override is respected", async () => {
+  await withTempDir(async (dir) => {
+    const holder = new FileLock(dir, { ttlMs: 60_000 });
+    await holder.acquire();
+
+    const shortTimeout = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 50,
+      maxWaitMs: 200,
+    });
+    const longTimeout = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 50,
+      maxWaitMs: 800,
+    });
+
+    const start1 = Date.now();
+    await assertRejects(() => shortTimeout.acquire(), LockTimeoutError);
+    const elapsed1 = Date.now() - start1;
+
+    const start2 = Date.now();
+    await assertRejects(() => longTimeout.acquire(), LockTimeoutError);
+    const elapsed2 = Date.now() - start2;
+
+    assert(
+      elapsed2 > elapsed1,
+      `longer timeout (${elapsed2}ms) should wait longer than shorter (${elapsed1}ms)`,
+    );
+
+    await holder.release();
   });
 });


### PR DESCRIPTION
## Summary

Addresses the remaining lock contention gaps after per-step locking landed (June 21-23). The primary contention pattern (workflows holding global locks for minutes) is already fixed; this PR targets the tail:

- **`SWAMP_LOCK_TIMEOUT_MS` env var** — configurable lock acquisition timeout, following the existing `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` pattern. Default remains 60s.
- **Jittered exponential backoff** — replaces fixed 1s polling in `FileLock.acquire` with exponential backoff (base 1s, max 8s, ±25% jitter), clamped to remaining budget. Reduces thundering herd when 10+ processes contend on the same model.
- **Contention metrics logging** — logs retry count and total wait time on successful acquisition after retries, giving operators visibility into lock contention.

The resolved timeout is threaded into all lock creation sites: `createModelLock`, `createDatastoreLock`, and inline constructions in `requireInitializedRepo` and flush paths.

**Out of scope** (future work): FIFO lock queuing, read/write lock patterns. Per-step locking substantially reduces the contention surface for these.

Fixes swamp-club#520

## Test Plan

- 7 new unit tests for `resolveLockTimeoutMs` env var resolution (override > env > default, invalid/zero/negative env values)
- 3 new unit tests for `FileLock` backoff (budget clamping, contention acquisition path, `maxWaitMs` override comparison)
- All 18 existing `FileLock` tests pass
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all clean

## Follow-up

- [ ] File docs issue in swamp-club/swamp-club for `datastore-configuration.md` manual reference (Distributed Locking section needs `SWAMP_LOCK_TIMEOUT_MS`)