### PR TITLE
fix(ci): pass TESSL_TOKEN to skill review job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,9 @@ jobs:
           node-version: "24"
 
       - name: Review skills
-        run: deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/review_skills.ts
+        env:
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+        run: deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY,TESSL_TOKEN --allow-write scripts/review_skills.ts
 
   skill-trigger-eval:
     name: Skill Trigger Eval


### PR DESCRIPTION
## Summary

- tessl now requires authentication for `skill review`, breaking the CI job
- Pass the `TESSL_TOKEN` GitHub Actions secret to the skill review step so it can authenticate non-interactively
- Expand `--allow-env` to include `TESSL_TOKEN` so Deno forwards it to the child process

## Test Plan

- [ ] Verify the `TESSL_TOKEN` secret is configured in the repo's GitHub Actions secrets
- [ ] Push a PR that touches `.claude/skills/` to trigger the skill-review job
- [ ] Confirm the job passes without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)