### PR TITLE
fix(serve): write admin grant definitions to .swamp/auto-definitions/ (swamp-club#886)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -65,7 +65,16 @@ import { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createAdminGrantStore,
   materializeAdmins,
+  migrateGrantDefinitions,
 } from "../../domain/access/admin_materializer.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
+import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
+import { join } from "@std/path";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -608,8 +617,36 @@ export const serveCommand = new Command()
     }
 
     const serveEventBus = new EventBus();
+
+    const modelsDir = join(resolvedRepoDir, "models");
+    const autoDefDir = swampPath(
+      resolvedRepoDir,
+      SWAMP_SUBDIRS.autoDefinitions,
+    );
+    const grantTypeDir = GRANT_MODEL_TYPE.toDirectoryPath();
+    const grantSourceDir = join(modelsDir, grantTypeDir);
+    const migrationResult = await migrateGrantDefinitions(
+      grantSourceDir,
+      join(autoDefDir, grantTypeDir),
+    );
+    if (migrationResult.moved > 0) {
+      logger
+        .info`Migrated ${migrationResult.moved} grant definition(s) from models/ to .swamp/auto-definitions/`;
+      await cleanupEmptyParentDirs(
+        join(grantSourceDir, "_placeholder"),
+        modelsDir,
+      );
+    }
+
+    const autoDefRepo = new YamlDefinitionRepository(
+      resolvedRepoDir,
+      undefined,
+      autoDefDir,
+      false,
+    );
     const adminGrantStore = createAdminGrantStore(
       repoContext.definitionRepo,
+      autoDefRepo,
       repoContext.unifiedDataRepo,
     );
     const materializeResult = await materializeAdmins(

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -18,6 +18,8 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -86,7 +88,8 @@ function buildAdminGrant(adminPrincipal: string): Grant {
 }
 
 export function createAdminGrantStore(
-  definitionRepo: DefinitionRepository,
+  readRepo: DefinitionRepository,
+  writeRepo: DefinitionRepository,
   dataRepo: UnifiedDataRepository,
 ): AdminGrantStore {
   return {
@@ -118,7 +121,7 @@ export function createAdminGrantStore(
     },
 
     async ensureDefinition(instanceName: string) {
-      let def = await definitionRepo.findByName(
+      let def = await readRepo.findByName(
         GRANT_MODEL_TYPE,
         instanceName,
       );
@@ -127,7 +130,7 @@ export function createAdminGrantStore(
           type: GRANT_MODEL_TYPE.normalized,
           name: instanceName,
         });
-        await definitionRepo.save(GRANT_MODEL_TYPE, def);
+        await writeRepo.save(GRANT_MODEL_TYPE, def);
       }
       return def.id;
     },
@@ -230,6 +233,55 @@ export async function materializeAdmins(
     const revokedSubject = subjectToString(grant.subject);
     result.revoked++;
     logger.info`Revoked admin grant for ${revokedSubject}`;
+  }
+
+  return result;
+}
+
+export interface MigrateGrantDefinitionsResult {
+  moved: number;
+  skipped: number;
+}
+
+export async function migrateGrantDefinitions(
+  sourceDir: string,
+  destDir: string,
+): Promise<MigrateGrantDefinitionsResult> {
+  const result: MigrateGrantDefinitionsResult = { moved: 0, skipped: 0 };
+
+  let entries: Deno.DirEntry[];
+  try {
+    entries = [];
+    for await (const entry of Deno.readDir(sourceDir)) {
+      entries.push(entry);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return result;
+    }
+    throw error;
+  }
+
+  await ensureDir(destDir);
+
+  for (const entry of entries) {
+    if (!entry.isFile || !entry.name.endsWith(".yaml")) continue;
+
+    const srcPath = join(sourceDir, entry.name);
+    const dstPath = join(destDir, entry.name);
+
+    try {
+      await Deno.stat(dstPath);
+      result.skipped++;
+      logger
+        .debug`Skipping grant definition migration for ${entry.name}: already exists at destination`;
+    } catch (statError) {
+      if (!(statError instanceof Deno.errors.NotFound)) throw statError;
+
+      await Deno.rename(srcPath, dstPath);
+      result.moved++;
+      logger.info`Migrated grant definition ${entry.name} to auto-definitions`;
+    }
   }
 
   return result;

--- a/src/domain/access/admin_materializer_test.ts
+++ b/src/domain/access/admin_materializer_test.ts
@@ -18,6 +18,8 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import type { Grant } from "../models/access/grant_model.ts";
 import {
@@ -25,6 +27,7 @@ import {
   hashPrincipal,
   instanceNameForAdmin,
   materializeAdmins,
+  migrateGrantDefinitions,
 } from "./admin_materializer.ts";
 
 await initializeLogging({});
@@ -257,4 +260,119 @@ Deno.test("instanceNameForAdmin: produces grant-config- prefix", () => {
     instanceNameForAdmin("abc123").startsWith("grant-config-"),
     true,
   );
+});
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+Deno.test("migrateGrantDefinitions: moves YAML files from source to destination", async () => {
+  await withTempDir(async (dir) => {
+    const sourceDir = join(dir, "models", "swamp", "grant");
+    const destDir = join(dir, ".swamp", "auto-definitions", "swamp", "grant");
+
+    await ensureDir(sourceDir);
+    await Deno.writeTextFile(
+      join(sourceDir, "abc-123.yaml"),
+      "name: grant-config-abc\ntype: swamp/grant\n",
+    );
+    await Deno.writeTextFile(
+      join(sourceDir, "def-456.yaml"),
+      "name: grant-config-def\ntype: swamp/grant\n",
+    );
+
+    const result = await migrateGrantDefinitions(sourceDir, destDir);
+
+    assertEquals(result.moved, 2);
+    assertEquals(result.skipped, 0);
+
+    const destContent1 = await Deno.readTextFile(
+      join(destDir, "abc-123.yaml"),
+    );
+    assertEquals(destContent1, "name: grant-config-abc\ntype: swamp/grant\n");
+
+    const destContent2 = await Deno.readTextFile(
+      join(destDir, "def-456.yaml"),
+    );
+    assertEquals(destContent2, "name: grant-config-def\ntype: swamp/grant\n");
+  });
+});
+
+Deno.test("migrateGrantDefinitions: no-op when source directory does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const sourceDir = join(dir, "models", "swamp", "grant");
+    const destDir = join(dir, ".swamp", "auto-definitions", "swamp", "grant");
+
+    const result = await migrateGrantDefinitions(sourceDir, destDir);
+
+    assertEquals(result.moved, 0);
+    assertEquals(result.skipped, 0);
+  });
+});
+
+Deno.test("migrateGrantDefinitions: skips files that already exist at destination", async () => {
+  await withTempDir(async (dir) => {
+    const sourceDir = join(dir, "models", "swamp", "grant");
+    const destDir = join(dir, ".swamp", "auto-definitions", "swamp", "grant");
+
+    await ensureDir(sourceDir);
+    await ensureDir(destDir);
+
+    await Deno.writeTextFile(
+      join(sourceDir, "abc-123.yaml"),
+      "source version",
+    );
+    await Deno.writeTextFile(
+      join(destDir, "abc-123.yaml"),
+      "dest version",
+    );
+    await Deno.writeTextFile(
+      join(sourceDir, "def-456.yaml"),
+      "only in source",
+    );
+
+    const result = await migrateGrantDefinitions(sourceDir, destDir);
+
+    assertEquals(result.moved, 1);
+    assertEquals(result.skipped, 1);
+
+    const destExisting = await Deno.readTextFile(
+      join(destDir, "abc-123.yaml"),
+    );
+    assertEquals(destExisting, "dest version");
+
+    const destMoved = await Deno.readTextFile(join(destDir, "def-456.yaml"));
+    assertEquals(destMoved, "only in source");
+  });
+});
+
+Deno.test("migrateGrantDefinitions: ignores non-YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const sourceDir = join(dir, "models", "swamp", "grant");
+    const destDir = join(dir, ".swamp", "auto-definitions", "swamp", "grant");
+
+    await ensureDir(sourceDir);
+    await Deno.writeTextFile(
+      join(sourceDir, "abc-123.yaml"),
+      "content",
+    );
+    await Deno.writeTextFile(
+      join(sourceDir, "notes.txt"),
+      "not a definition",
+    );
+
+    const result = await migrateGrantDefinitions(sourceDir, destDir);
+
+    assertEquals(result.moved, 1);
+    assertEquals(result.skipped, 0);
+  });
 });


### PR DESCRIPTION
## Summary

- Admin grant materializer was writing definition YAML files to `models/swamp/grant/` instead of `.swamp/auto-definitions/swamp/grant/`, polluting the user's source tree with untracked files
- Split `createAdminGrantStore` into separate read and write repos: the existing `definitionRepo` for lookups (spans both `models/` and `.swamp/auto-definitions/`), and a dedicated auto-definitions `YamlDefinitionRepository` for saves
- Added `migrateGrantDefinitions()` that moves existing grant definitions from `models/swamp/grant/` to `.swamp/auto-definitions/swamp/grant/` on serve startup, with empty directory cleanup

Closes swamp-club#886

## Test Plan

- [x] All 8008 existing tests pass (0 failures)
- [x] 4 new migration tests: moves files, no-op when source missing, skips existing at destination, ignores non-YAML files
- [x] DDD layer rules test passes (migration cleanup in CLI layer, not domain)
- [x] Manual verification: reproduced bug with current binary (`models/swamp/grant/` created), then compiled fixed binary — migration moved file to `.swamp/auto-definitions/swamp/grant/` and cleaned up empty dirs
- [x] Idempotent restart: second serve startup shows no migration, existing grant detected as unchanged
- [x] `deno check` / `deno lint` / `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)