### PR TITLE
feat(update): sync global skills automatically after binary update

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -111,10 +111,17 @@ Today these commands copy skills into the repo. Under the new model:
 
 ### Keeping Global Skills Current
 
-Global skills are overwritten on every `repo init` and `repo upgrade`. The
-bundled skill files in the binary are the source of truth — there is no version
-stamping or freshness check. Running `repo init` or `repo upgrade` in any repo
-updates the global copies to match the running binary.
+Global skills are synced automatically in three places:
+
+1. **`swamp update`** — after the binary is updated (interactive and background),
+   skills are written to all global tool directories. This is the primary sync
+   path and requires no repo context.
+2. **`swamp repo init`** — writes global skills as part of first-time setup.
+3. **`swamp repo upgrade`** — writes global skills as part of the upgrade flow.
+
+The bundled skill files in the binary are the source of truth. The sync is
+idempotent — writing the same content is harmless. Failures during sync (e.g.,
+permissions, disk full) log a warning and do not block the update or command.
 
 ## Migration: Local to Global
 
@@ -235,22 +242,21 @@ These files remain project-local because they contain repo-specific content:
 
 ## Open Questions
 
-1. **Auto-update on startup**: Should the CLI silently update global skills on
-   every invocation (GitButler pattern), or only on explicit
-   `swamp repo upgrade`? Auto-update is more convenient but means any CLI run
-   could write to `~/`. A middle ground: auto-update with a flag to opt out.
+1. ~~**Auto-update on startup**~~ — **Resolved**: skills sync during
+   `swamp update`, not on every CLI startup. This avoids writing to `~/` on
+   arbitrary invocations while keeping skills in sync with the binary. The
+   `repo init` and `repo upgrade` paths also sync as before.
 
 2. **Concurrent writes**: Multiple swamp processes (in different repos) could try
-   to update global skills simultaneously. Needs a file lock or atomic-write
-   strategy.
+   to update global skills simultaneously. Mitigated by the sync being idempotent
+   — concurrent writes produce the same result.
 
 3. **`swamp repo init` without `repo upgrade`**: Should `repo init` also update
    global skills, or only write them if missing? Currently `repo init` is the
    first entry point for new repos, so it should ensure global skills exist.
 
