### PR TITLE
fix(cli): accept --arg as hidden alias for --input

### DIFF
--- a/src/cli/commands/hidden_aliases_test.ts
+++ b/src/cli/commands/hidden_aliases_test.ts
@@ -107,6 +107,70 @@ Deno.test("vault type list is registered as a hidden subcommand", async () => {
   );
 });
 
+Deno.test("model method run has hidden --arg option", async () => {
+  const { modelMethodRunCommand } = await import("./model_method_run.ts");
+  const allOptions = modelMethodRunCommand.getOptions(true);
+  const argOpt = allOptions.find((o) => o.name === "arg");
+  assertEquals(argOpt !== undefined, true, "--arg should be registered");
+  assertEquals(argOpt!.hidden, true, "--arg should be hidden");
+
+  const visibleOptions = modelMethodRunCommand.getOptions();
+  const visibleArg = visibleOptions.find((o) => o.name === "arg");
+  assertEquals(
+    visibleArg,
+    undefined,
+    "--arg should not appear in visible options",
+  );
+});
+
+Deno.test("workflow run has hidden --arg option", async () => {
+  const { workflowRunCommand } = await import("./workflow_run.ts");
+  const allOptions = workflowRunCommand.getOptions(true);
+  const argOpt = allOptions.find((o) => o.name === "arg");
+  assertEquals(argOpt !== undefined, true, "--arg should be registered");
+  assertEquals(argOpt!.hidden, true, "--arg should be hidden");
+
+  const visibleOptions = workflowRunCommand.getOptions();
+  const visibleArg = visibleOptions.find((o) => o.name === "arg");
+  assertEquals(
+    visibleArg,
+    undefined,
+    "--arg should not appear in visible options",
+  );
+});
+
+Deno.test("workflow evaluate has hidden --arg option", async () => {
+  const { workflowEvaluateCommand } = await import("./workflow_evaluate.ts");
+  const allOptions = workflowEvaluateCommand.getOptions(true);
+  const argOpt = allOptions.find((o) => o.name === "arg");
+  assertEquals(argOpt !== undefined, true, "--arg should be registered");
+  assertEquals(argOpt!.hidden, true, "--arg should be hidden");
+
+  const visibleOptions = workflowEvaluateCommand.getOptions();
+  const visibleArg = visibleOptions.find((o) => o.name === "arg");
+  assertEquals(
+    visibleArg,
+    undefined,
+    "--arg should not appear in visible options",
+  );
+});
+
+Deno.test("workflow resume has hidden --arg option", async () => {
+  const { workflowResumeCommand } = await import("./workflow_resume.ts");
+  const allOptions = workflowResumeCommand.getOptions(true);
+  const argOpt = allOptions.find((o) => o.name === "arg");
+  assertEquals(argOpt !== undefined, true, "--arg should be registered");
+  assertEquals(argOpt!.hidden, true, "--arg should be hidden");
+
+  const visibleOptions = workflowResumeCommand.getOptions();
+  const visibleArg = visibleOptions.find((o) => o.name === "arg");
+  assertEquals(
+    visibleArg,
+    undefined,
+    "--arg should not appear in visible options",
+  );
+});
+
 Deno.test("repo init is registered as a visible subcommand", async () => {
   const { repoCommand } = await import("./repo_init.ts");
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -118,6 +118,10 @@ export const modelMethodRunCommand = new Command()
   .option("--input <value:string>", "Input values (key=value or JSON)", {
     collect: true,
   })
+  .option("--arg <value:string>", "Alias for --input", {
+    collect: true,
+    hidden: true,
+  })
   .option(
     "--input-file <file:string>",
     "Input values from YAML file (cannot combine with --stdin)",
@@ -229,9 +233,14 @@ export const modelMethodRunCommand = new Command()
         stdinItems = parseStdinContent(stdinContent);
       }
 
-      // Parse --input overrides (used standalone or merged with stdin items)
+      // Parse --input overrides (used standalone or merged with stdin items).
+      // --arg is a hidden alias; --input takes precedence when both are used.
+      const mergedInput = [
+        ...((options.arg as string[] | undefined) ?? []),
+        ...((options.input as string[] | undefined) ?? []),
+      ];
       const { inputs: cliInputs } = await parseInputs({
-        input: options.input as string[] | undefined,
+        input: mergedInput.length > 0 ? mergedInput : undefined,
         inputFile: stdinItems
           ? undefined
           : options.inputFile as string | undefined,

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -40,7 +40,12 @@ import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import { runFileSink } from "../../infrastructure/logging/logger.ts";
 import { GIT_SHA } from "./version.ts";
-import { deepMerge, parseInputs, parseStdinContent } from "../input_parser.ts";
+import {
+  deepMerge,
+  mergeInputArgs,
+  parseInputs,
+  parseStdinContent,
+} from "../input_parser.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 import { parseTags } from "../../libswamp/mod.ts";
 import { join } from "@std/path";
@@ -233,14 +238,8 @@ export const modelMethodRunCommand = new Command()
         stdinItems = parseStdinContent(stdinContent);
       }
 
-      // Parse --input overrides (used standalone or merged with stdin items).
-      // --arg is a hidden alias; --input takes precedence when both are used.
-      const mergedInput = [
-        ...((options.arg as string[] | undefined) ?? []),
-        ...((options.input as string[] | undefined) ?? []),
-      ];
       const { inputs: cliInputs } = await parseInputs({
-        input: mergedInput.length > 0 ? mergedInput : undefined,
+        input: mergeInputArgs(options),
         inputFile: stdinItems
           ? undefined
           : options.inputFile as string | undefined,
@@ -499,7 +498,7 @@ async function runMethodViaServer(
     stdinItems = parseStdinContent(stdinContent);
   }
   const { inputs: cliInputs } = await parseInputs({
-    input: options.input as string[] | undefined,
+    input: mergeInputArgs(options),
     inputFile: stdinItems ? undefined : options.inputFile as string | undefined,
   });
   const runtimeTags = options.tag

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -38,7 +38,7 @@ import { createWorkflowEvaluateRenderer } from "../../presentation/renderers/wor
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { extractModelReferencesFromWorkflow } from "../../domain/workflows/model_reference_extractor.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
-import { parseInputs } from "../input_parser.ts";
+import { mergeInputArgs, parseInputs } from "../input_parser.ts";
 import { InputValidationService } from "../../domain/inputs/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
@@ -76,14 +76,8 @@ export const workflowEvaluateCommand = new Command()
         "evaluate",
       ]);
 
-      // Parse input values.
-      // --arg is a hidden alias; --input takes precedence when both are used.
-      const mergedInput = [
-        ...((options.arg as string[] | undefined) ?? []),
-        ...((options.input as string[] | undefined) ?? []),
-      ];
       const { inputs } = await parseInputs({
-        input: mergedInput.length > 0 ? mergedInput : undefined,
+        input: mergeInputArgs(options),
         inputFile: options.inputFile as string | undefined,
       });
 

--- a/src/cli/commands/workflow_evaluate.ts
+++ b/src/cli/commands/workflow_evaluate.ts
@@ -64,6 +64,10 @@ export const workflowEvaluateCommand = new Command()
   .option("--input <value:string>", "Input values (key=value or JSON)", {
     collect: true,
   })
+  .option("--arg <value:string>", "Alias for --input", {
+    collect: true,
+    hidden: true,
+  })
   .option("--input-file <file:string>", "Input values from YAML file")
   .action(
     async function (options: AnyOptions, workflowIdOrName?: string) {
@@ -72,9 +76,14 @@ export const workflowEvaluateCommand = new Command()
         "evaluate",
       ]);
 
-      // Parse input values
+      // Parse input values.
+      // --arg is a hidden alias; --input takes precedence when both are used.
+      const mergedInput = [
+        ...((options.arg as string[] | undefined) ?? []),
+        ...((options.input as string[] | undefined) ?? []),
+      ];
       const { inputs } = await parseInputs({
-        input: options.input as string[] | undefined,
+        input: mergedInput.length > 0 ? mergedInput : undefined,
         inputFile: options.inputFile as string | undefined,
       });
 

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -83,6 +83,10 @@ export const workflowResumeCommand = new Command()
     "Override/additional input for the resumed run (key=value or JSON); merged over the original run inputs",
     { collect: true },
   )
+  .option("--arg <value:string>", "Alias for --input", {
+    collect: true,
+    hidden: true,
+  })
   .option(
     "--input-file <file:string>",
     "Override inputs from a YAML file (cannot combine with --stdin)",
@@ -124,8 +128,13 @@ export const workflowResumeCommand = new Command()
         stdinInputs = stdinItems[0] ?? {};
       }
 
+      // --arg is a hidden alias; --input takes precedence when both are used.
+      const mergedInput = [
+        ...((options.arg as string[] | undefined) ?? []),
+        ...((options.input as string[] | undefined) ?? []),
+      ];
       const { inputs: cliInputs } = await parseInputs({
-        input: options.input as string[] | undefined,
+        input: mergedInput.length > 0 ? mergedInput : undefined,
         inputFile: stdinContent !== null
           ? undefined
           : options.inputFile as string | undefined,

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -52,7 +52,12 @@ import {
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { GIT_SHA } from "./version.ts";
-import { deepMerge, parseInputs, parseStdinContent } from "../input_parser.ts";
+import {
+  deepMerge,
+  mergeInputArgs,
+  parseInputs,
+  parseStdinContent,
+} from "../input_parser.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
@@ -128,13 +133,8 @@ export const workflowResumeCommand = new Command()
         stdinInputs = stdinItems[0] ?? {};
       }
 
-      // --arg is a hidden alias; --input takes precedence when both are used.
-      const mergedInput = [
-        ...((options.arg as string[] | undefined) ?? []),
-        ...((options.input as string[] | undefined) ?? []),
-      ];
       const { inputs: cliInputs } = await parseInputs({
-        input: mergedInput.length > 0 ? mergedInput : undefined,
+        input: mergeInputArgs(options),
         inputFile: stdinContent !== null
           ? undefined
           : options.inputFile as string | undefined,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -45,7 +45,12 @@ import {
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
-import { deepMerge, parseInputs, parseStdinContent } from "../input_parser.ts";
+import {
+  deepMerge,
+  mergeInputArgs,
+  parseInputs,
+  parseStdinContent,
+} from "../input_parser.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { GIT_SHA } from "./version.ts";
@@ -202,14 +207,8 @@ export const workflowRunCommand = new Command()
       stdinItems = parseStdinContent(stdinContent);
     }
 
-    // Parse --input overrides (used standalone or merged with stdin items).
-    // --arg is a hidden alias; --input takes precedence when both are used.
-    const mergedInput = [
-      ...((options.arg as string[] | undefined) ?? []),
-      ...((options.input as string[] | undefined) ?? []),
-    ];
     const { inputs: cliInputs } = await parseInputs({
-      input: mergedInput.length > 0 ? mergedInput : undefined,
+      input: mergeInputArgs(options),
       inputFile: stdinItems
         ? undefined
         : options.inputFile as string | undefined,
@@ -469,7 +468,7 @@ async function runWorkflowViaServer(
     stdinItems = parseStdinContent(stdinContent);
   }
   const { inputs: cliInputs } = await parseInputs({
-    input: options.input as string[] | undefined,
+    input: mergeInputArgs(options),
     inputFile: stdinItems ? undefined : options.inputFile as string | undefined,
   });
   const runtimeTags = options.tag

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -115,6 +115,10 @@ export const workflowRunCommand = new Command()
   .option("--input <value:string>", "Input values (key=value or JSON)", {
     collect: true,
   })
+  .option("--arg <value:string>", "Alias for --input", {
+    collect: true,
+    hidden: true,
+  })
   .option(
     "--input-file <file:string>",
     "Input values from YAML file (cannot combine with --stdin)",
@@ -198,9 +202,14 @@ export const workflowRunCommand = new Command()
       stdinItems = parseStdinContent(stdinContent);
     }
 
-    // Parse --input overrides (used standalone or merged with stdin items)
+    // Parse --input overrides (used standalone or merged with stdin items).
+    // --arg is a hidden alias; --input takes precedence when both are used.
+    const mergedInput = [
+      ...((options.arg as string[] | undefined) ?? []),
+      ...((options.input as string[] | undefined) ?? []),
+    ];
     const { inputs: cliInputs } = await parseInputs({
-      input: options.input as string[] | undefined,
+      input: mergedInput.length > 0 ? mergedInput : undefined,
       inputFile: stdinItems
         ? undefined
         : options.inputFile as string | undefined,

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -28,6 +28,19 @@ export { coerceInputTypes } from "../domain/inputs/input_coercion.ts";
 export { deepMerge } from "../domain/inputs/input_merge.ts";
 
 /**
+ * Merges the hidden --arg alias with --input, giving --input precedence.
+ */
+export function mergeInputArgs(
+  options: { arg?: string[]; input?: string[] },
+): string[] | undefined {
+  const merged = [
+    ...((options.arg as string[] | undefined) ?? []),
+    ...((options.input as string[] | undefined) ?? []),
+  ];
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
  * Result of parsing inputs.
  */
 export interface ParsedInputs {

--- a/src/cli/input_parser_test.ts
+++ b/src/cli/input_parser_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import {
   deepMerge,
+  mergeInputArgs,
   parseInputs,
   parseKeyValueInputs,
   parseStdinContent,
@@ -553,4 +554,23 @@ Deno.test("parseStdinContent: complex nested JSON object", () => {
     server: { host: "localhost", port: 8080 },
     env: "prod",
   }]);
+});
+
+Deno.test("mergeInputArgs: returns undefined when both are absent", () => {
+  assertEquals(mergeInputArgs({}), undefined);
+});
+
+Deno.test("mergeInputArgs: returns --arg values alone", () => {
+  assertEquals(mergeInputArgs({ arg: ["a=1"] }), ["a=1"]);
+});
+
+Deno.test("mergeInputArgs: returns --input values alone", () => {
+  assertEquals(mergeInputArgs({ input: ["a=1"] }), ["a=1"]);
+});
+
+Deno.test("mergeInputArgs: --input values come after --arg values", () => {
+  assertEquals(
+    mergeInputArgs({ arg: ["a=1"], input: ["a=2"] }),
+    ["a=1", "a=2"],
+  );
 });


### PR DESCRIPTION
## Summary

- Adds `--arg` as a hidden, collected CLI option on all four commands that accept `--input`: `model method run`, `workflow run`, `workflow evaluate`, and `workflow resume`
- When both `--arg` and `--input` are provided, `--input` values take precedence (appended after `--arg` in the merged array, so later key=value pairs win)
- `--arg` does not appear in `--help` output — it exists solely to absorb a common agent mistake

## Test Plan

- Compiled the binary and initialized a fresh swamp repo in a temp directory
- Verified `swamp model method run --input 'run=echo hello'` works (canonical)
- Verified `swamp model method run --arg 'run=echo hello'` works (alias)
- Verified `--input` takes precedence over `--arg` when both are provided
- Verified `swamp workflow run --arg 'message=hello'` works
- Verified `--arg` is hidden from `--help` output
- All existing unit tests pass (`deno run test`, `deno fmt`, `deno lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)