### PR TITLE
feat(extension): surface type+method detail in extension info (swamp-club#825)

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -16,23 +16,61 @@ via `swamp-extension-publish`.
 
 ## Before Creating an Extension
 
-1. `swamp extension search <query>` — does a community extension already cover
-   it? Prefer `@swamp/*` official extensions first. Install with
-   `swamp extension pull <package>` and use it. Stop.
-2. `swamp model type search <query>` — check built-in/installed local types.
-3. Extend an existing type (including `@swamp` extensions) if it covers the
+1. **Search the registry.** Use filters to narrow results — don't rely on broad
+   keyword searches. Search by **service name**, not operation name (e.g. `ec2`
+   not `ebs` — extensions are organized by service, operations are methods
+   within types).
+
+   ```
+   swamp extension search <service> --platform <platform> --content-type models --json
+   ```
+
+   Available filters: `--platform` (aws, gcp, azure, …), `--content-type`
+   (models, workflows, vaults, datastores, drivers, reports), `--label`,
+   `--collective`. Prefer `@swamp/*` official extensions first.
+
+2. **Inspect before pulling.** Once you find a candidate, check its types and
+   methods with `extension info` — don't pull until you confirm it has what you
+   need:
+
+   ```
+   swamp extension info <package> --json
+   ```
+
+   The `contentMetadata` field in the JSON output lists every model type with
+   its methods and arguments, plus workflows, vaults, and other content. If the
+   type or method you need isn't listed, don't pull — move to step 5.
+
+3. **Pull and use.** If the extension has the right type and method, install it:
+   `swamp extension pull <package>`. Stop.
+
+4. **Check local types.** `swamp model type search <query>` — check
+   built-in/installed local types. **Cold-repo shortcut:** if no extensions are
+   installed (fresh repo, CI environment), skip this step — local search is
+   guaranteed-empty.
+
+5. **Extend an existing type** (including `@swamp` extensions) if it covers the
    domain but lacks the method you need. If the type is an official `@swamp/*`
    extension, also file a feature request so the maintainers learn about the
    gap: `swamp issue feature --extension @swamp/<name>`.
-4. For local or private extensions, use `swamp extension source add <path>`.
-5. Only create a new extension if nothing fits.
+
+6. **Confirmed no type/method exists?** If `extension info` and `type search`
+   both confirm no type or method covers the operation, stop searching.
+   `command/shell` or a custom model is the correct approach — file a feature
+   request (`swamp issue feature --extension @swamp/<name>`) to track the gap.
+
+7. For local or private extensions, use `swamp extension source add <path>`.
+
+8. Only create a new extension if nothing fits.
 
 Trusted collectives auto-resolve on first use. Only `@swamp/*` is trusted by
 default; trust others explicitly with `swamp extension trust add <collective>`
 (`swamp extension trust list` shows which).
 
-**Never** use `command/shell` to wrap service integrations — build a dedicated
-model.
+Don't use `command/shell` when an extension type covers the operation. If
+`extension info` confirms no type or method exists for the operation,
+`command/shell` or a custom model is the correct approach — file a feature
+request to track the gap.
 
 ## Choosing a Collective Name
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -95,6 +95,12 @@ by channel. No `--channel` shows all versions.
 `swamp extension info @name` shows per-channel latest versions (stable, rc,
 beta) when they exist. No flag needed — info always shows all channels.
 
+The info command also displays content metadata for the latest version: model
+types with their methods, workflows, vaults, datastores, drivers, reports, and
+skills. By default, models show the type name and method names. With `--verbose`,
+each method's arguments and descriptions are also displayed. JSON output
+(`--json`) includes the full `contentMetadata` object with all detail.
+
 ### Promotion
 
 `swamp extension promote @name 2026.06.10.1 --channel rc` promotes a beta

--- a/src/cli/commands/extension_info.ts
+++ b/src/cli/commands/extension_info.ts
@@ -55,7 +55,11 @@ export const extensionInfoCommand = new Command()
       const identity = await loadIdentity();
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
       const deps = createExtensionInfoDeps(identity.bearerToken, identity);
-      const renderer = createExtensionInfoRenderer(cliCtx.outputMode);
+      const verbose = cliCtx.verbosity === "verbose";
+      const renderer = createExtensionInfoRenderer(
+        cliCtx.outputMode,
+        verbose,
+      );
 
       await consumeStream(
         extensionInfo(ctx, deps, { extensionName: name }),

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -67,6 +67,14 @@ export interface LatestVersionInfo {
   channel?: string;
 }
 
+/** Detailed version info including content metadata from the /latest endpoint. */
+export interface LatestVersionDetail {
+  version: string;
+  publishedAt: string;
+  channel?: string;
+  contentMetadata: ExtensionContentMetadata | null;
+}
+
 /** Extension author metadata. */
 export interface ExtensionAuthor {
   username: string;
@@ -248,6 +256,50 @@ export class ExtensionApiClient {
     return {
       version: data.latestVersionDetail?.version ?? data.latestVersion,
       publishedAt: data.latestVersionDetail?.publishedAt ?? "",
+    };
+  }
+
+  /**
+   * Get full version detail including content metadata from the /latest endpoint.
+   * Returns null if not found or no versions exist.
+   */
+  async getLatestVersionDetail(
+    name: string,
+    apiKey?: string,
+  ): Promise<LatestVersionDetail | null> {
+    const encodedName = encodeURIComponent(name);
+    const headers = apiKey ? this.authHeaders(apiKey) : {};
+    const res = await this.fetch(
+      `/api/v1/extensions/${encodedName}/latest`,
+      {
+        method: "GET",
+        headers,
+      },
+    );
+
+    if (res.status === 404 || res.status === 410) {
+      await res.body?.cancel();
+      return null;
+    }
+
+    await this.checkResponse(res);
+    const data = await res.json();
+    const detail = data.latestVersionDetail;
+    if (!detail) return null;
+
+    return {
+      version: detail.version,
+      publishedAt: detail.publishedAt ?? "",
+      channel: detail.channel,
+      contentMetadata: {
+        models: detail.models ?? [],
+        workflows: detail.workflows ?? [],
+        vaults: detail.vaults ?? [],
+        drivers: detail.drivers ?? [],
+        datastores: detail.datastores ?? [],
+        reports: detail.reports ?? [],
+        skills: detail.skills ?? [],
+      },
     };
   }
 

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -21,9 +21,11 @@ import type {
   ExtensionAuthor,
   ExtensionInfo,
   ExtensionScoreSummary,
+  LatestVersionDetail,
 } from "../../infrastructure/http/extension_api_client.ts";
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
+import type { ExtensionContentMetadata } from "../../domain/extensions/extension_content.ts";
 import { resolveServerUrl } from "./pull.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -58,6 +60,7 @@ export interface ExtensionInfoData {
   repositoryVerifiedUrl: string | null;
   pullCount: number;
   score: ExtensionScoreSummary | null;
+  contentMetadata: ExtensionContentMetadata | null;
 }
 
 export type ExtensionInfoEvent =
@@ -72,6 +75,9 @@ export interface ExtensionInfoInput {
 
 export interface ExtensionInfoDeps {
   getExtension: (name: string) => Promise<ExtensionInfo | null>;
+  getLatestVersionDetail: (
+    name: string,
+  ) => Promise<LatestVersionDetail | null>;
 }
 
 export function createExtensionInfoDeps(
@@ -82,6 +88,8 @@ export function createExtensionInfoDeps(
   const client = new ExtensionApiClient(serverUrl, identity);
   return {
     getExtension: (name: string) => client.getExtension(name, apiKey),
+    getLatestVersionDetail: (name: string) =>
+      client.getLatestVersionDetail(name, apiKey),
   };
 }
 
@@ -106,6 +114,10 @@ export async function* extensionInfo(
           };
           return;
         }
+
+        const versionDetail = await deps.getLatestVersionDetail(
+          input.extensionName,
+        );
 
         yield {
           kind: "completed" as const,
@@ -138,6 +150,7 @@ export async function* extensionInfo(
             repositoryVerifiedUrl: info.repositoryVerifiedUrl,
             pullCount: info.pullCount,
             score: info.score,
+            contentMetadata: versionDetail?.contentMetadata ?? null,
           },
         };
       } catch (error) {

--- a/src/libswamp/extensions/info_test.ts
+++ b/src/libswamp/extensions/info_test.ts
@@ -20,7 +20,10 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
-import type { ExtensionInfo } from "../../infrastructure/http/extension_api_client.ts";
+import type {
+  ExtensionInfo,
+  LatestVersionDetail,
+} from "../../infrastructure/http/extension_api_client.ts";
 import {
   extensionInfo,
   type ExtensionInfoDeps,
@@ -63,11 +66,44 @@ function makeFullExtensionInfo(
   };
 }
 
+function makeVersionDetail(
+  overrides?: Partial<LatestVersionDetail>,
+): LatestVersionDetail {
+  return {
+    version: "2026.5.1",
+    publishedAt: "2026-05-20T14:22:00.000Z",
+    contentMetadata: {
+      models: [
+        {
+          fileName: "volume.ts",
+          type: "@swamp/aws/ec2/volume",
+          version: "2026.5.1",
+          globalArguments: [],
+          methods: [
+            { name: "get", description: "Get a volume", arguments: [] },
+            { name: "sync", description: "Sync volume state", arguments: [] },
+          ],
+          resources: [],
+          files: [],
+        },
+      ],
+      workflows: [],
+      vaults: [],
+      drivers: [],
+      datastores: [],
+      reports: [],
+      skills: [],
+    },
+    ...overrides,
+  };
+}
+
 function makeDeps(
   overrides?: Partial<ExtensionInfoDeps>,
 ): ExtensionInfoDeps {
   return {
     getExtension: () => Promise.resolve(null),
+    getLatestVersionDetail: () => Promise.resolve(null),
     ...overrides,
   };
 }
@@ -99,6 +135,37 @@ Deno.test("extensionInfo: returns full metadata when extension exists", async ()
   assertEquals(completed.data.pullCount, 142);
   assertEquals(completed.data.score?.grade, "A");
   assertEquals(completed.data.repositoryVerified, true);
+  assertEquals(completed.data.contentMetadata, null);
+});
+
+Deno.test("extensionInfo: includes content metadata from version detail", async () => {
+  const info = makeFullExtensionInfo();
+  const detail = makeVersionDetail();
+  const deps = makeDeps({
+    getExtension: () => Promise.resolve(info),
+    getLatestVersionDetail: () => Promise.resolve(detail),
+  });
+  const events = await collect<ExtensionInfoEvent>(
+    extensionInfo(createLibSwampContext(), deps, {
+      extensionName: "@stack72/aws-ec2",
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    ExtensionInfoEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.contentMetadata?.models.length, 1);
+  assertEquals(
+    completed.data.contentMetadata?.models[0].type,
+    "@swamp/aws/ec2/volume",
+  );
+  assertEquals(completed.data.contentMetadata?.models[0].methods.length, 2);
+  assertEquals(
+    completed.data.contentMetadata?.models[0].methods[0].name,
+    "get",
+  );
 });
 
 Deno.test("extensionInfo: handles nullable fields", async () => {

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -795,6 +795,18 @@ export {
   type ExtensionInfoEvent,
   type ExtensionInfoInput,
 } from "./extensions/info.ts";
+export type {
+  ExtensionContentMetadata,
+  ExtractedArgument,
+  ExtractedDatastore,
+  ExtractedDriver,
+  ExtractedMethod,
+  ExtractedModel,
+  ExtractedReport,
+  ExtractedSkill,
+  ExtractedVault,
+  ExtractedWorkflow,
+} from "../domain/extensions/extension_content.ts";
 export {
   detectLocalEditsForExtension,
   LocalEditsError,

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { EventHandlers, ExtensionInfoEvent } from "../../libswamp/mod.ts";
+import type {
+  EventHandlers,
+  ExtensionContentMetadata,
+  ExtensionInfoEvent,
+  ExtractedModel,
+} from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
@@ -28,9 +33,98 @@ function extractBasename(name: string): string {
   return slash >= 0 ? name.slice(slash + 1) : name;
 }
 
+function renderContentMetadata(
+  logger: ReturnType<typeof getSwampLogger>,
+  meta: ExtensionContentMetadata,
+  verbose: boolean,
+): void {
+  if (meta.models.length > 0) {
+    logger.info``;
+    logger.info`Models (${meta.models.length}):`;
+    for (const model of meta.models) {
+      const methods = model.methods.map((m) => m.name).join(", ");
+      const name = model.type || model.fileName;
+      logger.info`  ${name} — methods: ${methods || "none"}`;
+      if (verbose) {
+        renderModelDetail(logger, model);
+      }
+    }
+  }
+
+  if (meta.workflows.length > 0) {
+    logger.info``;
+    logger.info`Workflows (${meta.workflows.length}):`;
+    for (const wf of meta.workflows) {
+      logger.info`  ${wf.name} — ${wf.description || wf.id}`;
+    }
+  }
+
+  if (meta.vaults.length > 0) {
+    logger.info``;
+    logger.info`Vaults (${meta.vaults.length}):`;
+    for (const v of meta.vaults) {
+      logger.info`  ${v.type} — ${v.description || v.name}`;
+    }
+  }
+
+  if (meta.datastores.length > 0) {
+    logger.info``;
+    logger.info`Datastores (${meta.datastores.length}):`;
+    for (const ds of meta.datastores) {
+      logger.info`  ${ds.type} — ${ds.description || ds.name}`;
+    }
+  }
+
+  if (meta.drivers.length > 0) {
+    logger.info``;
+    logger.info`Drivers (${meta.drivers.length}):`;
+    for (const drv of meta.drivers) {
+      logger.info`  ${drv.type} — ${drv.description || drv.name}`;
+    }
+  }
+
+  if (meta.reports.length > 0) {
+    logger.info``;
+    logger.info`Reports (${meta.reports.length}):`;
+    for (const r of meta.reports) {
+      logger.info`  ${r.name} — ${r.description} (${r.scope})`;
+    }
+  }
+
+  if (meta.skills.length > 0) {
+    logger.info``;
+    logger.info`Skills (${meta.skills.length}):`;
+    for (const s of meta.skills) {
+      logger.info`  ${s.name} — ${s.description}`;
+    }
+  }
+}
+
+function renderModelDetail(
+  logger: ReturnType<typeof getSwampLogger>,
+  model: ExtractedModel,
+): void {
+  for (const method of model.methods) {
+    const args = method.arguments
+      .map((a) => `${a.name}${a.required ? "" : "?"}:${a.type}`)
+      .join(", ");
+    logger.info`    ${method.name}(${args})`;
+    if (method.description) {
+      logger.info`      ${method.description}`;
+    }
+  }
+}
+
 class LogExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
+  #verbose: boolean;
+
+  constructor(verbose: boolean) {
+    this.#verbose = verbose;
+  }
+
   handlers(): EventHandlers<ExtensionInfoEvent> {
     const logger = getSwampLogger(["extension", "info"]);
+    const verbose = this.#verbose;
     return {
       resolving: () => {},
       completed: (e) => {
@@ -71,6 +165,10 @@ class LogExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
         }
         if (d.contentNames.length > 0) {
           logger.info`Exports:     ${d.contentNames.join(", ")}`;
+        }
+
+        if (d.contentMetadata) {
+          renderContentMetadata(logger, d.contentMetadata, verbose);
         }
 
         logger.info``;
@@ -145,11 +243,12 @@ class JsonExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
 
 export function createExtensionInfoRenderer(
   mode: OutputMode,
+  verbose = false,
 ): Renderer<ExtensionInfoEvent> {
   switch (mode) {
     case "json":
       return new JsonExtensionInfoRenderer();
     case "log":
-      return new LogExtensionInfoRenderer();
+      return new LogExtensionInfoRenderer(verbose);
   }
 }

--- a/src/presentation/renderers/extension_info_test.ts
+++ b/src/presentation/renderers/extension_info_test.ts
@@ -1,0 +1,237 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  consumeStream,
+  type ExtensionContentMetadata,
+  type ExtensionInfoData,
+  type ExtensionInfoEvent,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { createExtensionInfoRenderer } from "./extension_info.ts";
+
+function makeInfoData(
+  overrides?: Partial<ExtensionInfoData>,
+): ExtensionInfoData {
+  return {
+    id: "abc123",
+    name: "@stack72/aws-ec2",
+    namespace: "@stack72",
+    description: "AWS EC2 model for swamp",
+    repository: "https://github.com/stack72/swamp-aws-ec2",
+    homepageUrl: "https://example.com",
+    license: "MIT",
+    platforms: ["aws"],
+    labels: ["networking", "compute"],
+    contentTypes: ["models"],
+    contentNames: ["aws-ec2"],
+    latestVersion: "2026.5.1",
+    latestRc: null,
+    latestBeta: null,
+    author: { username: "stack72", displayName: "Paul Stack" },
+    createdAt: "2026-01-15T10:30:00.000Z",
+    updatedAt: "2026-05-20T14:22:00.000Z",
+    yankedAt: null,
+    yankReason: null,
+    deprecatedAt: null,
+    deprecatedByUserId: null,
+    deprecationReason: null,
+    supersededBy: null,
+    repositoryVerified: true,
+    repositoryVerifiedAt: "2026-05-20T14:25:00.000Z",
+    repositoryVerifiedUrl: "https://github.com/stack72/swamp-aws-ec2",
+    pullCount: 142,
+    score: { percentage: 85, grade: "A" },
+    contentMetadata: null,
+    ...overrides,
+  };
+}
+
+const sampleContentMetadata: ExtensionContentMetadata = {
+  models: [
+    {
+      fileName: "volume.ts",
+      type: "@swamp/aws/ec2/volume",
+      version: "2026.5.1",
+      globalArguments: [
+        {
+          name: "region",
+          type: "string",
+          description: "AWS region",
+          required: true,
+        },
+      ],
+      methods: [
+        { name: "get", description: "Get a volume", arguments: [] },
+        {
+          name: "sync",
+          description: "Sync volume state",
+          arguments: [
+            {
+              name: "force",
+              type: "boolean",
+              description: "Force sync",
+              required: false,
+            },
+          ],
+        },
+      ],
+      resources: [],
+      files: [],
+    },
+    {
+      fileName: "instance.ts",
+      type: "@swamp/aws/ec2/instance",
+      version: "2026.5.1",
+      globalArguments: [],
+      methods: [
+        { name: "get", description: "Get an instance", arguments: [] },
+        { name: "sync", description: "Sync instance state", arguments: [] },
+        {
+          name: "terminate",
+          description: "Terminate an instance",
+          arguments: [],
+        },
+      ],
+      resources: [],
+      files: [],
+    },
+  ],
+  workflows: [],
+  vaults: [],
+  drivers: [],
+  datastores: [],
+  reports: [],
+  skills: [],
+};
+
+async function* toStream(
+  events: ExtensionInfoEvent[],
+): AsyncGenerator<ExtensionInfoEvent> {
+  for (const e of events) yield e;
+}
+
+Deno.test("LogExtensionInfoRenderer: completed event runs without error", async () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    { kind: "completed", data: makeInfoData() },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("LogExtensionInfoRenderer: renders content metadata without error", async () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({ contentMetadata: sampleContentMetadata }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("LogExtensionInfoRenderer: verbose renders method detail without error", async () => {
+  const renderer = createExtensionInfoRenderer("log", true);
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({ contentMetadata: sampleContentMetadata }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("JsonExtensionInfoRenderer: includes content metadata in JSON output", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionInfoRenderer("json");
+    const events: ExtensionInfoEvent[] = [
+      { kind: "resolving" },
+      {
+        kind: "completed",
+        data: makeInfoData({ contentMetadata: sampleContentMetadata }),
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.contentMetadata.models.length, 2);
+    assertEquals(
+      parsed.contentMetadata.models[0].type,
+      "@swamp/aws/ec2/volume",
+    );
+    assertEquals(parsed.contentMetadata.models[0].methods.length, 2);
+    assertEquals(parsed.contentMetadata.models[0].methods[0].name, "get");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonExtensionInfoRenderer: null contentMetadata in JSON output", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionInfoRenderer("json");
+    const events: ExtensionInfoEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: makeInfoData() },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.contentMetadata, null);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("LogExtensionInfoRenderer: not_found throws UserError", () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.not_found({
+        kind: "not_found",
+        extensionName: "@foo/bar",
+      }),
+    UserError,
+  );
+});
+
+Deno.test("LogExtensionInfoRenderer: error event throws UserError", () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error({
+        kind: "error",
+        error: { code: "lookup_failed", message: "Connection refused" },
+      }),
+    UserError,
+  );
+});


### PR DESCRIPTION
## Summary

- `swamp extension info` now displays content metadata (model types with methods, workflows, vaults, datastores, drivers, reports, skills) fetched from the registry's `/latest` endpoint
- Default output shows a summary per model (type/file name + method list); `--verbose` expands each method with arguments and description
- JSON output includes the full `contentMetadata` object for programmatic inspection by agents
- Updates the swamp skill's extension discovery flow: search filter guidance (`--platform`, `--content-type`), inspect-before-pull step via `extension info --json`, cold-repo shortcut, confirmed-no-type fallback heuristic
- The `command/shell` prohibition is now conditional (don't use when an extension type exists; use when none does)

Closes swamp-club#825

## Test Plan

- Unit tests for `extensionInfo` generator with content metadata present and absent (5 tests in `info_test.ts`)
- Unit tests for log and JSON renderers covering content metadata, verbose mode, null metadata, error cases (7 tests in `extension_info_test.ts`)
- Verified manually against live registry: `@swamp/aws/ec2` (106 models), `@swamp/aws/rds` (15 models), `@swamp/issue-lifecycle` (1 model with 16 methods), `@swamp/nonexistent` (error case)
- All 7945 existing tests pass
- UAT schema uses `.passthrough()` so no existing UAT tests break
- Filed swamp-club/swamp-uat#283 for new UAT coverage and swamp-club lab #842 for docs update