### PR TITLE
feat(data): batch delete by prefix or all (swamp-club#826)

### DIFF
--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -143,6 +143,11 @@ export const dataDeleteCommand = new Command()
             "Cannot combine --version with --prefix or --all. Version-specific delete only applies to single data names.",
           );
         }
+        if (prefix !== undefined && prefix.length === 0) {
+          throw new UserError(
+            "--prefix value cannot be empty. Use --all to delete all data.",
+          );
+        }
         if (prefix !== undefined && all) {
           throw new UserError(
             "Cannot combine --prefix and --all. Use one or the other.",

--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -19,13 +19,17 @@
 
 import { Command } from "@cliffy/command";
 import {
+  type BatchDeleteFilter,
   consumeStream,
   createDataDeleteDeps,
   createLibSwampContext,
+  dataBatchDelete,
+  dataBatchDeletePreview,
   dataDelete,
   dataDeletePreview,
 } from "../../libswamp/mod.ts";
 import {
+  createDataBatchDeleteRenderer,
   createDataDeleteRenderer,
   renderDataDeleteCancelled,
 } from "../../presentation/renderers/data_delete.ts";
@@ -57,7 +61,7 @@ type AnyOptions = any;
 export const dataDeleteCommand = new Command()
   .name("delete")
   .description(
-    "Delete a data artifact (all versions, or one when --version is set)",
+    "Delete data artifacts: one by name, many by prefix, or all for a model",
   )
   .example(
     "Delete an artifact (prompts for confirmation)",
@@ -70,6 +74,18 @@ export const dataDeleteCommand = new Command()
   .example(
     "Delete a specific version",
     "swamp data delete my-server hetzner-state --version 2",
+  )
+  .example(
+    "Delete all data matching a prefix",
+    "swamp data delete my-server --prefix run-",
+  )
+  .example(
+    "Preview what --prefix would delete",
+    "swamp data delete my-server --prefix run- --dry-run",
+  )
+  .example(
+    "Delete all data for a model",
+    "swamp data delete my-server --all",
   )
   .example(
     "Skip the confirmation prompt",
@@ -89,6 +105,12 @@ export const dataDeleteCommand = new Command()
     "Data name (alternative to positional argument)",
   )
   .option("--version <n:integer>", "Delete a specific version")
+  .option(
+    "--prefix <prefix:string>",
+    "Delete all data names starting with this prefix",
+  )
+  .option("--all", "Delete all data for the model")
+  .option("--dry-run", "Show what would be deleted without deleting")
   .option("-f, --force", "Skip confirmation prompt")
   .action(
     async function (
@@ -99,12 +121,46 @@ export const dataDeleteCommand = new Command()
       const modelIdOrName = (options.model as string | undefined) ??
         positionalModel;
       const dataName = (options.name as string | undefined) ?? positionalName;
+      const prefix = options.prefix as string | undefined;
+      const all = options.all as boolean | undefined;
+      const dryRun = options.dryRun as boolean | undefined;
 
-      if (!modelIdOrName || !dataName) {
-        throw new UserError(
-          "Both model and data name are required. Use positional arguments (swamp data delete <model> <name>) or flags (--model <model> --name <name>).",
-        );
+      const isBatchMode = prefix !== undefined || all;
+
+      if (isBatchMode) {
+        if (!modelIdOrName) {
+          throw new UserError(
+            "Model is required for batch delete. Use positional argument (swamp data delete <model> --prefix <prefix>) or flag (--model <model>).",
+          );
+        }
+        if (dataName) {
+          throw new UserError(
+            "Cannot combine data name with --prefix or --all. Use --prefix/--all for batch delete, or specify a data name for single delete.",
+          );
+        }
+        if (options.version !== undefined) {
+          throw new UserError(
+            "Cannot combine --version with --prefix or --all. Version-specific delete only applies to single data names.",
+          );
+        }
+        if (prefix !== undefined && all) {
+          throw new UserError(
+            "Cannot combine --prefix and --all. Use one or the other.",
+          );
+        }
+      } else {
+        if (!modelIdOrName || !dataName) {
+          throw new UserError(
+            "Both model and data name are required. Use positional arguments (swamp data delete <model> <name>) or flags (--model <model> --name <name>).",
+          );
+        }
+        if (dryRun) {
+          throw new UserError(
+            "--dry-run is only supported with --prefix or --all.",
+          );
+        }
       }
+
       const cliCtx = createContext(options as GlobalOptions, [
         "data",
         "delete",
@@ -117,43 +173,87 @@ export const dataDeleteCommand = new Command()
 
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const deps = createDataDeleteDeps(repoDir, datastoreResolver);
-      const renderer = createDataDeleteRenderer(cliCtx.outputMode);
 
-      // Phase 1: Preview + Prompt (only in interactive log mode without --force).
-      if (cliCtx.outputMode === "log" && !options.force) {
-        let preview;
-        try {
-          preview = await dataDeletePreview(ctx, deps, {
-            modelIdOrName,
-            dataName,
-          });
-        } catch (error) {
-          throw new UserError(
-            error instanceof Error ? error.message : String(error),
+      if (isBatchMode) {
+        const filter: BatchDeleteFilter = all
+          ? { kind: "all" }
+          : { kind: "prefix", value: prefix! };
+
+        // Phase 1: Preview + Prompt (unless --force or --dry-run).
+        if (cliCtx.outputMode === "log" && !options.force && !dryRun) {
+          let preview;
+          try {
+            preview = await dataBatchDeletePreview(ctx, deps, {
+              modelIdOrName: modelIdOrName!,
+              filter,
+            });
+          } catch (error) {
+            throw new UserError(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+
+          const filterDesc = filter.kind === "prefix"
+            ? `prefix "${filter.value}"`
+            : "all data";
+          const confirmed = await promptConfirmation(
+            `About to delete ${preview.totalItems} data artifact(s) (${preview.totalVersions} version(s)) matching ${filterDesc} from ${preview.modelName}. Proceed?`,
           );
+          if (!confirmed) {
+            renderDataDeleteCancelled(cliCtx.outputMode);
+            return;
+          }
         }
 
-        const target = options.version !== undefined
-          ? `version ${options.version} of "${dataName}"`
-          : `${preview.versionsCount} version(s) of "${dataName}"`;
-        const confirmed = await promptConfirmation(
-          `About to delete ${target} from ${preview.modelName}. Proceed?`,
+        // Phase 2: Execute batch delete.
+        const renderer = createDataBatchDeleteRenderer(cliCtx.outputMode);
+        await consumeStream(
+          dataBatchDelete(ctx, deps, {
+            modelIdOrName: modelIdOrName!,
+            filter,
+            dryRun: dryRun ?? false,
+          }),
+          renderer.handlers(),
         );
-        if (!confirmed) {
-          renderDataDeleteCancelled(cliCtx.outputMode);
-          return;
-        }
-      }
+      } else {
+        const renderer = createDataDeleteRenderer(cliCtx.outputMode);
 
-      // Phase 2: Execute delete.
-      await consumeStream(
-        dataDelete(ctx, deps, {
-          modelIdOrName,
-          dataName,
-          version: options.version,
-        }),
-        renderer.handlers(),
-      );
+        // Phase 1: Preview + Prompt (only in interactive log mode without --force).
+        if (cliCtx.outputMode === "log" && !options.force) {
+          let preview;
+          try {
+            preview = await dataDeletePreview(ctx, deps, {
+              modelIdOrName: modelIdOrName!,
+              dataName: dataName!,
+            });
+          } catch (error) {
+            throw new UserError(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+
+          const target = options.version !== undefined
+            ? `version ${options.version} of "${dataName}"`
+            : `${preview.versionsCount} version(s) of "${dataName}"`;
+          const confirmed = await promptConfirmation(
+            `About to delete ${target} from ${preview.modelName}. Proceed?`,
+          );
+          if (!confirmed) {
+            renderDataDeleteCancelled(cliCtx.outputMode);
+            return;
+          }
+        }
+
+        // Phase 2: Execute single delete.
+        await consumeStream(
+          dataDelete(ctx, deps, {
+            modelIdOrName: modelIdOrName!,
+            dataName: dataName!,
+            version: options.version,
+          }),
+          renderer.handlers(),
+        );
+      }
 
       cliCtx.logger.debug("Data delete command completed");
     },

--- a/src/cli/commands/data_delete_test.ts
+++ b/src/cli/commands/data_delete_test.ts
@@ -106,9 +106,3 @@ Deno.test("dataDeleteCommand has --dry-run option", async () => {
   const dryRunOpt = options.find((o) => o.name === "dry-run");
   assertEquals(dryRunOpt !== undefined, true);
 });
-
-Deno.test("dataDeleteCommand has updated description for batch support", async () => {
-  const { dataDeleteCommand } = await import("./data_delete.ts");
-  const desc = dataDeleteCommand.getDescription();
-  assertEquals(desc.includes("prefix"), true);
-});

--- a/src/cli/commands/data_delete_test.ts
+++ b/src/cli/commands/data_delete_test.ts
@@ -34,7 +34,7 @@ Deno.test("dataDeleteCommand has correct description", async () => {
   const { dataDeleteCommand } = await import("./data_delete.ts");
   assertEquals(
     dataDeleteCommand.getDescription(),
-    "Delete a data artifact (all versions, or one when --version is set)",
+    "Delete data artifacts: one by name, many by prefix, or all for a model",
   );
 });
 
@@ -84,4 +84,31 @@ Deno.test("dataDeleteCommand has --name option", async () => {
   const options = dataDeleteCommand.getOptions();
   const nameOpt = options.find((o) => o.name === "name");
   assertEquals(nameOpt !== undefined, true);
+});
+
+Deno.test("dataDeleteCommand has --prefix option", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const options = dataDeleteCommand.getOptions();
+  const prefixOpt = options.find((o) => o.name === "prefix");
+  assertEquals(prefixOpt !== undefined, true);
+});
+
+Deno.test("dataDeleteCommand has --all option", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const options = dataDeleteCommand.getOptions();
+  const allOpt = options.find((o) => o.name === "all");
+  assertEquals(allOpt !== undefined, true);
+});
+
+Deno.test("dataDeleteCommand has --dry-run option", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const options = dataDeleteCommand.getOptions();
+  const dryRunOpt = options.find((o) => o.name === "dry-run");
+  assertEquals(dryRunOpt !== undefined, true);
+});
+
+Deno.test("dataDeleteCommand has updated description for batch support", async () => {
+  const { dataDeleteCommand } = await import("./data_delete.ts");
+  const desc = dataDeleteCommand.getDescription();
+  assertEquals(desc.includes("prefix"), true);
 });

--- a/src/domain/data/data_delete_service.ts
+++ b/src/domain/data/data_delete_service.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { Data } from "./data.ts";
 import type { UnifiedDataRepository } from "./repositories.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { findDefinitionByIdOrName } from "../models/model_lookup.ts";
@@ -43,6 +44,41 @@ export interface DeletePreview {
   modelName: string;
   dataName: string;
   versionsCount: number;
+}
+
+export interface BatchDeleteResult {
+  modelType: string;
+  modelId: string;
+  modelName: string;
+  deleted: Array<{ dataName: string; versionsDeleted: number }>;
+  failed: Array<{ dataName: string; error: string }>;
+  totalDeleted: number;
+  totalVersionsDeleted: number;
+}
+
+export interface BatchDeletePreview {
+  modelType: string;
+  modelId: string;
+  modelName: string;
+  matchingItems: Array<{ dataName: string; versionsCount: number }>;
+  totalItems: number;
+  totalVersions: number;
+}
+
+export type BatchDeleteFilter =
+  | { kind: "prefix"; value: string }
+  | { kind: "all" };
+
+function matchesFilter(
+  data: Data,
+  filter: BatchDeleteFilter,
+): boolean {
+  switch (filter.kind) {
+    case "all":
+      return true;
+    case "prefix":
+      return data.name.startsWith(filter.value);
+  }
 }
 
 /**
@@ -139,6 +175,125 @@ export class DataDeleteService {
       modelName: definition.name,
       dataName,
       versionsCount: versions.length,
+    };
+  }
+
+  async batchDelete(
+    modelRef: string,
+    filter: BatchDeleteFilter,
+  ): Promise<BatchDeleteResult> {
+    const lookup = await findDefinitionByIdOrName(
+      this.definitionRepo,
+      modelRef,
+    );
+    if (!lookup) {
+      throw new Error(`Model not found: ${modelRef}`);
+    }
+    const { definition, type: modelType } = lookup;
+
+    const allData = await this.dataRepo.findAllForModel(
+      modelType,
+      definition.id,
+    );
+    const matching = allData.filter((d) => matchesFilter(d, filter));
+
+    if (matching.length === 0) {
+      const desc = filter.kind === "prefix"
+        ? `prefix "${filter.value}"`
+        : "any data";
+      throw new Error(
+        `No data matching ${desc} found for model ${definition.name}`,
+      );
+    }
+
+    const deleted: Array<{ dataName: string; versionsDeleted: number }> = [];
+    const failed: Array<{ dataName: string; error: string }> = [];
+    let totalVersionsDeleted = 0;
+
+    for (const data of matching) {
+      try {
+        const versions = await this.dataRepo.listVersions(
+          modelType,
+          definition.id,
+          data.name,
+        );
+        await this.dataRepo.delete(modelType, definition.id, data.name);
+        deleted.push({
+          dataName: data.name,
+          versionsDeleted: versions.length,
+        });
+        totalVersionsDeleted += versions.length;
+      } catch (error) {
+        failed.push({
+          dataName: data.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return {
+      modelType: modelType.normalized,
+      modelId: definition.id,
+      modelName: definition.name,
+      deleted,
+      failed,
+      totalDeleted: deleted.length,
+      totalVersionsDeleted,
+    };
+  }
+
+  async batchPreviewDelete(
+    modelRef: string,
+    filter: BatchDeleteFilter,
+  ): Promise<BatchDeletePreview> {
+    const lookup = await findDefinitionByIdOrName(
+      this.definitionRepo,
+      modelRef,
+    );
+    if (!lookup) {
+      throw new Error(`Model not found: ${modelRef}`);
+    }
+    const { definition, type: modelType } = lookup;
+
+    const allData = await this.dataRepo.findAllForModel(
+      modelType,
+      definition.id,
+    );
+    const matching = allData.filter((d) => matchesFilter(d, filter));
+
+    if (matching.length === 0) {
+      const desc = filter.kind === "prefix"
+        ? `prefix "${filter.value}"`
+        : "any data";
+      throw new Error(
+        `No data matching ${desc} found for model ${definition.name}`,
+      );
+    }
+
+    let totalVersions = 0;
+    const matchingItems: Array<{ dataName: string; versionsCount: number }> =
+      [];
+
+    for (const data of matching) {
+      const versions = await this.dataRepo.listVersions(
+        modelType,
+        definition.id,
+        data.name,
+      );
+      matchingItems.push({
+        dataName: data.name,
+        versionsCount: versions.length,
+      });
+      totalVersions += versions.length;
+    }
+
+    return {
+      modelType: modelType.normalized,
+      modelId: definition.id,
+      modelName: definition.name,
+      matchingItems,
+      totalItems: matching.length,
+      totalVersions,
     };
   }
 }

--- a/src/domain/data/data_delete_service_test.ts
+++ b/src/domain/data/data_delete_service_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import type { BatchDeleteFilter } from "./data_delete_service.ts";
 import { DataDeleteService } from "./data_delete_service.ts";
 import { ModelType } from "../models/model_type.ts";
 
@@ -31,6 +32,7 @@ class FakeDataRepository {
     dataName: string;
     version?: number;
   }> = [];
+  deleteError: string | null = null;
 
   listVersions = (
     _type: ModelType,
@@ -40,12 +42,24 @@ class FakeDataRepository {
     return Promise.resolve(this.versionsByName.get(dataName) ?? []);
   };
 
+  findAllForModel = (
+    _type: ModelType,
+    _modelId: string,
+  ): Promise<Array<{ name: string }>> => {
+    return Promise.resolve(
+      [...this.versionsByName.keys()].map((name) => ({ name })),
+    );
+  };
+
   delete = (
     type: ModelType,
     modelId: string,
     dataName: string,
     version?: number,
   ): Promise<void> => {
+    if (this.deleteError && dataName === this.deleteError) {
+      return Promise.reject(new Error(`Delete failed for ${dataName}`));
+    }
     this.deleteCalls.push({ type, modelId, dataName, version });
     return Promise.resolve();
   };
@@ -183,5 +197,105 @@ Deno.test("DataDeleteService.previewDelete: throws when artifact has no versions
     () => service.previewDelete("my-model", "my-data"),
     Error,
     'No data named "my-data" exists for model my-model',
+  );
+});
+
+// --- Batch delete tests ---
+
+Deno.test("DataDeleteService.batchDelete: deletes all items matching prefix", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("run-001", [1]);
+  dataRepo.versionsByName.set("run-002", [1, 2]);
+  dataRepo.versionsByName.set("keep-me", [1]);
+
+  const filter: BatchDeleteFilter = { kind: "prefix", value: "run-" };
+  const result = await service.batchDelete("my-model", filter);
+
+  assertEquals(result.totalDeleted, 2);
+  assertEquals(result.totalVersionsDeleted, 3);
+  assertEquals(result.failed.length, 0);
+  assertEquals(result.deleted.length, 2);
+  assertEquals(
+    dataRepo.deleteCalls.map((c) => c.dataName).sort(),
+    ["run-001", "run-002"],
+  );
+});
+
+Deno.test("DataDeleteService.batchDelete: deletes all items with 'all' filter", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("a", [1]);
+  dataRepo.versionsByName.set("b", [1, 2]);
+  dataRepo.versionsByName.set("c", [1]);
+
+  const filter: BatchDeleteFilter = { kind: "all" };
+  const result = await service.batchDelete("my-model", filter);
+
+  assertEquals(result.totalDeleted, 3);
+  assertEquals(result.totalVersionsDeleted, 4);
+});
+
+Deno.test("DataDeleteService.batchDelete: throws when no items match prefix", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("keep-me", [1]);
+
+  const filter: BatchDeleteFilter = { kind: "prefix", value: "run-" };
+  await assertRejects(
+    () => service.batchDelete("my-model", filter),
+    Error,
+    'No data matching prefix "run-" found for model my-model',
+  );
+});
+
+Deno.test("DataDeleteService.batchDelete: throws when model not found", async () => {
+  const { service } = makeService();
+
+  const filter: BatchDeleteFilter = { kind: "all" };
+  await assertRejects(
+    () => service.batchDelete("missing-model", filter),
+    Error,
+    "Model not found: missing-model",
+  );
+});
+
+Deno.test("DataDeleteService.batchDelete: continues on partial failure", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("run-001", [1]);
+  dataRepo.versionsByName.set("run-002", [1]);
+  dataRepo.versionsByName.set("run-003", [1]);
+  dataRepo.deleteError = "run-002";
+
+  const filter: BatchDeleteFilter = { kind: "prefix", value: "run-" };
+  const result = await service.batchDelete("my-model", filter);
+
+  assertEquals(result.totalDeleted, 2);
+  assertEquals(result.failed.length, 1);
+  assertEquals(result.failed[0].dataName, "run-002");
+  assertStringIncludes(result.failed[0].error, "Delete failed for run-002");
+});
+
+Deno.test("DataDeleteService.batchPreviewDelete: returns matching items without deleting", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("run-001", [1, 2]);
+  dataRepo.versionsByName.set("run-002", [1]);
+  dataRepo.versionsByName.set("keep-me", [1]);
+
+  const filter: BatchDeleteFilter = { kind: "prefix", value: "run-" };
+  const preview = await service.batchPreviewDelete("my-model", filter);
+
+  assertEquals(preview.totalItems, 2);
+  assertEquals(preview.totalVersions, 3);
+  assertEquals(preview.matchingItems.length, 2);
+  assertEquals(dataRepo.deleteCalls.length, 0);
+});
+
+Deno.test("DataDeleteService.batchPreviewDelete: throws when no items match", async () => {
+  const { service, dataRepo } = makeService();
+  dataRepo.versionsByName.set("keep-me", [1]);
+
+  const filter: BatchDeleteFilter = { kind: "prefix", value: "run-" };
+  await assertRejects(
+    () => service.batchPreviewDelete("my-model", filter),
+    Error,
+    'No data matching prefix "run-" found for model my-model',
   );
 });

--- a/src/libswamp/data/delete.ts
+++ b/src/libswamp/data/delete.ts
@@ -18,6 +18,9 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import {
+  type BatchDeleteFilter,
+  type BatchDeletePreview,
+  type BatchDeleteResult,
   DataDeleteService,
   type DeletePreview,
   type DeleteResult,
@@ -77,6 +80,14 @@ export interface DataDeleteDeps {
     modelIdOrName: string,
     dataName: string,
   ) => Promise<DeletePreview>;
+  batchDelete: (
+    modelIdOrName: string,
+    filter: BatchDeleteFilter,
+  ) => Promise<BatchDeleteResult>;
+  batchPreview: (
+    modelIdOrName: string,
+    filter: BatchDeleteFilter,
+  ) => Promise<BatchDeletePreview>;
 }
 
 /** Wires real infrastructure into DataDeleteDeps. */
@@ -107,6 +118,10 @@ export function createDataDeleteDeps(
       service.delete(modelIdOrName, dataName, version),
     preview: (modelIdOrName, dataName) =>
       service.previewDelete(modelIdOrName, dataName),
+    batchDelete: (modelIdOrName, filter) =>
+      service.batchDelete(modelIdOrName, filter),
+    batchPreview: (modelIdOrName, filter) =>
+      service.batchPreviewDelete(modelIdOrName, filter),
   };
 }
 
@@ -172,6 +187,139 @@ export async function* dataDelete(
           dataName: result.dataName,
           version: result.version,
           versionsDeleted: result.versionsDeleted,
+        },
+      };
+    })(),
+  );
+}
+
+/** Data structure for the batch delete completed event. */
+export interface DataBatchDeleteData {
+  modelId: string;
+  modelName: string;
+  modelType: string;
+  totalDeleted: number;
+  totalVersionsDeleted: number;
+  failed: Array<{ dataName: string; error: string }>;
+  dryRun: boolean;
+}
+
+/** Preview returned before batch confirmation. */
+export interface DataBatchDeletePreview {
+  modelId: string;
+  modelName: string;
+  modelType: string;
+  matchingItems: Array<{ dataName: string; versionsCount: number }>;
+  totalItems: number;
+  totalVersions: number;
+}
+
+export type DataBatchDeleteEvent =
+  | { kind: "deleting" }
+  | { kind: "completed"; data: DataBatchDeleteData }
+  | { kind: "error"; error: SwampError };
+
+/** Input for the batch delete operation. */
+export interface DataBatchDeleteInput {
+  modelIdOrName: string;
+  filter: BatchDeleteFilter;
+  dryRun: boolean;
+}
+
+export { type BatchDeleteFilter } from "../../domain/data/data_delete_service.ts";
+
+/** Gathers preview info for a batch delete without mutating state. */
+export async function dataBatchDeletePreview(
+  ctx: LibSwampContext,
+  deps: DataDeleteDeps,
+  input: { modelIdOrName: string; filter: BatchDeleteFilter },
+): Promise<DataBatchDeletePreview> {
+  ctx.logger
+    .debug`Previewing batch delete: model=${input.modelIdOrName}, filter=${input.filter.kind}`;
+  const preview = await deps.batchPreview(input.modelIdOrName, input.filter);
+  return {
+    modelId: preview.modelId,
+    modelName: preview.modelName,
+    modelType: preview.modelType,
+    matchingItems: preview.matchingItems,
+    totalItems: preview.totalItems,
+    totalVersions: preview.totalVersions,
+  };
+}
+
+/** Deletes data instances matching a filter (prefix or all). */
+export async function* dataBatchDelete(
+  ctx: LibSwampContext,
+  deps: DataDeleteDeps,
+  input: DataBatchDeleteInput,
+): AsyncIterable<DataBatchDeleteEvent> {
+  yield* withGeneratorSpan(
+    "swamp.data.batch_delete",
+    {
+      "batch.filter_kind": input.filter.kind,
+      "batch.dry_run": input.dryRun,
+    },
+    (async function* () {
+      yield { kind: "deleting" } as const;
+
+      ctx.logger
+        .debug`Batch deleting data: model=${input.modelIdOrName}, filter=${input.filter.kind}, dryRun=${input.dryRun}`;
+
+      if (input.dryRun) {
+        let preview: BatchDeletePreview;
+        try {
+          preview = await deps.batchPreview(
+            input.modelIdOrName,
+            input.filter,
+          );
+        } catch (error) {
+          yield {
+            kind: "error" as const,
+            error: validationFailed(
+              error instanceof Error ? error.message : String(error),
+            ),
+          };
+          return;
+        }
+
+        yield {
+          kind: "completed" as const,
+          data: {
+            modelId: preview.modelId,
+            modelName: preview.modelName,
+            modelType: preview.modelType,
+            totalDeleted: preview.totalItems,
+            totalVersionsDeleted: preview.totalVersions,
+            failed: [],
+            dryRun: true,
+          },
+        };
+        return;
+      }
+
+      let result: BatchDeleteResult;
+      try {
+        result = await deps.batchDelete(input.modelIdOrName, input.filter);
+      } catch (error) {
+        yield {
+          kind: "error" as const,
+          error: validationFailed(
+            error instanceof Error ? error.message : String(error),
+          ),
+        };
+        return;
+      }
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          modelId: result.modelId,
+          modelName: result.modelName,
+          modelType: result.modelType,
+          totalDeleted: result.totalDeleted,
+          totalVersionsDeleted: result.totalVersionsDeleted,
+          failed: result.failed,
+          dryRun: false,
         },
       };
     })(),

--- a/src/libswamp/data/delete_test.ts
+++ b/src/libswamp/data/delete_test.ts
@@ -21,6 +21,9 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  dataBatchDelete,
+  type DataBatchDeleteEvent,
+  dataBatchDeletePreview,
   dataDelete,
   type DataDeleteDeps,
   type DataDeleteEvent,
@@ -45,6 +48,31 @@ function makeDeps(overrides: Partial<DataDeleteDeps> = {}): DataDeleteDeps {
         modelType: "test/example",
         dataName: "my-data",
         versionsCount: 3,
+      }),
+    batchDelete: () =>
+      Promise.resolve({
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        deleted: [
+          { dataName: "run-001", versionsDeleted: 1 },
+          { dataName: "run-002", versionsDeleted: 2 },
+        ],
+        failed: [],
+        totalDeleted: 2,
+        totalVersionsDeleted: 3,
+      }),
+    batchPreview: () =>
+      Promise.resolve({
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        matchingItems: [
+          { dataName: "run-001", versionsCount: 1 },
+          { dataName: "run-002", versionsCount: 2 },
+        ],
+        totalItems: 2,
+        totalVersions: 3,
       }),
     ...overrides,
   };
@@ -191,4 +219,113 @@ Deno.test("dataDeletePreview: returns version count without invoking delete", as
   assertEquals(preview.modelName, "my-model");
   assertEquals(preview.modelType, "test/example");
   assertEquals(deleteCalled, false);
+});
+
+// --- Batch delete tests ---
+
+Deno.test("dataBatchDelete: yields completed with aggregated stats", async () => {
+  const deps = makeDeps();
+
+  const events = await collect<DataBatchDeleteEvent>(
+    dataBatchDelete(createLibSwampContext(), deps, {
+      modelIdOrName: "my-model",
+      filter: { kind: "prefix", value: "run-" },
+      dryRun: false,
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "deleting" });
+  const completed = events[1] as Extract<
+    DataBatchDeleteEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.totalDeleted, 2);
+  assertEquals(completed.data.totalVersionsDeleted, 3);
+  assertEquals(completed.data.failed.length, 0);
+  assertEquals(completed.data.dryRun, false);
+});
+
+Deno.test("dataBatchDelete: dry run uses preview without deleting", async () => {
+  let batchDeleteCalled = false;
+  const deps = makeDeps({
+    batchDelete: () => {
+      batchDeleteCalled = true;
+      return Promise.resolve({
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        deleted: [],
+        failed: [],
+        totalDeleted: 0,
+        totalVersionsDeleted: 0,
+      });
+    },
+  });
+
+  const events = await collect<DataBatchDeleteEvent>(
+    dataBatchDelete(createLibSwampContext(), deps, {
+      modelIdOrName: "my-model",
+      filter: { kind: "all" },
+      dryRun: true,
+    }),
+  );
+
+  assertEquals(batchDeleteCalled, false);
+  const completed = events[1] as Extract<
+    DataBatchDeleteEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.dryRun, true);
+  assertEquals(completed.data.totalDeleted, 2);
+  assertEquals(completed.data.totalVersionsDeleted, 3);
+});
+
+Deno.test("dataBatchDelete: yields error when service throws", async () => {
+  const deps = makeDeps({
+    batchDelete: () => {
+      throw new Error("Model not found: missing");
+    },
+  });
+
+  const events = await collect<DataBatchDeleteEvent>(
+    dataBatchDelete(createLibSwampContext(), deps, {
+      modelIdOrName: "missing",
+      filter: { kind: "all" },
+      dryRun: false,
+    }),
+  );
+
+  const last = events[1] as Extract<DataBatchDeleteEvent, { kind: "error" }>;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("dataBatchDeletePreview: returns matching items without deleting", async () => {
+  let batchDeleteCalled = false;
+  const deps = makeDeps({
+    batchDelete: () => {
+      batchDeleteCalled = true;
+      return Promise.resolve({
+        modelId: "def-1",
+        modelName: "my-model",
+        modelType: "test/example",
+        deleted: [],
+        failed: [],
+        totalDeleted: 0,
+        totalVersionsDeleted: 0,
+      });
+    },
+  });
+
+  const preview = await dataBatchDeletePreview(createLibSwampContext(), deps, {
+    modelIdOrName: "my-model",
+    filter: { kind: "prefix", value: "run-" },
+  });
+
+  assertEquals(preview.totalItems, 2);
+  assertEquals(preview.totalVersions, 3);
+  assertEquals(preview.matchingItems.length, 2);
+  assertEquals(batchDeleteCalled, false);
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1105,7 +1105,14 @@ export {
 
 // Data delete operations
 export {
+  type BatchDeleteFilter,
   createDataDeleteDeps,
+  dataBatchDelete,
+  type DataBatchDeleteData,
+  type DataBatchDeleteEvent,
+  type DataBatchDeleteInput,
+  type DataBatchDeletePreview,
+  dataBatchDeletePreview,
   dataDelete,
   type DataDeleteData,
   type DataDeleteDeps,

--- a/src/presentation/renderers/data_delete.ts
+++ b/src/presentation/renderers/data_delete.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { DataDeleteEvent, EventHandlers } from "../../libswamp/mod.ts";
+import type {
+  DataBatchDeleteEvent,
+  DataDeleteEvent,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -67,6 +71,60 @@ export function createDataDeleteRenderer(
       return new JsonDataDeleteRenderer();
     case "log":
       return new LogDataDeleteRenderer();
+  }
+}
+
+class LogDataBatchDeleteRenderer implements Renderer<DataBatchDeleteEvent> {
+  handlers(): EventHandlers<DataBatchDeleteEvent> {
+    const logger = getSwampLogger(["data", "delete"]);
+    return {
+      deleting: () => {},
+      completed: (e) => {
+        const data = e.data;
+        if (data.dryRun) {
+          logger
+            .info`Would delete ${data.totalDeleted} data artifact(s) (${data.totalVersionsDeleted} version(s)) from ${data.modelName} (${data.modelType})`;
+        } else {
+          logger
+            .info`Deleted ${data.totalDeleted} data artifact(s) (${data.totalVersionsDeleted} version(s)) from ${data.modelName} (${data.modelType})`;
+        }
+        if (data.failed.length > 0) {
+          logger
+            .warn`${data.failed.length} artifact(s) failed to delete`;
+          for (const f of data.failed) {
+            logger.warn`  ${f.dataName}: ${f.error}`;
+          }
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDataBatchDeleteRenderer implements Renderer<DataBatchDeleteEvent> {
+  handlers(): EventHandlers<DataBatchDeleteEvent> {
+    return {
+      deleting: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDataBatchDeleteRenderer(
+  mode: OutputMode,
+): Renderer<DataBatchDeleteEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonDataBatchDeleteRenderer();
+    case "log":
+      return new LogDataBatchDeleteRenderer();
   }
 }
 

--- a/src/presentation/renderers/data_delete_test.ts
+++ b/src/presentation/renderers/data_delete_test.ts
@@ -25,10 +25,14 @@ import {
 } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
+  createDataBatchDeleteRenderer,
   createDataDeleteRenderer,
   renderDataDeleteCancelled,
 } from "./data_delete.ts";
-import type { DataDeleteEvent } from "../../libswamp/mod.ts";
+import type {
+  DataBatchDeleteEvent,
+  DataDeleteEvent,
+} from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { validationFailed } from "../../libswamp/errors.ts";
 
@@ -189,4 +193,84 @@ Deno.test("renderDataDeleteCancelled: json mode emits cancelled envelope", () =>
 Deno.test("renderDataDeleteCancelled: log mode does not write to console.log", () => {
   const out = captureStdout(() => renderDataDeleteCancelled("log"));
   assertEquals(out, "");
+});
+
+// --- Batch delete renderer tests ---
+
+function makeBatchCompletedEvent(
+  overrides: Partial<
+    Extract<DataBatchDeleteEvent, { kind: "completed" }>["data"]
+  > = {},
+): Extract<DataBatchDeleteEvent, { kind: "completed" }> {
+  return {
+    kind: "completed",
+    data: {
+      modelId: "def-1",
+      modelName: "my-model",
+      modelType: "test/example",
+      totalDeleted: 5,
+      totalVersionsDeleted: 8,
+      failed: [],
+      dryRun: false,
+      ...overrides,
+    },
+  };
+}
+
+Deno.test("createDataBatchDeleteRenderer: log mode handles real delete", () => {
+  const renderer = createDataBatchDeleteRenderer("log");
+  const handlers = renderer.handlers();
+  const out = captureLog(() => handlers.completed!(makeBatchCompletedEvent()));
+  assertStringIncludes(out, "Deleted 5 data artifact(s)");
+  assertStringIncludes(out, "8 version(s)");
+});
+
+Deno.test("createDataBatchDeleteRenderer: log mode handles dry-run", () => {
+  const renderer = createDataBatchDeleteRenderer("log");
+  const handlers = renderer.handlers();
+  const out = captureLog(() =>
+    handlers.completed!(makeBatchCompletedEvent({ dryRun: true }))
+  );
+  assertStringIncludes(out, "Would delete 5 data artifact(s)");
+});
+
+Deno.test("createDataBatchDeleteRenderer: log mode shows partial failures", () => {
+  const renderer = createDataBatchDeleteRenderer("log");
+  const handlers = renderer.handlers();
+  const out = captureLog(() =>
+    handlers.completed!(makeBatchCompletedEvent({
+      failed: [{ dataName: "bad-item", error: "permission denied" }],
+    }))
+  );
+  assertStringIncludes(out, "1 artifact(s) failed");
+  assertStringIncludes(out, "bad-item");
+  assertStringIncludes(out, "permission denied");
+});
+
+Deno.test("createDataBatchDeleteRenderer: json mode emits data object", () => {
+  const renderer = createDataBatchDeleteRenderer("json");
+  const handlers = renderer.handlers();
+  const out = captureStdout(() =>
+    handlers.completed!(makeBatchCompletedEvent())
+  );
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.modelName, "my-model");
+  assertEquals(parsed.totalDeleted, 5);
+  assertEquals(parsed.totalVersionsDeleted, 8);
+  assertEquals(parsed.dryRun, false);
+  assertEquals(parsed.failed, []);
+});
+
+Deno.test("createDataBatchDeleteRenderer: error handler throws UserError", () => {
+  const renderer = createDataBatchDeleteRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error!({
+        kind: "error",
+        error: validationFailed("batch failed"),
+      } as Extract<DataBatchDeleteEvent, { kind: "error" }>),
+    UserError,
+    "batch failed",
+  );
 });


### PR DESCRIPTION
## Summary

Adds batch/prefix delete to `swamp data delete` so multiple data artifacts can be removed in a single lock acquisition, addressing the N-lock-acquisition problem described in swamp-club#826.

- **`--prefix <str>`** — delete all data names starting with the given prefix
- **`--all`** — delete all data for a model
- **`--dry-run`** — preview what would be deleted without mutating
- Follows the same bulk-discovery + confirmation + iteration pattern used by `data gc`
- Aggregated output (total counts) rather than per-item events for clean UX at scale
- Partial failure handling: continues on individual delete errors, reports failures at the end

### Files changed

| Layer | Files |
|-------|-------|
| Domain service | `data_delete_service.ts` — `batchDelete()`, `batchPreviewDelete()`, `BatchDeleteFilter` |
| Libswamp | `delete.ts` — `dataBatchDelete()`, `dataBatchDeletePreview()` generators |
| Exports | `mod.ts` — new batch types and functions |
| CLI | `data_delete.ts` — `--prefix`, `--all`, `--dry-run` flags with validation |
| Presentation | `renderers/data_delete.ts` — `createDataBatchDeleteRenderer()` |

## Test Plan

- Unit tests at all three layers (domain, libswamp, CLI) — 39 tests pass
- Full test suite — 7919 passed, 1 pre-existing failure (unrelated `tar` binary issue)
- Manual verification against scratch repo with 29 seeded artifacts across 3 prefix families:
  - `--prefix scratch- --dry-run` → correct preview (5 items)
  - `--prefix scratch- --force` → deleted 5, others survived
  - `--prefix run- --force` → deleted 20 (24 versions including multi-version artifact)
  - `--all --force` → deleted remaining 3
  - `--prefix nonexistent-` → clean error message
  - Invalid combos (`--prefix + --all`, `--prefix + data name`, `--dry-run` without batch) → clear errors
  - Single delete backwards compatibility → works as before

Closes swamp-club#826