### PR TITLE
fix(serve): bypass catalog backfill for admin grant materialization (swamp-club#882)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -61,7 +61,6 @@ import {
   type PolicyReloadMode,
   PolicySnapshotLoader,
 } from "../../domain/access/policy_snapshot_loader.ts";
-import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createAdminGrantStore,
@@ -609,12 +608,7 @@ export const serveCommand = new Command()
     }
 
     const serveEventBus = new EventBus();
-    const dataQueryService = new DataQueryService(
-      repoContext.catalogStore,
-      repoContext.unifiedDataRepo,
-    );
     const adminGrantStore = createAdminGrantStore(
-      dataQueryService,
       repoContext.definitionRepo,
       repoContext.unifiedDataRepo,
     );

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -18,8 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
-import type { DataQueryService } from "../data/data_query_service.ts";
-import type { DataRecord } from "../data/data_record.ts";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -32,6 +30,7 @@ import type { AuthMode } from "./serve_auth_config.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import { Definition } from "../definitions/definition.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
+import type { ModelType } from "../models/model_type.ts";
 import { createResourceWriter } from "../models/data_writer.ts";
 
 const logger = getLogger(["swamp", "admin-materializer"]);
@@ -87,28 +86,31 @@ function buildAdminGrant(adminPrincipal: string): Grant {
 }
 
 export function createAdminGrantStore(
-  dataQueryService: DataQueryService,
   definitionRepo: DefinitionRepository,
   dataRepo: UnifiedDataRepository,
 ): AdminGrantStore {
   return {
     async queryConfigGrants() {
-      const records = await dataQueryService.query(
-        `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
-        { loadAttributes: true },
-      );
+      const grantDataItems = await dataRepo.findAllForType(GRANT_MODEL_TYPE);
 
       const configGrants = new Map<
         string,
         { grant: Grant; modelId: string }
       >();
-      for (const record of records) {
-        const dataRecord = record as DataRecord;
-        const parsed = GrantSchema.safeParse(dataRecord.attributes);
+      for (const { data, modelType, modelId } of grantDataItems) {
+        const attrs = await readAttributes(
+          dataRepo,
+          modelType,
+          modelId,
+          data.name,
+        );
+        if (!attrs) continue;
+        const parsed = GrantSchema.safeParse(attrs);
         if (parsed.success && parsed.data.source === "config") {
-          configGrants.set(dataRecord.modelName, {
+          const modelName = data.tags["modelName"] ?? "";
+          configGrants.set(modelName, {
             grant: parsed.data,
-            modelId: dataRecord.modelId,
+            modelId,
           });
         }
       }
@@ -149,6 +151,24 @@ export function createAdminGrantStore(
       );
     },
   };
+}
+
+async function readAttributes(
+  dataRepo: UnifiedDataRepository,
+  modelType: ModelType,
+  modelId: string,
+  dataName: string,
+): Promise<Record<string, unknown> | null> {
+  const content = await dataRepo.getContent(modelType, modelId, dataName);
+  if (!content) return null;
+  try {
+    const text = new TextDecoder().decode(content);
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch (error) {
+    logger
+      .warn`Skipping ${modelType.normalized}/${modelId}/${dataName}: failed to parse JSON content: ${error}`;
+    return null;
+  }
 }
 
 export async function materializeAdmins(


### PR DESCRIPTION
## Summary

- `AdminGrantStore.queryConfigGrants()` was calling `DataQueryService.query()`,
  which triggers a full catalog backfill when the catalog isn't populated. On
  large repos (~2300 models, 1.9GB data), this backfill exhausts V8's 4GB heap
  limit during `swamp serve` startup.
- Changed `queryConfigGrants()` to read grants directly from the data repository
  via `findAllForType(GRANT_MODEL_TYPE)` + `getContent()`, bypassing the catalog
  entirely — same pattern as the #841 fix for `PolicySnapshotLoader`.
- Removed the unused local `DataQueryService` construction from `serve.ts` — the
  admin materializer was the only consumer.

**Note:** Runtime queries through `DataQueryService` (e.g. the generic
`data.query` WebSocket endpoint) can still trigger the catalog backfill on large
repos. A follow-up issue will address making the backfill itself scalable.

Closes swamp-club#882

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>

## Test Plan

- All 7977 existing tests pass (0 failures)
- Compiled binary starts `swamp serve --auth-mode token --admins 'user:testadmin'`
  cleanly — no catalog backfill triggered, admin grant created in <1s
- Idempotent restart: existing grants detected, no materialization needed
- `--auth-mode none` path still skips materialization entirely
- `deno check` / `deno lint` / `deno fmt` all pass