### PR TITLE
feat: execution cancellation — abort stuck workflow runs and model method runs (#808)

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -545,6 +545,36 @@ The output of the run will be written to a workflow run log, kept in the
 datastore at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
 `.swamp/workflow-runs/`).
 
+### Run Statuses
+
+- `pending` — created but not yet started
+- `running` — actively executing jobs/steps
+- `suspended` — paused at a manual approval gate
+- `succeeded` — all jobs completed successfully
+- `failed` — at least one job failed or an error occurred
+- `cancelled` — explicitly cancelled by user or daemon restart
+
+### Cancellation
+
+Runs can be cancelled via `swamp workflow cancel <workflow> [--run <runId>]`.
+When `swamp serve` is running, the cancel command sends a request to the serve
+cancel API (`POST /api/v1/cancel/workflow-run/<id>`), which fires the
+AbortController for live cancellation. When serve is not running, the command
+writes the cancelled status directly to the run YAML (offline cancel).
+
+`swamp workflow cancel --all` cancels all active runs across all workflows.
+
+On daemon restart, `swamp serve` automatically reaps orphaned runs left in
+`running` state by the previous process, marking them `cancelled` with reason
+`daemon restarted`.
+
+A `RunCancelRegistry` in the serve layer centralises AbortController tracking
+across all execution paths (scheduled, WebSocket ad-hoc, webhook). The cancel
+API checks both the registry and the `ScheduledExecutionService` running map.
+
+The same mechanism applies to model method runs via
+`swamp model cancel <model> [--run <id>]`.
+
 ## Domain Events
 
 The WorkflowRepository and WorkflowRunRepository emit domain events:

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -174,7 +174,10 @@ export class SwampClient {
       reject: (err) => queue.error(err),
       handlers: withDefaults<WorkflowRunEvent>({}, (event) => {
         queue.push(event);
-        if (event.kind === "completed" || event.kind === "error") {
+        if (
+          event.kind === "completed" || event.kind === "error" ||
+          event.kind === "cancelled"
+        ) {
           queue.done();
         }
       }),
@@ -205,7 +208,10 @@ export class SwampClient {
       reject: (err) => queue.error(err),
       handlers: withDefaults<ModelMethodRunEvent>({}, (event) => {
         queue.push(event);
-        if (event.kind === "completed" || event.kind === "error") {
+        if (
+          event.kind === "completed" || event.kind === "error" ||
+          event.kind === "cancelled"
+        ) {
           queue.done();
         }
       }),
@@ -266,7 +272,7 @@ export class SwampClient {
       }
 
       // Resolve/reject on terminal events
-      if (event.kind === "completed") {
+      if (event.kind === "completed" || event.kind === "cancelled") {
         this.pending.delete(msg.id);
         pending.resolve(event.run);
       } else if (event.kind === "error") {

--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -137,6 +137,7 @@ export type WorkflowRunEvent =
   }
   | { kind: "report_failed"; reportName: string; scope: string; error: string }
   | { kind: "completed"; run: WorkflowRunView }
+  | { kind: "cancelled"; run: WorkflowRunView; reason?: string }
   | { kind: "error"; error: SerializedError };
 
 /** Events emitted during a model method run. */
@@ -181,6 +182,7 @@ export type ModelMethodRunEvent =
   }
   | { kind: "report_failed"; reportName: string; scope: string; error: string }
   | { kind: "completed"; run: ModelMethodRunView }
+  | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
   | { kind: "error"; error: SerializedError };
 
 // ── Completed event payload types ────────────────────────────────────────

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -1,0 +1,154 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { killProcessTree } from "../../infrastructure/process/process_kill.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const modelCancelCommand = new Command()
+  .name("cancel")
+  .description("Cancel a running model method run")
+  .example("Cancel a model run", "swamp model cancel my-server")
+  .example(
+    "Cancel with reason",
+    "swamp model cancel my-server --reason 'No longer needed'",
+  )
+  .example("Cancel all running", "swamp model cancel --all")
+  .arguments("[model_id_or_name:model_name]")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--all", "Cancel all running model method runs")
+  .option("--reason <reason:string>", "Reason for cancellation")
+  // @ts-expect-error - Cliffy custom type returns unknown instead of string
+  .action(async function (options: AnyOptions, modelIdOrName?: string) {
+    const cliCtx = createContext(options as GlobalOptions, ["model", "cancel"]);
+
+    if (!options.all && !modelIdOrName) {
+      throw new UserError(
+        "Provide a model name or ID, or use --all to cancel all running runs",
+      );
+    }
+
+    const { repoContext } = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const outputRepo = repoContext.outputRepo;
+    const reason = options.reason as string | undefined;
+
+    if (options.all) {
+      const allOutputs = await outputRepo.findAllGlobal();
+      const running = allOutputs.filter((o) => o.output.status === "running");
+
+      if (running.length === 0) {
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({ cancelled: [] }));
+        } else {
+          cliCtx.logger.info("No running model method runs to cancel.");
+        }
+        return;
+      }
+
+      const cancelled: { id: string; type: string; method: string }[] = [];
+      for (const entry of running) {
+        if (entry.output.pid && entry.output.pid !== Deno.pid) {
+          await killProcessTree(entry.output.pid);
+        }
+        entry.output.markCancelled(reason);
+        await outputRepo.save(entry.type, entry.method, entry.output);
+        cancelled.push({
+          id: entry.output.id,
+          type: entry.type.normalized,
+          method: entry.method,
+        });
+      }
+
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify({
+          cancelled,
+          reason: reason ?? null,
+        }));
+      } else {
+        cliCtx.logger
+          .info`Cancelled ${cancelled.length} running model method run(s)`;
+        for (const c of cancelled) {
+          cliCtx.logger.info`  ${c.type}/${c.method} (${c.id})`;
+        }
+      }
+      return;
+    }
+
+    // Cancel a specific model's running output
+    const definitionRepo = repoContext.definitionRepo;
+    const resolved = await definitionRepo.findByNameGlobal(modelIdOrName!);
+    if (!resolved) {
+      throw new UserError(
+        `Model '${modelIdOrName}' not found`,
+      );
+    }
+
+    const { definition, type } = resolved;
+
+    const allOutputs = await outputRepo.findAll(type);
+    const running = allOutputs.filter(
+      (o) => o.definitionId === definition.id && o.status === "running",
+    );
+
+    if (running.length === 0) {
+      throw new UserError(
+        `No running method runs found for model '${definition.name}'`,
+      );
+    }
+
+    const latest = running.sort(
+      (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
+    )[0];
+
+    if (latest.pid && latest.pid !== Deno.pid) {
+      await killProcessTree(latest.pid);
+    }
+    latest.markCancelled(reason);
+    await outputRepo.save(type, latest.methodName, latest);
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({
+        id: latest.id,
+        modelName: definition.name,
+        type: type.normalized,
+        method: latest.methodName,
+        status: "cancelled",
+        reason: reason ?? null,
+      }));
+    } else {
+      cliCtx.logger
+        .info`Cancelled method run ${latest.methodName} for model ${definition.name} (${latest.id})`;
+    }
+  });

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -42,6 +42,7 @@ import { modelEditCommand } from "./model_edit.ts";
 import { modelEvaluateCommand } from "./model_evaluate.ts";
 import { modelOutputCommand } from "./model_output.ts";
 import { modelTypeCommand } from "./model_type.ts";
+import { modelCancelCommand } from "./model_cancel.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -97,6 +98,7 @@ export const modelCommand = new Command()
   .description("Manage models")
   .error(unknownCommandErrorHandler)
   .action(groupCommandAction)
+  .command("cancel", modelCancelCommand)
   .command("create", modelCreateCommand)
   .command("delete", modelDeleteCommand)
   .command("edit", modelEditCommand)

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -73,6 +73,7 @@ import {
   runModelMethodOverServer,
 } from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
+import { suppressSyncExitOnSignal } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { parseTimeout } from "../duration_parser.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
@@ -335,7 +336,12 @@ export const modelMethodRunCommand = new Command()
       const timeoutMs = options.timeout
         ? parseTimeout(options.timeout as string)
         : undefined;
-      const baseLibCtx = createLibSwampContext();
+      const abort = new AbortController();
+      const exitSuppress = suppressSyncExitOnSignal();
+      const shutdownHandle = registerShutdownHandler({
+        handler: () => abort.abort(),
+      });
+      const baseLibCtx = createLibSwampContext({ signal: abort.signal });
       const libCtx = timeoutMs !== undefined
         ? baseLibCtx.withTimeout(timeoutMs)
         : baseLibCtx;
@@ -406,6 +412,11 @@ export const modelMethodRunCommand = new Command()
             renderer.handlers(),
           );
 
