### PR TITLE
fix(audit): add hook fast-path to prevent non-zero exit from teardown failures (swamp-club#902)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -118,6 +118,7 @@ import {
   projectEnvSnapshot,
   setActiveTelemetryService,
 } from "./telemetry_integration.ts";
+import type { CommandInvocationData } from "../domain/telemetry/command_invocation.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";
@@ -497,6 +498,21 @@ export function commandNeedsLoaderSetup(args: string[]): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Checks whether the command is `audit record` (the PostToolUse hook).
+ * Hook commands need the fastest possible startup and must never exit
+ * non-zero from infrastructure code — they skip telemetry, update
+ * checks, and all post-parse teardown.
+ *
+ * @internal Exported for testing
+ */
+export function isHookCommand(
+  commandInfo: CommandInvocationData,
+): boolean {
+  return commandInfo.command === "audit" &&
+    commandInfo.subcommand === "record";
 }
 
 /** A deferred warning message to emit after logging is initialized. */
@@ -1153,11 +1169,16 @@ export async function runCli(args: string[]): Promise<void> {
   // Extract command info for telemetry (before parsing)
   const commandInfo = extractCommandInfo(args);
 
+  // Hook commands (audit record --from-hook) run as PostToolUse hooks and
+  // must be as fast as possible. Skip all non-essential startup and teardown
+  // to avoid infrastructure errors causing non-zero exit.
+  const hookMode = isHookCommand(commandInfo);
+
   const bootstrapSpan = getTracer().startSpan("swamp.cli.bootstrap");
 
   // Initialize telemetry service (only if in a swamp repo)
   let telemetryCtx: TelemetryContext | null = null;
-  if (!telemetryDisabled) {
+  if (!telemetryDisabled && !hookMode) {
     telemetryCtx = await initTelemetryService(repoDir);
   }
 
@@ -1168,23 +1189,28 @@ export async function runCli(args: string[]): Promise<void> {
     setActiveTelemetryService(telemetryCtx.service);
   }
 
-  // Read marker once for log level, extension loading, and auto-resolver
+  // Read marker once for log level, extension loading, and auto-resolver.
+  // Hook commands skip this — null marker gives default "info" log level.
   let marker: RepoMarkerData | null = null;
-  try {
-    const markerRepo = new RepoMarkerRepository();
-    const repoPath = RepoPath.create(repoDir);
-    marker = await markerRepo.read(repoPath);
-  } catch {
-    // Not in a swamp repo - marker stays null
+  if (!hookMode) {
+    try {
+      const markerRepo = new RepoMarkerRepository();
+      const repoPath = RepoPath.create(repoDir);
+      marker = await markerRepo.read(repoPath);
+    } catch {
+      // Not in a swamp repo - marker stays null
+    }
   }
 
   // Read extension sources (additional extension directories from
   // .swamp-sources.yaml). Resolved once and shared across all loaders.
   let resolvedSources: ResolvedSourceDirs[] = [];
-  const sourcesConfig = await readSwampSources(repoDir);
-  if (sourcesConfig) {
-    const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-    resolvedSources = await resolveSourceExtensionDirs(expanded);
+  if (!hookMode) {
+    const sourcesConfig = await readSwampSources(repoDir);
+    if (sourcesConfig) {
+      const expanded = await expandSourcePaths(sourcesConfig, repoDir);
+      resolvedSources = await resolveSourceExtensionDirs(expanded);
+    }
   }
 
   // Configure lazy extension loaders on each registry.
@@ -1210,24 +1236,28 @@ export async function runCli(args: string[]): Promise<void> {
 
   // Load cached auth collectives for membership-based trust
   let authCollectives: string[] | undefined;
-  try {
-    const authRepo = new AuthRepository();
-    const creds = await authRepo.load();
-    authCollectives = creds?.collectives;
-  } catch {
-    // Auth file unreadable — continue without membership collectives
+  if (!hookMode) {
+    try {
+      const authRepo = new AuthRepository();
+      const creds = await authRepo.load();
+      authCollectives = creds?.collectives;
+    } catch {
+      // Auth file unreadable — continue without membership collectives
+    }
   }
 
   // Create auto-resolver for trusted collectives (merging membership collectives)
-  const autoResolverIdentity = await loadIdentity();
-  setAuthenticated(autoResolverIdentity.bearerToken !== undefined);
-  configureExtensionAutoResolver(
-    repoDir,
-    marker,
-    authCollectives,
-    getOutputModeFromArgs(args),
-    autoResolverIdentity,
-  );
+  if (!hookMode) {
+    const autoResolverIdentity = await loadIdentity();
+    setAuthenticated(autoResolverIdentity.bearerToken !== undefined);
+    configureExtensionAutoResolver(
+      repoDir,
+      marker,
+      authCollectives,
+      getOutputModeFromArgs(args),
+      autoResolverIdentity,
+    );
+  }
 
   const cli = new Command()
     .name("swamp")
@@ -1339,6 +1369,12 @@ export async function runCli(args: string[]): Promise<void> {
       await cli.parse(args);
     });
 
+    // Hook commands exit immediately — no teardown needed. The action's
+    // own try/catch handles all errors; skipping teardown prevents
+    // infrastructure failures (telemetry flush, update checks) from
+    // causing a non-zero exit that disrupts the user's coding session.
+    if (hookMode) return;
+
     // Flush datastore sync (push to S3 + release lock)
     const teardownSpan = getTracer().startSpan("swamp.cli.teardown");
     try {
@@ -1346,27 +1382,31 @@ export async function runCli(args: string[]): Promise<void> {
 
       // Record successful invocation
       if (telemetryCtx) {
-        await telemetryCtx.service.recordSuccess(commandInfo, startTime);
+        try {
+          await telemetryCtx.service.recordSuccess(commandInfo, startTime);
 
-        const sender = new HttpTelemetrySender(
-          telemetryCtx.telemetryEndpoint,
-          USER_AGENT,
-        );
-        const flushed = await telemetryCtx.service.flushTelemetry({
-          sender,
-          distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
-          repoId: telemetryCtx.repoId,
-          authToken: telemetryCtx.authToken ?? undefined,
-          keepFlushed: telemetryCtx.keepFlushed,
-          signal: AbortSignal.timeout(2000),
-        });
-        if (!flushed) {
-          logger
-            .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+          const sender = new HttpTelemetrySender(
+            telemetryCtx.telemetryEndpoint,
+            USER_AGENT,
+          );
+          const flushed = await telemetryCtx.service.flushTelemetry({
+            sender,
+            distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
+            repoId: telemetryCtx.repoId,
+            authToken: telemetryCtx.authToken ?? undefined,
+            keepFlushed: telemetryCtx.keepFlushed,
+            signal: AbortSignal.timeout(2000),
+          });
+          if (!flushed) {
+            logger
+              .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+          }
+
+          // Trigger cleanup asynchronously (fire-and-forget)
+          telemetryCtx.service.cleanupOldTelemetry();
+        } catch {
+          // Best effort — never break the CLI for telemetry failures
         }
-
-        // Trigger cleanup asynchronously (fire-and-forget)
-        telemetryCtx.service.cleanupOldTelemetry();
       }
 
       // Proactive update notification (after telemetry, before exit)

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals } from "@std/assert";
 import {
   commandNeedsLoaderSetup,
+  isHookCommand,
   isLocalhostUrl,
   isTelemetryDisabledByConfig,
   isTelemetryDisabledByEnv,
@@ -29,6 +30,7 @@ import {
   resolveTelemetryEndpoint,
   resolveWorkflowsDir,
 } from "./mod.ts";
+import { extractCommandInfo } from "./telemetry_integration.ts";
 
 Deno.test("resolveModelsDir returns default 'extensions/models' when no config", () => {
   // Ensure env var is not set
@@ -620,5 +622,52 @@ Deno.test("commandNeedsLoaderSetup returns true for model type search with globa
   assertEquals(
     commandNeedsLoaderSetup(["--json", "model", "type", "search", "aws"]),
     true,
+  );
+});
+
+// isHookCommand tests
+
+Deno.test("isHookCommand: returns true for audit record --from-hook", () => {
+  assertEquals(
+    isHookCommand(extractCommandInfo(["audit", "record", "--from-hook"])),
+    true,
+  );
+});
+
+Deno.test("isHookCommand: returns true for audit record with --tool and --repo-dir", () => {
+  assertEquals(
+    isHookCommand(
+      extractCommandInfo([
+        "audit",
+        "record",
+        "--from-hook",
+        "--tool",
+        "cursor",
+        "--repo-dir",
+        "/tmp/repo",
+      ]),
+    ),
+    true,
+  );
+});
+
+Deno.test("isHookCommand: returns false for audit timeline viewer", () => {
+  assertEquals(
+    isHookCommand(extractCommandInfo(["audit"])),
+    false,
+  );
+});
+
+Deno.test("isHookCommand: returns false for model command", () => {
+  assertEquals(
+    isHookCommand(extractCommandInfo(["model", "create"])),
+    false,
+  );
+});
+
+Deno.test("isHookCommand: returns false for empty args", () => {
+  assertEquals(
+    isHookCommand(extractCommandInfo([])),
+    false,
   );
 });


### PR DESCRIPTION
## Summary

- Add `hookMode` fast-path in `runCli` for `audit record --from-hook` that skips non-essential startup (telemetry init, marker reading, identity loading, auto-resolver) and all post-parse teardown (telemetry flush, update checks, auth nudge)
- Wrap telemetry recording/flushing in try/catch as defense-in-depth for all commands — this was the only teardown section without its own error handling
- Reduces hook execution time from ~1.5s to ~0.4s

## Root Cause

The audit action's try/catch correctly prevents errors within the action from causing non-zero exit. However, `runCli`'s teardown path (`src/cli/mod.ts:1347-1370`) performs telemetry recording and HTTP flushing without its own try/catch. If either throws (e.g. HTTP abort, file I/O error), the error propagates to `main.ts` which calls `Deno.exit(exitCodeForError(error))`, producing the intermittent "non-blocking status code" error in Claude Code.

## Test Plan

- 5 new unit tests for `isHookCommand()` covering various arg combinations
- Verified compiled binary: hook exits 0 with valid input, invalid JSON, empty stdin, and non-Bash tools
- Verified audit entries are still recorded correctly with the fast-path
- Benchmarked: 1.5s → 0.4s (73% reduction in hook execution time)
- All 103 related tests pass, full `deno check` / `deno lint` / `deno fmt` clean

Closes swamp-club/lab#902