### PR TITLE
feat(data): opt-in automatic garbage collection after model method runs (swamp-club#823)

### DIFF
--- a/design/repo.md
+++ b/design/repo.md
@@ -101,9 +101,9 @@ attributes to control the behaviour of the swamp operations.
   `swamp extension trust auto-trust <on|off>`.
 - `autoGc`: Enable automatic garbage collection after model method runs.
   Default: `false`. When `true`, `collectGarbage` runs for the model that just
-  executed after the `completed` event is yielded (user sees their result first).
-  Reuses each data item's declared `garbageCollection` policy (version-count caps
-  and duration-based retention). Errors are logged but never fail the method run.
+  executed after reports complete and the method result is shown. Reuses each
+  data item's declared `garbageCollection` policy (version-count caps and
+  duration-based retention). Errors are logged but never fail the method run.
   The sync push includes GC deletions so the current push benefits immediately.
   `swamp data gc` remains available for repo-wide manual GC.
 

--- a/design/repo.md
+++ b/design/repo.md
@@ -99,6 +99,13 @@ attributes to control the behaviour of the swamp operations.
   to (cached from `auth login`/`auth whoami`). Default: `true`. Set to `false`
   to only trust the explicit `trustedCollectives` list. Toggleable via
   `swamp extension trust auto-trust <on|off>`.
+- `autoGc`: Enable automatic garbage collection after model method runs.
+  Default: `false`. When `true`, `collectGarbage` runs for the model that just
+  executed after the `completed` event is yielded (user sees their result first).
+  Reuses each data item's declared `garbageCollection` policy (version-count caps
+  and duration-based retention). Errors are logged but never fail the method run.
+  The sync push includes GC deletions so the current push benefits immediately.
+  `swamp data gc` remains available for repo-wide manual GC.
 
 ## RepoIndexService
 

--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -183,6 +183,11 @@ export type ModelMethodRunEvent =
   | { kind: "report_failed"; reportName: string; scope: string; error: string }
   | { kind: "completed"; run: ModelMethodRunView }
   | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
+  | {
+    kind: "auto_gc_completed";
+    versionsDeleted: number;
+    bytesReclaimed: number;
+  }
   | { kind: "error"; error: SerializedError };
 
 // ── Completed event payload types ────────────────────────────────────────

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -28,6 +28,8 @@ import {
   acquireModelLocks,
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { UserError } from "../../domain/errors.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
@@ -225,6 +227,11 @@ export const modelMethodRunCommand = new Command()
           outputMode: ctx.outputMode,
         });
 
+      const marker = await new RepoMarkerRepository().read(
+        RepoPath.create(repoDir),
+      );
+      const autoGc = marker?.autoGc === true;
+
       ctx.logger
         .debug`Running method '${methodName}' on model: ${modelIdOrName}`;
 
@@ -408,6 +415,7 @@ export const modelMethodRunCommand = new Command()
               reportNames: options.report as string[] | undefined,
               reportLabels: options.reportLabel as string[] | undefined,
               swampSha: GIT_SHA || undefined,
+              autoGc,
             }),
             renderer.handlers(),
           );

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -61,6 +61,7 @@ export interface RepoMarkerData {
   trustMemberCollectives?: boolean;
   lastSkillMigrationWarning?: string;
   skillMigrationDismissed?: boolean;
+  autoGc?: boolean;
 }
 
 /**

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -35,6 +35,9 @@ import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_servic
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import type { GarbageCollectionResult } from "../../domain/data/repositories.ts";
+import type { ModelType } from "../../domain/models/model_type.ts";
+import { getLogger } from "@logtape/logtape";
 
 /** Preview item for a single expired data entry. */
 export interface DataGcPreviewItem {
@@ -188,4 +191,42 @@ export async function* dataGc(
       };
     })(),
   );
