### PR TITLE
feat(run-tracker): SQLite run tracker for in-flight run lifecycle (swamp-club#655)

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -43,6 +43,7 @@ Route to the right guide based on what the user needs.
 | Extensions — create models/vaults/drivers/datastores/reports | [references/extension/guide.md](references/extension/guide.md)                 |
 | Publishing — push extensions to registry, deprecate          | [references/extension-publish/guide.md](references/extension-publish/guide.md) |
 | Issues — file bugs, features, security reports               | [references/issue/guide.md](references/issue/guide.md)                         |
+| Run tracking — active runs, stale detection, diagnostics     | [references/model/guide.md](references/model/guide.md)                         |
 | Troubleshooting — errors, health checks, diagnostics         | [references/troubleshooting/guide.md](references/troubleshooting/guide.md)     |
 
 ## Common Commands
@@ -65,6 +66,12 @@ swamp workflow create <name>                   # create a new workflow
 swamp workflow run <name>                      # execute a workflow
 swamp workflow validate <name>                 # validate DAG before running
 swamp workflow history <name>                  # view past workflow runs
+
+# Run tracking
+swamp run history                              # recent runs (last 24h)
+swamp run history --active                     # what's running right now?
+swamp run doctor                               # diagnose stale/orphaned runs
+swamp run doctor --fix                         # auto-reap stale runs
 
 # Vaults, Reports, Extensions
 swamp vault create <type> <name>               # create a vault for secrets

--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -73,5 +73,10 @@ create per-input ephemeral instances for concurrent dispatch. See
 | Get output details  | `swamp model output get <output_or_model> --json`                    |
 | View output logs    | `swamp model output logs <output_id> --json`                         |
 | View output data    | `swamp model output data <output_id> --json`                         |
+| Cancel a run        | `swamp model cancel <name>`                                          |
+| Cancel all runs     | `swamp model cancel --all`                                           |
+| Active runs         | `swamp run history --active`                                         |
+| Recent runs         | `swamp run history`                                                  |
+| Diagnose stale runs | `swamp run doctor`                                                   |
 
 For detailed walkthroughs of each operation, see [reference.md](reference.md).

--- a/.claude/skills/swamp/references/model/reference.md
+++ b/.claude/skills/swamp/references/model/reference.md
@@ -431,6 +431,31 @@ For single-output inspection, `swamp model output get <name> --json` is
 sufficient. For browsing N artifacts, `data query` with `--select` is the
 primary pattern.
 
+## Run Tracking
+
+swamp tracks in-flight runs — both model method executions and workflow runs —
+in a local SQLite database (`.swamp/run_tracker.db`). Every execution registers
+with the tracker, heartbeats every 30s, and completes on success/failure. Stale
+runs (heartbeat >90s old with a dead process) are automatically reaped on next
+invocation.
+
+The central command is `swamp run`:
+
+| Question                                  | Command                             |
+| ----------------------------------------- | ----------------------------------- |
+| What's running right now?                 | `swamp run history --active`        |
+| What ran recently (last 24h)?             | `swamp run history`                 |
+| Full history of tracked runs              | `swamp run history --all`           |
+| Structured output for scripting           | `swamp run history --json`          |
+| Are there stuck/orphaned runs?            | `swamp run doctor`                  |
+| Fix stuck runs automatically              | `swamp run doctor --fix`            |
+| Cancel a specific model's running method  | `swamp model cancel <name>`         |
+| Cancel all running model methods          | `swamp model cancel --all`          |
+| What completed runs exist (YAML outputs)? | `swamp model output search`         |
+| Execution history with duration/status    | `swamp model method history search` |
+
+See `swamp run history --help` for full details.
+
 ## Workflow Example
 
 **Design check — before creating a model, ask the user:**

--- a/.claude/skills/swamp/references/troubleshooting/guide.md
+++ b/.claude/skills/swamp/references/troubleshooting/guide.md
@@ -22,18 +22,20 @@ returns non-zero on user-facing failure.
 
 ## The Four Tiers
 
-| Tier                | When to use                                  | Key tool                                        |
-| ------------------- | -------------------------------------------- | ----------------------------------------------- |
-| 1. Health checks    | Known integration issues (extensions, audit) | `swamp doctor extensions`, `swamp doctor audit` |
-| 2. Error inspection | Command failures, unexpected output          | stderr, `--json`, exit codes                    |
-| 3. Tracing          | Slow workflows, timing questions             | OpenTelemetry spans                             |
-| 4. Source reading   | Internal behavior questions                  | `swamp source fetch`                            |
+| Tier                | When to use                          | Key tool                                      |
+| ------------------- | ------------------------------------ | --------------------------------------------- |
+| 1. Health checks    | Known integration issues, stale runs | `swamp doctor extensions`, `swamp run doctor` |
+| 2. Error inspection | Command failures, unexpected output  | stderr, `--json`, exit codes                  |
+| 3. Tracing          | Slow workflows, timing questions     | OpenTelemetry spans                           |
+| 4. Source reading   | Internal behavior questions          | `swamp source fetch`                          |
 
 ## Symptom → tier index
 
 | Symptom                                           | Start at                              |
 | ------------------------------------------------- | ------------------------------------- |
 | Extension not loaded / `swamp-warning:` on stderr | Tier 1 → `swamp doctor extensions`    |
+| Run stuck in "running" / orphaned after crash     | Tier 1 → `swamp run doctor --fix`     |
+| "Is anything running right now?"                  | Tier 1 → `swamp run history --active` |
 | Command errored — message is clear                | Tier 2 → read it, fix the named issue |
 | Command errored — message is vague                | Tier 2 → re-run with `--json`         |
 | Workflow / method / sync is slow                  | Tier 3 → enable tracing               |

--- a/.claude/skills/swamp/references/troubleshooting/reference.md
+++ b/.claude/skills/swamp/references/troubleshooting/reference.md
@@ -41,6 +41,8 @@ reach for it last.
 | Extension model/vault/driver/datastore/report not loaded | Tier 1 → `swamp doctor extensions`                        |
 | `swamp-warning:` line on stderr                          | Tier 1 → `swamp doctor extensions`                        |
 | CI preflight needs to gate on integration health         | Tier 1 → either doctor with `--json`                      |
+| Run stuck in "running" / orphaned after crash            | Tier 1 → `swamp run doctor --fix`                         |
+| "Is anything running right now?"                         | Tier 1 → `swamp run history --active`                     |
 | Command errored — message is clear                       | Tier 2 → read it, fix the named issue                     |
 | Command errored — message is vague or unhelpful          | Tier 2 → re-run with `--json`, then escalate              |
 | Item "not found" / "not in search results"               | Tier 2 → check stderr for `swamp-warning:`                |

--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -45,6 +45,8 @@ skill.
 | Reject step        | `swamp workflow reject <workflow> <step>`                     |
 | Resume workflow    | `swamp workflow resume <workflow> [--input k=v]`              |
 | List approvals     | `swamp workflow approvals`                                    |
+| Active runs        | `swamp run history --active`                                  |
+| Recent runs        | `swamp run history`                                           |
 | View run history   | `swamp workflow history search --json`                        |
 | Get latest run     | `swamp workflow history get <workflow> --json`                |
 | View run logs      | `swamp workflow history logs <run_or_workflow> --json`        |

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -341,6 +341,22 @@ swamp workflow history logs 7c9e6679-7425-40de-944b-e07fc1f90ae7 build.compile -
 }
 ```
 
+### Run Tracking
+
+Workflow runs and their individual model method step executions are tracked in
+the SQLite run tracker (`.swamp/run_tracker.db`). Use `swamp run history` to see
+both workflow-level and step-level runs in a single view:
+
+```bash
+swamp run history --active    # what's running right now?
+swamp run history             # recent runs (last 24h)
+swamp run doctor              # diagnose stale/orphaned runs
+swamp run doctor --fix        # auto-reap stale runs
+```
+
+The history output shows the `KIND` column as `workflow` or `method`, with the
+workflow name or model/method name respectively.
+
 ## Workflow Inputs
 
 Workflows can define an `inputs` schema for parameterization. Inputs are

--- a/design/run-tracker.md
+++ b/design/run-tracker.md
@@ -1,0 +1,62 @@
+# Run Tracker
+
+Local SQLite subsystem for tracking in-flight model method run lifecycle.
+
+## Problem
+
+`model method run` writes a `ModelOutput` YAML file with `status: "running"` at
+start, then updates it to a terminal state on completion. Process death (OOM,
+SIGKILL, power failure) leaves the YAML permanently stuck in "running" with no
+mechanism for detection.
+
+## Solution
+
+A SQLite database at `.swamp/run_tracker.db` that owns the in-flight lifecycle.
+Output YAMLs are only written once in terminal state (write-once invariant),
+preserving the `findAllGlobalSince()` mtime pre-filter optimization.
+
+### Schema
+
+```sql
+CREATE TABLE active_runs (
+  id            TEXT PRIMARY KEY,
+  run_kind      TEXT NOT NULL,
+  model_type    TEXT,
+  method_name   TEXT,
+  workflow_name TEXT,
+  pid           INTEGER NOT NULL,
+  hostname      TEXT NOT NULL,
+  started_at    TEXT NOT NULL,
+  heartbeat_at  TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'running'
+);
+```
+
+### Lifecycle
+
+1. **Register** — on method start, INSERT with `pid`, `hostname`,
+   `heartbeat_at = now`, `status = 'running'`
+2. **Heartbeat** — every 30s, `UPDATE heartbeat_at = now WHERE id = ?`
+3. **Complete** — on success/failure/cancel, UPDATE status
+4. **Reap** — on next CLI/serve invocation, find stale rows (heartbeat >90s):
+   same-machine checks `isProcessDead(pid)` first, cross-machine uses TTL alone
+
+### Coverage
+
+- **CLI `model method run`** and **`swamp serve` model method runs** both flow
+  through `modelMethodRun()` in `run.ts`, which registers with the tracker.
+- **Workflow-triggered model method runs** via `execution_service.ts` are NOT
+  covered — deferred to #519. Serve's workflow run YAML reaping is kept as a
+  fallback.
+
+### CLI Commands
+
+- `swamp model runs` — list active/recent runs from the tracker
+- `swamp model runs --active` — running only
+- `swamp doctor runs` — diagnose stale/orphaned runs
+- `swamp doctor runs --fix` — auto-reap stale runs
+
+### Related
+
+- #636 — OOM crash leaves run stuck in "running"
+- #519 — persistent, queryable workflow runs (builds on this foundation)

--- a/design/run-tracker.md
+++ b/design/run-tracker.md
@@ -1,6 +1,7 @@
 # Run Tracker
 
-Local SQLite subsystem for tracking in-flight model method run lifecycle.
+Local SQLite subsystem for tracking in-flight model method and workflow run
+lifecycle.
 
 ## Problem
 
@@ -20,7 +21,7 @@ preserving the `findAllGlobalSince()` mtime pre-filter optimization.
 ```sql
 CREATE TABLE active_runs (
   id            TEXT PRIMARY KEY,
-  run_kind      TEXT NOT NULL,
+  run_kind      TEXT NOT NULL,        -- 'model_method' | 'workflow'
   model_type    TEXT,
   method_name   TEXT,
   workflow_name TEXT,
@@ -28,35 +29,56 @@ CREATE TABLE active_runs (
   hostname      TEXT NOT NULL,
   started_at    TEXT NOT NULL,
   heartbeat_at  TEXT NOT NULL,
-  status        TEXT NOT NULL DEFAULT 'running'
+  status        TEXT NOT NULL DEFAULT 'running',
+  completed_at  TEXT
 );
 ```
 
+Schema versioning via `run_tracker_meta` table. Terminal rows older than 7 days
+are purged on startup.
+
 ### Lifecycle
 
-1. **Register** — on method start, INSERT with `pid`, `hostname`,
+1. **Register** — on method/workflow start, INSERT with `pid`, `hostname`,
    `heartbeat_at = now`, `status = 'running'`
 2. **Heartbeat** — every 30s, `UPDATE heartbeat_at = now WHERE id = ?`
-3. **Complete** — on success/failure/cancel, UPDATE status
+3. **Complete** — on success/failure/cancel/suspend, UPDATE status (guarded by
+   `AND status IN ('running', 'suspended')` to prevent TOCTOU races)
 4. **Reap** — on next CLI/serve invocation, find stale rows (heartbeat >90s):
    same-machine checks `isProcessDead(pid)` first, cross-machine uses TTL alone
+5. **Suspend** — workflow approval gates set status to `suspended`, which
+   excludes the row from stale detection
+6. **Reactivate** — on workflow resume, transitions `suspended` → `running` and
+   restarts heartbeat
 
 ### Coverage
 
 - **CLI `model method run`** and **`swamp serve` model method runs** both flow
   through `modelMethodRun()` in `run.ts`, which registers with the tracker.
-- **Workflow-triggered model method runs** via `execution_service.ts` are NOT
-  covered — deferred to #519. Serve's workflow run YAML reaping is kept as a
-  fallback.
+- **Workflow-triggered model method runs** via `execution_service.ts`
+  `DefaultStepExecutor.executeModelMethod()` register with the tracker.
+- **Workflow runs** themselves register at the `WorkflowExecutionService.run()`
+  level, tracking the overall workflow lifecycle.
+- Workflow suspend/approve/resume transitions are tracked (suspended → running →
+  completed).
 
 ### CLI Commands
 
-- `swamp model runs` — list active/recent runs from the tracker
-- `swamp model runs --active` — running only
-- `swamp doctor runs` — diagnose stale/orphaned runs
-- `swamp doctor runs --fix` — auto-reap stale runs
+- `swamp run history` — list recent runs (last 24h), model methods and workflows
+- `swamp run history --active` — running only
+- `swamp run history --all` — full tracked history
+- `swamp run doctor` — diagnose stale/orphaned runs
+- `swamp run doctor --fix` — auto-reap stale runs
+
+All commands support `--server` for querying a remote `swamp serve` instance and
+`--json` for structured output.
+
+### Local-only
+
+The tracker DB is NOT synced to remote datastores. PIDs and heartbeats are
+inherently local — a PID from machine A is meaningless on machine B.
 
 ### Related
 
 - #636 — OOM crash leaves run stuck in "running"
-- #519 — persistent, queryable workflow runs (builds on this foundation)
+- #519 — persistent, queryable workflow runs (foundation laid here)

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -142,7 +142,7 @@ export const modelCancelCommand = new Command()
       if (latest.pid !== Deno.pid) {
         await killProcessTree(latest.pid);
       }
-      runTracker.complete(latest.id, "cancelled");
+      runTracker.complete(latest.id, "cancelled", reason);
 
       if (cliCtx.outputMode === "json") {
         console.log(JSON.stringify({

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -26,6 +26,11 @@ import {
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { killProcessTree } from "../../infrastructure/process/process_kill.ts";
+import {
+  DEFAULT_STALE_TTL_MS,
+  RunTrackerStore,
+} from "../../infrastructure/persistence/run_tracker_store.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -56,38 +61,38 @@ export const modelCancelCommand = new Command()
       );
     }
 
-    const { repoContext } = await requireInitializedRepoUnlocked({
+    const { repoDir, repoContext } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 
-    const outputRepo = repoContext.outputRepo;
     const reason = options.reason as string | undefined;
+    const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
+    runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
 
     if (options.all) {
-      const allOutputs = await outputRepo.findAllGlobal();
-      const running = allOutputs.filter((o) => o.output.status === "running");
+      const trackerRuns = runTracker.findAllRunning();
 
-      if (running.length === 0) {
+      if (trackerRuns.length === 0) {
         if (cliCtx.outputMode === "json") {
           console.log(JSON.stringify({ cancelled: [] }));
         } else {
           cliCtx.logger.info("No running model method runs to cancel.");
         }
+        runTracker.close();
         return;
       }
 
       const cancelled: { id: string; type: string; method: string }[] = [];
-      for (const entry of running) {
-        if (entry.output.pid && entry.output.pid !== Deno.pid) {
-          await killProcessTree(entry.output.pid);
+      for (const run of trackerRuns) {
+        if (run.pid !== Deno.pid) {
+          await killProcessTree(run.pid);
         }
-        entry.output.markCancelled(reason);
-        await outputRepo.save(entry.type, entry.method, entry.output);
+        runTracker.complete(run.id, "cancelled");
         cancelled.push({
-          id: entry.output.id,
-          type: entry.type.normalized,
-          method: entry.method,
+          id: run.id,
+          type: run.modelType ?? "unknown",
+          method: run.methodName ?? "unknown",
         });
       }
 
@@ -103,6 +108,7 @@ export const modelCancelCommand = new Command()
           cliCtx.logger.info`  ${c.type}/${c.method} (${c.id})`;
         }
       }
+      runTracker.close();
       return;
     }
 
@@ -110,6 +116,7 @@ export const modelCancelCommand = new Command()
     const definitionRepo = repoContext.definitionRepo;
     const resolved = await definitionRepo.findByNameGlobal(modelIdOrName!);
     if (!resolved) {
+      runTracker.close();
       throw new UserError(
         `Model '${modelIdOrName}' not found`,
       );
@@ -117,38 +124,40 @@ export const modelCancelCommand = new Command()
 
     const { definition, type } = resolved;
 
-    const allOutputs = await outputRepo.findAll(type);
-    const running = allOutputs.filter(
-      (o) => o.definitionId === definition.id && o.status === "running",
+    const trackerRuns = runTracker.findAllRunning().filter(
+      (r) => r.modelType === type.normalized,
     );
 
-    if (running.length === 0) {
+    if (trackerRuns.length === 0) {
+      runTracker.close();
       throw new UserError(
         `No running method runs found for model '${definition.name}'`,
       );
     }
 
-    const latest = running.sort(
+    const latest = trackerRuns.sort(
       (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
     )[0];
 
-    if (latest.pid && latest.pid !== Deno.pid) {
+    if (latest.pid !== Deno.pid) {
       await killProcessTree(latest.pid);
     }
-    latest.markCancelled(reason);
-    await outputRepo.save(type, latest.methodName, latest);
+    runTracker.complete(latest.id, "cancelled");
 
     if (cliCtx.outputMode === "json") {
       console.log(JSON.stringify({
         id: latest.id,
         modelName: definition.name,
         type: type.normalized,
-        method: latest.methodName,
+        method: latest.methodName ?? "unknown",
         status: "cancelled",
         reason: reason ?? null,
       }));
     } else {
       cliCtx.logger
-        .info`Cancelled method run ${latest.methodName} for model ${definition.name} (${latest.id})`;
+        .info`Cancelled method run ${
+        latest.methodName ?? "unknown"
+      } for model ${definition.name} (${latest.id})`;
     }
+    runTracker.close();
   });

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -73,7 +73,9 @@ export const modelCancelCommand = new Command()
       runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
 
       if (options.all) {
-        const trackerRuns = runTracker.findAllRunning();
+        const trackerRuns = runTracker.findAllRunning().filter(
+          (r) => r.runKind === "model_method",
+        );
 
         if (trackerRuns.length === 0) {
           if (cliCtx.outputMode === "json") {

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -68,96 +68,96 @@ export const modelCancelCommand = new Command()
 
     const reason = options.reason as string | undefined;
     const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
-    runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
 
-    if (options.all) {
-      const trackerRuns = runTracker.findAllRunning();
+    try {
+      runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
 
-      if (trackerRuns.length === 0) {
-        if (cliCtx.outputMode === "json") {
-          console.log(JSON.stringify({ cancelled: [] }));
-        } else {
-          cliCtx.logger.info("No running model method runs to cancel.");
+      if (options.all) {
+        const trackerRuns = runTracker.findAllRunning();
+
+        if (trackerRuns.length === 0) {
+          if (cliCtx.outputMode === "json") {
+            console.log(JSON.stringify({ cancelled: [] }));
+          } else {
+            cliCtx.logger.info("No running model method runs to cancel.");
+          }
+          return;
         }
-        runTracker.close();
+
+        const cancelled: { id: string; type: string; method: string }[] = [];
+        for (const run of trackerRuns) {
+          if (run.pid !== Deno.pid) {
+            await killProcessTree(run.pid);
+          }
+          runTracker.complete(run.id, "cancelled");
+          cancelled.push({
+            id: run.id,
+            type: run.modelType ?? "unknown",
+            method: run.methodName ?? "unknown",
+          });
+        }
+
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({
+            cancelled,
+            reason: reason ?? null,
+          }));
+        } else {
+          cliCtx.logger
+            .info`Cancelled ${cancelled.length} running model method run(s)`;
+          for (const c of cancelled) {
+            cliCtx.logger.info`  ${c.type}/${c.method} (${c.id})`;
+          }
+        }
         return;
       }
 
-      const cancelled: { id: string; type: string; method: string }[] = [];
-      for (const run of trackerRuns) {
-        if (run.pid !== Deno.pid) {
-          await killProcessTree(run.pid);
-        }
-        runTracker.complete(run.id, "cancelled");
-        cancelled.push({
-          id: run.id,
-          type: run.modelType ?? "unknown",
-          method: run.methodName ?? "unknown",
-        });
+      // Cancel a specific model's running output
+      const definitionRepo = repoContext.definitionRepo;
+      const resolved = await definitionRepo.findByNameGlobal(modelIdOrName!);
+      if (!resolved) {
+        throw new UserError(
+          `Model '${modelIdOrName}' not found`,
+        );
       }
+
+      const { definition, type } = resolved;
+
+      const trackerRuns = runTracker.findAllRunning().filter(
+        (r) => r.modelType === type.normalized,
+      );
+
+      if (trackerRuns.length === 0) {
+        throw new UserError(
+          `No running method runs found for model '${definition.name}'`,
+        );
+      }
+
+      const latest = trackerRuns.sort(
+        (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
+      )[0];
+
+      if (latest.pid !== Deno.pid) {
+        await killProcessTree(latest.pid);
+      }
+      runTracker.complete(latest.id, "cancelled");
 
       if (cliCtx.outputMode === "json") {
         console.log(JSON.stringify({
-          cancelled,
+          id: latest.id,
+          modelName: definition.name,
+          type: type.normalized,
+          method: latest.methodName ?? "unknown",
+          status: "cancelled",
           reason: reason ?? null,
         }));
       } else {
         cliCtx.logger
-          .info`Cancelled ${cancelled.length} running model method run(s)`;
-        for (const c of cancelled) {
-          cliCtx.logger.info`  ${c.type}/${c.method} (${c.id})`;
-        }
+          .info`Cancelled method run ${
+          latest.methodName ?? "unknown"
+        } for model ${definition.name} (${latest.id})`;
       }
+    } finally {
       runTracker.close();
-      return;
     }
-
-    // Cancel a specific model's running output
-    const definitionRepo = repoContext.definitionRepo;
-    const resolved = await definitionRepo.findByNameGlobal(modelIdOrName!);
-    if (!resolved) {
-      runTracker.close();
-      throw new UserError(
-        `Model '${modelIdOrName}' not found`,
-      );
-    }
-
-    const { definition, type } = resolved;
-
-    const trackerRuns = runTracker.findAllRunning().filter(
-      (r) => r.modelType === type.normalized,
-    );
-
-    if (trackerRuns.length === 0) {
-      runTracker.close();
-      throw new UserError(
-        `No running method runs found for model '${definition.name}'`,
-      );
-    }
-
-    const latest = trackerRuns.sort(
-      (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
-    )[0];
-
-    if (latest.pid !== Deno.pid) {
-      await killProcessTree(latest.pid);
-    }
-    runTracker.complete(latest.id, "cancelled");
-
-    if (cliCtx.outputMode === "json") {
-      console.log(JSON.stringify({
-        id: latest.id,
-        modelName: definition.name,
-        type: type.normalized,
-        method: latest.methodName ?? "unknown",
-        status: "cancelled",
-        reason: reason ?? null,
-      }));
-    } else {
-      cliCtx.logger
-        .info`Cancelled method run ${
-        latest.methodName ?? "unknown"
-      } for model ${definition.name} (${latest.id})`;
-    }
-    runTracker.close();
   });

--- a/src/cli/commands/model_cancel.ts
+++ b/src/cli/commands/model_cancel.ts
@@ -91,7 +91,7 @@ export const modelCancelCommand = new Command()
           if (run.pid !== Deno.pid) {
             await killProcessTree(run.pid);
           }
-          runTracker.complete(run.id, "cancelled");
+          runTracker.complete(run.id, "cancelled", reason);
           cancelled.push({
             id: run.id,
             type: run.modelType ?? "unknown",

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -251,240 +251,249 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
         });
 
       const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
-      runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
-
-      const marker = await new RepoMarkerRepository().read(
-        RepoPath.create(repoDir),
-      );
-      const autoGc = marker?.autoGc === true;
-
-      ctx.logger
-        .debug`Running method '${methodName}' on model: ${modelIdOrName}`;
-
-      const stdinContent = options.stdin ? await readStdin() : null;
-      let stdinItems: Record<string, unknown>[] | null = null;
-      if (stdinContent !== null) {
-        if (options.inputFile) {
-          throw new UserError(
-            "Cannot combine --stdin with --input-file.",
-          );
-        }
-        stdinItems = parseStdinContent(stdinContent);
-      }
-
-      const { inputs: cliInputs } = await parseInputs({
-        input: mergeInputArgs(options),
-        inputFile: stdinItems
-          ? undefined
-          : options.inputFile as string | undefined,
-      });
-
-      // Parse runtime tags
-      const runtimeTags = options.tag
-        ? parseTags(options.tag as string[])
-        : undefined;
-
-      // Load all extension registries needed for method execution in parallel
-      await Promise.all([
-        modelRegistry.ensureLoaded(),
-        vaultTypeRegistry.ensureLoaded(),
-        reportRegistry.ensureLoaded(),
-      ]);
-
-      const deps: ModelMethodRunDeps = {
-        repoDir,
-        lookupDefinition: (idOrName) =>
-          findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
-        getModelDef: (type) => resolveModelType(type, getAutoResolver()),
-        createEvaluationService: () => {
-          const dqs = new DataQueryService(
-            repoContext.catalogStore,
-            repoContext.unifiedDataRepo,
-          );
-          return new ExpressionEvaluationService(
-            repoContext.definitionRepo,
-            repoDir,
-            {
-              dataRepo: repoContext.unifiedDataRepo,
-              dataQueryService: dqs,
-            },
-          );
-        },
-        loadEvaluatedDefinition: (type, name) =>
-          repoContext.evaluatedDefinitionRepo.findByName(type, name),
-        saveEvaluatedDefinition: (type, definition) =>
-          repoContext.evaluatedDefinitionRepo.save(type, definition),
-        createExecutionService: () => new DefaultMethodExecutionService(),
-        createVaultService: () => VaultService.fromRepository(repoDir),
-        dataRepo: repoContext.unifiedDataRepo,
-        definitionRepo: repoContext.definitionRepo,
-        outputRepo: repoContext.outputRepo,
-        dataQueryService: new DataQueryService(
-          repoContext.catalogStore,
-          repoContext.unifiedDataRepo,
-        ),
-        createRunLog: async (modelType, method, definitionId) => {
-          const redactor = new SecretRedactor();
-          const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-          const logFilePath = join(
-            swampPath(repoDir, SWAMP_SUBDIRS.outputs),
-            modelType.normalized,
-            method,
-            `${definitionId}-${timestamp}.log`,
-          );
-          const logHandle = await runFileSink.register(
-            [],
-            logFilePath,
-            redactor,
-            swampPath(repoDir),
-          );
-          return {
-            logFilePath,
-            redactor,
-            cleanup: () => runFileSink.unregister(logHandle),
-          };
-        },
-        createAndSaveDefinition: isDirectExecution
-          ? async (type, definition) => {
-            const autoDefRepo = new YamlDefinitionRepository(
-              repoDir,
-              undefined,
-              repoContext.autoDefinitionsDir,
-              false,
-            );
-            await autoDefRepo.save(type, definition);
-          }
-          : undefined,
-        getDefinitionPath: isDirectExecution
-          ? (type, id) => {
-            return join(
-              repoContext.autoDefinitionsDir,
-              type.toDirectoryPath(),
-              `${id}.yaml`,
-            );
-          }
-          : undefined,
-        runTracker,
-      };
-
-      const timeoutMs = options.timeout
-        ? parseTimeout(options.timeout as string)
-        : undefined;
-      const abort = new AbortController();
-      const exitSuppress = suppressSyncExitOnSignal();
-      const shutdownHandle = registerShutdownHandler({
-        handler: () => abort.abort(),
-      });
-      const baseLibCtx = createLibSwampContext({ signal: abort.signal });
-      const libCtx = timeoutMs !== undefined
-        ? baseLibCtx.withTimeout(timeoutMs)
-        : baseLibCtx;
-
-      // Pre-lookup for per-model lock acquisition (reads YAML — no lock needed)
-      const preResult = await findDefinitionByIdOrName(
-        repoContext.definitionRepo,
-        modelIdOrName,
-      );
-      let flushModelLocks: (() => Promise<void>) | null = null;
-      if (preResult) {
-        const lockResult = await acquireModelLocks(
-          datastoreConfig,
-          [
-            {
-              modelType: preResult.type.normalized,
-              modelId: preResult.definition.id,
-            },
-          ],
-          repoDir,
-          syncService,
-          repoContext.catalogStore,
-        );
-        if (lockResult.synced) repoContext.catalogStore.invalidate();
-        flushModelLocks = lockResult.flush;
-      }
-
-      // Build the list of input sets to iterate over
-      const inputSets: Record<string, unknown>[] = stdinItems
-        ? stdinItems.map((item) =>
-          Object.keys(cliInputs).length > 0 ? deepMerge(item, cliInputs) : item
-        )
-        : [cliInputs];
-
       try {
-        for (let i = 0; i < inputSets.length; i++) {
-          if (inputSets.length > 1) {
-            ctx.logger
-              .info`Running method ${methodName} [${
-              i + 1
-            }/${inputSets.length}]`;
+        runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
+
+        const marker = await new RepoMarkerRepository().read(
+          RepoPath.create(repoDir),
+        );
+        const autoGc = marker?.autoGc === true;
+
+        ctx.logger
+          .debug`Running method '${methodName}' on model: ${modelIdOrName}`;
+
+        const stdinContent = options.stdin ? await readStdin() : null;
+        let stdinItems: Record<string, unknown>[] | null = null;
+        if (stdinContent !== null) {
+          if (options.inputFile) {
+            throw new UserError(
+              "Cannot combine --stdin with --input-file.",
+            );
           }
-
-          const renderer = createModelMethodRunRenderer(ctx.outputMode, {
-            modelName: modelIdOrName,
-            methodName,
-            isAuthenticated: isAuthenticated(),
-          });
-
-          await consumeStream(
-            modelMethodRun(libCtx, deps, {
-              modelIdOrName,
-              methodName,
-              inputs: inputSets[i],
-              lastEvaluated: options.lastEvaluated as boolean,
-              typeArg,
-              definitionName,
-              runtimeTags,
-              skipCheckNames: options.skipCheck as string[] | undefined,
-              skipCheckLabels: options.skipCheckLabel as string[] | undefined,
-              skipAllChecks: options.skipChecks as boolean | undefined,
-              skipReportNames: options.skipReport as string[] | undefined,
-              skipReportLabels: options.skipReportLabel as string[] | undefined,
-              skipAllReports: options.skipReports as boolean | undefined,
-              reportNames: options.report as string[] | undefined,
-              reportLabels: options.reportLabel as string[] | undefined,
-              swampSha: GIT_SHA || undefined,
-              autoGc,
-            }),
-            renderer.handlers(),
-          );
-
-          if (abort.signal.aborted) {
-            Deno.exitCode = 1;
-            return;
-          }
-
-          if (renderer.runFailed()) {
-            Deno.exitCode = 1;
-            return;
-          }
+          stdinItems = parseStdinContent(stdinContent);
         }
-      } catch (error) {
-        if (error instanceof UserError) {
-          throw error;
-        }
-        const message = error instanceof Error ? error.message : String(error);
-        throw new UserError(`Method execution failed: ${message}`);
-      } finally {
-        runTracker.close();
-        shutdownHandle.dispose();
-        exitSuppress.dispose();
-        if (flushModelLocks) {
-          try {
-            await flushModelLocks();
-          } catch (releaseError) {
-            ctx.logger.warn(
-              "Failed to release locks during cleanup: {error}",
+
+        const { inputs: cliInputs } = await parseInputs({
+          input: mergeInputArgs(options),
+          inputFile: stdinItems
+            ? undefined
+            : options.inputFile as string | undefined,
+        });
+
+        // Parse runtime tags
+        const runtimeTags = options.tag
+          ? parseTags(options.tag as string[])
+          : undefined;
+
+        // Load all extension registries needed for method execution in parallel
+        await Promise.all([
+          modelRegistry.ensureLoaded(),
+          vaultTypeRegistry.ensureLoaded(),
+          reportRegistry.ensureLoaded(),
+        ]);
+
+        const deps: ModelMethodRunDeps = {
+          repoDir,
+          lookupDefinition: (idOrName) =>
+            findDefinitionByIdOrName(repoContext.definitionRepo, idOrName),
+          getModelDef: (type) => resolveModelType(type, getAutoResolver()),
+          createEvaluationService: () => {
+            const dqs = new DataQueryService(
+              repoContext.catalogStore,
+              repoContext.unifiedDataRepo,
+            );
+            return new ExpressionEvaluationService(
+              repoContext.definitionRepo,
+              repoDir,
               {
-                error: releaseError instanceof Error
-                  ? releaseError.message
-                  : String(releaseError),
+                dataRepo: repoContext.unifiedDataRepo,
+                dataQueryService: dqs,
               },
             );
+          },
+          loadEvaluatedDefinition: (type, name) =>
+            repoContext.evaluatedDefinitionRepo.findByName(type, name),
+          saveEvaluatedDefinition: (type, definition) =>
+            repoContext.evaluatedDefinitionRepo.save(type, definition),
+          createExecutionService: () => new DefaultMethodExecutionService(),
+          createVaultService: () => VaultService.fromRepository(repoDir),
+          dataRepo: repoContext.unifiedDataRepo,
+          definitionRepo: repoContext.definitionRepo,
+          outputRepo: repoContext.outputRepo,
+          dataQueryService: new DataQueryService(
+            repoContext.catalogStore,
+            repoContext.unifiedDataRepo,
+          ),
+          createRunLog: async (modelType, method, definitionId) => {
+            const redactor = new SecretRedactor();
+            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+            const logFilePath = join(
+              swampPath(repoDir, SWAMP_SUBDIRS.outputs),
+              modelType.normalized,
+              method,
+              `${definitionId}-${timestamp}.log`,
+            );
+            const logHandle = await runFileSink.register(
+              [],
+              logFilePath,
+              redactor,
+              swampPath(repoDir),
+            );
+            return {
+              logFilePath,
+              redactor,
+              cleanup: () => runFileSink.unregister(logHandle),
+            };
+          },
+          createAndSaveDefinition: isDirectExecution
+            ? async (type, definition) => {
+              const autoDefRepo = new YamlDefinitionRepository(
+                repoDir,
+                undefined,
+                repoContext.autoDefinitionsDir,
+                false,
+              );
+              await autoDefRepo.save(type, definition);
+            }
+            : undefined,
+          getDefinitionPath: isDirectExecution
+            ? (type, id) => {
+              return join(
+                repoContext.autoDefinitionsDir,
+                type.toDirectoryPath(),
+                `${id}.yaml`,
+              );
+            }
+            : undefined,
+          runTracker,
+        };
+
+        const timeoutMs = options.timeout
+          ? parseTimeout(options.timeout as string)
+          : undefined;
+        const abort = new AbortController();
+        const exitSuppress = suppressSyncExitOnSignal();
+        const shutdownHandle = registerShutdownHandler({
+          handler: () => abort.abort(),
+        });
+        const baseLibCtx = createLibSwampContext({ signal: abort.signal });
+        const libCtx = timeoutMs !== undefined
+          ? baseLibCtx.withTimeout(timeoutMs)
+          : baseLibCtx;
+
+        // Pre-lookup for per-model lock acquisition (reads YAML — no lock needed)
+        const preResult = await findDefinitionByIdOrName(
+          repoContext.definitionRepo,
+          modelIdOrName,
+        );
+        let flushModelLocks: (() => Promise<void>) | null = null;
+        if (preResult) {
+          const lockResult = await acquireModelLocks(
+            datastoreConfig,
+            [
+              {
+                modelType: preResult.type.normalized,
+                modelId: preResult.definition.id,
+              },
+            ],
+            repoDir,
+            syncService,
+            repoContext.catalogStore,
+          );
+          if (lockResult.synced) repoContext.catalogStore.invalidate();
+          flushModelLocks = lockResult.flush;
+        }
+
+        // Build the list of input sets to iterate over
+        const inputSets: Record<string, unknown>[] = stdinItems
+          ? stdinItems.map((item) =>
+            Object.keys(cliInputs).length > 0
+              ? deepMerge(item, cliInputs)
+              : item
+          )
+          : [cliInputs];
+
+        try {
+          for (let i = 0; i < inputSets.length; i++) {
+            if (inputSets.length > 1) {
+              ctx.logger
+                .info`Running method ${methodName} [${
+                i + 1
+              }/${inputSets.length}]`;
+            }
+
+            const renderer = createModelMethodRunRenderer(ctx.outputMode, {
+              modelName: modelIdOrName,
+              methodName,
+              isAuthenticated: isAuthenticated(),
+            });
+
+            await consumeStream(
+              modelMethodRun(libCtx, deps, {
+                modelIdOrName,
+                methodName,
+                inputs: inputSets[i],
+                lastEvaluated: options.lastEvaluated as boolean,
+                typeArg,
+                definitionName,
+                runtimeTags,
+                skipCheckNames: options.skipCheck as string[] | undefined,
+                skipCheckLabels: options.skipCheckLabel as string[] | undefined,
+                skipAllChecks: options.skipChecks as boolean | undefined,
+                skipReportNames: options.skipReport as string[] | undefined,
+                skipReportLabels: options.skipReportLabel as
+                  | string[]
+                  | undefined,
+                skipAllReports: options.skipReports as boolean | undefined,
+                reportNames: options.report as string[] | undefined,
+                reportLabels: options.reportLabel as string[] | undefined,
+                swampSha: GIT_SHA || undefined,
+                autoGc,
+              }),
+              renderer.handlers(),
+            );
+
+            if (abort.signal.aborted) {
+              Deno.exitCode = 1;
+              return;
+            }
+
+            if (renderer.runFailed()) {
+              Deno.exitCode = 1;
+              return;
+            }
+          }
+        } catch (error) {
+          if (error instanceof UserError) {
+            throw error;
+          }
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          throw new UserError(`Method execution failed: ${message}`);
+        } finally {
+          shutdownHandle.dispose();
+          exitSuppress.dispose();
+          if (flushModelLocks) {
+            try {
+              await flushModelLocks();
+            } catch (releaseError) {
+              ctx.logger.warn(
+                "Failed to release locks during cleanup: {error}",
+                {
+                  error: releaseError instanceof Error
+                    ? releaseError.message
+                    : String(releaseError),
+                },
+              );
+            }
           }
         }
-      }
 
-      ctx.logger.debug("Method run command completed");
+        ctx.logger.debug("Method run command completed");
+      } finally {
+        runTracker.close();
+      }
     },
   );
 

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -465,6 +465,7 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
         const message = error instanceof Error ? error.message : String(error);
         throw new UserError(`Method execution failed: ${message}`);
       } finally {
+        runTracker.close();
         shutdownHandle.dispose();
         exitSuppress.dispose();
         if (flushModelLocks) {

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -78,6 +78,10 @@ import { registerShutdownHandler } from "../../infrastructure/process/shutdown_h
 import { suppressSyncExitOnSignal } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { isAuthenticated } from "../auth_context.ts";
+import {
+  DEFAULT_STALE_TTL_MS,
+  RunTrackerStore,
+} from "../../infrastructure/persistence/run_tracker_store.ts";
 
 // Cliffy's custom type system returns `unknown` for custom types like `model_name`,
 // but we need to pass `options` to functions expecting specific types. Using `any`
@@ -246,6 +250,9 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
           outputMode: ctx.outputMode,
         });
 
+      const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
+      runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
+
       const marker = await new RepoMarkerRepository().read(
         RepoPath.create(repoDir),
       );
@@ -357,6 +364,7 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
             );
           }
           : undefined,
+        runTracker,
       };
 
       const timeoutMs = options.timeout

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -24,6 +24,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
 import {
   DEFAULT_STALE_TTL_MS,
   RunTrackerStore,
@@ -47,7 +48,10 @@ import type {
   RunDoctorResponse,
   RunHistoryResponse,
 } from "../../serve/protocol.ts";
-import { ActiveRun } from "../../domain/models/active_run.ts";
+import {
+  ActiveRun,
+  type ActiveRunStatus,
+} from "../../domain/models/active_run.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -64,7 +68,7 @@ function responseToActiveRuns(response: RunHistoryResponse): ActiveRun[] {
       hostname: r.hostname,
       startedAt: r.startedAt,
       heartbeatAt: r.heartbeatAt,
-      status: r.status as "running" | "completed" | "failed" | "cancelled",
+      status: r.status as ActiveRunStatus,
     })
   );
 }
@@ -84,9 +88,18 @@ const runHistoryCommand = withRemoteOptions(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
-    .option("--active", "Show only currently running")
-    .option("--all", "Show all tracked runs (not just recent)")
+    .option(
+      "--active",
+      "Show only currently running (mutually exclusive with --all)",
+    )
+    .option(
+      "--all",
+      "Show all tracked runs, not just recent (mutually exclusive with --active)",
+    )
     .action(async function (options: AnyOptions) {
+      if (options.active && options.all) {
+        throw new UserError("--active and --all are mutually exclusive");
+      }
       const ctx = createContext(options as GlobalOptions, ["run", "history"]);
 
       const server = resolveServeUrl(options.server as string | undefined);

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -167,20 +167,20 @@ const runDoctorCommand = withRemoteOptions(
             payload: { fix: !!options.fix },
           },
         );
+        const activeRuns = responseToActiveRuns({
+          runs: response.activeRuns ?? [],
+        });
+        const staleRuns = responseToActiveRuns({
+          runs: response.staleRuns ?? [],
+        });
         if (ctx.outputMode === "json") {
           writeDoctorRunsJson(
             response.totalTracked,
-            response.active,
-            response.stale,
+            activeRuns,
+            staleRuns,
             response.reaped,
           );
         } else {
-          const activeRuns = responseToActiveRuns({
-            runs: response.activeRuns ?? [],
-          });
-          const staleRuns = responseToActiveRuns({
-            runs: response.staleRuns ?? [],
-          });
           writeDoctorRunsLog(
             activeRuns,
             staleRuns,
@@ -213,8 +213,8 @@ const runDoctorCommand = withRemoteOptions(
         if (ctx.outputMode === "json") {
           writeDoctorRunsJson(
             allRuns.length,
-            active.length,
-            stale.length,
+            active,
+            stale,
             reaped,
           );
         } else {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,0 +1,234 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import {
+  DEFAULT_STALE_TTL_MS,
+  RunTrackerStore,
+} from "../../infrastructure/persistence/run_tracker_store.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import {
+  createModelRunsOutput,
+  writeDoctorRunsJson,
+  writeDoctorRunsLog,
+  writeModelRunsJson,
+  writeModelRunsLog,
+} from "../../presentation/output/model_runs_output.ts";
+import { groupCommandAction } from "../group_action.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type {
+  RunDoctorResponse,
+  RunHistoryResponse,
+} from "../../serve/protocol.ts";
+import { ActiveRun } from "../../domain/models/active_run.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+function responseToActiveRuns(response: RunHistoryResponse): ActiveRun[] {
+  return response.runs.map((r) =>
+    ActiveRun.fromData({
+      id: r.id,
+      runKind: r.runKind as "model_method" | "workflow",
+      modelType: r.modelType,
+      methodName: r.methodName,
+      workflowName: r.workflowName,
+      pid: r.pid,
+      hostname: r.hostname,
+      startedAt: r.startedAt,
+      heartbeatAt: r.heartbeatAt,
+      status: r.status as "running" | "completed" | "failed" | "cancelled",
+    })
+  );
+}
+
+const runHistoryCommand = withRemoteOptions(
+  new Command()
+    .name("history")
+    .description("List active and recent runs (model methods and workflows)")
+    .example("List recent runs (last 24h)", "swamp run history")
+    .example("List only active runs", "swamp run history --active")
+    .example("List all tracked runs", "swamp run history --all")
+    .example(
+      "List runs on a server",
+      "swamp run history --server http://127.0.0.1:7766",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--active", "Show only currently running")
+    .option("--all", "Show all tracked runs (not just recent)")
+    .action(async function (options: AnyOptions) {
+      const ctx = createContext(options as GlobalOptions, ["run", "history"]);
+
+      const server = resolveServeUrl(options.server as string | undefined);
+      if (server) {
+        const token = await resolveServerToken(
+          server,
+          options.token as string | undefined,
+        );
+        const response = await requestServerResponse<RunHistoryResponse>(
+          { server, token },
+          {
+            type: "run.history",
+            payload: {
+              active: !!options.active,
+              all: !!options.all,
+            },
+          },
+        );
+        const runs = responseToActiveRuns(response);
+        if (ctx.outputMode === "json") {
+          writeModelRunsJson(runs);
+        } else {
+          writeModelRunsLog(runs);
+        }
+        return;
+      }
+
+      const { repoDir } = await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: ctx.outputMode,
+      });
+
+      const tracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
+      const output = createModelRunsOutput(ctx.outputMode);
+
+      try {
+        const runs = options.active
+          ? tracker.findAllRunning()
+          : options.all
+          ? tracker.findAll()
+          : tracker.findRecent();
+
+        output.writeRuns(runs);
+      } finally {
+        tracker.close();
+      }
+    }),
+);
+
+const runDoctorCommand = withRemoteOptions(
+  new Command()
+    .name("doctor")
+    .description("Diagnose stale or orphaned runs")
+    .example("Check for stale runs", "swamp run doctor")
+    .example("Auto-reap stale runs", "swamp run doctor --fix")
+    .example(
+      "Check on a server",
+      "swamp run doctor --server http://127.0.0.1:7766",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--fix", "Automatically reap stale runs")
+    .action(async function (options: AnyOptions) {
+      const ctx = createContext(options as GlobalOptions, ["run", "doctor"]);
+
+      const server = resolveServeUrl(options.server as string | undefined);
+      if (server) {
+        const token = await resolveServerToken(
+          server,
+          options.token as string | undefined,
+        );
+        const response = await requestServerResponse<RunDoctorResponse>(
+          { server, token },
+          {
+            type: "run.doctor",
+            payload: { fix: !!options.fix },
+          },
+        );
+        if (ctx.outputMode === "json") {
+          writeDoctorRunsJson(
+            response.totalTracked,
+            response.active,
+            response.stale,
+            response.reaped,
+          );
+        } else {
+          const activeRuns = responseToActiveRuns({
+            runs: response.activeRuns ?? [],
+          });
+          const staleRuns = responseToActiveRuns({
+            runs: response.staleRuns ?? [],
+          });
+          writeDoctorRunsLog(
+            activeRuns,
+            staleRuns,
+            response.reaped,
+            !!options.fix,
+          );
+        }
+        return;
+      }
+
+      const { repoDir } = await requireInitializedRepoUnlocked({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: ctx.outputMode,
+      });
+
+      const tracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
+
+      try {
+        const allRuns = tracker.findAll();
+        const running = allRuns.filter((r) => r.status === "running");
+        const stale = tracker.findStaleRuns(DEFAULT_STALE_TTL_MS);
+        const active = running.filter((r) => !r.isStale(DEFAULT_STALE_TTL_MS));
+
+        let reaped = 0;
+        if (options.fix && stale.length > 0) {
+          const reapedRuns = tracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
+          reaped = reapedRuns.length;
+        }
+
+        if (ctx.outputMode === "json") {
+          writeDoctorRunsJson(
+            allRuns.length,
+            active.length,
+            stale.length,
+            reaped,
+          );
+        } else {
+          writeDoctorRunsLog(active, stale, reaped, !!options.fix);
+        }
+      } finally {
+        tracker.close();
+      }
+    }),
+);
+
+export const runCommand = new Command()
+  .name("run")
+  .description("Track and diagnose in-flight model method and workflow runs")
+  .action(groupCommandAction)
+  .command("history", runHistoryCommand)
+  .command("doctor", runDoctorCommand);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -71,6 +71,11 @@ import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_
 import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
 import { join } from "@std/path";
+import {
+  DEFAULT_STALE_TTL_MS,
+  RunTrackerStore,
+} from "../../infrastructure/persistence/run_tracker_store.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -672,20 +677,8 @@ export const serveCommand = new Command()
 
     const cancelRegistry = new RunCancelRegistry();
 
-    const connectionCtx = {
-      repoDir: resolvedRepoDir,
-      repoContext,
-      datastoreConfig,
-      syncService,
-      workerGateway,
-      policySnapshotLoader,
-      authConfig,
-      cancelRegistry,
-    };
-
     // Reap orphaned runs left in "running" state by a previous daemon.
-    // Only scan runs started within the last 7 days — anything older is
-    // either already terminal or so stale that it was cleaned up manually.
+    // Workflow runs still use YAML-based reaping (tracker wiring deferred to #519).
     const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const recentRuns = await repoContext.workflowRunRepo.findAllGlobalSince(
       reapCutoff,
@@ -700,19 +693,30 @@ export const serveCommand = new Command()
         await repoContext.workflowRunRepo.save(workflowId, run);
       }
     }
-    const recentOutputs = await repoContext.outputRepo.findAllGlobalSince(
-      reapCutoff,
+
+    // Model method runs use the SQLite run tracker for stale detection.
+    const runTracker = RunTrackerStore.fromSwampDir(
+      swampPath(resolvedRepoDir),
     );
-    for (const { output, type, method } of recentOutputs) {
-      if (output.status === "running") {
-        logger.warn(
-          "Reaping orphaned model output {outputId} (method: {methodName})",
-          { outputId: output.id, methodName: output.methodName },
-        );
-        output.markCancelled("daemon restarted");
-        await repoContext.outputRepo.save(type, method, output);
-      }
+    const reapedRuns = runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
+    for (const run of reapedRuns) {
+      logger.warn`Reaped stale model method run ${run.id} (method: ${
+        run.methodName ?? "unknown"
+      })`;
     }
+
+    const connectionCtx: import("../../serve/connection.ts").ConnectionContext =
+      {
+        repoDir: resolvedRepoDir,
+        repoContext,
+        datastoreConfig,
+        syncService,
+        workerGateway,
+        policySnapshotLoader,
+        authConfig,
+        cancelRegistry,
+        runTracker,
+      };
 
     const ac = new AbortController();
     const enableSchedule = options.schedule !== false;
@@ -733,6 +737,7 @@ export const serveCommand = new Command()
             signal,
             onEvent,
             syncService,
+            runTracker,
           ),
       });
 

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -35,7 +35,11 @@ import {
   type StepLockHook,
   WorkflowExecutionService,
 } from "../../domain/workflows/execution_service.ts";
-import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { RunTrackerStore } from "../../infrastructure/persistence/run_tracker_store.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
 import { isAuthenticated } from "../auth_context.ts";
 import { resolveOrCreateDefinition } from "../../libswamp/mod.ts";
@@ -335,6 +339,7 @@ export const workflowResumeCommand = withRemoteOptions(
       repoContext.markDirty,
       repoContext.unifiedDataRepo.namespace,
       stepLockHook,
+      RunTrackerStore.fromSwampDir(swampPath(repoDir)),
     );
 
     const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -343,6 +343,7 @@ export const workflowRunCommand = new Command()
             };
           };
 
+          const tracker = RunTrackerStore.fromSwampDir(swampPath(dir));
           return new WorkflowExecutionService(
             wfRepo,
             rnRepo,
@@ -354,7 +355,7 @@ export const workflowRunCommand = new Command()
             repoContext.markDirty,
             repoContext.unifiedDataRepo.namespace,
             stepLockHook,
-            RunTrackerStore.fromSwampDir(swampPath(dir)),
+            tracker,
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -40,7 +40,11 @@ import type { DefinitionId } from "../../domain/definitions/definition.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
+import { RunTrackerStore } from "../../infrastructure/persistence/run_tracker_store.ts";
 import {
   createWorkflowId,
   createWorkflowRunId,
@@ -350,6 +354,7 @@ export const workflowRunCommand = new Command()
             repoContext.markDirty,
             repoContext.unifiedDataRepo.namespace,
             stepLockHook,
+            RunTrackerStore.fromSwampDir(swampPath(dir)),
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -27,6 +27,7 @@ import { getLogger, parseLogLevel } from "@logtape/logtape";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { VERSION, versionCommand } from "./commands/version.ts";
 import { modelCommand } from "./commands/model_create.ts";
+import { runCommand } from "./commands/run.ts";
 import { repoCommand, repoInitCommand } from "./commands/repo_init.ts";
 import { workflowCommand } from "./commands/workflow.ts";
 import { completionCommand } from "./commands/completion.ts";
@@ -1316,6 +1317,7 @@ export async function runCli(args: string[]): Promise<void> {
     .command("summarise", summariseCommand)
     .command("datastore", datastoreCommand)
     .command("doctor", doctorCommand)
+    .command("run", runCommand)
     .command("report", reportCommand)
     .command("serve", serveCommand)
     .command("agent", agentCommand)

--- a/src/domain/models/active_run.ts
+++ b/src/domain/models/active_run.ts
@@ -1,0 +1,180 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export const RunKinds = ["model_method", "workflow"] as const;
+export type RunKind = typeof RunKinds[number];
+
+export const ActiveRunStatuses = [
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+export type ActiveRunStatus = typeof ActiveRunStatuses[number];
+
+export interface ActiveRunData {
+  readonly id: string;
+  readonly runKind: RunKind;
+  readonly modelType: string | null;
+  readonly methodName: string | null;
+  readonly workflowName: string | null;
+  readonly pid: number;
+  readonly hostname: string;
+  readonly startedAt: string;
+  readonly heartbeatAt: string;
+  readonly status: ActiveRunStatus;
+}
+
+export class ActiveRun {
+  private _status: ActiveRunStatus;
+  private _heartbeatAt: Date;
+
+  readonly id: string;
+  readonly runKind: RunKind;
+  readonly modelType: string | null;
+  readonly methodName: string | null;
+  readonly workflowName: string | null;
+  readonly pid: number;
+  readonly hostname: string;
+  readonly startedAt: Date;
+
+  private constructor(data: ActiveRunData) {
+    this.id = data.id;
+    this.runKind = data.runKind;
+    this.modelType = data.modelType;
+    this.methodName = data.methodName;
+    this.workflowName = data.workflowName;
+    this.pid = data.pid;
+    this.hostname = data.hostname;
+    this.startedAt = new Date(data.startedAt);
+    this._heartbeatAt = new Date(data.heartbeatAt);
+    this._status = data.status;
+  }
+
+  get status(): ActiveRunStatus {
+    return this._status;
+  }
+
+  get heartbeatAt(): Date {
+    return this._heartbeatAt;
+  }
+
+  static createModelMethodRun(opts: {
+    id: string;
+    modelType: string;
+    methodName: string;
+    pid: number;
+    hostname: string;
+  }): ActiveRun {
+    const now = new Date().toISOString();
+    return new ActiveRun({
+      id: opts.id,
+      runKind: "model_method",
+      modelType: opts.modelType,
+      methodName: opts.methodName,
+      workflowName: null,
+      pid: opts.pid,
+      hostname: opts.hostname,
+      startedAt: now,
+      heartbeatAt: now,
+      status: "running",
+    });
+  }
+
+  static createWorkflowRun(opts: {
+    id: string;
+    workflowName: string;
+    pid: number;
+    hostname: string;
+  }): ActiveRun {
+    const now = new Date().toISOString();
+    return new ActiveRun({
+      id: opts.id,
+      runKind: "workflow",
+      modelType: null,
+      methodName: null,
+      workflowName: opts.workflowName,
+      pid: opts.pid,
+      hostname: opts.hostname,
+      startedAt: now,
+      heartbeatAt: now,
+      status: "running",
+    });
+  }
+
+  static fromData(data: ActiveRunData): ActiveRun {
+    return new ActiveRun(data);
+  }
+
+  toData(): ActiveRunData {
+    return {
+      id: this.id,
+      runKind: this.runKind,
+      modelType: this.modelType,
+      methodName: this.methodName,
+      workflowName: this.workflowName,
+      pid: this.pid,
+      hostname: this.hostname,
+      startedAt: this.startedAt.toISOString(),
+      heartbeatAt: this._heartbeatAt.toISOString(),
+      status: this._status,
+    };
+  }
+
+  recordHeartbeat(): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot heartbeat a run in status '${this._status}'`,
+      );
+    }
+    this._heartbeatAt = new Date();
+  }
+
+  markCompleted(): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot mark run as completed from status '${this._status}'`,
+      );
+    }
+    this._status = "completed";
+  }
+
+  markFailed(): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot mark run as failed from status '${this._status}'`,
+      );
+    }
+    this._status = "failed";
+  }
+
+  markCancelled(): void {
+    if (this._status !== "running") {
+      throw new Error(
+        `Cannot mark run as cancelled from status '${this._status}'`,
+      );
+    }
+    this._status = "cancelled";
+  }
+
+  isStale(ttlMs: number): boolean {
+    if (this._status !== "running") return false;
+    return Date.now() - this._heartbeatAt.getTime() > ttlMs;
+  }
+}

