### PR TITLE
feat(datastore): two-phase sync to narrow global-lock critical section (swamp-club#829)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -357,7 +357,9 @@ acquired. The extension pulls exactly one model per call.
 
 **Push path.** The flush function calls `pushChanged()` once (not per-model)
 under the global lock. When `scopedSync` is `true`, context contains all
-deduplicated models.
+deduplicated models. When `twoPhaseSync` is `true`, the push is split into
+`preparePush` (outside global lock) and `commitPush` (under global lock) — see
+"Two-Phase Sync" below.
 
 **Catalog rebuild invariant.** `synced = true` is set after `pullChanged()`
 succeeds on both the scoped and full paths. This boolean is returned in
@@ -441,6 +443,74 @@ datastores, the built-in `namespace_manifest.ts` utility reads and writes
 manifest files directly. Both methods are optional on `DatastoreProvider` —
 when the extension does not implement them, the CLI warns that conflict
 detection is unavailable and proceeds with only the `.swamp.yaml` update.
+
+### Two-Phase Sync
+
+When an extension advertises `twoPhaseSync: true` in its capabilities, swamp
+core splits the push into two phases to narrow the global-lock critical section:
+
+```
+Single-phase (default — pushChanged under global lock):
+
+  acquire global lock
+  pushChanged()          ← entire sync: index read + file upload + index write
+  release global lock
+
+Two-phase (twoPhaseSync: true):
+
+  preparePush()          ← file uploads only, outside global lock
+  acquire global lock
+  commitPush(manifest)   ← index merge only, fast
+  release global lock
+```
+
+This matters for workloads with many concurrent per-model writers in the same
+namespace. Without two-phase sync, every writer acquires the global lock to
+do a full push — serializing all concurrent writes behind the lock. With
+two-phase sync, the expensive file I/O (`preparePush`) overlaps across
+writers, and only the fast index merge (`commitPush`) serializes.
+
+#### Extension contract
+
+Extensions implement two optional methods on `DatastoreSyncService`:
+
+- **`preparePush(options?)`** — Upload new/changed files to the remote.
+  Return an opaque `PushManifest` describing what changed. Do NOT update the
+  remote index. Do NOT clear the dirty flag (if `commitPush` fails, the dirty
+  flag must remain set so the next push retries).
+
+- **`commitPush(manifest, options?)`** — Read the **current** remote index
+  (not a cached copy — another writer may have committed between
+  `preparePush` and `commitPush`). **Merge** the manifest entries into the
+  index — never replace the entire index. Write the updated index back. Clear
+  the dirty flag only after the index write succeeds.
+
+The manifest type (`PushManifest`) is opaque to core — core passes it through
+from `preparePush` to `commitPush` without inspection. The extension defines
+what goes inside.
+
+#### Integrity guarantees
+
+Core provides the integrity guarantees; extensions do not need to implement
+their own concurrency control:
+
+1. **Global lock on `commitPush`** — the index read-modify-write is always
+   serialized. Two concurrent `commitPush` calls never overlap.
+2. **Per-model locks across both phases** — held from before `preparePush`
+   through after `commitPush`. Structural commands' symmetric drain waits
+   for these locks, so a concurrent delete/GC cannot interfere.
+3. **Additive merge** — since per-model locks guarantee non-overlapping file
+   paths between concurrent writers, manifests from different writers never
+   conflict. `commitPush` merges into whatever the current index contains.
+4. **Catalog export under lock** — `.catalog-export.json` is written inside
+   the global-lock critical section (between lock acquire and `commitPush`),
+   so concurrent catalog exports do not race.
+
+#### Fallback
+
+Extensions that do not advertise `twoPhaseSync` (or do not implement
+`preparePush`/`commitPush`) continue to use the single-phase
+`pushChanged`-under-global-lock path — zero regression.
 
 ### Zero-Diff Fast Path (Extension Guidance)
 

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -502,9 +502,11 @@ their own concurrency control:
 3. **Additive merge** — since per-model locks guarantee non-overlapping file
    paths between concurrent writers, manifests from different writers never
    conflict. `commitPush` merges into whatever the current index contains.
-4. **Catalog export under lock** — `.catalog-export.json` is written inside
-   the global-lock critical section (between lock acquire and `commitPush`),
-   so concurrent catalog exports do not race.
+4. **Catalog export before upload** — `.catalog-export.json` is written
+   before `preparePush` so it is included in the file upload phase. The
+   export is a full snapshot of the local catalog, so concurrent writers
+   that overwrite it produce a correct (more complete) result. This avoids
+   a gap where the export is dirty but never uploaded.
 
 #### Fallback
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -78,6 +78,7 @@ import type {
   DatastoreSyncService,
   HydrateFileHook,
   MarkDirtyHook,
+  PushManifest,
   SyncCapabilities,
   SyncContext,
 } from "../domain/datastore/datastore_sync_service.ts";
@@ -1201,103 +1202,47 @@ export async function acquireModelLocks(
     try {
       Deno.env.delete(SWAMP_LOCK_HOLDER_PID);
 
-      // For custom sync-capable datastores: push under global lock
+      // For custom sync-capable datastores: push changes to remote
       if (
         customSyncService && customProvider && isCustomDatastoreConfig(config)
       ) {
-        const pushLock = customProvider.createLock(
-          config.datastorePath,
-          {
-            ...datastoreGlobalLockOptions(config),
-            maxWaitMs: resolveLockTimeoutMs(),
-          },
-        );
-        try {
-          const lockStart = Date.now();
-          await pushLock.acquire();
-          const lockMs = Date.now() - lockStart;
-          if (
-            lockMs > 5_000 && isCustomDatastoreConfig(config) &&
-            !config.namespace
-          ) {
-            logger.warn(
-              "Lock acquisition took {ms}ms — multiple repos sharing this " +
-                "datastore without namespaces serialize all writes behind a " +
-                "single global lock. Run 'swamp datastore namespace set " +
-                "<name>' to scope each repo to its own lock and index",
-              { ms: lockMs },
-            );
-          }
-          logger.info`Pushing changes to datastore...`;
+        const pushNs = isCustomDatastoreConfig(config)
+          ? config.namespace
+          : undefined;
 
-          const pushNs = isCustomDatastoreConfig(config)
-            ? config.namespace
-            : undefined;
-
-          if (
-            pushNs && catalogStore &&
-            isCustomDatastoreConfig(config) && config.cachePath
-          ) {
-            try {
-              const exportCount = await writeCatalogExport(
-                catalogStore,
-                config.cachePath,
-                pushNs,
-              );
-              await customSyncService.markDirty({
-                relPath: `${pushNs}/.catalog-export.json`,
-              });
-              logger.info(
-                "Wrote catalog export ({count} row(s)) for namespace {namespace}",
-                { count: exportCount, namespace: pushNs },
-              );
-            } catch (error) {
-              logger.warn(
-                "Catalog export write failed: {error}",
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                },
-              );
-            }
-          }
-
-          let pushed: number | void;
-          if (caps?.scopedSync) {
-            const context: SyncContext = { models: unique };
-            pushed = await customSyncService.pushChanged({
-              context,
-              ...(pushNs ? { namespace: pushNs } : {}),
-            });
-          } else if (pushNs) {
-            pushed = await customSyncService.pushChanged({ namespace: pushNs });
-          } else {
-            pushed = await customSyncService.pushChanged();
-          }
-          if (pushed && pushed > 0) {
-            logger.info("Pushed {count} file(s) to datastore", {
-              count: pushed,
-            });
-          } else {
-            logger.info`Push complete, no changes`;
-          }
-        } catch (error) {
-          const { summary, fields } = summarizeSyncError(
-            "push",
-            config.type,
-            error,
+        if (
+          caps?.twoPhaseSync && customSyncService.preparePush &&
+          customSyncService.commitPush
+        ) {
+          // Two-phase push: file uploads outside global lock, index
+          // merge under global lock. Narrows the critical section from
+          // "entire sync" to "index read-modify-write" only.
+          await flushTwoPhasePush(
+            customProvider,
+            customSyncService,
+            config,
+            caps,
+            unique,
+            pushNs,
+            catalogStore,
+            logger,
           );
-          logger.error("{summary}", { summary, ...fields });
-          throw new Error(summary, { cause: error });
-        } finally {
-          try {
-            await pushLock.release();
-          } catch {
-            // Best-effort release
-          }
+        } else {
+          // Single-phase fallback: everything under global lock
+          await flushSinglePhasePush(
+            customProvider,
+            customSyncService,
+            config,
+            caps,
+            unique,
+            pushNs,
+            catalogStore,
+            logger,
+          );
         }
       }
     } finally {
-      // Always release per-model locks, even if S3 push fails
+      // Always release per-model locks, even if push fails
       for (const key of lockKeys) {
         await flushDatastoreSyncNamed(key);
       }
@@ -1305,6 +1250,228 @@ export async function acquireModelLocks(
   };
 
   return { flush, synced };
+}
+
+/**
+ * Single-phase push: everything under the global lock (existing behavior).
+ *
+ * Acquires the global lock, writes catalog export, calls `pushChanged`,
+ * then releases. Used when the extension does not advertise `twoPhaseSync`.
+ */
+export async function flushSinglePhasePush(
+  provider: DatastoreProvider,
+  syncService: DatastoreSyncService,
+  config: CustomDatastoreConfig,
+  caps: SyncCapabilities | undefined,
+  models: ReadonlyArray<{ modelType: string; modelId: string }>,
+  namespace: string | undefined,
+  catalogStore: CatalogStore | undefined,
+  logger: ReturnType<typeof getSwampLogger>,
+): Promise<void> {
+  const pushLock = provider.createLock(
+    config.datastorePath,
+    {
+      ...datastoreGlobalLockOptions(config),
+      maxWaitMs: resolveLockTimeoutMs(),
+    },
+  );
+  try {
+    const lockStart = Date.now();
+    await pushLock.acquire();
+    const lockMs = Date.now() - lockStart;
+    if (lockMs > 5_000 && !config.namespace) {
+      logger.warn(
+        "Lock acquisition took {ms}ms — multiple repos sharing this " +
+          "datastore without namespaces serialize all writes behind a " +
+          "single global lock. Run 'swamp datastore namespace set " +
+          "<name>' to scope each repo to its own lock and index",
+        { ms: lockMs },
+      );
+    }
+    logger.info`Pushing changes to datastore...`;
+
+    await writeCatalogExportIfNeeded(
+      syncService,
+      config,
+      namespace,
+      catalogStore,
+      logger,
+    );
+
+    let pushed: number | void;
+    if (caps?.scopedSync) {
+      const context: SyncContext = { models: [...models] };
+      pushed = await syncService.pushChanged({
+        context,
+        ...(namespace ? { namespace } : {}),
+      });
+    } else if (namespace) {
+      pushed = await syncService.pushChanged({ namespace });
+    } else {
+      pushed = await syncService.pushChanged();
+    }
+    if (pushed && pushed > 0) {
+      logger.info("Pushed {count} file(s) to datastore", {
+        count: pushed,
+      });
+    } else {
+      logger.info`Push complete, no changes`;
+    }
+  } catch (error) {
+    const { summary, fields } = summarizeSyncError(
+      "push",
+      config.type,
+      error,
+    );
+    logger.error("{summary}", { summary, ...fields });
+    throw new Error(summary, { cause: error });
+  } finally {
+    try {
+      await pushLock.release();
+    } catch {
+      // Best-effort release
+    }
+  }
+}
+
+/**
+ * Two-phase push: file I/O outside the lock, index merge under the lock.
+ *
+ * 1. `preparePush` — uploads changed files to the remote (expensive,
+ *    runs under per-model locks only, no global lock)
+ * 2. Acquire global lock
+ * 3. Write catalog export
+ * 4. `commitPush` — merges the manifest into the remote index (fast)
+ * 5. Release global lock
+ *
+ * This narrows the critical section from "entire sync" to "index
+ * read-modify-write" only. Concurrent writers to different models
+ * overlap on step 1 and serialize only on steps 2–5.
+ */
+export async function flushTwoPhasePush(
+  provider: DatastoreProvider,
+  syncService: DatastoreSyncService,
+  config: CustomDatastoreConfig,
+  caps: SyncCapabilities | undefined,
+  models: ReadonlyArray<{ modelType: string; modelId: string }>,
+  namespace: string | undefined,
+  catalogStore: CatalogStore | undefined,
+  logger: ReturnType<typeof getSwampLogger>,
+): Promise<void> {
+  // Phase 1: upload files outside the global lock
+  let manifest: PushManifest;
+  try {
+    logger.info`Preparing push (uploading files)...`;
+    const prepareOpts = caps?.scopedSync
+      ? {
+        context: { models: [...models] } as SyncContext,
+        ...(namespace ? { namespace } : {}),
+      }
+      : namespace
+      ? { namespace }
+      : undefined;
+    manifest = await syncService.preparePush!(prepareOpts);
+  } catch (error) {
+    const { summary, fields } = summarizeSyncError(
+      "push",
+      config.type,
+      error,
+    );
+    logger.error("{summary}", { summary, ...fields });
+    throw new Error(summary, { cause: error });
+  }
+
+  // Phase 2: index merge under global lock
+  const pushLock = provider.createLock(
+    config.datastorePath,
+    {
+      ...datastoreGlobalLockOptions(config),
+      maxWaitMs: resolveLockTimeoutMs(),
+    },
+  );
+  try {
+    const lockStart = Date.now();
+    await pushLock.acquire();
+    const lockMs = Date.now() - lockStart;
+    if (lockMs > 5_000 && !config.namespace) {
+      logger.warn(
+        "Lock acquisition took {ms}ms — multiple repos sharing this " +
+          "datastore without namespaces serialize all writes behind a " +
+          "single global lock. Run 'swamp datastore namespace set " +
+          "<name>' to scope each repo to its own lock and index",
+        { ms: lockMs },
+      );
+    }
+    logger.info`Committing index update...`;
+
+    await writeCatalogExportIfNeeded(
+      syncService,
+      config,
+      namespace,
+      catalogStore,
+      logger,
+    );
+
+    const commitOpts = namespace ? { namespace } : undefined;
+    const pushed = await syncService.commitPush!(manifest, commitOpts);
+    if (pushed && pushed > 0) {
+      logger.info("Committed {count} file(s) to datastore index", {
+        count: pushed,
+      });
+    } else {
+      logger.info`Commit complete, no index changes`;
+    }
+  } catch (error) {
+    const { summary, fields } = summarizeSyncError(
+      "push",
+      config.type,
+      error,
+    );
+    logger.error("{summary}", { summary, ...fields });
+    throw new Error(summary, { cause: error });
+  } finally {
+    try {
+      await pushLock.release();
+    } catch {
+      // Best-effort release
+    }
+  }
+}
+
+/**
+ * Writes `.catalog-export.json` for the namespace if applicable.
+ * Shared by both single-phase and two-phase push paths.
+ */
+export async function writeCatalogExportIfNeeded(
+  syncService: DatastoreSyncService,
+  config: CustomDatastoreConfig,
+  namespace: string | undefined,
+  catalogStore: CatalogStore | undefined,
+  logger: ReturnType<typeof getSwampLogger>,
+): Promise<void> {
+  if (namespace && catalogStore && config.cachePath) {
+    try {
+      const exportCount = await writeCatalogExport(
+        catalogStore,
+        config.cachePath,
+        namespace,
+      );
+      await syncService.markDirty({
+        relPath: `${namespace}/.catalog-export.json`,
+      });
+      logger.info(
+        "Wrote catalog export ({count} row(s)) for namespace {namespace}",
+        { count: exportCount, namespace },
+      );
+    } catch (error) {
+      logger.warn(
+        "Catalog export write failed: {error}",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
 }
 
 export interface VaultSyncResult {

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1206,9 +1206,7 @@ export async function acquireModelLocks(
       if (
         customSyncService && customProvider && isCustomDatastoreConfig(config)
       ) {
-        const pushNs = isCustomDatastoreConfig(config)
-          ? config.namespace
-          : undefined;
+        const pushNs = config.namespace;
 
         if (
           caps?.twoPhaseSync && customSyncService.preparePush &&
@@ -1358,6 +1356,18 @@ export async function flushTwoPhasePush(
   catalogStore: CatalogStore | undefined,
   logger: ReturnType<typeof getSwampLogger>,
 ): Promise<void> {
+  // Write catalog export before preparePush so it's included in the
+  // upload phase. The export is a full snapshot of the local catalog —
+  // safe to write outside the lock because a later concurrent writer
+  // simply overwrites with a more complete snapshot.
+  await writeCatalogExportIfNeeded(
+    syncService,
+    config,
+    namespace,
+    catalogStore,
+    logger,
+  );
+
   // Phase 1: upload files outside the global lock
   let manifest: PushManifest;
   try {
@@ -1403,14 +1413,6 @@ export async function flushTwoPhasePush(
       );
     }
     logger.info`Committing index update...`;
-
-    await writeCatalogExportIfNeeded(
-      syncService,
-      config,
-      namespace,
-      catalogStore,
-      logger,
-    );
 
     const commitOpts = namespace ? { namespace } : undefined;
     const pushed = await syncService.commitPush!(manifest, commitOpts);

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -30,6 +30,8 @@ import {
   acquireModelLocks,
   createModelLock,
   datastoreGlobalLockOptions,
+  flushSinglePhasePush,
+  flushTwoPhasePush,
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
   requireInitializedRepoUnlocked,
@@ -39,9 +41,11 @@ import {
 } from "./repo_context.ts";
 import { flushDatastoreSync } from "../infrastructure/persistence/datastore_sync_coordinator.ts";
 import {
+  type CustomDatastoreConfig,
   type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../domain/datastore/datastore_config.ts";
+import type { PushManifest } from "../domain/datastore/datastore_sync_service.ts";
 import { LockTimeoutError } from "../domain/datastore/distributed_lock.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
@@ -1771,5 +1775,366 @@ Deno.test("acquireModelLocks - namespace is threaded to pull and push", async ()
       "pushChanged must receive namespace from config",
     );
     assertExists(pushOpts?.context, "pushChanged must still receive context");
+  });
+});
+
+// ── Two-Phase Sync Tests ─────────────────────────────────────────────────────
+
+function createMockConfig(namespace?: string): CustomDatastoreConfig {
+  return {
+    type: "test-two-phase",
+    config: { bucket: "test" },
+    datastorePath: "/tmp/test-datastore",
+    cachePath: "/tmp/test-cache",
+    namespace,
+  };
+}
+
+function createMockProvider(events: string[]) {
+  return {
+    createLock: () => ({
+      acquire: () => {
+        events.push("global-lock-acquire");
+        return Promise.resolve();
+      },
+      release: () => {
+        events.push("global-lock-release");
+        return Promise.resolve();
+      },
+      withLock: <T>(fn: () => Promise<T>) => fn(),
+      inspect: () => Promise.resolve(null),
+      forceRelease: () => Promise.resolve(true),
+    }),
+    createVerifier: () => ({
+      verify: () =>
+        Promise.resolve({
+          healthy: true,
+          message: "ok",
+          latencyMs: 1,
+          datastoreType: "test",
+        }),
+    }),
+    resolveDatastorePath: () => "/tmp/test-datastore",
+    resolveCachePath: () => "/tmp/test-cache",
+  };
+}
+
+function createMockLogger() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as unknown as ReturnType<
+    typeof import("../infrastructure/logging/logger.ts").getSwampLogger
+  >;
+}
+
+Deno.test("flushTwoPhasePush: calls preparePush outside lock, commitPush inside lock", async () => {
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+  const mockManifest = { uploaded: ["a.json"] } as unknown as PushManifest;
+
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => {
+      events.push("pushChanged");
+      return Promise.resolve(0);
+    },
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ twoPhaseSync: true, scopedSync: true }),
+    preparePush: () => {
+      events.push("preparePush");
+      return Promise.resolve(mockManifest);
+    },
+    commitPush: () => {
+      events.push("commitPush");
+      return Promise.resolve(1);
+    },
+  };
+
+  await flushTwoPhasePush(
+    provider,
+    syncService,
+    createMockConfig(),
+    { twoPhaseSync: true, scopedSync: true },
+    [{ modelType: "test", modelId: "m1" }],
+    undefined,
+    undefined,
+    createMockLogger(),
+  );
+
+  assertEquals(events, [
+    "preparePush",
+    "global-lock-acquire",
+    "commitPush",
+    "global-lock-release",
+  ]);
+});
+
+Deno.test("flushSinglePhasePush: calls pushChanged under global lock", async () => {
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => {
+      events.push("pushChanged");
+      return Promise.resolve(0);
+    },
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ scopedSync: true }),
+  };
+
+  await flushSinglePhasePush(
+    provider,
+    syncService,
+    createMockConfig(),
+    { scopedSync: true },
+    [{ modelType: "test", modelId: "m1" }],
+    undefined,
+    undefined,
+    createMockLogger(),
+  );
+
+  assertEquals(events, [
+    "global-lock-acquire",
+    "pushChanged",
+    "global-lock-release",
+  ]);
+});
+
+Deno.test("flushTwoPhasePush: preparePush failure skips global lock", async () => {
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ twoPhaseSync: true }),
+    preparePush: () => {
+      events.push("preparePush");
+      return Promise.reject(new Error("upload failed"));
+    },
+    commitPush: () => {
+      events.push("commitPush");
+      return Promise.resolve(0);
+    },
+  };
+
+  await assertRejects(
+    () =>
+      flushTwoPhasePush(
+        provider,
+        syncService,
+        createMockConfig(),
+        { twoPhaseSync: true },
+        [{ modelType: "test", modelId: "m1" }],
+        undefined,
+        undefined,
+        createMockLogger(),
+      ),
+    Error,
+  );
+
+  assertEquals(events, ["preparePush"]);
+  assertEquals(events.includes("global-lock-acquire"), false);
+});
+
+Deno.test("flushTwoPhasePush: commitPush failure still releases global lock", async () => {
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+  const mockManifest = {} as unknown as PushManifest;
+
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ twoPhaseSync: true }),
+    preparePush: () => {
+      events.push("preparePush");
+      return Promise.resolve(mockManifest);
+    },
+    commitPush: () => {
+      events.push("commitPush");
+      return Promise.reject(new Error("index update failed"));
+    },
+  };
+
+  await assertRejects(
+    () =>
+      flushTwoPhasePush(
+        provider,
+        syncService,
+        createMockConfig(),
+        { twoPhaseSync: true },
+        [{ modelType: "test", modelId: "m1" }],
+        undefined,
+        undefined,
+        createMockLogger(),
+      ),
+    Error,
+  );
+
+  assertEquals(events.includes("global-lock-acquire"), true);
+  assertEquals(events.includes("global-lock-release"), true);
+  assertEquals(
+    events.indexOf("global-lock-release") > events.indexOf("commitPush"),
+    true,
+    "global lock must be released after commitPush failure",
+  );
+});
+
+Deno.test("flushTwoPhasePush: passes namespace to both phases", async () => {
+  const prepareOpts: unknown[] = [];
+  const commitOpts: unknown[] = [];
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+  const mockManifest = {} as unknown as PushManifest;
+
+  const syncService = {
+    pullChanged: () => Promise.resolve(0),
+    pushChanged: () => Promise.resolve(0),
+    markDirty: () => Promise.resolve(),
+    capabilities: () => ({ twoPhaseSync: true, scopedSync: true }),
+    preparePush: (opts?: unknown) => {
+      prepareOpts.push(opts);
+      return Promise.resolve(mockManifest);
+    },
+    commitPush: (_manifest: unknown, opts?: unknown) => {
+      commitOpts.push(opts);
+      return Promise.resolve(1);
+    },
+  };
+
+  await flushTwoPhasePush(
+    provider,
+    syncService,
+    createMockConfig("infra"),
+    { twoPhaseSync: true, scopedSync: true },
+    [{ modelType: "test", modelId: "m1" }],
+    "infra",
+    undefined,
+    createMockLogger(),
+  );
+
+  const prepOpts = prepareOpts[0] as { namespace?: string; context?: unknown };
+  assertEquals(prepOpts?.namespace, "infra");
+  assertExists(prepOpts?.context);
+
+  const cmtOpts = commitOpts[0] as { namespace?: string };
+  assertEquals(cmtOpts?.namespace, "infra");
+});
+
+Deno.test("acquireModelLocks: uses two-phase push when twoPhaseSync is advertised", async () => {
+  const { datastoreTypeRegistry } = await import(
+    "../domain/datastore/datastore_type_registry.ts"
+  );
+
+  const typeName = "test-two-phase-sync";
+  const events: string[] = [];
+  const mockManifest = {} as unknown as PushManifest;
+
+  if (!datastoreTypeRegistry.has(typeName)) {
+    datastoreTypeRegistry.register({
+      type: typeName,
+      name: "Test two-phase sync",
+      description: "Test extension for two-phase sync",
+      isBuiltIn: false,
+      createProvider: () => ({
+        createLock: () => ({
+          acquire: () => {
+            events.push("lock-acquire");
+            return Promise.resolve();
+          },
+          release: () => {
+            events.push("lock-release");
+            return Promise.resolve();
+          },
+          withLock: <T>(fn: () => Promise<T>) => fn(),
+          inspect: () => Promise.resolve(null),
+          forceRelease: () => Promise.resolve(true),
+        }),
+        createVerifier: () => ({
+          verify: () =>
+            Promise.resolve({
+              healthy: true,
+              message: "ok",
+              latencyMs: 1,
+              datastoreType: typeName,
+            }),
+        }),
+        resolveDatastorePath: (repoDir: string) => `${repoDir}/.test-store`,
+        resolveCachePath: (repoDir: string) => `${repoDir}/.test-cache`,
+        createSyncService: () => ({
+          pullChanged: () => Promise.resolve(0),
+          pushChanged: () => {
+            events.push("pushChanged");
+            return Promise.resolve(0);
+          },
+          markDirty: () => Promise.resolve(),
+          capabilities: () => ({
+            scopedSync: true,
+            twoPhaseSync: true,
+          }),
+          preparePush: () => {
+            events.push("preparePush");
+            return Promise.resolve(mockManifest);
+          },
+          commitPush: () => {
+            events.push("commitPush");
+            return Promise.resolve(1);
+          },
+        }),
+      }),
+    });
+  }
+
+  await withTempDir(async (dir) => {
+    await initializeRepo(dir);
+
+    const markerPath = join(dir, ".swamp.yaml");
+    const existing = await Deno.readTextFile(markerPath);
+    const datastoreYaml = [
+      "datastore:",
+      `  type: '${typeName}'`,
+      "  config:",
+      "    bucket: test-bucket",
+    ].join("\n");
+    await Deno.writeTextFile(
+      markerPath,
+      existing.trimEnd() + "\n" + datastoreYaml + "\n",
+    );
+
+    events.length = 0;
+
+    const { datastoreConfig } = await resolveDatastoreForRepo(dir);
+    const lockResult = await acquireModelLocks(datastoreConfig, [
+      { modelType: "test-type", modelId: "m1" },
+    ], dir);
+
+    await lockResult.flush();
+
+    assertEquals(
+      events.includes("preparePush"),
+      true,
+      "two-phase path must call preparePush",
+    );
+    assertEquals(
+      events.includes("commitPush"),
+      true,
+      "two-phase path must call commitPush",
+    );
+    assertEquals(
+      events.includes("pushChanged"),
+      false,
+      "two-phase path must NOT call pushChanged",
+    );
+    assertEquals(
+      events.indexOf("preparePush") < events.indexOf("commitPush"),
+      true,
+      "preparePush must run before commitPush",
+    );
   });
 });

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -36,7 +36,26 @@ export interface SyncCapabilities {
    * are expected to ignore it and sync everything (solo-mode behavior).
    */
   namespacedSync?: boolean;
+  /**
+   * When `true`, the extension supports two-phase push via
+   * {@link DatastoreSyncService.preparePush} +
+   * {@link DatastoreSyncService.commitPush}. Core splits the push so
+   * expensive file I/O runs outside the global lock (narrowing the
+   * critical section to the index merge only). Extensions that don't
+   * advertise this continue to use `pushChanged` under the global lock.
+   */
+  twoPhaseSync?: boolean;
 }