+}
+
+/** Result of auto-GC after a model method run. */
+export interface AutoGcResult {
+  versionsRemoved: number;
+  bytesReclaimed: number;
+}
+
+/**
+ * Runs garbage collection for a single model, scoped to data written during
+ * the method run. Catches all errors — auto-GC failure must never fail the
+ * method run.
+ */
+export async function autoGc(
+  dataRepo: {
+    collectGarbage: (
+      type: ModelType,
+      modelId: string,
+    ) => Promise<GarbageCollectionResult>;
+  },
+  type: ModelType,
+  modelId: string,
+): Promise<AutoGcResult | null> {
+  const logger = getLogger(["swamp", "auto-gc"]);
+  try {
+    const result = await dataRepo.collectGarbage(type, modelId);
+    if (result.versionsRemoved > 0) {
+      logger
+        .info`Auto-GC: removed ${result.versionsRemoved} version(s), reclaimed ${result.bytesReclaimed} bytes`;
+    }
+    return result;
+  } catch (error) {
+    logger
+      .warn`Auto-GC failed for ${type.normalized}/${modelId}: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    return null;
+  }
 }

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -193,16 +193,11 @@ export async function* dataGc(
   );
 }
 
-/** Result of auto-GC after a model method run. */
-export interface AutoGcResult {
-  versionsRemoved: number;
-  bytesReclaimed: number;
-}
-
 /**
- * Runs garbage collection for a single model, scoped to data written during
- * the method run. Catches all errors — auto-GC failure must never fail the
- * method run.
+ * Runs garbage collection for a single model. Catches all errors — auto-GC
+ * failure must never fail the method run. User-visible output is owned by the
+ * renderer via the auto_gc_completed event; this function only logs at debug
+ * and warn levels.
  */
 export async function autoGc(
   dataRepo: {
@@ -213,14 +208,12 @@ export async function autoGc(
   },
   type: ModelType,
   modelId: string,
-): Promise<AutoGcResult | null> {
+): Promise<GarbageCollectionResult | null> {
   const logger = getLogger(["swamp", "auto-gc"]);
   try {
     const result = await dataRepo.collectGarbage(type, modelId);
-    if (result.versionsRemoved > 0) {
-      logger
-        .info`Auto-GC: removed ${result.versionsRemoved} version(s), reclaimed ${result.bytesReclaimed} bytes`;
-    }
+    logger
+      .debug`Auto-GC for ${type.normalized}/${modelId}: ${result.versionsRemoved} version(s) removed, ${result.bytesReclaimed} bytes reclaimed`;
     return result;
   } catch (error) {
     logger

--- a/src/libswamp/data/gc_test.ts
+++ b/src/libswamp/data/gc_test.ts
@@ -21,11 +21,14 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  autoGc,
   dataGc,
   type DataGcDeps,
   type DataGcEvent,
   dataGcPreview,
 } from "./gc.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import type { GarbageCollectionResult } from "../../domain/data/repositories.ts";
 
 function makeDeps(overrides: Partial<DataGcDeps> = {}): DataGcDeps {
   return {
@@ -204,4 +207,41 @@ Deno.test("dataGc: passes dryRun flag through", async () => {
   );
 
   assertEquals(receivedDryRun, true);
+});
+
+// --- autoGc tests ---
+
+function makeFakeDataRepo(
+  result: GarbageCollectionResult = { versionsRemoved: 0, bytesReclaimed: 0 },
+) {
+  return {
+    collectGarbage: (
+      _type: ModelType,
+      _modelId: string,
+    ): Promise<GarbageCollectionResult> => Promise.resolve(result),
+  };
+}
+
+Deno.test("autoGc: returns result when versions are removed", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 10, bytesReclaimed: 4096 });
+  const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
+
+  assertEquals(result, { versionsRemoved: 10, bytesReclaimed: 4096 });
+});
+
+Deno.test("autoGc: returns result with zero versions when nothing to clean", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 0, bytesReclaimed: 0 });
+  const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
+
+  assertEquals(result, { versionsRemoved: 0, bytesReclaimed: 0 });
+});
+
+Deno.test("autoGc: catches errors and returns null", async () => {
+  const repo = {
+    collectGarbage: (): Promise<GarbageCollectionResult> =>
+      Promise.reject(new Error("disk full")),
+  };
+  const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
+
+  assertEquals(result, null);
 });

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -143,7 +143,7 @@ export type ModelMethodRunEvent =
   | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
   | {
     kind: "auto_gc_completed";
-    versionsRemoved: number;
+    versionsDeleted: number;
     bytesReclaimed: number;
   }
   | { kind: "error"; error: SwampError };
@@ -977,6 +977,22 @@ export async function* modelMethodRun(
         }
 
         reportsSpan.end();
+
+        if (input.autoGc) {
+          const gcResult = await autoGc(
+            deps.dataRepo,
+            modelType,
+            definition.id,
+          );
+          if (gcResult && gcResult.versionsRemoved > 0) {
+            yield {
+              kind: "auto_gc_completed" as const,
+              versionsDeleted: gcResult.versionsRemoved,
+              bytesReclaimed: gcResult.bytesReclaimed,
+            };
+          }
+        }
+
         postExecSpan.end();
 
         // --- Complete ---
@@ -993,21 +1009,6 @@ export async function* modelMethodRun(
           reports: reportResults,
         };
         yield { kind: "completed", run: view };
-
-        if (input.autoGc) {
-          const gcResult = await autoGc(
-            deps.dataRepo,
-            modelType,
-            definition.id,
-          );
-          if (gcResult && gcResult.versionsRemoved > 0) {
-            yield {
-              kind: "auto_gc_completed" as const,
-              versionsRemoved: gcResult.versionsRemoved,
-              bytesReclaimed: gcResult.bytesReclaimed,
-            };
-          }
-        }
       } finally {
         runLog.cleanup();
       }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -68,6 +68,7 @@ import {
   withGeneratorSpan,
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
+import { autoGc } from "../data/gc.ts";
 
 /**
  * Events emitted by the libswamp model method run generator.
@@ -140,6 +141,11 @@ export type ModelMethodRunEvent =
   }
   | { kind: "completed"; run: ModelMethodRunView }
   | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
+  | {
+    kind: "auto_gc_completed";
+    versionsRemoved: number;
+    bytesReclaimed: number;
+  }
   | { kind: "error"; error: SwampError };
 
 /**
@@ -212,6 +218,7 @@ export interface ModelMethodRunInput {
   reportNames?: string[];
   reportLabels?: string[];
   swampSha?: string;
+  autoGc?: boolean;
 }
 
 /**
@@ -986,6 +993,21 @@ export async function* modelMethodRun(
           reports: reportResults,
         };
         yield { kind: "completed", run: view };
+
+        if (input.autoGc) {
+          const gcResult = await autoGc(
+            deps.dataRepo,
+            modelType,
+            definition.id,
+          );
+          if (gcResult && gcResult.versionsRemoved > 0) {
+            yield {
+              kind: "auto_gc_completed" as const,
+              versionsRemoved: gcResult.versionsRemoved,
+              bytesReclaimed: gcResult.bytesReclaimed,
+            };
+          }
+        }
       } finally {
         runLog.cleanup();
       }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -977,22 +977,6 @@ export async function* modelMethodRun(
         }
 
         reportsSpan.end();
-
-        if (input.autoGc) {
-          const gcResult = await autoGc(
-            deps.dataRepo,
-            modelType,
-            definition.id,
-          );
-          if (gcResult && gcResult.versionsRemoved > 0) {
-            yield {
-              kind: "auto_gc_completed" as const,
-              versionsDeleted: gcResult.versionsRemoved,
-              bytesReclaimed: gcResult.bytesReclaimed,
-            };
-          }
-        }
-
         postExecSpan.end();
 
         // --- Complete ---
@@ -1009,6 +993,21 @@ export async function* modelMethodRun(
           reports: reportResults,
         };
         yield { kind: "completed", run: view };
+
+        if (input.autoGc) {
+          const gcResult = await autoGc(
+            deps.dataRepo,
+            modelType,
+            definition.id,
+          );
+          if (gcResult && gcResult.versionsRemoved > 0) {
+            yield {
+              kind: "auto_gc_completed" as const,
+              versionsDeleted: gcResult.versionsRemoved,
+              bytesReclaimed: gcResult.bytesReclaimed,
+            };
+          }
+        }
       } finally {
         runLog.cleanup();
       }

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -22,6 +22,7 @@ import {
   methodExecutionFailed,
   modelMethodRun,
   type ModelMethodRunDeps,
+  type ModelMethodRunEvent,
   type ModelMethodRunInput,
   modelNotFound,
   noEvaluatedDefinition,
@@ -88,8 +89,11 @@ function createFakeOutputRepo(): any {
   };
 }
 
-// deno-lint-ignore no-explicit-any
-function createFakeDataRepo(): any {
+function createFakeDataRepo(gcResult?: {
+  versionsRemoved: number;
+  bytesReclaimed: number;
+  // deno-lint-ignore no-explicit-any
+}): any {
   return {
     nextId: () => crypto.randomUUID(),
     getPath: (
@@ -101,6 +105,10 @@ function createFakeDataRepo(): any {
     getContent: () => Promise.resolve(null),
     findAllForModel: () => Promise.resolve([]),
     save: () => Promise.resolve({ version: 1 }),
+    collectGarbage: () =>
+      Promise.resolve(
+        gcResult ?? { versionsRemoved: 0, bytesReclaimed: 0 },
+      ),
   };
 }
 
@@ -703,4 +711,46 @@ Deno.test("modelMethodRun: direct execution strips @ fallback for repo-local typ
   if (autoCreated && autoCreated.kind === "auto_created") {
     assertEquals(autoCreated.modelType, "sandbox/coder-server");
   }
+});
+
+Deno.test("modelMethodRun: yields auto_gc_completed when autoGc is true and versions are removed", async () => {
+  const definition = createTestDefinition("test-model", "run");
+  const modelDef = createTestModelDef("run");
+  const deps = {
+    ...createTestDeps(definition, modelDef),
+    dataRepo: createFakeDataRepo({ versionsRemoved: 8, bytesReclaimed: 2048 }),
+  };
+
+  const events = await collect<ModelMethodRunEvent>(
+    modelMethodRun(createLibSwampContext(), deps, {
+      ...createTestInput("test-model", "run"),
+      autoGc: true,
+    }),
+  );
+
+  const gcEvent = events.find((e) => e.kind === "auto_gc_completed");
+  assertEquals(gcEvent !== undefined, true);
+  if (gcEvent && gcEvent.kind === "auto_gc_completed") {
+    assertEquals(gcEvent.versionsDeleted, 8);
+    assertEquals(gcEvent.bytesReclaimed, 2048);
+  }
+});
+
+Deno.test("modelMethodRun: does not yield auto_gc_completed when autoGc is false", async () => {
+  const definition = createTestDefinition("test-model", "run");
+  const modelDef = createTestModelDef("run");
+  const deps = {
+    ...createTestDeps(definition, modelDef),
+    dataRepo: createFakeDataRepo({ versionsRemoved: 8, bytesReclaimed: 2048 }),
+  };
+
+  const events = await collect<ModelMethodRunEvent>(
+    modelMethodRun(createLibSwampContext(), deps, {
+      ...createTestInput("test-model", "run"),
+      autoGc: false,
+    }),
+  );
+
+  const gcEvent = events.find((e) => e.kind === "auto_gc_completed");
+  assertEquals(gcEvent, undefined);
 });

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -193,9 +193,9 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
       },
       auto_gc_completed: (e) => {
         getRunLogger(this.modelName, this.methodName).info(
-          "Auto-GC: removed {versionsRemoved} version(s), reclaimed {bytesReclaimed} bytes",
+          "Auto-GC: removed {versionsDeleted} version(s), reclaimed {bytesReclaimed} bytes",
           {
-            versionsRemoved: e.versionsRemoved,
+            versionsDeleted: e.versionsDeleted,
             bytesReclaimed: e.bytesReclaimed,
           },
         );
@@ -272,7 +272,7 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       auto_gc_completed: (e) => {
         console.log(JSON.stringify({
           event: "auto_gc_completed",
-          versionsRemoved: e.versionsRemoved,
+          versionsDeleted: e.versionsDeleted,
           bytesReclaimed: e.bytesReclaimed,
         }));
       },

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -191,6 +191,15 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
             reason: e.reason,
           });
       },
+      auto_gc_completed: (e) => {
+        getRunLogger(this.modelName, this.methodName).info(
+          "Auto-GC: removed {versionsRemoved} version(s), reclaimed {bytesReclaimed} bytes",
+          {
+            versionsRemoved: e.versionsRemoved,
+            bytesReclaimed: e.bytesReclaimed,
+          },
+        );
+      },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);
       },
@@ -259,6 +268,13 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
       cancelled: (e) => {
         this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));
+      },
+      auto_gc_completed: (e) => {
+        console.log(JSON.stringify({
+          event: "auto_gc_completed",
+          versionsRemoved: e.versionsRemoved,
+          bytesReclaimed: e.bytesReclaimed,
+        }));
       },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);


### PR DESCRIPTION
## Summary

- Add `autoGc: true` config option to `.swamp.yaml` that enables automatic garbage collection after each model method run
- GC reuses the existing `collectGarbage` function scoped to the model that just ran — no new repository interface changes
- Runs after the `completed` event (user sees their result first) and before sync push (catalog export benefits immediately)
- Errors are caught and logged at warn level — auto-GC failure never fails the method run
- Addresses catalog export bloat from accumulated versions (#806, #811)

Closes swamp-club#823

## Test Plan

- Verified with a local Minio S3 datastore: 5 model instances × 30 runs each (150 total), then enabled `autoGc: true`
- First run with auto-GC removed 206 accumulated versions (1.8 MB reclaimed)
- Subsequent runs remove ~5 versions each (steady-state: one excess per data name beyond GC cap)
- Confirmed JSON output mode emits `auto_gc_completed` event
- All 7,871 existing tests pass with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)