### PR TITLE
fix(skill): warn that globalArguments don't inherit when --global-arg is omitted (swamp-club#832)

### DIFF
--- a/.claude/skills/swamp/references/model/reference.md
+++ b/.claude/skills/swamp/references/model/reference.md
@@ -112,6 +112,12 @@ Dot notation creates nested objects:
 # → globalArguments: { config: { db: { host: "localhost", port: "5432" } } }
 ```
 
+> **Warning:** Omitting `--global-arg` creates an instance with empty
+> `globalArguments`. There is no inheritance from sibling instances or schema
+> templates. Fields without a `default` in the type's `globalArgumentsSchema`
+> arrive as `undefined` in `context.globalArgs.*`. Re-pass every value your
+> methods read from globalArgs.
+
 **Output shape:**
 
 ```json


### PR DESCRIPTION
## Summary

- Adds a warning callout to the swamp skill's `--global-arg` documentation in `references/model/reference.md`, explaining that omitting `--global-arg` creates an instance with empty `globalArguments` — no inheritance from sibling instances or schema templates, and fields without a schema `default` arrive as `undefined`.

## Test Plan

- Verified formatting passes with `deno fmt --check`
- Verified linting passes with `deno lint`
- Documentation-only change; no runtime behavior affected