+
+/**
+ * Opaque manifest returned by {@link DatastoreSyncService.preparePush}
+ * and consumed by {@link DatastoreSyncService.commitPush}.
+ *
+ * Core treats this as passthrough — it never inspects or validates the
+ * contents. The extension defines what goes inside; core only
+ * orchestrates when each phase runs.
+ */
+export type PushManifest = { readonly __brand: unique symbol };
 
 /** Options accepted by sync service methods. */
 export interface DatastoreSyncOptions {
@@ -226,6 +245,51 @@ export interface DatastoreSyncService {
     namespace: string,
     relPath: string,
   ): Promise<Uint8Array | null>;
+
+  /**
+   * Phase 1 of two-phase push: upload changed files to the remote.
+   *
+   * Called **outside** the global lock (but under per-model locks) so the
+   * expensive file I/O runs concurrently across writers to different
+   * models. Returns an opaque {@link PushManifest} that
+   * {@link commitPush} consumes to update the remote index.
+   *
+   * Contract:
+   * 1. Upload new/changed/deleted files to the remote backend.
+   * 2. Return a manifest describing what changed — core passes it
+   *    through to `commitPush` without inspection.
+   * 3. Do NOT update the remote index — that happens in `commitPush`
+   *    under the global lock.
+   * 4. Do NOT clear the dirty flag — if `commitPush` fails, the dirty
+   *    flag must remain set so the next push retries.
+   *
+   * Optional — only implemented by extensions that advertise
+   * `twoPhaseSync: true` in their capabilities.
+   */
+  preparePush?(options?: DatastoreSyncOptions): Promise<PushManifest>;
+
+  /**
+   * Phase 2 of two-phase push: merge the manifest into the remote index.
+   *
+   * Called **under** the global lock so the index read-modify-write is
+   * serialized. Receives the manifest from {@link preparePush} and merges
+   * its entries into the current remote index — read the latest index,
+   * add/update/remove entries per the manifest, write the index back.
+   *
+   * Contract:
+   * 1. Read the **current** remote index (not a cached copy from
+   *    `preparePush` — another writer may have committed in between).
+   * 2. **Merge** manifest entries — never replace the entire index.
+   * 3. Clear the dirty flag only after the index write succeeds.
+   * 4. Return the number of files whose index entries were updated.
+   *
+   * Optional — only implemented by extensions that advertise
+   * `twoPhaseSync: true` in their capabilities.
+   */
+  commitPush?(
+    manifest: PushManifest,
+    options?: DatastoreSyncOptions,
+  ): Promise<number | void>;
 }
 
 /** A single foreign catalog export: the namespace it came from and its rows. */

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -52,6 +52,7 @@ export {
   type DatastoreSyncOptions,
   type DatastoreSyncService,
   type MarkDirtyHook,
+  type PushManifest,
   type SyncCapabilities,
   type SyncContext,
   type SyncDirection,


### PR DESCRIPTION
## Summary

- Add `twoPhaseSync` capability and `preparePush`/`commitPush` methods to `DatastoreSyncService`, enabling extensions to split push into file uploads (outside global lock) and index merge (under global lock)
- Extract `flushSinglePhasePush` and `flushTwoPhasePush` from the `acquireModelLocks` flush closure for testability
- Document the two-phase sync protocol, extension contract, and integrity guarantees in `design/datastores.md`

Closes swamp-club#829 — intra-namespace write concurrency bottleneck where whole-index sync under the global lock serialized fan-out workloads. This is the core enabler; the `@swamp/s3-datastore` extension needs a follow-up to implement `preparePush`/`commitPush` for the concurrency benefit to take effect.

## Test Plan

- 5 unit tests for `flushTwoPhasePush` and `flushSinglePhasePush`: lock ordering, preparePush failure skipping global lock, commitPush failure releasing lock, namespace threading, single-phase fallback
- 1 end-to-end test through `acquireModelLocks` with registered mock provider verifying two-phase dispatch
- `deno check`, `deno lint`, `deno fmt` all pass
- Full test suite: 8035/8036 pass (1 unrelated flaky SIGINT signal test)