--- a/src/domain/models/active_run.ts
+++ b/src/domain/models/active_run.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+export const STALE_TTL_MS = 90_000;
+
 export const RunKinds = ["model_method", "workflow"] as const;
 export type RunKind = typeof RunKinds[number];
 
@@ -25,6 +27,7 @@ export const ActiveRunStatuses = [
   "completed",
   "failed",
   "cancelled",
+  "suspended",
 ] as const;
 export type ActiveRunStatus = typeof ActiveRunStatuses[number];
 

--- a/src/domain/models/active_run_test.ts
+++ b/src/domain/models/active_run_test.ts
@@ -1,0 +1,210 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { ActiveRun } from "./active_run.ts";
+
+Deno.test("ActiveRun.createModelMethodRun: creates with running status", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  assertEquals(run.id, "test-id");
+  assertEquals(run.runKind, "model_method");
+  assertEquals(run.modelType, "@test/model");
+  assertEquals(run.methodName, "start");
+  assertEquals(run.workflowName, null);
+  assertEquals(run.pid, 1234);
+  assertEquals(run.hostname, "test-host");
+  assertEquals(run.status, "running");
+});
+
+Deno.test("ActiveRun.markCompleted: transitions from running to completed", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markCompleted();
+  assertEquals(run.status, "completed");
+});
+
+Deno.test("ActiveRun.markFailed: transitions from running to failed", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markFailed();
+  assertEquals(run.status, "failed");
+});
+
+Deno.test("ActiveRun.markCancelled: transitions from running to cancelled", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markCancelled();
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("ActiveRun.markCompleted: throws from non-running status", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markCompleted();
+  assertThrows(
+    () => run.markCompleted(),
+    Error,
+    "Cannot mark run as completed from status 'completed'",
+  );
+});
+
+Deno.test("ActiveRun.markFailed: throws from non-running status", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markFailed();
+  assertThrows(
+    () => run.markFailed(),
+    Error,
+    "Cannot mark run as failed from status 'failed'",
+  );
+});
+
+Deno.test("ActiveRun.recordHeartbeat: updates heartbeat time", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  const before = run.heartbeatAt;
+  // Small delay to ensure time difference
+  const spinUntil = Date.now() + 2;
+  while (Date.now() < spinUntil) { /* spin */ }
+  run.recordHeartbeat();
+  assertEquals(run.heartbeatAt.getTime() >= before.getTime(), true);
+});
+
+Deno.test("ActiveRun.recordHeartbeat: throws from non-running status", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markCompleted();
+  assertThrows(
+    () => run.recordHeartbeat(),
+    Error,
+    "Cannot heartbeat a run in status 'completed'",
+  );
+});
+
+Deno.test("ActiveRun.isStale: returns false when heartbeat is fresh", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  assertEquals(run.isStale(90_000), false);
+});
+
+Deno.test("ActiveRun.isStale: returns true when heartbeat exceeds TTL", () => {
+  const run = ActiveRun.fromData({
+    id: "test-id",
+    runKind: "model_method",
+    modelType: "@test/model",
+    methodName: "start",
+    workflowName: null,
+    pid: 1234,
+    hostname: "test-host",
+    startedAt: new Date(Date.now() - 120_000).toISOString(),
+    heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+    status: "running",
+  });
+
+  assertEquals(run.isStale(90_000), true);
+});
+
+Deno.test("ActiveRun.isStale: returns false for non-running status", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  run.markCompleted();
+  assertEquals(run.isStale(0), false);
+});
+
+Deno.test("ActiveRun.toData: roundtrips through fromData", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  const data = run.toData();
+  const restored = ActiveRun.fromData(data);
+
+  assertEquals(restored.id, run.id);
+  assertEquals(restored.runKind, run.runKind);
+  assertEquals(restored.modelType, run.modelType);
+  assertEquals(restored.methodName, run.methodName);
+  assertEquals(restored.pid, run.pid);
+  assertEquals(restored.hostname, run.hostname);
+  assertEquals(restored.status, run.status);
+});

