### PR TITLE
feat(serve): add daemon enable/disable/status subcommands (swamp-club#715)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -181,7 +181,7 @@ export function validateWebSocketOrigin(
   return { allowed: true };
 }
 
-function collectServeExtraArgs(options: AnyOptions): string[] {
+export function collectServeExtraArgs(options: AnyOptions): string[] {
   const args: string[] = [];
   if (options.schedule === false) {
     args.push("--no-schedule");

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -38,6 +38,16 @@ import { BundleRegistry } from "../../serve/bundle_registry.ts";
 import { DataPlane } from "../../serve/data_plane.ts";
 import { setRemoteStepDispatcher } from "../../domain/remote/remote_dispatch.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  createServiceScheduler,
+  resolveServiceMode,
+} from "../../infrastructure/daemon/service_scheduler_factory.ts";
+import {
+  renderDaemonDisabled,
+  renderDaemonEnabled,
+  renderDaemonStatus,
+} from "../../presentation/output/serve_daemon_output.ts";
+import { groupCommandAction } from "../group_action.ts";
 import { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
@@ -170,6 +180,189 @@ export function validateWebSocketOrigin(
 
   return { allowed: true };
 }
+
+function collectServeExtraArgs(options: AnyOptions): string[] {
+  const args: string[] = [];
+  if (options.schedule === false) {
+    args.push("--no-schedule");
+  }
+  if (options.grantReload && options.grantReload !== "manual") {
+    args.push("--grant-reload", options.grantReload as string);
+  }
+  const webhooks = options.webhook as string[] | undefined;
+  if (webhooks) {
+    for (const spec of webhooks) {
+      args.push("--webhook", spec);
+    }
+  }
+  if (options.authMode && options.authMode !== "none") {
+    args.push("--auth-mode", options.authMode as string);
+  }
+  if (options.admins) {
+    args.push("--admins", options.admins as string);
+  }
+  if (options.allowedCollectives) {
+    args.push("--allowed-collectives", options.allowedCollectives as string);
+  }
+  if (options.allowedUsers) {
+    args.push("--allowed-users", options.allowedUsers as string);
+  }
+  if (options.oauthProvider) {
+    args.push("--oauth-provider", options.oauthProvider as string);
+  }
+  if (options.oauthClientId) {
+    args.push("--oauth-client-id", options.oauthClientId as string);
+  }
+  if (options.groupsField) {
+    args.push("--groups-field", options.groupsField as string);
+  }
+  if (options.trustProxy) {
+    args.push("--trust-proxy");
+  }
+  return args;
+}
+
+const daemonEnableCommand = new Command()
+  .name("enable")
+  .description("Enable swamp serve as a system daemon (launchd/systemd)")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--port <port:number>", "Port for the daemon to listen on", {
+    default: 9090,
+  })
+  .option("--host <host:string>", "Host for the daemon to bind to", {
+    default: "127.0.0.1",
+  })
+  .option("--no-schedule", "Disable scheduled workflow execution")
+  .option(
+    "--cert-file <path:string>",
+    "Path to PEM-encoded TLS certificate",
+  )
+  .option(
+    "--key-file <path:string>",
+    "Path to PEM-encoded TLS private key",
+  )
+  .option(
+    "--grant-reload <mode:string>",
+    "Policy snapshot reload mode: manual (default) or auto",
+    { default: "manual" },
+  )
+  .option(
+    "--webhook <spec:string>",
+    "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]",
+    { collect: true },
+  )
+  .option(
+    "--auth-mode <mode:string>",
+    "Authentication mode: none (default, deprecated), token, or oauth",
+    { default: "none" },
+  )
+  .option(
+    "--admins <principals:string>",
+    "Comma-separated principal IDs for admin access",
+  )
+  .option(
+    "--allowed-collectives <list:string>",
+    "Comma-separated collective slugs for OAuth admission policy",
+  )
+  .option(
+    "--allowed-users <list:string>",
+    "Comma-separated user identifiers for OAuth admission policy",
+  )
+  .option(
+    "--oauth-provider <url:string>",
+    "OAuth authorization server URL (default: https://swamp-club.com)",
+  )
+  .option(
+    "--oauth-client-id <id:string>",
+    "OAuth client ID (required for oauth mode)",
+  )
+  .option(
+    "--groups-field <field:string>",
+    "Userinfo field name for group/collective memberships (default: collectives)",
+  )
+  .option(
+    "--trust-proxy",
+    "Trust X-Forwarded-For header for client IP in token auth rate limiting",
+  )
+  .example("Enable daemon", "swamp serve daemon enable")
+  .example(
+    "Enable with custom port",
+    "swamp serve daemon enable --port 8080",
+  )
+  .example(
+    "Enable with TLS and auth",
+    "swamp serve daemon enable --cert-file cert.pem --key-file key.pem --auth-mode token",
+  )
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "serve",
+      "daemon",
+      "enable",
+    ]);
+    const repoDir = resolveRepoDir(options.repoDir as string | undefined);
+    const mode = await resolveServiceMode();
+    const scheduler = await createServiceScheduler({ mode });
+    const extraArgs = collectServeExtraArgs(options);
+
+    await scheduler.enable({
+      binaryPath: Deno.execPath(),
+      repoDir,
+      port: options.port as number,
+      host: options.host as string,
+      certFile: options.certFile as string | undefined,
+      keyFile: options.keyFile as string | undefined,
+      extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
+    });
+
+    renderDaemonEnabled(ctx.outputMode);
+  });
+
+const daemonDisableCommand = new Command()
+  .name("disable")
+  .description("Disable and remove the swamp serve daemon")
+  .example("Disable daemon", "swamp serve daemon disable")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "serve",
+      "daemon",
+      "disable",
+    ]);
+    const mode = await resolveServiceMode();
+    const scheduler = await createServiceScheduler({ mode });
+
+    await scheduler.disable();
+
+    renderDaemonDisabled(ctx.outputMode);
+  });
+
+const daemonStatusCommand = new Command()
+  .name("status")
+  .description("Show the status of the swamp serve daemon")
+  .example("Check daemon status", "swamp serve daemon status")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "serve",
+      "daemon",
+      "status",
+    ]);
+    const mode = await resolveServiceMode();
+    const scheduler = await createServiceScheduler({ mode });
+
+    const status = await scheduler.status();
+
+    renderDaemonStatus(status, ctx.outputMode);
+  });
+
+const daemonCommand = new Command()
+  .name("daemon")
+  .description("Manage swamp serve as a system daemon")
+  .action(groupCommandAction)
+  .command("enable", daemonEnableCommand)
+  .command("disable", daemonDisableCommand)
+  .command("status", daemonStatusCommand);
 
 export const serveCommand = new Command()
   .name("serve")
