### PR TITLE
fix(serve): use datastore-resolved path for auto-definitions (swamp-club#890)

### DIFF
--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -195,7 +195,7 @@ export function buildModelMethodRunDeps(
         const autoDefRepo = new YamlDefinitionRepository(
           repoDir,
           undefined,
-          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           false,
         );
         await autoDefRepo.save(type, definition);
@@ -204,7 +204,7 @@ export function buildModelMethodRunDeps(
     getDefinitionPath: isDirectExecution
       ? (type, id) => {
         return join(
-          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           type.toDirectoryPath(),
           `${id}.yaml`,
         );

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -324,7 +324,7 @@ export const modelMethodRunCommand = new Command()
             const autoDefRepo = new YamlDefinitionRepository(
               repoDir,
               undefined,
-              swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+              repoContext.autoDefinitionsDir,
               false,
             );
             await autoDefRepo.save(type, definition);
@@ -333,7 +333,7 @@ export const modelMethodRunCommand = new Command()
         getDefinitionPath: isDirectExecution
           ? (type, id) => {
             return join(
-              swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+              repoContext.autoDefinitionsDir,
               type.toDirectoryPath(),
               `${id}.yaml`,
             );

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -68,10 +68,6 @@ import {
   migrateGrantDefinitions,
 } from "../../domain/access/admin_materializer.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
 import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
 import { join } from "@std/path";
@@ -619,10 +615,7 @@ export const serveCommand = new Command()
     const serveEventBus = new EventBus();
 
     const modelsDir = join(resolvedRepoDir, "models");
-    const autoDefDir = swampPath(
-      resolvedRepoDir,
-      SWAMP_SUBDIRS.autoDefinitions,
-    );
+    const autoDefDir = repoContext.autoDefinitionsDir;
     const grantTypeDir = GRANT_MODEL_TYPE.toDirectoryPath();
     const grantSourceDir = join(modelsDir, grantTypeDir);
     const migrationResult = await migrateGrantDefinitions(

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -35,10 +35,7 @@ import {
   type StepLockHook,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
 import { isAuthenticated } from "../auth_context.ts";
 import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
@@ -236,7 +233,7 @@ export const workflowResumeCommand = new Command()
         const autoDefRepo = new YamlDefinitionRepository(
           repoDir,
           undefined,
-          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           false,
         );
         const result = await resolveOrCreateDefinition(

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -40,10 +40,7 @@ import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import {
   createWorkflowId,
   createWorkflowRunId,
@@ -312,7 +309,7 @@ export const workflowRunCommand = new Command()
             const autoDefRepo = new YamlDefinitionRepository(
               dir,
               undefined,
-              swampPath(dir, SWAMP_SUBDIRS.autoDefinitions),
+              repoContext.autoDefinitionsDir,
               false,
             );
             const result = await resolveOrCreateDefinition(

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -346,6 +346,7 @@ export interface RepositoryContext {
   catalogStore: CatalogStore;
   dataQueryService: DataQueryService;
   markDirty?: MarkDirtyHook;
+  autoDefinitionsDir: string;
 }
 
 /**
@@ -474,5 +475,6 @@ export function createRepositoryContext(
     catalogStore,
     dataQueryService,
     markDirty,
+    autoDefinitionsDir: autoDefDir,
   };
 }

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -109,14 +109,14 @@ export async function createServerTokenRunDeps(
       const autoDefRepo = new YamlDefinitionRepository(
         repoDir,
         undefined,
-        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        repoContext.autoDefinitionsDir,
         false,
       );
       await autoDefRepo.save(type, definition);
     },
     getDefinitionPath: (type, id) => {
       return join(
-        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        repoContext.autoDefinitionsDir,
         type.toDirectoryPath(),
         `${id}.yaml`,
       );

--- a/src/libswamp/worker/run_deps.ts
+++ b/src/libswamp/worker/run_deps.ts
@@ -118,14 +118,14 @@ export async function createWorkerModelRunDeps(
       const autoDefRepo = new YamlDefinitionRepository(
         repoDir,
         undefined,
-        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        repoContext.autoDefinitionsDir,
         false,
       );
       await autoDefRepo.save(type, definition);
     },
     getDefinitionPath: (type, id) => {
       return join(
-        swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+        repoContext.autoDefinitionsDir,
         type.toDirectoryPath(),
         `${id}.yaml`,
       );

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -114,7 +114,7 @@ export async function createWorkflowRunDeps(
         const autoDefRepo = new YamlDefinitionRepository(
           dir,
           undefined,
-          swampPath(dir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           false,
         );
         const result = await resolveOrCreateDefinition(
@@ -232,7 +232,7 @@ export async function createModelMethodRunDeps(
         const autoDefRepo = new YamlDefinitionRepository(
           repoDir,
           undefined,
-          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           false,
         );
         await autoDefRepo.save(type, definition);
@@ -241,7 +241,7 @@ export async function createModelMethodRunDeps(
     getDefinitionPath: isDirectExecution
       ? (type, id) => {
         return join(
-          swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+          repoContext.autoDefinitionsDir,
           type.toDirectoryPath(),
           `${id}.yaml`,
         );


### PR DESCRIPTION
## Summary

- Fix token auth (`--auth-mode token`) rejecting every valid token on custom datastores (e.g. `@keeb/mongodb-datastore`)
- Root cause: `createAndSaveDefinition` wrote auto-definitions to the local `.swamp/auto-definitions/` path, while `repoContext.definitionRepo` searched the datastore-resolved path — on custom datastores these diverge, causing definition lookups to miss and create duplicates with new UUIDs
- Expose `autoDefinitionsDir` on `RepositoryContext` and update all 6 call sites to use it: serve deps, server token run deps, CLI model method run, workflow run/resume, access helpers, worker run deps, and the serve grant migration path

## Test Plan

- [x] `deno check` — type check passes
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno run test` — 8010 passed (2 pre-existing flaky failures unrelated to this change)
- [x] Manual verification: reproduced the bug with `@keeb/mongodb-datastore` (token auth rejected with "Server token does not exist"), applied fix, token auth succeeds
- [x] Verified no duplicate auto-definitions created — single UUID for mint + redeem
- [x] Verified `swamp data list <token>` works (previously returned "Model not found")
- [x] Verified filesystem datastore still works (paths are identical, no regression)

Closes swamp-club#890

🤖 Generated with [Claude Code](https://claude.com/claude-code)