### PR TITLE
fix(extensions): resolve version constraints in dependency install loop (swamp-club#866)

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -788,8 +788,9 @@ export class ExtensionApiClient {
       throw new UserError(serverMessage);
     }
 
+    const endpoint = res.url ? ` [${res.url}]` : "";
     throw new UserError(
-      `Extension API error (HTTP ${res.status}): ${serverMessage}`,
+      `Extension API error (HTTP ${res.status}): ${serverMessage}${endpoint}`,
     );
   }
 

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -904,3 +904,22 @@ Deno.test("ExtensionApiClient.downloadArchive does NOT send identity headers to 
     await s3Server.shutdown();
   }
 });
+
+Deno.test("ExtensionApiClient.checkResponse includes URL in error message", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response(JSON.stringify({ error: "Invalid path" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const error = await assertRejects(
+    () => client.getChecksum("@hivemq/asdlc-factory", "2026.06.27.1"),
+    UserError,
+  );
+  assertStringIncludes(error.message, "Extension API error (HTTP 400)");
+  assertStringIncludes(error.message, "Invalid path");
+  assertStringIncludes(error.message, "/api/v1/extensions/");
+  await server.shutdown();
+});

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -55,6 +55,7 @@ import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 const MAX_DEPENDENCY_DEPTH = 10;
+const VERSION_CONSTRAINT_PREFIX = /^[><=^~!]/;
 
 /** Parsed extension reference from CLI argument. */
 export interface ExtensionRef {
@@ -303,6 +304,14 @@ export function validateExtensionName(name: string): void {
       `Invalid extension name: "${name}". Must match @collective/name pattern (lowercase, alphanumeric, hyphens, underscores, additional /segments allowed).`,
     );
   }
+}
+
+/**
+ * Returns true if a version string is a semver constraint rather than
+ * an exact version. Constraints start with >=, <=, >, <, ^, ~, !, or =.
+ */
+export function isVersionConstraint(version: string): boolean {
+  return VERSION_CONSTRAINT_PREFIX.test(version);
 }
 
 /**
@@ -1130,7 +1139,8 @@ export async function installExtension(
     const dependencyResults: InstallResult[] = [];
     if (manifest.dependencies.length > 0) {
       for (const dep of manifest.dependencies) {
-        if (ctx.alreadyPulled.has(dep)) {
+        const depRef = parseExtensionRef(dep);
+        if (ctx.alreadyPulled.has(depRef.name)) {
           continue;
         }
 
@@ -1138,14 +1148,42 @@ export async function installExtension(
         // made — writeEntry updates the cache on every commit, and child
         // installs in this loop reuse the same repository instance, so
         // their writes are visible too.
-        const isInstalled = ctx.lockfileRepository.getEntry(dep) !== null;
+        const isInstalled =
+          ctx.lockfileRepository.getEntry(depRef.name) !== null;
 
         if (!isInstalled) {
-          const depRef = parseExtensionRef(dep);
-          const depResult = await installExtension(depRef, {
+          // Strip version constraints (>=, ^, ~, etc.) — pass version: null
+          // so installExtension resolves to the registry's latest version.
+          // When the dep has no stable version, resolve from beta/rc channels
+          // so beta-only extensions can satisfy dependency requirements.
+          const hasConstraint = depRef.version != null &&
+            isVersionConstraint(depRef.version);
+          let depVersion: string | null = hasConstraint ? null : depRef.version;
+          let depChannel: string | undefined = undefined;
+
+          if (depVersion === null) {
+            const depInfo = await ctx.getExtension(depRef.name);
+            if (depInfo) {
+              if (depInfo.latestVersion) {
+                depVersion = depInfo.latestVersion;
+              } else if (depInfo.latestBeta) {
+                depVersion = depInfo.latestBeta;
+                depChannel = "beta";
+              } else if (depInfo.latestRc) {
+                depVersion = depInfo.latestRc;
+                depChannel = "rc";
+              }
+            }
+          }
+
+          const resolvedRef: ExtensionRef = {
+            name: depRef.name,
+            version: depVersion,
+          };
+          const depResult = await installExtension(resolvedRef, {
             ...ctx,
             depth: ctx.depth + 1,
-            channel: undefined,
+            channel: depChannel,
           });
           if (depResult) {
             dependencyResults.push(depResult);

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -28,6 +28,7 @@ import {
   type ExtensionRef,
   type InstallContext,
   type InstallResult,
+  isVersionConstraint,
   parseExtensionRef,
   validateExtensionName,
 } from "./pull.ts";
@@ -362,5 +363,93 @@ Deno.test(
     }
 
     await Deno.remove(deps.repoDir, { recursive: true }).catch(() => {});
+  },
+);
+
+// ===== isVersionConstraint =====
+
+Deno.test("isVersionConstraint: detects >= prefix", () => {
+  assertEquals(isVersionConstraint(">=2026.04.24"), true);
+});
+
+Deno.test("isVersionConstraint: detects ^ prefix", () => {
+  assertEquals(isVersionConstraint("^1.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: detects ~ prefix", () => {
+  assertEquals(isVersionConstraint("~1.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: detects > prefix", () => {
+  assertEquals(isVersionConstraint(">1.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: detects < prefix", () => {
+  assertEquals(isVersionConstraint("<2.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: detects <= prefix", () => {
+  assertEquals(isVersionConstraint("<=2.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: detects = prefix", () => {
+  assertEquals(isVersionConstraint("=1.0.0"), true);
+});
+
+Deno.test("isVersionConstraint: returns false for exact version", () => {
+  assertEquals(isVersionConstraint("2026.04.24.1782575578"), false);
+});
+
+Deno.test("isVersionConstraint: returns false for simple semver", () => {
+  assertEquals(isVersionConstraint("1.0.0"), false);
+});
+
+// ===== Dependency version constraint resolution (swamp-club#866) =====
+
+Deno.test(
+  "dependency version constraint resolution: constraint stripped, name used for lookup",
+  () => {
+    // Verifies the logic applied in installExtension's dependency loop:
+    // 1. Parse the dep string to extract name (for lookups) and version
+    // 2. Detect version constraints and null them out so installExtension
+    //    resolves to extInfo.latestVersion
+    const depRef = parseExtensionRef("@bixu/launchd@>=2026.04.24");
+    assertEquals(depRef.name, "@bixu/launchd");
+    assertEquals(depRef.version, ">=2026.04.24");
+    assertEquals(isVersionConstraint(depRef.version!), true);
+
+    const resolvedRef: ExtensionRef = {
+      name: depRef.name,
+      version: isVersionConstraint(depRef.version!) ? null : depRef.version,
+    };
+    assertEquals(resolvedRef.name, "@bixu/launchd");
+    assertEquals(resolvedRef.version, null);
+
+    // Exact versions pass through unchanged
+    const exactRef = parseExtensionRef("@hivemq/asdlc@2026.06.27.1782598415");
+    assertEquals(isVersionConstraint(exactRef.version!), false);
+    const resolvedExact: ExtensionRef = {
+      name: exactRef.name,
+      version: isVersionConstraint(exactRef.version!) ? null : exactRef.version,
+    };
+    assertEquals(resolvedExact.version, "2026.06.27.1782598415");
+  },
+);
+
+Deno.test(
+  "parseExtensionRef: parses dependency with version constraint",
+  () => {
+    const ref = parseExtensionRef("@hivemq/asdlc@>=2026.06.27.1782598415");
+    assertEquals(ref.name, "@hivemq/asdlc");
+    assertEquals(ref.version, ">=2026.06.27.1782598415");
+  },
+);
+
+Deno.test(
+  "parseExtensionRef: parses dependency with caret constraint",
+  () => {
+    const ref = parseExtensionRef("@swamp/factory@^2026.06.16.1");
+    assertEquals(ref.name, "@swamp/factory");
+    assertEquals(ref.version, "^2026.06.16.1");
   },
 );

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -856,6 +856,7 @@ export {
   type InstallContext,
   installExtension,
   type InstallResult,
+  isVersionConstraint,
   parseExtensionRef,
   resolveServerUrl,
   validateExtensionName,


### PR DESCRIPTION
## Summary

- Fix `installExtension`'s dependency loop to parse dep names before lockfile/alreadyPulled lookups — the raw dep string (e.g. `@bixu/launchd@>=2026.04.24`) never matched lockfile entries keyed by just the name
- Strip version constraint prefixes (`>=`, `^`, `~`, `>`, `<`, `=`, `!`) and resolve dependencies to the registry's latest version instead of passing constraints as literal version strings to HTTP endpoints
- Fall back to beta/rc channels when a dependency has no stable release, so beta-only extensions can satisfy dependency requirements
- Include the request URL in `ExtensionApiClient` error messages for easier diagnosis of registry errors

## Test Plan

- [x] Reproduced the original bug: `swamp extension pull @hivemq/asdlc-factory --channel beta --force` → HTTP 400 "Invalid path"
- [x] Verified the fix: same command now resolves all 3 dependencies (`@bixu/launchd`, `@hivemq/asdlc`, `@swamp/software-factory`) and exits 0
- [x] 29 pull_test.ts tests pass (12 new: version constraint detection, dependency resolution, parseExtensionRef with constraints)
- [x] 37 extension_api_client_test.ts tests pass (1 new: URL inclusion in error messages)
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [x] Binary compiled and E2E verified against live registry

Fixes swamp-club#866

🤖 Generated with [Claude Code](https://claude.com/claude-code)