@@ -748,4 +941,5 @@ export const serveCommand = new Command()
     await server.finished;
 
     repoContext.catalogStore.close();
-  });
+  })
+  .command("daemon", daemonCommand);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -358,7 +358,7 @@ const daemonStatusCommand = new Command()
 
 const daemonCommand = new Command()
   .name("daemon")
-  .description("Manage swamp serve as a system daemon")
+  .description("Manage swamp serve as a system daemon (EXPERIMENTAL)")
   .action(groupCommandAction)
   .command("enable", daemonEnableCommand)
   .command("disable", daemonDisableCommand)

--- a/src/cli/commands/serve_daemon_test.ts
+++ b/src/cli/commands/serve_daemon_test.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collectServeExtraArgs } from "./serve.ts";
+
+Deno.test("collectServeExtraArgs: returns empty for defaults", () => {
+  const args = collectServeExtraArgs({
+    schedule: true,
+    grantReload: "manual",
+    authMode: "none",
+  });
+  assertEquals(args, []);
+});
+
+Deno.test("collectServeExtraArgs: includes --no-schedule", () => {
+  const args = collectServeExtraArgs({ schedule: false });
+  assertEquals(args, ["--no-schedule"]);
+});
+
+Deno.test("collectServeExtraArgs: includes --grant-reload when not manual", () => {
+  const args = collectServeExtraArgs({ grantReload: "auto" });
+  assertEquals(args, ["--grant-reload", "auto"]);
+});
+
+Deno.test("collectServeExtraArgs: skips --grant-reload when manual", () => {
+  const args = collectServeExtraArgs({ grantReload: "manual" });
+  assertEquals(args, []);
+});
+
+Deno.test("collectServeExtraArgs: includes multiple webhooks", () => {
+  const args = collectServeExtraArgs({
+    webhook: ["/hooks/a:wf1:secret1", "/hooks/b:wf2:secret2"],
+  });
+  assertEquals(args, [
+    "--webhook",
+    "/hooks/a:wf1:secret1",
+    "--webhook",
+    "/hooks/b:wf2:secret2",
+  ]);
+});
+
+Deno.test("collectServeExtraArgs: includes --auth-mode when not none", () => {
+  const args = collectServeExtraArgs({ authMode: "token" });
+  assertEquals(args, ["--auth-mode", "token"]);
+});
+
+Deno.test("collectServeExtraArgs: skips --auth-mode none", () => {
+  const args = collectServeExtraArgs({ authMode: "none" });
+  assertEquals(args, []);
+});
+
+Deno.test("collectServeExtraArgs: includes --admins", () => {
+  const args = collectServeExtraArgs({ admins: "user:oauth|admin-1" });
+  assertEquals(args, ["--admins", "user:oauth|admin-1"]);
+});
+
+Deno.test("collectServeExtraArgs: includes OAuth flags", () => {
+  const args = collectServeExtraArgs({
+    allowedCollectives: "team-a,team-b",
+    allowedUsers: "user1,user2",
+    oauthProvider: "https://auth.example.com",
+    oauthClientId: "client-123",
+    groupsField: "groups",
+  });
+  assertEquals(args, [
+    "--allowed-collectives",
+    "team-a,team-b",
+    "--allowed-users",
+    "user1,user2",
+    "--oauth-provider",
+    "https://auth.example.com",
+    "--oauth-client-id",
+    "client-123",
+    "--groups-field",
+    "groups",
+  ]);
+});
+
+Deno.test("collectServeExtraArgs: includes --trust-proxy", () => {
+  const args = collectServeExtraArgs({ trustProxy: true });
+  assertEquals(args, ["--trust-proxy"]);
+});
+
+Deno.test("collectServeExtraArgs: combines multiple flags", () => {
+  const args = collectServeExtraArgs({
+    schedule: false,
+    authMode: "oauth",
+    trustProxy: true,
+    admins: "user:oauth|admin-1",
+  });
+  assertEquals(args, [
+    "--no-schedule",
+    "--auth-mode",
+    "oauth",
+    "--admins",
+    "user:oauth|admin-1",
+    "--trust-proxy",
+  ]);
+});

