### PR TITLE
feat(data): accept --model/--name flags on all data subcommands (swamp-club#697)

### DIFF
--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -64,6 +64,10 @@ export const dataDeleteCommand = new Command()
     "swamp data delete my-server hetzner-state",
   )
   .example(
+    "Delete using flags",
+    "swamp data delete --model my-server --name hetzner-state",
+  )
+  .example(
     "Delete a specific version",
     "swamp data delete my-server hetzner-state --version 2",
   )
@@ -71,19 +75,36 @@ export const dataDeleteCommand = new Command()
     "Skip the confirmation prompt",
     "swamp data delete my-server hetzner-state --force",
   )
-  .arguments("<model_id_or_name:string> <data_name:string>")
+  .arguments("[model_id_or_name:string] [data_name:string]")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--model <model:string>",
+    "Model name or ID (alternative to positional argument)",
+  )
+  .option(
+    "--name <name:string>",
+    "Data name (alternative to positional argument)",
   )
   .option("--version <n:integer>", "Delete a specific version")
   .option("-f, --force", "Skip confirmation prompt")
   .action(
     async function (
       options: AnyOptions,
-      modelIdOrName: string,
-      dataName: string,
+      positionalModel?: string,
+      positionalName?: string,
     ) {
+      const modelIdOrName = (options.model as string | undefined) ??
+        positionalModel;
+      const dataName = (options.name as string | undefined) ?? positionalName;
+
+      if (!modelIdOrName || !dataName) {
+        throw new UserError(
+          "Both model and data name are required. Use positional arguments (swamp data delete <model> <name>) or flags (--model <model> --name <name>).",
+        );
+      }
       const cliCtx = createContext(options as GlobalOptions, [
         "data",
         "delete",

--- a/src/cli/commands/data_delete_test.ts
+++ b/src/cli/commands/data_delete_test.ts
@@ -66,8 +66,22 @@ Deno.test("dataDeleteCommand has --force option", async () => {
   assertEquals(forceOpt !== undefined, true);
 });
 
-Deno.test("dataDeleteCommand requires two arguments", async () => {
+Deno.test("dataDeleteCommand accepts two arguments", async () => {
   const { dataDeleteCommand } = await import("./data_delete.ts");
   const args = dataDeleteCommand.getArguments();
   assertEquals(args.length, 2);
+});
+
+Deno.test("dataDeleteCommand has --model option", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const options = dataDeleteCommand.getOptions();
+  const modelOpt = options.find((o) => o.name === "model");
+  assertEquals(modelOpt !== undefined, true);
+});
+
+Deno.test("dataDeleteCommand has --name option", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const options = dataDeleteCommand.getOptions();
+  const nameOpt = options.find((o) => o.name === "name");
+  assertEquals(nameOpt !== undefined, true);
 });

--- a/src/cli/commands/data_get.ts
+++ b/src/cli/commands/data_get.ts
@@ -52,6 +52,10 @@ export const dataGetCommand = withRemoteOptions(
     .description("Get data by model and name, or by workflow")
     .example("Get latest data", "swamp data get my-server system-info")
     .example(
+      "Get using flags",
+      "swamp data get --model my-server --name system-info",
+    )
+    .example(
       "Get a specific version",
       "swamp data get my-server system-info --version 2",
     )
@@ -73,6 +77,14 @@ export const dataGetCommand = withRemoteOptions(
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
     .option(
+      "--model <model:string>",
+      "Model name or ID (alternative to positional argument)",
+    )
+    .option(
+      "--name <name:string>",
+      "Data name (alternative to positional argument)",
+    )
+    .option(
       "--version <version:number>",
       "Specific version (defaults to latest)",
     )
@@ -92,9 +104,13 @@ export const dataGetCommand = withRemoteOptions(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   async function (
     options: AnyOptions,
-    modelIdOrName?: string,
-    dataName?: string,
+    positionalModel?: string,
+    positionalName?: string,
   ) {
+    const modelIdOrName = (options.model as string | undefined) ??
+      positionalModel;
+    const dataName = (options.name as string | undefined) ?? positionalName;
+
     const cliCtx = createContext(options as GlobalOptions, ["data", "get"]);
 
     const server = resolveServeUrl(options.server as string | undefined);

--- a/src/cli/commands/data_get_test.ts
+++ b/src/cli/commands/data_get_test.ts
@@ -72,3 +72,17 @@ Deno.test("dataGetCommand has --no-content option", async () => {
   const contentOpt = options.find((o) => o.name === "no-content");
   assertEquals(contentOpt !== undefined, true);
 });
+
+Deno.test("dataGetCommand has --model option", async () => {
+  const { dataGetCommand } = await import("./data_get.ts");
+  const options = dataGetCommand.getOptions();
+  const modelOpt = options.find((o) => o.name === "model");
+  assertEquals(modelOpt !== undefined, true);
+});
+
+Deno.test("dataGetCommand has --name option", async () => {
+  const { dataGetCommand } = await import("./data_get.ts");
+  const options = dataGetCommand.getOptions();
+  const nameOpt = options.find((o) => o.name === "name");
+  assertEquals(nameOpt !== undefined, true);
+});

--- a/src/cli/commands/data_list.ts
+++ b/src/cli/commands/data_list.ts
@@ -48,12 +48,17 @@ export const dataListCommand = withRemoteOptions(
     .name("list")
     .description("List all data for a model or workflow, grouped by type")
     .example("List all data for a model", "swamp data list my-server")
+    .example("List using flag", "swamp data list --model my-server")
     .example("Filter by type", "swamp data list my-server --type output")
     .example("List workflow run data", "swamp data list --workflow deploy")
     .arguments("[model_id_or_name:model_name]")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--model <model:string>",
+      "Model name or ID (alternative to positional argument)",
     )
     .option(
       "--type <type:string>",
@@ -69,7 +74,9 @@ export const dataListCommand = withRemoteOptions(
     ),
 ).action(
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
-  async function (options: AnyOptions, modelIdOrName?: string) {
+  async function (options: AnyOptions, positionalModel?: string) {
+    const modelIdOrName = (options.model as string | undefined) ??
+      positionalModel;
     const cliCtx = createContext(options as GlobalOptions, ["data", "list"]);
 
     const server = resolveServeUrl(options.server as string | undefined);

--- a/src/cli/commands/data_list_test.ts
+++ b/src/cli/commands/data_list_test.ts
@@ -65,3 +65,10 @@ Deno.test("dataListCommand accepts optional model argument", async () => {
   const args = dataListCommand.getArguments();
   assertEquals(args.length > 0, true);
 });
+
+Deno.test("dataListCommand has --model option", async () => {
+  const { dataListCommand } = await import("./data_list.ts");
+  const options = dataListCommand.getOptions();
+  const modelOpt = options.find((o) => o.name === "model");
+  assertEquals(modelOpt !== undefined, true);
+});

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -31,6 +31,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
 
 export const dataRenameCommand = new Command()
   .name("rename")
@@ -39,18 +40,49 @@ export const dataRenameCommand = new Command()
     "Rename with forwarding",
     "swamp data rename my-server old-name new-name",
   )
-  .arguments("<model_id_or_name:string> <old_name:string> <new_name:string>")
+  .example(
+    "Rename using flags",
+    "swamp data rename --model my-server --name old-name --new-name new-name",
+  )
+  .arguments("[model_id_or_name:string] [old_name:string] [new_name:string]")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--model <model:string>",
+    "Model name or ID (alternative to positional argument)",
+  )
+  .option(
+    "--name <name:string>",
+    "Current data name (alternative to positional argument)",
+  )
+  .option(
+    "--new-name <newName:string>",
+    "New data name (alternative to positional argument)",
+  )
   .action(
     async function (
-      options: { repoDir?: string; json?: boolean },
-      modelIdOrName: string,
-      oldName: string,
-      newName: string,
+      options: {
+        repoDir?: string;
+        json?: boolean;
+        model?: string;
+        name?: string;
+        newName?: string;
+      },
+      positionalModel?: string,
+      positionalOldName?: string,
+      positionalNewName?: string,
     ) {
+      const modelIdOrName = options.model ?? positionalModel;
+      const oldName = options.name ?? positionalOldName;
+      const newName = options.newName ?? positionalNewName;
+
+      if (!modelIdOrName || !oldName || !newName) {
+        throw new UserError(
+          "Model, current name, and new name are all required. Use positional arguments (swamp data rename <model> <old-name> <new-name>) or flags (--model <model> --name <name> --new-name <new-name>).",
+        );
+      }
       const cliCtx = createContext(options as GlobalOptions, [
         "data",
         "rename",

--- a/src/cli/commands/data_rename_test.ts
+++ b/src/cli/commands/data_rename_test.ts
@@ -53,8 +53,29 @@ Deno.test("dataRenameCommand has --repo-dir option", async () => {
   assertEquals(repoDirOpt !== undefined, true);
 });
 
-Deno.test("dataRenameCommand requires three arguments", async () => {
+Deno.test("dataRenameCommand accepts three arguments", async () => {
   const { dataRenameCommand } = await import("./data_rename.ts");
   const args = dataRenameCommand.getArguments();
   assertEquals(args.length, 3);
+});
+
+Deno.test("dataRenameCommand has --model option", async () => {
+  const { dataRenameCommand } = await import("./data_rename.ts");
+  const options = dataRenameCommand.getOptions();
+  const modelOpt = options.find((o) => o.name === "model");
+  assertEquals(modelOpt !== undefined, true);
+});
+
+Deno.test("dataRenameCommand has --name option", async () => {
+  const { dataRenameCommand } = await import("./data_rename.ts");
+  const options = dataRenameCommand.getOptions();
+  const nameOpt = options.find((o) => o.name === "name");
+  assertEquals(nameOpt !== undefined, true);
+});
+
+Deno.test("dataRenameCommand has --new-name option", async () => {
+  const { dataRenameCommand } = await import("./data_rename.ts");
+  const options = dataRenameCommand.getOptions();
+  const newNameOpt = options.find((o) => o.name === "new-name");
+  assertEquals(newNameOpt !== undefined, true);
 });

--- a/src/cli/commands/data_versions.ts
+++ b/src/cli/commands/data_versions.ts
@@ -31,6 +31,7 @@ import {
   dataVersions,
 } from "../../libswamp/mod.ts";
 import { createDataVersionsRenderer } from "../../presentation/renderers/data_versions.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -39,18 +40,40 @@ export const dataVersionsCommand = new Command()
   .name("versions")
   .description("List all versions of specific data")
   .example("List all versions", "swamp data versions my-server system-info")
-  .arguments("<model_id_or_name:model_name> <data_name:string>")
+  .example(
+    "List using flags",
+    "swamp data versions --model my-server --name system-info",
+  )
+  .arguments("[model_id_or_name:model_name] [data_name:string]")
   .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option(
+    "--model <model:string>",
+    "Model name or ID (alternative to positional argument)",
+  )
+  .option(
+    "--name <name:string>",
+    "Data name (alternative to positional argument)",
   )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
     async function (
       options: AnyOptions,
-      modelIdOrName: string,
-      dataName: string,
+      positionalModel?: string,
+      positionalName?: string,
     ) {
+      const modelIdOrName = (options.model as string | undefined) ??
+        positionalModel;
+      const dataName = (options.name as string | undefined) ?? positionalName;
+
+      if (!modelIdOrName || !dataName) {
+        throw new UserError(
+          "Both model and data name are required. Use positional arguments (swamp data versions <model> <name>) or flags (--model <model> --name <name>).",
+        );
+      }
+
       const cliCtx = createContext(options as GlobalOptions, [
         "data",
         "versions",

--- a/src/cli/commands/data_versions_test.ts
+++ b/src/cli/commands/data_versions_test.ts
@@ -45,3 +45,17 @@ Deno.test("dataVersionsCommand is registered as subcommand of dataCommand", asyn
   const versionsCmd = commands.find((c) => c.getName() === "versions");
   assertEquals(versionsCmd !== undefined, true);
 });
+
+Deno.test("dataVersionsCommand has --model option", async () => {
+  const { dataVersionsCommand } = await import("./data_versions.ts");
+  const options = dataVersionsCommand.getOptions();
+  const modelOpt = options.find((o) => o.name === "model");
+  assertEquals(modelOpt !== undefined, true);
+});
+
+Deno.test("dataVersionsCommand has --name option", async () => {
+  const { dataVersionsCommand } = await import("./data_versions.ts");
+  const options = dataVersionsCommand.getOptions();
+  const nameOpt = options.find((o) => o.name === "name");
+  assertEquals(nameOpt !== undefined, true);
+});


### PR DESCRIPTION
## Summary

- Adds `--model` and `--name` named flags to all `swamp data` subcommands (`get`, `list`, `versions`, `delete`, `rename`) as alternatives to positional arguments
- `data rename` also gets `--new-name` for the third positional
- Flags take precedence when both flag and positional are provided; positional args remain for backward compatibility
- Commands that previously required positional args (`versions`, `delete`, `rename`) now accept either form with validation ensuring all required values are supplied

Closes swamp-club#697

## Test Plan

- All 7856 unit and integration tests pass
- Compiled binary and verified all 5 commands end-to-end in a scratch repo:
  - `data get --model <m> --name <n>` returns correct data
  - `data list --model <m>` lists data items
  - `data versions --model <m> --name <n>` shows version history
  - `data rename --model <m> --name <old> --new-name <new>` renames successfully
  - `data delete --model <m> --name <n> --force` deletes successfully
- Verified positional args still work (backward compatible)
- Verified missing required args produce clear error messages with usage hints
- Verified all new flags appear in `--help` output with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)