### PR TITLE
feat(serve): make WebSocket idle timeout configurable (swamp-club#843)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -25,6 +25,7 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { parseTimeout } from "../duration_parser.ts";
 import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
 import { handleConnection } from "../../serve/connection.ts";
 import { authenticateServerToken } from "../../serve/token_auth.ts";
@@ -219,6 +220,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   }
   if (options.trustProxy) {
     args.push("--trust-proxy");
+  }
+  if (options.wsIdleTimeout) {
+    args.push("--ws-idle-timeout", options.wsIdleTimeout as string);
   }
   return args;
 }
@@ -447,6 +451,11 @@ export const serveCommand = new Command()
     "--trust-proxy",
     "Trust X-Forwarded-For header for client IP in token auth rate limiting (enable when behind a reverse proxy)",
   )
+  .option(
+    "--ws-idle-timeout <duration:string>",
+    "WebSocket idle timeout — how long the server waits for a pong before closing the connection (env: SWAMP_WS_IDLE_TIMEOUT). " +
+      "Accepts seconds (30), explicit units (2m, 5m), or 0 to disable. Default: 30s",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
@@ -494,6 +503,19 @@ export const serveCommand = new Command()
     }
     const tlsEnabled = cert !== undefined;
     const trustProxy = options.trustProxy === true;
+
+    const wsIdleTimeoutRaw = (options.wsIdleTimeout as string | undefined) ??
+      Deno.env.get("SWAMP_WS_IDLE_TIMEOUT") ?? undefined;
+    let wsIdleTimeoutSeconds: number | undefined;
+    if (wsIdleTimeoutRaw !== undefined) {
+      if (wsIdleTimeoutRaw === "0") {
+        wsIdleTimeoutSeconds = 0;
+      } else {
+        wsIdleTimeoutSeconds = Math.round(
+          parseTimeout(wsIdleTimeoutRaw) / 1000,
+        );
+      }
+    }
 
     const authConfig = buildServeAuthConfig({
       authMode: options.authMode as string | undefined,
@@ -803,6 +825,11 @@ export const serveCommand = new Command()
       }
     }
 
+    const wsUpgradeOpts: Deno.UpgradeWebSocketOptions = {};
+    if (wsIdleTimeoutSeconds !== undefined) {
+      wsUpgradeOpts.idleTimeout = wsIdleTimeoutSeconds;
+    }
+
     const wsScheme = tlsEnabled ? "wss" : "ws";
     const server = Deno.serve(
       {
@@ -895,11 +922,17 @@ export const serveCommand = new Command()
             }
             clearRateLimit(remoteAddr);
             const principal = parsePrincipal(result.principalId);
-            const { socket, response } = Deno.upgradeWebSocket(req);
+            const { socket, response } = Deno.upgradeWebSocket(
+              req,
+              wsUpgradeOpts,
+            );
             handleConnection(socket, connectionCtx, principal);
             return response;
           }
-          const { socket, response } = Deno.upgradeWebSocket(req);
+          const { socket, response } = Deno.upgradeWebSocket(
+            req,
+            wsUpgradeOpts,
+          );
           handleConnection(socket, connectionCtx, null);
           return response;
         }

--- a/src/cli/commands/serve_daemon_test.ts
+++ b/src/cli/commands/serve_daemon_test.ts
@@ -98,6 +98,16 @@ Deno.test("collectServeExtraArgs: includes --trust-proxy", () => {
   assertEquals(args, ["--trust-proxy"]);
 });
 
+Deno.test("collectServeExtraArgs: includes --ws-idle-timeout", () => {
+  const args = collectServeExtraArgs({ wsIdleTimeout: "2m" });
+  assertEquals(args, ["--ws-idle-timeout", "2m"]);
+});
+
+Deno.test("collectServeExtraArgs: skips --ws-idle-timeout when not set", () => {
+  const args = collectServeExtraArgs({});
+  assertEquals(args, []);
+});
+
 Deno.test("collectServeExtraArgs: combines multiple flags", () => {
   const args = collectServeExtraArgs({
     schedule: false,


### PR DESCRIPTION
## Summary

- Add `--ws-idle-timeout <duration>` flag (env: `SWAMP_WS_IDLE_TIMEOUT`) to `swamp serve` that sets the `idleTimeout` on `Deno.upgradeWebSocket()` calls
- Uses the existing `parseTimeout` utility — accepts seconds (`30`), explicit units (`2m`, `5m`), or `0` to disable
- When unset, Deno's default (30s) is preserved
- Forward the flag through `collectServeExtraArgs` for daemon mode

## Test Plan

- [x] Unit tests for `collectServeExtraArgs` with the new flag (2 new tests in `serve_daemon_test.ts`)
- [x] Manual before/after verification with a raw TCP WebSocket client that ignores pings:
  - **Before** (default 30s): server sends ping at ~15s, closes connection at 30s
  - **After** (`--ws-idle-timeout 2m`): server sends ping at ~60s, closes connection at 120s
- [x] Type check, lint, format all pass
- [x] Full test suite: 7973 passed, 0 failed

## Follow-up

- #1699 — docs update for `serve-flags.md`

Closes #843