### PR TITLE
fix(extensions): merge local-extension methods into pulled base types (swamp-club#903)

### DIFF
--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -49,6 +49,18 @@ const VALIDATION_FAILED_DROPPED_MIGRATION_KEY =
   "migration_applied:validation-failed-dropped-v1";
 
 /**
+ * Marker key in bundle_meta recording that the extends_type backfill has
+ * run on this catalog. Pre-fix catalogs (swamp-club#903) persisted
+ * extension rows with an empty `extends_type` via the aggregate writer, so
+ * `findExtensionsForType` never matched them and their methods were
+ * dropped. The aggregate writer is fixed at the source, but existing rows
+ * whose fingerprint is unchanged never transition and so are never
+ * rewritten — this one-shot migration heals them on catalog open.
+ */
+const EXTENDS_TYPE_BACKFILL_MIGRATION_KEY =
+  "migration_applied:extension-extends-type-backfill-v1";
+
+/**
  * Bundle layout version stored in `bundle_meta`. Bumped whenever the
  * on-disk bundle path scheme changes; loaders compare this against the
  * catalog's current value via {@link ExtensionRepository.invalidationGuards}
@@ -285,6 +297,54 @@ export class ExtensionCatalogStore {
     // gated on its own bundle_meta marker AND a pragma_table_info probe
     // for defence in depth.
     this.dropValidationFailedColumn();
+    // swamp-club#903: heal extension rows that were persisted with an empty
+    // extends_type before the aggregate-writer fix. Runs last so `state`
+    // and `extends_type` are guaranteed present; gated on its own marker.
+    this.backfillExtensionExtendsType();
+  }
+
+  /**
+   * Returns true if {@link backfillExtensionExtendsType} has already run
+   * on this catalog.
+   */
+  private isExtendsTypeBackfilled(): boolean {
+    const stmt = this.db.prepare(
+      "SELECT value FROM bundle_meta WHERE key = ?",
+    );
+    const row = stmt.get(EXTENDS_TYPE_BACKFILL_MIGRATION_KEY) as
+      | { value: string }
+      | undefined;
+    return row?.value === "true";
+  }
+
+  /**
+   * swamp-club#903 data migration: backfill `extends_type` from
+   * `type_normalized` for Indexed extension rows left empty by the
+   * pre-fix aggregate writer. For an extension row `type_normalized` is
+   * the target type, and `extends_type` must equal it for the merge query
+   * (`findExtensionsForType`: WHERE extends_type = ? AND kind = 'extension')
+   * to match. Idempotent (empty-only predicate) and gated on a bundle_meta
+   * marker so it runs at most once. Extension rows are exempt from the
+   * I-Repo-1 uniqueness check, so backfilling cannot introduce a
+   * duplicate-type violation.
+   */
+  private backfillExtensionExtendsType(): void {
+    if (this.isExtendsTypeBackfilled()) return;
+    this.db
+      .prepare(
+        `UPDATE bundle_types
+           SET extends_type = type_normalized
+         WHERE kind = 'extension'
+           AND extends_type = ''
+           AND type_normalized <> ''
+           AND state = 'Indexed'`,
+      )
+      .run();
+    this.db
+      .prepare(
+        "INSERT OR REPLACE INTO bundle_meta (key, value) VALUES (?, 'true')",
+      )
+      .run(EXTENDS_TYPE_BACKFILL_MIGRATION_KEY);
   }
 
   /**

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -594,6 +594,177 @@ for (
   );
 }
 
+// --- extends_type backfill migration tests (swamp-club#903) ---
+//
+// Pre-fix catalogs persisted extension rows with an empty extends_type via
+// the aggregate writer, so findExtensionsForType never matched them and the
+// extension's methods were silently dropped ("Unknown method"). Opening
+// through ExtensionCatalogStore must backfill extends_type from
+// type_normalized for Indexed extension rows, once, on catalog open.
+
+/**
+ * Seeds a DB carrying the full current schema plus the other migrations'
+ * markers, so opening it runs ONLY the swamp-club#903 extends_type
+ * backfill. Inserts the given extension row rows verbatim.
+ */
+function seedCatalogAwaitingExtendsBackfill(
+  dbPath: string,
+  rows: Array<{
+    sourcePath: string;
+    typeNormalized: string;
+    kind: string;
+    extendsType: string;
+    state: string;
+  }>,
+): void {
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE bundle_types (
+      source_path        TEXT NOT NULL PRIMARY KEY,
+      type_normalized    TEXT NOT NULL,
+      kind               TEXT NOT NULL DEFAULT 'model',
+      bundle_path        TEXT NOT NULL,
+      version            TEXT NOT NULL DEFAULT '',
+      description        TEXT NOT NULL DEFAULT '',
+      extends_type       TEXT NOT NULL DEFAULT '',
+      source_mtime       TEXT NOT NULL DEFAULT '',
+      source_fingerprint TEXT NOT NULL DEFAULT '',
+      state              TEXT NOT NULL DEFAULT 'Indexed',
+      extension_name     TEXT NOT NULL DEFAULT '',
+      extension_version  TEXT NOT NULL DEFAULT '',
+      last_error         TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE bundle_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+  `);
+  // Mark the earlier migrations applied so only the #903 backfill runs.
+  const meta = seed.prepare(
+    "INSERT INTO bundle_meta (key, value) VALUES (?, 'true')",
+  );
+  meta.run("migration_applied:per-extension-aggregate-v3");
+  const insert = seed.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path, version,
+      description, extends_type, source_mtime, source_fingerprint, state,
+      extension_name, extension_version, last_error
+    ) VALUES (?, ?, ?, ?, '', '', ?, '', 'fp', ?, '@scope/ext', '1.0.0', '')`,
+  );
+  for (const r of rows) {
+    insert.run(
+      r.sourcePath,
+      r.typeNormalized,
+      r.kind,
+      "/bundle.js",
+      r.extendsType,
+      r.state,
+    );
+  }
+  seed.close();
+}
+
+Deno.test("ExtensionCatalogStore: backfills empty extends_type on Indexed extension rows (swamp-club#903)", () => {
+  const dbPath = makeTempDbPath();
+  const sourcePath = join(
+    dirname(dirname(dbPath)),
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "ext",
+    "models",
+    "probe.ts",
+  );
+  seedCatalogAwaitingExtendsBackfill(dbPath, [{
+    sourcePath,
+    typeNormalized: "@keeb/docker/compose",
+    kind: "extension",
+    extendsType: "",
+    state: "Indexed",
+  }]);
+
+  // Opening runs the backfill: the row now matches the merge query.
+  const store = new ExtensionCatalogStore(dbPath);
+  const matches = store.findExtensionsForType("@keeb/docker/compose");
+  assertEquals(matches.length, 1);
+  assertEquals(matches[0].extends_type, "@keeb/docker/compose");
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: extends_type backfill leaves primary and non-Indexed rows untouched (swamp-club#903)", () => {
+  const dbPath = makeTempDbPath();
+  const base = join(dirname(dirname(dbPath)), ".swamp", "pulled-extensions");
+  seedCatalogAwaitingExtendsBackfill(dbPath, [
+    // Primary model — must stay empty.
+    {
+      sourcePath: join(base, "@scope", "base", "models", "thing.ts"),
+      typeNormalized: "@scope/base/thing",
+      kind: "model",
+      extendsType: "",
+      state: "Indexed",
+    },
+    // ValidationFailed extension — typeless, must stay empty so it keeps
+    // falling out of findExtensionsForType.
+    {
+      sourcePath: join(base, "@scope", "broken", "models", "bad.ts"),
+      typeNormalized: "",
+      kind: "extension",
+      extendsType: "",
+      state: "ValidationFailed",
+    },
+  ]);
+
+  const store = new ExtensionCatalogStore(dbPath);
+  assertEquals(
+    store.findByType("@scope/base/thing", "model")?.extends_type,
+    "",
+  );
+  assertEquals(store.findExtensionsForType("@scope/base/thing").length, 0);
+  store.close();
+});
+
+Deno.test("ExtensionCatalogStore: extends_type backfill runs at most once (swamp-club#903)", () => {
+  const dbPath = makeTempDbPath();
+  const sourcePath = join(
+    dirname(dirname(dbPath)),
+    ".swamp",
+    "pulled-extensions",
+    "@scope",
+    "ext",
+    "models",
+    "probe.ts",
+  );
+  seedCatalogAwaitingExtendsBackfill(dbPath, [{
+    sourcePath,
+    typeNormalized: "@keeb/docker/compose",
+    kind: "extension",
+    extendsType: "",
+    state: "Indexed",
+  }]);
+
+  // First open heals the seeded row and records the marker.
+  const store = new ExtensionCatalogStore(dbPath);
+  assertEquals(
+    store.findExtensionsForType("@keeb/docker/compose").length,
+    1,
+  );
+  store.close();
+
+  // Inject a second broken row directly, then reopen. Because the marker is
+  // set, the backfill does not run again and the new row stays empty —
+  // proving the once-only contract. (New rows written through the fixed
+  // aggregate writer already carry a correct extends_type, so this is a
+  // deliberately-broken injection, not a realistic post-fix state.)
+  const inject = new DatabaseSync(dbPath);
+  inject.prepare(
+    `INSERT INTO bundle_types (
+      source_path, type_normalized, kind, bundle_path, extends_type, state
+    ) VALUES (?, ?, 'extension', '/b.js', '', 'Indexed')`,
+  ).run(sourcePath + "2", "@keeb/docker/engine");
+  inject.close();
+
+  const store2 = new ExtensionCatalogStore(dbPath);
+  assertEquals(store2.findExtensionsForType("@keeb/docker/engine").length, 0);
+  store2.close();
+});
+
 // --- RowState column tests (swamp-club#211, W1a) ---
 //
 // The state column subsumes the legacy validation_failed boolean and

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -732,6 +732,17 @@ function sourceToRow(
     lastError = state.lastError;
   }
 
+  // For extension-kind sources the row's type_normalized IS the target
+  // type (state.type carries it for Indexed/Bundled), so extends_type
+  // must mirror it — matching the loader path (extension_loader.ts, which
+  // writes extends_type: typeNormalized). Without this the merge query
+  // `findExtensionsForType` (WHERE extends_type = ? AND kind = 'extension')
+  // never matches and the extension's methods are silently dropped
+  // (swamp-club#903). typeNormalized stays "" for the typeless states
+  // (ValidationFailed, OrphanedBundleOnly, ...), so broken extension rows
+  // still write "" and correctly fall out of the query.
+  const extendsType = source.kind === "extension" ? typeNormalized : "";
+
   return {
     source_path: source.id.canonicalPath,
     type_normalized: typeNormalized,
@@ -739,7 +750,7 @@ function sourceToRow(
     bundle_path: bundlePath,
     version: extension.version,
     description: "",
-    extends_type: "",
+    extends_type: extendsType,
     source_mtime: source.sourceMtime,
     source_fingerprint: source.fingerprint,
     state: state.tag,

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -894,3 +894,98 @@ Deno.test("ExtensionRepository: I-Repo-1 allows multiple extension rows targetin
     }
   });
 });
