### PR TITLE
feat(error): surface lock_timeout as exit code 75 and document error codes (swamp-club#874)

### DIFF
--- a/design/libswamp.md
+++ b/design/libswamp.md
@@ -777,6 +777,45 @@ expected errors. Cancellation is also an error event with
 Unexpected errors (bugs, infrastructure failures) may still throw and should be
 caught at the adapter boundary.
 
+### Known error codes
+
+Codes used across libswamp generators and the CLI error boundary:
+
+| Code                       | Origin             | Meaning                                              |
+| -------------------------- | ------------------ | ---------------------------------------------------- |
+| `not_authenticated`        | `libswamp/errors`  | No valid auth credentials                            |
+| `invalid_api_key`          | `libswamp/errors`  | Stored API key is no longer valid                    |
+| `cancelled`                | `libswamp/errors`  | Operation cancelled (e.g. Ctrl+C, AbortSignal)       |
+| `not_found`                | `libswamp/errors`  | Generic entity not found                             |
+| `already_exists`           | `libswamp/errors`  | Entity already exists                                |
+| `validation_failed`        | `libswamp/errors`  | Input or configuration validation failed             |
+| `lock_timeout`             | `distributed_lock` | Lock held by another process; timed out waiting      |
+| `model_not_found`          | `models/run`       | No model matches the given name                      |
+| `unknown_model_type`       | `models/run`       | Type prefix does not match any installed type         |
+| `unknown_method`           | `models/run`       | Model does not define the requested method            |
+| `no_evaluated_definition`  | `models/run`       | No evaluated definition exists                       |
+| `method_execution_failed`  | `models/run`       | Execution driver returned an error                   |
+| `missing_deps`             | `models/run`       | Required extension dependencies not installed         |
+| `workflow_not_found`       | `workflows/run`    | No workflow matches the given name                   |
+| `workflow_execution_failed`| `workflows/run`    | Workflow step execution failed                       |
+| `input_validation_failed`  | `workflows/run`    | Workflow input validation failed                     |
+
+This table is not exhaustive — generators may define additional codes for
+domain-specific errors. The `code` field is always a `snake_case` string.
+
+### CLI exit codes
+
+| Exit code | Meaning                                                    |
+| --------- | ---------------------------------------------------------- |
+| `0`       | Success                                                    |
+| `1`       | General error (default for all unrecognized error codes)   |
+| `2`       | Unknown command                                            |
+| `75`      | Lock contention / temporary failure (`lock_timeout`) — callers should retry with backoff |
+
+Callers that only need pass/fail should check `$? -ne 0`. Callers that
+want to handle specific failure modes (e.g. retry on lock contention)
+should match the numeric exit code.
+
 ### Error handling by adapters
 
 ```typescript

--- a/main.ts
+++ b/main.ts
@@ -24,7 +24,10 @@
 import "./src/infrastructure/runtime/tls_trust_bootstrap.ts";
 import { runCli } from "./src/cli/mod.ts";
 import { initializeLogging } from "./src/infrastructure/logging/logger.ts";
-import { renderError } from "./src/presentation/output/error_output.ts";
+import {
+  exitCodeForError,
+  renderError,
+} from "./src/presentation/output/error_output.ts";
 import { flushDatastoreSync } from "./src/infrastructure/persistence/datastore_sync_coordinator.ts";
 import { getOutputModeFromArgs } from "./src/cli/context.ts";
 import {
@@ -45,7 +48,7 @@ if (import.meta.main) {
       jsonMode: outputMode === "json",
     });
     renderError(error, outputMode);
-    Deno.exit(1);
+    Deno.exit(exitCodeForError(error));
   } finally {
     await shutdownTracing();
   }

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -110,7 +110,25 @@ export const modelMethodRunCommand = new Command()
     'printf \'{"env":"dev"}\\n{"env":"prod"}\' | swamp model method run my-server deploy --stdin',
   )
   .description(
-    "Execute a method on a model. With @type prefix, auto-creates the definition if needed.",
+    `Execute a method on a model. With @type prefix, auto-creates the definition if needed.
+
+When --json is set, errors are written to stderr as a JSON envelope:
+
+    { "error": "<message>", "code": "<error_code>" }
+
+The "code" field is a stable, machine-readable identifier. Callers should match on "code" rather than parsing the error message. Known codes for this command:
+
+    lock_timeout             Another invocation holds the model lock (exit 75)
+    model_not_found          No model matches the given name
+    unknown_model_type       The @type prefix does not match any installed type
+    unknown_method           The model does not define the requested method
+    no_evaluated_definition  No evaluated definition exists (use --last-evaluated)
+    missing_deps             Required extension dependencies are not installed
+    method_execution_failed  The method's execution driver returned an error
+    not_authenticated        Not signed in (run 'swamp auth login')
+    cancelled                Operation was cancelled (e.g. Ctrl+C)
+
+Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — retry with backoff).`,
   )
   .arguments(
     "<model_or_type:model_name> <method_name:string> [definition_name:string]",

--- a/src/cli/commands/model_method_run_test.ts
+++ b/src/cli/commands/model_method_run_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Initialize logging for tests
@@ -33,10 +33,13 @@ Deno.test("modelMethodRunCommand module loads", async () => {
 
 Deno.test("modelMethodRunCommand has correct description", async () => {
   const { modelMethodRunCommand } = await import("./model_method_run.ts");
-  assertEquals(
-    modelMethodRunCommand.getDescription(),
+  const desc = modelMethodRunCommand.getDescription();
+  assertStringIncludes(
+    desc,
     "Execute a method on a model. With @type prefix, auto-creates the definition if needed.",
   );
+  assertStringIncludes(desc, "lock_timeout");
+  assertStringIncludes(desc, "Exit codes:");
 });
 
 Deno.test("modelMethodCommand module loads", async () => {

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -81,6 +81,19 @@ export function buildErrorJson(err: Error): Record<string, unknown> {
 }
 
 /**
+ * Returns the process exit code for an error.
+ *
+ * - `75` (EX_TEMPFAIL) for `lock_timeout` — a temporary failure that
+ *   callers should retry with backoff.
+ * - `1` for all other errors.
+ */
+export function exitCodeForError(error: unknown): number {
+  const code = (error as { code?: unknown })?.code;
+  if (code === "lock_timeout") return 75;
+  return 1;
+}
+
+/**
  * Renders an error to the user.
  *
  * In JSON mode this is the SINGLE emitter for fatal output: it writes

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -20,8 +20,13 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { ValidationError } from "@cliffy/command";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
-import { buildErrorJson, renderError } from "./error_output.ts";
+import {
+  buildErrorJson,
+  exitCodeForError,
+  renderError,
+} from "./error_output.ts";
 import { UserError } from "../../domain/errors.ts";
+import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_user_error.ts";
 
 await initializeLogging({});
@@ -433,3 +438,44 @@ Deno.test(
     );
   },
 );
+
+// ============================================================================
+// exitCodeForError tests
+// ============================================================================
+
+Deno.test("exitCodeForError: returns 75 for LockTimeoutError", () => {
+  const err = new LockTimeoutError("/path/.lock", null, 60000);
+  assertEquals(exitCodeForError(err), 75);
+});
+
+Deno.test("exitCodeForError: returns 75 for UserError with lock_timeout code", () => {
+  const err = new UserError("timed out", "lock_timeout");
+  assertEquals(exitCodeForError(err), 75);
+});
+
+Deno.test("exitCodeForError: returns 1 for UserError without code", () => {
+  const err = new UserError("something broke");
+  assertEquals(exitCodeForError(err), 1);
+});
+
+Deno.test("exitCodeForError: returns 1 for UserError with other code", () => {
+  const err = new UserError("not found", "model_not_found");
+  assertEquals(exitCodeForError(err), 1);
+});
+
+Deno.test("exitCodeForError: returns 1 for plain Error", () => {
+  assertEquals(exitCodeForError(new Error("crash")), 1);
+});
+
+Deno.test("exitCodeForError: returns 1 for non-Error values", () => {
+  assertEquals(exitCodeForError("string error"), 1);
+  assertEquals(exitCodeForError(null), 1);
+  assertEquals(exitCodeForError(undefined), 1);
+});
+
+Deno.test("buildErrorJson: LockTimeoutError includes code field", () => {
+  const err = new LockTimeoutError("/path/.lock", null, 60000);
+  const result = buildErrorJson(err);
+  assertEquals(result.code, "lock_timeout");
+  assertStringIncludes(result.error as string, "timed out after 60000ms");
+});


### PR DESCRIPTION
## Summary

- Add distinct exit code **75** (EX_TEMPFAIL) for `lock_timeout` errors on `model method run`, giving downstream extensions a stable signal to detect lock contention and retry with backoff
- Document the JSON error envelope structure (`{ error, code }`) and known error codes in `model method run --help`
- Add error code registry and exit code convention tables to `design/libswamp.md`
- 7 new unit tests for `exitCodeForError` and `buildErrorJson` with `LockTimeoutError`

Closes swamp-club#874

## Context

When `swamp model method run` fails because another invocation holds the per-model lock, the error already includes `"code": "lock_timeout"` in the JSON envelope — but this was undocumented and all errors exited with code 1. Downstream extensions (e.g. `@hivemq/asdlc-factory`) had to substring-match the error message to detect lock contention, which is brittle across versions.

After this change, callers can branch on exit code:
```bash
swamp model method run my-model deploy --json 2>err.json
status=$?
if [ $status -eq 75 ]; then
  # lock contention — retry with backoff
elif [ $status -ne 0 ]; then
  # other failure — abort
fi
```

## Test Plan

- [x] 7 new unit tests for `exitCodeForError` (LockTimeoutError → 75, other errors → 1, edge cases)
- [x] `buildErrorJson` test verifying `LockTimeoutError` includes `code: "lock_timeout"`
- [x] Existing description assertion test updated to match new help text
- [x] E2E verified: compiled binary, created two concurrent `model method run` invocations, confirmed exit code 75 on lock timeout with `SWAMP_LOCK_TIMEOUT_MS=2000`
- [x] Existing UAT adversarial tests checked — none assert `exitCode === 1` for lock scenarios, so no regressions
- [x] Filed swamp-club/swamp-uat#287 for dedicated exit code 75 UAT coverage