### PR TITLE
feat(cel): enable .? optional select for null-safe data access

### DIFF
--- a/.claude/skills/swamp/references/model/references/examples.md
+++ b/.claude/skills/swamp/references/model/references/examples.md
@@ -14,6 +14,7 @@
 | Expression Pattern                                           | Description                               | Example Value                 |
 | ------------------------------------------------------------ | ----------------------------------------- | ----------------------------- |
 | `data.latest("<model>", "<name>").attributes.<field>`        | Latest data (PREFERRED, sync disk read)   | VPC ID, subnet CIDR, etc.     |
+| `data.latest("<model>", "<name>").?attributes.?<field>`      | Null-safe — returns null if missing       | Prior cycle findings          |
 | `data.version("<model>", "<name>", N).attributes.<field>`    | Specific version of data                  | Rollback to version 1         |
 | `data.findBySpec("<model>", "<spec>")`                       | Find all instances from a spec            | All subnets from scanner      |
 | `data.findByTag("<key>", "<value>")`                         | Find data by tag                          | All resources tagged env=prod |

--- a/.claude/skills/swamp/references/model/references/expressions.md
+++ b/.claude/skills/swamp/references/model/references/expressions.md
@@ -69,6 +69,12 @@ allResources: ${{ data.findByTag("type", "resource") }}
 
 # Find all instances from a factory model's output spec
 subnets: ${{ data.findBySpec("my-scanner", "subnet") }}
+
+# Null-safe access — use .? when data might not exist yet
+priorFindings: ${{ data.latest("factory", "code-review").?attributes.?findings }}
+
+# With inline default via .orValue()
+priorFindings: ${{ data.latest("factory", "code-review").?attributes.?findings.orValue([]) }}
 ```
 
 ## Example with Expressions

--- a/.claude/skills/swamp/references/workflow/references/data-chaining.md
+++ b/.claude/skills/swamp/references/workflow/references/data-chaining.md
@@ -103,6 +103,22 @@ just specific fields.
 **Avoid `model.*.resource` / `model.*.file`** — these patterns are deprecated
 and will emit a warning. Migrate to `data.latest()` or `data.query()`.
 
+**Use `.?` (optional select)** when the data might not exist yet — for example,
+referencing a prior cycle's output on the first cycle of a rework loop. `.?`
+returns `null` instead of throwing when the data is missing. Chain `.orValue()`
+to provide an inline default:
+
+```yaml
+# Throws if artifact doesn't exist:
+findings: ${{ data.latest('factory', 'code-review').attributes.findings }}
+
+# Returns null if missing:
+findings: ${{ data.latest('factory', 'code-review').?attributes.?findings }}
+
+# Returns [] if missing:
+findings: ${{ data.latest('factory', 'code-review').?attributes.?findings.orValue([]) }}
+```
+
 Use explicit `dependsOn` to control step ordering.
 
 ## Example: Multi-Step Infrastructure Workflow

--- a/design/data-query.md
+++ b/design/data-query.md
@@ -49,6 +49,20 @@ key, or history access beyond a single version.
 Results from any shortcut are structurally identical to the equivalent
 `data.query()` call — same `DataRecord[]` type, same fields, same semantics.
 
+### Null-safe access (.?)
+
+`data.latest()` and `data.version()` return `null` when the named instance
+doesn't exist. Use `.?` (optional select) to chain through a potentially null
+result instead of throwing:
+
+```cel
+data.latest("m", "n").?attributes.?payload.?findings           // null if missing
+data.latest("m", "n").?attributes.?findings.orValue([])        // [] if missing
+data.latest("m", "n").attributes.findings                      // throws if missing
+```
+
+See [expressions.md](./expressions.md#null-safe-optional-access-) for details.
+
 ### Cross-namespace queries (giga-swamp Phase 4)
 
 Point-lookup helpers (`data.latest`, `data.version`, `data.findBySpec`,

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -319,6 +319,29 @@ attributes:
   historySize: ${{ size(data.listVersions('processor', 'result')) }}
 ```
 
