### PR TITLE
feat(model): add code conformance review to issue lifecycle

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -47,6 +47,8 @@ repository root. If these files exist, they customize how each phase works:
   requirements
 - `agent-constraints/triage-conventions.md` — codebase exploration and bug
   reproduction
+- `agent-constraints/code-conformance-dimensions.md` — code vs plan review
+  criteria
 - `agent-constraints/implementation-conventions.md` — build, verify, and PR
   conventions
 
@@ -97,11 +99,17 @@ running the review first. Covers: challenging the plan across repo-specific
 dimensions, verifying against the codebase, recording findings, presenting to
 the human, and the iteration loop until approval.
 
-### Phase 4: Implementation
+### Phase 4: Implementation & Code Conformance Review
 
 Read [references/implementation.md](references/implementation.md) after plan
-approval. Covers: signalling implementation start, doing the work, verifying
-fixes against the reproduction, creating the PR, and completing the issue.
+approval. Covers: signalling implementation start and doing the work.
+
+After the code is written, read
+[references/code-conformance-review.md](references/code-conformance-review.md)
+**before creating a PR.** This adversarially compares the implemented code
+against the approved plan. Deviations are expected — they just need a documented
+justification. The `link_pr` method will fail until all deviations are
+justified.
 
 ### Phase 5: Contributor Notification
 
@@ -175,7 +183,7 @@ Use this table to determine what to do next:
 | `classified`     | Read [references/planning.md](references/planning.md)                      |
 | `plan_generated` | Read [references/adversarial-review.md](references/adversarial-review.md)  |
 | `approved`       | Read [references/implementation.md](references/implementation.md)          |
-| `implementing`   | Link a PR with `link_pr` or call `complete`                                |
+| `implementing`   | Run code conformance review, then link a PR with `link_pr`                 |
 | `pr_open`        | Wait 3 min, then check PR: `pr_merged` if merged, `pr_failed` if failed    |
 | `pr_failed`      | Fix the issue, then `link_pr` (new PR) or `implement` (major rework)       |
 | `releasing`      | Check release build: `ship` when done, or `complete` as fallback           |