--- a/src/domain/models/run_tracker_repository.ts
+++ b/src/domain/models/run_tracker_repository.ts
@@ -24,7 +24,7 @@ export interface RunTrackerRepository {
 
   heartbeat(runId: string): void;
 
-  complete(runId: string, status: ActiveRunStatus): void;
+  complete(runId: string, status: ActiveRunStatus, reason?: string): void;
 
   reactivate(runId: string): void;
 

--- a/src/domain/models/run_tracker_repository.ts
+++ b/src/domain/models/run_tracker_repository.ts
@@ -1,0 +1,42 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ActiveRun, ActiveRunStatus } from "./active_run.ts";
+
+export interface RunTrackerRepository {
+  register(run: ActiveRun): void;
+
+  heartbeat(runId: string): void;
+
+  complete(runId: string, status: ActiveRunStatus): void;
+
+  findById(runId: string): ActiveRun | null;
+
+  findAllRunning(): ActiveRun[];
+
+  findStaleRuns(ttlMs: number): ActiveRun[];
+
+  findAll(): ActiveRun[];
+
+  findRecent(hours?: number): ActiveRun[];
+
+  reapStaleRuns(ttlMs: number): ActiveRun[];
+
+  close(): void;
+}

--- a/src/domain/models/run_tracker_repository.ts
+++ b/src/domain/models/run_tracker_repository.ts
@@ -26,6 +26,8 @@ export interface RunTrackerRepository {
 
   complete(runId: string, status: ActiveRunStatus): void;
 
+  reactivate(runId: string): void;
+
   findById(runId: string): ActiveRun | null;
 
   findAllRunning(): ActiveRun[];

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -48,6 +48,9 @@ import {
 } from "../../infrastructure/persistence/paths.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 import type { OutputRepository } from "../models/repositories.ts";
+import type { RunTrackerRepository } from "../models/run_tracker_repository.ts";
+import { ActiveRun } from "../models/active_run.ts";
+import { hostname } from "node:os";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
 import type { MethodExecutionService } from "../models/method_execution_service.ts";
 import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
@@ -201,6 +204,7 @@ export interface StepExecutionContext {
    * namespaced data path.
    */
   namespace?: Namespace;
+  runTracker?: RunTrackerRepository;
 }
 
 /**
@@ -277,6 +281,7 @@ export interface StepExecutorDeps {
   vaultService: VaultService;
   expressionEvaluator: ExpressionEvaluationService;
   directTypeResolver?: DirectTypeResolver;
+  runTracker?: RunTrackerRepository;
 }
 
 /**
@@ -333,6 +338,9 @@ export class DefaultStepExecutor implements StepExecutor {
     });
     if (this._directTypeResolver) {
       deps.directTypeResolver = this._directTypeResolver;
+    }
+    if (ctx.runTracker) {
+      deps.runTracker = ctx.runTracker;
     }
     return deps;
   }
@@ -650,6 +658,27 @@ export class DefaultStepExecutor implements StepExecutor {
     }
     await outputRepo.save(modelType, task.methodName, output);
 
+    // Register with the run tracker (if available) and start heartbeat.
+    const { runTracker } = allDeps;
+    let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+    if (runTracker) {
+      const activeRun = ActiveRun.createModelMethodRun({
+        id: output.id,
+        modelType: modelType.normalized,
+        methodName: task.methodName,
+        pid: Deno.pid,
+        hostname: hostname(),
+      });
+      runTracker.register(activeRun);
+      heartbeatInterval = setInterval(() => {
+        try {
+          runTracker.heartbeat(output.id);
+        } catch {
+          // Heartbeat failure is non-fatal
+        }
+      }, 30_000);
+    }
+
     // Declared outside try so the catch block can record artifacts written
     // before a throw (e.g. model writes data then throws on verdict=FAIL).
     // Each phase owns its mutations of this list; the orchestrator only
@@ -691,6 +720,9 @@ export class DefaultStepExecutor implements StepExecutor {
           secretBag,
         });
 
+        if (heartbeatInterval) clearInterval(heartbeatInterval);
+        if (runTracker) runTracker.complete(output.id, "completed");
+
         return await this.handleMethodSuccess({
           task,
           ctx,
@@ -709,6 +741,9 @@ export class DefaultStepExecutor implements StepExecutor {
           savedArtifacts,
         });
       } catch (error) {
+        if (heartbeatInterval) clearInterval(heartbeatInterval);
+        if (runTracker) runTracker.complete(output.id, "failed");
+
         await this.handleMethodFailure({
           task,
           ctx,
@@ -1254,6 +1289,7 @@ export class WorkflowExecutionService {
     private readonly markDirty?: MarkDirtyHook,
     private readonly namespace: Namespace = SOLO_NAMESPACE,
     stepLockHook?: StepLockHook,
+    private readonly runTracker?: RunTrackerRepository,
   ) {
     this.executor = executor ??
       new DefaultStepExecutor(
@@ -1422,6 +1458,17 @@ export class WorkflowExecutionService {
         // Start execution
         run.start(Deno.pid);
 
+        // Register workflow run with the tracker
+        if (this.runTracker) {
+          const wfActiveRun = ActiveRun.createWorkflowRun({
+            id: run.id,
+            workflowName: workflow.name,
+            pid: Deno.pid,
+            hostname: hostname(),
+          });
+          this.runTracker.register(wfActiveRun);
+        }
+
         if (expressionContext) {
           expressionContext.run = {
             id: run.id,
@@ -1448,6 +1495,19 @@ export class WorkflowExecutionService {
       };
 
       await this.saveRun(workflow.id, run);
+
+      let wfHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
+      if (this.runTracker) {
+        const tracker = this.runTracker;
+        const runId = run.id;
+        wfHeartbeatInterval = setInterval(() => {
+          try {
+            tracker.heartbeat(runId);
+          } catch {
+            // Heartbeat failure is non-fatal
+          }
+        }, 30_000);
+      }
 
       const stepOpts: StepOptions = {
         lastEvaluated: options?.lastEvaluated,
@@ -1572,6 +1632,8 @@ export class WorkflowExecutionService {
 
       // Check if the run was cancelled via abort signal
       if (options?.signal?.aborted) {
+        if (wfHeartbeatInterval) clearInterval(wfHeartbeatInterval);
+        if (this.runTracker) this.runTracker.complete(run.id, "cancelled");
         run.cancel(
           abortReason(options.signal),
         );
@@ -1583,6 +1645,8 @@ export class WorkflowExecutionService {
       }
 
       // Complete workflow
+      if (wfHeartbeatInterval) clearInterval(wfHeartbeatInterval);
+      if (this.runTracker) this.runTracker.complete(run.id, "completed");
       const wfTeardownSpan = tracer.startSpan("swamp.workflow.teardown");
       try {
         run.complete();
@@ -1622,6 +1686,8 @@ export class WorkflowExecutionService {
       runSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
       if (error instanceof WorkflowSuspendedError && workflowRun) {
+        // Suspended workflows pause heartbeat — the run stays "running"
+        // in the tracker so it's visible as in-flight during approval wait.
         runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
@@ -1637,6 +1703,9 @@ export class WorkflowExecutionService {
       if (
         workflowRun && options?.signal?.aborted
       ) {
+        if (this.runTracker) {
+          this.runTracker.complete(workflowRun.id, "cancelled");
+        }
         workflowRun.cancel(
           abortReason(options.signal),
         );
@@ -1650,6 +1719,9 @@ export class WorkflowExecutionService {
         return;
       }
       if (workflowRun) {
+        if (this.runTracker) {
+          this.runTracker.complete(workflowRun.id, "failed");
+        }
         workflowRun.complete();
         await this.saveRun(
           createWorkflowId(workflowRun.workflowId),
@@ -1896,6 +1968,9 @@ export class WorkflowExecutionService {
       }
 
       if (options?.signal?.aborted) {
+        if (this.runTracker) {
+          this.runTracker.complete(existingRun.id, "cancelled");
+        }
         existingRun.cancel(
           abortReason(options.signal),
         );
@@ -1905,6 +1980,9 @@ export class WorkflowExecutionService {
         return;
       }
 
+      if (this.runTracker) {
+        this.runTracker.complete(existingRun.id, "completed");
+      }
       existingRun.complete();
 
       yield* this.runWorkflowReports(
@@ -1934,6 +2012,9 @@ export class WorkflowExecutionService {
         return;
       }
       if (options?.signal?.aborted) {
+        if (this.runTracker) {
+          this.runTracker.complete(existingRun.id, "cancelled");
+        }
         existingRun.cancel(
           abortReason(options.signal),
         );
@@ -1941,6 +2022,9 @@ export class WorkflowExecutionService {
         yield { kind: "cancelled" as const, run: existingRun };
         runFileSink.unregister(workflowLogHandle);
         return;
+      }
+      if (this.runTracker) {
+        this.runTracker.complete(existingRun.id, "failed");
       }
       existingRun.complete();
       await this.saveRun(workflow.id, existingRun);
@@ -2323,6 +2407,7 @@ export class WorkflowExecutionService {
           dataBaseDir: this.dataBaseDir,
           catalogStore: this.catalogStore,
           namespace: this.namespace,
+          runTracker: this.runTracker,
         };
         return this.executor.execute(step, ctx);
       });
@@ -2560,6 +2645,8 @@ export class WorkflowExecutionService {
       undefined,
       this.markDirty,
       this.namespace,
+      undefined,
+      this.runTracker,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -658,7 +658,7 @@ export class DefaultStepExecutor implements StepExecutor {
     }
     await outputRepo.save(modelType, task.methodName, output);
 
-    // Register with the run tracker (if available) and start heartbeat.
+    // Register with the run tracker (if available).
     const { runTracker } = allDeps;
     let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
     if (runTracker) {
@@ -670,13 +670,6 @@ export class DefaultStepExecutor implements StepExecutor {
         hostname: hostname(),
       });
       runTracker.register(activeRun);
-      heartbeatInterval = setInterval(() => {
-        try {
-          runTracker.heartbeat(output.id);
-        } catch {
-          // Heartbeat failure is non-fatal
-        }
-      }, 30_000);
     }
 
     // Declared outside try so the catch block can record artifacts written
@@ -703,6 +696,16 @@ export class DefaultStepExecutor implements StepExecutor {
       flushLock = lockResult.flush;
     }
     try {
+      // Start heartbeat inside try so it's always cleaned up on error.
+      if (runTracker) {
+        heartbeatInterval = setInterval(() => {
+          try {
+            runTracker.heartbeat(output.id);
+          } catch {
+            // Heartbeat failure is non-fatal
+          }
+        }, 30_000);
+      }
       try {
         const result = await this.invokeMethod({
           task,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1357,6 +1357,7 @@ export class WorkflowExecutionService {
 
     let workflowRun: WorkflowRun | undefined;
     let workflowLogHandle: string | undefined;
+    let wfHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
     try {
       const wfSetupSpan = tracer.startSpan("swamp.workflow.setup");
       let workflow: Workflow;
@@ -1496,7 +1497,6 @@ export class WorkflowExecutionService {
 
       await this.saveRun(workflow.id, run);
 
-      let wfHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
       if (this.runTracker) {
         const tracker = this.runTracker;
         const runId = run.id;
@@ -1685,9 +1685,11 @@ export class WorkflowExecutionService {
       }
       runSpan.setStatus({ code: SpanStatusCode.OK });
     } catch (error) {
+      if (wfHeartbeatInterval) clearInterval(wfHeartbeatInterval);
       if (error instanceof WorkflowSuspendedError && workflowRun) {
-        // Suspended workflows pause heartbeat — the run stays "running"
-        // in the tracker so it's visible as in-flight during approval wait.
+        if (this.runTracker) {
+          this.runTracker.complete(workflowRun.id, "suspended");
+        }
         runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
@@ -1874,6 +1876,21 @@ export class WorkflowExecutionService {
       swampSha: options?.swampSha,
     };
 
+    // Re-activate the tracker row (suspended → running) and start heartbeat
+    let resumeHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
+    if (this.runTracker) {
+      this.runTracker.reactivate(existingRun.id);
+      const tracker = this.runTracker;
+      const runId = existingRun.id;
+      resumeHeartbeatInterval = setInterval(() => {
+        try {
+          tracker.heartbeat(runId);
+        } catch {
+          // Heartbeat failure is non-fatal
+        }
+      }, 30_000);
+    }
+
     const jobNodes: GraphNode[] = resolvedWorkflow.jobs.map((job) => ({
       name: job.name,
       weight: job.weight,
@@ -1968,6 +1985,7 @@ export class WorkflowExecutionService {
       }
 
       if (options?.signal?.aborted) {
+        if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
         if (this.runTracker) {
           this.runTracker.complete(existingRun.id, "cancelled");
         }
@@ -1980,6 +1998,7 @@ export class WorkflowExecutionService {
         return;
       }
 
+      if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
       if (this.runTracker) {
         this.runTracker.complete(existingRun.id, "completed");
       }
@@ -1999,7 +2018,11 @@ export class WorkflowExecutionService {
       await this.saveRun(workflow.id, existingRun);
       runFileSink.unregister(workflowLogHandle);
     } catch (error) {
+      if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
       if (error instanceof WorkflowSuspendedError) {
+        if (this.runTracker) {
+          this.runTracker.complete(existingRun.id, "suspended");
+        }
         runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -35,57 +35,7 @@ import type {
 } from "../../domain/datastore/distributed_lock.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../logging/logger.ts";
-
-/**
- * Check if a process with the given PID is no longer running.
- *
- * POSIX hosts use `Deno.kill(pid, "SIGCONT")` — a no-op for live
- * processes, `NotFound` when the PID is gone. Windows shells out to
- * `tasklist`. Returns `false` (not dead) on any unexpected error so
- * TTL-based detection remains the fallback and a busted probe never
- * clobbers a valid lock.
- */
-function isProcessDead(pid: number): boolean {
-  if (Deno.build.os === "windows") {
-    return isProcessDeadWindows(pid);
-  }
-  try {
-    Deno.kill(pid, "SIGCONT");
-    return false; // Process exists
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      return true; // Process does not exist
-    }
-    // PermissionDenied or other error — can't determine, fall back to TTL
-    return false;
-  }
-}
-
-function isProcessDeadWindows(pid: number): boolean {
-  try {
-    const result = new Deno.Command("tasklist", {
-      args: ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
-      stdout: "piped",
-      stderr: "null",
-    }).outputSync();
-    if (!result.success) {
-      // Non-zero exit from tasklist itself — fall back to TTL.
-      return false;
-    }
-    const stdout = new TextDecoder().decode(result.stdout);
-    // tasklist always exits 0 — alive vs dead is signalled by output content.
-    // The CSV row (with /NH) always quotes the PID in the second column:
-    //   "swamp.exe","1234","Console","1","123,456 K"
-    // The "no match" message is localized on non-English Windows
-    // (`INFO:` / `信息:` / `情報:` / `INFORMATIONEN:` …) but never
-    // contains a bare-quoted PID, so substring-matching `"<pid>"` is
-    // locale-agnostic.
-    return !stdout.includes(`"${pid}"`);
-  } catch {
-    // tasklist not on PATH, or spawn failed — fall back to TTL.
-    return false;
-  }
-}
+import { isProcessDead } from "../runtime/process.ts";
 
 const DEFAULT_TTL_MS = 30_000;
 const DEFAULT_RETRY_INTERVAL_MS = 1_000;

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -37,7 +37,7 @@ const logger = getLogger(["swamp", "persistence", "run-tracker"]);
 const RUN_TRACKER_DB_NAME = "run_tracker.db";
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
-export const DEFAULT_STALE_TTL_MS = 90_000;
+export { STALE_TTL_MS as DEFAULT_STALE_TTL_MS } from "../../domain/models/active_run.ts";
 const RETENTION_DAYS = 7;
 const SCHEMA_VERSION = 1;
 