+### Null-safe Optional Access (.?)
+
+`data.latest()` and `data.version()` return `null` when the named instance
+doesn't exist. Accessing properties on `null` with `.` throws an error. Use
+`.?` (optional select) to chain through a potentially null result — the
+expression returns `null` instead of throwing:
+
+```yaml
+inputs:
+  # Throws if the data doesn't exist:
+  findings: ${{ data.latest('factory', 'code-review').attributes.findings }}
+
+  # Returns null if the data doesn't exist:
+  findings: ${{ data.latest('factory', 'code-review').?attributes.?findings }}
+
+  # Use .orValue() for an inline default:
+  findings: ${{ data.latest('factory', 'code-review').?attributes.?findings.orValue([]) }}
+```
+
+Use `.?` when the data **might not exist yet** — for example, referencing a
+prior cycle's output on the first cycle of a rework loop. Use regular `.` when
+the data **must exist** — a missing result is a bug and should fail loudly.
+
 ### data.findBySpec(modelName, specName)
 
 Returns all data records for a model that match a given output spec name.

--- a/packages/testing/_cel_environment.ts
+++ b/packages/testing/_cel_environment.ts
@@ -32,7 +32,10 @@
 import { Environment } from "cel-js";
 
 export function createExtensionCelEnvironment(): Environment {
-  const env = new Environment({ unlistedVariablesAreDyn: true });
+  const env = new Environment({
+    unlistedVariablesAreDyn: true,
+    enableOptionalTypes: true,
+  });
 
   env.registerOperator(
     "double + int",

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -240,6 +240,8 @@ Deno.test("cel env factory parity: both factories produce identical results", ()
     ["a / 2", { a: 5.0 }],
     ["a % 2", { a: 5.0 }],
     ["2 + a", { a: 1.5 }],
+    ["a.?b", { a: { b: 42 } }],
+    ["a.?b", { a: null }],
   ];
 
   const a = canonicalFactory();

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Environment } from "cel-js";
+import { Environment, Optional } from "cel-js";
 import { getLogger } from "@logtape/logtape";
 import { InvalidExpressionError } from "../../domain/expressions/errors.ts";
 import { transformHyphenatedModelRefs } from "../../domain/expressions/expression_parser.ts";
@@ -29,6 +29,18 @@ import { composeDataName } from "../../domain/data/mod.ts";
 export interface ValidationResult {
   valid: boolean;
   error?: string;
+}
+
+/**
+ * Unwraps a CEL Optional value at the expression boundary.
+ * Optional.of(v) becomes v, Optional.none() becomes null.
+ * Non-Optional values pass through unchanged.
+ */
+function unwrapOptional(value: unknown): unknown {
+  if (value instanceof Optional) {
+    return value.hasValue() ? value.value() : null;
+  }
+  return value;
 }
 
 /**
@@ -238,7 +250,10 @@ function registerArithmeticOverloads(env: Environment): void {
 export { registerArithmeticOverloads };
 
 export function createExtensionCelEnvironment(): Environment {
-  const env = new Environment({ unlistedVariablesAreDyn: true });
+  const env = new Environment({
+    unlistedVariablesAreDyn: true,
+    enableOptionalTypes: true,
+  });
   registerArithmeticOverloads(env);
   return env;
 }
@@ -255,8 +270,6 @@ export class CelEvaluator {
   private readonly warnedPatterns = new Set<string>();
 
   constructor() {
-    // Start from the shared extension baseline, then layer swamp's internal
-    // namespace types on top.
     this.env = createExtensionCelEnvironment();
 
     // Register namespace types so cel-js recognizes them via constructor
@@ -371,7 +384,8 @@ export class CelEvaluator {
       // resolve receiver methods instead of treating them as maps.
       const wrappedContext = this.wrapNamespaces(context);
 
-      const result = this.env.evaluate(transformedExpr, wrappedContext);
+      const rawResult = this.env.evaluate(transformedExpr, wrappedContext);
+      const result = unwrapOptional(rawResult);
 
       // Detect unresolved Promises from async CEL functions (data.latest,
       // data.findByTag, data.findBySpec, data.query).  These functions are
@@ -432,8 +446,11 @@ export class CelEvaluator {
       const transformedExpr = transformHyphenatedModelRefs(expression);
       this.warnDeprecatedPatterns(transformedExpr);
       const wrappedContext = this.wrapNamespaces(context);
-      const result = await this.env.evaluate(transformedExpr, wrappedContext);
-      return coerceBigInts(result);
+      const rawResult = await this.env.evaluate(
+        transformedExpr,
+        wrappedContext,
+      );
+      return coerceBigInts(unwrapOptional(rawResult));
     } catch (error) {
       throw new InvalidExpressionError(
         error instanceof Error ? error.message : String(error),

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -31,11 +31,6 @@ export interface ValidationResult {
   error?: string;
 }
 
-/**
- * Unwraps a CEL Optional value at the expression boundary.
- * Optional.of(v) becomes v, Optional.none() becomes null.
- * Non-Optional values pass through unchanged.
- */
 function unwrapOptional(value: unknown): unknown {
   if (value instanceof Optional) {
     return value.hasValue() ? value.value() : null;

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -980,6 +980,161 @@ Deno.test("CelEvaluator: directly-missing input throws InvalidExpressionError", 
   );
 });
 
+// --- Optional select .? for null-safe data access (Issue #783) ---
+// data.latest() and data.version() return null when the instance doesn't exist.
+// Using .? (optional select) on null should return null instead of throwing.
+// Regular . still throws on null — .? is an explicit opt-in.
+
+Deno.test("CelEvaluator: .? on null returns null instead of throwing", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => null,
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.latest("model", "instance").?attributes.?payload.?findings',
+    context,
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("CelEvaluator: .? on existing record returns the value", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (m: string, d: string) => {
+        if (m === "model" && d === "instance") {
+          return {
+            attributes: { payload: { findings: ["bug1", "bug2"] } },
+          };
+        }
+        return null;
+      },
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.latest("model", "instance").?attributes.?payload.?findings',
+    context,
+  );
+  assertEquals(result, ["bug1", "bug2"]);
+});
+
+Deno.test("CelEvaluator: .? with data.version() returns null for missing version", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      version: (_m: string, _d: string, _v: unknown) => null,
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.version("model", "instance", 1).?attributes.?status',
+    context,
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("CelEvaluator: .? with vary returns null for missing instance", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => null,
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.latest("model", "instance", ["prod"]).?attributes.?value',
+    context,
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("CelEvaluator: .? with .orValue() provides inline default", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => null,
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.latest("model", "instance").?attributes.?payload.?findings.orValue([])',
+    context,
+  );
+  assertEquals(result, []);
+});
+
+Deno.test("CelEvaluator: .? with .orValue() returns value when exists", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => ({
+        attributes: { payload: { findings: ["f1"] } },
+      }),
+    },
+  };
+
+  const result = evaluator.evaluate(
+    'data.latest("model", "instance").?attributes.?payload.?findings.orValue([])',
+    context,
+  );
+  assertEquals(result, ["f1"]);
+});
+
+Deno.test("CelEvaluator: regular . still throws on null (no silent null propagation)", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => null,
+    },
+  };
+
+  assertThrows(
+    () =>
+      evaluator.evaluate(
+        'data.latest("model", "instance").attributes',
+        context,
+      ),
+    InvalidExpressionError,
+  );
+});
+
+Deno.test("CelEvaluator: .? async returns null for missing instance", async () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => Promise.resolve(null),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    'data.latest("model", "instance").?attributes.?payload.?findings',
+    context,
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("CelEvaluator: .? async returns value when exists", async () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) =>
+        Promise.resolve({
+          attributes: { payload: { findings: ["f1"] } },
+        }),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    'data.latest("model", "instance").?attributes.?payload.?findings',
+    context,
+  );
+  assertEquals(result, ["f1"]);
+});
+
 // --- Promise detection in sync evaluate (Issue #88) ---
 
 Deno.test("evaluate: throws InvalidExpressionError when data.latest returns a Promise", () => {


### PR DESCRIPTION
## Summary

- Enable CEL optional types (`enableOptionalTypes: true`) in both the internal `CelEvaluator` and `createExtensionCelEnvironment()`
- Add `unwrapOptional()` at the expression boundary so `.?` chains resolve to plain values or `null` — users never see Optional objects
- Document `.?` syntax in design docs and skill references as the recommended pattern for accessing data that might not exist

Fixes swamp-club#783

## Test Plan

- 9 new unit tests in `cel_evaluator_test.ts`:
  - `.?` on null returns null (sync + async)
  - `.?` on existing record returns the value (sync + async)
  - `.?` with `data.version()`, vary dimensions
  - `.orValue()` provides inline default
  - Regular `.` still throws on null (no silent propagation)
- All 7797 existing tests pass — zero regressions
- Integration tests for CEL data access, giga-swamp namespaces, and cross-model access all pass