--- a/src/domain/serve/service_config.ts
+++ b/src/domain/serve/service_config.ts
@@ -1,0 +1,29 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface ServiceConfig {
+  readonly binaryPath: string;
+  readonly repoDir: string;
+  readonly port: number;
+  readonly host: string;
+  readonly certFile?: string;
+  readonly keyFile?: string;
+  readonly extraArgs?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+}

--- a/src/domain/serve/service_scheduler.ts
+++ b/src/domain/serve/service_scheduler.ts
@@ -1,0 +1,33 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ServiceConfig } from "./service_config.ts";
+
+export interface ServiceStatus {
+  readonly enabled: boolean;
+  readonly running: boolean;
+  readonly pid?: number;
+  readonly logPath?: string;
+}
+
+export interface ServiceScheduler {
+  enable(config: ServiceConfig): Promise<void>;
+  disable(): Promise<void>;
+  status(): Promise<ServiceStatus>;
+}

--- a/src/infrastructure/daemon/launchd_service_scheduler.ts
+++ b/src/infrastructure/daemon/launchd_service_scheduler.ts
@@ -1,0 +1,231 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type { ServiceConfig } from "../../domain/serve/service_config.ts";
+import type {
+  ServiceScheduler,
+  ServiceStatus,
+} from "../../domain/serve/service_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import { escapeXml } from "../update/launchd_scheduler.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+import { homeDirectory } from "../persistence/paths.ts";
+
+const LABEL = "club.swamp.serve";
+
+function agentPlistPath(): string {
+  return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
+}
+
+function daemonPlistPath(): string {
+  return join("/Library", "LaunchDaemons", `${LABEL}.plist`);
+}
+
+function plistPathForMode(mode: LaunchdMode): string {
+  return mode === "agent" ? agentPlistPath() : daemonPlistPath();
+}
+
+export function serveLogDir(mode: LaunchdMode = "agent"): string {
+  if (mode === "daemon") {
+    return join("/var", "log", "swamp");
+  }
+  return join(homeDirectory(), "Library", "Logs", "swamp");
+}
+
+export function buildServePlist(
+  config: ServiceConfig,
+  mode: LaunchdMode = "agent",
+): string {
+  const escapedBinary = escapeXml(config.binaryPath);
+  const logDir = serveLogDir(mode);
+  const stdoutLog = escapeXml(join(logDir, "serve.stdout.log"));
+  const stderrLog = escapeXml(join(logDir, "serve.stderr.log"));
+  const escapedRepoDir = escapeXml(config.repoDir);
+
+  const userNameEntry = mode === "daemon"
+    ? `\n  <key>UserName</key>\n  <string>root</string>`
+    : "";
+
+  const args = [
+    `    <string>${escapedBinary}</string>`,
+    `    <string>serve</string>`,
+    `    <string>--repo-dir</string>`,
+    `    <string>${escapedRepoDir}</string>`,
+    `    <string>--port</string>`,
+    `    <string>${config.port}</string>`,
+    `    <string>--host</string>`,
+    `    <string>${escapeXml(config.host)}</string>`,
+  ];
+
+  if (config.certFile) {
+    args.push(`    <string>--cert-file</string>`);
+    args.push(`    <string>${escapeXml(config.certFile)}</string>`);
+  }
+  if (config.keyFile) {
+    args.push(`    <string>--key-file</string>`);
+    args.push(`    <string>${escapeXml(config.keyFile)}</string>`);
+  }
+  if (config.extraArgs) {
+    for (const arg of config.extraArgs) {
+      args.push(`    <string>${escapeXml(arg)}</string>`);
+    }
+  }
+
+  let envBlock = "";
+  if (config.env && Object.keys(config.env).length > 0) {
+    const entries = Object.entries(config.env)
+      .map(
+        ([k, v]) =>
+          `    <key>${escapeXml(k)}</key>\n    <string>${
+            escapeXml(v)
+          }</string>`,
+      )
+      .join("\n");
+    envBlock =
+      `\n  <key>EnvironmentVariables</key>\n  <dict>\n${entries}\n  </dict>`;
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.join("\n")}
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${escapedRepoDir}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>${userNameEntry}${envBlock}
+  <key>StandardOutPath</key>
+  <string>${stdoutLog}</string>
+  <key>StandardErrorPath</key>
+  <string>${stderrLog}</string>
+</dict>
+</plist>
+`;
+}
+
+async function getUid(): Promise<string> {
+  const cmd = new Deno.Command("id", {
+    args: ["-u"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+export class LaunchdServiceScheduler implements ServiceScheduler {
+  readonly mode: LaunchdMode;
+
+  constructor(mode: LaunchdMode = "agent") {
+    this.mode = mode;
+  }
+
+  async enable(config: ServiceConfig): Promise<void> {
+    await this.disable();
+
+    const path = plistPathForMode(this.mode);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.mkdir(serveLogDir(this.mode), { recursive: true });
+    await atomicWriteTextFile(path, buildServePlist(config, this.mode), {
+      mode: 0o600,
+    });
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["bootstrap", domain, path],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) {
+      throw new Error(
+        `launchctl bootstrap failed with exit code ${result.code}`,
+      );
+    }
+  }
+
+  async disable(): Promise<void> {
+    const path = plistPathForMode(this.mode);
+    try {
+      await Deno.stat(path);
+    } catch {
+      return;
+    }
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["bootout", `${domain}/${LABEL}`],
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+
+    await Deno.remove(path).catch(() => {});
+  }
+
+  async status(): Promise<ServiceStatus> {
+    const path = plistPathForMode(this.mode);
+    try {
+      await Deno.stat(path);
+    } catch {
+      return { enabled: false, running: false };
+    }
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["print", `${domain}/${LABEL}`],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    const output = new TextDecoder().decode(result.stdout);
+
+    const running = result.success;
+    let pid: number | undefined;
+    const pidMatch = output.match(/pid\s*=\s*(\d+)/);
+    if (pidMatch) {
+      pid = parseInt(pidMatch[1], 10);
+    }
+
+    return {
+      enabled: true,
+      running,
+      pid,
+      logPath: serveLogDir(this.mode),
+    };
+  }
+
+  private async launchctlDomain(): Promise<string> {
+    if (this.mode === "daemon") {
+      return "system";
+    }
+    const uid = await getUid();
+    return `gui/${uid}`;
+  }
+}

--- a/src/infrastructure/daemon/launchd_service_scheduler_test.ts
+++ b/src/infrastructure/daemon/launchd_service_scheduler_test.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { assertFalse } from "@std/assert/false";
+import { buildServePlist } from "./launchd_service_scheduler.ts";
+import type { ServiceConfig } from "../../domain/serve/service_config.ts";
+
+const baseConfig: ServiceConfig = {
+  binaryPath: "/usr/local/bin/swamp",
+  repoDir: "/home/user/myrepo",
+  port: 9090,
+  host: "127.0.0.1",
+};
+
+Deno.test("buildServePlist: includes KeepAlive", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<key>KeepAlive</key>");
+  assertStringIncludes(plist, "<true/>");
+});
+
+Deno.test("buildServePlist: includes RunAtLoad", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<key>RunAtLoad</key>");
+});
+
+Deno.test("buildServePlist: includes ThrottleInterval", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<key>ThrottleInterval</key>");
+  assertStringIncludes(plist, "<integer>10</integer>");
+});
+
+Deno.test("buildServePlist: includes label club.swamp.serve", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<string>club.swamp.serve</string>");
+});
+
+Deno.test("buildServePlist: includes working directory", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<key>WorkingDirectory</key>");
+  assertStringIncludes(plist, "<string>/home/user/myrepo</string>");
+});
+
+Deno.test("buildServePlist: includes port and host args", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<string>--port</string>");
+  assertStringIncludes(plist, "<string>9090</string>");
+  assertStringIncludes(plist, "<string>--host</string>");
+  assertStringIncludes(plist, "<string>127.0.0.1</string>");
+});
+
+Deno.test("buildServePlist: includes repo-dir arg", () => {
+  const plist = buildServePlist(baseConfig);
+  assertStringIncludes(plist, "<string>--repo-dir</string>");
+  assertStringIncludes(plist, "<string>/home/user/myrepo</string>");
+});
+
+Deno.test("buildServePlist: includes cert and key args when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    certFile: "/path/to/cert.pem",
+    keyFile: "/path/to/key.pem",
+  };
+  const plist = buildServePlist(config);
+  assertStringIncludes(plist, "<string>--cert-file</string>");
+  assertStringIncludes(plist, "<string>/path/to/cert.pem</string>");
+  assertStringIncludes(plist, "<string>--key-file</string>");
+  assertStringIncludes(plist, "<string>/path/to/key.pem</string>");
+});
+
+Deno.test("buildServePlist: omits cert/key args when not provided", () => {
+  const plist = buildServePlist(baseConfig);
+  assertFalse(plist.includes("--cert-file"));
+  assertFalse(plist.includes("--key-file"));
+});
+
+Deno.test("buildServePlist: includes environment variables when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    env: { MY_VAR: "hello" },
+  };
+  const plist = buildServePlist(config);
+  assertStringIncludes(plist, "<key>EnvironmentVariables</key>");
+  assertStringIncludes(plist, "<key>MY_VAR</key>");
+  assertStringIncludes(plist, "<string>hello</string>");
+});
+
+Deno.test("buildServePlist: omits env block when no env vars", () => {
+  const plist = buildServePlist(baseConfig);
+  assertFalse(plist.includes("EnvironmentVariables"));
+});
+
+Deno.test("buildServePlist: daemon mode includes UserName root", () => {
+  const plist = buildServePlist(baseConfig, "daemon");
+  assertStringIncludes(plist, "<key>UserName</key>");
+  assertStringIncludes(plist, "<string>root</string>");
+});
+
+Deno.test("buildServePlist: agent mode omits UserName", () => {
+  const plist = buildServePlist(baseConfig, "agent");
+  assertFalse(plist.includes("UserName"));
+});
+
+Deno.test("buildServePlist: escapes XML special characters", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    binaryPath: '/path/to/swamp "quoted" & <special>',
+  };
+  const plist = buildServePlist(config);
+  assertStringIncludes(plist, "&amp;");
+  assertStringIncludes(plist, "&lt;special&gt;");
+  assertStringIncludes(plist, "&quot;quoted&quot;");
+});
+
+Deno.test("buildServePlist: includes extraArgs when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    extraArgs: ["--auth-mode", "token", "--no-schedule"],
+  };
+  const plist = buildServePlist(config);
+  assertStringIncludes(plist, "<string>--auth-mode</string>");
+  assertStringIncludes(plist, "<string>token</string>");
+  assertStringIncludes(plist, "<string>--no-schedule</string>");
+});
+
+Deno.test("buildServePlist: omits extraArgs when not provided", () => {
+  const plist = buildServePlist(baseConfig);
+  assertFalse(plist.includes("--auth-mode"));
+  assertFalse(plist.includes("--no-schedule"));
+});
+
+Deno.test("buildServePlist: does not include StartInterval", () => {
+  const plist = buildServePlist(baseConfig);
+  assertFalse(plist.includes("StartInterval"));
+});

--- a/src/infrastructure/daemon/service_scheduler_factory.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory.ts
@@ -1,0 +1,88 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ServiceScheduler } from "../../domain/serve/service_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import { UserError } from "../../domain/errors.ts";
+import { detectBinaryOwnership } from "../update/scheduler_factory.ts";
+import { LaunchdServiceScheduler } from "./launchd_service_scheduler.ts";
+import { SystemdServiceScheduler } from "./systemd_service_scheduler.ts";
+
+async function hasSystemctl(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("systemctl", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    return result.success;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveServiceMode(): Promise<LaunchdMode> {
+  let currentUid: number | null = null;
+  let binaryUid: number | null = null;
+  try {
+    currentUid = Deno.uid();
+    const stat = await Deno.stat(Deno.execPath());
+    binaryUid = stat.uid;
+  } catch {
+    return "agent";
+  }
+
+  const result = detectBinaryOwnership(binaryUid, currentUid);
+  if (result === "foreign") {
+    throw new UserError(
+      `The swamp binary at ${Deno.execPath()} is owned by uid ${binaryUid}, ` +
+        `not the current user or root.\n` +
+        `Fix the installation so the binary is owned by your user or root:\n\n` +
+        `  Option 1: sudo chown $(whoami) ${Deno.execPath()}\n` +
+        `  Option 2: sudo chown root ${Deno.execPath()}`,
+    );
+  }
+  return result;
+}
+
+export interface ServiceSchedulerOptions {
+  mode?: LaunchdMode;
+}
+
+export async function createServiceScheduler(
+  options?: ServiceSchedulerOptions,
+): Promise<ServiceScheduler> {
+  const mode = options?.mode ?? "agent";
+  switch (Deno.build.os) {
+    case "darwin":
+      return new LaunchdServiceScheduler(mode);
+    case "linux":
+      if (await hasSystemctl()) {
+        return new SystemdServiceScheduler(mode);
+      }
+      throw new UserError(
+        "swamp serve daemon requires systemd on Linux, but systemctl was not found",
+      );
+    default:
+      throw new UserError(
+        `swamp serve daemon is not yet supported on ${Deno.build.os}`,
+      );
+  }
+}

--- a/src/infrastructure/daemon/service_scheduler_factory.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory.ts
@@ -78,7 +78,9 @@ export async function createServiceScheduler(
         return new SystemdServiceScheduler(mode);
       }
       throw new UserError(
-        "swamp serve daemon requires systemd on Linux, but systemctl was not found",
+        "swamp serve daemon currently requires systemd on Linux, but systemctl was not found.\n" +
+          "If you need support for your init system, please file a feature request:\n\n" +
+          "  swamp issue feature",
       );
     default:
       throw new UserError(

--- a/src/infrastructure/daemon/systemd_service_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler.ts
@@ -36,7 +36,10 @@ function servicePath(mode: LaunchdMode = "agent"): string {
   return join(systemdUnitDir(mode), `${UNIT_NAME}.service`);
 }
 
-export function buildServeService(config: ServiceConfig): string {
+export function buildServeService(
+  config: ServiceConfig,
+  mode: LaunchdMode = "agent",
+): string {
   const escapedBinary = escapeSystemdPath(config.binaryPath);
   const escapedRepoDir = escapeSystemdPath(config.repoDir);
 
@@ -48,7 +51,7 @@ export function buildServeService(config: ServiceConfig): string {
     "--port",
     String(config.port),
     "--host",
-    config.host,
+    `"${escapeSystemdPath(config.host)}"`,
   ];
 
   if (config.certFile) {
@@ -59,7 +62,7 @@ export function buildServeService(config: ServiceConfig): string {
   }
   if (config.extraArgs) {
     for (const arg of config.extraArgs) {
-      args.push(arg);
+      args.push(`"${escapeSystemdPath(arg)}"`);
     }
   }
 
@@ -86,7 +89,7 @@ Restart=always
 RestartSec=10${envBlock}
 
 [Install]
-WantedBy=default.target
+WantedBy=${mode === "daemon" ? "multi-user.target" : "default.target"}
 `;
 }
 