@@ -210,8 +210,16 @@ export class RunTrackerStore implements RunTrackerRepository {
     const now = new Date().toISOString();
     this.db.prepare(`
       UPDATE active_runs SET status = ?, completed_at = ?
-      WHERE id = ?
+      WHERE id = ? AND status IN ('running', 'suspended')
     `).run(status, now, runId);
+  }
+
+  reactivate(runId: string): void {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      UPDATE active_runs SET status = 'running', heartbeat_at = ?, completed_at = NULL
+      WHERE id = ? AND status = 'suspended'
+    `).run(now, runId);
   }
 
   findById(runId: string): ActiveRun | null {

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -53,6 +53,7 @@ interface ActiveRunRow {
   heartbeat_at: string;
   status: string;
   completed_at: string | null;
+  cancel_reason: string | null;
 }
 
 export class RunTrackerStore implements RunTrackerRepository {
@@ -115,7 +116,7 @@ export class RunTrackerStore implements RunTrackerRepository {
     if (currentVersion >= SCHEMA_VERSION) return;
 
     if (currentVersion < 1) {
-      // v0 → v1: add completed_at column if table already exists without it
+      // v0 → v1: add completed_at and cancel_reason columns if table exists without them
       const tableExists = this.db.prepare(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='active_runs'",
       ).get();
@@ -123,10 +124,14 @@ export class RunTrackerStore implements RunTrackerRepository {
         const columns = this.db.prepare(
           "PRAGMA table_info(active_runs)",
         ).all() as unknown as { name: string }[];
-        const hasCompletedAt = columns.some((c) => c.name === "completed_at");
-        if (!hasCompletedAt) {
+        if (!columns.some((c) => c.name === "completed_at")) {
           this.db.exec(
             "ALTER TABLE active_runs ADD COLUMN completed_at TEXT",
+          );
+        }
+        if (!columns.some((c) => c.name === "cancel_reason")) {
+          this.db.exec(
+            "ALTER TABLE active_runs ADD COLUMN cancel_reason TEXT",
           );
         }
       }
@@ -150,7 +155,8 @@ export class RunTrackerStore implements RunTrackerRepository {
         started_at    TEXT NOT NULL,
         heartbeat_at  TEXT NOT NULL,
         status        TEXT NOT NULL DEFAULT 'running',
-        completed_at  TEXT
+        completed_at  TEXT,
+        cancel_reason TEXT
       );
 
       CREATE INDEX IF NOT EXISTS idx_active_runs_status
@@ -206,12 +212,12 @@ export class RunTrackerStore implements RunTrackerRepository {
     }
   }
 
-  complete(runId: string, status: ActiveRunStatus): void {
+  complete(runId: string, status: ActiveRunStatus, reason?: string): void {
     const now = new Date().toISOString();
     this.db.prepare(`
-      UPDATE active_runs SET status = ?, completed_at = ?
+      UPDATE active_runs SET status = ?, completed_at = ?, cancel_reason = ?
       WHERE id = ? AND status IN ('running', 'suspended')
-    `).run(status, now, runId);
+    `).run(status, now, reason ?? null, runId);
   }
 
   reactivate(runId: string): void {

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -165,7 +165,7 @@ export class RunTrackerStore implements RunTrackerRepository {
       Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
     ).toISOString();
     const result = this.db.prepare(
-      "DELETE FROM active_runs WHERE status != 'running' AND completed_at IS NOT NULL AND completed_at < ?",
+      "DELETE FROM active_runs WHERE status NOT IN ('running', 'suspended') AND completed_at IS NOT NULL AND completed_at < ?",
     ).run(cutoff);
     if (result.changes > 0) {
       logger

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -1,0 +1,301 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { DatabaseSync } from "node:sqlite";
+import { dirname } from "@std/path";
+import { ensureDirSync } from "@std/fs";
+import { hostname } from "node:os";
+import { getLogger } from "@logtape/logtape";
+import {
+  ActiveRun,
+  type ActiveRunData,
+  type ActiveRunStatus,
+} from "../../domain/models/active_run.ts";
+import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
+import { isProcessDead } from "../runtime/process.ts";
+
+import { join } from "@std/path";
+
+const logger = getLogger(["swamp", "persistence", "run-tracker"]);
+
+const RUN_TRACKER_DB_NAME = "run_tracker.db";
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const DEFAULT_STALE_TTL_MS = 90_000;
+const RETENTION_DAYS = 7;
+const SCHEMA_VERSION = 1;
+
+interface ActiveRunRow {
+  id: string;
+  run_kind: string;
+  model_type: string | null;
+  method_name: string | null;
+  workflow_name: string | null;
+  pid: number;
+  hostname: string;
+  started_at: string;
+  heartbeat_at: string;
+  status: string;
+  completed_at: string | null;
+}
+
+export class RunTrackerStore implements RunTrackerRepository {
+  private db: DatabaseSync;
+  private readonly dbPath: string;
+  private closed = false;
+
+  constructor(dbPath: string) {
+    this.dbPath = dbPath;
+    ensureDirSync(dirname(dbPath));
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec("PRAGMA busy_timeout=5000");
+    this.initializeWithRetry();
+  }
+
+  private initializeWithRetry(): void {
+    const MAX_RETRIES = 5;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const modeRow = this.db.prepare("PRAGMA journal_mode").get() as
+          | { journal_mode: string }
+          | undefined;
+        if (modeRow?.journal_mode !== "wal") {
+          this.db.exec("PRAGMA journal_mode=WAL");
+        }
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS run_tracker_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+          );
+        `);
+        this.migrateIfNeeded();
+        this.createSchema();
+        this.purgeOldRuns();
+        return;
+      } catch (error: unknown) {
+        const isLock = error instanceof Error &&
+          /database is (locked|busy)/i.test(error.message);
+        if (isLock && attempt < MAX_RETRIES) {
+          const delay = 100 * Math.pow(2, attempt) +
+            Math.floor(Math.random() * 50);
+          Atomics.wait(
+            new Int32Array(new SharedArrayBuffer(4)),
+            0,
+            0,
+            delay,
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private migrateIfNeeded(): void {
+    const row = this.db.prepare(
+      "SELECT value FROM run_tracker_meta WHERE key = 'schema_version'",
+    ).get() as { value: string } | undefined;
+    const currentVersion = row ? Number(row.value) : 0;
+    if (currentVersion >= SCHEMA_VERSION) return;
+
+    if (currentVersion < 1) {
+      // v0 → v1: add completed_at column if table already exists without it
+      const tableExists = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='active_runs'",
+      ).get();
+      if (tableExists) {
+        const columns = this.db.prepare(
+          "PRAGMA table_info(active_runs)",
+        ).all() as unknown as { name: string }[];
+        const hasCompletedAt = columns.some((c) => c.name === "completed_at");
+        if (!hasCompletedAt) {
+          this.db.exec(
+            "ALTER TABLE active_runs ADD COLUMN completed_at TEXT",
+          );
+        }
+      }
+    }
+
+    this.db.prepare(
+      "INSERT OR REPLACE INTO run_tracker_meta (key, value) VALUES ('schema_version', ?)",
+    ).run(String(SCHEMA_VERSION));
+  }
+
+  private createSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS active_runs (
+        id            TEXT PRIMARY KEY,
+        run_kind      TEXT NOT NULL,
+        model_type    TEXT,
+        method_name   TEXT,
+        workflow_name TEXT,
+        pid           INTEGER NOT NULL,
+        hostname      TEXT NOT NULL,
+        started_at    TEXT NOT NULL,
+        heartbeat_at  TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'running',
+        completed_at  TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_active_runs_status
+        ON active_runs(status);
+      CREATE INDEX IF NOT EXISTS idx_active_runs_heartbeat
+        ON active_runs(heartbeat_at);
+    `);
+  }
+
+  private purgeOldRuns(): void {
+    const cutoff = new Date(
+      Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const result = this.db.prepare(
+      "DELETE FROM active_runs WHERE status != 'running' AND completed_at IS NOT NULL AND completed_at < ?",
+    ).run(cutoff);
+    if (result.changes > 0) {
+      logger
+        .debug`Purged ${result.changes} terminal run(s) older than ${RETENTION_DAYS} days`;
+    }
+  }
+
+  register(run: ActiveRun): void {
+    const data = run.toData();
+    this.db.prepare(`
+      INSERT INTO active_runs
+        (id, run_kind, model_type, method_name, workflow_name,
+         pid, hostname, started_at, heartbeat_at, status)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      data.id,
+      data.runKind,
+      data.modelType,
+      data.methodName,
+      data.workflowName,
+      data.pid,
+      data.hostname,
+      data.startedAt,
+      data.heartbeatAt,
+      data.status,
+    );
+  }
+
+  heartbeat(runId: string): void {
+    const now = new Date().toISOString();
+    const result = this.db.prepare(`
+      UPDATE active_runs SET heartbeat_at = ?
+      WHERE id = ? AND status = 'running'
+    `).run(now, runId);
+    if (result.changes === 0) {
+      logger
+        .debug`Heartbeat skipped for run ${runId} — not found or not running`;
+    }
+  }
+
+  complete(runId: string, status: ActiveRunStatus): void {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      UPDATE active_runs SET status = ?, completed_at = ?
+      WHERE id = ?
+    `).run(status, now, runId);
+  }
+
+  findById(runId: string): ActiveRun | null {
+    const row = this.db.prepare(
+      "SELECT * FROM active_runs WHERE id = ?",
+    ).get(runId) as ActiveRunRow | undefined;
+    if (!row) return null;
+    return ActiveRun.fromData(this.rowToData(row));
+  }
+
+  findAllRunning(): ActiveRun[] {
+    const rows = this.db.prepare(
+      "SELECT * FROM active_runs WHERE status = 'running' ORDER BY started_at DESC",
+    ).all() as unknown as ActiveRunRow[];
+    return rows.map((r) => ActiveRun.fromData(this.rowToData(r)));
+  }
+
+  findStaleRuns(ttlMs: number): ActiveRun[] {
+    const cutoff = new Date(Date.now() - ttlMs).toISOString();
+    const rows = this.db.prepare(
+      "SELECT * FROM active_runs WHERE status = 'running' AND heartbeat_at < ? ORDER BY started_at DESC",
+    ).all(cutoff) as unknown as ActiveRunRow[];
+    return rows.map((r) => ActiveRun.fromData(this.rowToData(r)));
+  }
+
+  findAll(): ActiveRun[] {
+    const rows = this.db.prepare(
+      "SELECT * FROM active_runs ORDER BY started_at DESC",
+    ).all() as unknown as ActiveRunRow[];
+    return rows.map((r) => ActiveRun.fromData(this.rowToData(r)));
+  }
+
+  findRecent(hours: number = 24): ActiveRun[] {
+    const cutoff = new Date(
+      Date.now() - hours * 60 * 60 * 1000,
+    ).toISOString();
+    const rows = this.db.prepare(
+      "SELECT * FROM active_runs WHERE started_at > ? OR status = 'running' ORDER BY started_at DESC",
+    ).all(cutoff) as unknown as ActiveRunRow[];
+    return rows.map((r) => ActiveRun.fromData(this.rowToData(r)));
+  }
+
+  reapStaleRuns(ttlMs: number): ActiveRun[] {
+    const currentHostname = hostname();
+    const stale = this.findStaleRuns(ttlMs);
+    const reaped: ActiveRun[] = [];
+
+    for (const run of stale) {
+      const shouldReap = run.hostname === currentHostname
+        ? isProcessDead(run.pid)
+        : true; // Cross-machine: rely on TTL alone
+
+      if (shouldReap) {
+        this.complete(run.id, "failed");
+        reaped.push(run);
+      }
+    }
+
+    return reaped;
+  }
+
+  close(): void {
+    if (!this.closed) {
+      this.closed = true;
+      this.db.close();
+    }
+  }
+
+  static fromSwampDir(swampDir: string): RunTrackerStore {
+    return new RunTrackerStore(join(swampDir, RUN_TRACKER_DB_NAME));
+  }
+
+  private rowToData(row: ActiveRunRow): ActiveRunData {
+    return {
+      id: row.id,
+      runKind: row.run_kind as ActiveRunData["runKind"],
+      modelType: row.model_type,
+      methodName: row.method_name,
+      workflowName: row.workflow_name,
+      pid: row.pid,
+      hostname: row.hostname,
+      startedAt: row.started_at,
+      heartbeatAt: row.heartbeat_at,
+      status: row.status as ActiveRunStatus,
+    };
+  }
+}

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -1,0 +1,250 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ActiveRun } from "../../domain/models/active_run.ts";
+import { RunTrackerStore } from "./run_tracker_store.ts";
+
+function makeTempDbPath(): string {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-run-tracker-test-" });
+  return join(dir, "run_tracker.db");
+}
+
+function makeRun(overrides: Partial<{
+  id: string;
+  modelType: string;
+  methodName: string;
+  pid: number;
+  hostname: string;
+}> = {}): ActiveRun {
+  return ActiveRun.createModelMethodRun({
+    id: overrides.id ?? crypto.randomUUID(),
+    modelType: overrides.modelType ?? "@test/model",
+    methodName: overrides.methodName ?? "start",
+    pid: overrides.pid ?? Deno.pid,
+    hostname: overrides.hostname ?? "test-host",
+  });
+}
+
+Deno.test("RunTrackerStore: register and findById", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = makeRun({ id: "run-1" });
+    store.register(run);
+
+    const found = store.findById("run-1");
+    assertEquals(found?.id, "run-1");
+    assertEquals(found?.runKind, "model_method");
+    assertEquals(found?.modelType, "@test/model");
+    assertEquals(found?.methodName, "start");
+    assertEquals(found?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: findById returns null for missing run", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    assertEquals(store.findById("nonexistent"), null);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: heartbeat updates heartbeat_at", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = makeRun({ id: "run-1" });
+    store.register(run);
+
+    const before = store.findById("run-1")!.heartbeatAt;
+    const spinUntil = Date.now() + 2;
+    while (Date.now() < spinUntil) { /* spin */ }
+    store.heartbeat("run-1");
+    const after = store.findById("run-1")!.heartbeatAt;
+
+    assertEquals(after.getTime() >= before.getTime(), true);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: complete changes status", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = makeRun({ id: "run-1" });
+    store.register(run);
+    store.complete("run-1", "completed");
+
+    const found = store.findById("run-1");
+    assertEquals(found?.status, "completed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: findAllRunning returns only running runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    store.register(makeRun({ id: "run-1" }));
+    store.register(makeRun({ id: "run-2" }));
+    store.register(makeRun({ id: "run-3" }));
+    store.complete("run-2", "completed");
+
+    const running = store.findAllRunning();
+    assertEquals(running.length, 2);
+    const ids = running.map((r) => r.id).sort();
+    assertEquals(ids, ["run-1", "run-3"]);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: findStaleRuns finds stale runs by TTL", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    // Insert a "stale" run with old heartbeat via raw fromData
+    const staleRun = ActiveRun.fromData({
+      id: "stale-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 99999,
+      hostname: "test-host",
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+    });
+    store.register(staleRun);
+
+    // Insert a fresh run
+    store.register(makeRun({ id: "fresh-1" }));
+
+    const stale = store.findStaleRuns(90_000);
+    assertEquals(stale.length, 1);
+    assertEquals(stale[0].id, "stale-1");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapStaleRuns marks stale runs as failed", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const staleRun = ActiveRun.fromData({
+      id: "stale-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647, // Non-existent PID
+      hostname: "test-host",
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+    });
+    store.register(staleRun);
+
+    const reaped = store.reapStaleRuns(90_000);
+
+    // Cross-host stale runs are reaped by TTL alone
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "stale-1");
+
+    const updated = store.findById("stale-1");
+    assertEquals(updated?.status, "failed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapStaleRuns is idempotent", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const staleRun = ActiveRun.fromData({
+      id: "stale-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: "test-host",
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+    });
+    store.register(staleRun);
+
+    const first = store.reapStaleRuns(90_000);
+    assertEquals(first.length, 1);
+
+    // Second reap finds nothing — already reaped
+    const second = store.reapStaleRuns(90_000);
+    assertEquals(second.length, 0);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: findAll returns all runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    store.register(makeRun({ id: "run-1" }));
+    store.register(makeRun({ id: "run-2" }));
+    store.complete("run-1", "failed");
+
+    const all = store.findAll();
+    assertEquals(all.length, 2);
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: heartbeat is no-op for completed runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    store.register(makeRun({ id: "run-1" }));
+    store.complete("run-1", "completed");
+
+    // Should not throw, just log a debug message
+    store.heartbeat("run-1");
+    assertEquals(store.findById("run-1")?.status, "completed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: concurrent stores on same DB file", () => {
+  const dbPath = makeTempDbPath();
+  const store1 = new RunTrackerStore(dbPath);
+  const store2 = new RunTrackerStore(dbPath);
+  try {
+    store1.register(makeRun({ id: "run-1" }));
+    store2.register(makeRun({ id: "run-2" }));
+
+    assertEquals(store1.findAllRunning().length, 2);
+    assertEquals(store2.findAllRunning().length, 2);
+  } finally {
+    store1.close();
+    store2.close();
+  }
+});

--- a/src/infrastructure/runtime/process.ts
+++ b/src/infrastructure/runtime/process.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Check if a process with the given PID is no longer running.
+ *
+ * POSIX hosts use `Deno.kill(pid, "SIGCONT")` — a no-op for live
+ * processes, `NotFound` when the PID is gone. Windows shells out to
+ * `tasklist`. Returns `false` (not dead) on any unexpected error so
+ * TTL-based detection remains the fallback and a busted probe never
+ * clobbers a valid lock or tracker row.
+ */
+export function isProcessDead(pid: number): boolean {
+  if (Deno.build.os === "windows") {
+    return isProcessDeadWindows(pid);
+  }
+  try {
+    Deno.kill(pid, "SIGCONT");
+    return false;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function isProcessDeadWindows(pid: number): boolean {
+  try {
+    const result = new Deno.Command("tasklist", {
+      args: ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
+      stdout: "piped",
+      stderr: "null",
+    }).outputSync();
+    if (!result.success) {
+      return false;
+    }
+    const stdout = new TextDecoder().decode(result.stdout);
+    // tasklist always exits 0 — alive vs dead is signalled by output content.
+    // The CSV row (with /NH) always quotes the PID in the second column:
+    //   "swamp.exe","1234","Console","1","123,456 K"
+    // The "no match" message is localized on non-English Windows
+    // (`INFO:` / `信息:` / `情報:` / `INFORMATIONEN:` …) but never
+    // contains a bare-quoted PID, so substring-matching `"<pid>"` is
+    // locale-agnostic.
+    return !stdout.includes(`"${pid}"`);
+  } catch {
+    return false;
+  }
+}

--- a/src/infrastructure/runtime/process_test.ts
+++ b/src/infrastructure/runtime/process_test.ts
@@ -1,0 +1,30 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { isProcessDead } from "./process.ts";
+
+Deno.test("isProcessDead: returns false for the current process", () => {
+  assertEquals(isProcessDead(Deno.pid), false);
+});
+
+Deno.test("isProcessDead: returns true for a non-existent PID", () => {
+  // PID 2147483647 is the max 32-bit signed int — extremely unlikely to be in use
+  assertEquals(isProcessDead(2147483647), true);
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -593,7 +593,7 @@ export async function* modelMethodRun(
         output.markRunning(Deno.pid);
         output.setLogFile(logFilePath);
 
-        // Register with the run tracker (if available) and start heartbeat.
+        // Register with the run tracker (if available).
         // Output YAML is only written in terminal state (write-once).
         let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
         if (deps.runTracker) {
@@ -605,6 +605,13 @@ export async function* modelMethodRun(
             hostname: hostname(),
           });
           deps.runTracker.register(activeRun);
+        }
+
+        const vaultService = await deps.createVaultService();
+        const executionService = deps.createExecutionService();
+
+        // Start heartbeat inside the try so it's always cleaned up on error.
+        if (deps.runTracker) {
           heartbeatInterval = setInterval(() => {
             try {
               deps.runTracker!.heartbeat(output.id);
@@ -613,9 +620,6 @@ export async function* modelMethodRun(
             }
           }, 30_000);
         }
-
-        const vaultService = await deps.createVaultService();
-        const executionService = deps.createExecutionService();
 
         preExecSpan.end();
         setupSpan.end();

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -69,6 +69,9 @@ import {
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
 import { autoGc } from "../data/gc.ts";
+import { ActiveRun } from "../../domain/models/active_run.ts";
+import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
+import { hostname } from "node:os";
 
 /**
  * Events emitted by the libswamp model method run generator.
@@ -194,6 +197,7 @@ export interface ModelMethodRunDeps {
     definition: Definition,
   ) => Promise<void>;
   getDefinitionPath?: (type: ModelType, id: string) => string;
+  runTracker?: RunTrackerRepository;
 }
 
 /**
@@ -588,7 +592,27 @@ export async function* modelMethodRun(
         });
         output.markRunning(Deno.pid);
         output.setLogFile(logFilePath);
-        await deps.outputRepo.save(modelType, input.methodName, output);
+
+        // Register with the run tracker (if available) and start heartbeat.
+        // Output YAML is only written in terminal state (write-once).
+        let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+        if (deps.runTracker) {
+          const activeRun = ActiveRun.createModelMethodRun({
+            id: output.id,
+            modelType: modelType.normalized,
+            methodName: input.methodName,
+            pid: Deno.pid,
+            hostname: hostname(),
+          });
+          deps.runTracker.register(activeRun);
+          heartbeatInterval = setInterval(() => {
+            try {
+              deps.runTracker!.heartbeat(output.id);
+            } catch {
+              // Heartbeat failure is non-fatal
+            }
+          }, 30_000);
+        }
 
         const vaultService = await deps.createVaultService();
         const executionService = deps.createExecutionService();
@@ -664,15 +688,23 @@ export async function* modelMethodRun(
             : String(error);
           const errorStack = error instanceof Error ? error.stack : undefined;
 
+          if (heartbeatInterval) clearInterval(heartbeatInterval);
+
           if (
             ctx.signal.aborted ||
             (error instanceof DOMException && error.name === "AbortError")
           ) {
             output.markCancelled("aborted");
             await deps.outputRepo.save(modelType, input.methodName, output);
+            if (deps.runTracker) {
+              deps.runTracker.complete(output.id, "cancelled");
+            }
           } else {
             output.markFailed({ message: errorMessage, stack: errorStack });
             await deps.outputRepo.save(modelType, input.methodName, output);
+            if (deps.runTracker) {
+              deps.runTracker.complete(output.id, "failed");
+            }
           }
 
           // Run method-summary report for failed executions so JSON consumers
@@ -825,9 +857,13 @@ export async function* modelMethodRun(
           }
         }
 
-        // Mark output as succeeded and save
+        // Mark output as succeeded and save (write-once)
+        if (heartbeatInterval) clearInterval(heartbeatInterval);
         output.markSucceeded();
         await deps.outputRepo.save(modelType, input.methodName, output);
+        if (deps.runTracker) {
+          deps.runTracker.complete(output.id, "completed");
+        }
 
         // --- Post-run reports ---
         const reportsSpan = getTracer().startSpan(

--- a/src/presentation/output/model_runs_output.ts
+++ b/src/presentation/output/model_runs_output.ts
@@ -19,10 +19,11 @@
 
 import { bold, dim, green, red, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import type { ActiveRun } from "../../domain/models/active_run.ts";
+import {
+  type ActiveRun,
+  STALE_TTL_MS,
+} from "../../domain/models/active_run.ts";
 import type { OutputMode } from "./output.ts";
-
-const STALE_TTL_MS = 90_000;
 
 function formatDuration(ms: number): string {
   if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
@@ -124,7 +125,7 @@ export function writeDoctorRunsLog(
   fix: boolean,
 ): void {
   if (active.length === 0 && stale.length === 0) {
-    writeOutput("No active or stale model method runs.");
+    writeOutput("No active or stale runs.");
     return;
   }
 
@@ -177,11 +178,30 @@ export function writeDoctorRunsLog(
 
 export function writeDoctorRunsJson(
   totalTracked: number,
-  active: number,
-  stale: number,
+  activeRuns: ActiveRun[],
+  staleRuns: ActiveRun[],
   reaped: number,
 ): void {
-  console.log(JSON.stringify({ totalTracked, active, stale, reaped }));
+  const mapRun = (r: ActiveRun) => ({
+    id: r.id,
+    runKind: r.runKind,
+    modelType: r.modelType,
+    methodName: r.methodName,
+    workflowName: r.workflowName,
+    pid: r.pid,
+    hostname: r.hostname,
+    status: r.status,
+    startedAt: r.startedAt.toISOString(),
+    heartbeatAt: r.heartbeatAt.toISOString(),
+  });
+  console.log(JSON.stringify({
+    totalTracked,
+    active: activeRuns.length,
+    stale: staleRuns.length,
+    reaped,
+    activeRuns: activeRuns.map(mapRun),
+    staleRuns: staleRuns.map(mapRun),
+  }));
 }
 
 export function createModelRunsOutput(mode: OutputMode) {

--- a/src/presentation/output/model_runs_output.ts
+++ b/src/presentation/output/model_runs_output.ts
@@ -131,12 +131,17 @@ export function writeDoctorRunsLog(
 
   const lines: string[] = [];
 
+  const runName = (r: ActiveRun) =>
+    r.runKind === "workflow"
+      ? r.workflowName ?? "unknown"
+      : `${r.modelType ?? "unknown"}/${r.methodName ?? "unknown"}`;
+
   if (active.length > 0) {
     lines.push(bold(`${active.length} active run(s):`));
-    const headers = ["MODEL", "METHOD", "ID", "AGE", "PID"];
+    const headers = ["KIND", "NAME", "ID", "AGE", "PID"];
     const rows = active.map((r) => [
-      r.modelType ?? "unknown",
-      r.methodName ?? "unknown",
+      r.runKind === "workflow" ? "workflow" : "method",
+      runName(r),
       r.id.slice(0, 8),
       formatDuration(Date.now() - r.startedAt.getTime()),
       String(r.pid),
@@ -150,10 +155,10 @@ export function writeDoctorRunsLog(
   if (stale.length > 0) {
     if (lines.length > 0) lines.push("");
     lines.push(bold(red(`${stale.length} stale run(s) detected:`)));
-    const headers = ["MODEL", "METHOD", "ID", "HEARTBEAT AGE", "PID"];
+    const headers = ["KIND", "NAME", "ID", "HEARTBEAT AGE", "PID"];
     const rows = stale.map((r) => [
-      r.modelType ?? "unknown",
-      r.methodName ?? "unknown",
+      r.runKind === "workflow" ? "workflow" : "method",
+      runName(r),
       r.id.slice(0, 8),
       formatDuration(Date.now() - r.heartbeatAt.getTime()),
       String(r.pid),
@@ -193,6 +198,7 @@ export function writeDoctorRunsJson(
     status: r.status,
     startedAt: r.startedAt.toISOString(),
     heartbeatAt: r.heartbeatAt.toISOString(),
+    stale: r.isStale(STALE_TTL_MS),
   });
   console.log(JSON.stringify({
     totalTracked,

--- a/src/presentation/output/model_runs_output.ts
+++ b/src/presentation/output/model_runs_output.ts
@@ -155,13 +155,14 @@ export function writeDoctorRunsLog(
   if (stale.length > 0) {
     if (lines.length > 0) lines.push("");
     lines.push(bold(red(`${stale.length} stale run(s) detected:`)));
-    const headers = ["KIND", "NAME", "ID", "HEARTBEAT AGE", "PID"];
+    const headers = ["KIND", "NAME", "ID", "HEARTBEAT AGE", "PID", "HOST"];
     const rows = stale.map((r) => [
       r.runKind === "workflow" ? "workflow" : "method",
       runName(r),
       r.id.slice(0, 8),
       formatDuration(Date.now() - r.heartbeatAt.getTime()),
       String(r.pid),
+      r.hostname,
     ]);
     lines.push(...tableLines(headers, rows, (col, value) => {
       if (col === 2) return dim(value);

--- a/src/presentation/output/model_runs_output.ts
+++ b/src/presentation/output/model_runs_output.ts
@@ -1,0 +1,198 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { ActiveRun } from "../../domain/models/active_run.ts";
+import type { OutputMode } from "./output.ts";
+
+const STALE_TTL_MS = 90_000;
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${Math.round(ms / 3_600_000)}h`;
+}
+
+function tableLines(
+  headers: string[],
+  rows: string[][],
+  colorCell?: (columnIndex: number, value: string) => string,
+): string[] {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length))
+  );
+  const lines: string[] = [
+    dim(headers.map((header, i) => header.padEnd(widths[i])).join("  ")),
+  ];
+  for (const row of rows) {
+    lines.push(
+      row
+        .map((cell, i) => {
+          const padded = cell.padEnd(widths[i]);
+          return colorCell ? colorCell(i, padded) : padded;
+        })
+        .join("  ")
+        .trimEnd(),
+    );
+  }
+  return lines;
+}
+
+export function writeModelRunsLog(runs: ActiveRun[]): void {
+  if (runs.length === 0) {
+    writeOutput("No tracked runs.");
+    return;
+  }
+
+  const headers = ["STATUS", "KIND", "NAME", "ID", "AGE", "PID", "HOST"];
+  const rows = runs.map((run) => {
+    const stale = run.isStale(STALE_TTL_MS);
+    const age = formatDuration(Date.now() - run.startedAt.getTime());
+    const kind = run.runKind === "workflow" ? "workflow" : "method";
+    const name = run.runKind === "workflow"
+      ? run.workflowName ?? "unknown"
+      : `${run.modelType ?? "unknown"}/${run.methodName ?? "unknown"}`;
+    return [
+      stale ? `${run.status} [STALE]` : run.status,
+      kind,
+      name,
+      run.id.slice(0, 8),
+      age,
+      String(run.pid),
+      run.hostname,
+    ];
+  });
+
+  const lines = tableLines(headers, rows, (col, value) => {
+    if (col === 0) {
+      const trimmed = value.trim();
+      if (trimmed.includes("[STALE]")) {
+        return value.replace(trimmed, red(trimmed));
+      }
+      if (trimmed === "running") return value.replace(trimmed, green(trimmed));
+      if (trimmed === "failed") return value.replace(trimmed, red(trimmed));
+      if (trimmed === "cancelled") {
+        return value.replace(trimmed, yellow(trimmed));
+      }
+    }
+    if (col === 3) return dim(value);
+    return value;
+  });
+
+  writeOutput(lines.join("\n"));
+}
+
+export function writeModelRunsJson(runs: ActiveRun[]): void {
+  console.log(JSON.stringify({
+    runs: runs.map((r) => ({
+      id: r.id,
+      runKind: r.runKind,
+      modelType: r.modelType,
+      methodName: r.methodName,
+      workflowName: r.workflowName,
+      pid: r.pid,
+      hostname: r.hostname,
+      status: r.status,
+      startedAt: r.startedAt.toISOString(),
+      heartbeatAt: r.heartbeatAt.toISOString(),
+      stale: r.isStale(STALE_TTL_MS),
+    })),
+  }));
+}
+
+export function writeDoctorRunsLog(
+  active: ActiveRun[],
+  stale: ActiveRun[],
+  reaped: number,
+  fix: boolean,
+): void {
+  if (active.length === 0 && stale.length === 0) {
+    writeOutput("No active or stale model method runs.");
+    return;
+  }
+
+  const lines: string[] = [];
+
+  if (active.length > 0) {
+    lines.push(bold(`${active.length} active run(s):`));
+    const headers = ["MODEL", "METHOD", "ID", "AGE", "PID"];
+    const rows = active.map((r) => [
+      r.modelType ?? "unknown",
+      r.methodName ?? "unknown",
+      r.id.slice(0, 8),
+      formatDuration(Date.now() - r.startedAt.getTime()),
+      String(r.pid),
+    ]);
+    lines.push(...tableLines(headers, rows, (col, value) => {
+      if (col === 2) return dim(value);
+      return value;
+    }));
+  }
+
+  if (stale.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push(bold(red(`${stale.length} stale run(s) detected:`)));
+    const headers = ["MODEL", "METHOD", "ID", "HEARTBEAT AGE", "PID"];
+    const rows = stale.map((r) => [
+      r.modelType ?? "unknown",
+      r.methodName ?? "unknown",
+      r.id.slice(0, 8),
+      formatDuration(Date.now() - r.heartbeatAt.getTime()),
+      String(r.pid),
+    ]);
+    lines.push(...tableLines(headers, rows, (col, value) => {
+      if (col === 2) return dim(value);
+      if (col === 3) return red(value);
+      return value;
+    }));
+
+    if (fix) {
+      lines.push("");
+      lines.push(green(`Reaped ${reaped} stale run(s).`));
+    } else {
+      lines.push("");
+      lines.push(dim("Run with --fix to automatically reap stale runs."));
+    }
+  }
+
+  writeOutput(lines.join("\n"));
+}
+
+export function writeDoctorRunsJson(
+  totalTracked: number,
+  active: number,
+  stale: number,
+  reaped: number,
+): void {
+  console.log(JSON.stringify({ totalTracked, active, stale, reaped }));
+}
+
+export function createModelRunsOutput(mode: OutputMode) {
+  return {
+    writeRuns: mode === "json" ? writeModelRunsJson : writeModelRunsLog,
+    writeEmpty: (msg: string) => {
+      if (mode === "json") {
+        console.log(JSON.stringify({ runs: [] }));
+      } else {
+        writeOutput(msg);
+      }
+    },
+  };
+}

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -28,6 +28,7 @@ import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import type { RunCancelRegistry } from "./run_cancel_registry.ts";
 import type { RunTrackerRepository } from "../domain/models/run_tracker_repository.ts";
+import { type ActiveRun, STALE_TTL_MS } from "../domain/models/active_run.ts";
 import {
   auditTimeline,
   consumeStream,
@@ -1747,6 +1748,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        principal,
       ));
       break;
     case "run.doctor":
@@ -1755,6 +1757,7 @@ export function handleMessage(
         ctx,
         request.id,
         request.payload,
+        principal,
       ));
       break;
   }
@@ -5871,14 +5874,21 @@ function handleRunHistory(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
-  payload?: { active?: boolean; all?: boolean },
+  payload: { active?: boolean; all?: boolean } | undefined,
+  principal: Principal | null,
 ): void {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
   if (!ctx.runTracker) {
     sendError(socket, requestId, "not_available", "Run tracker not available");
     return;
   }
 
-  const STALE_TTL_MS = 90_000;
   const runs = payload?.active
     ? ctx.runTracker.findAllRunning()
     : payload?.all
@@ -5910,14 +5920,21 @@ function handleRunDoctor(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
-  payload?: { fix?: boolean },
+  payload: { fix?: boolean } | undefined,
+  principal: Principal | null,
 ): void {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
   if (!ctx.runTracker) {
     sendError(socket, requestId, "not_available", "Run tracker not available");
     return;
   }
 
-  const STALE_TTL_MS = 90_000;
   const allRuns = ctx.runTracker.findAll();
   const running = allRuns.filter((r) => r.status === "running");
   const stale = ctx.runTracker.findStaleRuns(STALE_TTL_MS);
@@ -5929,7 +5946,7 @@ function handleRunDoctor(
     reaped = reapedRuns.length;
   }
 
-  const mapRun = (r: import("../domain/models/active_run.ts").ActiveRun) => ({
+  const mapRun = (r: ActiveRun) => ({
     id: r.id,
     runKind: r.runKind,
     modelType: r.modelType,

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -27,6 +27,7 @@ import type { RepositoryContext } from "../infrastructure/persistence/repository
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import type { RunCancelRegistry } from "./run_cancel_registry.ts";
+import type { RunTrackerRepository } from "../domain/models/run_tracker_repository.ts";
 import {
   auditTimeline,
   consumeStream,
@@ -882,6 +883,23 @@ const DoctorExtensionsRequestSchema = z.object({
   id: z.string().min(1).max(256),
 });
 
+const RunHistoryRequestSchema = z.object({
+  type: z.literal("run.history"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    active: z.boolean().optional(),
+    all: z.boolean().optional(),
+  }).optional(),
+});
+
+const RunDoctorRequestSchema = z.object({
+  type: z.literal("run.doctor"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    fix: z.boolean().optional(),
+  }).optional(),
+});
+
 const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkflowRunRequestSchema,
   ModelMethodRunRequestSchema,
@@ -947,6 +965,8 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   DoctorSecretsRequestSchema,
   DoctorWorkflowsRequestSchema,
   DoctorExtensionsRequestSchema,
+  RunHistoryRequestSchema,
+  RunDoctorRequestSchema,
   CancelRequestSchema,
 ]);
 
@@ -989,6 +1009,7 @@ export interface ConnectionContext {
   policySnapshotLoader?: PolicySnapshotLoader;
   authConfig: ServeAuthConfig;
   cancelRegistry?: RunCancelRegistry;
+  runTracker?: RunTrackerRepository;
 }
 
 export function handleConnection(
@@ -1720,6 +1741,22 @@ export function handleMessage(
         principal,
       );
       break;
+    case "run.history":
+      task = Promise.resolve(handleRunHistory(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+      ));
+      break;
+    case "run.doctor":
+      task = Promise.resolve(handleRunDoctor(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+      ));
+      break;
   }
 
   task
@@ -1876,6 +1913,7 @@ async function handleWorkflowRun(
         send(socket, { type: "event", id: requestId, event: serialized });
       },
       ctx.syncService,
+      ctx.runTracker,
     );
     send(socket, { type: "done", id: requestId });
   } catch (error) {
@@ -1972,7 +2010,7 @@ async function handleModelMethodRun(
     const deps = await createModelMethodRunDeps(
       ctx.repoDir,
       ctx.repoContext,
-      { directExecution: isDirectExecution },
+      { directExecution: isDirectExecution, runTracker: ctx.runTracker },
     );
     const libCtx = createLibSwampContext({ signal: controller.signal });
 
@@ -5015,6 +5053,7 @@ async function handleWorkflowResume(
       ctx.repoContext.markDirty,
       ctx.repoContext.unifiedDataRepo.namespace,
       stepLockHook,
+      ctx.runTracker,
     );
 
     const resumeGenerator = async function* (): AsyncGenerator<
@@ -5826,4 +5865,94 @@ function sendError(
   message: string,
 ): void {
   send(socket, { type: "error", id, error: { code, message } });
+}
+
+function handleRunHistory(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload?: { active?: boolean; all?: boolean },
+): void {
+  if (!ctx.runTracker) {
+    sendError(socket, requestId, "not_available", "Run tracker not available");
+    return;
+  }
+
+  const STALE_TTL_MS = 90_000;
+  const runs = payload?.active
+    ? ctx.runTracker.findAllRunning()
+    : payload?.all
+    ? ctx.runTracker.findAll()
+    : ctx.runTracker.findRecent();
+
+  send(socket, {
+    type: "run.history",
+    id: requestId,
+    payload: {
+      runs: runs.map((r) => ({
+        id: r.id,
+        runKind: r.runKind,
+        modelType: r.modelType,
+        methodName: r.methodName,
+        workflowName: r.workflowName,
+        pid: r.pid,
+        hostname: r.hostname,
+        status: r.status,
+        startedAt: r.startedAt.toISOString(),
+        heartbeatAt: r.heartbeatAt.toISOString(),
+        stale: r.isStale(STALE_TTL_MS),
+      })),
+    },
+  });
+}
+
+function handleRunDoctor(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload?: { fix?: boolean },
+): void {
+  if (!ctx.runTracker) {
+    sendError(socket, requestId, "not_available", "Run tracker not available");
+    return;
+  }
+
+  const STALE_TTL_MS = 90_000;
+  const allRuns = ctx.runTracker.findAll();
+  const running = allRuns.filter((r) => r.status === "running");
+  const stale = ctx.runTracker.findStaleRuns(STALE_TTL_MS);
+  const active = running.filter((r) => !r.isStale(STALE_TTL_MS));
+
+  let reaped = 0;
+  if (payload?.fix && stale.length > 0) {
+    const reapedRuns = ctx.runTracker.reapStaleRuns(STALE_TTL_MS);
+    reaped = reapedRuns.length;
+  }
+
+  const mapRun = (r: import("../domain/models/active_run.ts").ActiveRun) => ({
+    id: r.id,
+    runKind: r.runKind,
+    modelType: r.modelType,
+    methodName: r.methodName,
+    workflowName: r.workflowName,
+    pid: r.pid,
+    hostname: r.hostname,
+    status: r.status,
+    startedAt: r.startedAt.toISOString(),
+    heartbeatAt: r.heartbeatAt.toISOString(),
+    stale: r.isStale(STALE_TTL_MS),
+  });
+
+  send(socket, {
+    type: "run.doctor",
+    id: requestId,
+    payload: {
+      totalTracked: allRuns.length,
+      active: active.length,
+      stale: stale.length,
+      reaped,
+      activeRuns: active.map(mapRun),
+      staleRuns: stale.map(mapRun),
+    },
+  });
 }

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -38,6 +38,7 @@ import {
   WorkflowExecutionService,
 } from "../domain/workflows/execution_service.ts";
 import { createWorkflowId } from "../domain/workflows/workflow_id.ts";
+import type { RunTrackerRepository } from "../domain/models/run_tracker_repository.ts";
 import { TriggerInputResolver } from "../domain/workflows/trigger_input_resolver.ts";
 import { buildEnvContext } from "../domain/expressions/model_resolver.ts";
 import { CelEvaluator } from "../infrastructure/cel/cel_evaluator.ts";
@@ -69,6 +70,7 @@ export async function createWorkflowRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
   stepLockHook?: StepLockHook,
+  runTracker?: RunTrackerRepository,
 ): Promise<WorkflowRunDeps> {
   await Promise.all([
     modelRegistry.ensureLoaded(),
@@ -153,6 +155,7 @@ export async function createWorkflowRunDeps(
         repoContext.markDirty,
         repoContext.unifiedDataRepo.namespace,
         stepLockHook,
+        runTracker,
       );
     },
     catalogStore: repoContext.catalogStore,
@@ -164,7 +167,10 @@ export async function createWorkflowRunDeps(
 export async function createModelMethodRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
-  options?: { directExecution?: boolean },
+  options?: {
+    directExecution?: boolean;
+    runTracker?: ModelMethodRunDeps["runTracker"];
+  },
 ): Promise<ModelMethodRunDeps> {
   await Promise.all([
     modelRegistry.ensureLoaded(),
@@ -247,6 +253,7 @@ export async function createModelMethodRunDeps(
         );
       }
       : undefined,
+    runTracker: options?.runTracker,
   };
 }
 
@@ -266,13 +273,8 @@ export async function executeWorkflowWithLocks(
   input: WorkflowRunInput,
   signal: AbortSignal,
   onEvent: (event: WorkflowRunEvent) => void,
-  /**
-   * Sync service shared with the repo context's markDirty hook so the
-   * fast-path watermark read here sees the writes the hook flipped. See
-   * `design/datastores.md` for the contract; omit only for filesystem
-   * datastores where no service exists.
-   */
   syncService?: DatastoreSyncService,
+  runTracker?: RunTrackerRepository,
 ): Promise<void> {
   // Pre-lookup workflow for trigger.inputs resolution
   const workflowRepo = repoContext.workflowRepo;
@@ -294,7 +296,12 @@ export async function executeWorkflowWithLocks(
     return result;
   };
 
-  const deps = await createWorkflowRunDeps(repoDir, repoContext, stepLockHook);
+  const deps = await createWorkflowRunDeps(
+    repoDir,
+    repoContext,
+    stepLockHook,
+    runTracker,
+  );
   const libCtx = createLibSwampContext({ signal });
 
   // Layer the workflow's trigger.inputs under any caller-supplied inputs so

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -522,6 +522,16 @@ export type ServerRequest =
     id: string;
     payload?: DoctorExtensionsPayload;
   }
+  | {
+    type: "run.history";
+    id: string;
+    payload?: RunHistoryPayload;
+  }
+  | {
+    type: "run.doctor";
+    id: string;
+    payload?: RunDoctorPayload;
+  }
   | { type: "cancel"; id: string };
 
 // ── Outbound (server → client) ───────────────────────────────────────────
@@ -799,6 +809,40 @@ export interface DoctorExtensionsResponse {
   data: Record<string, unknown>;
 }
 
+export interface RunHistoryPayload {
+  active?: boolean;
+  all?: boolean;
+}
+
+export interface RunDoctorPayload {
+  fix?: boolean;
+}
+
+export interface RunHistoryResponse {
+  runs: Array<{
+    id: string;
+    runKind: string;
+    modelType: string | null;
+    methodName: string | null;
+    workflowName: string | null;
+    pid: number;
+    hostname: string;
+    status: string;
+    startedAt: string;
+    heartbeatAt: string;
+    stale: boolean;
+  }>;
+}
+
+export interface RunDoctorResponse {
+  totalTracked: number;
+  active: number;
+  stale: number;
+  reaped: number;
+  activeRuns: RunHistoryResponse["runs"];
+  staleRuns: RunHistoryResponse["runs"];
+}
+
 export type ServerMessage =
   | { type: "event"; id: string; event: SerializedEvent }
   | { type: "error"; id: string; error: SerializedError }
@@ -921,4 +965,6 @@ export type ServerMessage =
     type: "doctor.extensions";
     id: string;
     payload: DoctorExtensionsResponse;
-  };
+  }
+  | { type: "run.history"; id: string; payload: RunHistoryResponse }
+  | { type: "run.doctor"; id: string; payload: RunDoctorResponse };


### PR DESCRIPTION
## Summary

- Adds a local SQLite run tracker (`.swamp/run_tracker.db`) that tracks in-flight model method runs and workflow runs with heartbeat-based stale detection
- Central `swamp run history` command shows both model method and workflow runs with `--server` support
- `swamp run doctor` diagnoses and reaps stale/orphaned runs (also with `--server`)
- `model cancel` now queries the tracker instead of scanning output YAML
- Output YAML for model method runs is now write-once (terminal states only), preserving the `findAllGlobalSince()` mtime optimization
- Schema versioning and 7-day retention keep the DB bounded

## What's tracked

Every model method execution (CLI, serve, workflow step) and every workflow run registers with the tracker, heartbeats every 30s, and completes on success/failure/cancel. Stale runs (heartbeat >90s with dead PID) are automatically reaped on next CLI or serve invocation.

## New CLI commands

```
swamp run history              # recent runs (last 24h)
swamp run history --active     # what's running right now?
swamp run history --all        # full history
swamp run history --server URL # query a remote server
swamp run doctor               # diagnose stale runs
swamp run doctor --fix         # auto-reap stale runs
```

## Test plan

- [x] 25 new unit tests (ActiveRun entity, RunTrackerStore CRUD/heartbeat/stale/reap/concurrent, isProcessDead)
- [x] 8061 existing tests pass (0 failures)
- [x] Manual E2E: CLI model method run → tracked, output search works, data get works
- [x] Manual E2E: serve model method run → tracked, queryable via `--server`
- [x] Manual E2E: workflow run → both workflow and step runs tracked
- [x] Manual E2E: workflow suspend/approve/resume → tracker transitions correctly
- [x] Manual E2E: workflow cancel → tracker shows failed
- [x] Manual E2E: model cancel (--all, specific model, --reason, --json, nonexistent, nothing running)
- [x] Manual E2E: stale run detection + doctor --fix reaping
- [x] Manual E2E: serve startup reaping
- [x] Manual E2E: `swamp run history --server` and `swamp run doctor --server`
- [x] `deno check`, `deno lint`, `deno fmt` all clean

Closes swamp-club#655

🤖 Generated with [Claude Code](https://claude.com/claude-code)