### PR TITLE
fix(output): write JSON error envelopes to stderr instead of stdout

### DIFF
--- a/integration/json_isolation_test.ts
+++ b/integration/json_isolation_test.ts
@@ -55,21 +55,23 @@ Deno.test("--json: version stdout is parseable JSON", async () => {
   assertEquals(typeof parsed.version, "string");
 });
 
-Deno.test("--json: error path emits exactly one JSON document on stdout", async () => {
+Deno.test("--json: error path emits exactly one JSON document on stderr", async () => {
   // `data list` without a model name fails with a UserError. The renderError
-  // path should write the error JSON to stdout exactly once — no double
-  // emission and no LogTape pretty-formatted FTL line.
+  // path should write the error JSON to stderr exactly once — no double
+  // emission and no LogTape pretty-formatted FTL line. Stdout must be empty
+  // so callers can reliably separate success data from error diagnostics.
   await withTempDir(async (dir) => {
     await initializeTestRepo(dir);
-    const { stdout, code } = await runCliCommand(
+    const { stdout, stderr, code } = await runCliCommand(
       ["data", "list", "--json"],
       dir,
     );
     assertEquals(code, 1);
+    assertEquals(stdout, "");
     // Parse must succeed with one document. If the double-emission bug
-    // returns, stdout would have two concatenated JSON objects which
+    // returns, stderr would have two concatenated JSON objects which
     // JSON.parse rejects.
-    const parsed = JSON.parse(stdout);
+    const parsed = JSON.parse(stderr);
     assertEquals(typeof parsed.error, "string");
   });
 });

--- a/src/cli/group_action.ts
+++ b/src/cli/group_action.ts
@@ -30,7 +30,7 @@ export function groupCommandAction(this: Command<any>): void {
     const json = buildErrorJson(new UserError("No subcommand specified"));
     json.availableCommands = commands;
     // deno-lint-ignore no-console
-    console.log(JSON.stringify(json, null, 2));
+    console.error(JSON.stringify(json, null, 2));
     Deno.exit(1);
   }
   this.showHelp();

--- a/src/cli/group_action_test.ts
+++ b/src/cli/group_action_test.ts
@@ -23,7 +23,7 @@ import { groupCommandAction } from "./group_action.ts";
 
 Deno.test("groupCommandAction: emits JSON error when --json is in args", () => {
   const originalArgs = Deno.args;
-  const originalLog = console.log;
+  const originalError = console.error;
   const originalExit = Deno.exit;
   let output = "";
   let exitCode: number | undefined;
@@ -33,7 +33,7 @@ Deno.test("groupCommandAction: emits JSON error when --json is in args", () => {
       value: ["--json"],
       configurable: true,
     });
-    console.log = (...args: unknown[]) => {
+    console.error = (...args: unknown[]) => {
       output += args.join(" ");
     };
     // deno-lint-ignore no-explicit-any
@@ -57,7 +57,7 @@ Deno.test("groupCommandAction: emits JSON error when --json is in args", () => {
       value: originalArgs,
       configurable: true,
     });
-    console.log = originalLog;
+    console.error = originalError;
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
   }
@@ -97,7 +97,7 @@ Deno.test("groupCommandAction: calls showHelp when not in JSON mode", () => {
 
 Deno.test("groupCommandAction: JSON output is valid parseable JSON", () => {
   const originalArgs = Deno.args;
-  const originalLog = console.log;
+  const originalError = console.error;
   const originalExit = Deno.exit;
   let output = "";
 
@@ -106,7 +106,7 @@ Deno.test("groupCommandAction: JSON output is valid parseable JSON", () => {
       value: ["--json"],
       configurable: true,
     });
-    console.log = (...args: unknown[]) => {
+    console.error = (...args: unknown[]) => {
       output += args.join(" ");
     };
     // deno-lint-ignore no-explicit-any
@@ -128,7 +128,7 @@ Deno.test("groupCommandAction: JSON output is valid parseable JSON", () => {
       value: originalArgs,
       configurable: true,
     });
-    console.log = originalLog;
+    console.error = originalError;
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
   }

--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -201,7 +201,7 @@ export function unknownCommandErrorHandler(error: Error, cmd: Command): void {
       if (getOutputModeFromArgs(Deno.args) === "json") {
         const jsonError = buildErrorJson(new Error(message));
         // deno-lint-ignore no-console
-        console.log(JSON.stringify(jsonError, null, 2));
+        console.error(JSON.stringify(jsonError, null, 2));
       }
       console.error(red(`error: ${message}`));
       Deno.exit(2);

--- a/src/cli/unknown_command_handler.ts
+++ b/src/cli/unknown_command_handler.ts
@@ -202,6 +202,7 @@ export function unknownCommandErrorHandler(error: Error, cmd: Command): void {
         const jsonError = buildErrorJson(new Error(message));
         // deno-lint-ignore no-console
         console.error(JSON.stringify(jsonError, null, 2));
+        Deno.exit(2);
       }
       console.error(red(`error: ${message}`));
       Deno.exit(2);

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -88,7 +88,7 @@ export async function initializeLogging(
   if (options.jsonMode) {
     // JSON mode: the renderError() function in
     // src/presentation/output/error_output.ts is the single emitter for
-    // fatal output (it writes JSON to stdout and skips logger.fatal).
+    // fatal output (it writes JSON to stderr and skips logger.fatal).
     // The root logger has no sinks so nothing leaks via the standard
     // logging pipeline. Audit at swamp-club#235: only error_output.ts
     // calls logger.fatal in src/, both inside renderError itself.

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -84,7 +84,7 @@ export function buildErrorJson(err: Error): Record<string, unknown> {
  * Renders an error to the user.
  *
  * In JSON mode this is the SINGLE emitter for fatal output: it writes
- * the JSON error to stdout and does NOT call `logger.fatal`, so log-mode
+ * the JSON error to stderr and does NOT call `logger.fatal`, so log-mode
  * sinks never produce a duplicate FTL line. In log mode it falls
  * through to LogTape — UserError / Cliffy ValidationError emit just the
  * message; other errors emit the full Error (stack trace included).
@@ -94,7 +94,7 @@ export function renderError(error: unknown, outputMode?: OutputMode): void {
 
   if (outputMode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify(buildErrorJson(err), null, 2));
+    console.error(JSON.stringify(buildErrorJson(err), null, 2));
     return;
   }
 

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -129,11 +129,11 @@ Deno.test("renderError suppresses Cliffy Command dump on ValidationError (issue 
 });
 
 Deno.test("renderError: json mode emits clean JSON for ValidationError (issue #171)", () => {
-  const stdoutLogs: string[] = [];
+  const stderrLogs: string[] = [];
   const originalLog = console.log;
   const originalError = console.error;
-  console.log = (...args: unknown[]) => stdoutLogs.push(args.join(" "));
-  console.error = () => {};
+  console.log = () => {};
+  console.error = (...args: unknown[]) => stderrLogs.push(args.join(" "));
 
   try {
     const error = new ValidationError(
@@ -145,8 +145,8 @@ Deno.test("renderError: json mode emits clean JSON for ValidationError (issue #1
 
     renderError(error, "json");
 
-    assertEquals(stdoutLogs.length, 1);
-    const parsed = JSON.parse(stdoutLogs[0]);
+    assertEquals(stderrLogs.length, 1);
+    const parsed = JSON.parse(stderrLogs[0]);
     assertEquals(
       parsed.error,
       'Unknown option "--inputs". Did you mean option "--input"?',
@@ -154,8 +154,8 @@ Deno.test("renderError: json mode emits clean JSON for ValidationError (issue #1
     // ValidationError should never produce a stack in JSON output.
     assertEquals(parsed.stack, undefined);
     // And the raw payload must not leak.
-    assertEquals(stdoutLogs[0].includes("Command {"), false);
-    assertEquals(stdoutLogs[0].includes("[Circular"), false);
+    assertEquals(stderrLogs[0].includes("Command {"), false);
+    assertEquals(stderrLogs[0].includes("[Circular"), false);
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -183,7 +183,7 @@ Deno.test("renderError uses fatal level for all errors", () => {
 // JSON stdout output tests
 // ============================================================================
 
-Deno.test("renderError: json mode is single-emitter (stdout JSON, no stderr)", () => {
+Deno.test("renderError: json mode is single-emitter (stderr JSON, no stdout)", () => {
   const stdoutLogs: string[] = [];
   const stderrLogs: string[] = [];
   const originalLog = console.log;
@@ -194,14 +194,13 @@ Deno.test("renderError: json mode is single-emitter (stdout JSON, no stderr)", (
   try {
     renderError(new UserError("Model not found"), "json");
 
-    assertEquals(stdoutLogs.length, 1);
-    const parsed = JSON.parse(stdoutLogs[0]);
+    assertEquals(stderrLogs.length, 1);
+    const parsed = JSON.parse(stderrLogs[0]);
     assertEquals(parsed.error, "Model not found");
     assertEquals(parsed.stack, undefined);
-    // Single-emission contract: in JSON mode renderError is the only
-    // emitter — logger.fatal must not be called, so stderr stays
-    // untouched. (See swamp-club#235.)
-    assertEquals(stderrLogs.length, 0);
+    // Single-emission contract: in JSON mode renderError writes to
+    // stderr only — stdout stays clean for success data.
+    assertEquals(stdoutLogs.length, 0);
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -209,16 +208,16 @@ Deno.test("renderError: json mode is single-emitter (stdout JSON, no stderr)", (
 });
 
 Deno.test("renderError: json mode surfaces UserError code field", () => {
-  const stdoutLogs: string[] = [];
+  const stderrLogs: string[] = [];
   const originalLog = console.log;
   const originalError = console.error;
-  console.log = (...args: unknown[]) => stdoutLogs.push(args.join(" "));
-  console.error = () => {};
+  console.log = () => {};
+  console.error = (...args: unknown[]) => stderrLogs.push(args.join(" "));
 
   try {
     renderError(new UserError("Operation timed out", "timeout"), "json");
-    assertEquals(stdoutLogs.length, 1);
-    const parsed = JSON.parse(stdoutLogs[0]);
+    assertEquals(stderrLogs.length, 1);
+    const parsed = JSON.parse(stderrLogs[0]);
     assertEquals(parsed.error, "Operation timed out");
     assertEquals(parsed.code, "timeout");
   } finally {
@@ -230,18 +229,18 @@ Deno.test("renderError: json mode surfaces UserError code field", () => {
 Deno.test("renderError: json mode surfaces a `code` property from any error", () => {
   // Errors thrown from libswamp paths often carry a `code` via duck typing
   // rather than via UserError (e.g. cancellations, validation failures).
-  const stdoutLogs: string[] = [];
+  const stderrLogs: string[] = [];
   const originalLog = console.log;
   const originalError = console.error;
-  console.log = (...args: unknown[]) => stdoutLogs.push(args.join(" "));
-  console.error = () => {};
+  console.log = () => {};
+  console.error = (...args: unknown[]) => stderrLogs.push(args.join(" "));
 
   try {
     const error = new Error("Operation was cancelled.");
     Object.assign(error, { code: "cancelled" });
     renderError(error, "json");
-    assertEquals(stdoutLogs.length, 1);
-    const parsed = JSON.parse(stdoutLogs[0]);
+    assertEquals(stderrLogs.length, 1);
+    const parsed = JSON.parse(stderrLogs[0]);
     assertEquals(parsed.code, "cancelled");
   } finally {
     console.log = originalLog;


### PR DESCRIPTION
## Summary

- Move all `--json` mode error output from `console.log` (stdout) to `console.error` (stderr) so callers can reliably separate success data from error diagnostics using the standard Unix convention (non-zero exit + diagnostic on stderr).
- Update `renderError()`, `groupCommandAction()`, and `unknownCommandErrorHandler()` to use `console.error` for JSON error envelopes.
- Update comments in `error_output.ts` and `logger.ts` to reflect the new stderr contract.
- Update all JSON-mode tests to assert error output lands on stderr with stdout remaining clean.

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test src/presentation/output/error_output_test.ts` — all 20 tests pass
- [x] Verified success JSON output (`writeOutput`, renderers) remains on stdout — untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)