@@ -122,7 +125,7 @@ export class SystemdServiceScheduler implements ServiceScheduler {
 
     await atomicWriteTextFile(
       servicePath(this.mode),
-      buildServeService(config),
+      buildServeService(config, this.mode),
       { mode: 0o600 },
     );
 
@@ -176,10 +179,15 @@ export class SystemdServiceScheduler implements ServiceScheduler {
       }
     }
 
+    const logHint = this.mode === "agent"
+      ? `journalctl --user -u ${UNIT_NAME}`
+      : `journalctl -u ${UNIT_NAME}`;
+
     return {
       enabled: true,
       running,
       pid,
+      logPath: logHint,
     };
   }
 }

--- a/src/infrastructure/daemon/systemd_service_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler.ts
@@ -1,0 +1,185 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { ServiceConfig } from "../../domain/serve/service_config.ts";
+import type {
+  ServiceScheduler,
+  ServiceStatus,
+} from "../../domain/serve/service_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import {
+  escapeSystemdPath,
+  systemdUnitDir,
+} from "../update/systemd_scheduler.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+
+const UNIT_NAME = "swamp-serve";
+
+function servicePath(mode: LaunchdMode = "agent"): string {
+  return join(systemdUnitDir(mode), `${UNIT_NAME}.service`);
+}
+
+export function buildServeService(config: ServiceConfig): string {
+  const escapedBinary = escapeSystemdPath(config.binaryPath);
+  const escapedRepoDir = escapeSystemdPath(config.repoDir);
+
+  const args = [
+    `"${escapedBinary}"`,
+    "serve",
+    "--repo-dir",
+    `"${escapedRepoDir}"`,
+    "--port",
+    String(config.port),
+    "--host",
+    config.host,
+  ];
+
+  if (config.certFile) {
+    args.push("--cert-file", `"${escapeSystemdPath(config.certFile)}"`);
+  }
+  if (config.keyFile) {
+    args.push("--key-file", `"${escapeSystemdPath(config.keyFile)}"`);
+  }
+  if (config.extraArgs) {
+    for (const arg of config.extraArgs) {
+      args.push(arg);
+    }
+  }
+
+  const envLines: string[] = [];
+  if (config.env) {
+    for (const [k, v] of Object.entries(config.env)) {
+      envLines.push(
+        `Environment="${escapeSystemdPath(k)}=${escapeSystemdPath(v)}"`,
+      );
+    }
+  }
+  const envBlock = envLines.length > 0 ? "\n" + envLines.join("\n") : "";
+
+  return `[Unit]
+Description=Swamp serve daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${args.join(" ")}
+WorkingDirectory=${escapedRepoDir}
+Restart=always
+RestartSec=10${envBlock}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+async function systemctl(
+  mode: LaunchdMode,
+  ...args: string[]
+): Promise<{ success: boolean; stdout: string }> {
+  const modeArgs = mode === "agent" ? ["--user"] : [];
+  const cmd = new Deno.Command("systemctl", {
+    args: [...modeArgs, ...args],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return {
+    success: result.success,
+    stdout: new TextDecoder().decode(result.stdout).trim(),
+  };
+}
+
+export class SystemdServiceScheduler implements ServiceScheduler {
+  readonly mode: LaunchdMode;
+
+  constructor(mode: LaunchdMode = "agent") {
+    this.mode = mode;
+  }
+
+  async enable(config: ServiceConfig): Promise<void> {
+    await this.disable();
+
+    const dir = systemdUnitDir(this.mode);
+    await Deno.mkdir(dir, { recursive: true });
+
+    await atomicWriteTextFile(
+      servicePath(this.mode),
+      buildServeService(config),
+      { mode: 0o600 },
+    );
+
+    await systemctl(this.mode, "daemon-reload");
+    const result = await systemctl(
+      this.mode,
+      "enable",
+      "--now",
+      `${UNIT_NAME}.service`,
+    );
+    if (!result.success) {
+      throw new Error(
+        `Failed to enable systemd service ${UNIT_NAME}.service`,
+      );
+    }
+  }
+
+  async disable(): Promise<void> {
+    await systemctl(this.mode, "disable", "--now", `${UNIT_NAME}.service`);
+    await systemctl(this.mode, "daemon-reload");
+
+    await Deno.remove(servicePath(this.mode)).catch(() => {});
+  }
+
+  async status(): Promise<ServiceStatus> {
+    try {
+      await Deno.stat(servicePath(this.mode));
+    } catch {
+      return { enabled: false, running: false };
+    }
+
+    const isActive = await systemctl(
+      this.mode,
+      "is-active",
+      `${UNIT_NAME}.service`,
+    );
+    const running = isActive.stdout === "active";
+
+    let pid: number | undefined;
+    const showPid = await systemctl(
+      this.mode,
+      "show",
+      "--property=MainPID",
+      `${UNIT_NAME}.service`,
+    );
+    const pidMatch = showPid.stdout.match(/MainPID=(\d+)/);
+    if (pidMatch) {
+      const parsed = parseInt(pidMatch[1], 10);
+      if (parsed > 0) {
+        pid = parsed;
+      }
+    }
+
+    return {
+      enabled: true,
+      running,
+      pid,
+    };
+  }
+}

--- a/src/infrastructure/daemon/systemd_service_scheduler_test.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler_test.ts
@@ -101,10 +101,15 @@ Deno.test("buildServeService: includes network ordering", () => {
   assertStringIncludes(unit, "Wants=network-online.target");
 });
 
-Deno.test("buildServeService: includes install section", () => {
-  const unit = buildServeService(baseConfig);
+Deno.test("buildServeService: agent mode uses default.target", () => {
+  const unit = buildServeService(baseConfig, "agent");
   assertStringIncludes(unit, "[Install]");
   assertStringIncludes(unit, "WantedBy=default.target");
+});
+
+Deno.test("buildServeService: daemon mode uses multi-user.target", () => {
+  const unit = buildServeService(baseConfig, "daemon");
+  assertStringIncludes(unit, "WantedBy=multi-user.target");
 });
 
 Deno.test("buildServeService: includes extraArgs when provided", () => {
@@ -113,7 +118,21 @@ Deno.test("buildServeService: includes extraArgs when provided", () => {
     extraArgs: ["--auth-mode", "token", "--no-schedule"],
   };
   const unit = buildServeService(config);
-  assertStringIncludes(unit, "--auth-mode token --no-schedule");
+  assertStringIncludes(unit, '"--auth-mode" "token" "--no-schedule"');
+});
+
+Deno.test("buildServeService: escapes percent specifiers in extraArgs", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    extraArgs: ["--webhook", "/hooks/gh:wf:secret%nwith%%percents"],
+  };
+  const unit = buildServeService(config);
+  assertStringIncludes(unit, "secret%%nwith%%%%percents");
+});
+
+Deno.test("buildServeService: escapes and quotes host", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, '"127.0.0.1"');
 });
 
 Deno.test("buildServeService: omits extraArgs when not provided", () => {

--- a/src/infrastructure/daemon/systemd_service_scheduler_test.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler_test.ts
@@ -1,0 +1,129 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { assertFalse } from "@std/assert/false";
+import { buildServeService } from "./systemd_service_scheduler.ts";
+import type { ServiceConfig } from "../../domain/serve/service_config.ts";
+
+const baseConfig: ServiceConfig = {
+  binaryPath: "/usr/local/bin/swamp",
+  repoDir: "/home/user/myrepo",
+  port: 9090,
+  host: "127.0.0.1",
+};
+
+Deno.test("buildServeService: includes Restart=always", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "Restart=always");
+});
+
+Deno.test("buildServeService: includes RestartSec", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "RestartSec=10");
+});
+
+Deno.test("buildServeService: includes Type=simple", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "Type=simple");
+});
+
+Deno.test("buildServeService: includes working directory", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "WorkingDirectory=/home/user/myrepo");
+});
+
+Deno.test("buildServeService: includes ExecStart with serve args", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "ExecStart=");
+  assertStringIncludes(unit, "serve");
+  assertStringIncludes(unit, "--port");
+  assertStringIncludes(unit, "9090");
+  assertStringIncludes(unit, "--host");
+  assertStringIncludes(unit, "127.0.0.1");
+});
+
+Deno.test("buildServeService: includes repo-dir arg", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "--repo-dir");
+});
+
+Deno.test("buildServeService: includes cert and key args when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    certFile: "/path/to/cert.pem",
+    keyFile: "/path/to/key.pem",
+  };
+  const unit = buildServeService(config);
+  assertStringIncludes(unit, "--cert-file");
+  assertStringIncludes(unit, "--key-file");
+});
+
+Deno.test("buildServeService: omits cert/key args when not provided", () => {
+  const unit = buildServeService(baseConfig);
+  assertFalse(unit.includes("--cert-file"));
+  assertFalse(unit.includes("--key-file"));
+});
+
+Deno.test("buildServeService: includes environment variables when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    env: { MY_VAR: "hello" },
+  };
+  const unit = buildServeService(config);
+  assertStringIncludes(unit, 'Environment="MY_VAR=hello"');
+});
+
+Deno.test("buildServeService: omits env block when no env vars", () => {
+  const unit = buildServeService(baseConfig);
+  assertFalse(unit.includes("Environment="));
+});
+
+Deno.test("buildServeService: includes network ordering", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "After=network-online.target");
+  assertStringIncludes(unit, "Wants=network-online.target");
+});
+
+Deno.test("buildServeService: includes install section", () => {
+  const unit = buildServeService(baseConfig);
+  assertStringIncludes(unit, "[Install]");
+  assertStringIncludes(unit, "WantedBy=default.target");
+});
+
+Deno.test("buildServeService: includes extraArgs when provided", () => {
+  const config: ServiceConfig = {
+    ...baseConfig,
+    extraArgs: ["--auth-mode", "token", "--no-schedule"],
+  };
+  const unit = buildServeService(config);
+  assertStringIncludes(unit, "--auth-mode token --no-schedule");
+});
+
+Deno.test("buildServeService: omits extraArgs when not provided", () => {
+  const unit = buildServeService(baseConfig);
+  assertFalse(unit.includes("--auth-mode"));
+  assertFalse(unit.includes("--no-schedule"));
+});
+
+Deno.test("buildServeService: does not include OnCalendar or timer config", () => {
+  const unit = buildServeService(baseConfig);
+  assertFalse(unit.includes("OnCalendar"));
+  assertFalse(unit.includes("[Timer]"));
+});

--- a/src/presentation/output/serve_daemon_output.ts
+++ b/src/presentation/output/serve_daemon_output.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { ServiceStatus } from "../../domain/serve/service_scheduler.ts";
+import type { OutputMode } from "./output.ts";
+
+export function renderDaemonEnabled(mode: OutputMode): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify({ enabled: true }, null, 2));
+  } else {
+    writeOutput(
+      `${green("✓")} Daemon enabled — swamp serve will start automatically`,
+    );
+  }
+}
+
+export function renderDaemonDisabled(mode: OutputMode): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify({ enabled: false }, null, 2));
+  } else {
+    writeOutput(`${green("✓")} Daemon disabled — service definition removed`);
+  }
+}
+
+export function renderDaemonStatus(
+  status: ServiceStatus,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify(status, null, 2));
+    return;
+  }
+
+  if (!status.enabled) {
+    writeOutput(`${dim("Status:")} ${dim("not configured")}`);
+    writeOutput(
+      `${dim("Run")} ${bold("swamp serve daemon enable")} ${
+        dim("to set up the daemon")
+      }`,
+    );
+    return;
+  }
+
+  const stateLabel = status.running ? green("running") : red("stopped");
+
+  writeOutput(`${dim("Status:")}  ${stateLabel}`);
+  writeOutput(`${dim("Enabled:")} ${green("yes")}`);
+  if (status.pid !== undefined) {
+    writeOutput(`${dim("PID:")}     ${String(status.pid)}`);
+  }
+  if (status.logPath) {
+    writeOutput(`${dim("Logs:")}    ${status.logPath}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `swamp serve daemon enable/disable/status` subcommand group (marked EXPERIMENTAL) to manage swamp serve as a supervised system daemon via macOS launchd or Linux systemd. Closes swamp-club#715.

- **`swamp serve daemon enable`** generates and registers a platform-native service definition (LaunchAgent plist or systemd user service) with all serve flags baked in (port, host, TLS, auth mode, webhooks, admins, OAuth, etc.)
- **`swamp serve daemon disable`** unloads and removes the service definition
- **`swamp serve daemon status`** reports enabled/running state, PID, and log path — supports both log and JSON output modes
- Service files written with `0600` permissions since webhook secrets may be present in args
- macOS plist uses `KeepAlive` + `ThrottleInterval` (10s) to auto-restart and mitigate EADDRINUSE races
- Linux systemd unit uses `Restart=always` + `RestartSec=10`
- Follows existing `LaunchdScheduler`/`SystemdScheduler` patterns from autoupdate; new code lives in `src/infrastructure/daemon/` to avoid collision with existing `src/serve/`
- `resolveServiceMode()` determines agent vs daemon mode based on binary ownership, independent of autoupdate state
- Non-systemd Linux shows a clear error directing users to `swamp issue feature`

### Verification note

macOS launchd path verified end-to-end (enable → status with PID → curl health endpoint → disable). Linux systemd unit generation verified in Docker (file content, permissions, status, disable) but `systemctl enable --now` cannot be tested without systemd as PID 1. The systemd integration follows the same proven pattern as the existing `SystemdScheduler` for autoupdate. Would appreciate a Linux smoke test of the full enable/disable cycle before removing the EXPERIMENTAL tag.

## Test Plan

- 32 unit tests covering plist and systemd unit generation (KeepAlive, Restart, ThrottleInterval, extraArgs, env vars, XML escaping, agent/daemon modes)
- Full end-to-end lifecycle verified on macOS: enable → status (running, PID) → curl health endpoint → disable → status (not configured)
- Docker test on Alpine (no systemctl): verified error message with feature request guidance
- Docker test on Debian (with systemctl): verified unit file generation, status, and disable lifecycle
- Verified plist file permissions are `0600` (owner-only)
- Verified bare `swamp serve` still works unchanged
- All 7820 existing tests pass, no regressions
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)