### PR TITLE
fix(lock): prevent subprocess deadlock and infinite busy-spin in per-model lock drain (swamp-club#863)

### DIFF
--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -38,7 +38,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
 async function promptConfirmation(message: string): Promise<boolean> {
@@ -171,95 +175,138 @@ export const dataDeleteCommand = new Command()
         "delete",
       ]);
 
-      const { repoDir, datastoreResolver } = await requireInitializedRepo({
+      const {
+        repoDir,
+        repoContext,
+        datastoreResolver,
+        datastoreConfig,
+        syncService,
+      } = await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 
-      const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataDeleteDeps(repoDir, datastoreResolver);
-
-      if (isBatchMode) {
-        const filter: BatchDeleteFilter = all
-          ? { kind: "all" }
-          : { kind: "prefix", value: prefix! };
-
-        // Phase 1: Preview + Prompt (unless --force or --dry-run).
-        if (cliCtx.outputMode === "log" && !options.force && !dryRun) {
-          let preview;
-          try {
-            preview = await dataBatchDeletePreview(ctx, deps, {
-              modelIdOrName: modelIdOrName!,
-              filter,
-            });
-          } catch (error) {
-            throw new UserError(
-              error instanceof Error ? error.message : String(error),
-            );
-          }
-
-          const filterDesc = filter.kind === "prefix"
-            ? `prefix "${filter.value}"`
-            : "all data";
-          const confirmed = await promptConfirmation(
-            `About to delete ${preview.totalItems} data artifact(s) (${preview.totalVersions} version(s)) matching ${filterDesc} from ${preview.modelName}. Proceed?`,
-          );
-          if (!confirmed) {
-            renderDataDeleteCancelled(cliCtx.outputMode);
-            return;
-          }
-        }
-
-        // Phase 2: Execute batch delete.
-        const renderer = createDataBatchDeleteRenderer(cliCtx.outputMode);
-        await consumeStream(
-          dataBatchDelete(ctx, deps, {
-            modelIdOrName: modelIdOrName!,
-            filter,
-            dryRun: dryRun ?? false,
-          }),
-          renderer.handlers(),
-        );
-      } else {
-        const renderer = createDataDeleteRenderer(cliCtx.outputMode);
-
-        // Phase 1: Preview + Prompt (only in interactive log mode without --force).
-        if (cliCtx.outputMode === "log" && !options.force) {
-          let preview;
-          try {
-            preview = await dataDeletePreview(ctx, deps, {
-              modelIdOrName: modelIdOrName!,
-              dataName: dataName!,
-            });
-          } catch (error) {
-            throw new UserError(
-              error instanceof Error ? error.message : String(error),
-            );
-          }
-
-          const target = options.version !== undefined
-            ? `version ${options.version} of "${dataName}"`
-            : `${preview.versionsCount} version(s) of "${dataName}"`;
-          const confirmed = await promptConfirmation(
-            `About to delete ${target} from ${preview.modelName}. Proceed?`,
-          );
-          if (!confirmed) {
-            renderDataDeleteCancelled(cliCtx.outputMode);
-            return;
-          }
-        }
-
-        // Phase 2: Execute single delete.
-        await consumeStream(
-          dataDelete(ctx, deps, {
-            modelIdOrName: modelIdOrName!,
-            dataName: dataName!,
-            version: options.version,
-          }),
-          renderer.handlers(),
-        );
+      const preResult = await findDefinitionByIdOrName(
+        repoContext.definitionRepo,
+        modelIdOrName!,
+      );
+      if (!preResult) {
+        throw new UserError(`Model not found: ${modelIdOrName}`);
       }
 
-      cliCtx.logger.debug("Data delete command completed");
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+
+      try {
+        const ctx = createLibSwampContext({ logger: cliCtx.logger });
+        const deps = createDataDeleteDeps(repoDir, datastoreResolver);
+
+        if (isBatchMode) {
+          const filter: BatchDeleteFilter = all
+            ? { kind: "all" }
+            : { kind: "prefix", value: prefix! };
+
+          // Phase 1: Preview + Prompt (unless --force or --dry-run).
+          if (cliCtx.outputMode === "log" && !options.force && !dryRun) {
+            let preview;
+            try {
+              preview = await dataBatchDeletePreview(ctx, deps, {
+                modelIdOrName: modelIdOrName!,
+                filter,
+              });
+            } catch (error) {
+              throw new UserError(
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+
+            const filterDesc = filter.kind === "prefix"
+              ? `prefix "${filter.value}"`
+              : "all data";
+            const confirmed = await promptConfirmation(
+              `About to delete ${preview.totalItems} data artifact(s) (${preview.totalVersions} version(s)) matching ${filterDesc} from ${preview.modelName}. Proceed?`,
+            );
+            if (!confirmed) {
+              renderDataDeleteCancelled(cliCtx.outputMode);
+              return;
+            }
+          }
+
+          // Phase 2: Execute batch delete.
+          const renderer = createDataBatchDeleteRenderer(cliCtx.outputMode);
+          await consumeStream(
+            dataBatchDelete(ctx, deps, {
+              modelIdOrName: modelIdOrName!,
+              filter,
+              dryRun: dryRun ?? false,
+            }),
+            renderer.handlers(),
+          );
+        } else {
+          const renderer = createDataDeleteRenderer(cliCtx.outputMode);
+
+          // Phase 1: Preview + Prompt (only in interactive log mode without --force).
+          if (cliCtx.outputMode === "log" && !options.force) {
+            let preview;
+            try {
+              preview = await dataDeletePreview(ctx, deps, {
+                modelIdOrName: modelIdOrName!,
+                dataName: dataName!,
+              });
+            } catch (error) {
+              throw new UserError(
+                error instanceof Error ? error.message : String(error),
+              );
+            }
+
+            const target = options.version !== undefined
+              ? `version ${options.version} of "${dataName}"`
+              : `${preview.versionsCount} version(s) of "${dataName}"`;
+            const confirmed = await promptConfirmation(
+              `About to delete ${target} from ${preview.modelName}. Proceed?`,
+            );
+            if (!confirmed) {
+              renderDataDeleteCancelled(cliCtx.outputMode);
+              return;
+            }
+          }
+
+          // Phase 2: Execute single delete.
+          await consumeStream(
+            dataDelete(ctx, deps, {
+              modelIdOrName: modelIdOrName!,
+              dataName: dataName!,
+              version: options.version,
+            }),
+            renderer.handlers(),
+          );
+        }
+
+        cliCtx.logger.debug("Data delete command completed");
+      } finally {
+        try {
+          await lockResult.flush();
+        } catch (releaseError) {
+          cliCtx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
     },
   );

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -30,7 +30,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
 export const dataRenameCommand = new Command()
@@ -88,19 +92,62 @@ export const dataRenameCommand = new Command()
         "rename",
       ]);
 
-      const { repoDir, datastoreResolver } = await requireInitializedRepo({
+      const {
+        repoDir,
+        repoContext,
+        datastoreResolver,
+        datastoreConfig,
+        syncService,
+      } = await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 
-      const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataRenameDeps(repoDir, datastoreResolver);
-      const renderer = createDataRenameRenderer(cliCtx.outputMode);
-      await consumeStream(
-        dataRename(ctx, deps, { modelIdOrName, oldName, newName }),
-        renderer.handlers(),
+      const preResult = await findDefinitionByIdOrName(
+        repoContext.definitionRepo,
+        modelIdOrName,
       );
+      if (!preResult) {
+        throw new UserError(`Model not found: ${modelIdOrName}`);
+      }
 
-      cliCtx.logger.debug("Data rename command completed");
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [
+          {
+            modelType: preResult.type.normalized,
+            modelId: preResult.definition.id,
+          },
+        ],
+        repoDir,
+        syncService,
+        repoContext.catalogStore,
+      );
+      if (lockResult.synced) repoContext.catalogStore.invalidate();
+
+      try {
+        const ctx = createLibSwampContext({ logger: cliCtx.logger });
+        const deps = createDataRenameDeps(repoDir, datastoreResolver);
+        const renderer = createDataRenameRenderer(cliCtx.outputMode);
+        await consumeStream(
+          dataRename(ctx, deps, { modelIdOrName, oldName, newName }),
+          renderer.handlers(),
+        );
+
+        cliCtx.logger.debug("Data rename command completed");
+      } finally {
+        try {
+          await lockResult.flush();
+        } catch (releaseError) {
+          cliCtx.logger.warn(
+            "Failed to release locks during cleanup: {error}",
+            {
+              error: releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+            },
+          );
+        }
+      }
     },
   );

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -34,7 +34,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import {
+  acquireModelLocks,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
+import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -73,75 +77,120 @@ export const modelDeleteCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["model", "delete"]);
     cliCtx.logger.debug`Deleting model: ${modelIdOrName}`;
 
-    const { repoDir, datastoreResolver } = await requireInitializedRepo({
+    const {
+      repoDir,
+      repoContext,
+      datastoreResolver,
+      datastoreConfig,
+      syncService,
+    } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createModelDeleteDeps(repoDir, datastoreResolver);
-    const force = !!options.force;
-
-    // Phase 1: Preview — gather what will be affected
-    let preview;
-    try {
-      preview = await modelDeletePreview(ctx, deps, {
-        modelIdOrName,
-        force,
-      });
-    } catch (error) {
-      if ("code" in (error as Record<string, unknown>)) {
-        throw new UserError((error as { message: string }).message);
-      }
-      throw error;
-    }
-
-    // Block if referenced by workflows
-    if (preview.referencingWorkflows.length > 0) {
-      throw new UserError(
-        `Model '${preview.name}' is referenced by workflow(s): ${
-          preview.referencingWorkflows.join(", ")
-        }. ` +
-          `Remove the model from these workflows before deleting.`,
-      );
-    }
-
-    // Block if data artifacts exist and no --force
-    if (preview.dataArtifactCount > 0 && !force) {
-      throw new UserError(
-        `Model '${preview.name}' has ${preview.dataArtifactCount} associated data artifact(s). ` +
-          `Delete the data first, or use --force to delete all.`,
-      );
-    }
-
-    // Phase 2: Prompt (CLI concern)
-    if (cliCtx.outputMode === "log" && !force) {
-      let deleteDetails = "";
-      if (preview.outputCount > 0) {
-        deleteDetails += ` ${preview.outputCount} output(s),`;
-      }
-      if (preview.dataArtifactCount > 0) {
-        deleteDetails += ` ${preview.dataArtifactCount} data artifact(s),`;
-      }
-      if (deleteDetails) {
-        deleteDetails = ` This will also delete:${deleteDetails.slice(0, -1)}.`;
-      }
-
-      const confirmed = await promptConfirmation(
-        `Delete model '${preview.name}' (${preview.id})?${deleteDetails}`,
-      );
-      if (!confirmed) {
-        renderModelDeleteCancelled(cliCtx.outputMode);
-        return;
-      }
-    }
-
-    // Phase 3: Execute mutation
-    const renderer = createModelDeleteRenderer(cliCtx.outputMode);
-    await consumeStream(
-      modelDelete(ctx, deps, { modelIdOrName, force }),
-      renderer.handlers(),
+    const preResult = await findDefinitionByIdOrName(
+      repoContext.definitionRepo,
+      modelIdOrName,
     );
+    if (!preResult) {
+      throw new UserError(`Model not found: ${modelIdOrName}`);
+    }
 
-    cliCtx.logger.debug("Model delete command completed");
+    const lockResult = await acquireModelLocks(
+      datastoreConfig,
+      [
+        {
+          modelType: preResult.type.normalized,
+          modelId: preResult.definition.id,
+        },
+      ],
+      repoDir,
+      syncService,
+      repoContext.catalogStore,
+    );
+    if (lockResult.synced) repoContext.catalogStore.invalidate();
+
+    try {
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const deps = createModelDeleteDeps(repoDir, datastoreResolver);
+      const force = !!options.force;
+
+      // Phase 1: Preview — gather what will be affected (under lock)
+      let preview;
+      try {
+        preview = await modelDeletePreview(ctx, deps, {
+          modelIdOrName,
+          force,
+        });
+      } catch (error) {
+        if ("code" in (error as Record<string, unknown>)) {
+          throw new UserError((error as { message: string }).message);
+        }
+        throw error;
+      }
+
+      // Block if referenced by workflows
+      if (preview.referencingWorkflows.length > 0) {
+        throw new UserError(
+          `Model '${preview.name}' is referenced by workflow(s): ${
+            preview.referencingWorkflows.join(", ")
+          }. ` +
+            `Remove the model from these workflows before deleting.`,
+        );
+      }
+
+      // Block if data artifacts exist and no --force
+      if (preview.dataArtifactCount > 0 && !force) {
+        throw new UserError(
+          `Model '${preview.name}' has ${preview.dataArtifactCount} associated data artifact(s). ` +
+            `Delete the data first, or use --force to delete all.`,
+        );
+      }
+
+      // Phase 2: Prompt (CLI concern)
+      if (cliCtx.outputMode === "log" && !force) {
+        let deleteDetails = "";
+        if (preview.outputCount > 0) {
+          deleteDetails += ` ${preview.outputCount} output(s),`;
+        }
+        if (preview.dataArtifactCount > 0) {
+          deleteDetails += ` ${preview.dataArtifactCount} data artifact(s),`;
+        }
+        if (deleteDetails) {
+          deleteDetails = ` This will also delete:${
+            deleteDetails.slice(0, -1)
+          }.`;
+        }
+
+        const confirmed = await promptConfirmation(
+          `Delete model '${preview.name}' (${preview.id})?${deleteDetails}`,
+        );
+        if (!confirmed) {
+          renderModelDeleteCancelled(cliCtx.outputMode);
+          return;
+        }
+      }
+
+      // Phase 3: Execute mutation
+      const renderer = createModelDeleteRenderer(cliCtx.outputMode);
+      await consumeStream(
+        modelDelete(ctx, deps, { modelIdOrName, force }),
+        renderer.handlers(),
+      );
+
+      cliCtx.logger.debug("Model delete command completed");
+    } finally {
+      try {
+        await lockResult.flush();
+      } catch (releaseError) {
+        cliCtx.logger.warn(
+          "Failed to release locks during cleanup: {error}",
+          {
+            error: releaseError instanceof Error
+              ? releaseError.message
+              : String(releaseError),
+          },
+        );
+      }
+    }
   });

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -891,16 +891,26 @@ export async function waitForPerModelLocks(
       return count;
     });
 
+  const maxWaitMs = resolveLockTimeoutMs();
   const held = await findModelLocks();
   if (held > 0) {
     logger.info(
       "Waiting for {count} per-model lock(s) to be released",
       { count: held },
     );
+    const waitStart = Date.now();
     while (true) {
       await new Promise((resolve) => setTimeout(resolve, 1_000));
       const remaining = await findModelLocks();
       if (remaining === 0) break;
+      const elapsed = Date.now() - waitStart;
+      if (elapsed >= maxWaitMs) {
+        throw new LockTimeoutError(
+          "per-model locks",
+          null,
+          elapsed,
+        );
+      }
     }
     logger.info`Per-model locks released`;
   }
@@ -1085,6 +1095,7 @@ export async function acquireModelLocks(
     const lock = customProvider && isCustomDatastoreConfig(config)
       ? customProvider.createLock(config.datastorePath, {
         lockKey: lockFileKey,
+        maxWaitMs: resolveLockTimeoutMs(),
       })
       : await createModelLock(config, modelType, modelId);
     // Unique coordinator key so parallel steps on the same model get
@@ -1184,8 +1195,12 @@ export async function acquireModelLocks(
     }
   }
 
+  Deno.env.set(SWAMP_LOCK_HOLDER_PID, String(Deno.pid));
+
   const flush = async () => {
     try {
+      Deno.env.delete(SWAMP_LOCK_HOLDER_PID);
+
       // For custom sync-capable datastores: push under global lock
       if (
         customSyncService && customProvider && isCustomDatastoreConfig(config)

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -42,6 +42,7 @@ import {
   type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../domain/datastore/datastore_config.ts";
+import { LockTimeoutError } from "../domain/datastore/distributed_lock.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
 import { UserError } from "../domain/errors.ts";
@@ -1071,6 +1072,31 @@ Deno.test(
 );
 
 Deno.test(
+  "waitForPerModelLocks - throws LockTimeoutError when locks are not released within timeout",
+  async () => {
+    const scanner = (): Promise<number> => Promise.resolve(1);
+
+    await assertRejects(
+      async () => {
+        // Force a short timeout via env var to keep the test fast
+        const prev = Deno.env.get("SWAMP_LOCK_TIMEOUT_MS");
+        Deno.env.set("SWAMP_LOCK_TIMEOUT_MS", "2000");
+        try {
+          await waitForPerModelLocks("/unused/datastore/path", scanner);
+        } finally {
+          if (prev !== undefined) {
+            Deno.env.set("SWAMP_LOCK_TIMEOUT_MS", prev);
+          } else {
+            Deno.env.delete("SWAMP_LOCK_TIMEOUT_MS");
+          }
+        }
+      },
+      LockTimeoutError,
+    );
+  },
+);
+
+Deno.test(
   "requireInitializedRepo - second drain catches a per-model lock that " +
     "appears between the first drain and the global lock acquisition " +
     "(regression for issue #234)",
@@ -1234,6 +1260,46 @@ Deno.test(
         elapsed >= 1_000,
         true,
         `expected to wait for lock to go stale without env var, elapsed=${elapsed}ms`,
+      );
+    });
+  },
+);
+
+// ============================================================================
+// acquireModelLocks — SWAMP_LOCK_HOLDER_PID Lifecycle Tests
+// ============================================================================
+
+Deno.test(
+  "acquireModelLocks - sets SWAMP_LOCK_HOLDER_PID on acquire and clears on flush",
+  async () => {
+    await withTempDir(async (dir) => {
+      await initializeRepo(dir);
+      const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+
+      assertEquals(
+        Deno.env.get(SWAMP_LOCK_HOLDER_PID),
+        undefined,
+        "env var should not be set before acquire",
+      );
+
+      const lockResult = await acquireModelLocks(
+        datastoreConfig,
+        [{ modelType: "test-type", modelId: "test-model" }],
+        dir,
+      );
+
+      assertEquals(
+        Deno.env.get(SWAMP_LOCK_HOLDER_PID),
+        String(Deno.pid),
+        "env var should be set to current PID after acquire",
+      );
+
+      await lockResult.flush();
+
+      assertEquals(
+        Deno.env.get(SWAMP_LOCK_HOLDER_PID),
+        undefined,
+        "env var should be cleared after flush",
       );
     });
   },


### PR DESCRIPTION
## Summary

- Add configurable timeout to `waitForPerModelLocks` (honors `SWAMP_LOCK_TIMEOUT_MS`, default 60s) — throws `LockTimeoutError` instead of spinning at 99% CPU forever
- Wire up `SWAMP_LOCK_HOLDER_PID` in `acquireModelLocks` (set on acquire, cleared on flush) so child processes skip their parent's per-model locks in the drain — the design doc documented this contract but it was never implemented
- Migrate `model delete`, `data delete`, and `data rename` from the structural lock path (`requireInitializedRepo` / global lock + symmetric drain) to per-model locking (`requireInitializedRepoUnlocked` + `acquireModelLocks`) — these commands operate on a single model and don't need the global lock that waits for ALL per-model locks
- Fix pre-existing bug where custom provider per-model locks in `acquireModelLocks` didn't pass `maxWaitMs`, ignoring `SWAMP_LOCK_TIMEOUT_MS`

Fixes swamp-club#863

## Test Plan

- Unit tests: `waitForPerModelLocks` timeout throws `LockTimeoutError`, `acquireModelLocks` sets/clears `SWAMP_LOCK_HOLDER_PID` (2 new tests, all 43 repo_context tests pass)
- Full test suite: 7978 tests pass including the 50-iteration concurrent write + delete integration test (no ENOTEMPTY)
- Manual S3/MinIO verification:
  - `data delete` and `model delete` work correctly with S3 per-model locking
  - Deleting model C while model B's lock is held completes in 1s (no global lock contention)
  - Deleting a locked model times out cleanly after `SWAMP_LOCK_TIMEOUT_MS` with actionable error message
  - `data rename` on S3 works with per-model locking (forwarding intact)
  - Concurrent write + delete on same model: delete waits for writer to finish, then deletes cleanly (no ENOTEMPTY)
  - Parent method spawning `swamp data gc --dry-run` subprocess: completes in 3s (parent lock skipped via `SWAMP_LOCK_HOLDER_PID`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)