### PR TITLE
fix(datastore): materialize namespace manifest in local cache to prevent push deletion (swamp-club#834)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -432,11 +432,15 @@ The manifest lives at `{namespace}/.namespace.json` in the remote datastore
 
 For extension datastores, `DatastoreProvider.registerNamespace()` and
 `DatastoreProvider.listNamespaces()` manage manifests via the remote API
-(S3 PUT/GET, GCS equivalent). For filesystem datastores, the built-in
-`namespace_manifest.ts` utility reads and writes manifest files directly.
-Both methods are optional on `DatastoreProvider` — when the extension does
-not implement them, the CLI warns that conflict detection is unavailable and
-proceeds with only the `.swamp.yaml` update.
+(S3 PUT/GET, GCS equivalent). After writing to the remote, swamp core also
+materializes the manifest into the local cache at
+`{cachePath}/{namespace}/.namespace.json`. This ensures the extension's
+`pushChanged()` orphan detection sees a local counterpart for the manifest
+and does not delete the remote copy (swamp-club#834). For filesystem
+datastores, the built-in `namespace_manifest.ts` utility reads and writes
+manifest files directly. Both methods are optional on `DatastoreProvider` —
+when the extension does not implement them, the CLI warns that conflict
+detection is unavailable and proceeds with only the `.swamp.yaml` update.
 
 ### Zero-Diff Fast Path (Extension Guidance)
 

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -130,6 +130,14 @@ export const datastoreNamespaceSetCommand = new Command()
             namespace,
             rId,
           );
+          // Materialize the manifest into the local cache so push's
+          // orphan detection sees a local counterpart and does not
+          // delete the remote copy (swamp-club#834).
+          const cachePath =
+            (datastoreConfig as CustomDatastoreConfig).cachePath;
+          if (cachePath) {
+            await writeNamespaceManifest(cachePath, namespace, rId);
+          }
           return;
         }
         await writeNamespaceManifest(dsBasePath, namespace, rId);

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -38,6 +38,7 @@ import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/fi
 import { getSwampDataDir } from "../../infrastructure/persistence/paths.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { summarizeSyncError } from "../../infrastructure/persistence/sync_error_diagnostic.ts";
+import { writeNamespaceManifest } from "../../infrastructure/persistence/namespace_manifest.ts";
 import { runBoundedSync } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -487,6 +488,10 @@ export async function* datastoreSetupExtension(
         if (provider.registerNamespace) {
           try {
             await provider.registerNamespace(datastorePath, ns, input.repoId);
+            // Materialize the manifest into the local cache so push's
+            // orphan detection sees a local counterpart and does not
+            // delete the remote copy (swamp-club#834).
+            await writeNamespaceManifest(cachePath, ns, input.repoId);
             ctx.logger.info`Registered namespace ${ns} in datastore`;
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import { z } from "zod";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
@@ -32,6 +33,7 @@ import {
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
 import type { DatastoreSyncOptions } from "../../domain/datastore/datastore_sync_service.ts";
+import { readNamespaceManifest } from "../../infrastructure/persistence/namespace_manifest.ts";
 
 function makeDeps(
   overrides: Partial<DatastoreSetupDeps> = {},
@@ -1061,4 +1063,62 @@ Deno.test("datastoreSetupExtension: rejects invalid namespace slug", async () =>
   assertEquals(error.kind, "error");
   assertEquals(error.error.code, "validation_failed");
   assertStringIncludes(error.error.message, "Invalid namespace");
+});
+
+// ============================================================================
+// Namespace manifest cache materialization tests (swamp-club#834)
+// ============================================================================
+
+Deno.test("datastoreSetupExtension: materializes namespace manifest in local cache", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp-setup-834-" });
+  try {
+    let registered = false;
+    const NS_CACHE_TYPE = "test-ext-ns-cache-834";
+    if (!datastoreTypeRegistry.has(NS_CACHE_TYPE)) {
+      datastoreTypeRegistry.register({
+        type: NS_CACHE_TYPE,
+        name: "NS Cache Test",
+        description: "Test namespace manifest cache materialization",
+        isBuiltIn: false,
+        createProvider: () => ({
+          ...createStubProvider(),
+          resolveDatastorePath: () => join(tmpDir, "remote"),
+          resolveCachePath: () => join(tmpDir, "cache"),
+          registerNamespace: () => {
+            registered = true;
+            return Promise.resolve();
+          },
+        }),
+      });
+    }
+
+    const deps = makeDeps();
+    const input = makeExtensionInput({
+      type: NS_CACHE_TYPE,
+      repoDir: tmpDir,
+      namespace: "infra",
+      repoId: "repo-834",
+      skipMigration: true,
+    });
+
+    await collect<DatastoreSetupEvent>(
+      datastoreSetupExtension(createLibSwampContext(), deps, input),
+    );
+
+    assertEquals(registered, true, "provider.registerNamespace must be called");
+
+    const manifest = await readNamespaceManifest(
+      join(tmpDir, "cache"),
+      "infra",
+    );
+    assertEquals(
+      manifest !== null,
+      true,
+      "manifest must be materialized in the local cache",
+    );
+    assertEquals(manifest?.namespace, "infra");
+    assertEquals(manifest?.repoId, "repo-834");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
 });


### PR DESCRIPTION
## Summary

- `registerNamespace()` writes `.namespace.json` to the remote datastore but never materializes it into the local cache. When `pushChanged()` reconciles local vs remote, it treats the manifest as an orphan (no local counterpart) and deletes it — silently un-registering the namespace.
- After `provider.registerNamespace()`, also call `writeNamespaceManifest(cachePath, ...)` so the manifest exists in both the remote and local cache. Fixed at both call sites: `namespace set` command and `datastore setup` flow.
- Filed follow-up #1694 for defense-in-depth: add `.namespace.json` to `isInternalCacheFile()` in the S3/GCS extensions.

## Root Cause

The GCS extension uses `bulkInvalidated` for orphan detection (fires on any bulk `markDirty`, including `namespace migrate`), while the S3 extension uses the stricter `dirtyPathsOverflowed` (requires 200+ dirty paths). The manifest was only in the remote — not the local cache — so the GCS orphan scan deleted it on the first push after migrate.

## Test Plan

- Added unit test verifying `datastoreSetupExtension` materializes the manifest in the local cache when `registerNamespace` is called
- Reproduced the bug end-to-end against fake-gcs-server: `namespace set → migrate → sync --push` deleted the manifest before the fix and preserves it after
- All existing tests pass (40/40 in setup_test, 7/7 in namespace_set_test)
- Full `deno check`, `deno lint`, `deno fmt` pass

Closes swamp-club#834