+          if (abort.signal.aborted) {
+            Deno.exitCode = 1;
+            return;
+          }
+
           if (renderer.runFailed()) {
             Deno.exitCode = 1;
             return;
@@ -418,6 +429,8 @@ export const modelMethodRunCommand = new Command()
         const message = error instanceof Error ? error.message : String(error);
         throw new UserError(`Method execution failed: ${message}`);
       } finally {
+        shutdownHandle.dispose();
+        exitSuppress.dispose();
         if (flushModelLocks) {
           try {
             await flushModelLocks();

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -945,7 +945,7 @@ export const serveCommand = new Command()
             if (
               !found && executionType === "workflow-run" && scheduledExecution
             ) {
-              found = scheduledExecution.cancelRun(executionId);
+              found = scheduledExecution.cancelByRunId(executionId);
             }
             if (found) {
               return Response.json({

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -52,6 +52,7 @@ import { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
+import { RunCancelRegistry } from "../../serve/run_cancel_registry.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
@@ -610,6 +611,8 @@ export const serveCommand = new Command()
       mode: grantReloadMode,
     });
 
+    const cancelRegistry = new RunCancelRegistry();
+
     const connectionCtx = {
       repoDir: resolvedRepoDir,
       repoContext,
@@ -618,7 +621,39 @@ export const serveCommand = new Command()
       workerGateway,
       policySnapshotLoader,
       authConfig,
+      cancelRegistry,
     };
+
+    // Reap orphaned runs left in "running" state by a previous daemon.
+    // Only scan runs started within the last 7 days — anything older is
+    // either already terminal or so stale that it was cleaned up manually.
+    const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const recentRuns = await repoContext.workflowRunRepo.findAllGlobalSince(
+      reapCutoff,
+    );
+    for (const { run, workflowId } of recentRuns) {
+      if (run.status === "running") {
+        logger.warn(
+          "Reaping orphaned workflow run {runId} (workflow: {workflowName})",
+          { runId: run.id, workflowName: run.workflowName },
+        );
+        run.cancel("daemon restarted");
+        await repoContext.workflowRunRepo.save(workflowId, run);
+      }
+    }
+    const recentOutputs = await repoContext.outputRepo.findAllGlobalSince(
+      reapCutoff,
+    );
+    for (const { output, type, method } of recentOutputs) {
+      if (output.status === "running") {
+        logger.warn(
+          "Reaping orphaned model output {outputId} (method: {methodName})",
+          { outputId: output.id, methodName: output.methodName },
+        );
+        output.markCancelled("daemon restarted");
+        await repoContext.outputRepo.save(type, method, output);
+      }
+    }
 
     const ac = new AbortController();
     const enableSchedule = options.schedule !== false;
@@ -869,6 +904,86 @@ export const serveCommand = new Command()
         if (webhookService && req.method === "POST") {
           const webhookResponse = await webhookService.handleRequest(req);
           if (webhookResponse) return webhookResponse;
+        }
+
+        // Cancel endpoint (authenticated — same auth as WebSocket)
+        if (req.method === "POST") {
+          const url = new URL(req.url);
+          const cancelMatch = url.pathname.match(
+            /^\/api\/v1\/cancel\/(workflow-run|method-run)\/(.+)$/,
+          );
+          const isBulkCancel = url.pathname === "/api/v1/cancel";
+          if (cancelMatch || isBulkCancel) {
+            if (authConfig.mode !== "none") {
+              const authHeader = req.headers.get("authorization");
+              const token = authHeader?.startsWith("Bearer ")
+                ? authHeader.slice(7)
+                : null;
+              if (!token) {
+                return new Response("Unauthorized: token required", {
+                  status: 401,
+                });
+              }
+              const authResult = await authenticateServerToken(
+                token,
+                resolvedRepoDir,
+                repoContext,
+              );
+              if (!authResult.ok) {
+                return new Response("Unauthorized", { status: 401 });
+              }
+            }
+          }
+          if (cancelMatch) {
+            const executionType = cancelMatch[1] as
+              | "workflow-run"
+              | "method-run";
+            const executionId = cancelMatch[2];
+            // Check cancel registry first (WebSocket ad-hoc and webhook runs)
+            let found = cancelRegistry.cancel(executionType, executionId);
+            // For workflow runs, also check scheduled execution service
+            if (
+              !found && executionType === "workflow-run" && scheduledExecution
+            ) {
+              found = scheduledExecution.cancelRun(executionId);
+            }
+            if (found) {
+              return Response.json({
+                status: "cancelled",
+                executionType,
+                executionId,
+              });
+            }
+            return Response.json({
+              status: "not_found",
+              message:
+                `No active ${executionType} with id ${executionId} in this serve instance`,
+            }, { status: 404 });
+          }
+          if (url.pathname === "/api/v1/cancel") {
+            const body = await req.json().catch(() => ({}));
+            const typeFilter = body.executionType as
+              | "workflow-run"
+              | "method-run"
+              | undefined;
+            if (
+              typeFilter && typeFilter !== "workflow-run" &&
+              typeFilter !== "method-run"
+            ) {
+              return Response.json({
+                status: "error",
+                message: "executionType must be 'workflow-run' or 'method-run'",
+              }, { status: 400 });
+            }
+            let count = cancelRegistry.cancelAll(typeFilter);
+            if (
+              (!typeFilter || typeFilter === "workflow-run") &&
+              scheduledExecution
+            ) {
+              count += scheduledExecution.cancelAllRuns();
+            }
+            return Response.json({ status: "cancelled", count });
+          }
         }
 
         // Health check endpoint

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -910,7 +910,7 @@ export const serveCommand = new Command()
         if (req.method === "POST") {
           const url = new URL(req.url);
           const cancelMatch = url.pathname.match(
-            /^\/api\/v1\/cancel\/(workflow-run|method-run)\/(.+)$/,
+            /^\/api\/v1\/cancel\/(workflow-run|method-run)\/([^/]+)$/,
           );
           const isBulkCancel = url.pathname === "/api/v1/cancel";
           if (cancelMatch || isBulkCancel) {
@@ -962,10 +962,9 @@ export const serveCommand = new Command()
           }
           if (url.pathname === "/api/v1/cancel") {
             const body = await req.json().catch(() => ({}));
-            const typeFilter = body.executionType as
-              | "workflow-run"
-              | "method-run"
-              | undefined;
+            const typeFilter = typeof body.executionType === "string"
+              ? body.executionType
+              : undefined;
             if (
               typeFilter && typeFilter !== "workflow-run" &&
               typeFilter !== "method-run"

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -36,6 +36,7 @@ import { workflowApproveCommand } from "./workflow_approve.ts";
 import { workflowRejectCommand } from "./workflow_reject.ts";
 import { workflowResumeCommand } from "./workflow_resume.ts";
 import { workflowApprovalsCommand } from "./workflow_approvals.ts";
+import { workflowCancelCommand } from "./workflow_cancel.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 export const workflowCommand = new Command()
@@ -53,6 +54,7 @@ export const workflowCommand = new Command()
   .command("search", workflowSearchCommand)
   .command("run", workflowRunCommand)
   .command("approve", workflowApproveCommand)
+  .command("cancel", workflowCancelCommand)
   .command("reject", workflowRejectCommand)
   .command("resume", workflowResumeCommand)
   .command("approvals", workflowApprovalsCommand)

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -1,0 +1,235 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "../../domain/workflows/repositories.ts";
+import { killProcessTree } from "../../infrastructure/process/process_kill.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
+
+async function cancelRun(run: WorkflowRun, reason: string): Promise<void> {
+  if (run.pid && run.pid !== Deno.pid) {
+    await killProcessTree(run.pid);
+  }
+  run.cancel(reason);
+}
+
+async function findAllActiveRuns(
+  workflowRepo: WorkflowRepository,
+  runRepo: WorkflowRunRepository,
+): Promise<
+  { run: WorkflowRun; workflowId: WorkflowId; workflowName: string }[]
+> {
+  const workflows = await workflowRepo.findAll();
+  const results: {
+    run: WorkflowRun;
+    workflowId: WorkflowId;
+    workflowName: string;
+  }[] = [];
+
+  for (const workflow of workflows) {
+    const runs = await runRepo.findAllByWorkflowId(workflow.id);
+    for (const run of runs) {
+      if (!TERMINAL_STATUSES.has(run.status)) {
+        results.push({
+          run,
+          workflowId: workflow.id,
+          workflowName: workflow.name,
+        });
+      }
+    }
+  }
+  return results;
+}
+
+export const workflowCancelCommand = new Command()
+  .name("cancel")
+  .description("Cancel a running workflow run")
+  .example(
+    "Cancel latest running run",
+    "swamp workflow cancel my-workflow",
+  )
+  .example(
+    "Cancel a specific run",
+    "swamp workflow cancel my-workflow --run <run-id>",
+  )
+  .example(
+    "Cancel all running runs",
+    "swamp workflow cancel --all",
+  )
+  .example(
+    "Cancel with reason",
+    "swamp workflow cancel my-workflow --reason 'No longer needed'",
+  )
+  .arguments("[workflow_id_or_name:string]")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--run <run_id:string>", "Target a specific run ID")
+  .option("--all", "Cancel all running workflow runs")
+  .option("--reason <reason:string>", "Reason for cancellation")
+  .action(
+    async function (
+      options: AnyOptions,
+      workflowIdOrName?: string,
+    ) {
+      const cliCtx = createContext(options as GlobalOptions, [
+        "workflow",
+        "cancel",
+      ]);
+
+      if (!options.all && !workflowIdOrName) {
+        throw new UserError(
+          "Provide a workflow name or ID, or use --all to cancel all running runs",
+        );
+      }
+
+      const { repoContext } = await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
+
+      const workflowRepo = repoContext.workflowRepo;
+      const runRepo = repoContext.workflowRunRepo;
+      const reason = options.reason ?? "Cancelled by user";
+
+      if (options.all) {
+        const activeRuns = await findAllActiveRuns(workflowRepo, runRepo);
+        if (activeRuns.length === 0) {
+          throw new UserError("No active workflow runs found to cancel");
+        }
+
+        const cancelled: {
+          runId: string;
+          workflowName: string;
+          previousStatus: string;
+        }[] = [];
+        for (const { run, workflowId, workflowName } of activeRuns) {
+          const previousStatus = run.status;
+          await cancelRun(run, reason);
+          await runRepo.save(workflowId, run);
+          cancelled.push({
+            runId: run.id,
+            workflowName,
+            previousStatus,
+          });
+        }
+
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({
+            cancelled,
+            count: cancelled.length,
+            reason,
+          }));
+        } else {
+          cliCtx.logger
+            .info`Cancelled ${cancelled.length} workflow run(s)`;
+          for (const entry of cancelled) {
+            cliCtx.logger
+              .info`  ${entry.workflowName} (${entry.runId}): ${entry.previousStatus} -> cancelled`;
+          }
+        }
+        return;
+      }
+
+      // Single workflow cancel path
+      const workflow = await workflowRepo.findByName(workflowIdOrName!) ??
+        await workflowRepo.findById(
+          createWorkflowId(workflowIdOrName!),
+        );
+      if (!workflow) {
+        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+      }
+
+      let run: WorkflowRun;
+      if (options.run) {
+        const found = await runRepo.findById(
+          workflow.id,
+          (await import("../../domain/workflows/workflow_id.ts"))
+            .createWorkflowRunId(options.run),
+        );
+        if (!found) {
+          throw new UserError(`Workflow run not found: ${options.run}`);
+        }
+        run = found;
+      } else {
+        const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
+        const activeRuns = allRuns.filter(
+          (r) => !TERMINAL_STATUSES.has(r.status),
+        );
+
+        if (activeRuns.length === 0) {
+          throw new UserError(
+            `No active runs found for workflow "${workflow.name}"`,
+          );
+        }
+
+        run = activeRuns.reduce((latest, current) => {
+          if (!latest.startedAt) return current;
+          if (!current.startedAt) return latest;
+          return current.startedAt > latest.startedAt ? current : latest;
+        });
+      }
+
+      if (TERMINAL_STATUSES.has(run.status)) {
+        throw new UserError(
+          `Run ${run.id} is already in a terminal state (status: ${run.status})`,
+        );
+      }
+
+      const previousStatus = run.status;
+      await cancelRun(run, reason);
+      await runRepo.save(createWorkflowId(workflow.id), run);
+
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify({
+          runId: run.id,
+          workflowName: workflow.name,
+          previousStatus,
+          status: "cancelled",
+          reason,
+        }));
+      } else {
+        cliCtx.logger
+          .info`Cancelled run ${run.id} of workflow ${workflow.name}`;
+        cliCtx.logger
+          .info`Status: ${previousStatus} -> cancelled`;
+        if (options.reason) {
+          cliCtx.logger.info`Reason: ${reason}`;
+        }
+      }
+    },
+  );

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -25,7 +25,10 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type {
@@ -129,7 +132,12 @@ export const workflowCancelCommand = new Command()
       if (options.all) {
         const activeRuns = await findAllActiveRuns(workflowRepo, runRepo);
         if (activeRuns.length === 0) {
-          throw new UserError("No active workflow runs found to cancel");
+          if (cliCtx.outputMode === "json") {
+            console.log(JSON.stringify({ cancelled: [] }));
+          } else {
+            cliCtx.logger.info("No active workflow runs found to cancel.");
+          }
+          return;
         }
 
         const cancelled: {
@@ -178,8 +186,7 @@ export const workflowCancelCommand = new Command()
       if (options.run) {
         const found = await runRepo.findById(
           workflow.id,
-          (await import("../../domain/workflows/workflow_id.ts"))
-            .createWorkflowRunId(options.run),
+          createWorkflowRunId(options.run),
         );
         if (!found) {
           throw new UserError(`Workflow run not found: ${options.run}`);

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -78,6 +78,7 @@ import {
   runWorkflowOverServer,
 } from "../remote_run.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
+import { suppressSyncExitOnSignal } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -234,6 +235,9 @@ export const workflowRunCommand = new Command()
       return result;
     };
 
+    const abort = new AbortController();
+    const exitSuppress = suppressSyncExitOnSignal();
+    let shutdownHandle: { dispose(): void } | undefined;
     try {
       const runRepo = repoContext.workflowRunRepo;
 
@@ -355,7 +359,10 @@ export const workflowRunCommand = new Command()
       const timeoutMs = options.timeout
         ? parseTimeout(options.timeout as string)
         : undefined;
-      const baseLibCtx = createLibSwampContext();
+      shutdownHandle = registerShutdownHandler({
+        handler: () => abort.abort(),
+      });
+      const baseLibCtx = createLibSwampContext({ signal: abort.signal });
       const libCtx = timeoutMs !== undefined
         ? baseLibCtx.withTimeout(timeoutMs)
         : baseLibCtx;
@@ -380,25 +387,29 @@ export const workflowRunCommand = new Command()
           forceLog: ctx.forceLog,
         });
 
-        await consumeStream(
-          workflowRun(libCtx, deps, {
-            workflowIdOrName,
-            lastEvaluated,
-            inputs: inputSets[i],
-            runtimeTags,
-            verbose: ctx.verbosity === "verbose",
-            skipAllReports: options.skipReports as boolean | undefined,
-            skipReportNames: options.skipReport as string[] | undefined,
-            skipReportLabels: options.skipReportLabel as string[] | undefined,
-            reportNames: options.report as string[] | undefined,
-            reportLabels: options.reportLabel as string[] | undefined,
-            swampSha: GIT_SHA || undefined,
-            skipAllChecks: options.skipChecks as boolean | undefined,
-            skipCheckNames: options.skipCheck as string[] | undefined,
-            skipCheckLabels: options.skipCheckLabel as string[] | undefined,
-          }),
-          renderer.handlers(),
-        );
+        const eventStream = workflowRun(libCtx, deps, {
+          workflowIdOrName,
+          lastEvaluated,
+          inputs: inputSets[i],
+          runtimeTags,
+          verbose: ctx.verbosity === "verbose",
+          skipAllReports: options.skipReports as boolean | undefined,
+          skipReportNames: options.skipReport as string[] | undefined,
+          skipReportLabels: options.skipReportLabel as string[] | undefined,
+          reportNames: options.report as string[] | undefined,
+          reportLabels: options.reportLabel as string[] | undefined,
+          swampSha: GIT_SHA || undefined,
+          skipAllChecks: options.skipChecks as boolean | undefined,
+          skipCheckNames: options.skipCheck as string[] | undefined,
+          skipCheckLabels: options.skipCheckLabel as string[] | undefined,
+        });
+
+        await consumeStream(eventStream, renderer.handlers());
+
+        if (abort.signal.aborted) {
+          Deno.exitCode = 1;
+          return;
+        }
 
         if (renderer.workflowFailed()) {
           Deno.exitCode = 1;
@@ -406,11 +417,37 @@ export const workflowRunCommand = new Command()
         }
       }
     } catch (error) {
+      if (abort.signal.aborted) {
+        // Ctrl+C or timeout — the generator may not have saved the
+        // cancelled status. Find the latest running run and cancel it.
+        try {
+          const workflows = await repoContext.workflowRepo.findAll();
+          const wf = workflows.find((w) => w.name === workflowIdOrName) ??
+            workflows.find((w) => w.id === workflowIdOrName);
+          if (wf) {
+            const runs = await repoContext.workflowRunRepo
+              .findAllByWorkflowId(wf.id);
+            for (const run of runs) {
+              if (run.status === "running") {
+                run.cancel("aborted");
+                await repoContext.workflowRunRepo.save(wf.id, run);
+              }
+            }
+          }
+        } catch {
+          // Best-effort — if we can't save, the daemon reaper will catch it
+        }
+        Deno.exitCode = 1;
+        return;
+      }
       if (error instanceof UserError) {
         throw error;
       }
       const message = error instanceof Error ? error.message : String(error);
       throw new UserError(`Workflow execution failed: ${message}`);
+    } finally {
+      shutdownHandle?.dispose();
+      exitSuppress.dispose();
     }
   })
   .command("search", workflowRunSearchCommand)

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -44,7 +44,10 @@ import {
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
 import {
   deepMerge,
   mergeInputArgs,
@@ -238,6 +241,7 @@ export const workflowRunCommand = new Command()
     const abort = new AbortController();
     const exitSuppress = suppressSyncExitOnSignal();
     let shutdownHandle: { dispose(): void } | undefined;
+    let currentRunId: string | undefined;
     try {
       const runRepo = repoContext.workflowRunRepo;
 
@@ -386,7 +390,6 @@ export const workflowRunCommand = new Command()
           workflowName: workflowIdOrName,
           forceLog: ctx.forceLog,
         });
-
         const eventStream = workflowRun(libCtx, deps, {
           workflowIdOrName,
           lastEvaluated,
@@ -404,7 +407,15 @@ export const workflowRunCommand = new Command()
           skipCheckLabels: options.skipCheckLabel as string[] | undefined,
         });
 
-        await consumeStream(eventStream, renderer.handlers());
+        const baseHandlers = renderer.handlers();
+        const wrappedHandlers = {
+          ...baseHandlers,
+          started: (e: WorkflowRunEvent & { kind: "started" }) => {
+            currentRunId = e.runId;
+            baseHandlers.started(e);
+          },
+        };
+        await consumeStream(eventStream, wrappedHandlers);
 
         if (abort.signal.aborted) {
           Deno.exitCode = 1;
@@ -419,16 +430,18 @@ export const workflowRunCommand = new Command()
     } catch (error) {
       if (abort.signal.aborted) {
         // Ctrl+C or timeout — the generator may not have saved the
-        // cancelled status. Find the latest running run and cancel it.
+        // cancelled status. Cancel only the specific run we started.
         try {
-          const workflows = await repoContext.workflowRepo.findAll();
-          const wf = workflows.find((w) => w.name === workflowIdOrName) ??
-            workflows.find((w) => w.id === workflowIdOrName);
-          if (wf) {
-            const runs = await repoContext.workflowRunRepo
-              .findAllByWorkflowId(wf.id);
-            for (const run of runs) {
-              if (run.status === "running") {
+          if (currentRunId) {
+            const workflows = await repoContext.workflowRepo.findAll();
+            const wf = workflows.find((w) => w.name === workflowIdOrName) ??
+              workflows.find((w) => w.id === workflowIdOrName);
+            if (wf) {
+              const run = await repoContext.workflowRunRepo.findById(
+                wf.id,
+                createWorkflowRunId(currentRunId),
+              );
+              if (run && run.status === "running") {
                 run.cancel("aborted");
                 await repoContext.workflowRunRepo.save(wf.id, run);
               }

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -133,6 +133,7 @@ async function executeCommand(
       cwd: args.workingDir,
       env: Object.keys(shellEnv).length > 0 ? shellEnv : undefined,
       timeoutMs: args.timeout,
+      signal: context.signal,
       logger: context.logger,
       redactor: context.redactor,
       onOutput: context.onEvent

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -40,6 +40,7 @@ export const ExecutionStatuses = [
   "running",
   "succeeded",
   "failed",
+  "cancelled",
 ] as const;
 export type ExecutionStatus = typeof ExecutionStatuses[number];
 
@@ -130,6 +131,7 @@ export const ModelOutputSchema = z.object({
   provenance: ExecutionProvenanceSchema,
   artifacts: ArtifactsProducedSchema.optional(),
   logFile: z.string().optional(),
+  pid: z.number().int().positive().optional(),
 });
 
 /**
@@ -174,6 +176,7 @@ export class ModelOutput {
     readonly provenance: ExecutionProvenance,
     private _artifacts: ArtifactsProduced,
     private _logFile: string | undefined,
+    private _pid: number | undefined = undefined,
   ) {}
 
   /**
@@ -214,6 +217,7 @@ export class ModelOutput {
       validated.provenance,
       validated.artifacts ?? { dataArtifacts: [] },
       validated.logFile,
+      validated.pid,
     );
   }
 
@@ -238,6 +242,7 @@ export class ModelOutput {
       validated.provenance,
       validated.artifacts ?? { dataArtifacts: [] },
       validated.logFile,
+      validated.pid,
     );
   }
 
@@ -246,6 +251,10 @@ export class ModelOutput {
    */
   get status(): ExecutionStatus {
     return this._status;
+  }
+
+  get pid(): number | undefined {
+    return this._pid;
   }
 
   /**
@@ -302,13 +311,14 @@ export class ModelOutput {
   /**
    * Marks the execution as running.
    */
-  markRunning(): void {
+  markRunning(pid?: number): void {
     if (this._status !== "pending") {
       throw new Error(
         `Cannot mark output as running: status is ${this._status}`,
       );
     }
     this._status = "running";
+    this._pid = pid;
   }
 
   /**
@@ -348,6 +358,28 @@ export class ModelOutput {
   }
 
   /**
+   * Marks the execution as cancelled.
+   *
+   * @param reason - Optional reason for cancellation
+   */
+  markCancelled(reason?: string): void {
+    if (
+      this._status !== "pending" && this._status !== "running"
+    ) {
+      throw new Error(
+        `Cannot mark output as cancelled: status is ${this._status}`,
+      );
+    }
+    const completed = new Date();
+    this._status = "cancelled";
+    this._completedAt = completed;
+    this._durationMs = completed.getTime() - this.startedAt.getTime();
+    if (reason !== undefined) {
+      this._error = { message: reason };
+    }
+  }
+
+  /**
    * Increments the retry count.
    */
   incrementRetryCount(): void {
@@ -369,7 +401,8 @@ export class ModelOutput {
    * Checks if the execution is in a terminal state.
    */
   get isComplete(): boolean {
-    return this._status === "succeeded" || this._status === "failed";
+    return this._status === "succeeded" || this._status === "failed" ||
+      this._status === "cancelled";
   }
 
   /**
@@ -400,6 +433,9 @@ export class ModelOutput {
     }
     if (this._logFile) {
       data.logFile = this._logFile;
+    }
+    if (this._pid !== undefined) {
+      data.pid = this._pid;
     }
 
     return data;

--- a/src/domain/models/model_output_test.ts
+++ b/src/domain/models/model_output_test.ts
@@ -484,3 +484,92 @@ Deno.test("computeDefinitionHash different for different values", async () => {
 
   assertEquals(hash1 !== hash2, true);
 });
+
+// markCancelled tests
+
+Deno.test("ModelOutput.markCancelled: marks running output as cancelled", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+
+  output.markCancelled();
+
+  assertEquals(output.status, "cancelled");
+  assertEquals(output.completedAt !== undefined, true);
+  assertEquals(output.durationMs !== undefined, true);
+  assertEquals(output.error, undefined);
+});
+
+Deno.test("ModelOutput.markCancelled: stores reason in error", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+
+  output.markCancelled("User requested cancellation");
+
+  assertEquals(output.status, "cancelled");
+  assertEquals(output.error?.message, "User requested cancellation");
+});
+
+Deno.test("ModelOutput.markCancelled: works from pending status", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  output.markCancelled();
+
+  assertEquals(output.status, "cancelled");
+  assertEquals(output.isComplete, true);
+});
+
+Deno.test("ModelOutput.markCancelled: throws if already succeeded", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+  output.markSucceeded();
+
+  assertThrows(
+    () => output.markCancelled(),
+    Error,
+    "Cannot mark output as cancelled: status is succeeded",
+  );
+});
+
+Deno.test("ModelOutput.markCancelled: throws if already failed", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    status: "running",
+    provenance: defaultProvenance,
+  });
+  output.markFailed({ message: "error" });
+
+  assertThrows(
+    () => output.markCancelled(),
+    Error,
+    "Cannot mark output as cancelled: status is failed",
+  );
+});
+
+Deno.test("ModelOutput.isComplete: returns true for cancelled", () => {
+  const output = ModelOutput.create({
+    definitionId: createDefinitionId(crypto.randomUUID()),
+    methodName: "create",
+    provenance: defaultProvenance,
+  });
+
+  output.markCancelled();
+
+  assertEquals(output.isComplete, true);
+});

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -153,6 +153,7 @@ export type WorkflowExecutionEvent =
     stepId?: string;
   }
   | { kind: "completed"; run: WorkflowRun }
+  | { kind: "cancelled"; run: WorkflowRun; reason?: string }
   | {
     kind: "suspended";
     run: WorkflowRun;

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -114,6 +114,14 @@ import { getTracer, SpanStatusCode } from "../../infrastructure/tracing/mod.ts";
 import { extractSensitiveFieldValues } from "../models/sensitive_field_extractor.ts";
 
 /**
+ * Extracts a human-readable reason from an AbortSignal. Returns the
+ * Error message when the reason is an Error, or "aborted" otherwise.
+ */
+function abortReason(signal: AbortSignal): string {
+  return signal.reason instanceof Error ? signal.reason.message : "aborted";
+}
+
+/**
  * Thrown when a manual_approval step suspends the workflow. Uses an
  * exception for control flow because the generator stack (runStep →
  * runJob → merge → run) has no other way to unwind cleanly — yield
@@ -1582,9 +1590,7 @@ export class WorkflowExecutionService {
       // Check if the run was cancelled via abort signal
       if (options?.signal?.aborted) {
         run.cancel(
-          options.signal.reason instanceof Error
-            ? options.signal.reason.message
-            : "aborted",
+          abortReason(options.signal),
         );
         await this.saveRun(workflow.id, run);
         yield { kind: "cancelled" as const, run };
@@ -1649,9 +1655,7 @@ export class WorkflowExecutionService {
         workflowRun && options?.signal?.aborted
       ) {
         workflowRun.cancel(
-          options.signal.reason instanceof Error
-            ? options.signal.reason.message
-            : "aborted",
+          abortReason(options.signal),
         );
         await this.saveRun(
           createWorkflowId(workflowRun.workflowId),
@@ -1910,9 +1914,7 @@ export class WorkflowExecutionService {
 
       if (options?.signal?.aborted) {
         existingRun.cancel(
-          options.signal.reason instanceof Error
-            ? options.signal.reason.message
-            : "aborted",
+          abortReason(options.signal),
         );
         await this.saveRun(workflow.id, existingRun);
         yield { kind: "cancelled" as const, run: existingRun };
@@ -1950,9 +1952,7 @@ export class WorkflowExecutionService {
       }
       if (options?.signal?.aborted) {
         existingRun.cancel(
-          options.signal.reason instanceof Error
-            ? options.signal.reason.message
-            : "aborted",
+          abortReason(options.signal),
         );
         await this.saveRun(workflow.id, existingRun);
         yield { kind: "cancelled" as const, run: existingRun };

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -652,7 +652,7 @@ export class DefaultStepExecutor implements StepExecutor {
     });
 
     // Mark as running and save
-    output.markRunning();
+    output.markRunning(Deno.pid);
     // Reference the workflow run's log file for history access
     if (ctx.workflowRun?.logFile) {
       output.setLogFile(ctx.workflowRun.logFile);
@@ -1429,7 +1429,7 @@ export class WorkflowExecutionService {
         runSpan.setAttribute("workflow.run_id", run.id);
 
         // Start execution
-        run.start();
+        run.start(Deno.pid);
 
         if (expressionContext) {
           expressionContext.run = {
@@ -1579,6 +1579,20 @@ export class WorkflowExecutionService {
         }
       }
 
+      // Check if the run was cancelled via abort signal
+      if (options?.signal?.aborted) {
+        run.cancel(
+          options.signal.reason instanceof Error
+            ? options.signal.reason.message
+            : "aborted",
+        );
+        await this.saveRun(workflow.id, run);
+        yield { kind: "cancelled" as const, run };
+        runFileSink.unregister(workflowLogHandle);
+        runSpan.setStatus({ code: SpanStatusCode.OK });
+        return;
+      }
+
       // Complete workflow
       const wfTeardownSpan = tracer.startSpan("swamp.workflow.teardown");
       try {
@@ -1628,6 +1642,23 @@ export class WorkflowExecutionService {
           prompt: error.prompt,
           timeout: error.timeout,
         };
+        runSpan.setStatus({ code: SpanStatusCode.OK });
+        return;
+      }
+      if (
+        workflowRun && options?.signal?.aborted
+      ) {
+        workflowRun.cancel(
+          options.signal.reason instanceof Error
+            ? options.signal.reason.message
+            : "aborted",
+        );
+        await this.saveRun(
+          createWorkflowId(workflowRun.workflowId),
+          workflowRun,
+        );
+        yield { kind: "cancelled" as const, run: workflowRun };
+        runFileSink.unregister(workflowLogHandle);
         runSpan.setStatus({ code: SpanStatusCode.OK });
         return;
       }
@@ -1877,6 +1908,18 @@ export class WorkflowExecutionService {
         }
       }
 
+      if (options?.signal?.aborted) {
+        existingRun.cancel(
+          options.signal.reason instanceof Error
+            ? options.signal.reason.message
+            : "aborted",
+        );
+        await this.saveRun(workflow.id, existingRun);
+        yield { kind: "cancelled" as const, run: existingRun };
+        runFileSink.unregister(workflowLogHandle);
+        return;
+      }
+
       existingRun.complete();
 
       yield* this.runWorkflowReports(
@@ -1903,6 +1946,17 @@ export class WorkflowExecutionService {
           prompt: error.prompt,
           timeout: error.timeout,
         };
+        return;
+      }
+      if (options?.signal?.aborted) {
+        existingRun.cancel(
+          options.signal.reason instanceof Error
+            ? options.signal.reason.message
+            : "aborted",
+        );
+        await this.saveRun(workflow.id, existingRun);
+        yield { kind: "cancelled" as const, run: existingRun };
+        runFileSink.unregister(workflowLogHandle);
         return;
       }
       existingRun.complete();

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -649,6 +649,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   /**
    * Marks the workflow run as cancelled with an optional reason.
+   *
+   * Deliberately no-ops on terminal states (succeeded, failed, cancelled)
+   * so that late cancellation signals don't corrupt an already-finalized run.
+   * This differs from ModelOutput.markCancelled which throws on terminal states.
    */
   cancel(reason?: string): void {
     if (

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -96,12 +96,20 @@ export const WorkflowRunSchema = z.object({
   id: z.string().uuid(),
   workflowId: z.string().uuid(),
   workflowName: z.string().min(1),
-  status: z.enum(["pending", "running", "suspended", "succeeded", "failed"]),
+  status: z.enum([
+    "pending",
+    "running",
+    "suspended",
+    "succeeded",
+    "failed",
+    "cancelled",
+  ]),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   jobs: z.array(JobRunSchema),
   workflowDataArtifacts: z.array(DataArtifactRefSchema).optional(),
   logFile: z.string().optional(),
+  pid: z.number().int().positive().optional(),
   tags: z.record(z.string(), z.string()).default({}),
   // Effective workflow inputs captured when a run suspends, so post-resume
   // steps can resolve `inputs.*`. Optional for backward compatibility with
@@ -473,7 +481,8 @@ export class WorkflowRun implements TriggerEvaluationContext {
       | "running"
       | "suspended"
       | "succeeded"
-      | "failed",
+      | "failed"
+      | "cancelled",
     private _startedAt: Date | undefined,
     private _completedAt: Date | undefined,
     private _jobs: JobRun[],
@@ -482,6 +491,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _workflowDataArtifacts: DataArtifactRef[] = [],
     private _inputs: Record<string, unknown> = {},
     private _resumeInputs: string[] = [],
+    private _pid: number | undefined = undefined,
   ) {}
 
   /**
@@ -533,6 +543,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       validated.workflowDataArtifacts ?? [],
       validated.inputs ?? {},
       validated.resumeInputs ?? [],
+      validated.pid,
     );
   }
 
@@ -541,7 +552,8 @@ export class WorkflowRun implements TriggerEvaluationContext {
     | "running"
     | "suspended"
     | "succeeded"
-    | "failed" {
+    | "failed"
+    | "cancelled" {
     return this._status;
   }
 
@@ -551,6 +563,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   get completedAt(): Date | undefined {
     return this._completedAt;
+  }
+
+  get pid(): number | undefined {
+    return this._pid;
   }
 
   get jobs(): ReadonlyArray<JobRun> {
@@ -608,22 +624,44 @@ export class WorkflowRun implements TriggerEvaluationContext {
   }
 
   /**
-   * Marks the workflow run as started.
+   * Marks the workflow run as started and records the owning process ID.
    */
-  start(): void {
+  start(pid?: number): void {
     this._status = "running";
     this._startedAt = new Date();
+    this._pid = pid;
   }
 
   /**
    * Marks the workflow run as completed (succeeded or failed based on job results).
+   * No-ops if the run is already cancelled.
    */
   complete(): void {
+    if (this._status === "cancelled") {
+      return;
+    }
     const anyNonTerminal = this._jobs.some((j) =>
       j.status !== "succeeded" && j.status !== "skipped"
     );
     this._status = anyNonTerminal ? "failed" : "succeeded";
     this._completedAt = new Date();
+  }
+
+  /**
+   * Marks the workflow run as cancelled with an optional reason.
+   */
+  cancel(reason?: string): void {
+    if (
+      this._status === "succeeded" || this._status === "failed" ||
+      this._status === "cancelled"
+    ) {
+      return;
+    }
+    this._status = "cancelled";
+    this._completedAt = new Date();
+    if (reason) {
+      this._tags["cancel_reason"] = reason;
+    }
   }
 
   /**
@@ -705,6 +743,9 @@ export class WorkflowRun implements TriggerEvaluationContext {
       jobs: this._jobs.map((j) => j.toData()),
       tags: { ...this._tags },
     };
+    if (this._pid !== undefined) {
+      data.pid = this._pid;
+    }
     if (this._logFile) {
       data.logFile = this._logFile;
     }

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -757,3 +757,95 @@ Deno.test("WorkflowRun.fromData tolerates legacy records lacking inputs/resumeIn
   assertEquals(run.inputs, {});
   assertEquals(run.resumeInputs, []);
 });
+
+// WorkflowRun cancel tests
+
+Deno.test("WorkflowRun.cancel: marks running run as cancelled", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.cancel();
+  assertEquals(run.status, "cancelled");
+  assertEquals(run.completedAt instanceof Date, true);
+});
+
+Deno.test("WorkflowRun.cancel: stores reason in tags", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.cancel("user requested");
+  assertEquals(run.tags.cancel_reason, "user requested");
+});
+
+Deno.test("WorkflowRun.cancel: no-ops on succeeded run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.getJob("job1")?.start();
+  run.getJob("job1")?.succeed();
+  run.getJob("job2")?.start();
+  run.getJob("job2")?.succeed();
+  run.complete();
+  run.cancel();
+  assertEquals(run.status, "succeeded");
+});
+
+Deno.test("WorkflowRun.cancel: no-ops on failed run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.getJob("job1")?.start();
+  run.getJob("job1")?.succeed();
+  run.getJob("job2")?.start();
+  run.getJob("job2")?.fail();
+  run.complete();
+  run.cancel();
+  assertEquals(run.status, "failed");
+});
+
+Deno.test("WorkflowRun.cancel: no-ops on already cancelled run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.cancel();
+  run.cancel();
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("WorkflowRun.cancel: works on suspended run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.suspend();
+  run.cancel();
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("WorkflowRun.cancel: works on pending run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.cancel();
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("WorkflowRun.complete: no-ops on cancelled run", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.cancel();
+  run.complete();
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("WorkflowRun: cancelled round-trips through serialization", () => {
+  const workflow = createTestWorkflow();
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  run.cancel("test reason");
+
+  const data = run.toData();
+  const restored = WorkflowRun.fromData(data);
+
+  assertEquals(restored.status, "cancelled");
+  assertEquals(restored.tags.cancel_reason, "test reason");
+});

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -118,7 +118,9 @@ function installSignalHandler(): void {
         .map((e) => e.lock!.release().catch(() => {}));
       Promise.all(releases).finally(() => {
         clearTimeout(forceExit);
-        Deno.exit(130);
+        if (!exitSuppressed) {
+          Deno.exit(130);
+        }
       });
     },
     includePosixSignals: false,
@@ -132,6 +134,23 @@ function maybeRemoveSignalHandler(): void {
   if (entries.size > 0 || !shutdownHandle) return;
   shutdownHandle.dispose();
   shutdownHandle = null;
+}
+
+let exitSuppressed = false;
+
+/**
+ * Temporarily suppresses the `Deno.exit(130)` call in the SIGINT handler.
+ * Lock releases still happen, but the process stays alive so the caller can
+ * do its own cleanup (e.g. save a cancelled workflow run and render the
+ * final TUI state). Call the returned dispose function to re-enable.
+ */
+export function suppressSyncExitOnSignal(): { dispose(): void } {
+  exitSuppressed = true;
+  return {
+    dispose() {
+      exitSuppressed = false;
+    },
+  };
 }
 
 /**

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -118,7 +118,7 @@ function installSignalHandler(): void {
         .map((e) => e.lock!.release().catch(() => {}));
       Promise.all(releases).finally(() => {
         clearTimeout(forceExit);
-        if (!exitSuppressed) {
+        if (suppressCount === 0) {
           Deno.exit(130);
         }
       });
@@ -136,19 +136,26 @@ function maybeRemoveSignalHandler(): void {
   shutdownHandle = null;
 }
 
-let exitSuppressed = false;
+let suppressCount = 0;
 
 /**
  * Temporarily suppresses the `Deno.exit(130)` call in the SIGINT handler.
  * Lock releases still happen, but the process stays alive so the caller can
  * do its own cleanup (e.g. save a cancelled workflow run and render the
  * final TUI state). Call the returned dispose function to re-enable.
+ *
+ * Reference-counted: if two callers suppress, the first dispose does not
+ * re-enable exit for the second.
  */
 export function suppressSyncExitOnSignal(): { dispose(): void } {
-  exitSuppressed = true;
+  suppressCount++;
+  let disposed = false;
   return {
     dispose() {
-      exitSuppressed = false;
+      if (!disposed) {
+        disposed = true;
+        suppressCount--;
+      }
     },
   };
 }

--- a/src/infrastructure/process/process_kill.ts
+++ b/src/infrastructure/process/process_kill.ts
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["process", "kill"]);
+
+/**
+ * Verifies that the process at the given PID is a swamp process by
+ * inspecting its command line. Returns false if the PID doesn't exist
+ * or belongs to a different program — guarding against PID reuse.
+ */
+async function isSwampProcess(pid: number): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("ps", {
+      args: ["-p", String(pid), "-o", "command="],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const output = await cmd.output();
+    if (!output.success) return false;
+    const cmdline = new TextDecoder().decode(output.stdout).trim();
+    return cmdline.includes("swamp");
+  } catch {
+    return false;
+  }
+}
+
+async function findChildPids(ppid: number): Promise<number[]> {
+  try {
+    const cmd = new Deno.Command("pgrep", {
+      args: ["-P", String(ppid)],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const output = await cmd.output();
+    const text = new TextDecoder().decode(output.stdout).trim();
+    if (!text) return [];
+    return text.split("\n").map(Number).filter((n) => !isNaN(n));
+  } catch {
+    return [];
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    Deno.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Kills a process tree (parent + children) after verifying the parent is
+ * a swamp process. Sends SIGTERM for graceful shutdown, waits up to
+ * {@link maxWaitMs} for exit, then SIGKILL anything still alive.
+ *
+ * Returns true if the process was found and killed, false if the PID was
+ * not a swamp process (PID reuse) or already dead.
+ */
+export async function killProcessTree(
+  pid: number,
+  { maxWaitMs = 2000 }: { maxWaitMs?: number } = {},
+): Promise<boolean> {
+  if (!isProcessAlive(pid)) {
+    return false;
+  }
+
+  if (!await isSwampProcess(pid)) {
+    logger
+      .warn`PID ${pid} is not a swamp process — skipping kill (possible PID reuse)`;
+    return false;
+  }
+
+  // Snapshot children before killing parent (reparented after parent dies)
+  const children = await findChildPids(pid);
+
+  try {
+    Deno.kill(pid, "SIGTERM");
+  } catch { /* race: died between check and kill */ }
+
+  // Poll until parent exits or timeout
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  // Force kill parent if still alive
+  if (isProcessAlive(pid)) {
+    try {
+      Deno.kill(pid, "SIGKILL");
+    } catch { /* already gone */ }
+  }
+
+  // Force kill all children
+  for (const child of children) {
+    if (isProcessAlive(child)) {
+      try {
+        Deno.kill(child, "SIGKILL");
+      } catch { /* already gone */ }
+    }
+  }
+
+  // Final wait for everything to be gone
+  const finalDeadline = Date.now() + 500;
+  while (Date.now() < finalDeadline) {
+    const anyAlive = [pid, ...children].some(isProcessAlive);
+    if (!anyAlive) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  return true;
+}

--- a/src/infrastructure/process/process_kill.ts
+++ b/src/infrastructure/process/process_kill.ts
@@ -27,6 +27,9 @@ const logger = getLogger(["process", "kill"]);
  * or belongs to a different program — guarding against PID reuse.
  */
 async function isSwampProcess(pid: number): Promise<boolean> {
+  // Windows lacks `ps`; skip verification and trust the caller's PID.
+  if (Deno.build.os === "windows") return true;
+
   try {
     const cmd = new Deno.Command("ps", {
       args: ["-p", String(pid), "-o", "command="],
@@ -44,6 +47,27 @@ async function isSwampProcess(pid: number): Promise<boolean> {
 
 async function findChildPids(ppid: number): Promise<number[]> {
   try {
+    if (Deno.build.os === "windows") {
+      const cmd = new Deno.Command("wmic", {
+        args: [
+          "process",
+          "where",
+          `(ParentProcessId=${ppid})`,
+          "get",
+          "ProcessId",
+        ],
+        stdout: "piped",
+        stderr: "null",
+      });
+      const output = await cmd.output();
+      const text = new TextDecoder().decode(output.stdout).trim();
+      if (!text) return [];
+      // wmic output has a header line ("ProcessId") followed by PID values
+      return text.split("\n").map((l) => l.trim()).map(Number).filter((n) =>
+        !isNaN(n)
+      );
+    }
+
     const cmd = new Deno.Command("pgrep", {
       args: ["-P", String(ppid)],
       stdout: "piped",

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -139,6 +139,7 @@ export type ModelMethodRunEvent =
     error: string;
   }
   | { kind: "completed"; run: ModelMethodRunView }
+  | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
   | { kind: "error"; error: SwampError };
 
 /**
@@ -578,7 +579,7 @@ export async function* modelMethodRun(
             triggeredBy: "manual",
           },
         });
-        output.markRunning();
+        output.markRunning(Deno.pid);
         output.setLogFile(logFilePath);
         await deps.outputRepo.save(modelType, input.methodName, output);
 
@@ -651,17 +652,28 @@ export async function* modelMethodRun(
               ),
           );
         } catch (error) {
-          // Mark output as failed and save
           const errorMessage = error instanceof Error
             ? error.message
             : String(error);
           const errorStack = error instanceof Error ? error.stack : undefined;
-          output.markFailed({ message: errorMessage, stack: errorStack });
-          await deps.outputRepo.save(modelType, input.methodName, output);
+
+          if (
+            ctx.signal.aborted ||
+            (error instanceof DOMException && error.name === "AbortError")
+          ) {
+            output.markCancelled("aborted");
+            await deps.outputRepo.save(modelType, input.methodName, output);
+          } else {
+            output.markFailed({ message: errorMessage, stack: errorStack });
+            await deps.outputRepo.save(modelType, input.methodName, output);
+          }
 
           // Run method-summary report for failed executions so JSON consumers
           // see structured error output (not just the raw error event).
-          if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
+          if (
+            output.status === "failed" && !input.skipAllReports &&
+            reportRegistry.getAll().length > 0
+          ) {
             const failedMethodContext = buildMethodReportContext(
               {
                 repoDir: deps.repoDir,
@@ -735,6 +747,10 @@ export async function* modelMethodRun(
                 };
               }
             }
+          }
+
+          if (output.status === "cancelled") {
+            return;
           }
 
           if (

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -327,17 +327,26 @@ Deno.test("modelMethodRun yields error on execution failure", async () => {
   }
 });
 
-Deno.test("modelMethodRun yields cancelled error on abort", async () => {
+Deno.test("modelMethodRun marks output cancelled on abort", async () => {
   const definition = createTestDefinition("test-model", "run");
   const modelDef = createTestModelDef("run");
   const controller = new AbortController();
+  const savedOutputs: { status: string }[] = [];
   const deps: ModelMethodRunDeps = {
     ...createTestDeps(definition, modelDef),
     createExecutionService: () =>
       createFailingExecutionService(
         new DOMException("The operation was aborted.", "AbortError"),
       ),
-    outputRepo: createFakeOutputRepo(),
+    outputRepo: {
+      ...createFakeOutputRepo(),
+      save: (_type: unknown, _method: unknown, output: unknown) => {
+        savedOutputs.push({
+          status: (output as { status: string }).status,
+        });
+        return Promise.resolve();
+      },
+    } as ReturnType<typeof createFakeOutputRepo>,
   };
 
   // Abort before execution to simulate cancellation
@@ -347,11 +356,12 @@ Deno.test("modelMethodRun yields cancelled error on abort", async () => {
     modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
   );
 
-  const last = events[events.length - 1];
-  assertEquals(last.kind, "error");
-  if (last.kind === "error") {
-    assertEquals(last.error.code, "cancelled");
-  }
+  // No error event should be yielded — the output is marked cancelled
+  const errorEvents = events.filter((e) => e.kind === "error");
+  assertEquals(errorEvents.length, 0);
+  // The output should have been saved as cancelled
+  const cancelledSaves = savedOutputs.filter((o) => o.status === "cancelled");
+  assertEquals(cancelledSaves.length > 0, true);
 });
 
 // --- Error factory tests ---

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -176,6 +176,7 @@ export type WorkflowRunEvent =
     stepId?: string;
   }
   | { kind: "completed"; run: WorkflowRunView }
+  | { kind: "cancelled"; run: WorkflowRunView; reason?: string }
   | {
     kind: "suspended";
     run: WorkflowRunView;
@@ -408,6 +409,14 @@ export function mapWorkflowExecutionEvent(
       const data = toRunData(event.run, path, verbose);
       return { kind: "completed", run: data };
     }
+    case "cancelled": {
+      const path = runRepo.getPath(
+        createWorkflowId(event.run.workflowId),
+        createWorkflowRunId(event.run.id),
+      );
+      const data = toRunData(event.run, path, verbose);
+      return { kind: "cancelled", run: data, reason: event.reason };
+    }
     case "suspended": {
       const path = runRepo.getPath(
         createWorkflowId(event.run.workflowId),
@@ -578,7 +587,8 @@ export async function* workflowRun(
           }
 
           if (
-            (mapped.kind === "completed" || mapped.kind === "suspended") &&
+            (mapped.kind === "completed" || mapped.kind === "cancelled" ||
+              mapped.kind === "suspended") &&
             reportResults.length > 0
           ) {
             mapped = {

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -112,7 +112,10 @@ export interface ScheduledExecutionDeps {
 export class ScheduledExecutionService {
   private readonly scheduler: WorkflowScheduler;
   private readonly watcher: WorkflowWatcher;
-  private readonly running = new Map<WorkflowId, AbortController>();
+  private readonly running = new Map<
+    WorkflowId,
+    { controller: AbortController; runId: string }
+  >();
   private readonly workflowNames = new Map<WorkflowId, string>();
   private readonly runQueue: Array<{
     workflowId: WorkflowId;
@@ -168,12 +171,12 @@ export class ScheduledExecutionService {
     this.runQueue.length = 0;
 
     // Abort all in-flight runs
-    for (const [workflowId, controller] of this.running) {
+    for (const [workflowId, entry] of this.running) {
       logger.info(
         "Aborting in-flight scheduled run for workflow {workflowId}",
         { workflowId },
       );
-      controller.abort();
+      entry.controller.abort();
     }
 
     // Drain the processing promise — runs exit quickly after abort
@@ -205,13 +208,30 @@ export class ScheduledExecutionService {
    */
   cancelRun(workflowId: string): boolean {
     const id = workflowId as WorkflowId;
-    const controller = this.running.get(id);
-    if (!controller) {
+    const entry = this.running.get(id);
+    if (!entry) {
       return false;
     }
     logger.info`Cancelling scheduled run for workflow ${workflowId}`;
-    controller.abort(new Error("cancelled by user"));
+    entry.controller.abort(new Error("cancelled by user"));
     return true;
+  }
+
+  /**
+   * Cancels a scheduled run by run ID (reverse lookup). Used by the REST
+   * cancel endpoint which receives a run ID, not a workflow ID.
+   * Returns true if found and aborted.
+   */
+  cancelByRunId(runId: string): boolean {
+    for (const [workflowId, entry] of this.running) {
+      if (entry.runId === runId) {
+        logger
+          .info`Cancelling scheduled run ${runId} for workflow ${workflowId}`;
+        entry.controller.abort(new Error("cancelled by user"));
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -219,9 +239,9 @@ export class ScheduledExecutionService {
    */
   cancelAllRuns(): number {
     let count = 0;
-    for (const [workflowId, controller] of this.running) {
+    for (const [workflowId, entry] of this.running) {
       logger.info`Cancelling scheduled run for workflow ${workflowId}`;
-      controller.abort(new Error("cancelled by user"));
+      entry.controller.abort(new Error("cancelled by user"));
       count++;
     }
     return count;
@@ -313,7 +333,7 @@ export class ScheduledExecutionService {
     workflowName: string,
   ): Promise<void> {
     const controller = new AbortController();
-    this.running.set(workflowId, controller);
+    this.running.set(workflowId, { controller, runId: "" });
 
     try {
       let runId = "";
@@ -326,6 +346,8 @@ export class ScheduledExecutionService {
         (event) => {
           if (event.kind === "started") {
             runId = event.runId;
+            // Update the running entry with the actual run ID
+            this.running.set(workflowId, { controller, runId });
           }
           if (event.kind === "completed") {
             completedRun = event.run;

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -200,6 +200,33 @@ export class ScheduledExecutionService {
     return this.running.has(workflowId);
   }
 
+  /**
+   * Cancels a scheduled run by workflow ID. Returns true if found and aborted.
+   */
+  cancelRun(workflowId: string): boolean {
+    const id = workflowId as WorkflowId;
+    const controller = this.running.get(id);
+    if (!controller) {
+      return false;
+    }
+    logger.info`Cancelling scheduled run for workflow ${workflowId}`;
+    controller.abort(new Error("cancelled by user"));
+    return true;
+  }
+
+  /**
+   * Cancels all scheduled runs. Returns the number of runs cancelled.
+   */
+  cancelAllRuns(): number {
+    let count = 0;
+    for (const [workflowId, controller] of this.running) {
+      logger.info`Cancelling scheduled run for workflow ${workflowId}`;
+      controller.abort(new Error("cancelled by user"));
+      count++;
+    }
+    return count;
+  }
+
   private handleScheduleChange(
     workflowId: WorkflowId,
     schedule: string | null,

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -333,6 +333,9 @@ export class ScheduledExecutionService {
     workflowName: string,
   ): Promise<void> {
     const controller = new AbortController();
+    // runId starts empty until the "started" event arrives with the real ID.
+    // During this narrow window cancelByRunId() cannot match this run;
+    // the window closes as soon as executeWorkflow emits "started".
     this.running.set(workflowId, { controller, runId: "" });
 
     try {
@@ -352,6 +355,9 @@ export class ScheduledExecutionService {
           if (event.kind === "completed") {
             completedRun = event.run;
           }
+          if (event.kind === "cancelled") {
+            completedRun = event.run;
+          }
           if (event.kind === "error") {
             streamError = event.error.message;
           }
@@ -368,6 +374,18 @@ export class ScheduledExecutionService {
         logger.info(
           "Scheduled run completed for workflow {name} (run: {runId})",
           { name: workflowName, runId },
+        );
+      } else if (completedRun?.status === "cancelled") {
+        const message = "workflow was cancelled";
+        this.emit({
+          kind: "schedule_failed",
+          workflowId,
+          workflowName,
+          error: message,
+        });
+        logger.warn(
+          "Scheduled run cancelled for workflow {name}: {error}",
+          { name: workflowName, error: message },
         );
       } else {
         const message = completedRun

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -83,7 +83,13 @@ export interface WorkflowRunView {
   id: string;
   workflowId: string;
   workflowName: string;
-  status: "pending" | "running" | "suspended" | "succeeded" | "failed";
+  status:
+    | "pending"
+    | "running"
+    | "suspended"
+    | "succeeded"
+    | "failed"
+    | "cancelled";
   jobs: JobRunView[];
   duration?: number;
   path?: string;

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -181,6 +181,16 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
             });
         }
       },
+      cancelled: (e) => {
+        this._failed = true;
+        getRunLogger(e.run.modelName, e.run.methodName)
+          .with({ summary: true })
+          .warn("Method {method} cancelled on {model}", {
+            method: e.run.methodName,
+            model: e.run.modelName,
+            reason: e.reason,
+          });
+      },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);
       },
@@ -244,6 +254,10 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       report_failed: () => {},
       completed: (e) => {
         if (e.run.status === "failed") this._failed = true;
+        console.log(JSON.stringify(e.run, null, 2));
+      },
+      cancelled: (e) => {
+        this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));
       },
       error: (e) => {

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -214,6 +214,11 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
           this.renderDataArtifactHints(e.run, wfLogger);
         }
       },
+      cancelled: (e) => {
+        const wfLogger = getWorkflowRunLogger(this.workflowName);
+        const reason = e.reason ? `: ${e.reason}` : "";
+        wfLogger.warn("Workflow cancelled{reason}", { reason });
+      },
       suspended: (e) => {
         const wfLogger = getWorkflowRunLogger(this.workflowName);
         wfLogger.info("Workflow suspended — awaiting approval on step {step}", {
@@ -315,6 +320,9 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       report_failed: () => {},
       completed: (e) => {
         if (e.run.status === "failed") this._failed = true;
+        console.log(JSON.stringify(e.run, null, 2));
+      },
+      cancelled: (e) => {
         console.log(JSON.stringify(e.run, null, 2));
       },
       suspended: (e) => {

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -215,9 +215,15 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
         }
       },
       cancelled: (e) => {
+        this._failed = true;
         const wfLogger = getWorkflowRunLogger(this.workflowName);
-        const reason = e.reason ? `: ${e.reason}` : "";
-        wfLogger.warn("Workflow cancelled{reason}", { reason });
+        if (e.reason) {
+          wfLogger.warn("Workflow cancelled: {reason}", {
+            reason: e.reason,
+          });
+        } else {
+          wfLogger.warn("Workflow cancelled");
+        }
       },
       suspended: (e) => {
         const wfLogger = getWorkflowRunLogger(this.workflowName);
@@ -323,6 +329,7 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
         console.log(JSON.stringify(e.run, null, 2));
       },
       cancelled: (e) => {
+        this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));
       },
       suspended: (e) => {

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -69,7 +69,11 @@ function renderLogWorkflowRun(data: WorkflowRunView): void {
     }
   }
 
-  const resultLevel = data.status === "failed" ? "error" : "info";
+  const resultLevel = data.status === "failed"
+    ? "error"
+    : data.status === "cancelled"
+    ? "warn"
+    : "info";
   const durationSuffix = data.duration !== undefined
     ? ` (${data.duration}ms)`
     : "";
@@ -90,7 +94,8 @@ function statusIcon(
     | "waiting_approval"
     | "succeeded"
     | "failed"
-    | "skipped",
+    | "skipped"
+    | "cancelled",
 ): string {
   const icons: Record<string, string> = {
     pending: "\u25CB",
@@ -99,6 +104,7 @@ function statusIcon(
     succeeded: "\u2713",
     failed: "\u2717",
     skipped: "\u2298",
+    cancelled: "\u2298",
   };
   return icons[status] ?? "?";
 }

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -104,7 +104,7 @@ function statusIcon(
     succeeded: "\u2713",
     failed: "\u2717",
     skipped: "\u2298",
-    cancelled: "\u2298",
+    cancelled: "\u2716",
   };
   return icons[status] ?? "?";
 }

--- a/src/presentation/renderers/workflow_run_tree/components/scrollback_item.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/scrollback_item.tsx
@@ -60,6 +60,8 @@ function CompletedJobBlock(
     ? "failed"
     : item.status === "skipped"
     ? "skipped"
+    : item.status === "cancelled"
+    ? "cancelled"
     : "completed";
 
   const dur = item.duration !== null

--- a/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
+++ b/src/presentation/renderers/workflow_run_tree/components/status_icon.tsx
@@ -31,7 +31,8 @@ interface StatusIconProps {
     | "completed"
     | "failed"
     | "skipped"
-    | "succeeded";
+    | "succeeded"
+    | "cancelled";
   spinnerFrame?: string;
 }
 
@@ -42,6 +43,8 @@ export function StatusIcon({ status, spinnerFrame }: StatusIconProps) {
       return <Text color="green">✓</Text>;
     case "failed":
       return <Text color="red">✗</Text>;
+    case "cancelled":
+      return <Text color="yellow">⊘</Text>;
     case "running":
       return <Text color="cyan">{(spinnerFrame ?? "\u280B") + " "}</Text>;
     case "waiting_approval":

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -97,6 +97,7 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
         this.cleanup?.();
       },
       cancelled: async (e) => {
+        this._failed = true;
         forward(e);
         this.bridge.close();
         await this.exitPromise;

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -52,7 +52,7 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
           this._failed = failed;
         }}
       />,
-      { maxFps: 15 },
+      { maxFps: 15, exitOnCtrlC: false },
     );
     this.exitPromise = instance.waitUntilExit().then(
       () => {},
@@ -95,6 +95,15 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
         this.bridge.close();
         await this.exitPromise;
         this.cleanup?.();
+      },
+      cancelled: async (e) => {
+        forward(e);
+        this.bridge.close();
+        await this.exitPromise;
+        this.cleanup?.();
+        const reason = e.reason ? `: ${e.reason}` : "";
+        console.log("");
+        console.log(`Workflow cancelled${reason}`);
       },
       suspended: async (e) => {
         forward(e);

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -606,6 +606,16 @@ function treeReducerSingle(
       };
     }
 
+    case "cancelled": {
+      return {
+        ...state,
+        phase: "done",
+        failed: false,
+        finalRun: event.run,
+        activeReport: null,
+      };
+    }
+
     case "suspended": {
       return {
         ...state,

--- a/src/presentation/renderers/workflow_run_tree/state.ts
+++ b/src/presentation/renderers/workflow_run_tree/state.ts
@@ -610,7 +610,7 @@ function treeReducerSingle(
       return {
         ...state,
         phase: "done",
-        failed: false,
+        failed: true,
         finalRun: event.run,
         activeReport: null,
       };

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import type { RunCancelRegistry } from "./run_cancel_registry.ts";
 import {
   auditTimeline,
   consumeStream,
@@ -451,6 +452,7 @@ export interface ConnectionContext {
   workerGateway?: WorkerGateway;
   policySnapshotLoader?: PolicySnapshotLoader;
   authConfig: ServeAuthConfig;
+  cancelRegistry?: RunCancelRegistry;
 }
 
 export function handleConnection(
@@ -894,6 +896,7 @@ async function handleWorkflowRun(
     }, ctx)
   ) return;
 
+  let registeredRunId: string | undefined;
   try {
     await executeWorkflowWithLocks(
       ctx.repoDir,
@@ -908,6 +911,17 @@ async function handleWorkflowRun(
       },
       controller.signal,
       (event) => {
+        if (
+          event.kind === "started" && ctx.cancelRegistry
+        ) {
+          const startedEvent = event as { runId: string };
+          registeredRunId = startedEvent.runId;
+          ctx.cancelRegistry.register(
+            "workflow-run",
+            registeredRunId,
+            controller,
+          );
+        }
         if (socket.readyState !== WebSocket.OPEN) return;
         const serialized = serializeEvent(
           event as { kind: string; [key: string]: unknown },
@@ -923,6 +937,10 @@ async function handleWorkflowRun(
     } else {
       const message = sanitizeErrorForClient(error);
       sendError(socket, requestId, "workflow_execution_failed", message);
+    }
+  } finally {
+    if (registeredRunId && ctx.cancelRegistry) {
+      ctx.cancelRegistry.deregister("workflow-run", registeredRunId);
     }
   }
 }

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1029,6 +1029,11 @@ async function handleModelMethodRun(
     );
     const libCtx = createLibSwampContext({ signal: controller.signal });
 
+    // Register method run in cancel registry using the requestId as executionId
+    if (ctx.cancelRegistry) {
+      ctx.cancelRegistry.register("method-run", requestId, controller);
+    }
+
     for await (
       const event of modelMethodRun(libCtx, deps, {
         modelIdOrName: payload.modelIdOrName,
@@ -1061,6 +1066,9 @@ async function handleModelMethodRun(
       );
     }
   } finally {
+    if (ctx.cancelRegistry) {
+      ctx.cancelRegistry.deregister("method-run", requestId);
+    }
     if (flushLocks) {
       try {
         await flushLocks();

--- a/src/serve/run_cancel_registry.ts
+++ b/src/serve/run_cancel_registry.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["serve", "cancel-registry"]);
+
+export type ExecutionType = "workflow-run" | "method-run";
+
+export interface RunCancelEntry {
+  executionType: ExecutionType;
+  executionId: string;
+  controller: AbortController;
+  registeredAt: Date;
+}
+
+export class RunCancelRegistry {
+  private readonly entries = new Map<string, RunCancelEntry>();
+
+  private key(type: ExecutionType, id: string): string {
+    return `${type}:${id}`;
+  }
+
+  register(
+    executionType: ExecutionType,
+    executionId: string,
+    controller: AbortController,
+  ): void {
+    const k = this.key(executionType, executionId);
+    this.entries.set(k, {
+      executionType,
+      executionId,
+      controller,
+      registeredAt: new Date(),
+    });
+    logger.debug`Registered ${executionType} ${executionId}`;
+  }
+
+  deregister(executionType: ExecutionType, executionId: string): void {
+    const k = this.key(executionType, executionId);
+    if (this.entries.delete(k)) {
+      logger.debug`Deregistered ${executionType} ${executionId}`;
+    }
+  }
+
+  cancel(executionType: ExecutionType, executionId: string): boolean {
+    const k = this.key(executionType, executionId);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      return false;
+    }
+    logger.info`Cancelling ${executionType} ${executionId}`;
+    entry.controller.abort(new Error("cancelled by user"));
+    return true;
+  }
+
+  cancelAll(executionType?: ExecutionType): number {
+    let count = 0;
+    for (const entry of this.entries.values()) {
+      if (executionType && entry.executionType !== executionType) {
+        continue;
+      }
+      logger.info`Cancelling ${entry.executionType} ${entry.executionId}`;
+      entry.controller.abort(new Error("cancelled by user"));
+      count++;
+    }
+    return count;
+  }
+
+  list(executionType?: ExecutionType): ReadonlyArray<RunCancelEntry> {
+    const result: RunCancelEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (executionType && entry.executionType !== executionType) {
+        continue;
+      }
+      result.push(entry);
+    }
+    return result;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/serve/run_cancel_registry_test.ts
+++ b/src/serve/run_cancel_registry_test.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { RunCancelRegistry } from "./run_cancel_registry.ts";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+Deno.test("RunCancelRegistry.register: adds an entry", () => {
+  const registry = new RunCancelRegistry();
+  const controller = new AbortController();
+  registry.register("workflow-run", "run-1", controller);
+  assertEquals(registry.size, 1);
+});
+
+Deno.test("RunCancelRegistry.deregister: removes an entry", () => {
+  const registry = new RunCancelRegistry();
+  const controller = new AbortController();
+  registry.register("workflow-run", "run-1", controller);
+  registry.deregister("workflow-run", "run-1");
+  assertEquals(registry.size, 0);
+});
+
+Deno.test("RunCancelRegistry.deregister: no-ops for missing entry", () => {
+  const registry = new RunCancelRegistry();
+  registry.deregister("workflow-run", "missing");
+  assertEquals(registry.size, 0);
+});
+
+Deno.test("RunCancelRegistry.cancel: aborts the controller and returns true", () => {
+  const registry = new RunCancelRegistry();
+  const controller = new AbortController();
+  registry.register("workflow-run", "run-1", controller);
+
+  const result = registry.cancel("workflow-run", "run-1");
+  assertEquals(result, true);
+  assertEquals(controller.signal.aborted, true);
+});
+
+Deno.test("RunCancelRegistry.cancel: returns false for missing entry", () => {
+  const registry = new RunCancelRegistry();
+  const result = registry.cancel("workflow-run", "missing");
+  assertEquals(result, false);
+});
+
+Deno.test("RunCancelRegistry.cancelAll: aborts all entries of matching type", () => {
+  const registry = new RunCancelRegistry();
+  const c1 = new AbortController();
+  const c2 = new AbortController();
+  const c3 = new AbortController();
+  registry.register("workflow-run", "run-1", c1);
+  registry.register("workflow-run", "run-2", c2);
+  registry.register("method-run", "run-3", c3);
+
+  const count = registry.cancelAll("workflow-run");
+  assertEquals(count, 2);
+  assertEquals(c1.signal.aborted, true);
+  assertEquals(c2.signal.aborted, true);
+  assertEquals(c3.signal.aborted, false);
+});
+
+Deno.test("RunCancelRegistry.cancelAll: aborts all entries when no type filter", () => {
+  const registry = new RunCancelRegistry();
+  const c1 = new AbortController();
+  const c2 = new AbortController();
+  registry.register("workflow-run", "run-1", c1);
+  registry.register("method-run", "run-2", c2);
+
+  const count = registry.cancelAll();
+  assertEquals(count, 2);
+  assertEquals(c1.signal.aborted, true);
+  assertEquals(c2.signal.aborted, true);
+});
+
+Deno.test("RunCancelRegistry.list: returns entries filtered by type", () => {
+  const registry = new RunCancelRegistry();
+  registry.register("workflow-run", "run-1", new AbortController());
+  registry.register("method-run", "run-2", new AbortController());
+
+  assertEquals(registry.list("workflow-run").length, 1);
+  assertEquals(registry.list("method-run").length, 1);
+  assertEquals(registry.list().length, 2);
+});


### PR DESCRIPTION
## Summary

- Adds `cancelled` terminal status to `WorkflowRun` and `ModelOutput` entities with full cancellation infrastructure
- New CLI commands: `swamp workflow cancel` and `swamp model cancel` with `--all` bulk cancel, `--reason` audit trail, PID tracking, and process tree kill
- SIGINT/SIGTERM on `swamp workflow run` and `swamp model method run` now gracefully cancel the run (marks `cancelled`, kills subprocess)
- TUI (Ink) displays "Workflow cancelled" cleanly on Ctrl+C
- `RunCancelRegistry` in serve centralises AbortController tracking across WebSocket and scheduled execution paths
- Cancel REST endpoint (`POST /api/v1/cancel/:type/:id`) with authentication for live cancellation through serve
- Daemon-restart reaping: `swamp serve` startup scans recent runs stuck in `running` and marks them `cancelled`
- Passes abort signal through to `command/shell` `executeProcess()` so subprocess kill propagates on cancel
- PID reuse safety: verifies process is a swamp process via `ps` before sending signals
- `suppressSyncExitOnSignal` prevents the datastore sync coordinator's `Deno.exit(130)` from racing the cancel save

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` && `deno fmt` — clean
- [x] `deno run test` — 7879 tests pass (0 failed)
- [x] `deno run compile` — binary compiles
- [x] Manual: `swamp workflow cancel` kills process + marks cancelled
- [x] Manual: `swamp model cancel` kills process + marks cancelled
- [x] Manual: `swamp workflow cancel --all` bulk cancel
- [x] Manual: PID reuse safety — non-swamp processes not killed
- [x] Manual: JSON output mode
- [x] Manual: SIGTERM on workflow run → `cancelled`
- [x] Manual: SIGINT on workflow run → `cancelled`
- [x] Manual: SIGTERM on model method run → `cancelled`
- [x] Manual: SIGINT on model method run → `cancelled`
- [x] Manual: TUI Ctrl+C shows "Workflow cancelled" cleanly
- [x] Manual: Normal fast runs still complete as `succeeded`
- [x] Manual: Serve REST cancel endpoint kills subprocess + marks `cancelled`
- [x] Manual: Ministack S3 datastore — cancel mid-execution, data integrity verified, recovery runs succeed

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)