### PR TITLE
fix(serve): bypass catalog backfill for policy snapshot loading (swamp-club#841)

### DIFF
--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -182,7 +182,7 @@ export const accessCheckCommand = new Command()
 
     const eventBus = new EventBus();
     const loader = new PolicySnapshotLoader(
-      repoContext.dataQueryService,
+      repoContext.unifiedDataRepo,
       eventBus,
     );
 

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -109,7 +109,7 @@ export const accessReloadCommand = new Command()
 
     const eventBus = new EventBus();
     const loader = new PolicySnapshotLoader(
-      repoContext.dataQueryService,
+      repoContext.unifiedDataRepo,
       eventBus,
       "manual",
     );

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -610,7 +610,7 @@ export const serveCommand = new Command()
     }
 
     const policySnapshotLoader = new PolicySnapshotLoader(
-      dataQueryService,
+      repoContext.unifiedDataRepo,
       serveEventBus,
       grantReloadMode as PolicyReloadMode,
     );

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -236,7 +236,9 @@ export class PolicySnapshotLoader {
     try {
       const text = new TextDecoder().decode(content);
       return JSON.parse(text) as Record<string, unknown>;
-    } catch {
+    } catch (error) {
+      logger
+        .warn`Skipping ${modelType.normalized}/${modelId}/${dataName}: failed to parse JSON content: ${error}`;
       return null;
     }
   }

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -20,8 +20,7 @@
 import { getLogger } from "@logtape/logtape";
 import { Environment } from "cel-js";
 import { registerArithmeticOverloads } from "../../infrastructure/cel/cel_evaluator.ts";
