### PR TITLE
feat(cli): add auth nudge for unauthenticated users

### DIFF
--- a/integration/auth_nudge_test.ts
+++ b/integration/auth_nudge_test.ts
@@ -1,0 +1,236 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeTestRepo } from "./test_helpers.ts";
+import { CLI_ARGS } from "./test_helpers.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { SHELL_MODEL_TYPE } from "../src/domain/models/command/shell/shell_model.ts";
+import { AUTH_NUDGE_MESSAGE } from "../src/domain/auth/auth_nudge.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-auth-nudge-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function runCliCommand(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+    env: { ...Deno.env.toObject(), ...env },
+  });
+
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+Deno.test({
+  name: "auth nudge: model method run shows nudge for unauthenticated user",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        await initializeTestRepo(repoDir);
+        const definitionRepo = new YamlDefinitionRepository(repoDir);
+        await definitionRepo.save(
+          SHELL_MODEL_TYPE,
+          Definition.create({
+            name: "echo-model",
+            methods: {
+              execute: {
+                arguments: { run: "echo hello", workingDir: "/tmp" },
+              },
+            },
+          }),
+        );
+
+        const result = await runCliCommand(
+          [
+            "model",
+            "method",
+            "run",
+            "echo-model",
+            "execute",
+            "--repo-dir",
+            repoDir,
+            "--no-telemetry",
+          ],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        assertEquals(result.code, 0, `run failed: ${result.stderr}`);
+        const combined = result.stdout + result.stderr;
+        assertStringIncludes(combined, AUTH_NUDGE_MESSAGE);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "auth nudge: model method run suppresses nudge for authenticated user",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        await initializeTestRepo(repoDir);
+        const definitionRepo = new YamlDefinitionRepository(repoDir);
+        await definitionRepo.save(
+          SHELL_MODEL_TYPE,
+          Definition.create({
+            name: "echo-model",
+            methods: {
+              execute: {
+                arguments: { run: "echo hello", workingDir: "/tmp" },
+              },
+            },
+          }),
+        );
+
+        // Simulate authenticated user via SWAMP_API_KEY
+        const result = await runCliCommand(
+          [
+            "model",
+            "method",
+            "run",
+            "echo-model",
+            "execute",
+            "--repo-dir",
+            repoDir,
+            "--no-telemetry",
+          ],
+          repoDir,
+          {
+            XDG_CONFIG_HOME: configDir,
+            NO_COLOR: "1",
+            SWAMP_API_KEY: "swamp_test_fake_key",
+          },
+        );
+
+        assertEquals(result.code, 0, `run failed: ${result.stderr}`);
+        const combined = result.stdout + result.stderr;
+        assertEquals(
+          combined.includes(AUTH_NUDGE_MESSAGE),
+          false,
+          "nudge should not appear for authenticated users",
+        );
+      });
+    });
+  },
+});
+
+Deno.test(
+  "auth nudge: repo init includes auth login in next steps",
+  async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        const result = await runCliCommand(
+          ["repo", "init", "--tool", "none", "--no-telemetry"],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        assertEquals(result.code, 0, `init failed: ${result.stderr}`);
+        const combined = result.stdout + result.stderr;
+        assertStringIncludes(combined, "swamp auth login");
+      });
+    });
+  },
+);
+
+Deno.test({
+  name:
+    "auth nudge: exit banner shows for unauthenticated user and throttles to once per day",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        await initializeTestRepo(repoDir);
+
+        // First run: nudge should appear in stderr
+        const first = await runCliCommand(
+          ["version", "--no-telemetry"],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        assertEquals(first.code, 0, `version failed: ${first.stderr}`);
+        assertStringIncludes(
+          first.stderr,
+          "Join & participate in the community",
+        );
+        assertStringIncludes(first.stderr, "swamp auth login");
+
+        // Second run: nudge should be throttled (already shown today)
+        const second = await runCliCommand(
+          ["version", "--no-telemetry"],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        assertEquals(second.code, 0, `version failed: ${second.stderr}`);
+        assertEquals(
+          second.stderr.includes("Join & participate in the community"),
+          false,
+          "nudge should be throttled on second run within 24h",
+        );
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "auth nudge: exit banner suppressed in --json mode",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        await initializeTestRepo(repoDir);
+
+        const result = await runCliCommand(
+          ["--json", "version", "--no-telemetry"],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        assertEquals(result.code, 0, `version failed: ${result.stderr}`);
+        assertEquals(
+          result.stderr.includes("Join & participate in the community"),
+          false,
+          "nudge should not appear in --json mode",
+        );
+      });
+    });
+  },
+});

--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -1,0 +1,28 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+let authenticated = false;
+
+export function setAuthenticated(value: boolean): void {
+  authenticated = value;
+}
+
+export function isAuthenticated(): boolean {
+  return authenticated;
+}