+
+// ===== Test: swamp-club#903 — saving an extension-kind Source through the
+// aggregate populates extends_type so findExtensionsForType matches it =====
+Deno.test("ExtensionRepository: saving an Indexed extension Source persists extends_type = target (swamp-club#903)", () => {
+  withRepository((repo, cat, repoRoot) => {
+    const extRoot = `${repoRoot}/.swamp/pulled-extensions/@scope/ext`;
+    const abs = `${extRoot}/models/probe.ts`;
+    const ext = makeExtension({
+      name: "@scope/ext",
+      version: "1.0.0",
+      origin: "local",
+      extensionRoot: extRoot,
+      sources: [
+        makeSource({
+          id: makeSourceLocation(abs, extRoot),
+          kind: "extension",
+          fingerprint: "fp-probe",
+          state: {
+            tag: "Indexed",
+            type: "@keeb/docker/compose",
+            bundle: makeBundleLocation(
+              `${repoRoot}/.swamp/bundles/probe.js`,
+              "fp-probe",
+            ),
+          },
+          sourceMtime: "2026-01-15T10:00:00.000Z",
+        }),
+      ],
+    });
+    repo.save(ext);
+
+    // The persisted row carries the target type in extends_type...
+    const row = cat.findAll().find((r) => r.kind === "extension");
+    assert(row, "expected an extension row");
+    assertEquals(row.extends_type, "@keeb/docker/compose");
+
+    // ...so the runtime merge query finds it. Before the fix this returned
+    // nothing (extends_type was hardcoded ""), dropping the extension's
+    // methods with "Unknown method".
+    const matches = cat.findExtensionsForType("@keeb/docker/compose");
+    assertEquals(matches.length, 1);
+    assertPathEquals(matches[0].source_path, canonicalizePath(abs));
+  });
+});
+
+// ===== Test: swamp-club#903 — primary and non-Indexed extension rows keep
+// an empty extends_type (the gate is neither too broad nor self-defeating) =====
+Deno.test("ExtensionRepository: primary rows and ValidationFailed extension rows keep empty extends_type (swamp-club#903)", () => {
+  withRepository((repo, cat, repoRoot) => {
+    // Primary model source: extends_type stays "".
+    const primary = pulledExtension({
+      repoRoot,
+      name: "@scope/base",
+      version: "1.0.0",
+      sources: [{ relPath: "models/thing.ts", type: "@scope/base/thing" }],
+    });
+    repo.save(primary);
+    const primaryRow = cat.findAll().find((r) => r.kind === "model");
+    assert(primaryRow, "expected a model row");
+    assertEquals(primaryRow.extends_type, "");
+
+    // ValidationFailed extension source: typeless state → extends_type ""
+    // so it correctly falls out of findExtensionsForType.
+    const extRoot = `${repoRoot}/.swamp/pulled-extensions/@scope/broken`;
+    const abs = `${extRoot}/models/bad.ts`;
+    const broken = makeExtension({
+      name: "@scope/broken",
+      version: "1.0.0",
+      origin: "local",
+      extensionRoot: extRoot,
+      sources: [
+        makeSource({
+          id: makeSourceLocation(abs, extRoot),
+          kind: "extension",
+          fingerprint: "fp-bad",
+          state: {
+            tag: "ValidationFailed",
+            bundle: makeBundleLocation(
+              `${repoRoot}/.swamp/bundles/bad.js`,
+              "fp-bad",
+            ),
+            lastError: "schema rejected",
+          },
+          sourceMtime: "2026-01-15T10:00:00.000Z",
+        }),
+      ],
+    });
+    repo.save(broken);
+    const brokenRow = cat.findAll().find((r) =>
+      r.kind === "extension" && r.state === "ValidationFailed"
+    );
+    assert(brokenRow, "expected a ValidationFailed extension row");
+    assertEquals(brokenRow.extends_type, "");
+  });
+});

