### PR TITLE
fix(data): coerce BigInt in select projection path (swamp-club#830)

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -19,6 +19,7 @@
 
 import { getLogger } from "@logtape/logtape";
 import { Environment } from "cel-js";
+import { coerceBigInts } from "../../infrastructure/cel/cel_evaluator.ts";
 import type {
   CatalogRow,
   CatalogStore,
@@ -288,7 +289,7 @@ export class DataQueryService {
             r as unknown as Record<string, unknown>,
           ) as Record<string, unknown>;
           selectCtx["ns"] = r.namespace;
-          return selectParsed(selectCtx);
+          return coerceBigInts(selectParsed(selectCtx));
         } catch {
           return null;
         }

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -370,6 +370,69 @@ Deno.test("DataQueryService: select loads attributes for map literal projection"
   catalog.close();
 });
 
+Deno.test("DataQueryService: select coerces CEL BigInt to number", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-select-bigint-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "my-data",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(
+    join(dataDir, "raw"),
+    JSON.stringify({ items: ["a", "b", "c"] }),
+  );
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "my-data",
+      id: "00000000-0000-1000-8000-000000000001",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "my-data", "latest"),
+    "1",
+  );
+
+  catalog.upsert(makeRow());
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  const results = service.querySync('modelName == "ingest"', {
+    select: "attributes.items.size()",
+  });
+  assertEquals(results.length, 1);
+  assertEquals(results[0], 3);
+  assertEquals(typeof results[0], "number");
+
+  const mapResults = service.querySync('modelName == "ingest"', {
+    select: '{"len": attributes.items.size()}',
+  });
+  assertEquals(mapResults.length, 1);
+  const projected = mapResults[0] as Record<string, unknown>;
+  assertEquals(projected["len"], 3);
+  assertEquals(typeof projected["len"], "number");
+
+  catalog.close();
+});
+
 Deno.test("DataQueryService: backfill triggers on unpopulated catalog", async () => {
   const dir = Deno.makeTempDirSync({ prefix: "swamp-query-backfill-" });
   const dbPath = join(dir, ".swamp", "data", "_catalog.db");

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -44,7 +44,7 @@ function unwrapOptional(value: unknown): unknown {
  * expects regular JS numbers. Values outside Number.MAX_SAFE_INTEGER are
  * left as bigint to avoid silent precision loss.
  */
-function coerceBigInts(value: unknown): unknown {
+export function coerceBigInts(value: unknown): unknown {
   if (typeof value === "bigint") {
     if (value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER) {
       return Number(value);


### PR DESCRIPTION
## Summary

- Export `coerceBigInts` from the CEL evaluator so the data query service can reuse it
- Apply `coerceBigInts` to `--select` projection results — the select path called parsed CEL expressions directly, bypassing `CelEvaluator.evaluate()` which normalizes BigInt to Number
- Add unit test covering both scalar and map projections with `size()`

Closes swamp-club#830

## Test Plan

- Unit test: `deno run test src/domain/data/data_query_service_test.ts` — new test "select coerces CEL BigInt to number" asserts scalar and map projections return JS numbers
- Manual verification: `swamp data query '...' --select 'attributes.items.size()' --json` no longer crashes with "Do not know how to serialize a BigInt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)