### PR TITLE
fix(workflow): resolve dynamic workflow task targets in forEach (swamp-club#814)

### DIFF
--- a/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
@@ -66,10 +66,12 @@ With `--input '{"tags": {"env": "prod", "team": "platform"}}'`, creates steps:
 - `tag-env` (with `self.tag.key="env"`, `self.tag.value="prod"`)
 - `tag-team` (with `self.tag.key="team"`, `self.tag.value="platform"`)
 
-### Dynamic Model Targeting
+### Dynamic Targeting
 
-`self.*` expressions resolve in `modelIdOrName` and `methodName`, enabling
-forEach steps to target different model instances per iteration:
+During forEach expansion, `self.*` expressions resolve in **any** task field —
+the step `name`, model targets (`modelIdOrName`, `modelName`, `methodName`),
+workflow targets (`workflowIdOrName`), `inputs`, and shell `args` — so each
+iteration can pick a different target:
 
 ```yaml
 steps:
@@ -88,6 +90,25 @@ steps:
 With `regions: ["us-east-1", "eu-west-1"]`, this creates two steps targeting
 `aws-alarms-us-east-1` and `aws-alarms-eu-west-1` respectively. The resolved
 names appear in `--last-evaluated` output.
+
+The same applies to workflow tasks, so a planner can emit waves whose items each
+select a workflow implementation:
+
+```yaml
+steps:
+  - name: apply-${{ self.item.host }}-${{ self.item.capability }}
+    forEach:
+      item: item
+      in: ${{ inputs.items }}
+    task:
+      type: workflow
+      workflowIdOrName: ${{ self.item.implementation.workflowIdOrName }}
+      inputs:
+        host: ${{ self.item.host }}
+```
+
+`vault.*`/`env.*` and step-output/`data.*` references are left untouched during
+expansion — they resolve at their own runtime/execution stage.
 
 ### forEach Variables
 

--- a/.claude/skills/swamp/references/workflow/references/nested-workflows.md
+++ b/.claude/skills/swamp/references/workflow/references/nested-workflows.md
@@ -178,6 +178,30 @@ jobs:
             environment: ${{ self.env }}
 ```
 
+`workflowIdOrName` itself can be a `self.*` expression, so each item chooses
+which workflow to run — useful when a planner emits items that each name their
+implementation:
+
+```yaml
+jobs:
+  - name: apply-wave
+    steps:
+      - name: apply-${{ self.item.host }}
+        forEach:
+          item: item
+          in: ${{ inputs.items }}
+        task:
+          type: workflow
+          workflowIdOrName: ${{ self.item.implementation.workflowIdOrName }}
+          inputs:
+            host: ${{ self.item.host }}
+```
+
+With items like
+`[{ "host": "gitea", "implementation": { "workflowIdOrName": "lab-capability-ssh" } }]`,
+the step targets `lab-capability-ssh`. The resolved target appears in
+`--last-evaluated` output.
+
 ## Data Access in Sub-Workflows
 
 Sub-workflow model instances can access data produced by the parent workflow

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -340,8 +340,10 @@ output.
       uri: ${{ self.ep.magnet }}
 ```
 
-`self.*` expressions also resolve in `modelIdOrName` and `methodName`, enabling
-forEach steps to target different model instances per iteration:
+During forEach expansion, `self.*` expressions resolve in **any** task field —
+the step `name`, model targets (`modelIdOrName`, `modelName`, `methodName`),
+workflow targets (`workflowIdOrName`), `inputs`, and shell `args` — so a forEach
+step can pick a different target per iteration:
 
 ```yaml
 # Fan out across region-specific model instances:
@@ -356,6 +358,24 @@ forEach steps to target different model instances per iteration:
     inputs:
       historyHours: 24
 ```
+
+```yaml
+# Each wave item selects which workflow implementation to run:
+- name: apply-${{ self.item.host }}-${{ self.item.capability }}
+  forEach:
+    item: item
+    in: ${{ inputs.items }}
+  task:
+    type: workflow
+    workflowIdOrName: ${{ self.item.implementation.workflowIdOrName }}
+    inputs:
+      host: ${{ self.item.host }}
+```
+
+Resolution is uniform across fields: every `${{ }}` expression that can be
+evaluated against the per-iteration context is resolved, while `vault.*`/`env.*`
+and step-output/`data.*` references are left for their later runtime/execution
+stages.
 
 Results are **not** run-scoped — `findBySpec` returns every matching record
 in the catalog. Add a `workflowRunId` predicate via `data.query()` when you

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -76,7 +76,10 @@ task:
 `globalArgs` is only valid with direct type execution — the schema rejects it
 for `modelIdOrName` tasks.
 
-For `forEach` steps, `modelName` supports CEL template expressions:
+For `forEach` steps, `self.*` CEL template expressions resolve in every task
+target field — `modelIdOrName`, `modelName`, `methodName`, and (for workflow
+tasks) `workflowIdOrName` — as well as the step `name`, `inputs`, and shell
+`args`:
 
 ```yaml
 - name: scan-${{self.host}}

--- a/integration/workflow_foreach_concurrency_test.ts
+++ b/integration/workflow_foreach_concurrency_test.ts
@@ -251,3 +251,221 @@ Deno.test("CLI: forEach concurrency>1 fanning out child workflows does not fail 
     }
   });
 });
