### PR TITLE
feat(serve): add @env= and @file= webhook secret indirection (swamp-club#758)

### DIFF
--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -134,6 +134,9 @@ The signature scheme is set per endpoint on `swamp serve`'s `--webhook` flag:
 `<route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]`, where `scheme`
 is `github` (default), `linear`, `stripe`, `slack`, or `generic` (requires
 header; optional prefix). Omitting the scheme preserves the original behavior.
+The secret field supports indirection to avoid exposing secrets in argv:
+`@env=VAR_NAME` reads from an environment variable, `@file=/path` reads from a
+file (trailing newline trimmed). Plain strings are literal secrets.
 
 ## Edit a Workflow
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -252,7 +252,9 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--webhook <spec:string>",
-    "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]",
+    "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
+      "Secret may use @env=VAR to read from an environment variable or " +
+      "@file=/path to read from a file (avoids secrets in argv)",
     { collect: true },
   )
   .option(
@@ -407,7 +409,9 @@ export const serveCommand = new Command()
     "--webhook <spec:string>",
     "Register a webhook endpoint: <route>:<workflow>:<secret>[:<scheme>[:<header>[:<prefix>]]]. " +
       "scheme is one of github (default), linear, stripe, slack, generic; " +
-      "generic requires a header name and accepts an optional value prefix",
+      "generic requires a header name and accepts an optional value prefix. " +
+      "Secret may use @env=VAR to read from an environment variable or " +
+      "@file=/path to read from a file (avoids secrets in argv)",
     { collect: true },
   )
   .option(
@@ -452,13 +456,17 @@ export const serveCommand = new Command()
     "swamp serve --auth-mode token --admins 'user:oauth|user-123'",
   )
   .example(
-    "Webhook trigger",
-    "swamp serve --webhook '/hooks/github:my-workflow:$WEBHOOK_SECRET'",
+    "Webhook (secret from env var)",
+    "swamp serve --webhook '/hooks/github:my-workflow:@env=WEBHOOK_SECRET'",
+  )
+  .example(
+    "Webhook (secret from file)",
+    "swamp serve --webhook '/hooks/github:my-workflow:@file=/run/secrets/webhook'",
   )
   .example(
     "Webhook with a provider scheme",
-    "swamp serve --webhook '/hooks/linear:my-workflow:$SECRET:linear' " +
-      "--webhook '/hooks/custom:my-workflow:$SECRET:generic:X-Signature:sha256='",
+    "swamp serve --webhook '/hooks/linear:my-workflow:@env=LINEAR_SECRET:linear' " +
+      "--webhook '/hooks/custom:my-workflow:@env=CUSTOM_SECRET:generic:X-Signature:sha256='",
   )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["serve"]);

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -77,6 +77,47 @@ export function buildWebhookPayload(
   return { body: parsed, headers: exposedHeaders, route };
 }
 
