### PR TITLE
docs(skill): prohibit bare zod imports in extension guide (swamp-club#883)

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -78,6 +78,15 @@ Run `swamp auth whoami --json` to see available collectives. If multiple are
 returned, **always ask the user** which one to use. Use `@collective/name` from
 the start — placeholder prefixes like `@local/` are rejected during push.
 
+## Import Rules
+
+Always use `import { z } from "npm:zod@4";` in source files — never bare
+`from "zod"`. A `deno.json` imports map may map `"zod"` for local tooling, but
+source files must still use the inline `npm:zod@4` specifier. The swamp-club
+scorer runs `deno doc --lint` in a hermetic sandbox that strips the repo's
+`deno.json` and writes its own with no imports map, so bare specifiers resolve
+locally but fail at score time.
+
 ## Quick Reference
 
 | Task                | Command/Action                                 |

--- a/.claude/skills/swamp/references/extension/reference.md
+++ b/.claude/skills/swamp/references/extension/reference.md
@@ -245,7 +245,10 @@ All extension types follow the same lifecycle:
 
 ## Key Rules (All Types)
 
-1. **Import**: `import { z } from "npm:zod@4";` — always required
+1. **Import**: `import { z } from "npm:zod@4";` — never bare `"zod"` in source
+   files. The scorer strips the repo's `deno.json` and runs without an imports
+   map, so bare specifiers fail at score time even if a `deno.json` maps them
+   locally.
 2. **Static imports only**: Dynamic `import()` is rejected during push
 3. **Pin npm versions**: Always pin — inline, via `deno.json`, or `package.json`
 4. **Reserved collectives**: Cannot use `swamp` or `si` in the type


### PR DESCRIPTION
## Summary

- Add an **Import Rules** section to `guide.md` (the extension development entry point) with an explicit prohibition on bare `"zod"` imports and a brief explanation of the scorer sandbox hermeticity constraint
- Expand **Key Rules** rule #1 in `reference.md` to explain *why* bare `"zod"` fails — the scorer strips the repo's `deno.json` and runs without an imports map
- Acknowledges that `deno.json` import maps are valid for local tooling/CI, but source files must use the inline `npm:zod@4` specifier

Fixes swamp-club#883

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] Verified guidance is consistent with existing explanation in `publishing.md` and `quality/templates.md`
- [x] Confirmed no code changes needed — quality checker and scorer already enforce bare specifier detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)