### PR TITLE
feat(skill): add datastore namespace guidance to bundled swamp skill (swamp-club#833)

### DIFF
--- a/.claude/skills/swamp/references/data/references/examples.md
+++ b/.claude/skills/swamp/references/data/references/examples.md
@@ -46,6 +46,11 @@ your intent matches a shortcut — prefer them when they fit and reach for
 `data.query()` when you need a multi-field predicate or a projection. See
 [references/expressions.md](expressions.md) for the full shortcut mapping table.
 
+When the repo uses a datastore namespace, these lookups are implicitly scoped to
+the current namespace. To read data from a foreign namespace, pull its catalog
+first with `swamp datastore catalog pull --namespaces <list>` — see the repo
+skill's [namespaces reference](../../repo/references/namespaces.md) for details.
+
 ```yaml
 # Shortcut — single-model-and-name lookup reads clearly as data.latest()
 globalArguments:

--- a/.claude/skills/swamp/references/extension/references/datastore/api.md
+++ b/.claude/skills/swamp/references/extension/references/datastore/api.md
@@ -21,6 +21,14 @@ interface DatastoreProvider {
   createSyncService?(repoDir: string, cachePath: string): DatastoreSyncService;
   resolveDatastorePath(repoDir: string): string;
   resolveCachePath?(repoDir: string): string | undefined;
+
+  registerNamespace?(
+    datastorePath: string,
+    namespace: string,
+    repoId: string,
+  ): Promise<void>;
+
+  listNamespaces?(datastorePath: string): Promise<string[]>;
 }
 ```
 
@@ -59,6 +67,18 @@ locally accessible (no sync needed).
 Returns the absolute path where runtime data should be stored. For local
 datastores, this is the actual data directory. For remote datastores, this
 should be the local cache path.
+
+### `registerNamespace(datastorePath, namespace, repoId)?`
+
+Optional. Register a namespace in the datastore by writing a
+`{namespace}/.namespace.json` manifest. Fails if the namespace slug is already
+claimed by a different `repoId`. Solo-mode backends that don't support
+namespaces omit this method.
+
+### `listNamespaces(datastorePath)?`
+
+Optional. List all registered namespaces by scanning for `.namespace.json`
+manifests. Returns namespace slugs as strings. An empty array means solo mode.
 
 ### `resolveCachePath(repoDir)?`
 
@@ -165,13 +185,30 @@ Optional interface for remote datastore synchronization.
 interface DatastoreSyncService {
   pullChanged(options?: DatastoreSyncOptions): Promise<number | void>;
   pushChanged(options?: DatastoreSyncOptions): Promise<number | void>;
+  capabilities?(): SyncCapabilities;
   markDirty(options?: DatastoreSyncOptions): Promise<void>;
+  exportCatalog?(namespace: string): Promise<void>;
+  pullForeignCatalogs?(
+    namespaces: readonly string[],
+  ): Promise<CatalogExportEntry[]>;
+  fetchForeignContent?(
+    namespace: string,
+    relPath: string,
+  ): Promise<Uint8Array | null>;
+}
+
+interface SyncCapabilities {
+  scopedSync?: boolean;
+  lazyHydration?: boolean;
+  namespacedSync?: boolean;
 }
 
 interface DatastoreSyncOptions {
   signal?: AbortSignal;
   /** Cache-relative path of the file about to be written or removed. */
   relPath?: string;
+  /** Namespace subtree this sync operation targets. */
+  namespace?: string;
 }
 ```
 
@@ -211,3 +248,37 @@ nothing to invalidate and can return `Promise.resolve()` — fully backward
 compatible.
 
 `markDirty()` must be idempotent and cheap — core does not deduplicate calls.
+
+### `capabilities()?`
+
+Optional. Returns a `SyncCapabilities` object advertising what this sync service
+supports:
+
+- `namespacedSync` — when `true`, the extension correctly handles the
+  `namespace` field on `DatastoreSyncOptions`, scoping its index walk and upload
+  to `{namespace}/` in the remote datastore. Extensions that don't advertise
+  this still receive the namespace field but are expected to ignore it
+  (solo-mode behavior).
+- `scopedSync` — supports domain-level sync context.
+- `lazyHydration` — supports metadata-only pulls with on-demand content fetch.
+
+### `exportCatalog(namespace)?`
+
+Optional. Export the local catalog for the given namespace as a flat JSON array
+at `{namespace}/.catalog-export.json` in the remote datastore. Called after
+`pushChanged` so the export reflects the latest state.
+
+### `pullForeignCatalogs(namespaces)?`
+
+Optional. Pull catalog exports from the given foreign namespaces. Each
+namespace's export lives at `{namespace}/.catalog-export.json`. Returns one
+`CatalogExportEntry` per namespace that was successfully fetched. Missing
+exports are silently skipped.
+
+### `fetchForeignContent(namespace, relPath)?`
+
+Optional. Download a single file from a foreign namespace. Used for on-demand
+cross-namespace content access when a CEL expression references another
+namespace's data attributes. Returns the file contents, or `null` if the file
+does not exist. Fetched content is NOT persisted locally — it is ephemeral,
+cached only for the duration of the current command.

--- a/.claude/skills/swamp/references/repo/guide.md
+++ b/.claude/skills/swamp/references/repo/guide.md
@@ -19,6 +19,11 @@ machine-readable output.
 | Sync remote datastore      | `swamp datastore sync --json`                                     |
 | Check lock status          | `swamp datastore lock status --json`                              |
 | Force-release stuck lock   | `swamp datastore lock release --force --json`                     |
+| Set namespace              | `swamp datastore namespace set <slug> --json`                     |
+| Migrate namespace layout   | `swamp datastore namespace migrate [--confirm] --json`            |
+| List namespaces            | `swamp datastore namespace list --json`                           |
+| Remove namespace           | `swamp datastore namespace unset --json`                          |
+| Pull foreign catalogs      | `swamp datastore catalog pull --namespaces <list> --json`         |
 | Add extension source       | `swamp extension source add <path> [--only models,vaults,...]`    |
 | Remove extension source    | `swamp extension source rm <path>`                                |
 | List extension sources     | `swamp extension source list --json`                              |

--- a/.claude/skills/swamp/references/repo/reference.md
+++ b/.claude/skills/swamp/references/repo/reference.md
@@ -258,6 +258,31 @@ export SWAMP_DATASTORE='@myorg/my-store:{"key":"val"}'
 
 For custom datastore or driver implementations, see the `swamp-extension` skill.
 
+### Namespaces (Multi-Repo Datastores)
+
+When multiple repos share a remote datastore, each must own a **namespace** to
+avoid index collisions. Without namespaces, two repos writing to the same prefix
+clobber each other's `.datastore-index.json`.
+
+```bash
+swamp datastore namespace set <slug> --json            # Assign namespace
+swamp datastore namespace migrate --confirm --json     # Move data to namespaced layout
+swamp datastore namespace list --json                  # List all namespaces
+swamp datastore namespace unset --json                 # Remove namespace
+swamp datastore catalog pull --namespaces <list> --json # Pull foreign catalogs
+```
+
+Standard multi-repo flow:
+
+```bash
+swamp datastore namespace set infra
+swamp datastore namespace migrate --confirm
+swamp datastore sync --push
+```
+
+For the full command reference, output shapes, and cross-namespace data access,
+see [references/namespaces.md](references/namespaces.md).
+
 ## Extension Sources
 
 Load extensions from external filesystem paths without copying files. Use this
@@ -354,6 +379,9 @@ pointing at your local development copy — your local version loads instead.
   swamp in CI, GitHub Actions examples, and version pinning
 - **Structure**: See [references/structure.md](references/structure.md) for
   complete directory layout reference
+- **Namespaces**: See [references/namespaces.md](references/namespaces.md) for
+  multi-repo shared datastores, namespace commands, and cross-namespace data
+  access
 - **Troubleshooting**: See
   [references/troubleshooting.md](references/troubleshooting.md) for config
   problems and recovery procedures

--- a/.claude/skills/swamp/references/repo/references/namespaces.md
+++ b/.claude/skills/swamp/references/repo/references/namespaces.md
@@ -1,0 +1,139 @@
+# Datastore Namespaces (Giga-Swamp)
+
+Namespaces partition a shared remote datastore so multiple repos can use the
+same bucket/prefix without colliding. Each repo owns a namespace slug; all
+runtime data (model data, outputs, workflow runs) is written under
+`{namespace}/` instead of at the root.
+
+## Why Namespaces Matter
+
+Without namespaces, two repos sharing one datastore prefix both write
+`.datastore-index.json` at the same path — the second writer silently clobbers
+the first. **Namespacing is required before a second repo joins a shared
+datastore.**
+
+## CLI Commands
+
+All commands support `--json` for machine-readable output.
+
+### Assign a Namespace
+
+```bash
+swamp datastore namespace set <slug> --json
+```
+
+- Validates the slug (lowercase alphanumeric + hyphens, max 64 chars)
+- Checks for conflicts — rejects if the slug is already registered by a
+  different repo (via `.namespace.json` manifest)
+- Registers the namespace manifest at `{slug}/.namespace.json`
+- Updates `.swamp.yaml` with `datastore.namespace: <slug>`
+
+The slug must be unique per datastore. Two repos cannot claim the same
+namespace.
+
+### Migrate Data Layout
+
+```bash
+swamp datastore namespace migrate --json           # Preview (dry run)
+swamp datastore namespace migrate --confirm --json # Execute
+swamp datastore namespace migrate --reverse --json # Preview reverse
+swamp datastore namespace migrate --reverse --confirm --json # Execute reverse
+```
+
+Moves data between solo layout (`{prefix}/data/...`) and namespaced layout
+(`{prefix}/{namespace}/data/...`).
+
+- **Preview mode** (no `--confirm`): scans all subdirectories, reports file
+  counts and sizes. No data is moved.
+- **Execute mode** (`--confirm`): moves files, invalidates the catalog, and
+  marks extension datastores dirty for the next sync.
+- **Reverse** (`--reverse`): flattens namespaced paths back to solo layout.
+  Refuses if the un-namespaced path already contains data (collision detection).
+
+### List Namespaces
+
+```bash
+swamp datastore namespace list --json
+# Alias:
+swamp datastore namespaces --json
+```
+
+Lists all registered namespaces in the datastore by scanning for
+`.namespace.json` manifests. Shows which namespace (if any) belongs to the
+current repo.
+
+### Remove a Namespace
+
+```bash
+swamp datastore namespace unset --json                  # Remove from config only
+swamp datastore namespace unset --migrate --json        # Preview reverse migration
+swamp datastore namespace unset --migrate --confirm --json  # Execute reverse + remove
+```
+
+Clears `datastore.namespace` from `.swamp.yaml`. With `--migrate`, also reverses
+the data layout (same as `namespace migrate --reverse`).
+
+## Multi-Repo Workflow
+
+The standard flow when two repos share a remote datastore (e.g. S3 or GCS):
+
+```bash
+# Repo 1 (infra):
+swamp datastore namespace set infra
+swamp datastore namespace migrate --confirm
+swamp datastore sync --push
+
+# Repo 2 (platform):
+swamp datastore namespace set platform
+swamp datastore namespace migrate --confirm
+swamp datastore sync --push
+```
+
+After this, each repo's data lives under its own namespace prefix. Locks are
+per-namespace (`{prefix}/.locks/{namespace}.lock`), so the repos don't contend.
+
+## Cross-Namespace Data Access
+
+CEL point lookups (`data.latest`, `data.version`) are implicitly scoped to the
+current namespace. To read data from another namespace, use foreign catalog
+methods:
+
+```bash
+# Pull catalog metadata from foreign namespaces
+swamp datastore catalog pull --namespaces infra,platform --json
+```
+
+This fetches `.catalog-export.json` from each foreign namespace and imports it
+into the local catalog. After pulling, `data.query` can reference models from
+those namespaces.
+
+Foreign content (the actual data attributes) is fetched on demand when a CEL
+expression accesses them — it is not persisted locally.
+
+## Namespace Manifests
+
+Each namespace is tracked by a `.namespace.json` file at
+`{namespace}/.namespace.json` in the datastore:
+
+```json
+{
+  "namespace": "infra",
+  "repoId": "uuid-of-the-repo",
+  "registeredAt": "2026-06-03T00:00:00.000Z"
+}
+```
+
+The manifest enables:
+
+- **Conflict detection**: `namespace set` checks if the slug is already claimed
+  by a different `repoId`
+- **Discovery**: `namespace list` scans for manifests to enumerate all
+  namespaces
+
+## Path Resolution
+
+- **Solo mode** (no namespace): `{datastore}/{subdir}/...`
+- **Namespaced mode**: `{datastore}/{namespace}/{subdir}/...`
+
+The local tier (`.swamp/`) is never namespaced — only the remote/external
+datastore is partitioned.


### PR DESCRIPTION
## Summary

- Adds new deep-dive reference (`references/repo/references/namespaces.md`) covering the full namespace CLI surface (`set`, `migrate`, `list`, `unset`), multi-repo shared datastore workflow, cross-namespace data access via foreign catalogs, namespace manifests and conflict detection, and the un-namespaced index-clobber footgun.
- Updates the repo guide Quick Reference table and reference.md with namespace commands and pointers to the deep-dive.
- Updates the extension datastore API doc with namespace-related provider methods (`registerNamespace?`, `listNamespaces?`) and sync service methods (`exportCatalog`, `pullForeignCatalogs`, `fetchForeignContent`, `namespacedSync` capability, `namespace` on `DatastoreSyncOptions`).
- Adds a note to the data skill examples that CEL point lookups (`data.latest`, `data.version`) are namespace-scoped and cross-namespace reads require foreign catalog pull.

Closes swamp-club/lab#833

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — 7905 tests pass
- [x] `npx tessl skill review .claude/skills/swamp` — 98% score
- [x] All new commands/flags verified against source code interfaces