### PR TITLE
fix(repo): clarify superseded and shadowing skill warnings (swamp-club#898)

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -168,7 +168,7 @@ local copies manually.
 **During `swamp repo upgrade`**, local copies are detected and reported:
 
 ```
-WRN Local swamp skill copies are shadowing the globally installed skills.
+WRN Local copies of swamp, swamp-getting-started are shadowing the globally installed skills.
     Delete them manually:
       .claude/skills/swamp
       .claude/skills/swamp-getting-started

--- a/design/repo.md
+++ b/design/repo.md
@@ -63,7 +63,7 @@ tools' skill directories for superseded subdirectories. If any are found, a
 warning is emitted via the deferred-warning system:
 
 ```
-WRN 2 superseded skill(s) found: swamp-data-query, swamp-extension-model. Run 'swamp repo upgrade' to update skills.
+WRN 2 old swamp-managed skill(s) can be safely deleted: swamp-data-query, swamp-extension-model. These have been replaced by the bundled swamp skill.
 ```
 
 This check is non-fatal — it never blocks startup. `swamp repo upgrade`

--- a/design/repo.md
+++ b/design/repo.md
@@ -63,7 +63,7 @@ tools' skill directories for superseded subdirectories. If any are found, a
 warning is emitted via the deferred-warning system:
 
 ```
-WRN 2 old swamp-managed skill(s) can be safely deleted: swamp-data-query, swamp-extension-model. These have been replaced by the bundled swamp skill.
+WRN 2 old swamp-managed skill(s) can be safely deleted: swamp-data-query, swamp-extension-model. These have been replaced by the bundled swamp skill. Run 'swamp repo upgrade' to remove them.
 ```
 
 This check is non-fatal — it never blocks startup. `swamp repo upgrade`

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -911,9 +911,10 @@ async function checkForSupersededSkills(
       deferredWarnings.push({
         kind: "skills",
         file: repoDir,
-        error: `${names.length} superseded skill(s) found: ${
-          names.join(", ")
-        }. Run 'swamp repo upgrade' to update skills.`,
+        error:
+          `${names.length} old swamp-managed skill(s) can be safely deleted: ${
+            names.join(", ")
+          }. These have been replaced by the bundled swamp skill.`,
       });
     }
   } catch {
@@ -945,6 +946,7 @@ async function checkForLocalBundledSkills(
     );
     if (localCopies.length === 0) return;
 
+    const allNames = localCopies.flatMap((c) => c.names);
     const dirs = localCopies.map((c) =>
       c.names.map((n) => `  ${join(c.skillsDir, n)}/`)
     ).flat();
@@ -953,9 +955,8 @@ async function checkForLocalBundledSkills(
       kind: "skill-migration",
       file: repoDir,
       error:
-        "Swamp skills are now installed globally but this repo still has local " +
-        "copies that take precedence. Run 'swamp repo upgrade' to clean up.\n\n" +
-        "  Local copies found:\n" +
+        `Local copies of ${allNames.join(", ")} are shadowing the globally ` +
+        "installed skills. Delete them manually:\n\n" +
         dirs.join("\n"),
     });
 

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -914,7 +914,7 @@ async function checkForSupersededSkills(
         error:
           `${names.length} old swamp-managed skill(s) can be safely deleted: ${
             names.join(", ")
-          }. These have been replaced by the bundled swamp skill.`,
+          }. These have been replaced by the bundled swamp skill. Run 'swamp repo upgrade' to remove them.`,
       });
     }
   } catch {

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -259,9 +259,10 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
         }
 
         if (data.localSkillCopies.length > 0) {
+          const allNames = data.localSkillCopies.flatMap((c) => c.names);
           logger.warn(
-            "Local swamp skill copies are shadowing the globally " +
-              "installed skills. Delete them manually:",
+            `Local copies of ${allNames.join(", ")} are shadowing the ` +
+              "globally installed skills. Delete them manually:",
           );
           for (const copy of data.localSkillCopies) {
             for (const name of copy.names) {

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -202,6 +202,32 @@ Deno.test(
   },
 );
 
+function captureUpgradeLogOutput(
+  events: RepoUpgradeEvent[],
+  opts?: { isAuthenticated?: boolean },
+): string {
+  return captureLog(() => {
+    const renderer = createRepoUpgradeRenderer("log", opts);
+    const handlers = renderer.handlers();
+    for (const event of events) {
+      switch (event.kind) {
+        case "upgrading":
+          handlers.upgrading?.(event);
+          break;
+        case "extensions":
+          handlers.extensions?.(event);
+          break;
+        case "completed":
+          handlers.completed?.(event);
+          break;
+        case "error":
+          handlers.error?.(event);
+          break;
+      }
+    }
+  });
+}
+
 /**
  * Runs a sequence of `RepoUpgradeEvent`s through the JSON renderer and
  * captures everything written to stdout. Used to assert the "exactly
@@ -331,5 +357,50 @@ Deno.test(
 
     const parsed = JSON.parse(output);
     assertEquals(parsed.extensionInstall, undefined);
+  },
+);
+
+Deno.test(
+  "LogRepoUpgradeRenderer: shadowing warning lists skill names explicitly",
+  () => {
+    const output = captureUpgradeLogOutput([
+      { kind: "upgrading" },
+      {
+        kind: "completed",
+        data: {
+          path: "/tmp/x",
+          previousVersion: "0.1.0",
+          newVersion: "0.1.1",
+          upgradedAt: "2026-04-24T00:00:00Z",
+          skillsUpdated: ["swamp", "swamp-getting-started"],
+          instructionsUpdated: false,
+          settingsUpdated: false,
+          gitignoreAction: "unchanged",
+          previousTools: ["claude"],
+          tools: ["claude"],
+          addedTools: [],
+          removedTools: [],
+          extensionsToReinstall: [],
+          localSkillCopies: [
+            {
+              skillsDir: "/home/user/.claude/skills",
+              names: ["swamp", "swamp-getting-started"],
+            },
+          ],
+          changedFiles: [],
+          tool: null,
+        },
+      },
+    ]);
+
+    assertStringIncludes(
+      output,
+      "Local copies of swamp, swamp-getting-started are shadowing",
+    );
+    assertStringIncludes(output, "/home/user/.claude/skills/swamp");
+    assertStringIncludes(
+      output,
+      "/home/user/.claude/skills/swamp-getting-started",
+    );
   },
 );

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -27,6 +27,7 @@ import {
   createRepoInitRenderer,
   createRepoUpgradeRenderer,
 } from "./repo_init.ts";
+import { assertPathStringIncludes } from "../../infrastructure/persistence/path_test_helpers.ts";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 await initializeLogging({ noColor: true });
@@ -397,8 +398,8 @@ Deno.test(
       output,
       "Local copies of swamp, swamp-getting-started are shadowing",
     );
-    assertStringIncludes(output, "/home/user/.claude/skills/swamp");
-    assertStringIncludes(
+    assertPathStringIncludes(output, "/home/user/.claude/skills/swamp");
+    assertPathStringIncludes(
       output,
       "/home/user/.claude/skills/swamp-getting-started",
     );


### PR DESCRIPTION
## Summary

- Superseded skills warning now says "old swamp-managed skill(s) can be safely deleted" instead of the vague "superseded skill(s) found", making clear these are swamp's own old skills — not user-created project skills
- Shadowing warnings (both startup and post-upgrade) now name the specific skills being shadowed (e.g. "Local copies of swamp, swamp-getting-started are shadowing...")
- Startup shadowing warning no longer falsely claims `swamp repo upgrade` will auto-remove local copies — directs to manual deletion instead
- Updated design docs (`design/repo.md`, `design/global-skills.md`) with new warning text

Closes swamp-club#898

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt --check` — formatting passes
- [x] `deno run test` — all 8037 tests pass
- [x] New test verifies skill names appear in shadowing warning output