### PR TITLE
fix(datastore): exclude bundle directories from datastore sync (swamp-club#869)

### DIFF
--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -33,7 +33,13 @@
  * Note: definitions, workflows, and vault configs now live in top-level
  * directories (models/, workflows/, vaults/) and are no longer .swamp/ subdirs.
  */
-export const ALWAYS_LOCAL_SUBDIRS = ["secrets"] as const;
+export const ALWAYS_LOCAL_SUBDIRS = [
+  "secrets",
+  "bundles",
+  "vault-bundles",
+  "driver-bundles",
+  "report-bundles",
+] as const;
 
 /**
  * Default subdirectories that belong to the datastore tier.
@@ -57,11 +63,14 @@ export const DEFAULT_DATASTORE_SUBDIRS = [
   "files",
 ] as const;
 
-// Note: "datastore-bundles" is intentionally excluded from the datastore tier.
-// The datastore loader runs during bootstrap BEFORE the DatastorePathResolver
-// exists, so datastore extension bundles must always remain in local .swamp/.
-// Including it here causes the setup migration to delete .swamp/datastore-bundles/
-// after copying to cache, breaking subsequent extension loading.
+// All bundle directories are always-local: bundles are derived artifacts
+// rebuildable from source (local extensions) or re-extractable from archives
+// (pulled extensions). Syncing them via the datastore allows a stale remote
+// copy to shadow a freshly rebuilt local bundle (swamp-club#869).
+//
+// "datastore-bundles" has an additional constraint: the datastore loader runs
+// during bootstrap BEFORE the DatastorePathResolver exists, so it must remain
+// in local .swamp/ regardless.
 
 /**
  * Default timeout (milliseconds) for a single direction of datastore sync.

--- a/src/domain/datastore/datastore_config_test.ts
+++ b/src/domain/datastore/datastore_config_test.ts
@@ -166,6 +166,23 @@ Deno.test("getDatastoreDirectories: excludes secrets from default list", () => {
   );
 });
 
+Deno.test("getDatastoreDirectories: excludes bundle directories from default list", () => {
+  const dirs = getDatastoreDirectories(filesystemConfig);
+  for (
+    const bundleDir of [
+      "bundles",
+      "vault-bundles",
+      "driver-bundles",
+      "report-bundles",
+    ]
+  ) {
+    assertFalse(
+      dirs.includes(bundleDir),
+      `${bundleDir} must not appear in datastore directories`,
+    );
+  }
+});
+
 Deno.test("getDatastoreDirectories: excludes secrets even when explicitly listed in config", () => {
   const config: FilesystemDatastoreConfig = {
     ...filesystemConfig,
@@ -175,6 +192,22 @@ Deno.test("getDatastoreDirectories: excludes secrets even when explicitly listed
   assertFalse(
     dirs.includes("secrets"),
     "secrets must be filtered even when explicitly configured",
+  );
+});
+
+Deno.test("getDatastoreDirectories: excludes bundles even when explicitly listed in config", () => {
+  const config: FilesystemDatastoreConfig = {
+    ...filesystemConfig,
+    directories: ["data", "bundles", "vault-bundles", "outputs"],
+  };
+  const dirs = getDatastoreDirectories(config);
+  assertFalse(
+    dirs.includes("bundles"),
+    "bundles must be filtered even when explicitly configured",
+  );
+  assertFalse(
+    dirs.includes("vault-bundles"),
+    "vault-bundles must be filtered even when explicitly configured",
   );
 });
 
@@ -206,6 +239,41 @@ Deno.test("ALWAYS_LOCAL_SUBDIRS: contains secrets", () => {
     (ALWAYS_LOCAL_SUBDIRS as readonly string[]).includes("secrets"),
     true,
   );
+});
+
+Deno.test("ALWAYS_LOCAL_SUBDIRS: contains bundle directories", () => {
+  const always = ALWAYS_LOCAL_SUBDIRS as readonly string[];
+  for (
+    const bundleDir of [
+      "bundles",
+      "vault-bundles",
+      "driver-bundles",
+      "report-bundles",
+    ]
+  ) {
+    assertEquals(
+      always.includes(bundleDir),
+      true,
+      `${bundleDir} must be in ALWAYS_LOCAL_SUBDIRS`,
+    );
+  }
+});
+
+Deno.test("isAlwaysLocal: returns true for bundle directories", () => {
+  for (
+    const bundleDir of [
+      "bundles",
+      "vault-bundles",
+      "driver-bundles",
+      "report-bundles",
+    ]
+  ) {
+    assertEquals(
+      isAlwaysLocal(bundleDir),
+      true,
+      `${bundleDir} must be always-local`,
+    );
+  }
 });
 
 Deno.test("DEFAULT_DATASTORE_SUBDIRS: still lists secrets for backwards compatibility", () => {

--- a/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
+++ b/src/infrastructure/persistence/default_datastore_path_resolver_test.ts
@@ -195,21 +195,21 @@ Deno.test("DefaultDatastorePathResolver - config returns the stored config", () 
   assertEquals(resolver.config(), config);
 });
 
-Deno.test("DefaultDatastorePathResolver - bundle subdirs are recognized as datastore subdirs", () => {
+Deno.test("DefaultDatastorePathResolver - bundle subdirs are always-local", () => {
   const config: DatastoreConfig = {
     type: "filesystem",
     path: "/data/store",
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
-  assertEquals(resolver.isDatastoreSubdir("bundles"), true);
-  assertEquals(resolver.isDatastoreSubdir("vault-bundles"), true);
-  assertEquals(resolver.isDatastoreSubdir("driver-bundles"), true);
-  // datastore-bundles intentionally excluded — bootstrap ordering
+  // All bundle dirs are always-local — derived artifacts, not synced (swamp-club#869)
+  assertEquals(resolver.isDatastoreSubdir("bundles"), false);
+  assertEquals(resolver.isDatastoreSubdir("vault-bundles"), false);
+  assertEquals(resolver.isDatastoreSubdir("driver-bundles"), false);
   assertEquals(resolver.isDatastoreSubdir("datastore-bundles"), false);
-  assertEquals(resolver.isDatastoreSubdir("report-bundles"), true);
+  assertEquals(resolver.isDatastoreSubdir("report-bundles"), false);
 });
 
-Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to S3 cache", () => {
+Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to local .swamp", () => {
   const config: DatastoreConfig = {
     type: "s3",
     config: { bucket: "my-bucket" },
@@ -218,26 +218,26 @@ Deno.test("DefaultDatastorePathResolver - resolvePath routes bundles to S3 cache
   };
   const resolver = new DefaultDatastorePathResolver("/repo", config);
 
+  // Bundles are always-local — never routed to S3 cache (swamp-club#869)
   assertPathEquals(
     resolver.resolvePath("bundles", "2e4ea9ae", "aws/logs.js"),
-    "/home/user/.swamp/repos/abc/bundles/2e4ea9ae/aws/logs.js",
+    "/repo/.swamp/bundles/2e4ea9ae/aws/logs.js",
   );
   assertPathEquals(
     resolver.resolvePath("vault-bundles", "ff00aa11", "sm.js"),
-    "/home/user/.swamp/repos/abc/vault-bundles/ff00aa11/sm.js",
+    "/repo/.swamp/vault-bundles/ff00aa11/sm.js",
   );
   assertPathEquals(
     resolver.resolvePath("driver-bundles", "bb22cc33", "driver.js"),
-    "/home/user/.swamp/repos/abc/driver-bundles/bb22cc33/driver.js",
+    "/repo/.swamp/driver-bundles/bb22cc33/driver.js",
   );
-  // datastore-bundles stays local (bootstrap ordering — excluded from datastore tier)
   assertPathEquals(
     resolver.resolvePath("datastore-bundles", "dd44ee55", "ds.js"),
     "/repo/.swamp/datastore-bundles/dd44ee55/ds.js",
   );
   assertPathEquals(
     resolver.resolvePath("report-bundles", "66778899", "report.js"),
-    "/home/user/.swamp/repos/abc/report-bundles/66778899/report.js",
+    "/repo/.swamp/report-bundles/66778899/report.js",
   );
 });
 


### PR DESCRIPTION
## Summary

- Add bundle directories (`bundles`, `vault-bundles`, `driver-bundles`, `report-bundles`) to `ALWAYS_LOCAL_SUBDIRS` so they are never routed to the datastore cache or synced to S3
- Bundles are derived artifacts rebuildable from source (local extensions) or re-extractable from archives (pulled extensions) — syncing them allowed a stale remote copy to shadow a freshly rebuilt local bundle
- Follows the existing pattern used for `secrets`

Fixes swamp-club#869

## Test Plan

- Added tests verifying bundle dirs are excluded from `getDatastoreDirectories()` output
- Added tests verifying bundle dirs are filtered even when explicitly listed in user config
- Added tests verifying `ALWAYS_LOCAL_SUBDIRS` contains all bundle dirs and `isAlwaysLocal()` returns true for them
- Updated `DefaultDatastorePathResolver` tests to verify bundles route to local `.swamp/` instead of S3 cache
- All existing datastore domain tests pass (80/80)
- All path resolver tests pass (20/20)
- Full `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)