### PR TITLE
fix(render): suppress auto_gc_completed from --json stdout (swamp-club#851)

### DIFF
--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -278,13 +278,7 @@ class JsonModelMethodRunRenderer implements ModelMethodRunRenderer {
         this._failed = true;
         console.log(JSON.stringify(e.run, null, 2));
       },
-      auto_gc_completed: (e) => {
-        console.log(JSON.stringify({
-          event: "auto_gc_completed",
-          versionsDeleted: e.versionsDeleted,
-          bytesReclaimed: e.bytesReclaimed,
-        }));
-      },
+      auto_gc_completed: () => {},
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);
       },

--- a/src/presentation/renderers/model_method_run_test.ts
+++ b/src/presentation/renderers/model_method_run_test.ts
@@ -433,6 +433,34 @@ Deno.test("LogModelMethodRunRenderer - suppresses auth nudge on failed run", () 
   assertEquals(output.includes(AUTH_NUDGE_MESSAGE), false);
 });
 
+Deno.test("JsonModelMethodRunRenderer - auto_gc_completed does not write to stdout", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createModelMethodRunRenderer("json", {
+      modelName: "test-model",
+      methodName: "run",
+    });
+    const runView = makeRunView("succeeded");
+    const events: ModelMethodRunEvent[] = [
+      ...fullEventStream(runView),
+      {
+        kind: "auto_gc_completed",
+        versionsDeleted: 3,
+        bytesReclaimed: 4096,
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.modelName, "test-model");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("JsonModelMethodRunRenderer - never shows auth nudge", async () => {
   const logs: string[] = [];
   const originalLog = console.log;


### PR DESCRIPTION
## Summary

- Fix regression from swamp-club#823 where `JsonModelMethodRunRenderer.auto_gc_completed` wrote a second JSON object to stdout after the method result, breaking any consumer that does a single parse of `--json` output
- Make the handler a no-op in JSON mode — the `autoGc` function already logs at debug level via LogTape, so GC stats are available with `--log-level debug`

## Test Plan

- Added unit test verifying `auto_gc_completed` does not produce stdout output in JSON mode
- All 15 existing renderer tests continue to pass
- `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#851