-4. **Permissions**: Writing to `~/.claude/skills/` etc. requires the user's home
-   directory to be writable. Should fail gracefully with a clear error if the
-   directory is read-only or doesn't exist.
+4. ~~**Permissions**~~ — **Resolved**: sync catches errors and logs a warning
+   without blocking the update or command.
 
 5. **`none` tool**: The `none` tool currently writes to
    `.swamp/pulled-extensions/skills/`. With global skills, it could either remain

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -51,11 +51,38 @@ import {
 } from "../../domain/update/autoupdate_log.ts";
 import type { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
+import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
+import {
+  GLOBAL_SKILL_DIRS,
+  resolveUniqueGlobalSkillsDirs,
+} from "../../domain/repo/skill_dirs.ts";
+import { removeSupersededSkills } from "../../domain/repo/superseded_skills.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
 const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function syncGlobalSkills(
+  logger: ReturnType<typeof getSwampLogger>,
+): Promise<void> {
+  const allTools = Object.keys(GLOBAL_SKILL_DIRS);
+  let globalDirs: string[];
+  try {
+    globalDirs = resolveUniqueGlobalSkillsDirs(allTools);
+  } catch {
+    logger.warn`Skipping global skill sync: home directory not available`;
+    return;
+  }
+  if (globalDirs.length === 0) return;
+
+  const skillAssets = new SkillAssets();
+  for (const dir of globalDirs) {
+    await skillAssets.copySkillsTo(dir);
+    await removeSupersededSkills(dir);
+    logger.info`Synced global skills to ${dir}`;
+  }
+}
 
 function privilegedSchedulerDescription(): string {
   switch (Deno.build.os) {
@@ -171,6 +198,18 @@ async function runBackgroundUpdate(
     clearTimeout(timeoutId!);
     entry.outcome = "error";
     entry.error = error instanceof Error ? error.message : String(error);
+  }
+
+  if (entry.outcome === "updated") {
+    try {
+      await syncGlobalSkills(ctx.logger);
+      ctx.logger.debug`Background skill sync completed`;
+    } catch (err) {
+      ctx.logger
+        .warn`Background skill sync failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+    }
   }
 
   await logRepo.append(entry);
@@ -449,6 +488,18 @@ export const updateCommand = new Command()
         }),
         renderer.handlers(),
       );
+
+      if (renderer.updated) {
+        spinner?.update("Syncing global skills...");
+        try {
+          await syncGlobalSkills(ctx.logger);
+        } catch (err) {
+          ctx.logger
+            .warn`Failed to sync global skills: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+      }
 
       spinner?.stop();
     } catch (err) {

--- a/src/cli/commands/update_test.ts
+++ b/src/cli/commands/update_test.ts
@@ -22,6 +22,11 @@ import type { UpdateChecker } from "../../domain/update/update_service.ts";
 import { UpdateService } from "../../domain/update/update_service.ts";
 import { Platform } from "../../domain/update/platform.ts";
 import { Spinner } from "../../presentation/spinner.ts";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { consumeStream, type UpdateCheckEvent } from "../../libswamp/mod.ts";
+import { createUpdateCheckRenderer } from "../../presentation/renderers/update_check.ts";
+
+await initializeLogging({});
 
 const platform = Platform.from("darwin", "aarch64");
 const currentVersion = "20260207.123456.0-sha.abc12345";
@@ -143,4 +148,55 @@ Deno.test("spinner is created in log mode", () => {
   const outputMode: string = "log";
   const spinner = outputMode !== "json" ? new Spinner() : null;
   assertEquals(spinner instanceof Spinner, true);
+});
+
+// --- UpdateCheckRenderer.updated flag ---
+
+async function* fakeUpdateStream(
+  status: "updated" | "up_to_date",
+): AsyncIterable<UpdateCheckEvent> {
+  yield { kind: "checking" };
+  if (status === "updated") {
+    yield {
+      kind: "completed",
+      data: {
+        status: "updated",
+        previousVersion: "1.0.0",
+        newVersion: "2.0.0",
+      },
+    };
+  } else {
+    yield {
+      kind: "completed",
+      data: { status: "up_to_date", currentVersion: "1.0.0" },
+    };
+  }
+}
+
+Deno.test("createUpdateCheckRenderer: updated is true after successful update (log mode)", async () => {
+  const renderer = createUpdateCheckRenderer("log");
+  assertEquals(renderer.updated, false);
+
+  await consumeStream(fakeUpdateStream("updated"), renderer.handlers());
+  assertEquals(renderer.updated, true);
+});
+
+Deno.test("createUpdateCheckRenderer: updated is false when already up to date (log mode)", async () => {
+  const renderer = createUpdateCheckRenderer("log");
+  await consumeStream(fakeUpdateStream("up_to_date"), renderer.handlers());
+  assertEquals(renderer.updated, false);
+});
+
+Deno.test("createUpdateCheckRenderer: updated is true after successful update (json mode)", async () => {
+  const renderer = createUpdateCheckRenderer("json");
+  assertEquals(renderer.updated, false);
+
+  await consumeStream(fakeUpdateStream("updated"), renderer.handlers());
+  assertEquals(renderer.updated, true);
+});
+
+Deno.test("createUpdateCheckRenderer: updated is false when already up to date (json mode)", async () => {
+  const renderer = createUpdateCheckRenderer("json");
+  await consumeStream(fakeUpdateStream("up_to_date"), renderer.handlers());
+  assertEquals(renderer.updated, false);
 });

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -40,6 +40,7 @@ import {
   resolveSkillsDir,
   resolveUniqueGlobalSkillsDirs,
 } from "./skill_dirs.ts";
+import { removeSupersededSkills } from "./superseded_skills.ts";
 import { assertPathContained, type ToolConfig } from "./custom_tool.ts";
 import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
@@ -91,51 +92,10 @@ function formatToolsList(tools: string[]): string {
   return tools.length === 0 ? "none" : tools.join(", ");
 }
 
-export const SUPERSEDED_SKILLS: readonly string[] = [
-  "swamp-extension-model",
-  "swamp-extension-vault",
-  "swamp-extension-driver",
-  "swamp-extension-datastore",
-  "swamp-extension-quality",
-  "swamp-data-query",
-  "swamp-model",
-  "swamp-workflow",
-  "swamp-data",
-  "swamp-vault",
-  "swamp-extension",
-  "swamp-extension-publish",
-  "swamp-repo",
-  "swamp-report",
-  "swamp-troubleshooting",
-  "swamp-issue",
-];
-
-async function removeSupersededSkills(skillsDir: string): Promise<void> {
-  for (const name of SUPERSEDED_SKILLS) {
-    const dir = join(skillsDir, name);
-    try {
-      await Deno.remove(dir, { recursive: true });
-      logger.info`Removed superseded skill ${name}`;
-    } catch (e) {
-      if (!(e instanceof Deno.errors.NotFound)) throw e;
-    }
-  }
-}
-
-export async function detectSupersededSkills(
-  skillsDir: string,
-): Promise<string[]> {
-  const found: string[] = [];
-  for (const name of SUPERSEDED_SKILLS) {
-    try {
-      await Deno.stat(join(skillsDir, name));
-      found.push(name);
-    } catch {
-      // Not found — not stale
-    }
-  }
-  return found;
-}
+export {
+  detectSupersededSkills,
+  SUPERSEDED_SKILLS,
+} from "./superseded_skills.ts";
 
 export const BUNDLED_SKILL_NAMES = ["swamp", "swamp-getting-started"];
 

--- a/src/domain/repo/superseded_skills.ts
+++ b/src/domain/repo/superseded_skills.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+
+const logger = getLogger(["swamp", "repo", "skills"]);
+
+export const SUPERSEDED_SKILLS: readonly string[] = [
+  "swamp-extension-model",
+  "swamp-extension-vault",
+  "swamp-extension-driver",
+  "swamp-extension-datastore",
+  "swamp-extension-quality",
+  "swamp-data-query",
+  "swamp-model",
+  "swamp-workflow",
+  "swamp-data",
+  "swamp-vault",
+  "swamp-extension",
+  "swamp-extension-publish",
+  "swamp-repo",
+  "swamp-report",
+  "swamp-troubleshooting",
+  "swamp-issue",
+];
+
+export async function removeSupersededSkills(
+  skillsDir: string,
+): Promise<void> {
+  for (const name of SUPERSEDED_SKILLS) {
+    const dir = join(skillsDir, name);
+    try {
+      await Deno.remove(dir, { recursive: true });
+      logger.info`Removed superseded skill ${name}`;
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) throw e;
+    }
+  }
+}
+
+export async function detectSupersededSkills(
+  skillsDir: string,
+): Promise<string[]> {
+  const found: string[] = [];
+  for (const name of SUPERSEDED_SKILLS) {
+    try {
+      await Deno.stat(join(skillsDir, name));
+      found.push(name);
+    } catch {
+      // Not found — not stale
+    }
+  }
+  return found;
+}

--- a/src/domain/repo/superseded_skills_test.ts
+++ b/src/domain/repo/superseded_skills_test.ts
@@ -1,0 +1,103 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import {
+  detectSupersededSkills,
+  removeSupersededSkills,
+  SUPERSEDED_SKILLS,
+} from "./superseded_skills.ts";
+
+await initializeLogging({});
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp_superseded_test_" });
+  try {
+    await fn(tempDir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  }
+}
+
+Deno.test("removeSupersededSkills: removes matching directories", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(join(tempDir, "swamp-extension-model"));
+    await Deno.mkdir(join(tempDir, "swamp-data-query"));
+    await Deno.mkdir(join(tempDir, "swamp"));
+
+    await removeSupersededSkills(tempDir);
+
+    const remaining = [];
+    for await (const entry of Deno.readDir(tempDir)) {
+      remaining.push(entry.name);
+    }
+    assertEquals(remaining, ["swamp"]);
+  });
+});
+
+Deno.test("removeSupersededSkills: no-ops when directory has no superseded skills", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(join(tempDir, "swamp"));
+    await Deno.mkdir(join(tempDir, "my-custom-skill"));
+
+    await removeSupersededSkills(tempDir);
+
+    const remaining = [];
+    for await (const entry of Deno.readDir(tempDir)) {
+      remaining.push(entry.name);
+    }
+    assertEquals(remaining.sort(), ["my-custom-skill", "swamp"]);
+  });
+});
+
+Deno.test("removeSupersededSkills: handles nonexistent directory gracefully", async () => {
+  await removeSupersededSkills("/tmp/nonexistent-dir-superseded-test");
+});
+
+Deno.test("detectSupersededSkills: returns empty when no superseded dirs exist", async () => {
+  await withTempDir(async (tempDir) => {
+    const result = await detectSupersededSkills(tempDir);
+    assertEquals(result, []);
+  });
+});
+
+Deno.test("detectSupersededSkills: detects superseded skill directories", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(join(tempDir, "swamp-extension-model"));
+    await Deno.mkdir(join(tempDir, "swamp-data-query"));
+    await Deno.mkdir(join(tempDir, "swamp"));
+
+    const result = await detectSupersededSkills(tempDir);
+    assertEquals(result.sort(), ["swamp-data-query", "swamp-extension-model"]);
+  });
+});
+
+Deno.test("SUPERSEDED_SKILLS: contains expected entries", () => {
+  assertEquals(SUPERSEDED_SKILLS.includes("swamp-extension-model"), true);
+  assertEquals(SUPERSEDED_SKILLS.includes("swamp-data-query"), true);
+  assertEquals(SUPERSEDED_SKILLS.includes("swamp"), false);
+});

