### PR TITLE
feat(cli): add write-secret alias for vault put

### DIFF
--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -135,6 +135,7 @@ type AnyOptions = any;
 export const vaultPutCommand = withRemoteOptions(
   new Command()
     .name("put")
+    .alias("write-secret")
     .description(
       `Store a secret in a vault.
 
@@ -168,6 +169,10 @@ When using --server, the value must be passed as a positional argument or KEY=VA
     .example(
       "Auto-refresh GCP token every 50 minutes",
       'swamp vault put my-vault GCP_TOKEN --refresh-from "gcloud auth print-access-token" --refresh-ttl 50m',
+    )
+    .example(
+      "Write a secret (alias)",
+      "swamp vault write-secret my-vault API_KEY=sk-1234567890",
     )
     .example(
       "Remove refresh hook from a secret",

--- a/src/cli/commands/vault_put_test.ts
+++ b/src/cli/commands/vault_put_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { parseKeyValue, resolveKeyValue } from "./vault_put.ts";
+import {
+  parseKeyValue,
+  resolveKeyValue,
+  vaultPutCommand,
+} from "./vault_put.ts";
 
 Deno.test("parseKeyValue - simple key=value", () => {
   const result = parseKeyValue("API_KEY=secret123");
@@ -58,6 +62,10 @@ Deno.test("parseKeyValue - key with dashes", () => {
 Deno.test("parseKeyValue - key with underscores", () => {
   const result = parseKeyValue("MY_API_KEY=secret");
   assertEquals(result, { key: "MY_API_KEY", value: "secret" });
+});
+
+Deno.test("vaultPutCommand: exposes the write-secret alias", () => {
+  assertEquals(vaultPutCommand.getAliases().includes("write-secret"), true);
 });
 
 // resolveKeyValue tests


### PR DESCRIPTION
## Summary

- Adds `write-secret` as an alias for `swamp vault put`, pairing with the existing `read-secret` command for a more intuitive command pair
- Adds an example showing the alias form in help output
- Adds alias registration test following the established pattern (auth_whoami, access_grant, summarise)

## Test Plan

- `deno fmt --check` passes
- `deno lint` passes
- `deno run test src/cli/commands/vault_put_test.ts` — all 18 tests pass including new alias test
- Verified `swamp vault write-secret --help` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)