--- a/src/libswamp/extensions/reconcile_from_disk_service_test.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service_test.ts
@@ -60,6 +60,23 @@ export const model = {
 };
 `;
 
+const MINIMAL_EXTENSION_CODE = (targetType: string) => `
+import { z } from "npm:zod@4";
+
+export const extension = {
+  type: "${targetType}",
+  methods: [
+    {
+      probe: {
+        description: "probe",
+        arguments: z.object({}),
+        execute: async () => ({ probed: true }),
+      },
+    },
+  ],
+};
+`;
+
 async function withFixtureRepo(
   fn: (args: {
     repoDir: string;
@@ -152,6 +169,43 @@ Deno.test(
           true,
           "must have an Indexed transition",
         );
+      },
+    );
+  },
+);
+
+Deno.test(
+  "ReconcileFromDisk: local extension gets extends_type so findExtensionsForType matches it (swamp-club#903)",
+  async () => {
+    await withFixtureRepo(
+      async ({ repoDir, repository, catalog, lockfileRepository }) => {
+        const ts = Date.now();
+        const baseType = `@test/reconcile-base-${ts}`;
+        await Deno.writeTextFile(
+          join(repoDir, "extensions", "models", "base.ts"),
+          MINIMAL_MODEL_CODE(baseType),
+        );
+        await Deno.writeTextFile(
+          join(repoDir, "extensions", "models", "ext.ts"),
+          MINIMAL_EXTENSION_CODE(baseType),
+        );
+
+        const service = new ReconcileFromDiskService({
+          denoRuntime: testDenoRuntime,
+          repository,
+          lockfileRepository,
+          repoDir,
+        });
+        const result = await service.execute();
+        assertEquals(result.applied, true);
+
+        // The reconcile path (saveAll → sourceToRow) is the sole writer here.
+        // Before the fix it wrote extends_type "", so the extension's methods
+        // were dropped. The row must now be findable by its target type.
+        const matches = catalog.findExtensionsForType(baseType);
+        assertEquals(matches.length, 1, "extension must target the base type");
+        assertEquals(matches[0].extends_type, baseType);
+        assertEquals(matches[0].kind, "extension");
       },
     );
   },


### PR DESCRIPTION
## Summary

Fixes swamp-club#903. A local `export const extension` that targets a **pulled** base type (e.g. a local `extensions/models/*.ts` extending `@keeb/docker/compose`) was indexed as `Indexed` but its methods were **never merged** into the target type — calling one failed with `Unknown method`. Methods from pulled packages merged fine, and the fully-local case worked, which is what made this subtle.

### Root cause

`bundle_types` has two writers. The loader path (`extension_loader.ts`) writes an extension row's `extends_type = type_normalized` (the target type). The aggregate/reconcile writer, `sourceToRow` (`extension_repository.ts`), hardcoded `extends_type: ""`. The runtime merge query keys off it:

```sql
SELECT * FROM bundle_types WHERE extends_type = ? AND kind = 'extension'
```

For a local extension of a pulled type, the reconcile writer wins, so the row's `extends_type` is empty and the query never matches — the methods are silently dropped. The fully-local case works only because the loader path overwrites the row with the correct value.

### Fix

1. **`sourceToRow`** now writes `extends_type = type_normalized` for `kind === "extension"` sources (mirroring the loader). Typeless states (`ValidationFailed`, `OrphanedBundleOnly`, …) keep `""`, so broken rows still correctly fall out of the query. This fixes **new** extension adds.
2. **One-shot keyed catalog migration** (`migration_applied:extension-extends-type-backfill-v1`) backfills `extends_type` from `type_normalized` for existing Indexed extension rows on catalog open. Needed because `saveAll` is transition-gated (`reconcile_from_disk_service.ts:186`) and won't rewrite an unchanged row — so installs already carrying the empty value would not otherwise self-heal.

## Test Plan

- **New tests** (all green):
  - `extension_repository_test.ts` — saving an Indexed extension-kind Source via `repo.save` persists `extends_type = target` and is returned by `findExtensionsForType`; primary and `ValidationFailed` extension rows keep `""`.
  - `reconcile_from_disk_service_test.ts` — end-to-end: a base model + local extension on disk, reconciled, is findable by target type (the reconcile path is the sole writer here, so it directly guards the bug).
  - `extension_catalog_store_test.ts` — migration heals a seeded broken row, leaves primary/`ValidationFailed` rows untouched, and runs at most once.
- `deno check` / `deno lint` / `deno fmt --check` clean; **full suite 8047 passed, 0 failed**; `deno run compile` OK.
- **Firsthand repro** with the compiled binary: local extension of `@keeb/docker/compose` — `probe` now succeeds (was `Unknown method 'probe'`); row `extends_type=@keeb/docker/compose`. A simulated pre-fix catalog (blanked `extends_type` + deleted marker) self-healed on the next plain command **without editing the source**. Fully-local case unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)