+// ── Secret Resolution ─────────────────────────────────────────────────
+
+const ENV_PREFIX = "@env=";
+const FILE_PREFIX = "@file=";
+
+export function resolveSecret(raw: string): string {
+  if (raw.startsWith(ENV_PREFIX)) {
+    const varName = raw.slice(ENV_PREFIX.length);
+    const value = Deno.env.get(varName);
+    if (!value) {
+      throw new UserError(
+        `Webhook secret references environment variable '${varName}' ` +
+          `(via ${ENV_PREFIX}), but it is not set or is empty`,
+      );
+    }
+    return value;
+  }
+
+  if (raw.startsWith(FILE_PREFIX)) {
+    const filePath = raw.slice(FILE_PREFIX.length);
+    let content: string;
+    try {
+      content = Deno.readTextFileSync(filePath);
+    } catch (cause) {
+      throw new UserError(
+        `Webhook secret references file '${filePath}' ` +
+          `(via ${FILE_PREFIX}), but it could not be read: ${cause}`,
+      );
+    }
+    content = content.replace(/\r?\n$/, "");
+    if (!content) {
+      throw new UserError(
+        `Webhook secret file '${filePath}' is empty`,
+      );
+    }
+    return content;
+  }
+
+  return raw;
+}
+
 // ── Value Objects ──────────────────────────────────────────────────────
 
 /**
@@ -146,6 +187,8 @@ export function parseWebhookFlag(flag: string): WebhookEndpoint {
     secret = flag.slice(secondColon + 1);
     verifier = { scheme: "github" };
   }
+
+  secret = resolveSecret(secret);
 
   if (!route || !workflowIdOrName || !secret) {
     throw new UserError(

--- a/src/serve/webhook_test.ts
+++ b/src/serve/webhook_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import {
   buildWebhookPayload,
   parseWebhookFlag,
+  resolveSecret,
   WebhookService,
 } from "./webhook.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
@@ -212,6 +213,141 @@ Deno.test("parseWebhookFlag: rejects route without leading slash", () => {
     Error,
     "must start with '/'",
   );
+});
+
+// ── resolveSecret ─────────────────────────────────────────────────────
+
+Deno.test("resolveSecret: returns a literal string unchanged", () => {
+  assertEquals(resolveSecret("mysecretvalue"), "mysecretvalue");
+});
+
+Deno.test("resolveSecret: reads from an environment variable via @env=", () => {
+  Deno.env.set("TEST_WEBHOOK_SECRET_758", "env-secret-value");
+  try {
+    assertEquals(
+      resolveSecret("@env=TEST_WEBHOOK_SECRET_758"),
+      "env-secret-value",
+    );
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET_758");
+  }
+});
+
+Deno.test("resolveSecret: throws for an unset environment variable", () => {
+  Deno.env.delete("NONEXISTENT_WEBHOOK_VAR_758");
+  assertThrows(
+    () => resolveSecret("@env=NONEXISTENT_WEBHOOK_VAR_758"),
+    Error,
+    "not set or is empty",
+  );
+});
+
+Deno.test("resolveSecret: throws for an empty environment variable", () => {
+  Deno.env.set("EMPTY_WEBHOOK_VAR_758", "");
+  try {
+    assertThrows(
+      () => resolveSecret("@env=EMPTY_WEBHOOK_VAR_758"),
+      Error,
+      "not set or is empty",
+    );
+  } finally {
+    Deno.env.delete("EMPTY_WEBHOOK_VAR_758");
+  }
+});
+
+Deno.test("resolveSecret: reads from a file via @file=", () => {
+  const tmpFile = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(tmpFile, "file-secret-value\n");
+    assertEquals(resolveSecret(`@file=${tmpFile}`), "file-secret-value");
+  } finally {
+    Deno.removeSync(tmpFile);
+  }
+});
+
+Deno.test("resolveSecret: trims trailing CRLF from file", () => {
+  const tmpFile = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(tmpFile, "file-secret\r\n");
+    assertEquals(resolveSecret(`@file=${tmpFile}`), "file-secret");
+  } finally {
+    Deno.removeSync(tmpFile);
+  }
+});
+
+Deno.test("resolveSecret: throws for a missing file", () => {
+  assertThrows(
+    () => resolveSecret("@file=/tmp/nonexistent-webhook-secret-758"),
+    Error,
+    "could not be read",
+  );
+});
+
+Deno.test("resolveSecret: throws for an empty file", () => {
+  const tmpFile = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(tmpFile, "");
+    assertThrows(
+      () => resolveSecret(`@file=${tmpFile}`),
+      Error,
+      "is empty",
+    );
+  } finally {
+    Deno.removeSync(tmpFile);
+  }
+});
+
+Deno.test("resolveSecret: throws for a file containing only a newline", () => {
+  const tmpFile = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(tmpFile, "\n");
+    assertThrows(
+      () => resolveSecret(`@file=${tmpFile}`),
+      Error,
+      "is empty",
+    );
+  } finally {
+    Deno.removeSync(tmpFile);
+  }
+});
+
+// ── parseWebhookFlag with secret indirection ──────────────────────────
+
+Deno.test("parseWebhookFlag: resolves @env= secret in legacy form", () => {
+  Deno.env.set("TEST_WH_SECRET_LEGACY_758", "resolved-secret");
+  try {
+    const result = parseWebhookFlag(
+      "/hooks/gh:wf:@env=TEST_WH_SECRET_LEGACY_758",
+    );
+    assertEquals(result.secret, "resolved-secret");
+    assertEquals(result.verifier, { scheme: "github" });
+  } finally {
+    Deno.env.delete("TEST_WH_SECRET_LEGACY_758");
+  }
+});
+
+Deno.test("parseWebhookFlag: resolves @env= secret in scheme-qualified form", () => {
+  Deno.env.set("TEST_WH_SECRET_SCHEME_758", "resolved-secret");
+  try {
+    const result = parseWebhookFlag(
+      "/hooks/linear:wf:@env=TEST_WH_SECRET_SCHEME_758:linear",
+    );
+    assertEquals(result.secret, "resolved-secret");
+    assertEquals(result.verifier, { scheme: "linear" });
+  } finally {
+    Deno.env.delete("TEST_WH_SECRET_SCHEME_758");
+  }
+});
+
+Deno.test("parseWebhookFlag: resolves @file= secret", () => {
+  const tmpFile = Deno.makeTempFileSync();
+  try {
+    Deno.writeTextFileSync(tmpFile, "file-resolved\n");
+    const result = parseWebhookFlag(`/hooks/gh:wf:@file=${tmpFile}`);
+    assertEquals(result.secret, "file-resolved");
+  } finally {
+    Deno.removeSync(tmpFile);
+  }
 });
 
 // ── listEndpoints ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `@env=VAR` and `@file=/path` prefix syntax to the `--webhook` flag's secret field, so HMAC signing secrets can be sourced from environment variables or files instead of appearing as literal values in process argv
- Uses `=` as the prefix delimiter (not `:` as proposed in the issue) to avoid collision with the colon-delimited flag format — the issue's own example would break with `:` because `@env:VAR` splits across field boundaries in `parseWebhookFlag()`
- Fails fast at startup with a clear `UserError` if the env var is unset/empty or the file is missing/empty

Closes swamp-club#758

## Test Plan

- [x] Unit tests for `resolveSecret()`: literal passthrough, `@env=` set/unset/empty, `@file=` present/missing/empty/newline-trimming (9 tests)
- [x] Integration tests for `parseWebhookFlag()` with `@env=` and `@file=` in both legacy and scheme-qualified forms (3 tests)
- [x] All 7917 existing tests pass
- [x] End-to-end verification with compiled binary:
  - `@env=` with set variable → webhook registered
  - `@file=` with valid file → webhook registered
  - `@env=` with unset variable → clear startup error
  - `@file=` with missing file → clear startup error
  - `@env=` with scheme-qualified form (`:linear`) → correct scheme + resolved secret
  - Literal secret (backward compat) → unchanged behavior

## Why `=` instead of `:` from the issue

The issue proposed `@env:VAR` / `@file:/path`, but the `--webhook` flag is colon-delimited (`route:workflow:secret:scheme`). The colon in `@env:` splits across field boundaries:

```
/hooks/linear:wf:@env:MY_VAR:linear
→ fields = ["/hooks/linear", "wf", "@env", "MY_VAR", "linear"]
→ fields[3] = "MY_VAR" (not a scheme) → legacy path → secret = "@env:MY_VAR:linear" ✗
```

Using `=` avoids this entirely:

```
/hooks/linear:wf:@env=MY_VAR:linear
→ fields = ["/hooks/linear", "wf", "@env=MY_VAR", "linear"]
→ fields[3] = "linear" (scheme) → secret = "@env=MY_VAR" → resolves correctly ✓
```

Co-authored-by: Blake Irvin <blakeirvin@me.com>