### PR TITLE
feat(vault): extend inspect with size, valueType, and graceful degradation

### DIFF
--- a/.claude/skills/swamp/references/vault/guide.md
+++ b/.claude/skills/swamp/references/vault/guide.md
@@ -19,23 +19,23 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 
 ## Quick Reference
 
-| Task               | Command                                                 |
-| ------------------ | ------------------------------------------------------- |
-| List vault types   | `swamp vault type search --json`                        |
-| Create a vault     | `swamp vault create <type> <name> --json`               |
-| Search vaults      | `swamp vault search [query] --json`                     |
-| Get vault details  | `swamp vault get <name_or_id> --json`                   |
-| Edit vault config  | `swamp vault edit <name_or_id>`                         |
-| Store a secret     | `swamp vault put <vault> KEY` (prompts for value)       |
-| Store from stdin   | `echo "$VAL" \| swamp vault put <vault> KEY --json`     |
-| Store inline       | `swamp vault put <vault> KEY=VALUE --json` (insecure)   |
-| Read a secret      | `swamp vault read-secret <vault> <key> --force --json`  |
-| List secret keys   | `swamp vault list-keys <vault> --json`                  |
-| Annotate a secret  | `swamp vault annotate <vault> <key> --url <u>`          |
-| Remove a label     | `swamp vault annotate <vault> <key> --remove-label <k>` |
-| Inspect annotation | `swamp vault inspect <vault> <key> --json`              |
-| Clear annotation   | `swamp vault annotate <vault> <key> --clear`            |
-| Migrate backend    | `swamp vault migrate <vault> --to-type <type>`          |
+| Task              | Command                                                 |
+| ----------------- | ------------------------------------------------------- |
+| List vault types  | `swamp vault type search --json`                        |
+| Create a vault    | `swamp vault create <type> <name> --json`               |
+| Search vaults     | `swamp vault search [query] --json`                     |
+| Get vault details | `swamp vault get <name_or_id> --json`                   |
+| Edit vault config | `swamp vault edit <name_or_id>`                         |
+| Store a secret    | `swamp vault put <vault> KEY` (prompts for value)       |
+| Store from stdin  | `echo "$VAL" \| swamp vault put <vault> KEY --json`     |
+| Store inline      | `swamp vault put <vault> KEY=VALUE --json` (insecure)   |
+| Read a secret     | `swamp vault read-secret <vault> <key> --force --json`  |
+| List secret keys  | `swamp vault list-keys <vault> --json`                  |
+| Annotate a secret | `swamp vault annotate <vault> <key> --url <u>`          |
+| Remove a label    | `swamp vault annotate <vault> <key> --remove-label <k>` |
+| Inspect metadata  | `swamp vault inspect <vault> <key> --json`              |
+| Clear annotation  | `swamp vault annotate <vault> <key> --clear`            |
+| Migrate backend   | `swamp vault migrate <vault> --to-type <type>`          |
 
 ## Repository Structure
 
@@ -224,9 +224,10 @@ swamp vault annotate my-vault API_KEY --remove-label team
 swamp vault annotate my-vault API_KEY --clear
 ```
 
-## Inspect Secret Annotations
+## Inspect Secret Metadata
 
-View the metadata attached to a secret:
+View all available metadata for a secret (size, type, annotations, refresh
+hooks) without exposing the secret value:
 
 ```bash
 swamp vault inspect my-vault API_KEY --json
@@ -239,15 +240,26 @@ swamp vault inspect my-vault API_KEY --json
   "vaultName": "my-vault",
   "secretKey": "API_KEY",
   "vaultType": "local_encryption",
