### PR TITLE
fix(extensions): skip broken-bundle warning for deleted source files (swamp-club#894)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1231,7 +1231,9 @@ Recovery paths:
 - **`swamp extension pull <name> --force`** manually re-downloads the extension
   including its pre-built bundle.
 - **User-facing warning:** `registerLazyFromCatalog` warns when extensions are
-  skipped due to failure states, directing users to the recovery commands.
+  skipped due to failure states, directing users to the recovery commands. The
+  warning checks source file existence before firing — stale catalog entries
+  for deleted source files are silently skipped (swamp-club#894).
 
 `BUNDLE_LAYOUT_VERSION` must be bumped whenever a change to the bundler, runtime
 interface, or zod global shape would make existing bundles incompatible.

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -735,6 +735,7 @@ export class ExtensionLoader {
           entry.state === "ValidationFailed" ||
           entry.state === "BundleBuildFailed"
         ) {
+          if (!this.sourceExistsOnDisk(entry.source_path)) continue;
           const name = entry.extension_name || entry.type_normalized;
           if (name && !skippedExtensions.has(name)) {
             skippedExtensions.add(name);
@@ -748,6 +749,16 @@ export class ExtensionLoader {
     for (const name of skippedExtensions) {
       this.logger
         .warn`Extension ${name} has broken bundles and is not available. Run 'swamp doctor extensions --repair' or 'swamp extension pull ${name} --force' to fix.`;
+    }
+  }
+
+  private sourceExistsOnDisk(sourcePath: string): boolean {
+    try {
+      Deno.statSync(sourcePath);
+      return true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) return true;
+      return false;
     }
   }
 

--- a/src/domain/extensions/extension_loader_test.ts
+++ b/src/domain/extensions/extension_loader_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { toFileUrl } from "@std/path";
 import { findStaleFiles, type FreshnessCatalog } from "./bundle_freshness.ts";
+import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { ExtensionTypeRow } from "../../infrastructure/persistence/extension_catalog_store.ts";
 
 Deno.test("importBundleByPath: non-empty fingerprint appends ?fp= to import URL", async () => {
@@ -211,4 +212,122 @@ Deno.test("fingerprint URL guard: distinct fingerprints produce distinct URLs", 
   assertEquals(url3.includes("?fp="), false);
   assertEquals(url4, baseUrl);
   assertEquals(url4.includes("?fp="), false);
+});
+
+// -- BundleBuildFailed stale-entry preservation (swamp-club#894) -----------
+
+Deno.test("findStaleFiles: BundleBuildFailed entries for missing sources are preserved in catalog", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_stale_bbf_" });
+  try {
+    const dbPath = join(dir, "catalog.db");
+    const catalog = new ExtensionCatalogStore(dbPath);
+    try {
+      const existingSource = join(dir, "valid_model.ts");
+      const deletedSource = join(dir, "deleted_model.ts");
+      await Deno.writeTextFile(existingSource, "export const model = {};");
+
+      catalog.upsert({
+        source_path: existingSource,
+        type_normalized: "valid-model",
+        kind: "model",
+        bundle_path: join(dir, "valid_model.js"),
+        version: "1.0.0",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "fp-valid",
+        state: "Indexed",
+        extension_name: "@local/test",
+        extension_version: "1.0.0",
+        last_error: "",
+      });
+
+      catalog.upsert({
+        source_path: deletedSource,
+        type_normalized: "",
+        kind: "model",
+        bundle_path: "",
+        version: "1.0.0",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "fp-deleted",
+        state: "BundleBuildFailed",
+        extension_name: "@local/test",
+        extension_version: "1.0.0",
+        last_error: "some build error",
+      });
+
+      await findStaleFiles({
+        modelsDir: dir,
+        catalog,
+        discoverFiles: discoverExcludingTestFiles,
+        kinds: ["model"],
+      });
+
+      const remaining = catalog.findByKind("model");
+      const bbfEntry = remaining.find((r) => r.state === "BundleBuildFailed");
+      assertEquals(
+        bbfEntry !== undefined,
+        true,
+        "BundleBuildFailed entry for deleted source must be preserved by findStaleFiles (reconcile handles cleanup)",
+      );
+
+      const indexedEntry = remaining.find((r) => r.state === "Indexed");
+      assertEquals(
+        indexedEntry !== undefined,
+        true,
+        "Indexed entry for existing source must survive",
+      );
+    } finally {
+      catalog.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("findStaleFiles: ValidationFailed entries for missing sources are removed from catalog", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_stale_vf_" });
+  try {
+    const dbPath = join(dir, "catalog.db");
+    const catalog = new ExtensionCatalogStore(dbPath);
+    try {
+      const deletedSource = join(dir, "deleted_model.ts");
+
+      catalog.upsert({
+        source_path: deletedSource,
+        type_normalized: "",
+        kind: "model",
+        bundle_path: "",
+        version: "1.0.0",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "fp-deleted",
+        state: "ValidationFailed",
+        extension_name: "@local/test",
+        extension_version: "1.0.0",
+        last_error: "validation error",
+      });
+
+      await findStaleFiles({
+        modelsDir: dir,
+        catalog,
+        discoverFiles: discoverExcludingTestFiles,
+        kinds: ["model"],
+      });
+
+      const remaining = catalog.findByKind("model");
+      assertEquals(
+        remaining.length,
+        0,
+        "ValidationFailed entry for deleted source must be removed by findStaleFiles",
+      );
+    } finally {
+      catalog.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
 });


### PR DESCRIPTION
## Summary

- `registerLazyFromCatalog` now checks source file existence before warning about `BundleBuildFailed`/`ValidationFailed` catalog entries
- Stale entries for deleted source files are silently skipped, fixing the false "broken bundles / not available" warning that contradicted `doctor extensions` PASS
- Added tests verifying `findStaleFiles` preserves `BundleBuildFailed` entries for missing sources (existing behavior) and removes `ValidationFailed` entries (existing behavior)
- Updated `design/extension.md` to document the source-existence check

Closes swamp-club#894

## Root Cause

When a source file with `BundleBuildFailed` state is deleted, the catalog entry persists because `findStaleFiles` preserves failure-state entries for retry. But there's nothing to retry when the source is gone. `registerLazyFromCatalog` sees the stale entry and warns "broken bundles / not available." Meanwhile, `doctor extensions` runs reconcile first (which transitions the entry to `OrphanedBundleOnly`), finds no failures, and reports PASS — contradicting the warning.

## Fix

Added a `sourceExistsOnDisk` check (via `Deno.statSync`) gated behind the existing `ValidationFailed`/`BundleBuildFailed` state check. If the source is gone, the entry is stale — skip it. If the source exists, the failure is real — warn as before.

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test` — 8038 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Reproduction verified: created scratch repo with a broken model, deleted the source, confirmed no false warning with fixed binary
- [x] Verified `doctor extensions` reports PASS and agrees with the regular command

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>