--- a/src/presentation/renderers/update_check.ts
+++ b/src/presentation/renderers/update_check.ts
@@ -23,7 +23,13 @@ import type { OutputMode } from "../output/output.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 
-class LogUpdateCheckRenderer implements Renderer<UpdateCheckEvent> {
+export interface UpdateCheckRenderer extends Renderer<UpdateCheckEvent> {
+  readonly updated: boolean;
+}
+
+class LogUpdateCheckRenderer implements UpdateCheckRenderer {
+  updated = false;
+
   handlers(): EventHandlers<UpdateCheckEvent> {
     const logger = getSwampLogger(["update"]);
     return {
@@ -40,12 +46,13 @@ class LogUpdateCheckRenderer implements Renderer<UpdateCheckEvent> {
             logger.info("Run `swamp update` to install");
             break;
           case "updated":
+            this.updated = true;
             logger.info("swamp updated successfully!");
             logger.info`${data.previousVersion} \u2192 ${data.newVersion}`;
             logger.info("SHA-256 integrity check passed");
             logger.info("The swamp binary has been updated globally.");
             logger.info(
-              "Run `swamp repo upgrade` in your repositories to update skills and settings.",
+              "Run `swamp repo upgrade` in your repositories to update settings and instructions.",
             );
             break;
         }
@@ -60,11 +67,16 @@ class LogUpdateCheckRenderer implements Renderer<UpdateCheckEvent> {
   }
 }
 
-class JsonUpdateCheckRenderer implements Renderer<UpdateCheckEvent> {
+class JsonUpdateCheckRenderer implements UpdateCheckRenderer {
+  updated = false;
+
   handlers(): EventHandlers<UpdateCheckEvent> {
     return {
       checking: () => {},
       completed: (e) => {
+        if (e.data.status === "updated") {
+          this.updated = true;
+        }
         console.log(JSON.stringify(e.data, null, 2));
       },
       error: (e) => {
@@ -76,7 +88,7 @@ class JsonUpdateCheckRenderer implements Renderer<UpdateCheckEvent> {
 
 export function createUpdateCheckRenderer(
   mode: OutputMode,
-): Renderer<UpdateCheckEvent> {
+): UpdateCheckRenderer {
   switch (mode) {
     case "json":
       return new JsonUpdateCheckRenderer();


### PR DESCRIPTION
## Summary

- After `swamp update` upgrades the binary (interactive and background), automatically write bundled skills to all global tool directories (`~/.claude/skills/`, `~/.agents/skills/`, `~/.kiro/skills/`) so skills stay in sync without requiring `swamp repo upgrade`
- Extract `removeSupersededSkills` to a shared module so both `RepoService` and the update command can use it
- Update the post-update message to only mention settings/instructions (skills now sync automatically)
- Resolve open questions #1 and #4 in `design/global-skills.md`

Closes swamp-club#852

## Test Plan

- [x] Unit tests for extracted `removeSupersededSkills` (6 tests)
- [x] Renderer tests verifying `updated` flag in both log and json modes (4 tests)
- [x] `deno check` — no type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — formatted
- [x] `deno run test` — 8022 passed, 0 failed
- [x] `deno run compile` — binary built successfully