+  "sizeBytes": 42,
+  "sizeChars": 42,
+  "valueType": "string",
+  "supportsAnnotations": true,
   "hasAnnotation": true,
   "annotation": {
     "url": "https://console.aws.com/iam",
     "notes": "Production API key for service X",
     "labels": { "env": "prod", "team": "infra" },
     "updatedAt": "2026-05-22T21:00:00.000Z"
-  }
+  },
+  "supportsRefreshHooks": true,
+  "hasRefreshHook": false,
+  "refreshHook": null
 }
 ```
+
+Inspect degrades gracefully — providers that don't support annotations or
+refresh hooks return `null` for those fields with `supportsAnnotations: false`
+or `supportsRefreshHooks: false`.
 
 ## Vault Expressions
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -203,6 +203,52 @@ existing fields are preserved. `--remove-label` removes a single label by key
 (repeatable). `--clear` removes all annotations and cannot be combined with
 other annotation flags.
 
+### Vault Inspect Output
+
+`swamp vault inspect <vault> <key>` shows all available metadata for a vault
+item without exposing the secret value:
+
+- `sizeBytes` — byte length of the stored value (UTF-8 encoded)
+- `sizeChars` — character count of the stored value
+- `valueType` — always `"string"` (the vault provider interface stores strings)
+- `annotation` — url, notes, labels, updatedAt (if the provider supports
+  annotations)
+- `refreshHook` — command, ttl, lastRefreshedAt (if the provider supports
+  refresh hooks)
+
+Inspect degrades gracefully: providers that don't support annotations or refresh
+hooks return `null` for those fields with explicit `supportsAnnotations` /
+`supportsRefreshHooks` booleans so consumers can distinguish "not supported" from
+"supported but empty."
+
+The secret value is never returned. Size is measured internally via a deps
+factory function that calls `get()`, measures the byte length, and returns only
+the number — the secret never enters the operation's scope.
+
+### JSON Output
+
+```json
+{
+  "vaultName": "my-vault",
+  "secretKey": "API_KEY",
+  "vaultType": "local_encryption",
+  "sizeBytes": 42,
+  "sizeChars": 42,
+  "valueType": "string",
+  "supportsAnnotations": true,
+  "hasAnnotation": true,
+  "annotation": {
+    "url": "https://console.aws.amazon.com/iam",
+    "notes": "Production API key",
+    "labels": { "env": "prod" },
+    "updatedAt": "2026-01-15T10:30:00.000Z"
+  },
+  "supportsRefreshHooks": false,
+  "hasRefreshHook": false,
+  "refreshHook": null
+}
+```
+
 ## Expression Syntax
 
 Vaults are accessed in CEL expressions using the `vault.get()` and `vault.put()`

--- a/src/cli/commands/vault_inspect.ts
+++ b/src/cli/commands/vault_inspect.ts
@@ -38,14 +38,15 @@ type AnyOptions = any;
 export const vaultInspectCommand = new Command()
   .name("inspect")
   .description(
-    `Show annotations for a vault secret.
+    `Show metadata for a vault secret.
 
-Displays the metadata (URL, notes, labels) attached to a secret
-via \`swamp vault annotate\`.`,
+Displays size, type, annotations, and refresh-hook info for a secret
+without exposing the secret value. Works on all vault providers; annotation
+and refresh-hook fields are omitted when not supported.`,
   )
   .arguments("<vault_name:string> <key:string>")
   .example(
-    "Inspect a secret's annotations",
+    "Inspect a secret's metadata",
     "swamp vault inspect my-vault API_KEY",
   )
   .example(

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -36,8 +36,13 @@ export interface VaultInspectData {
   vaultName: string;
   secretKey: string;
   vaultType: string;
+  sizeBytes: number;
+  sizeChars: number;
+  valueType: string;
+  supportsAnnotations: boolean;
   hasAnnotation: boolean;
   annotation: VaultAnnotationData | null;
+  supportsRefreshHooks: boolean;
   hasRefreshHook: boolean;
   refreshHook: RefreshHookData | null;
 }
@@ -51,6 +56,10 @@ export interface VaultInspectDeps {
   findVault: (name: string) => Promise<VaultInspectConfigInfo | null>;
   listVaultNames: () => Promise<string[]>;
   secretExists: (vaultName: string, key: string) => Promise<boolean>;
+  measureSecretSize: (
+    vaultName: string,
+    key: string,
+  ) => Promise<{ bytes: number; chars: number }>;
   supportsAnnotations: (vaultName: string) => Promise<boolean>;
   getAnnotation: (
     vaultName: string,
@@ -84,6 +93,14 @@ export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
       const svc = await getVaultService();
       const keys = await svc.list(vaultName);
       return keys.includes(key);
+    },
+    measureSecretSize: async (vaultName, key) => {
+      const svc = await getVaultService();
+      const value = await svc.get(vaultName, key);
+      return {
+        bytes: new TextEncoder().encode(value).byteLength,
+        chars: value.length,
+      };
     },
     supportsAnnotations: async (vaultName) => {
       const svc = await getVaultService();
@@ -153,21 +170,19 @@ export async function* vaultInspect(
         return;
       }
 
-      if (!await deps.supportsAnnotations(vaultName)) {
-        yield {
-          kind: "error",
-          error: validationFailed(
-            `Vault '${vaultName}' (type: ${config.type}) does not support annotations`,
-          ),
-        };
-        return;
+      const { bytes: sizeBytes, chars: sizeChars } = await deps
+        .measureSecretSize(vaultName, secretKey);
+
+      const hasAnnotationSupport = await deps.supportsAnnotations(vaultName);
+      let annotation: VaultAnnotationData | null = null;
+      if (hasAnnotationSupport) {
+        annotation = await deps.getAnnotation(vaultName, secretKey);
+        ctx.logger.debug`Retrieved annotation for ${secretKey}`;
       }
 
-      const annotation = await deps.getAnnotation(vaultName, secretKey);
-      ctx.logger.debug`Retrieved annotation for ${secretKey}`;
-
+      const hasRefreshHookSupport = await deps.supportsRefreshHooks(vaultName);
       let refreshHook: RefreshHookData | null = null;
-      if (await deps.supportsRefreshHooks(vaultName)) {
+      if (hasRefreshHookSupport) {
         refreshHook = await deps.getRefreshHook(vaultName, secretKey);
       }
 
@@ -177,8 +192,13 @@ export async function* vaultInspect(
           vaultName,
           secretKey,
           vaultType: config.type,
+          sizeBytes,
+          sizeChars,
+          valueType: "string",
+          supportsAnnotations: hasAnnotationSupport,
           hasAnnotation: annotation !== null,
           annotation,
+          supportsRefreshHooks: hasRefreshHookSupport,
           hasRefreshHook: refreshHook !== null,
           refreshHook,
         },

--- a/src/libswamp/vaults/inspect_test.ts
+++ b/src/libswamp/vaults/inspect_test.ts
@@ -35,6 +35,7 @@ function makeDeps(
       Promise.resolve({ id: "v1", name: "my-vault", type: "env" }),
     listVaultNames: () => Promise.resolve(["my-vault"]),
     secretExists: () => Promise.resolve(true),
+    measureSecretSize: () => Promise.resolve({ bytes: 11, chars: 11 }),
     supportsAnnotations: () => Promise.resolve(true),
     getAnnotation: () => Promise.resolve(null),
     supportsRefreshHooks: () => Promise.resolve(false),
@@ -81,7 +82,7 @@ Deno.test("vaultInspect: yields validation_failed when secret does not exist", a
   assertStringIncludes(last.error.message, "does not exist");
 });
 
-Deno.test("vaultInspect: yields validation_failed when annotations not supported", async () => {
+Deno.test("vaultInspect: degrades gracefully when annotations not supported", async () => {
   const deps = makeDeps({
     supportsAnnotations: () => Promise.resolve(false),
   });
@@ -90,13 +91,40 @@ Deno.test("vaultInspect: yields validation_failed when annotations not supported
     vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
   );
 
-  const last = events[events.length - 1] as Extract<
+  const completed = events[events.length - 1] as Extract<
     VaultInspectEvent,
-    { kind: "error" }
+    { kind: "completed" }
   >;
-  assertEquals(last.kind, "error");
-  assertEquals(last.error.code, "validation_failed");
-  assertStringIncludes(last.error.message, "does not support annotations");
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.supportsAnnotations, false);
+  assertEquals(completed.data.hasAnnotation, false);
+  assertEquals(completed.data.annotation, null);
+  assertEquals(completed.data.sizeBytes, 11);
+  assertEquals(completed.data.sizeChars, 11);
+  assertEquals(completed.data.valueType, "string");
+});
+
+Deno.test("vaultInspect: degrades gracefully when neither annotations nor refresh hooks supported", async () => {
+  const deps = makeDeps({
+    supportsAnnotations: () => Promise.resolve(false),
+    supportsRefreshHooks: () => Promise.resolve(false),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.supportsAnnotations, false);
+  assertEquals(completed.data.annotation, null);
+  assertEquals(completed.data.supportsRefreshHooks, false);
+  assertEquals(completed.data.refreshHook, null);
+  assertEquals(completed.data.sizeBytes, 11);
+  assertEquals(completed.data.sizeChars, 11);
 });
 
 Deno.test("vaultInspect: yields completed with annotation data", async () => {
@@ -124,8 +152,12 @@ Deno.test("vaultInspect: yields completed with annotation data", async () => {
   assertEquals(completed.data.vaultName, "my-vault");
   assertEquals(completed.data.secretKey, "API_KEY");
   assertEquals(completed.data.vaultType, "env");
+  assertEquals(completed.data.supportsAnnotations, true);
   assertEquals(completed.data.hasAnnotation, true);
   assertEquals(completed.data.annotation, annotationData);
+  assertEquals(completed.data.sizeBytes, 11);
+  assertEquals(completed.data.sizeChars, 11);
+  assertEquals(completed.data.valueType, "string");
 });
 
 Deno.test("vaultInspect: yields completed with no annotation", async () => {
@@ -146,6 +178,44 @@ Deno.test("vaultInspect: yields completed with no annotation", async () => {
   assertEquals(completed.data.vaultName, "my-vault");
   assertEquals(completed.data.secretKey, "API_KEY");
   assertEquals(completed.data.vaultType, "env");
+  assertEquals(completed.data.supportsAnnotations, true);
   assertEquals(completed.data.hasAnnotation, false);
   assertEquals(completed.data.annotation, null);
+});
+
+Deno.test("vaultInspect: measures secret size correctly", async () => {
+  const deps = makeDeps({
+    measureSecretSize: () => Promise.resolve({ bytes: 42, chars: 38 }),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    VaultInspectEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.sizeBytes, 42);
+  assertEquals(completed.data.sizeChars, 38);
+  assertEquals(completed.data.valueType, "string");
+});
+
+Deno.test("vaultInspect: output never contains the secret value", async () => {
+  const secretValue = "super-secret-api-key-12345";
+  const deps = makeDeps({
+    measureSecretSize: () =>
+      Promise.resolve({
+        bytes: new TextEncoder().encode(secretValue).byteLength,
+        chars: secretValue.length,
+      }),
+  });
+
+  const events = await collect<VaultInspectEvent>(
+    vaultInspect(createLibSwampContext(), deps, "my-vault", "API_KEY"),
+  );
+
+  const serialized = JSON.stringify(events);
+  assertEquals(serialized.includes(secretValue), false);
 });

--- a/src/presentation/renderers/vault_inspect.ts
+++ b/src/presentation/renderers/vault_inspect.ts
@@ -33,7 +33,6 @@ class LogVaultInspectRenderer implements Renderer<VaultInspectEvent> {
           .info`Metadata for ${e.data.secretKey} in vault ${e.data.vaultName}:`;
         logger
           .info`  size: ${e.data.sizeChars} chars (${e.data.sizeBytes} bytes)`;
-        logger.info`  type: ${e.data.valueType}`;
         if (e.data.supportsAnnotations) {
           if (e.data.hasAnnotation && e.data.annotation) {
             const a = e.data.annotation;
@@ -45,6 +44,8 @@ class LogVaultInspectRenderer implements Renderer<VaultInspectEvent> {
               }
             }
             logger.info`  updated: ${a.updatedAt}`;
+          } else {
+            logger.info`  annotation: (none)`;
           }
         }
         if (e.data.supportsRefreshHooks) {
@@ -58,6 +59,8 @@ class LogVaultInspectRenderer implements Renderer<VaultInspectEvent> {
             } else {
               logger.info`    last refreshed: never`;
             }
+          } else {
+            logger.info`  refresh-hook: (none)`;
           }
         }
       },

--- a/src/presentation/renderers/vault_inspect.ts
+++ b/src/presentation/renderers/vault_inspect.ts
@@ -29,34 +29,35 @@ class LogVaultInspectRenderer implements Renderer<VaultInspectEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        const hasContent = e.data.hasAnnotation || e.data.hasRefreshHook;
-        if (!hasContent) {
-          logger
-            .info`No metadata found for ${e.data.secretKey} in vault ${e.data.vaultName}`;
-          return;
-        }
         logger
           .info`Metadata for ${e.data.secretKey} in vault ${e.data.vaultName}:`;
-        if (e.data.hasAnnotation && e.data.annotation) {
-          const a = e.data.annotation;
-          if (a.url) logger.info`  url: ${a.url}`;
-          if (a.notes) logger.info`  notes: ${a.notes}`;
-          if (a.labels && Object.keys(a.labels).length > 0) {
-            for (const [k, v] of Object.entries(a.labels)) {
-              logger.info`  label: ${k}=${v}`;
+        logger
+          .info`  size: ${e.data.sizeChars} chars (${e.data.sizeBytes} bytes)`;
+        logger.info`  type: ${e.data.valueType}`;
+        if (e.data.supportsAnnotations) {
+          if (e.data.hasAnnotation && e.data.annotation) {
+            const a = e.data.annotation;
+            if (a.url) logger.info`  url: ${a.url}`;
+            if (a.notes) logger.info`  notes: ${a.notes}`;
+            if (a.labels && Object.keys(a.labels).length > 0) {
+              for (const [k, v] of Object.entries(a.labels)) {
+                logger.info`  label: ${k}=${v}`;
+              }
             }
+            logger.info`  updated: ${a.updatedAt}`;
           }
-          logger.info`  updated: ${a.updatedAt}`;
         }
-        if (e.data.hasRefreshHook && e.data.refreshHook) {
-          const rh = e.data.refreshHook;
-          logger.info`  refresh:`;
-          logger.info`    command: ${rh.command}`;
-          logger.info`    ttl: ${rh.ttl}`;
-          if (rh.lastRefreshedAt) {
-            logger.info`    last refreshed: ${rh.lastRefreshedAt}`;
-          } else {
-            logger.info`    last refreshed: never`;
+        if (e.data.supportsRefreshHooks) {
+          if (e.data.hasRefreshHook && e.data.refreshHook) {
+            const rh = e.data.refreshHook;
+            logger.info`  refresh:`;
+            logger.info`    command: ${rh.command}`;
+            logger.info`    ttl: ${rh.ttl}`;
+            if (rh.lastRefreshedAt) {
+              logger.info`    last refreshed: ${rh.lastRefreshedAt}`;
+            } else {
+              logger.info`    last refreshed: never`;
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

Closes swamp-club#781

- Extend `vault inspect` to report `sizeBytes`, `sizeChars`, and `valueType` for vault items without exposing the secret value
- Fix graceful degradation: inspect no longer errors when the provider doesn't support annotations — returns null with explicit `supportsAnnotations`/`supportsRefreshHooks` capability flags
- Secret isolation enforced via `measureSecretSize` in the deps factory — calls `get()`, measures the value, returns only the counts; the secret never enters the operation scope

## Test Plan

- Unit tests: 8 tests covering size measurement, graceful degradation (annotations unsupported, nothing supported), annotation data, secret-never-in-output security check
- End-to-end verified against `local_encryption` (full annotation + refresh hook support) and `@swamp/aws-sm` via localstack (annotations supported, refresh hooks gracefully null)
- `deno check`, `deno lint`, `deno fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)