### PR TITLE
fix(lock): migrate definition-only commands off global lock to eliminate concurrent contention (swamp-club#885)

### DIFF
--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -31,7 +31,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { parseKeyValueInputs } from "../input_parser.ts";
 import { modelValidateCommand } from "./model_validate.ts";
 import { modelMethodCommand } from "./model_method_run.ts";
@@ -71,7 +71,7 @@ export const modelCreateCommand = new Command()
     cliCtx.logger
       .debug`Creating model definition: type=${typeArg}, name=${name}`;
 
-    const { repoDir } = await requireInitializedRepo({
+    const { repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/model_edit.ts
+++ b/src/cli/commands/model_edit.ts
@@ -33,7 +33,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
@@ -55,7 +55,7 @@ export const modelEditCommand = new Command()
     const cliCtx = createContext(options as GlobalOptions, ["model", "edit"]);
     cliCtx.logger.debug`Editing model: ${modelIdOrName ?? "(interactive)"}`;
 
-    const { repoContext, repoDir } = await requireInitializedRepo({
+    const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -30,7 +30,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -81,7 +81,7 @@ export const vaultCreateCommand = new Command()
         "vault",
         "create",
       ]);
-      const { repoDir } = await requireInitializedRepo({
+      const { repoDir } = await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -34,7 +34,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
@@ -93,7 +93,7 @@ Both the source and target vaults must be different types.`,
     ]);
     cliCtx.logger.debug`Migrating vault: ${vaultName}`;
 
-    const { repoDir } = await requireInitializedRepo({
+    const { repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/workflow_approve.ts
+++ b/src/cli/commands/workflow_approve.ts
@@ -23,7 +23,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
 import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
@@ -61,7 +61,7 @@ export const workflowApproveCommand = new Command()
         "approve",
       ]);
 
-      const { repoContext } = await requireInitializedRepo({
+      const { repoContext } = await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });

--- a/src/cli/commands/workflow_create.ts
+++ b/src/cli/commands/workflow_create.ts
@@ -30,7 +30,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -50,7 +50,7 @@ export const workflowCreateCommand = new Command()
     ]);
     cliCtx.logger.debug`Creating workflow: name=${name}`;
 
-    const { repoDir } = await requireInitializedRepo({
+    const { repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/workflow_edit.ts
+++ b/src/cli/commands/workflow_edit.ts
@@ -33,7 +33,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { readStdin } from "../../infrastructure/io/stdin_reader.ts";
 
@@ -59,7 +59,7 @@ export const workflowEditCommand = new Command()
     cliCtx.logger
       .debug`Editing workflow: ${workflowIdOrName ?? "(interactive)"}`;
 
-    const { repoContext, repoDir } = await requireInitializedRepo({
+    const { repoContext, repoDir } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -23,7 +23,7 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepo } from "../repo_context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
@@ -60,7 +60,7 @@ export const workflowRejectCommand = new Command()
         "reject",
       ]);
 
-      const { repoContext } = await requireInitializedRepo({
+      const { repoContext } = await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -575,9 +575,11 @@ async function loadUserModels(
       "models",
     );
 
-    // Set type loader on the registry for on-demand loading
-    modelRegistry.setTypeLoader(async (type) => {
-      await loader.loadSingleType(type);
+    // Set type loader on the registry for on-demand loading.
+    // The lazy entry carries bundle/source paths from the catalog index,
+    // avoiding a redundant SQLite read inside loadSingleType.
+    modelRegistry.setTypeLoader(async (type, lazyEntry) => {
+      await loader.loadSingleType(type, lazyEntry);
     });
 
     // Build the index: reads catalog + mtime scan for freshness.

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -497,14 +497,27 @@ export class ExtensionLoader {
     return fullResult;
   }
 
-  async loadSingleType(typeNormalized: string): Promise<void> {
+  async loadSingleType(
+    typeNormalized: string,
+    lazyEntry?: {
+      bundlePath: string;
+      sourcePath: string;
+      sourceFingerprint?: string;
+    },
+  ): Promise<void> {
     const catalog = this.requireRepository("loadSingleType").getCatalogStore();
     installZodGlobal();
 
-    const entry = catalog.findByType(
-      typeNormalized,
-      this.adapter.catalogKinds[0],
-    );
+    // Use the in-memory lazy entry when available — avoids a SQLite read
+    // that contends under concurrent process startups.
+    const entry = lazyEntry
+      ? {
+        type_normalized: typeNormalized,
+        bundle_path: lazyEntry.bundlePath,
+        source_path: lazyEntry.sourcePath,
+        source_fingerprint: lazyEntry.sourceFingerprint,
+      }
+      : catalog.findByType(typeNormalized, this.adapter.catalogKinds[0]);
     if (!entry) {
       throw new Error(
         `No catalog entry for ${this.adapter.kind} type: ${typeNormalized}`,

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -462,6 +462,7 @@ export const modelKindAdapter: KindAdapter = {
       bundlePath: entry.bundle_path,
       sourcePath: entry.source_path,
       version: entry.version,
+      sourceFingerprint: entry.source_fingerprint,
     });
   },
 

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -724,6 +724,7 @@ export interface LazyModelEntry {
   bundlePath: string;
   sourcePath: string;
   version: string;
+  sourceFingerprint?: string;
 }
 
 /**
@@ -747,7 +748,7 @@ export class ModelRegistry {
   private extensionsLoaded = false;
   private typeLoadPromises = new Map<string, Promise<void>>();
   private typeLoader:
-    | ((type: string) => Promise<void>)
+    | ((type: string, lazyEntry?: LazyModelEntry) => Promise<void>)
     | null = null;
 
   /**
@@ -763,7 +764,9 @@ export class ModelRegistry {
    * Configures the per-type loader for on-demand bundle imports.
    * Called by {@link ensureTypeLoaded} to import a single bundle.
    */
-  setTypeLoader(loader: (type: string) => Promise<void>): void {
+  setTypeLoader(
+    loader: (type: string, lazyEntry?: LazyModelEntry) => Promise<void>,
+  ): void {
     this.typeLoader = loader;
   }
 
@@ -850,7 +853,8 @@ export class ModelRegistry {
     let promise = this.typeLoadPromises.get(key);
     if (!promise) {
       const loader = this.typeLoader;
-      promise = loader(key).then(() => {
+      const lazyEntry = this.lazyTypes.get(key);
+      promise = loader(key, lazyEntry ?? undefined).then(() => {
         // promoteFromLazy() already deleted the lazy entry during
         // the loader call, so no lazyTypes cleanup needed here.
         // Prune the resolved promise — it's no longer needed since

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -116,16 +116,22 @@ export class CatalogStore {
 
   /**
    * Initializes WAL mode and schema with retry logic.
-   * PRAGMA journal_mode=WAL requires an exclusive lock to switch modes.
-   * When multiple processes open the database simultaneously, the SQLite
-   * busy handler may not cover the mode switch reliably, so we retry at
-   * the application level with exponential backoff.
+   *
+   * `PRAGMA journal_mode=WAL` requires an **exclusive** lock to switch
+   * modes. WAL mode persists on disk, so we skip the mode switch when
+   * the database is already in WAL mode — avoiding the exclusive lock
+   * that serializes concurrent process startups.
    */
   private initializeWithRetry(): void {
     const MAX_RETRIES = 5;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        this.db.exec("PRAGMA journal_mode=WAL");
+        const modeRow = this.db.prepare("PRAGMA journal_mode").get() as
+          | { journal_mode: string }
+          | undefined;
+        if (modeRow?.journal_mode !== "wal") {
+          this.db.exec("PRAGMA journal_mode=WAL");
+        }
 
         // Ensure catalog_meta exists so migrateIfNeeded() can read schema_version.
         // Must run before createSchema() because v2-only indexes fail on a v1 table.

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -170,16 +170,28 @@ export class ExtensionCatalogStore {
 
   /**
    * Initializes WAL mode and schema with retry logic.
-   * PRAGMA journal_mode=WAL requires an exclusive lock to switch modes.
-   * When multiple processes open the database simultaneously, the SQLite
-   * busy handler may not cover the mode switch reliably, so we retry at
-   * the application level with exponential backoff.
+   *
+   * `PRAGMA journal_mode=WAL` requires an **exclusive** lock to switch
+   * modes. When N concurrent processes open the database simultaneously
+   * (e.g. 10 concurrent `model create` during startup reconciliation),
+   * every process contending on the exclusive lock is the primary
+   * catalog-contention bottleneck.
+   *
+   * WAL mode persists on disk — once a database has been switched to WAL,
+   * re-opening it does not require another mode switch. We read the
+   * current journal mode first (a shared-lock operation) and only issue
+   * the mode switch when the database is not yet in WAL mode.
    */
   private initializeWithRetry(): void {
     const MAX_RETRIES = 5;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        this.db.exec("PRAGMA journal_mode=WAL");
+        const modeRow = this.db.prepare("PRAGMA journal_mode").get() as
+          | { journal_mode: string }
+          | undefined;
+        if (modeRow?.journal_mode !== "wal") {
+          this.db.exec("PRAGMA journal_mode=WAL");
+        }
         this.createSchema();
         this.migrateSchema();
         return;


### PR DESCRIPTION
## Summary

- Migrates 8 CLI commands from `requireInitializedRepo` (global lock + symmetric drain) to `requireInitializedRepoUnlocked` — these commands only write YAML definition files and don't need the global lock that protects the datastore data path
- Skips the `PRAGMA journal_mode=WAL` exclusive lock in both catalog stores when the database is already in WAL mode
- Passes in-memory lazy entry through to `loadSingleType` to avoid a redundant `findByType` SQLite read during type resolution

**Commands migrated:** `model create`, `model edit`, `workflow create`, `workflow edit`, `workflow approve`, `workflow reject`, `vault create`, `vault migrate`

**Commands left on global lock (correctly):** `datastore compact`, `datastore setup`, `datastore sync`, `data gc` — these perform structural/cross-model operations that require the global lock.

**Benchmark** (5 concurrent `model create` on filesystem datastore):

| Concurrent creates | Before | After | Speedup |
|---|---|---|---|
| N=3 | 6.7s | 2.3s | 2.9× |
| N=5 | 17.5s | 2.3s | 7.6× |
| N=10 | 36.1s | 2.7s | 13.4× |

Before times scale linearly (serialized by global lock). After times stay flat (~2.3s regardless of N).

Addresses the concurrency/locking section of swamp-club#885 — the engine/harness pattern filed by @bixu from HiveMQ's agentic software-delivery harness.

## Test Plan

- [x] `deno check` — all 14 changed files type-check clean
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno run test` — 8003 passed
- [x] `deno run compile` — binary compiles
- [x] Manual: N=3,5,10 concurrent `model create` benchmarked before/after
- [x] Verified `model create` only writes YAML to `models/` (not `.swamp/data/`)
- [x] Audited all 15 commands using `requireInitializedRepo` — only migrated commands that write to definition directories, not datastore data

🤖 Generated with [Claude Code](https://claude.com/claude-code)