### PR TITLE
fix(serve): bypass catalog backfill for type-scoped serve queries and add GC breathing room (swamp-club#884)

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -73,6 +73,7 @@ export class DataQueryService {
   private redactor?: SecretRedactor;
   private foreignContentFetcher?: ForeignContentFetcher;
   private readonly foreignContentCache = new Map<string, Uint8Array | null>();
+  private backfillPromise: Promise<void> | null = null;
 
   constructor(
     private readonly catalogStore: CatalogStore,
@@ -114,7 +115,17 @@ export class DataQueryService {
     options?: DataQueryOptions,
   ): Promise<DataRecord[] | unknown[]> {
     if (!this.catalogStore.isPopulated()) {
-      await this.backfillAsync();
+      if (this.backfillPromise) {
+        await this.backfillPromise;
+      } else {
+        const promise = this.backfillAsync();
+        this.backfillPromise = promise;
+        try {
+          await promise;
+        } finally {
+          this.backfillPromise = null;
+        }
+      }
     }
     const results = this.executeQuery(predicate, options);
 
@@ -309,47 +320,72 @@ export class DataQueryService {
 
   private async backfillAsync(): Promise<void> {
     const allData = await this.dataRepo.findAllGlobal();
-    // Gather every (row, isLatest) we want to write, THEN commit them to
-    // SQLite in one batch. Historical metadata.yaml reads are async and
-    // slow; interleaving them with individual SQLite writes would hold the
-    // database in a partially-populated state across many fsyncs and, on
-    // large repos, produces "database is locked" under contention.
+
+    // Group by model type so we can yield to the event loop between types,
+    // giving V8 GC a chance to reclaim intermediate YAML/Zod allocations.
+    const byType = new Map<
+      string,
+      Array<{ data: Data; modelType: ModelType; modelId: string }>
+    >();
+    for (const item of allData) {
+      const key = item.modelType.normalized;
+      let group = byType.get(key);
+      if (!group) {
+        group = [];
+        byType.set(key, group);
+      }
+      group.push(item);
+    }
+
+    // Gather every row we want to write, THEN commit them to SQLite in one
+    // batch. Historical metadata.yaml reads are async and slow; interleaving
+    // them with individual SQLite writes would hold the database in a
+    // partially-populated state across many fsyncs and, on large repos,
+    // produces "database is locked" under contention.
     const rows: CatalogRow[] = [];
-    for (const { data: latest, modelType, modelId } of allData) {
-      if (latest.isRenamed || latest.isDeleted) continue;
-      const versions = await this.dataRepo.listVersions(
-        modelType,
-        modelId,
-        latest.name,
-      );
-      if (versions.length === 0) continue;
-      const maxVersion = Math.max(...versions);
-      for (const version of versions) {
-        try {
-          const data = version === latest.version
-            ? latest
-            : await this.dataRepo.findByName(
-              modelType,
-              modelId,
-              latest.name,
-              version,
+    for (const [, items] of byType) {
+      for (const { data: latest, modelType, modelId } of items) {
+        if (latest.isRenamed || latest.isDeleted) continue;
+        const versions = await this.dataRepo.listVersions(
+          modelType,
+          modelId,
+          latest.name,
+        );
+        if (versions.length === 0) continue;
+        const maxVersion = Math.max(...versions);
+        for (const version of versions) {
+          try {
+            const data = version === latest.version
+              ? latest
+              : await this.dataRepo.findByName(
+                modelType,
+                modelId,
+                latest.name,
+                version,
+              );
+            if (!data) continue;
+            if (data.isRenamed || data.isDeleted) continue;
+            rows.push(
+              this.toCatalogRow(
+                data,
+                modelType,
+                modelId,
+                version === maxVersion,
+              ),
             );
-          if (!data) continue;
-          if (data.isRenamed || data.isDeleted) continue;
-          rows.push(
-            this.toCatalogRow(data, modelType, modelId, version === maxVersion),
-          );
-        } catch (error) {
-          // Skip individual corrupted versions rather than abort the entire
-          // backfill — a half-populated catalog left behind would force
-          // every subsequent query to retry from scratch.
-          logger
-            .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
-            String(error)
-          }`;
+          } catch (error) {
+            logger
+              .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
+              String(error)
+            }`;
+          }
         }
       }
+      // Yield to the event loop between model types so V8 can run a major
+      // GC cycle and reclaim intermediate objects from metadata parsing.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
+
     const ns = this.dataRepo.namespace;
     if (ns && ns.length > 0) {
       this.catalogStore.bulkReplaceNamespace(ns, rows);
@@ -361,36 +397,58 @@ export class DataQueryService {
 
   private backfillSync(): void {
     const allData = this.dataRepo.findAllGlobalSync();
+
+    const byType = new Map<
+      string,
+      Array<{ data: Data; modelType: ModelType; modelId: string }>
+    >();
+    for (const item of allData) {
+      const key = item.modelType.normalized;
+      let group = byType.get(key);
+      if (!group) {
+        group = [];
+        byType.set(key, group);
+      }
+      group.push(item);
+    }
+
     const rows: CatalogRow[] = [];
-    for (const { data: latest, modelType, modelId } of allData) {
-      if (latest.isRenamed || latest.isDeleted) continue;
-      const versions = this.dataRepo.listVersionsSync(
-        modelType,
-        modelId,
-        latest.name,
-      );
-      if (versions.length === 0) continue;
-      const maxVersion = Math.max(...versions);
-      for (const version of versions) {
-        try {
-          const data = version === latest.version
-            ? latest
-            : this.dataRepo.findByNameSync(
-              modelType,
-              modelId,
-              latest.name,
-              version,
+    for (const [, items] of byType) {
+      for (const { data: latest, modelType, modelId } of items) {
+        if (latest.isRenamed || latest.isDeleted) continue;
+        const versions = this.dataRepo.listVersionsSync(
+          modelType,
+          modelId,
+          latest.name,
+        );
+        if (versions.length === 0) continue;
+        const maxVersion = Math.max(...versions);
+        for (const version of versions) {
+          try {
+            const data = version === latest.version
+              ? latest
+              : this.dataRepo.findByNameSync(
+                modelType,
+                modelId,
+                latest.name,
+                version,
+              );
+            if (!data) continue;
+            if (data.isRenamed || data.isDeleted) continue;
+            rows.push(
+              this.toCatalogRow(
+                data,
+                modelType,
+                modelId,
+                version === maxVersion,
+              ),
             );
-          if (!data) continue;
-          if (data.isRenamed || data.isDeleted) continue;
-          rows.push(
-            this.toCatalogRow(data, modelType, modelId, version === maxVersion),
-          );
-        } catch (error) {
-          logger
-            .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
-            String(error)
-          }`;
+          } catch (error) {
+            logger
+              .debug`Skipping ${modelType.normalized}/${modelId}/${latest.name}@${version} during backfill: ${
+              String(error)
+            }`;
+          }
         }
       }
     }

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -116,7 +116,6 @@ import {
 } from "../domain/models/access/group_model.ts";
 import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
 import { ModelType } from "../domain/models/model_type.ts";
-import type { DataRecord } from "../domain/data/data_record.ts";
 import {
   parsePrincipal,
   type Principal,
@@ -1100,19 +1099,33 @@ async function handleAccessGrantList(
 
   try {
     await modelRegistry.ensureLoaded();
-    const records = await ctx.repoContext.dataQueryService.query(
-      `modelType == "${GRANT_MODEL_TYPE.normalized}"`,
-      { loadAttributes: true },
+    const dataItems = await ctx.repoContext.unifiedDataRepo.findAllForType(
+      GRANT_MODEL_TYPE,
     );
 
     let results: { grant: Grant; instanceName: string }[] = [];
-    for (const record of records) {
-      const dataRecord = record as DataRecord;
-      const parsed = GrantSchema.safeParse(dataRecord.attributes);
+    for (const { data, modelType, modelId } of dataItems) {
+      if (data.isRenamed || data.isDeleted) continue;
+      const content = await ctx.repoContext.unifiedDataRepo.getContent(
+        modelType,
+        modelId,
+        data.name,
+      );
+      if (!content) continue;
+      let attrs: Record<string, unknown>;
+      try {
+        attrs = JSON.parse(new TextDecoder().decode(content)) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        continue;
+      }
+      const parsed = GrantSchema.safeParse(attrs);
       if (parsed.success && parsed.data.state === "active") {
         results.push({
           grant: parsed.data,
-          instanceName: dataRecord.modelName ?? "",
+          instanceName: data.tags["modelName"] ?? "",
         });
       }
     }
@@ -1163,16 +1176,29 @@ async function handleAccessGroupList(
 
   try {
     await modelRegistry.ensureLoaded();
-    const records = await ctx.repoContext.dataQueryService.query(
-      `modelType == "${GROUP_MODEL_TYPE.normalized}"`,
-      { loadAttributes: true },
+    const dataItems = await ctx.repoContext.unifiedDataRepo.findAllForType(
+      GROUP_MODEL_TYPE,
     );
 
     let groups: Group[] = [];
-    for (const record of records) {
-      const parsed = GroupSchema.safeParse(
-        (record as DataRecord).attributes,
+    for (const { data, modelType, modelId } of dataItems) {
+      if (data.isRenamed || data.isDeleted) continue;
+      const content = await ctx.repoContext.unifiedDataRepo.getContent(
+        modelType,
+        modelId,
+        data.name,
       );
+      if (!content) continue;
+      let attrs: Record<string, unknown>;
+      try {
+        attrs = JSON.parse(new TextDecoder().decode(content)) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        continue;
+      }
+      const parsed = GroupSchema.safeParse(attrs);
       if (parsed.success) {
         groups.push(parsed.data);
       }

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -615,15 +615,24 @@ export class WorkerGateway {
    */
   async #defaultReadTokenExpiresAt(tokenName: string): Promise<string | null> {
     try {
-      const records = await this.#options.repoContext.dataQueryService.query(
-        `modelType == "${ENROLLMENT_TOKEN_MODEL_TYPE.normalized}" && ` +
-          `name == "${TOKEN_DATA_NAME}"`,
-        { loadAttributes: true },
-      );
-      for (const record of records) {
-        const parsed = EnrollmentTokenSchema.safeParse(
-          (record as { attributes?: unknown }).attributes,
-        );
+      const dataItems = await this.#options.repoContext.unifiedDataRepo
+        .findAllForType(ENROLLMENT_TOKEN_MODEL_TYPE);
+      for (const { data, modelType, modelId } of dataItems) {
+        if (data.isRenamed || data.isDeleted) continue;
+        if (data.name !== TOKEN_DATA_NAME) continue;
+        const content = await this.#options.repoContext.unifiedDataRepo
+          .getContent(modelType, modelId, data.name);
+        if (!content) continue;
+        let attrs: Record<string, unknown>;
+        try {
+          attrs = JSON.parse(new TextDecoder().decode(content)) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          continue;
+        }
+        const parsed = EnrollmentTokenSchema.safeParse(attrs);
         if (parsed.success && parsed.data.name === tokenName) {
           return parsed.data.expiresAt;
         }


### PR DESCRIPTION
## Summary

- **Bypass catalog backfill for 3 type-scoped serve endpoints** — grant list (`connection.ts:1103`), group list (`connection.ts:1166`), and worker token expiry (`worker_gateway.ts:618`) now use `findAllForType()` + `getContent()` directly instead of `DataQueryService.query()`, which triggered a full catalog backfill on large repos. Same pattern as #882's admin_materializer fix, with explicit `isDeleted`/`isRenamed` filtering to match catalog behavior.
- **Add backfill mutex** — `DataQueryService` gains a `#backfillPromise` field so concurrent `query()` callers coalesce on a single backfill instead of racing.
- **Add GC breathing room to backfill** — `backfillAsync()` groups items by model type and yields to the event loop between types via `setTimeout(resolve, 0)`, giving V8 GC safepoints to reclaim intermediate YAML parse and Zod validation objects that cause OOM on large repos (~2300 models, 1.9GB data).

## Test Plan

- All 8004 tests pass (including 29 DataQueryService, 117 connection, 17 worker gateway)
- `deno check`, `deno lint`, `deno fmt --check` all clean
- Manual verification on large repo needed to confirm bounded memory during backfill

Closes swamp-club#884

🤖 Generated with [Claude Code](https://claude.com/claude-code)