### PR TITLE
fix(extensions): repair OrphanedBundleOnly rows and evict stale bundles (swamp-club#901)

### DIFF
--- a/src/libswamp/extensions/doctor_repair.ts
+++ b/src/libswamp/extensions/doctor_repair.ts
@@ -60,9 +60,8 @@ export interface RepairDeps {
  * - Pulled extensions with BundleBuildFailed or ValidationFailed sources
  *   (re-pulled from registry to restore pre-built bundles).
  *
- * OrphanedBundleOnly rows are excluded from state-based pruning because
- * they still reference a live bundle file — pruning the row would strand
- * the file as an orphan on the next run, breaking idempotence.
+ * OrphanedBundleOnly rows are pruned together with their associated
+ * bundle file in a single pass to maintain idempotence.
  */
 export async function repairExtensions(
   deps: RepairDeps,
@@ -71,12 +70,8 @@ export async function repairExtensions(
   const report = deps.aggregateReport;
 
   // Phase 1: Identify cleanup-eligible catalog rows.
-  // Only Tombstoned rows are pruned. OrphanedBundleOnly is deliberately
-  // excluded — those rows still reference a bundle file on disk, and
-  // pruning the row would strand the file as an orphan on the NEXT run,
-  // breaking idempotence. OrphanedBundleOnly cleanup is deferred to a
-  // follow-up workstream that can handle row + file atomically.
   const rowsToPrune: string[] = [];
+  const orphanedBundlePaths: string[] = [];
   for (const detail of report.sourceDetails) {
     if (detail.stateTag === "Tombstoned") {
       rowsToPrune.push(detail.sourcePath);
@@ -85,6 +80,22 @@ export async function repairExtensions(
         path: detail.sourcePath,
         reason: `Tombstoned row — no longer active`,
       });
+    } else if (detail.stateTag === "OrphanedBundleOnly") {
+      rowsToPrune.push(detail.sourcePath);
+      operations.push({
+        kind: "catalog-row-pruned",
+        path: detail.sourcePath,
+        reason:
+          `OrphanedBundleOnly row — source deleted, evicting row and bundle`,
+      });
+      if (detail.bundlePath) {
+        orphanedBundlePaths.push(detail.bundlePath);
+        operations.push({
+          kind: "bundle-file-evicted",
+          path: detail.bundlePath,
+          reason: `Bundle for deleted source — no longer needed`,
+        });
+      }
     }
   }
 
@@ -131,7 +142,7 @@ export async function repairExtensions(
   }
 
   let actualPruned = rowsToPrune.length + unreachableRows.length;
-  let actualEvicted = filesToEvict.length;
+  let actualEvicted = filesToEvict.length + orphanedBundlePaths.length;
   let actualRepulled = extensionsToRepull.size;
 
   if (deps.apply) {
@@ -141,7 +152,7 @@ export async function repairExtensions(
       logger.info`Pruned ${actualPruned} catalog row(s)`;
     }
     actualEvicted = 0;
-    for (const file of filesToEvict) {
+    for (const file of [...filesToEvict, ...orphanedBundlePaths]) {
       try {
         await Deno.remove(file);
         actualEvicted++;

--- a/src/libswamp/extensions/doctor_repair_test.ts
+++ b/src/libswamp/extensions/doctor_repair_test.ts
@@ -522,3 +522,108 @@ Deno.test("repairExtensions: dry-run reports but does not prune unreachable rows
     true,
   );
 });
+
+Deno.test("repairExtensions: prunes OrphanedBundleOnly rows and evicts their bundles", async () => {
+  await withTempDir(async (dir) => {
+    const bundlePath = join(dir, "orphaned.js");
+    await Deno.writeTextFile(bundlePath, "// orphaned bundle");
+
+    const deleted: string[] = [];
+    const report = makeEmptyReport({
+      sourceDetails: [
+        {
+          sourcePath: "/fake/deleted-source.ts",
+          stateTag: "OrphanedBundleOnly",
+          fingerprint: "abc",
+          bundlePath,
+          kind: "model",
+        },
+      ],
+    });
+
+    const result = await repairExtensions({
+      aggregateReport: report,
+      deleteBySourcePaths: (paths) => {
+        deleted.push(...paths);
+        return paths.length;
+      },
+      apply: true,
+    });
+
+    assertEquals(result.prunedRowCount, 1);
+    assertEquals(result.evictedFileCount, 1);
+    assertEquals(deleted, ["/fake/deleted-source.ts"]);
+
+    let exists = true;
+    try {
+      await Deno.stat(bundlePath);
+    } catch {
+      exists = false;
+    }
+    assertFalse(exists);
+  });
+});
+
+Deno.test("repairExtensions: dry-run reports OrphanedBundleOnly without executing", async () => {
+  await withTempDir(async (dir) => {
+    const bundlePath = join(dir, "orphaned.js");
+    await Deno.writeTextFile(bundlePath, "// orphaned bundle");
+
+    let deleteCalled = false;
+    const report = makeEmptyReport({
+      sourceDetails: [
+        {
+          sourcePath: "/fake/deleted-source.ts",
+          stateTag: "OrphanedBundleOnly",
+          fingerprint: "abc",
+          bundlePath,
+          kind: "model",
+        },
+      ],
+    });
+
+    const result = await repairExtensions({
+      aggregateReport: report,
+      deleteBySourcePaths: () => {
+        deleteCalled = true;
+        return 0;
+      },
+      apply: false,
+    });
+
+    assertEquals(result.mode, "dry-run");
+    assertEquals(result.prunedRowCount, 1);
+    assertEquals(result.evictedFileCount, 1);
+    assertFalse(deleteCalled);
+
+    const stat = await Deno.stat(bundlePath);
+    assertEquals(stat.isFile, true);
+  });
+});
+
+Deno.test("repairExtensions: OrphanedBundleOnly prunes row even when bundle already missing", async () => {
+  const deleted: string[] = [];
+  const report = makeEmptyReport({
+    sourceDetails: [
+      {
+        sourcePath: "/fake/deleted-source.ts",
+        stateTag: "OrphanedBundleOnly",
+        fingerprint: "abc",
+        bundlePath: "/nonexistent/path/orphaned.js",
+        kind: "model",
+      },
+    ],
+  });
+
+  const result = await repairExtensions({
+    aggregateReport: report,
+    deleteBySourcePaths: (paths) => {
+      deleted.push(...paths);
+      return paths.length;
+    },
+    apply: true,
+  });
+
+  assertEquals(result.prunedRowCount, 1);
+  assertEquals(deleted, ["/fake/deleted-source.ts"]);
+});


### PR DESCRIPTION
## Summary

- `doctor extensions --repair` now prunes `OrphanedBundleOnly` catalog rows and evicts their associated bundle files in a single pass
- Previously, these stale entries were explicitly skipped ("deferred to a follow-up workstream"), leaving orphaned bundles on disk after local source files were deleted
- Added 3 unit tests: apply prunes+evicts, dry-run reports without executing, already-missing bundle still prunes row

## Root Cause

When a local extension source file is deleted, reconcile transitions the catalog entry to `OrphanedBundleOnly` (bundle still exists on disk). The repair flow handled `Tombstoned` rows, unreachable rows, and orphaned bundle files — but explicitly skipped `OrphanedBundleOnly` entries. Both the catalog row and bundle file persisted, requiring manual `rm -rf .swamp/bundles/<hash>/` to clean up.

## Fix

Added `OrphanedBundleOnly` handling alongside the existing `Tombstoned` loop in Phase 1 of `repairExtensions`. The source path goes to `rowsToPrune` (catalog deletion via `deleteBySourcePaths`) and the bundle path goes to `orphanedBundlePaths` (file eviction via `Deno.remove`). Both happen in the same apply pass, preserving idempotence.

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test src/libswamp/extensions/doctor_repair_test.ts` — 18 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Reproduction verified: created local extension, ran doctor (Indexed), deleted source, ran `--repair` — catalog row pruned and bundle file evicted
- [x] Idempotence verified: second `--repair` run reports "Nothing to clean up"

Closes swamp-club#901

Co-authored-by: Kenichi Fukunaga <dmc@users.noreply.github.com>