+
+// swamp-club#814: a forEach step whose task.workflowIdOrName is itself an
+// expression of the iteration item must resolve the target per item, the same
+// way dynamic modelIdOrName already resolves. Without the fix the run path
+// passed `${{ self.item.workflowIdOrName }}` literally to the child lookup, so
+// the child workflow was never found and the step failed. This drives the real
+// `swamp workflow run` path end to end.
+Deno.test("CLI: forEach resolves dynamic workflowIdOrName per item and runs the selected child", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+    await createShellModel(repoDir, "child-model");
+
+    // Two distinct child workflows; each item selects one of them by name.
+    for (const childName of ["child-ssh", "child-vault"]) {
+      await writeWorkflow(repoDir, {
+        id: crypto.randomUUID(),
+        name: childName,
+        version: 1,
+        inputs: {},
+        jobs: [
+          {
+            name: "work",
+            steps: [
+              {
+                name: "run-child",
+                task: {
+                  type: "model_method",
+                  modelIdOrName: "child-model",
+                  methodName: "execute",
+                },
+                dependsOn: [],
+                weight: 0,
+              },
+            ],
+            dependsOn: [],
+            weight: 0,
+          },
+        ],
+      });
+    }
+
+    // Parent: forEach over wave items, each item selecting its workflow
+    // implementation via a dynamic target — the issue's exact shape.
+    await writeWorkflow(repoDir, {
+      id: crypto.randomUUID(),
+      name: "planner-parent",
+      version: 1,
+      inputs: {
+        properties: {
+          items: { type: "array", items: { type: "object" }, minItems: 1 },
+        },
+        required: ["items"],
+      },
+      jobs: [
+        {
+          name: "fan-out",
+          steps: [
+            {
+              name: "apply-${{ self.item.host }}",
+              forEach: {
+                item: "item",
+                in: "${{ inputs.items }}",
+              },
+              task: {
+                type: "workflow",
+                workflowIdOrName:
+                  "${{ self.item.implementation.workflowIdOrName }}",
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    });
+
+    const items = [
+      { host: "gitea", implementation: { workflowIdOrName: "child-ssh" } },
+      { host: "bao", implementation: { workflowIdOrName: "child-vault" } },
+    ];
+    const result = await runCliCommand([
+      "workflow",
+      "run",
+      "planner-parent",
+      "--repo-dir",
+      repoDir,
+      "--input",
+      JSON.stringify({ items }),
+      "--json",
+    ]);
+
+    assertEquals(
+      result.code,
+      0,
+      `Workflow should succeed (dynamic child targets must resolve). stderr: ${result.stderr}\n${result.stdout}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    const job = output.jobs?.find(
+      (j: { name: string }) => j.name === "fan-out",
+    );
+    const steps = (job?.steps ?? []) as { name: string; status: string }[];
+    const expanded = steps.filter((s) => !s.name.includes("${{"));
+
+    // Step names resolved per item, and each selected child ran successfully.
+    assertEquals(
+      expanded.map((s) => s.name).sort(),
+      ["apply-bao", "apply-gitea"],
+    );
+    for (const step of expanded) {
+      assertEquals(
+        step.status,
+        "succeeded",
+        `Expected ${step.name} to succeed but got ${step.status}`,
+      );
+    }
+  });
+});
+
+// swamp-club#814: dynamic workflowIdOrName must be resolved BEFORE cycle
+// detection, so a target that resolves to a workflow already on the call stack
+// is caught — and the error names the RESOLVED workflow, not the literal
+// expression. If resolution ran after the guard (or not at all), the literal
+// would never match an ancestor and the cycle would go undetected (surfacing
+// instead as a "not found" error).
+Deno.test("CLI: forEach dynamic workflowIdOrName resolving into the ancestor chain still trips cycle detection", async () => {
+  await withTempDir(async (repoDir) => {
+    await initializeTestRepo(repoDir);
+
+    // A workflow that forEach-targets itself via a dynamic expression.
+    await writeWorkflow(repoDir, {
+      id: crypto.randomUUID(),
+      name: "self-cycle",
+      version: 1,
+      inputs: {
+        properties: {
+          names: { type: "array", items: { type: "string" }, minItems: 1 },
+        },
+        required: ["names"],
+      },
+      jobs: [
+        {
+          name: "loop",
+          steps: [
+            {
+              name: "call-${{ self.item }}",
+              forEach: {
+                item: "item",
+                in: "${{ inputs.names }}",
+              },
+              task: {
+                type: "workflow",
+                workflowIdOrName: "${{ self.item }}",
+                inputs: { names: ["self-cycle"] },
+              },
+              dependsOn: [],
+              weight: 0,
+            },
+          ],
+          dependsOn: [],
+          weight: 0,
+        },
+      ],
+    });
+
+    const result = await runCliCommand([
+      "workflow",
+      "run",
+      "self-cycle",
+      "--repo-dir",
+      repoDir,
+      "--input",
+      JSON.stringify({ names: ["self-cycle"] }),
+      "--json",
+    ]);
+
+    assertEquals(
+      result.code !== 0,
+      true,
+      `Self-cycling workflow should fail. stdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    );
+
+    const output = JSON.parse(result.stdout);
+    const job = output.jobs?.find((j: { name: string }) => j.name === "loop");
+    const steps = (job?.steps ?? []) as {
+      name: string;
+      status: string;
+      error?: string;
+    }[];
+    const expanded = steps.filter((s) => !s.name.includes("${{"));
+
+    // The step name resolved per item (call-self-cycle, not the raw template),
+    // and that step failed.
+    const cycled = expanded.find((s) => s.name === "call-self-cycle");
+    assertEquals(
+      cycled?.status,
+      "failed",
+      `Expected the expanded step to fail. Steps: ${JSON.stringify(expanded)}`,
+    );
+    // The failure names the RESOLVED child ("self-cycle"), proving the target
+    // was resolved so the child lookup found it, it was invoked, and it failed
+    // fast on cycle detection. If resolution had not happened (or happened after
+    // the guard) the literal `${{ self.item }}` would never match an ancestor
+    // and would instead surface as a "not found" lookup error.
+    assertEquals(
+      (cycled?.error ?? "").includes("self-cycle"),
+      true,
+      `Expected the resolved child name in the failure. Got: ${cycled?.error}`,
+    );
+    assertEquals(
+      (cycled?.error ?? "").toLowerCase().includes("not found"),
+      false,
+      `Expected a cycle failure, not a lookup miss (resolution must precede the guard). Got: ${cycled?.error}`,
+    );
+  });
+});

--- a/src/domain/expressions/available_expression_resolver.ts
+++ b/src/domain/expressions/available_expression_resolver.ts
@@ -1,0 +1,90 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { extractExpressions, replaceExpressions } from "./expression_parser.ts";
+import { containsRuntimeExpression } from "./expression_evaluation_service.ts";
+import { hasStepOutputDependency } from "./dependency_extractor.ts";
+
+/**
+ * A synchronous CEL evaluator: evaluates a single CEL expression against a
+ * context and returns the resulting value. Both `WorkflowEvaluateDeps.evaluateCel`
+ * and `CelEvaluator.evaluate` satisfy this shape.
+ */
+export type SyncCelEvaluator = (
+  expression: string,
+  context: Record<string, unknown>,
+) => unknown;
+
+/**
+ * Resolves every `${{ }}` expression anywhere in `data` that can be evaluated
+ * against `context` right now, deferring only the kinds that must be resolved at
+ * a later, dedicated stage:
+ *
+ *   - `vault.*` / `env.*` (via {@link containsRuntimeExpression}) — resolved at
+ *     runtime through the secret bag.
+ *   - step-output / `data.*` dependencies (via {@link hasStepOutputDependency}) —
+ *     resolved at step-execution time, once upstream outputs exist.
+ *
+ * Everything else is evaluated against `context`. An expression that throws —
+ * because it references a binding not yet in `context` (e.g. `run.*` during
+ * workflow evaluation) or because it is a bad reference — is left raw. This
+ * makes the resolver context-adaptive: the same function resolves `self.*`
+ * during forEach expansion and additionally `run.*` and available step outputs
+ * at execution time, with no per-call configuration. It is the inverse of the
+ * skip-list in `WorkflowExpressionEvaluator.evaluate()` (which defers the same
+ * runtime/execution-stage kinds), and the two should stay in sync.
+ *
+ * This replaces the per-field allowlists that previously lived in
+ * `resolveForEachTaskExpressions` (libswamp/workflows/evaluate.ts) and
+ * `executeModelMethod` (workflows/execution_service.ts), so no task field can be
+ * accidentally omitted from resolution.
+ *
+ * The input is never mutated. A whole-string single expression keeps the
+ * evaluated value's native type; expressions embedded in a larger string are
+ * stringified and substituted in place (see {@link replaceExpressions}). A
+ * reference that cannot be resolved survives as its literal `${{ }}` text and
+ * surfaces later as a clear downstream error (e.g. "workflow not found") rather
+ * than as silent data loss.
+ */
+export function resolveAvailableExpressions(
+  data: unknown,
+  context: Record<string, unknown>,
+  evaluate: SyncCelEvaluator,
+): unknown {
+  const locations = extractExpressions(data);
+  if (locations.length === 0) return data;
+
+  const values = new Map<string, unknown>();
+  for (const { raw, celExpression } of locations) {
+    if (values.has(raw)) continue;
+    // Deferred to runtime (resolved via the secret bag).
+    if (containsRuntimeExpression(celExpression)) continue;
+    // Deferred to step execution (upstream step outputs / async data.* helpers).
+    if (hasStepOutputDependency(celExpression)) continue;
+    try {
+      values.set(raw, evaluate(celExpression, context));
+    } catch {
+      // Not resolvable against this context yet (e.g. run.* during evaluation)
+      // or a bad reference — leave the expression raw.
+    }
+  }
+
+  if (values.size === 0) return data;
+  return replaceExpressions(data, values);
+}

--- a/src/domain/expressions/available_expression_resolver_test.ts
+++ b/src/domain/expressions/available_expression_resolver_test.ts
@@ -1,0 +1,168 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  resolveAvailableExpressions,
+  type SyncCelEvaluator,
+} from "./available_expression_resolver.ts";
+
+/**
+ * Deterministic stub evaluator: resolves a dotted CEL path against the context
+ * and throws when any segment is missing — mirroring how the real CEL evaluator
+ * fails on an unbound reference. Records the expressions it was asked to
+ * evaluate so tests can assert deferred kinds are never evaluated.
+ */
+function makeEvaluator(): { evaluate: SyncCelEvaluator; calls: string[] } {
+  const calls: string[] = [];
+  const evaluate: SyncCelEvaluator = (expr, ctx) => {
+    calls.push(expr);
+    const parts = expr.split(".");
+    let cur: unknown = ctx;
+    for (const part of parts) {
+      if (cur === null || typeof cur !== "object" || !(part in cur)) {
+        throw new Error(`unbound reference: ${expr}`);
+      }
+      cur = (cur as Record<string, unknown>)[part];
+    }
+    return cur;
+  };
+  return { evaluate, calls };
+}
+
+Deno.test("resolveAvailableExpressions: resolves self.* in a target string", () => {
+  const { evaluate } = makeEvaluator();
+  const result = resolveAvailableExpressions(
+    { workflowIdOrName: "${{ self.item.impl }}" },
+    { self: { item: { impl: "lab-capability-ssh" } } },
+    evaluate,
+  );
+  assertEquals(result, { workflowIdOrName: "lab-capability-ssh" });
+});
+
+Deno.test("resolveAvailableExpressions: whole-string single expression keeps native type", () => {
+  const { evaluate } = makeEvaluator();
+  const result = resolveAvailableExpressions(
+    {
+      inputs: { count: "${{ self.item.count }}", obj: "${{ self.item.obj }}" },
+    },
+    { self: { item: { count: 5, obj: { a: 1 } } } },
+    evaluate,
+  ) as { inputs: { count: unknown; obj: unknown } };
+  assertEquals(result.inputs.count, 5);
+  assertEquals(typeof result.inputs.count, "number");
+  assertEquals(result.inputs.obj, { a: 1 });
+});
+
+Deno.test("resolveAvailableExpressions: embedded multi-expression string substitutes all", () => {
+  const { evaluate } = makeEvaluator();
+  const result = resolveAvailableExpressions(
+    { name: "apply-${{ self.item.host }}-${{ self.item.capability }}" },
+    { self: { item: { host: "gitea", capability: "ssh" } } },
+    evaluate,
+  );
+  assertEquals(result, { name: "apply-gitea-ssh" });
+});
+
+Deno.test("resolveAvailableExpressions: vault and env expressions are always left raw", () => {
+  const { evaluate, calls } = makeEvaluator();
+  const data = {
+    a: '${{ vault.get("secret") }}',
+    b: "${{ env.HOME }}",
+  };
+  const result = resolveAvailableExpressions(data, {}, evaluate);
+  assertEquals(result, data);
+  // Deferred kinds must never be handed to the evaluator.
+  assertEquals(calls, []);
+});
+
+Deno.test("resolveAvailableExpressions: step-output / data.* dependencies are left raw", () => {
+  const { evaluate, calls } = makeEvaluator();
+  const data = {
+    a: '${{ data.latest("spec", "name") }}',
+    b: "${{ model.foo.resource.bar }}",
+  };
+  const result = resolveAvailableExpressions(data, {}, evaluate);
+  assertEquals(result, data);
+  assertEquals(calls, []);
+});
+
+Deno.test("resolveAvailableExpressions: run.* resolves when in context, stays raw when not", () => {
+  const { evaluate } = makeEvaluator();
+
+  // run not in context -> evaluator throws -> left raw (the evaluate-stage case)
+  const evalStage = resolveAvailableExpressions(
+    { modelIdOrName: "scan-${{ run.id }}" },
+    { self: { item: {} } },
+    evaluate,
+  );
+  assertEquals(evalStage, { modelIdOrName: "scan-${{ run.id }}" });
+
+  // run in context -> resolves (the execution-stage case)
+  const runStage = resolveAvailableExpressions(
+    { modelIdOrName: "scan-${{ run.id }}" },
+    { run: { id: "abc123" } },
+    evaluate,
+  );
+  assertEquals(runStage, { modelIdOrName: "scan-abc123" });
+});
+
+Deno.test("resolveAvailableExpressions: a bad reference is left raw", () => {
+  const { evaluate } = makeEvaluator();
+  const result = resolveAvailableExpressions(
+    { workflowIdOrName: "${{ self.item.typo }}" },
+    { self: { item: { impl: "real" } } },
+    evaluate,
+  );
+  assertEquals(result, { workflowIdOrName: "${{ self.item.typo }}" });
+});
+
+Deno.test("resolveAvailableExpressions: walks nested objects and arrays", () => {
+  const { evaluate } = makeEvaluator();
+  const result = resolveAvailableExpressions(
+    {
+      task: {
+        workflowIdOrName: "${{ self.item.impl }}",
+        inputs: {
+          hosts: ["${{ self.item.host }}", "static"],
+          nested: { vm: "${{ self.item.vm }}" },
+        },
+      },
+    },
+    { self: { item: { impl: "wf-a", host: "h1", vm: "vm1" } } },
+    evaluate,
+  );
+  assertEquals(result, {
+    task: {
+      workflowIdOrName: "wf-a",
+      inputs: {
+        hosts: ["h1", "static"],
+        nested: { vm: "vm1" },
+      },
+    },
+  });
+});
+
+Deno.test("resolveAvailableExpressions: leaves expression-free data untouched and returns input when nothing to resolve", () => {
+  const { evaluate, calls } = makeEvaluator();
+  const data = { workflowIdOrName: "static-name", inputs: { n: 1 } };
+  const result = resolveAvailableExpressions(data, {}, evaluate);
+  assertEquals(result, data);
+  assertEquals(calls, []);
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -79,10 +79,8 @@ import { ModelOutput } from "../models/model_output.ts";
 import type { Definition } from "../definitions/definition.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { MethodResult, ModelDefinition } from "../models/model.ts";
-import {
-  containsRuntimeExpression,
-  ExpressionEvaluationService,
-} from "../expressions/expression_evaluation_service.ts";
+import { ExpressionEvaluationService } from "../expressions/expression_evaluation_service.ts";
+import { resolveAvailableExpressions } from "../expressions/available_expression_resolver.ts";
 import {
   buildEnvContext,
   type DataRecord,
@@ -411,33 +409,18 @@ export class DefaultStepExecutor implements StepExecutor {
       expressionEvaluator,
     } = allDeps;
 
-    // Resolve forEach self.* expressions in modelIdOrName/modelName and methodName
-    // before model lookup. The expression context has self populated with
-    // the forEach variable by runStep().
+    // Resolve every available expression (self.* from the forEach variable,
+    // run.*, etc.) anywhere in the task before model lookup. The expression
+    // context has self populated with the forEach variable by runStep().
+    // resolveAvailableExpressions defers vault/env and step-output kinds to their
+    // dedicated stages — see available_expression_resolver.ts.
     if (ctx.expressionContext) {
       const celEvaluator = new CelEvaluator();
-      const resolve = (value: string): string =>
-        value.replace(
-          /\$\{\{\s*(.+?)\s*\}\}/g,
-          (_match: string, expr: string) => {
-            if (containsRuntimeExpression(expr)) return _match;
-            try {
-              return String(
-                celEvaluator.evaluate(expr, ctx.expressionContext!),
-              );
-            } catch {
-              return _match;
-            }
-          },
-        );
-      task = {
-        ...task,
-        modelIdOrName: task.modelIdOrName
-          ? resolve(task.modelIdOrName)
-          : undefined,
-        modelName: task.modelName ? resolve(task.modelName) : undefined,
-        methodName: resolve(task.methodName),
-      };
+      task = resolveAvailableExpressions(
+        task,
+        ctx.expressionContext,
+        (expr, context) => celEvaluator.evaluate(expr, context),
+      ) as typeof task;
     }
 
     let originalDefinition: Definition;
@@ -2446,6 +2429,21 @@ export class WorkflowExecutionService {
     expressionContext: ExpressionContext | undefined,
     options: StepOptions,
   ): AsyncGenerator<WorkflowExecutionEvent> {
+    // Resolve every available expression (self.* from the forEach variable,
+    // run.*, etc.) in the task BEFORE the recursion-depth guard, cycle
+    // detection, ancestor-set additions, and the child invocation, so they all
+    // operate on the resolved workflowIdOrName rather than a literal `${{ }}`.
+    // Vault/env and step-output kinds are deferred to their dedicated stages;
+    // the inputs evaluateData pass below still resolves the rest.
+    if (expressionContext) {
+      const celEvaluator = new CelEvaluator();
+      task = resolveAvailableExpressions(
+        task,
+        expressionContext,
+        (expr, context) => celEvaluator.evaluate(expr, context),
+      ) as typeof task;
+    }
+
     // Recursion guard
     const depth = options.workflowNestingDepth ?? 0;
     if (depth >= MAX_WORKFLOW_NESTING_DEPTH) {

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -32,6 +32,7 @@ import {
   replaceExpressions,
 } from "../../domain/expressions/expression_parser.ts";
 import { containsRuntimeExpression } from "../../domain/expressions/expression_evaluation_service.ts";
+import { resolveAvailableExpressions } from "../../domain/expressions/available_expression_resolver.ts";
 import { hasStepOutputDependency } from "../../domain/expressions/dependency_extractor.ts";
 import type { ExpressionContext } from "../../domain/expressions/model_resolver.ts";
 import { ModelResolver } from "../../domain/expressions/model_resolver.ts";
@@ -262,35 +263,48 @@ async function evaluateWorkflowInternal(
       const itemName = stepData.forEach.item;
       const nameHasExpression = /\$\{\{.+?\}\}/.test(stepData.name);
 
+      // Build one expanded step for a single forEach item: resolve every
+      // available expression (self.* etc.) across the step name AND task in one
+      // pass via the shared resolver, then apply the unique-name suffix policy.
+      const buildExpandedStep = (
+        // deno-lint-ignore no-explicit-any
+        stepContext: any,
+        fallbackSuffix: string,
+      ) => {
+        const resolved = resolveAvailableExpressions(
+          { name: stepData.name, task: stepData.task },
+          stepContext,
+          deps.evaluateCel,
+        ) as { name: string; task: typeof stepData.task };
+
+        let expandedName: string;
+        if (nameHasExpression) {
+          expandedName = resolved.name;
+          // If any expression in the name could not be resolved, the raw name
+          // would repeat across iterations — append a suffix to keep names
+          // unique (matches ForEachExpansionService.resolveForEachStepName).
+          if (/\$\{\{.+?\}\}/.test(expandedName)) {
+            expandedName = `${expandedName}-${fallbackSuffix}`;
+          }
+        } else {
+          expandedName = `${stepData.name}-${fallbackSuffix}`;
+        }
+
+        return {
+          ...stepData,
+          name: expandedName,
+          task: resolved.task,
+          forEach: undefined,
+        };
+      };
+
       if (Array.isArray(items)) {
         for (const item of items) {
           const stepContext = {
             ...context,
             self: { ...context.self, [itemName]: item },
           };
-
-          // Resolve step name
-          let expandedName = stepData.name;
-          const nameMatch = stepData.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
-          if (nameMatch) {
-            const value = deps.evaluateCel(nameMatch[1], stepContext);
-            expandedName = stepData.name.replace(nameMatch[0], String(value));
-          } else if (!nameHasExpression) {
-            expandedName = `${stepData.name}-${String(item)}`;
-          }
-
-          const expandedTask = resolveForEachTaskExpressions(
-            stepData.task,
-            stepContext,
-            deps,
-          );
-
-          expandedSteps.push({
-            ...stepData,
-            name: expandedName,
-            task: expandedTask,
-            forEach: undefined,
-          });
+          expandedSteps.push(buildExpandedStep(stepContext, String(item)));
         }
       } else if (items && typeof items === "object") {
         for (const [key, value] of Object.entries(items)) {
@@ -299,32 +313,7 @@ async function evaluateWorkflowInternal(
             ...context,
             self: { ...context.self, [itemName]: objItem },
           };
-
-          // Resolve step name
-          let expandedName = stepData.name;
-          const nameMatch = stepData.name.match(/\$\{\{\s*(.+?)\s*\}\}/);
-          if (nameMatch) {
-            const evalValue = deps.evaluateCel(nameMatch[1], stepContext);
-            expandedName = stepData.name.replace(
-              nameMatch[0],
-              String(evalValue),
-            );
-          } else if (!nameHasExpression) {
-            expandedName = `${stepData.name}-${key}`;
-          }
-
-          const expandedTask = resolveForEachTaskExpressions(
-            stepData.task,
-            stepContext,
-            deps,
-          );
-
-          expandedSteps.push({
-            ...stepData,
-            name: expandedName,
-            task: expandedTask,
-            forEach: undefined,
-          });
+          expandedSteps.push(buildExpandedStep(stepContext, key));
         }
       } else {
         // Not iterable — keep original step
@@ -356,77 +345,6 @@ async function evaluateWorkflowInternal(
     outputPath: deps.getEvaluatedPath(workflow.id),
     jobs: expandedWorkflowData.jobs,
   };
-}
-
-/**
- * Resolves forEach self.* expressions in a task's modelIdOrName, methodName,
- * inputs, and args. Vault expressions are left raw for runtime resolution.
- */
-function resolveForEachTaskExpressions(
-  // deno-lint-ignore no-explicit-any
-  taskData: any,
-  // deno-lint-ignore no-explicit-any
-  stepContext: any,
-  deps: Pick<WorkflowEvaluateDeps, "evaluateCel">,
-  // deno-lint-ignore no-explicit-any
-): any {
-  const expandedTask = JSON.parse(JSON.stringify(taskData));
-
-  // Resolve expressions in modelIdOrName and methodName
-  for (const field of ["modelIdOrName", "methodName"] as const) {
-    if (expandedTask[field] && typeof expandedTask[field] === "string") {
-      expandedTask[field] = (expandedTask[field] as string).replace(
-        /\$\{\{\s*(.+?)\s*\}\}/g,
-        (_match: string, expr: string) => {
-          if (containsRuntimeExpression(expr)) return _match;
-          try {
-            return String(deps.evaluateCel(expr, stepContext));
-          } catch {
-            return _match;
-          }
-        },
-      );
-    }
-  }
-
-  // Resolve expressions in task inputs (model and workflow tasks)
-  if (expandedTask.inputs) {
-    for (const [key, val] of Object.entries(expandedTask.inputs)) {
-      if (typeof val === "string") {
-        const exprMatch = (val as string).match(/\$\{\{\s*(.+?)\s*\}\}/);
-        if (exprMatch && !containsRuntimeExpression(exprMatch[1])) {
-          try {
-            expandedTask.inputs[key] = deps.evaluateCel(
-              exprMatch[1],
-              stepContext,
-            );
-          } catch {
-            // Leave as-is if evaluation fails
-          }
-        }
-      }
-    }
-  }
-
-  // Resolve expressions in shell args
-  if (expandedTask.args && Array.isArray(expandedTask.args)) {
-    expandedTask.args = expandedTask.args.map((arg: unknown) => {
-      if (typeof arg !== "string") return arg;
-      return (arg as string).replace(
-        /\$\{\{\s*(.+?)\s*\}\}/g,
-        (_match: string, expr: string) => {
-          if (containsRuntimeExpression(expr)) return _match;
-          try {
-            return String(deps.evaluateCel(expr, stepContext));
-          } catch {
-            return _match;
-          }
-        },
-      );
-    });
-  }
-
-  return expandedTask;
 }
 
 /** Evaluates all workflow definitions. */

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -383,6 +383,188 @@ Deno.test("forEach: resolves self.* in modelIdOrName with object iteration", asy
   assertEquals(asModelMethodTask(steps[1].task).modelIdOrName, "device-beta");
 });
 
+// Builds a forEach workflow whose step runs a `type: workflow` task, so we can
+// exercise dynamic workflowIdOrName resolution (swamp-club#814).
+function makeForEachWorkflowTask(overrides: {
+  workflowIdOrName: string;
+  stepName: string;
+  forEachIn: string;
+  forEachItem: string;
+  inputs?: Record<string, unknown>;
+}): Workflow {
+  return Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000003",
+    name: "foreach-workflow",
+    inputs: {},
+    jobs: [{
+      name: "default",
+      steps: [{
+        name: overrides.stepName,
+        forEach: {
+          item: overrides.forEachItem,
+          in: overrides.forEachIn,
+        },
+        task: {
+          type: "workflow",
+          workflowIdOrName: overrides.workflowIdOrName,
+          ...(overrides.inputs ? { inputs: overrides.inputs } : {}),
+        },
+      }],
+    }],
+  });
+}
+
+interface WorkflowTaskData {
+  type: "workflow";
+  workflowIdOrName: string;
+  inputs?: Record<string, unknown>;
+}
+
+function asWorkflowTask(
+  // deno-lint-ignore no-explicit-any
+  task: any,
+): WorkflowTaskData {
+  return task as WorkflowTaskData;
+}
+
+Deno.test("forEach: resolves self.* in workflowIdOrName (workflow task)", async () => {
+  const workflow = makeForEachWorkflowTask({
+    workflowIdOrName: "${{ self.item.implementation.workflowIdOrName }}",
+    stepName: "apply-${{ self.item.host }}",
+    forEachIn: "${{ items }}",
+    forEachItem: "item",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        {
+          model: {},
+          env: {},
+          self: {},
+          items: [
+            {
+              host: "gitea",
+              implementation: { workflowIdOrName: "lab-capability-ssh" },
+            },
+            {
+              host: "bao",
+              implementation: { workflowIdOrName: "lab-capability-vault" },
+            },
+          ],
+        } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(
+    asWorkflowTask(steps[0].task).workflowIdOrName,
+    "lab-capability-ssh",
+  );
+  assertEquals(
+    asWorkflowTask(steps[1].task).workflowIdOrName,
+    "lab-capability-vault",
+  );
+});
+
+Deno.test("forEach: resolves all expressions in a multi-expression step name", async () => {
+  const workflow = makeForEachWorkflowTask({
+    workflowIdOrName: "${{ self.item.implementation.workflowIdOrName }}",
+    stepName: "apply-${{ self.item.host }}-${{ self.item.capability }}",
+    forEachIn: "${{ items }}",
+    forEachItem: "item",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        {
+          model: {},
+          env: {},
+          self: {},
+          items: [
+            {
+              host: "gitea",
+              capability: "ssh",
+              implementation: { workflowIdOrName: "lab-capability-ssh" },
+            },
+          ],
+        } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  // Both expressions in the name resolve, not just the first.
+  assertEquals(steps[0].name, "apply-gitea-ssh");
+});
+
+Deno.test("forEach: leaves vault expressions in workflowIdOrName unresolved", async () => {
+  const workflow = makeForEachWorkflowTask({
+    workflowIdOrName: '${{ vault.get("which-workflow") }}',
+    stepName: "apply-${{ self.item.host }}",
+    forEachIn: "${{ items }}",
+    forEachItem: "item",
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        {
+          model: {},
+          env: {},
+          self: {},
+          items: [{ host: "gitea" }],
+        } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(
+    asWorkflowTask(steps[0].task).workflowIdOrName,
+    '${{ vault.get("which-workflow") }}',
+  );
+});
+
+Deno.test("forEach: resolves self.* in modelName (model task parity)", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000004",
+    name: "foreach-workflow",
+    inputs: {},
+    jobs: [{
+      name: "default",
+      steps: [{
+        name: "scan-${{ self.region }}",
+        forEach: { item: "region", in: "${{ items }}" },
+        task: {
+          type: "model_method",
+          modelType: "@acme/scanner",
+          modelName: "scanner-${{ self.region }}",
+          methodName: "scan",
+        },
+      }],
+    }],
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["us-east-1", "eu-west-1"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  // deno-lint-ignore no-explicit-any
+  assertEquals((steps[0].task as any).modelName, "scanner-us-east-1");
+  // deno-lint-ignore no-explicit-any
+  assertEquals((steps[1].task as any).modelName, "scanner-eu-west-1");
+});
+
 Deno.test("isWorkflowEvaluateAllData: returns true for AllData, false for ItemData", () => {
   const allData: WorkflowEvaluateAllData = {
     items: [],


### PR DESCRIPTION
## Summary

A forEach step could pass resolved item fields into task `inputs`, but the
workflow task target itself (`task.workflowIdOrName`) was left as a literal
`${{ ... }}` expression, so a planner that emits dependency waves couldn't select
a workflow implementation per item. Dynamic model targeting
(`modelIdOrName`/`modelName`/`methodName`) already worked — workflow targets just
fell through the cracks.

The root cause was **three hand-maintained per-field expression allowlists** (in
`evaluate.ts`, `executeModelMethod`, and a separate non-global step-name
resolver). Every dynamic-targetable field had to be remembered, which is why
`workflowIdOrName` and `modelName` were missed and multi-expression step names
only partially resolved.

### Fix

Introduce one generic resolver — `resolveAvailableExpressions` in
`src/domain/expressions/available_expression_resolver.ts` — and route all three
sites through it. It walks the whole task/name structure and resolves **every**
`${{ }}` expression evaluable against the current context, deferring only the
runtime/execution-stage kinds:

- `vault.*` / `env.*` → resolved later via the secret bag
- step-output / `data.*` deps → resolved at step execution

Anything that can't be evaluated yet (e.g. `run.*` during evaluation) is left
raw. This is context-adaptive with no prefix allowlist: `run.*` resolves at
execution time and stays raw at evaluate time automatically — preserving all
existing behavior while generalizing across fields.

This fixes, in one change:
- `task.workflowIdOrName` now resolves from the forEach item (the headline bug)
- `modelName` (a latent parallel gap) now resolves
- step names with multiple `${{ }}` expressions fully resolve (was non-global)
- embedded-expression `inputs` keep their surrounding text (was truncated — a
  latent bug; called out here as an intentional behavior change)

On the run path, `runWorkflowStep` resolves the target **before** the
recursion-depth and cycle-detection guards, so a dynamic target that resolves
into the ancestor chain is still caught (with the resolved name in the error).

## Test Plan

- **New unit tests**: `available_expression_resolver_test.ts` (resolves
  self.*/run.* when in context, defers vault/env + step-output/data.*, leaves
  unresolvable raw, typed-vs-embedded substitution, nested walk).
- **Evaluate tests** (`evaluate_test.ts`): dynamic `workflowIdOrName`,
  multi-expression step name, vault left raw, `modelName` parity.
- **Run-path integration** (`workflow_foreach_concurrency_test.ts`): per-item
  distinct child selection end-to-end; cycle detection on a resolved dynamic
  target.
- **Regression oracle**: existing `evaluate_test.ts`,
  `for_each_expansion_service_test.ts`, and `integration/foreach_test.ts`
  (model-path) pass **unchanged**.
- **Before/after `swamp workflow evaluate`** on the issue's example: `inputs`
  byte-identical; `workflowIdOrName` now resolves (`lab-capability-ssh`) and the
  step name fully resolves (`apply-gitea-ssh`) — matching the issue's Expected
  output.
- `deno check`, `deno lint`, `deno fmt`, `deno run test` (one unrelated flaky in
  the vaults domain, passes in isolation), `deno run compile` all green.

## Follow-ups

- UAT coverage gap filed: swamp-club/swamp-uat#281.
- Manual-docs update for `content/manual/reference/workflows.md` could not be
  filed (issues disabled on swamp-club/swamp-club); needs the website repo's own
  process.

Closes swamp-club#814