--- a/.claude/skills/issue-lifecycle/references/code-conformance-review.md
+++ b/.claude/skills/issue-lifecycle/references/code-conformance-review.md
@@ -1,0 +1,136 @@
+# Code Conformance Review
+
+Read this after the implementation is complete and before creating a PR. The
+code conformance review compares what was actually built against the approved
+plan. Deviations are expected — implementations always discover things the plan
+didn't anticipate. The value is in documenting **why** the code differs.
+
+**This review is mandatory.** Both `link_pr` and `complete` will fail if no
+conformance review exists or if any deviations lack justifications.
+
+## Step 1: Retrieve the Approved Plan
+
+```
+swamp data get issue-<N> plan-main --json
+```
+
+Parse the plan to get the step list, DDD analysis, testing strategy, and
+potential challenges. Note the plan version — the conformance review must
+reference it.
+
+## Step 2: Review the Code Changes
+
+Diff the branch against main to see all changes:
+
+```
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+For each plan step, read the files listed in the step and verify the described
+change exists in the diff. Record the status:
+
+- `implemented` — the code matches what the plan described
+- `deviated` — the code does something different than planned
+- `partially_implemented` — some but not all of the step was done
+- `missing` — the step was not implemented at all
+- `added` — a change exists in the diff that no plan step covers
+
+## Step 3: Document Justifications Upfront
+
+For any step that is not `implemented`, provide a justification if you already
+understand why. Common justifications:
+
+- "Discovered existing helper function, skipped implementing from scratch"
+- "Step was unnecessary — the existing code already handled this case"
+- "Combined with step N for cleaner implementation"
+- "Approach changed after discovering X during implementation"
+- "Added defensive validation not anticipated in the plan"
+
+Steps where you don't know the justification should be left without one — the
+human will explain.
+
+## Step 4: Read Review Dimensions
+
+Read `agent-constraints/code-conformance-dimensions.md` at the repo root for the
+review criteria specific to this repository. If it does not exist, evaluate
+across the default dimensions: plan completeness, scope adherence, file
+coverage, DDD conformance, testing coverage, risk mitigation, and convention
+compliance.
+
+## Step 5: Record the Review
+
+Write the verification to an issue-scoped YAML file:
+
+```yaml
+# /tmp/conformance-issue-<N>.yaml
+steps:
+  - order: 1
+    status: implemented
+    description: "Added CompositeKey value object in src/domain/data/composite_key.ts"
+  - order: 2
+    status: deviated
+    description: "Used existing parseKey helper instead of creating new parser"
+    justification: "parseKey already handles all the cases step 2 described"
+  - order: 3
+    status: missing
+    description: "Integration test for cross-repo queries was not added"
+  - order: 100
+    status: added
+    description: "Fixed typo in adjacent error message"
+    justification: "One-character fix in the same file — trivial scope addition"
+```
+
+Then record it:
+
+```
+swamp model @swamp/issue-lifecycle method run code_conformance_review issue-<N> \
+  --input-file /tmp/conformance-issue-<N>.yaml
+```
+
+Use order numbers 100+ for `added` steps (unplanned changes) to distinguish them
+from plan steps.
+
+## Step 6: Present to the Human
+
+Show the verification results grouped by status:
+
+1. Missing steps (need explanation)
+2. Deviated steps without justification (need explanation)
+3. Deviated steps with justification (for awareness)
+4. Added steps without justification (need explanation)
+5. Implemented steps (for completeness)
+
+If there are unjustified deviations, say:
+
+> "The code conformance review found N deviation(s) from the plan that need
+> justification before we can create a PR. Here's what differs: ..."
+
+If all deviations are justified, say:
+
+> "Code conformance review complete — all deviations from the plan are
+> justified. Ready to create a PR when you are."
+
+## Step 7: Justify Remaining Deviations
+
+When the human explains a deviation, record the justification:
+
+```yaml
+# /tmp/justifications-issue-<N>.yaml
+justifications:
+  - order: 3
+    justification: "Decided to defer cross-repo integration tests to a follow-up issue"
+```
+
+```
+swamp model @swamp/issue-lifecycle method run justify_deviations issue-<N> \
+  --input-file /tmp/justifications-issue-<N>.yaml
+```
+
+Keep iterating until all deviations are justified. Only then can `link_pr`
+proceed.
+
+## Next Phase
+
+All deviations justified. Read [implementation.md](implementation.md) step 4
+onward to create and link the PR.

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -35,6 +35,13 @@ Report verification results to the human before creating the PR:
 - "Verified: reproduction scenario now passes" or
 - "Verification failed: <what still breaks>"
 
+## 3a. Code Conformance Review
+
+**Before creating a PR**, read
+[code-conformance-review.md](code-conformance-review.md) and run the code
+conformance review. This adversarially compares the implemented code against the
+approved plan. All deviations must be justified before `link_pr` will succeed.
+
 ## 4. Create a PR
 
 **Always ask the human before opening a PR.** Do not create the PR automatically

--- a/agent-constraints/code-conformance-dimensions.md
+++ b/agent-constraints/code-conformance-dimensions.md
@@ -1,0 +1,70 @@
+# Code Conformance Review Dimensions
+
+Compare the implemented code against the approved plan. The plan is a guide, not
+a rigid contract — deviations are expected. What matters is understanding and
+documenting **why** the code differs.
+
+For each plan step, verify whether the code implements it, then check for
+unplanned changes not covered by the plan.
+
+## Plan Completeness
+
+Was every planned step implemented? For each step in the plan:
+
+- Read the files listed in the step and verify the described change exists
+- If a step is missing or incomplete, record the status and ask why
+- A step may have been intentionally skipped — that's fine if justified
+
+## Scope Adherence
+
+Are there changes beyond what the plan specified?
+
+- Diff the branch against main and identify files changed that aren't in any plan
+  step
+- Unplanned changes are recorded as `added` steps with status `added`
+- Refactoring adjacent code, fixing unrelated bugs, or adding unplanned features
+  all count as scope deviations that need justification
+
+## File Coverage
+
+Were the planned files touched? Were unexpected files changed?
+
+- Cross-reference the plan's `files` arrays against the actual diff
+- Files in the plan but not in the diff suggest missing implementation
+- Files in the diff but not in the plan suggest unplanned changes
+
+## DDD Conformance
+
+Does the implementation match the plan's DDD analysis?
+
+- If the plan specified domain boundaries, verify the code respects them
+- New types, services, or repositories should align with the DDD analysis
+- Deviations from the DDD analysis should be justified — sometimes implementation
+  reveals that the planned domain model was wrong
+
+## Testing Coverage
+
+Does test coverage match the planned testing strategy?
+
+- Verify that the planned test types (unit, integration, end-to-end) were written
+- Check that edge cases identified in the plan have corresponding tests
+- Missing tests are a deviation that needs justification
+
+## Risk Mitigation
+
+Were the identified risks and challenges properly addressed?
+
+- For each risk listed in `potentialChallenges`, verify the implementation
+  handles it
+- For each step-level `risks` annotation, check that the risk was mitigated
+- Unaddressed risks need justification — sometimes a risk turned out to be
+  irrelevant
+
+## Convention Compliance
+
+Does the code follow project patterns from `design/*.md`?
+
+- Verify naming conventions, file placement, and architectural patterns
+- Check that CLAUDE.md conventions were followed (license headers, no `any`
+  types, etc.)
+- This dimension catches implementation quality issues the plan couldn't predict

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -76,6 +76,8 @@ export const TRANSITIONS: Record<string, Phase[]> = {
   implement: ["approved", "pr_failed"],
   adversarial_review: ["plan_generated"],
   resolve_findings: ["plan_generated"],
+  code_conformance_review: ["implementing", "pr_failed"],
+  justify_deviations: ["implementing", "pr_failed"],
   link_pr: ["implementing", "pr_open", "pr_failed"],
   pr_merged: ["pr_open"],
   pr_failed: ["pr_open"],
@@ -184,6 +186,47 @@ export const AdversarialReviewSchema = z.object({
 });
 
 export type AdversarialReviewData = z.infer<typeof AdversarialReviewSchema>;
+
+// ---------------------------------------------------------------------------
+// Code Conformance Review Schemas
+// ---------------------------------------------------------------------------
+
+export const StepVerificationSchema = z.object({
+  order: z.number().describe(
+    "Plan step order number, or a new number for unplanned changes",
+  ),
+  status: z.enum([
+    "implemented",
+    "deviated",
+    "partially_implemented",
+    "missing",
+    "added",
+  ]).describe(
+    "How the code relates to the plan step: implemented (matches plan), " +
+      "deviated (done differently), partially_implemented (incomplete), " +
+      "missing (not done), added (unplanned change not in the plan)",
+  ),
+  description: z.string().describe(
+    "What was found in the code for this step",
+  ),
+  justification: z.string().optional().describe(
+    "Why the code differs from the plan. Required when status is not 'implemented'.",
+  ),
+});
+
+export const CodeConformanceReviewSchema = z.object({
+  planVersion: z.number().describe(
+    "The approved plan version this review compares against",
+  ),
+  steps: z.array(StepVerificationSchema).describe(
+    "Per-step verification of plan conformance, plus entries for unplanned changes",
+  ),
+  reviewedAt: z.string(),
+});
+
+export type CodeConformanceReviewData = z.infer<
+  typeof CodeConformanceReviewSchema
+>;
 
 export const PullRequestSchema = z.object({
   url: z.string().min(1).describe(

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -20,6 +20,8 @@ import {
   type AdversarialReviewData,
   AdversarialReviewSchema,
   ClassificationSchema,
+  type CodeConformanceReviewData,
+  CodeConformanceReviewSchema,
   ContextSchema,
   FeedbackSchema,
   GlobalArgsSchema,
@@ -32,6 +34,7 @@ import {
   PullRequestSchema,
   type StateData,
   StateSchema,
+  StepVerificationSchema,
   TRANSITIONS,
 } from "./_lib/schemas.ts";
 import { createSwampClubClient, loadAuthFile } from "./_lib/swamp_club.ts";
@@ -70,7 +73,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.06.18.1",
+  version: "2026.06.29.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -142,6 +145,16 @@ export const model = {
         "No globalArguments changes.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.06.29.1",
+      description:
+        "Add code conformance review — adversarial comparison of implemented code " +
+        "against the approved plan. New codeConformanceReview resource, " +
+        "code_conformance_review and justify_deviations methods, " +
+        "code-conformance-clear check gating link_pr. " +
+        "No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
 
   resources: {
@@ -180,6 +193,15 @@ export const model = {
       schema: AdversarialReviewSchema,
       lifetime: "infinite" as const,
       garbageCollection: 20,
+    },
+    "codeConformanceReview": {
+      description:
+        "Adversarial comparison of implemented code against the approved plan. " +
+        "Records per-step verification status and justifications for deviations. " +
+        "Gates link_pr — all deviations must be justified before a PR can be linked.",
+      schema: CodeConformanceReviewSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 10,
     },
     "pullRequest": {
       description:
@@ -347,6 +369,78 @@ export const model = {
             ],
           };
         }
+        return { pass: true };
+      },
+    },
+
+    "code-conformance-clear": {
+      description:
+        "Ensures all code-vs-plan deviations are justified before a PR can be linked",
+      labels: ["policy"],
+      appliesTo: ["link_pr", "complete"],
+      execute: async (context: {
+        dataRepository: {
+          getContent: (
+            type: string,
+            modelId: string,
+            dataName: string,
+          ) => Promise<Uint8Array | null>;
+        };
+        modelType: string;
+        modelId: string;
+      }) => {
+        const planContent = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "plan-main",
+        );
+        if (!planContent) {
+          return { pass: false, errors: ["No plan exists."] };
+        }
+        const plan = JSON.parse(
+          new TextDecoder().decode(planContent),
+        ) as PlanData;
+
+        const reviewContent = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          "codeConformanceReview-main",
+        );
+        if (!reviewContent) {
+          return {
+            pass: false,
+            errors: [
+              "No code conformance review exists. Run 'code_conformance_review' before linking a PR.",
+            ],
+          };
+        }
+        const review = JSON.parse(
+          new TextDecoder().decode(reviewContent),
+        ) as CodeConformanceReviewData;
+
+        if (review.planVersion !== plan.version) {
+          return {
+            pass: false,
+            errors: [
+              `Code conformance review is for plan v${review.planVersion} but current plan is v${plan.version}. Re-run 'code_conformance_review'.`,
+            ],
+          };
+        }
+
+        const unjustified = review.steps.filter(
+          (s) => s.status !== "implemented" && !s.justification,
+        );
+
+        if (unjustified.length > 0) {
+          const orders = unjustified.map((s) => `step ${s.order}`).join(", ");
+          return {
+            pass: false,
+            errors: [
+              `${unjustified.length} unjustified deviation(s): ${orders}. Run 'justify_deviations' to explain why the code differs from the plan.`,
+            ],
+          };
+        }
+
         return { pass: true };
       },
     },
@@ -1119,6 +1213,213 @@ export const model = {
             resolved,
             remaining,
             resolutions: args.resolutions,
+          },
+          isVerbose: false,
+        });
+
+        return { dataHandles: handles };
+      },
+    },
+
+    code_conformance_review: {
+      description:
+        "Record an adversarial comparison of implemented code against the approved plan. " +
+        "Each plan step is verified as implemented, deviated, partially implemented, or missing. " +
+        "Unplanned changes are recorded as 'added' steps. Deviations are expected — " +
+        "they just need a justification explaining why the code differs.",
+      arguments: z.object({
+        steps: z.array(StepVerificationSchema).describe(
+          "Per-step verification of plan conformance, plus entries for unplanned changes",
+        ),
+      }),
+      execute: async (
+        args: {
+          steps: {
+            order: number;
+            status:
+              | "implemented"
+              | "deviated"
+              | "partially_implemented"
+              | "missing"
+              | "added";
+            description: string;
+            justification?: string;
+          }[];
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const handles = [];
+
+        const plan = await context.readResource!("plan-main") as
+          | PlanData
+          | null;
+        if (!plan) {
+          throw new Error("No plan exists. Run 'plan' first.");
+        }
+
+        handles.push(
+          await context.writeResource(
+            "codeConformanceReview",
+            "codeConformanceReview-main",
+            {
+              planVersion: plan.version,
+              steps: args.steps,
+              reviewedAt: new Date().toISOString(),
+            },
+          ),
+        );
+
+        const implemented =
+          args.steps.filter((s) => s.status === "implemented").length;
+        const deviated = args.steps.filter((s) => s.status !== "implemented")
+          .length;
+        const unjustified = args.steps.filter(
+          (s) => s.status !== "implemented" && !s.justification,
+        ).length;
+
+        context.logger.info(
+          "Code conformance review for plan v{planVersion}: {implemented} implemented, {deviated} deviated ({unjustified} unjustified)",
+          {
+            planVersion: plan.version,
+            implemented,
+            deviated,
+            unjustified,
+          },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "code_conformance_review",
+          targetStatus: "in_progress",
+          summary:
+            `Code conformance review (plan v${plan.version}): ${implemented} implemented, ${deviated} deviated (${unjustified} unjustified)`,
+          emoji: "\u{1F50D}",
+          payload: {
+            planVersion: plan.version,
+            steps: args.steps,
+            implemented,
+            deviated,
+            unjustified,
+          },
+          isVerbose: true,
+        });
+
+        return { dataHandles: handles };
+      },
+    },
+
+    justify_deviations: {
+      description:
+        "Add justifications to code conformance review steps that deviate from the plan. " +
+        "Deviations are expected — this method records why the code differs.",
+      arguments: z.object({
+        justifications: z.array(z.object({
+          order: z.number().describe(
+            "Step order number to justify",
+          ),
+          justification: z.string().describe(
+            "Why the code differs from the plan for this step",
+          ),
+        })),
+      }),
+      execute: async (
+        args: {
+          justifications: { order: number; justification: string }[];
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+          readResource: (
+            instanceName: string,
+            version?: number,
+          ) => Promise<Record<string, unknown> | null>;
+        },
+      ) => {
+        const handles = [];
+
+        const current = await context.readResource!(
+          "codeConformanceReview-main",
+        ) as CodeConformanceReviewData | null;
+        if (!current) {
+          throw new Error(
+            "No code conformance review exists. Run 'code_conformance_review' first.",
+          );
+        }
+
+        const justificationMap = new Map(
+          args.justifications.map((j) => [j.order, j.justification]),
+        );
+
+        const updatedSteps = current.steps.map((s) => {
+          const justification = justificationMap.get(s.order);
+          if (justification) {
+            return { ...s, justification };
+          }
+          return s;
+        });
+
+        handles.push(
+          await context.writeResource(
+            "codeConformanceReview",
+            "codeConformanceReview-main",
+            {
+              planVersion: current.planVersion,
+              steps: updatedSteps,
+              reviewedAt: new Date().toISOString(),
+            },
+          ),
+        );
+
+        const justified = args.justifications.length;
+        const remaining = updatedSteps.filter(
+          (s) => s.status !== "implemented" && !s.justification,
+        ).length;
+
+        context.logger.info(
+          "Justified {justified} deviation(s), {remaining} unjustified deviation(s) remain",
+          { justified, remaining },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "deviations_justified",
+          targetStatus: "in_progress",
+          summary:
+            `${justified} deviation(s) justified, ${remaining} unjustified remain`,
+          emoji: "\u{2705}",
+          payload: {
+            justified,
+            remaining,
+            justifications: args.justifications,
           },
           isVerbose: false,
         });

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.06.18.1", () => {
-  assertEquals(model.version, "2026.06.18.1");
+Deno.test("model: version bumped to 2026.06.29.1", () => {
+  assertEquals(model.version, "2026.06.29.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -1052,4 +1052,333 @@ Deno.test("model: exposes notify method definition", () => {
 
 Deno.test("model: exposes skip_notify method definition", () => {
   assertEquals("skip_notify" in model.methods, true);
+});
+
+// ---------------------------------------------------------------------------
+// code_conformance_review
+// ---------------------------------------------------------------------------
+
+Deno.test("code_conformance_review: writes codeConformanceReview-main with plan version and steps", async () => {
+  const { context, writes, restore } = await buildTestContext(42, {
+    resources: {
+      "plan-main": {
+        version: 3,
+        summary: "Fix the bug",
+        dddAnalysis: "n/a",
+        steps: [{ order: 1, description: "Step 1", files: ["a.ts"] }],
+        testingStrategy: "unit",
+        potentialChallenges: [],
+        feedbackIncorporated: [],
+        generatedAt: "2026-06-29T00:00:00.000Z",
+      },
+    },
+  });
+  try {
+    await model.methods.code_conformance_review.execute(
+      {
+        steps: [
+          {
+            order: 1,
+            status: "implemented" as const,
+            description: "Step 1 done",
+          },
+          {
+            order: 2,
+            status: "deviated" as const,
+            description: "Did it differently",
+            justification: "Existing helper already covered this",
+          },
+        ],
+      },
+      context,
+    );
+
+    const reviewWrite = writes.find(
+      (w) => w.specName === "codeConformanceReview",
+    );
+    assertEquals(reviewWrite !== undefined, true);
+    assertEquals(reviewWrite!.instanceName, "codeConformanceReview-main");
+    assertEquals(reviewWrite!.data.planVersion, 3);
+    assertEquals(
+      (reviewWrite!.data.steps as unknown[]).length,
+      2,
+    );
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("code_conformance_review: throws when no plan exists", async () => {
+  const { context, restore } = await buildTestContext(42);
+  try {
+    await assertRejects(
+      () =>
+        model.methods.code_conformance_review.execute(
+          { steps: [] },
+          context,
+        ),
+      Error,
+      "No plan exists",
+    );
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// justify_deviations
+// ---------------------------------------------------------------------------
+
+Deno.test("justify_deviations: adds justification to unjustified steps", async () => {
+  const { context, writes, restore } = await buildTestContext(42, {
+    resources: {
+      "codeConformanceReview-main": {
+        planVersion: 1,
+        steps: [
+          {
+            order: 1,
+            status: "implemented",
+            description: "Done",
+          },
+          {
+            order: 2,
+            status: "missing",
+            description: "Not done",
+          },
+        ],
+        reviewedAt: "2026-06-29T00:00:00.000Z",
+      },
+    },
+  });
+  try {
+    await model.methods.justify_deviations.execute(
+      {
+        justifications: [
+          {
+            order: 2,
+            justification: "Deferred to follow-up issue #100",
+          },
+        ],
+      },
+      context,
+    );
+
+    const reviewWrite = writes.find(
+      (w) => w.specName === "codeConformanceReview",
+    );
+    assertEquals(reviewWrite !== undefined, true);
+    const steps = reviewWrite!.data.steps as {
+      order: number;
+      justification?: string;
+    }[];
+    const step2 = steps.find((s) => s.order === 2);
+    assertEquals(step2!.justification, "Deferred to follow-up issue #100");
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("justify_deviations: throws when no conformance review exists", async () => {
+  const { context, restore } = await buildTestContext(42);
+  try {
+    await assertRejects(
+      () =>
+        model.methods.justify_deviations.execute(
+          { justifications: [{ order: 1, justification: "reason" }] },
+          context,
+        ),
+      Error,
+      "No code conformance review exists",
+    );
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// code-conformance-clear check
+// ---------------------------------------------------------------------------
+
+Deno.test("code-conformance-clear: passes when all deviations are justified", async () => {
+  const checkContext = {
+    methodName: "link_pr",
+    dataRepository: {
+      getContent: (
+        _type: string,
+        _modelId: string,
+        dataName: string,
+      ) => {
+        if (dataName === "plan-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(JSON.stringify({ version: 1 })),
+          );
+        }
+        if (dataName === "codeConformanceReview-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(
+              JSON.stringify({
+                planVersion: 1,
+                steps: [
+                  { order: 1, status: "implemented", description: "Done" },
+                  {
+                    order: 2,
+                    status: "deviated",
+                    description: "Different",
+                    justification: "Better approach",
+                  },
+                ],
+              }),
+            ),
+          );
+        }
+        return Promise.resolve(null);
+      },
+    },
+    modelType: "@swamp/issue-lifecycle",
+    modelId: "issue-42",
+  };
+
+  const result = await model.checks["code-conformance-clear"].execute(
+    checkContext,
+  );
+  assertEquals(result.pass, true);
+});
+
+Deno.test("code-conformance-clear: rejects when no conformance review exists", async () => {
+  const checkContext = {
+    methodName: "link_pr",
+    dataRepository: {
+      getContent: (
+        _type: string,
+        _modelId: string,
+        dataName: string,
+      ) => {
+        if (dataName === "plan-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(JSON.stringify({ version: 1 })),
+          );
+        }
+        return Promise.resolve(null);
+      },
+    },
+    modelType: "@swamp/issue-lifecycle",
+    modelId: "issue-42",
+  };
+
+  const result = await model.checks["code-conformance-clear"].execute(
+    checkContext,
+  );
+  assertEquals(result.pass, false);
+  assertStringIncludes(result.errors![0], "No code conformance review exists");
+});
+
+Deno.test("code-conformance-clear: rejects when review is stale (wrong plan version)", async () => {
+  const checkContext = {
+    methodName: "link_pr",
+    dataRepository: {
+      getContent: (
+        _type: string,
+        _modelId: string,
+        dataName: string,
+      ) => {
+        if (dataName === "plan-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(JSON.stringify({ version: 2 })),
+          );
+        }
+        if (dataName === "codeConformanceReview-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(
+              JSON.stringify({
+                planVersion: 1,
+                steps: [],
+              }),
+            ),
+          );
+        }
+        return Promise.resolve(null);
+      },
+    },
+    modelType: "@swamp/issue-lifecycle",
+    modelId: "issue-42",
+  };
+
+  const result = await model.checks["code-conformance-clear"].execute(
+    checkContext,
+  );
+  assertEquals(result.pass, false);
+  assertStringIncludes(result.errors![0], "plan v1");
+  assertStringIncludes(result.errors![0], "plan is v2");
+});
+
+Deno.test("code-conformance-clear: rejects when unjustified deviations remain", async () => {
+  const checkContext = {
+    methodName: "link_pr",
+    dataRepository: {
+      getContent: (
+        _type: string,
+        _modelId: string,
+        dataName: string,
+      ) => {
+        if (dataName === "plan-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(JSON.stringify({ version: 1 })),
+          );
+        }
+        if (dataName === "codeConformanceReview-main") {
+          return Promise.resolve(
+            new TextEncoder().encode(
+              JSON.stringify({
+                planVersion: 1,
+                steps: [
+                  { order: 1, status: "implemented", description: "Done" },
+                  {
+                    order: 2,
+                    status: "missing",
+                    description: "Not done",
+                  },
+                  {
+                    order: 3,
+                    status: "deviated",
+                    description: "Changed",
+                    justification: "Better way",
+                  },
+                ],
+              }),
+            ),
+          );
+        }
+        return Promise.resolve(null);
+      },
+    },
+    modelType: "@swamp/issue-lifecycle",
+    modelId: "issue-42",
+  };
+
+  const result = await model.checks["code-conformance-clear"].execute(
+    checkContext,
+  );
+  assertEquals(result.pass, false);
+  assertStringIncludes(result.errors![0], "1 unjustified");
+  assertStringIncludes(result.errors![0], "step 2");
+});
+
+// ---------------------------------------------------------------------------
+// Model registration smoke tests (code conformance)
+// ---------------------------------------------------------------------------
+
+Deno.test("model: exposes codeConformanceReview resource definition", () => {
+  assertEquals("codeConformanceReview" in model.resources, true);
+});
+
+Deno.test("model: exposes code_conformance_review method definition", () => {
+  assertEquals("code_conformance_review" in model.methods, true);
+});
+
+Deno.test("model: exposes justify_deviations method definition", () => {
+  assertEquals("justify_deviations" in model.methods, true);
+});
+
+Deno.test("model: exposes code-conformance-clear check definition", () => {
+  assertEquals("code-conformance-clear" in model.checks, true);
 });


### PR DESCRIPTION
## Summary

- Adds a mandatory code conformance review step to the issue lifecycle that adversarially compares implemented code against the approved plan before a PR can be created
- Deviations from the plan are expected — they just need a documented justification explaining why the code differs
- Both `link_pr` and `complete` are gated by the new `code-conformance-clear` check, so there is no escape hatch
- Both new methods (`code_conformance_review` and `justify_deviations`) post structured lifecycle entries to swamp-club for full audit trail

## Test Plan

- [x] 12 new tests covering methods, check (pass/fail/stale/unjustified), and model registration
- [x] All 56 model tests pass
- [x] `deno check`, `deno lint`, `deno fmt --check` all clean
- [x] Pre-existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)