--- a/src/cli/auth_context_test.ts
+++ b/src/cli/auth_context_test.ts
@@ -1,0 +1,38 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isAuthenticated, setAuthenticated } from "./auth_context.ts";
+
+Deno.test("auth_context: defaults to not authenticated", () => {
+  setAuthenticated(false);
+  assertEquals(isAuthenticated(), false);
+});
+
+Deno.test("auth_context: setAuthenticated true makes isAuthenticated return true", () => {
+  setAuthenticated(true);
+  assertEquals(isAuthenticated(), true);
+  setAuthenticated(false);
+});
+
+Deno.test("auth_context: setAuthenticated false makes isAuthenticated return false", () => {
+  setAuthenticated(true);
+  setAuthenticated(false);
+  assertEquals(isAuthenticated(), false);
+});

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -42,6 +42,7 @@ import {
   modelMethodRun,
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
+import { isAuthenticated } from "../auth_context.ts";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -162,6 +163,7 @@ const accessGrantCreateCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: instanceName,
         methodName: "create",
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({
@@ -237,6 +239,7 @@ const accessGrantCreateCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: instanceName,
         methodName: "create",
+        isAuthenticated: isAuthenticated(),
       });
 
       await consumeStream(
@@ -457,6 +460,7 @@ const accessGrantRevokeCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: match.instanceName,
         methodName: "revoke",
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({
@@ -537,6 +541,7 @@ const accessGrantRevokeCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: match.instanceName,
         methodName: "revoke",
+        isAuthenticated: isAuthenticated(),
       });
 
       await consumeStream(

--- a/src/cli/commands/access_group.ts
+++ b/src/cli/commands/access_group.ts
@@ -42,6 +42,7 @@ import {
   modelMethodRun,
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunRenderer } from "../../presentation/renderers/model_method_run.ts";
+import { isAuthenticated } from "../auth_context.ts";
 import {
   type Group,
   GROUP_MODEL_TYPE,
@@ -137,6 +138,7 @@ async function runGroupMethod(
     const renderer = createModelMethodRunRenderer(ctx.outputMode, {
       modelName: instanceName,
       methodName,
+      isAuthenticated: isAuthenticated(),
     });
 
     const typeArg = isDirectExecution
@@ -223,6 +225,7 @@ const accessGroupCreateCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: name,
         methodName: "create",
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({
@@ -299,6 +302,7 @@ const accessGroupAddMemberCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: group,
         methodName: "add-member",
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({
@@ -373,6 +377,7 @@ const accessGroupRemoveMemberCommand = new Command()
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: group,
         methodName: "remove-member",
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -77,6 +77,7 @@ import {
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { suppressSyncExitOnSignal } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { parseTimeout } from "../duration_parser.ts";
+import { isAuthenticated } from "../auth_context.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
 // but we need to pass `options` to functions expecting specific types. Using `any`
@@ -395,6 +396,7 @@ export const modelMethodRunCommand = new Command()
           const renderer = createModelMethodRunRenderer(ctx.outputMode, {
             modelName: modelIdOrName,
             methodName,
+            isAuthenticated: isAuthenticated(),
           });
 
           await consumeStream(
@@ -557,6 +559,7 @@ async function runMethodViaServer(
       const renderer = createModelMethodRunRenderer(ctx.outputMode, {
         modelName: modelIdOrName,
         methodName,
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runModelMethodOverServer({

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -38,6 +38,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { createExtensionInstallDeps } from "../create_extension_install_deps.ts";
+import { isAuthenticated } from "../auth_context.ts";
 import { VERSION } from "./version.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -99,7 +100,9 @@ export async function repoInitAction(
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });
   const deps = createRepoInitDeps(VERSION);
-  const renderer = createRepoInitRenderer(cliCtx.outputMode);
+  const renderer = createRepoInitRenderer(cliCtx.outputMode, {
+    isAuthenticated: isAuthenticated(),
+  });
   await consumeStream(
     repoInit(ctx, deps, {
       path: pathArg ?? ".",
@@ -178,7 +181,9 @@ export const repoUpgradeCommand = new Command()
       cliCtx.logger,
     );
 
-    const renderer = createRepoUpgradeRenderer(cliCtx.outputMode);
+    const renderer = createRepoUpgradeRenderer(cliCtx.outputMode, {
+      isAuthenticated: isAuthenticated(),
+    });
     await consumeStream(
       repoUpgrade(ctx, deps, {
         path: pathArg ?? ".",

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -40,6 +40,7 @@ import {
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
+import { isAuthenticated } from "../auth_context.ts";
 import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
@@ -278,6 +279,7 @@ export const workflowResumeCommand = new Command()
 
       const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
         workflowName,
+        isAuthenticated: isAuthenticated(),
       });
 
       const resumeGenerator = async function* (): AsyncGenerator<

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -74,6 +74,7 @@ import {
   type WorkflowTelemetrySink,
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
+import { isAuthenticated } from "../auth_context.ts";
 import { getActiveTelemetryService } from "../telemetry_integration.ts";
 import {
   resolveServerToken,
@@ -389,6 +390,7 @@ export const workflowRunCommand = new Command()
         const renderer = createWorkflowRunRenderer(ctx.outputMode, {
           workflowName: workflowIdOrName,
           forceLog: ctx.forceLog,
+          isAuthenticated: isAuthenticated(),
         });
         const eventStream = workflowRun(libCtx, deps, {
           workflowIdOrName,
@@ -556,6 +558,7 @@ async function runWorkflowViaServer(
       const renderer = createWorkflowRunRenderer(ctx.outputMode, {
         workflowName: workflowIdOrName,
         forceLog: ctx.forceLog,
+        isAuthenticated: isAuthenticated(),
       });
       await consumeStream(
         runWorkflowOverServer({

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -99,6 +99,7 @@ import { ExtensionAutoResolver } from "../domain/extensions/extension_auto_resol
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
 import { loadIdentity, USER_AGENT } from "./load_identity.ts";
+import { isAuthenticated, setAuthenticated } from "./auth_context.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../domain/auth/auth_credentials.ts";
 import { setAutoResolver } from "./auto_resolver_context.ts";
 import {
@@ -128,6 +129,9 @@ import { UpdateCheckCacheFileRepository } from "../infrastructure/update/update_
 import { HttpUpdateChecker } from "../infrastructure/update/http_update_checker.ts";
 import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/renderers/update_notification.ts";
+import { renderAuthNudge } from "../presentation/renderers/auth_nudge.ts";
+import { shouldShowAuthNudge } from "../domain/auth/auth_nudge.ts";
+import { AuthNudgeRepository } from "../infrastructure/persistence/auth_nudge_repository.ts";
 import { UpdatePreferencesFileRepository } from "../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../infrastructure/update/autoupdate_log_file_repository.ts";
 import {
@@ -1213,6 +1217,7 @@ export async function runCli(args: string[]): Promise<void> {
 
   // Create auto-resolver for trusted collectives (merging membership collectives)
   const autoResolverIdentity = await loadIdentity();
+  setAuthenticated(autoResolverIdentity.bearerToken !== undefined);
   configureExtensionAutoResolver(
     repoDir,
     marker,
@@ -1452,6 +1457,27 @@ export async function runCli(args: string[]): Promise<void> {
             }
           } catch {
             // Silently ignore — never break the CLI for update checks
+          }
+        }
+      }
+
+      // Auth nudge banner (throttled to once per day, suppressed once logged in).
+      // Skip for `repo init/upgrade` — those renderers include their own nudge.
+      {
+        const outputMode = getOutputModeFromArgs(args);
+        const isRepoSetup = commandInfo.command === "repo" &&
+          (commandInfo.subcommand === "init" ||
+            commandInfo.subcommand === "upgrade");
+        if (outputMode === "log" && !isAuthenticated() && !isRepoSetup) {
+          try {
+            const nudgeRepo = new AuthNudgeRepository();
+            const nudgeState = await nudgeRepo.read();
+            if (shouldShowAuthNudge(nudgeState)) {
+              renderAuthNudge();
+              await nudgeRepo.markShown();
+            }
+          } catch {
+            // Best effort — never break the CLI for nudge state
           }
         }
       }

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1462,13 +1462,16 @@ export async function runCli(args: string[]): Promise<void> {
       }
 
       // Auth nudge banner (throttled to once per day, suppressed once logged in).
-      // Skip for `repo init/upgrade` — those renderers include their own nudge.
+      // Skip for commands whose renderers already include their own nudge.
       {
         const outputMode = getOutputModeFromArgs(args);
-        const isRepoSetup = commandInfo.command === "repo" &&
+        const hasInlineNudge = (commandInfo.command === "repo" &&
           (commandInfo.subcommand === "init" ||
-            commandInfo.subcommand === "upgrade");
-        if (outputMode === "log" && !isAuthenticated() && !isRepoSetup) {
+            commandInfo.subcommand === "upgrade")) ||
+          (commandInfo.command === "model" &&
+            commandInfo.subcommand === "method") ||
+          commandInfo.command === "workflow";
+        if (outputMode === "log" && !isAuthenticated() && !hasInlineNudge) {
           try {
             const nudgeRepo = new AuthNudgeRepository();
             const nudgeState = await nudgeRepo.read();

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1462,7 +1462,13 @@ export async function runCli(args: string[]): Promise<void> {
       }
 
       // Auth nudge banner (throttled to once per day, suppressed once logged in).
-      // Skip for commands whose renderers already include their own nudge.
+      // Skip for commands whose renderers already include their own inline
+      // nudge to avoid showing it twice. If you add an inline nudge to a
+      // new renderer, add the command here too.
+      //   - repo init/upgrade: src/presentation/renderers/repo_init.ts
+      //   - model method run: src/presentation/renderers/model_method_run.ts
+      //   - workflow run/resume: src/presentation/renderers/workflow_run.ts
+      //   - access grant/group: via model_method_run renderer
       {
         const outputMode = getOutputModeFromArgs(args);
         const hasInlineNudge = (commandInfo.command === "repo" &&
@@ -1470,7 +1476,10 @@ export async function runCli(args: string[]): Promise<void> {
             commandInfo.subcommand === "upgrade")) ||
           (commandInfo.command === "model" &&
             commandInfo.subcommand === "method") ||
-          commandInfo.command === "workflow";
+          (commandInfo.command === "workflow" &&
+            (commandInfo.subcommand === "run" ||
+              commandInfo.subcommand === "resume")) ||
+          commandInfo.command === "access";
         if (outputMode === "log" && !isAuthenticated() && !hasInlineNudge) {
           try {
             const nudgeRepo = new AuthNudgeRepository();

--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -1,0 +1,33 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export const AUTH_NUDGE_MESSAGE =
+  "Tip: Join & participate in the community by logging in to swamp-club.com: swamp auth login";
+
+export interface AuthNudgeState {
+  lastShown?: string;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export function shouldShowAuthNudge(state: AuthNudgeState): boolean {
+  if (!state.lastShown) return true;
+  const lastShown = new Date(state.lastShown).getTime();
+  return Date.now() - lastShown >= ONE_DAY_MS;
+}

--- a/src/domain/auth/auth_nudge_test.ts
+++ b/src/domain/auth/auth_nudge_test.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { shouldShowAuthNudge } from "./auth_nudge.ts";
+
+Deno.test("shouldShowAuthNudge: returns true when no lastShown", () => {
+  assertEquals(shouldShowAuthNudge({}), true);
+});
+
+Deno.test("shouldShowAuthNudge: returns true when lastShown is over 24 hours ago", () => {
+  const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  assertEquals(shouldShowAuthNudge({ lastShown: twoDaysAgo }), true);
+});
+
+Deno.test("shouldShowAuthNudge: returns false when lastShown is within 24 hours", () => {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  assertEquals(shouldShowAuthNudge({ lastShown: oneHourAgo }), false);
+});
+
+Deno.test("shouldShowAuthNudge: returns true when lastShown is exactly 24 hours ago", () => {
+  const exactly24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  assertEquals(shouldShowAuthNudge({ lastShown: exactly24h }), true);
+});

--- a/src/infrastructure/persistence/auth_nudge_repository.ts
+++ b/src/infrastructure/persistence/auth_nudge_repository.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { AuthNudgeState } from "../../domain/auth/auth_nudge.ts";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+import { getSwampConfigDir } from "./paths.ts";
+
+const NUDGE_FILE = "auth_nudge.json";
+
+export class AuthNudgeRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? join(getSwampConfigDir(), NUDGE_FILE);
+  }
+
+  async read(): Promise<AuthNudgeState> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      return JSON.parse(content) as AuthNudgeState;
+    } catch {
+      return {};
+    }
+  }
+
+  async markShown(): Promise<void> {
+    const state: AuthNudgeState = { lastShown: new Date().toISOString() };
+    try {
+      await Deno.mkdir(getSwampConfigDir(), { recursive: true });
+      await atomicWriteTextFile(
+        this.filePath,
+        JSON.stringify(state, null, 2) + "\n",
+      );
+    } catch {
+      // Best effort — don't break the CLI for nudge state
+    }
+  }
+}

--- a/src/infrastructure/persistence/auth_nudge_repository.ts
+++ b/src/infrastructure/persistence/auth_nudge_repository.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import type { AuthNudgeState } from "../../domain/auth/auth_nudge.ts";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { getSwampConfigDir } from "./paths.ts";
@@ -43,7 +43,7 @@ export class AuthNudgeRepository {
   async markShown(): Promise<void> {
     const state: AuthNudgeState = { lastShown: new Date().toISOString() };
     try {
-      await Deno.mkdir(getSwampConfigDir(), { recursive: true });
+      await Deno.mkdir(dirname(this.filePath), { recursive: true });
       await atomicWriteTextFile(
         this.filePath,
         JSON.stringify(state, null, 2) + "\n",

--- a/src/infrastructure/persistence/auth_nudge_repository_test.ts
+++ b/src/infrastructure/persistence/auth_nudge_repository_test.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { AuthNudgeRepository } from "./auth_nudge_repository.ts";
+
+Deno.test("AuthNudgeRepository: read returns empty state when file does not exist", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new AuthNudgeRepository(
+      join(tmpDir, "nonexistent", "auth_nudge.json"),
+    );
+    const state = await repo.read();
+    assertEquals(state.lastShown, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("AuthNudgeRepository: markShown writes timestamp and read returns it", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const filePath = join(tmpDir, "auth_nudge.json");
+    const repo = new AuthNudgeRepository(filePath);
+
+    await repo.markShown();
+    const state = await repo.read();
+
+    assertEquals(typeof state.lastShown, "string");
+    const parsed = new Date(state.lastShown!).getTime();
+    const now = Date.now();
+    assertEquals(now - parsed < 5000, true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("AuthNudgeRepository: markShown overwrites previous state", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const filePath = join(tmpDir, "auth_nudge.json");
+    const repo = new AuthNudgeRepository(filePath);
+
+    await repo.markShown();
+    const first = await repo.read();
+
+    await repo.markShown();
+    const second = await repo.read();
+
+    assertEquals(typeof first.lastShown, "string");
+    assertEquals(typeof second.lastShown, "string");
+    assertEquals(
+      new Date(second.lastShown!).getTime() >=
+        new Date(first.lastShown!).getTime(),
+      true,
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/presentation/renderers/auth_nudge.ts
+++ b/src/presentation/renderers/auth_nudge.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, cyan } from "@std/fmt/colors";
+import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
+
+export function renderAuthNudge(): void {
+  console.error("");
+  console.error(
+    cyan(
+      `${
+        AUTH_NUDGE_MESSAGE.replace(
+          "swamp auth login",
+          bold("`swamp auth login`"),
+        )
+      }`,
+    ),
+  );
+}

--- a/src/presentation/renderers/auth_nudge_test.ts
+++ b/src/presentation/renderers/auth_nudge_test.ts
@@ -17,17 +17,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { bold, cyan } from "@std/fmt/colors";
-import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderAuthNudge } from "./auth_nudge.ts";
 
-export function renderAuthNudge(): void {
-  console.error("");
-  console.error(
-    cyan(
-      AUTH_NUDGE_MESSAGE.replace(
-        "swamp auth login",
-        bold("`swamp auth login`"),
-      ),
-    ),
-  );
-}
+Deno.test("renderAuthNudge: outputs nudge message to stderr", () => {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  try {
+    renderAuthNudge();
+  } finally {
+    console.error = original;
+  }
+
+  assertEquals(lines.length, 2);
+  assertEquals(lines[0], "");
+  // deno-lint-ignore no-control-regex
+  const stripped = lines[1].replace(/\x1b\[[0-9;]*m/g, "");
+  assertStringIncludes(stripped, "Join & participate in the community");
+  assertStringIncludes(stripped, "swamp auth login");
+});

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -27,10 +27,12 @@ import {
 import { UserError } from "../../domain/errors.ts";
 import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
 import { getTerminalColumns } from "../output/terminal_size.ts";
+import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
 
 export interface ModelMethodRunRenderOpts {
   modelName: string;
   methodName: string;
+  isAuthenticated?: boolean;
 }
 
 export interface ModelMethodRunRenderer extends Renderer<ModelMethodRunEvent> {
@@ -40,11 +42,13 @@ export interface ModelMethodRunRenderer extends Renderer<ModelMethodRunEvent> {
 class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
   private modelName: string;
   private methodName: string;
+  private isAuthenticated: boolean;
   private _failed = false;
 
   constructor(opts: ModelMethodRunRenderOpts) {
     this.modelName = opts.modelName;
     this.methodName = opts.methodName;
+    this.isAuthenticated = opts.isAuthenticated ?? false;
   }
 
   handlers(): EventHandlers<ModelMethodRunEvent> {
@@ -179,6 +183,11 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
               model: e.run.modelName,
               artifacts: e.run.dataArtifacts.length,
             });
+          if (!this.isAuthenticated) {
+            getRunLogger(e.run.modelName, e.run.methodName).info("");
+            getRunLogger(e.run.modelName, e.run.methodName)
+              .info(AUTH_NUDGE_MESSAGE);
+          }
         }
       },
       cancelled: (e) => {

--- a/src/presentation/renderers/model_method_run_test.ts
+++ b/src/presentation/renderers/model_method_run_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   consumeStream,
@@ -26,6 +26,7 @@ import {
 } from "../../libswamp/mod.ts";
 import { createModelMethodRunRenderer } from "./model_method_run.ts";
 import { UserError } from "../../domain/errors.ts";
+import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
 
 await initializeLogging({});
 
@@ -353,4 +354,101 @@ Deno.test("createModelMethodRunRenderer - factory returns correct type per mode"
   assertEquals(typeof logRenderer.runFailed, "function");
   assertEquals(typeof jsonRenderer.handlers, "function");
   assertEquals(typeof jsonRenderer.runFailed, "function");
+});
+
+// --- Auth nudge tests ---
+
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const methods = ["log", "info", "warn", "error", "debug"] as const;
+  const originals = methods.map((m) => [m, console[m]] as const);
+  for (const [m] of originals) {
+    console[m] = (...args: unknown[]) => {
+      lines.push(
+        args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+      );
+    };
+  }
+  try {
+    fn();
+  } finally {
+    for (const [m, orig] of originals) {
+      console[m] = orig;
+    }
+  }
+  return lines.join("\n");
+}
+
+Deno.test("LogModelMethodRunRenderer - shows auth nudge on success when not authenticated", () => {
+  const renderer = createModelMethodRunRenderer("log", {
+    modelName: "test-model",
+    methodName: "run",
+    isAuthenticated: false,
+  });
+  const events = fullEventStream(makeRunView("succeeded"));
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertStringIncludes(output, AUTH_NUDGE_MESSAGE);
+});
+
+Deno.test("LogModelMethodRunRenderer - suppresses auth nudge when authenticated", () => {
+  const renderer = createModelMethodRunRenderer("log", {
+    modelName: "test-model",
+    methodName: "run",
+    isAuthenticated: true,
+  });
+  const events = fullEventStream(makeRunView("succeeded"));
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertEquals(output.includes(AUTH_NUDGE_MESSAGE), false);
+});
+
+Deno.test("LogModelMethodRunRenderer - suppresses auth nudge on failed run", () => {
+  const renderer = createModelMethodRunRenderer("log", {
+    modelName: "test-model",
+    methodName: "run",
+    isAuthenticated: false,
+  });
+  const events: ModelMethodRunEvent[] = [
+    { kind: "validating_inputs" },
+    { kind: "completed", run: makeRunView("failed") },
+  ];
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertEquals(output.includes(AUTH_NUDGE_MESSAGE), false);
+});
+
+Deno.test("JsonModelMethodRunRenderer - never shows auth nudge", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createModelMethodRunRenderer("json", {
+      modelName: "test-model",
+      methodName: "run",
+      isAuthenticated: false,
+    });
+    const events = fullEventStream(makeRunView("succeeded"));
+    await consumeStream(toStream(events), renderer.handlers());
+    const combined = logs.join("\n");
+    assertEquals(combined.includes(AUTH_NUDGE_MESSAGE), false);
+  } finally {
+    console.log = originalLog;
+  }
 });

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -156,6 +156,9 @@ class LogRepoInitRenderer implements Renderer<RepoInitEvent> {
           logger.info(`  → ${step}`);
         }
         logger.info("  → Read the manual at https://swamp-club.com/manual");
+        logger.info(
+          "  → Join & participate in the community: swamp auth login",
+        );
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -175,6 +178,9 @@ class JsonRepoInitRenderer implements Renderer<RepoInitEvent> {
         if (steps.length === 0) {
           steps.push("Run `swamp --help` to see available commands");
         }
+        steps.push(
+          "Join & participate in the community: swamp auth login",
+        );
         console.log(JSON.stringify({ ...e.data, nextSteps: steps }, null, 2));
       },
       error: (e) => {
@@ -258,6 +264,9 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
             logger.info(`    ${file}`);
           }
         }
+        logger.info(
+          "  → Join & participate in the community: swamp auth login",
+        );
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -89,6 +89,12 @@ function orphanedPathsFor(
 }
 
 class LogRepoInitRenderer implements Renderer<RepoInitEvent> {
+  private isAuthenticated: boolean;
+
+  constructor(isAuthenticated: boolean) {
+    this.isAuthenticated = isAuthenticated;
+  }
+
   handlers(): EventHandlers<RepoInitEvent> {
     const logger = getSwampLogger(["repo", "init"]);
     return {
@@ -156,9 +162,11 @@ class LogRepoInitRenderer implements Renderer<RepoInitEvent> {
           logger.info(`  → ${step}`);
         }
         logger.info("  → Read the manual at https://swamp-club.com/manual");
-        logger.info(
-          "  → Join & participate in the community: swamp auth login",
-        );
+        if (!this.isAuthenticated) {
+          logger.info(
+            "  → Join & participate in the community: swamp auth login",
+          );
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -168,6 +176,12 @@ class LogRepoInitRenderer implements Renderer<RepoInitEvent> {
 }
 
 class JsonRepoInitRenderer implements Renderer<RepoInitEvent> {
+  private isAuthenticated: boolean;
+
+  constructor(isAuthenticated: boolean) {
+    this.isAuthenticated = isAuthenticated;
+  }
+
   handlers(): EventHandlers<RepoInitEvent> {
     return {
       initializing: () => {},
@@ -178,9 +192,11 @@ class JsonRepoInitRenderer implements Renderer<RepoInitEvent> {
         if (steps.length === 0) {
           steps.push("Run `swamp --help` to see available commands");
         }
-        steps.push(
-          "Join & participate in the community: swamp auth login",
-        );
+        if (!this.isAuthenticated) {
+          steps.push(
+            "Join & participate in the community: swamp auth login",
+          );
+        }
         console.log(JSON.stringify({ ...e.data, nextSteps: steps }, null, 2));
       },
       error: (e) => {
@@ -191,6 +207,12 @@ class JsonRepoInitRenderer implements Renderer<RepoInitEvent> {
 }
 
 class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
+  private isAuthenticated: boolean;
+
+  constructor(isAuthenticated: boolean) {
+    this.isAuthenticated = isAuthenticated;
+  }
+
   handlers(): EventHandlers<RepoUpgradeEvent> {
     const logger = getSwampLogger(["repo", "upgrade"]);
     // Delegate per-extension install/migration progress to the extension
@@ -264,9 +286,11 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
             logger.info(`    ${file}`);
           }
         }
-        logger.info(
-          "  → Join & participate in the community: swamp auth login",
-        );
+        if (!this.isAuthenticated) {
+          logger.info(
+            "  → Join & participate in the community: swamp auth login",
+          );
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -335,22 +359,26 @@ function dispatchInstallEvent(
 
 export function createRepoInitRenderer(
   mode: OutputMode,
+  opts?: { isAuthenticated?: boolean },
 ): Renderer<RepoInitEvent> {
+  const authed = opts?.isAuthenticated ?? false;
   switch (mode) {
     case "json":
-      return new JsonRepoInitRenderer();
+      return new JsonRepoInitRenderer(authed);
     case "log":
-      return new LogRepoInitRenderer();
+      return new LogRepoInitRenderer(authed);
   }
 }
 
 export function createRepoUpgradeRenderer(
   mode: OutputMode,
+  opts?: { isAuthenticated?: boolean },
 ): Renderer<RepoUpgradeEvent> {
+  const authed = opts?.isAuthenticated ?? false;
   switch (mode) {
     case "json":
       return new JsonRepoUpgradeRenderer();
     case "log":
-      return new LogRepoUpgradeRenderer();
+      return new LogRepoUpgradeRenderer(authed);
   }
 }

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -71,9 +71,10 @@ function captureLog(fn: () => void): string {
 function captureInitOutput(
   events: RepoInitEvent[],
   mode: "log" | "json",
+  opts?: { isAuthenticated?: boolean },
 ): string {
   return captureLog(() => {
-    const renderer = createRepoInitRenderer(mode);
+    const renderer = createRepoInitRenderer(mode, opts);
     const handlers = renderer.handlers();
     for (const event of events) {
       switch (event.kind) {
@@ -151,6 +152,22 @@ Deno.test(
     ], "log");
 
     assertStringIncludes(output, "swamp auth login");
+  },
+);
+
+Deno.test(
+  "LogRepoInitRenderer: suppresses community login when authenticated",
+  () => {
+    const output = captureInitOutput(
+      [
+        { kind: "initializing" },
+        { kind: "completed", data: makeInitData(["claude"]) },
+      ],
+      "log",
+      { isAuthenticated: true },
+    );
+
+    assertEquals(output.includes("swamp auth login"), false);
   },
 );
 

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -143,6 +143,18 @@ Deno.test(
 );
 
 Deno.test(
+  "LogRepoInitRenderer: shows community login next step",
+  () => {
+    const output = captureInitOutput([
+      { kind: "initializing" },
+      { kind: "completed", data: makeInitData(["claude"]) },
+    ], "log");
+
+    assertStringIncludes(output, "swamp auth login");
+  },
+);
+
+Deno.test(
   "JsonRepoInitRenderer: includes nextSteps array in JSON output",
   () => {
     const output = captureInitOutput([
@@ -152,8 +164,9 @@ Deno.test(
 
     const parsed = JSON.parse(output);
     assertEquals(Array.isArray(parsed.nextSteps), true);
-    assertEquals(parsed.nextSteps.length, 1);
+    assertEquals(parsed.nextSteps.length, 2);
     assertStringIncludes(parsed.nextSteps[0], "/swamp-getting-started");
+    assertStringIncludes(parsed.nextSteps[1], "swamp auth login");
   },
 );
 
@@ -166,8 +179,9 @@ Deno.test(
     ], "json");
 
     const parsed = JSON.parse(output);
-    assertEquals(parsed.nextSteps.length, 1);
+    assertEquals(parsed.nextSteps.length, 2);
     assertStringIncludes(parsed.nextSteps[0], "swamp --help");
+    assertStringIncludes(parsed.nextSteps[1], "swamp auth login");
   },
 );
 

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -33,6 +33,7 @@ import {
 import { UserError } from "../../domain/errors.ts";
 import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
 import { InkWorkflowRunRenderer } from "./workflow_run_tree/mod.ts";
+import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
 
 function isStdoutTty(): boolean {
   try {
@@ -45,6 +46,7 @@ function isStdoutTty(): boolean {
 export interface WorkflowRunRenderOpts {
   workflowName: string;
   forceLog?: boolean;
+  isAuthenticated?: boolean;
 }
 
 export interface WorkflowRunRenderer extends Renderer<WorkflowRunEvent> {
@@ -53,10 +55,12 @@ export interface WorkflowRunRenderer extends Renderer<WorkflowRunEvent> {
 
 class LogWorkflowRunRenderer implements WorkflowRunRenderer {
   private workflowName: string;
+  private isAuthenticated: boolean;
   private _failed = false;
 
   constructor(opts: WorkflowRunRenderOpts) {
     this.workflowName = opts.workflowName;
+    this.isAuthenticated = opts.isAuthenticated ?? false;
   }
 
   handlers(): EventHandlers<WorkflowRunEvent> {
@@ -212,6 +216,10 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
             status: e.run.status,
           });
           this.renderDataArtifactHints(e.run, wfLogger);
+          if (!this.isAuthenticated) {
+            wfLogger.info("");
+            wfLogger.info(AUTH_NUDGE_MESSAGE);
+          }
         }
       },
       cancelled: (e) => {

--- a/src/presentation/renderers/workflow_run_test.ts
+++ b/src/presentation/renderers/workflow_run_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   consumeStream,
@@ -26,6 +31,7 @@ import {
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "./workflow_run.ts";
 import { UserError } from "../../domain/errors.ts";
+import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
 
 await initializeLogging({});
 
@@ -608,4 +614,111 @@ Deno.test("createWorkflowRunRenderer: json mode ignores forceLog", () => {
     forceLog: true,
   });
   assertEquals(renderer.workflowFailed(), false);
+});
+
+// --- Auth nudge tests ---
+
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const methods = ["log", "info", "warn", "error", "debug"] as const;
+  const originals = methods.map((m) => [m, console[m]] as const);
+  for (const [m] of originals) {
+    console[m] = (...args: unknown[]) => {
+      lines.push(
+        args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+      );
+    };
+  }
+  try {
+    fn();
+  } finally {
+    for (const [m, orig] of originals) {
+      console[m] = orig;
+    }
+  }
+  return lines.join("\n");
+}
+
+Deno.test("LogWorkflowRunRenderer - shows auth nudge on success when not authenticated", () => {
+  const renderer = createWorkflowRunRenderer("log", {
+    workflowName: "test-workflow",
+    isAuthenticated: false,
+  });
+  const events = fullEventStream(makeRunData("succeeded"));
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertStringIncludes(output, AUTH_NUDGE_MESSAGE);
+});
+
+Deno.test("LogWorkflowRunRenderer - suppresses auth nudge when authenticated", () => {
+  const renderer = createWorkflowRunRenderer("log", {
+    workflowName: "test-workflow",
+    isAuthenticated: true,
+  });
+  const events = fullEventStream(makeRunData("succeeded"));
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertEquals(output.includes(AUTH_NUDGE_MESSAGE), false);
+});
+
+Deno.test("LogWorkflowRunRenderer - suppresses auth nudge on failed run", () => {
+  const renderer = createWorkflowRunRenderer("log", {
+    workflowName: "test-workflow",
+    isAuthenticated: false,
+  });
+  const events: WorkflowRunEvent[] = [
+    { kind: "validating_inputs" },
+    {
+      kind: "started",
+      runId: "run-1",
+      workflowName: "test-workflow",
+      jobs: [],
+    },
+    { kind: "job_started", jobId: "job-1" },
+    {
+      kind: "step_failed",
+      jobId: "job-1",
+      stepId: "step-1",
+      error: "something broke",
+    },
+    { kind: "job_completed", jobId: "job-1", status: "failed" },
+    { kind: "completed", run: makeRunData("failed") },
+  ];
+  const output = captureLog(() => {
+    for (const event of events) {
+      const handler = renderer.handlers()[event.kind];
+      // deno-lint-ignore no-explicit-any
+      handler(event as any);
+    }
+  });
+  assertEquals(output.includes(AUTH_NUDGE_MESSAGE), false);
+});
+
+Deno.test("JsonWorkflowRunRenderer - never shows auth nudge", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createWorkflowRunRenderer("json", {
+      workflowName: "test-workflow",
+      isAuthenticated: false,
+    });
+    const events = fullEventStream(makeRunData("succeeded"));
+    await consumeStream(toStream(events), renderer.handlers());
+    const combined = logs.join("\n");
+    assertEquals(combined.includes(AUTH_NUDGE_MESSAGE), false);
+  } finally {
+    console.log = originalLog;
+  }
 });

--- a/src/presentation/renderers/workflow_run_tree/renderer.tsx
+++ b/src/presentation/renderers/workflow_run_tree/renderer.tsx
@@ -26,6 +26,7 @@ import type {
   WorkflowRunRenderOpts,
 } from "../workflow_run.ts";
 import { UserError } from "../../../domain/errors.ts";
+import { AUTH_NUDGE_MESSAGE } from "../../../domain/auth/auth_nudge.ts";
 import { suppressInkTtyErrors } from "../../output/ink_lifecycle.ts";
 import { EventBridge, WorkflowRunTree } from "./workflow_run_tree.tsx";
 
@@ -35,9 +36,11 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
   private cleanup: (() => void) | null = null;
   private exitPromise: Promise<void> | null = null;
   private workflowName: string;
+  private isAuthenticated: boolean;
 
   constructor(opts: WorkflowRunRenderOpts) {
     this.workflowName = opts.workflowName;
+    this.isAuthenticated = opts.isAuthenticated ?? false;
     this.bridge = new EventBridge();
   }
 
@@ -95,6 +98,10 @@ export class InkWorkflowRunRenderer implements WorkflowRunRenderer {
         this.bridge.close();
         await this.exitPromise;
         this.cleanup?.();
+        if (e.run.status !== "failed" && !this.isAuthenticated) {
+          console.log("");
+          console.log(AUTH_NUDGE_MESSAGE);
+        }
       },
       cancelled: async (e) => {
         this._failed = true;


### PR DESCRIPTION
## Summary

- Prompt anonymous users to join the community and log in at key moments: after `repo init`/`repo upgrade` (in "What's next" steps), after successful model method and workflow runs, and as a once-per-day CLI exit banner on stderr
- All nudges are suppressed once the user is authenticated (via `auth.json` or `SWAMP_API_KEY`), and the exit banner is throttled to once per 24 hours via `~/.config/swamp/auth_nudge.json`
- JSON and quiet output modes are unaffected

## Test Plan

- Unit tests for throttle logic (`shouldShowAuthNudge`), repository read/write, and auth context module state
- Renderer tests verify the nudge appears when `isAuthenticated: false` + success, and is suppressed when authenticated, on failure, or in JSON mode — for both model method run and workflow run
- Integration tests run the CLI binary with isolated `XDG_CONFIG_HOME` to verify end-to-end: nudge shown for anonymous users, suppressed with `SWAMP_API_KEY`, throttled on second run, suppressed in `--json` mode, and present in repo init output
- Full test suite passes (7961 tests, 0 failures)
- Manually verified all five scenarios with the compiled binary