-import type { DataRecord } from "../data/data_record.ts";
-import type { DataQueryService } from "../data/data_query_service.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
 import type { EventBus } from "../events/event_bus.ts";
 import type { ModelCreated, ModelUpdated } from "../events/types.ts";
 import {
@@ -34,6 +33,7 @@ import {
   GROUP_MODEL_TYPE,
   GroupSchema,
 } from "../models/access/group_model.ts";
+import type { ModelType } from "../models/model_type.ts";
 import type { PrincipalContext } from "./principal_context.ts";
 import type { ConditionEvaluator } from "./policy_snapshot.ts";
 import { PolicySnapshot } from "./policy_snapshot.ts";
@@ -97,7 +97,7 @@ function buildConditionEvaluator(): ConditionEvaluator {
 export type PolicyReloadMode = "manual" | "auto";
 
 export class PolicySnapshotLoader {
-  readonly #dataQueryService: DataQueryService;
+  readonly #dataRepo: UnifiedDataRepository;
   readonly #unsubscribers: (() => void)[] = [];
   readonly #conditionEvaluator: ConditionEvaluator;
   #snapshot: PolicySnapshot = PolicySnapshot.empty();
@@ -106,11 +106,11 @@ export class PolicySnapshotLoader {
   #cachedDecisionService: GrantBasedAccessDecisionService | null = null;
 
   constructor(
-    dataQueryService: DataQueryService,
+    dataRepo: UnifiedDataRepository,
     eventBus: EventBus,
     mode: PolicyReloadMode = "auto",
   ) {
-    this.#dataQueryService = dataQueryService;
+    this.#dataRepo = dataRepo;
     this.#conditionEvaluator = buildConditionEvaluator();
 
     if (mode === "auto") {
@@ -188,20 +188,15 @@ export class PolicySnapshotLoader {
     grantCount: number;
     groupCount: number;
   }> {
-    const [grantRecords, groupRecords] = await Promise.all([
-      this.#dataQueryService.query(
-        `modelType == "${GRANT_MODEL_TYPE_STR}"`,
-        { loadAttributes: true },
-      ),
-      this.#dataQueryService.query(
-        `modelType == "${GROUP_MODEL_TYPE_STR}"`,
-        { loadAttributes: true },
-      ),
+    const [grantDataItems, groupDataItems] = await Promise.all([
+      this.#dataRepo.findAllForType(GRANT_MODEL_TYPE),
+      this.#dataRepo.findAllForType(GROUP_MODEL_TYPE),
     ]);
 
     const grants: Grant[] = [];
-    for (const record of grantRecords) {
-      const attrs = (record as DataRecord).attributes;
+    for (const { data, modelType, modelId } of grantDataItems) {
+      const attrs = await this.#readAttributes(modelType, modelId, data.name);
+      if (!attrs) continue;
       const parsed = GrantSchema.safeParse(attrs);
       if (parsed.success && parsed.data.state === "active") {
         grants.push(parsed.data);
@@ -209,8 +204,9 @@ export class PolicySnapshotLoader {
     }
 
     const groups: Group[] = [];
-    for (const record of groupRecords) {
-      const attrs = (record as DataRecord).attributes;
+    for (const { data, modelType, modelId } of groupDataItems) {
+      const attrs = await this.#readAttributes(modelType, modelId, data.name);
+      if (!attrs) continue;
       const parsed = GroupSchema.safeParse(attrs);
       if (parsed.success) {
         groups.push(parsed.data);
@@ -224,6 +220,25 @@ export class PolicySnapshotLoader {
       grantCount: grants.length,
       groupCount: groups.length,
     };
+  }
+
+  async #readAttributes(
+    modelType: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<Record<string, unknown> | null> {
+    const content = await this.#dataRepo.getContent(
+      modelType,
+      modelId,
+      dataName,
+    );
+    if (!content) return null;
+    try {
+      const text = new TextDecoder().decode(content);
+      return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
   }
 
   #scheduleRebuild(): void {

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -19,77 +19,20 @@
 
 import { assertEquals } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
-import type { DataRecord } from "../data/data_record.ts";
-import type { DataQueryService } from "../data/data_query_service.ts";
+import { Data } from "../data/data.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
 import { EventBus } from "../events/event_bus.ts";
 import { createModelCreated, createModelUpdated } from "../events/types.ts";
 import type { Grant } from "../models/access/grant_model.ts";
+import { GRANT_MODEL_TYPE } from "../models/access/grant_model.ts";
 import type { Group } from "../models/access/group_model.ts";
+import { GROUP_MODEL_TYPE } from "../models/access/group_model.ts";
+import type { ModelType } from "../models/model_type.ts";
 import { PolicySnapshotLoader } from "./policy_snapshot_loader.ts";
 
 await initializeLogging({});
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-
-function makeGrantRecord(grant: Grant): DataRecord {
-  return {
-    id: crypto.randomUUID(),
-    name: "grant-main",
-    version: 1,
-    isLatest: true,
-    createdAt: "2026-01-01T00:00:00Z",
-    namespace: "",
-    attributes: grant as unknown as Record<string, unknown>,
-    tags: {},
-    modelName: `grant-${grant.id}`,
-    modelId: crypto.randomUUID(),
-    modelType: "swamp/grant",
-    specName: "grant",
-    dataType: "grant",
-    contentType: "application/json",
-    lifetime: "infinite",
-    ownerType: "model-method",
-    streaming: false,
-    size: 0,
-    content: "",
-    ownerRef: "",
-    workflowRunId: "",
-    workflowName: "",
-    jobName: "",
-    stepName: "",
-    source: "",
-  };
-}
-
-function makeGroupRecord(group: Group): DataRecord {
-  return {
-    id: crypto.randomUUID(),
-    name: "group-main",
-    version: 1,
-    isLatest: true,
-    createdAt: "2026-01-01T00:00:00Z",
-    namespace: "",
-    attributes: group as unknown as Record<string, unknown>,
-    tags: {},
-    modelName: group.name,
-    modelId: crypto.randomUUID(),
-    modelType: "swamp/group",
-    specName: "group",
-    dataType: "group",
-    contentType: "application/json",
-    lifetime: "infinite",
-    ownerType: "model-method",
-    streaming: false,
-    size: 0,
-    content: "",
-    ownerRef: "",
-    workflowRunId: "",
-    workflowName: "",
-    jobName: "",
-    stepName: "",
-    source: "",
-  };
-}
 
 function makeGrant(overrides: Partial<Grant> = {}): Grant {
   return {
@@ -115,32 +58,92 @@ function makeGroup(name: string, memberIds: string[]): Group {
   };
 }
 
-function createMockQueryService(
-  grantRecords: DataRecord[],
-  groupRecords: DataRecord[],
-): DataQueryService {
-  return {
-    query(predicate: string) {
-      if (predicate.includes("swamp/grant")) {
-        return Promise.resolve(grantRecords);
-      }
-      if (predicate.includes("swamp/group")) {
-        return Promise.resolve(groupRecords);
-      }
-      return Promise.resolve([]);
-    },
-  } as unknown as DataQueryService;
+function makeData(name: string): Data {
+  return Data.create({
+    name,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "resource" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+  });
 }
 
-Deno.test("PolicySnapshotLoader.load: builds snapshot from DataQueryService", async () => {
+interface ContentEntry {
+  type: string;
+  modelId: string;
+  dataName: string;
+  content: Record<string, unknown>;
+}
+
+function createMockDataRepo(
+  grantItems: Array<{ attrs: Grant; modelId: string; dataName: string }>,
+  groupItems: Array<{ attrs: Group; modelId: string; dataName: string }>,
+): UnifiedDataRepository {
+  const contentMap = new Map<string, Uint8Array>();
+
+  const entries: ContentEntry[] = [];
+  for (const item of grantItems) {
+    const key =
+      `${GRANT_MODEL_TYPE.normalized}/${item.modelId}/${item.dataName}`;
+    contentMap.set(
+      key,
+      new TextEncoder().encode(JSON.stringify(item.attrs)),
+    );
+    entries.push({
+      type: GRANT_MODEL_TYPE.normalized,
+      modelId: item.modelId,
+      dataName: item.dataName,
+      content: item.attrs as unknown as Record<string, unknown>,
+    });
+  }
+  for (const item of groupItems) {
+    const key =
+      `${GROUP_MODEL_TYPE.normalized}/${item.modelId}/${item.dataName}`;
+    contentMap.set(
+      key,
+      new TextEncoder().encode(JSON.stringify(item.attrs)),
+    );
+    entries.push({
+      type: GROUP_MODEL_TYPE.normalized,
+      modelId: item.modelId,
+      dataName: item.dataName,
+      content: item.attrs as unknown as Record<string, unknown>,
+    });
+  }
+
+  return {
+    findAllForType(type: ModelType) {
+      const typeStr = type.normalized;
+      const matching = entries.filter((e) => e.type === typeStr);
+      return Promise.resolve(
+        matching.map((e) => ({
+          data: makeData(e.dataName),
+          modelType: type,
+          modelId: e.modelId,
+        })),
+      );
+    },
+    getContent(
+      type: ModelType,
+      modelId: string,
+      dataName: string,
+    ) {
+      const key = `${type.normalized}/${modelId}/${dataName}`;
+      return Promise.resolve(contentMap.get(key) ?? null);
+    },
+  } as unknown as UnifiedDataRepository;
+}
+
+Deno.test("PolicySnapshotLoader.load: builds snapshot from data repository", async () => {
   const grant = makeGrant();
   const group = makeGroup("devs", ["adam"]);
-  const queryService = createMockQueryService(
-    [makeGrantRecord(grant)],
-    [makeGroupRecord(group)],
+  const dataRepo = createMockDataRepo(
+    [{ attrs: grant, modelId: "g1", dataName: "grant-main" }],
+    [{ attrs: group, modelId: "grp1", dataName: "group-main" }],
   );
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   const snapshot = await loader.load();
 
@@ -153,12 +156,15 @@ Deno.test("PolicySnapshotLoader.load: builds snapshot from DataQueryService", as
 Deno.test("PolicySnapshotLoader.load: filters out revoked grants", async () => {
   const active = makeGrant({ state: "active" });
   const revoked = makeGrant({ state: "revoked" });
-  const queryService = createMockQueryService(
-    [makeGrantRecord(active), makeGrantRecord(revoked)],
+  const dataRepo = createMockDataRepo(
+    [
+      { attrs: active, modelId: "g1", dataName: "grant-main" },
+      { attrs: revoked, modelId: "g2", dataName: "grant-main" },
+    ],
     [],
   );
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   const snapshot = await loader.load();
   assertEquals(snapshot.grantsForSubjects(["user:adam"]).length, 1);
@@ -169,21 +175,38 @@ Deno.test("PolicySnapshotLoader.load: filters out revoked grants", async () => {
 Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant model", async () => {
   let callCount = 0;
   const grant = makeGrant();
-  const queryService = {
-    query(predicate: string) {
-      if (predicate.includes("swamp/grant")) {
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized) {
         callCount++;
         if (callCount > 1) {
-          return Promise.resolve([makeGrantRecord(grant)]);
+          return Promise.resolve([{
+            data: makeData("grant-main"),
+            modelType: type,
+            modelId: "g1",
+          }]);
         }
         return Promise.resolve([]);
       }
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized && callCount > 1) {
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(grant)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   await loader.load();
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
@@ -201,21 +224,38 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelCreated for grant mod
 Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group model", async () => {
   let callCount = 0;
   const group = makeGroup("devs", ["adam"]);
-  const queryService = {
-    query(predicate: string) {
-      if (predicate.includes("swamp/group")) {
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GROUP_MODEL_TYPE.normalized) {
         callCount++;
         if (callCount > 1) {
-          return Promise.resolve([makeGroupRecord(group)]);
+          return Promise.resolve([{
+            data: makeData("group-main"),
+            modelType: type,
+            modelId: "grp1",
+          }]);
         }
         return Promise.resolve([]);
       }
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GROUP_MODEL_TYPE.normalized && callCount > 1) {
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(group)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   await loader.load();
   assertEquals(loader.snapshot.groupsForPrincipal("user:adam").length, 0);
@@ -231,43 +271,49 @@ Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for group mod
 });
 
 Deno.test("PolicySnapshotLoader: ignores events for non-access models", async () => {
-  let queryCallCount = 0;
-  const queryService = {
-    query() {
-      queryCallCount++;
+  let findAllCallCount = 0;
+  const dataRepo = {
+    findAllForType() {
+      findAllCallCount++;
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent() {
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   await loader.load();
-  const initialCount = queryCallCount;
+  const initialCount = findAllCallCount;
 
   await eventBus.publish(
     createModelCreated("swamp/echo", "789", "my-echo"),
   );
 
-  assertEquals(queryCallCount, initialCount);
+  assertEquals(findAllCallCount, initialCount);
 
   await loader.dispose();
 });
 
 Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () => {
-  let queryCallCount = 0;
-  const queryService = {
-    query() {
-      queryCallCount++;
+  let findAllCallCount = 0;
+  const dataRepo = {
+    findAllForType() {
+      findAllCallCount++;
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent() {
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus);
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
 
   await loader.load();
-  const initialCount = queryCallCount;
+  const initialCount = findAllCallCount;
 
   await loader.dispose();
 
@@ -275,29 +321,32 @@ Deno.test("PolicySnapshotLoader.dispose: unsubscribes from EventBus", async () =
     createModelCreated("swamp/grant", "123", "my-grant"),
   );
 
-  assertEquals(queryCallCount, initialCount);
+  assertEquals(findAllCallCount, initialCount);
 });
 
 Deno.test("PolicySnapshotLoader: manual mode does not subscribe to EventBus", async () => {
-  let queryCallCount = 0;
-  const queryService = {
-    query() {
-      queryCallCount++;
+  let findAllCallCount = 0;
+  const dataRepo = {
+    findAllForType() {
+      findAllCallCount++;
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent() {
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus, "manual");
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus, "manual");
 
   await loader.load();
-  const initialCount = queryCallCount;
+  const initialCount = findAllCallCount;
 
   await eventBus.publish(
     createModelCreated("swamp/grant", "123", "my-grant"),
   );
 
-  assertEquals(queryCallCount, initialCount);
+  assertEquals(findAllCallCount, initialCount);
 
   await loader.dispose();
 });
@@ -305,21 +354,38 @@ Deno.test("PolicySnapshotLoader: manual mode does not subscribe to EventBus", as
 Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => {
   let callCount = 0;
   const grant = makeGrant();
-  const queryService = {
-    query(predicate: string) {
-      if (predicate.includes("swamp/grant")) {
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized) {
         callCount++;
         if (callCount > 1) {
-          return Promise.resolve([makeGrantRecord(grant)]);
+          return Promise.resolve([{
+            data: makeData("grant-main"),
+            modelType: type,
+            modelId: "g1",
+          }]);
         }
         return Promise.resolve([]);
       }
       return Promise.resolve([]);
     },
-  } as unknown as DataQueryService;
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized && callCount > 1) {
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(grant)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus, "auto");
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus, "auto");
 
   await loader.load();
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
@@ -337,13 +403,13 @@ Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => 
 Deno.test("PolicySnapshotLoader.loadWithCounts: returns counts", async () => {
   const grant = makeGrant();
   const group = makeGroup("devs", ["adam"]);
-  const queryService = createMockQueryService(
-    [makeGrantRecord(grant)],
-    [makeGroupRecord(group)],
+  const dataRepo = createMockDataRepo(
+    [{ attrs: grant, modelId: "g1", dataName: "grant-main" }],
+    [{ attrs: group, modelId: "grp1", dataName: "group-main" }],
   );
 
   const eventBus = new EventBus();
-  const loader = new PolicySnapshotLoader(queryService, eventBus, "manual");
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus, "manual");
   const result = await loader.loadWithCounts();
 
   assertEquals(result.grantCount, 1);

--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -69,6 +69,18 @@ export interface UnifiedDataRepository {
   >;
 
   /**
+   * Finds all data for a single model type across all models of that type.
+   *
+   * @param type - The model type to scan
+   * @returns Array of data with their model type and model ID
+   */
+  findAllForType(
+    type: ModelTypeInput,
+  ): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  >;
+
+  /**
    * Finds data by name, optionally for a specific version.
    *
    * @param type - The model type

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -216,6 +216,7 @@ function createMockDataRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -43,6 +43,7 @@ function createMockRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -200,6 +200,7 @@ function createMockDataRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -165,6 +165,7 @@ function createMockDataRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -197,6 +197,7 @@ function createMockDataRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1110,6 +1110,7 @@ function createMockDataRepo(): UnifiedDataRepository {
   return {
     namespace: SOLO_NAMESPACE,
     findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
     findByName: () => Promise.resolve(null),
     findById: () => Promise.resolve(null),
     listVersions: () => Promise.resolve([]),

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -190,6 +190,40 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
    * the same walk shape as `findAllGlobal`, plus a stat per file before
    * parse.
    */
+  async findAllForType(
+    type: ModelTypeInput,
+  ): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > {
+    const modelType = coerceModelType(type);
+    const typeDir = this.getTypeDir(modelType);
+    const results: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+
+    try {
+      for await (const entry of Deno.readDir(typeDir)) {
+        if (!entry.isDirectory) continue;
+        const modelId = entry.name;
+        try {
+          const dataItems = await this.findAllForModel(modelType, modelId);
+          for (const data of dataItems) {
+            results.push({ data, modelType, modelId });
+          }
+        } catch {
+          // Skip invalid model directories
+        }
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    return results;
+  }
+
   async findAllGlobalSince(
     cutoff: Date,
   ): Promise<Array<{ data: Data; modelType: ModelType; modelId: string }>> {

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -180,16 +180,6 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return results;
   }
 
-  /**
-   * Finds all data items whose `createdAt` is at or after the cutoff using a
-   * two-stage filter (mtime pre-filter, then parse-and-verify) on each
-   * version's metadata.yaml. Old version files are skipped without parse.
-   *
-   * The `_catalog.db` SQLite catalog does not track `createdAt`, so the only
-   * source of truth for time-bounded filtering is the metadata YAML — hence
-   * the same walk shape as `findAllGlobal`, plus a stat per file before
-   * parse.
-   */
   async findAllForType(
     type: ModelTypeInput,
   ): Promise<
@@ -224,6 +214,16 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return results;
   }
 
+  /**
+   * Finds all data items whose `createdAt` is at or after the cutoff using a
+   * two-stage filter (mtime pre-filter, then parse-and-verify) on each
+   * version's metadata.yaml. Old version files are skipped without parse.
+   *
+   * The `_catalog.db` SQLite catalog does not track `createdAt`, so the only
+   * source of truth for time-bounded filtering is the metadata YAML — hence
+   * the same walk shape as `findAllGlobal`, plus a stat per file before
+   * parse.
+   */
   async findAllGlobalSince(
     cutoff: Date,
   ): Promise<Array<{ data: Data; modelType: ModelType; modelId: string }>> {

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -620,6 +620,79 @@ Deno.test("findAllForModelSync returns empty for missing model", () => {
   assertEquals(results, []);
 });
 
+Deno.test("findAllForType: returns data scoped to one model type", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+
+    const otherType = ModelType.create("other/type");
+    const data1 = makeJsonData("item-a");
+    const data2 = makeJsonData("item-b");
+    const data3 = makeJsonData("item-c");
+
+    await repo.save(
+      testType,
+      "model-1",
+      data1,
+      new TextEncoder().encode('{"a":1}'),
+    );
+    await repo.save(
+      otherType,
+      "model-2",
+      data2,
+      new TextEncoder().encode('{"b":2}'),
+    );
+    await repo.save(
+      testType,
+      "model-3",
+      data3,
+      new TextEncoder().encode('{"c":3}'),
+    );
+
+    const results = await repo.findAllForType(testType);
+    assertEquals(results.length, 2);
+    const names = results.map((r) => r.data.name).sort();
+    assertEquals(names, ["item-a", "item-c"]);
+    for (const r of results) {
+      assertEquals(r.modelType.normalized, testType.normalized);
+    }
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("findAllForType: returns empty for missing type directory", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+
+    const results = await repo.findAllForType(
+      ModelType.create("nonexistent/type"),
+    );
+    assertEquals(results, []);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
 // Pins the markDirty contract from design/datastores.md: every public mutation
 // that writes into the cache must call the sync service's markDirty hook before
 // the write begins, so the fast-path sidecar cannot short-circuit past it. Also

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -199,6 +199,7 @@ function createRemoteDataRepository(
     // writes flow through the remote writers, never raw repository saves.
     findAllGlobal: () => unsupported("dataRepository.findAllGlobal"),
     findAllForModel: () => unsupported("dataRepository.findAllForModel"),
+    findAllForType: () => unsupported("dataRepository.findAllForType"),
     save: () => unsupported("dataRepository.save"),
     append: () => unsupported("dataRepository.append"),
     allocateVersion: () => unsupported("dataRepository.allocateVersion"),


### PR DESCRIPTION
## Summary

- `PolicySnapshotLoader` was querying grants/groups through `DataQueryService.query()`, which triggered a full catalog backfill — scanning **every** data version across **all** model types — before returning the few grant/group records it actually needed. On repos with 50+ models and ~100K data versions, this added ~4.5 minutes to `swamp serve` startup.
- Added `findAllForType(type)` to `UnifiedDataRepository` — walks only one model type's directory instead of the entire data tree.
- Changed `PolicySnapshotLoader` to read grants/groups directly from the data repository via `findAllForType()`, bypassing the catalog and `DataQueryService` entirely.
- Updated all three `PolicySnapshotLoader` construction sites (`serve.ts`, `access_reload.ts`, `access_check.ts`) to pass `UnifiedDataRepository` instead of `DataQueryService`.

## Test Plan

- All 7937 existing tests pass (0 failures)
- PolicySnapshotLoader tests rewritten for the new dependency — 9/9 pass
- Compiled binary starts `swamp serve` cleanly; policy snapshot loads in <1s
- `deno check` / `deno lint` / `deno fmt` all pass

Closes swamp-club#841

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>