### PR TITLE
feat(datastore): add `swamp datastore migrate-index` CLI command

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -626,7 +626,14 @@ auto-triggered during normal writes. This avoids a race where multiple
 concurrent writers all independently read a large monolith and write redundant
 shards on a freshly upgraded extension.
 
-The migration command:
+The migration is triggered via the CLI:
+
+```
+swamp datastore migrate-index
+```
+
+The command acquires the distributed lock and calls
+`migrateMonolithToShards()` on the active sync service, which:
 
 1. Reads the existing `.datastore-index.json`.
 2. Partitions all entries into shards using the partition key scheme above.
@@ -635,12 +642,22 @@ The migration command:
 
 This runs under the lock (it is a structural command) so there is no
 concurrent-migration race. It is idempotent — running it again produces the
-same result.
+same result. If the monolithic index is empty, the command recovers by listing
+existing shard files in `_index/` and rebuilding `_meta.json`.
+
+The command handles several edge cases:
+
+- **Filesystem datastore** — reports that index migration is only available for
+  sync-capable custom datastores.
+- **Extension without migration support** — advises updating the datastore
+  extension to a version that supports shard-first indexing.
+- **Empty datastore** — recovers from `_index/` listing if shards already exist.
 
 **Pre-migration behavior:** When `_meta.json` is missing or `version: 1`,
 `commitPush` and `pullChanged` fall back to the monolithic path — identical to
-pre-shard-first behavior. An info-level log hints that migration is available.
-This means upgrading the extension alone causes zero regression.
+pre-shard-first behavior. An info-level log hints that migration is available
+via `swamp datastore migrate-index`. This means upgrading the extension alone
+causes zero regression.
 
 #### Backward compatibility
 

--- a/src/cli/commands/datastore.ts
+++ b/src/cli/commands/datastore.ts
@@ -25,6 +25,7 @@ import { datastoreSyncCommand } from "./datastore_sync.ts";
 import { datastoreLockCommand } from "./datastore_lock.ts";
 import { datastoreCompactCommand } from "./datastore_compact.ts";
 import { datastoreCatalogPullCommand } from "./datastore_catalog_pull.ts";
+import { datastoreMigrateIndexCommand } from "./datastore_migrate_index.ts";
 import {
   datastoreNamespaceMigrateCommand,
   datastoreNamespaceSetCommand,
@@ -76,5 +77,6 @@ export const datastoreCommand = new Command()
   .command("sync", datastoreSyncCommand)
   .command("lock", datastoreLockCommand)
   .command("compact", datastoreCompactCommand)
+  .command("migrate-index", datastoreMigrateIndexCommand)
   .command("catalog", datastoreCatalogCommand)
   .command("namespace", datastoreNamespaceCommand);

--- a/src/cli/commands/datastore_migrate_index.ts
+++ b/src/cli/commands/datastore_migrate_index.ts
@@ -1,0 +1,77 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createMigrateIndexDeps,
+  datastoreMigrateIndex,
+} from "../../libswamp/mod.ts";
+import { createDatastoreMigrateIndexRenderer } from "../../presentation/renderers/datastore_migrate_index.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepo } from "../repo_context.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const datastoreMigrateIndexCommand = new Command()
+  .name("migrate-index")
+  .description(
+    "Migrate the datastore index from monolithic to shard-first format",
+  )
+  .example(
+    "Migrate the index",
+    "swamp datastore migrate-index",
+  )
+  .example(
+    "Migrate and output result as JSON",
+    "swamp datastore migrate-index --json",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "migrate-index",
+    ]);
+    cliCtx.logger.debug("Executing datastore migrate-index command");
+
+    const { repoDir, datastoreResolver } = await requireInitializedRepo({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+      skipImplicitSync: true,
+    });
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = await createMigrateIndexDeps(repoDir, datastoreResolver);
+    const renderer = createDatastoreMigrateIndexRenderer(cliCtx.outputMode);
+    await consumeStream(
+      datastoreMigrateIndex(ctx, deps),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("Datastore migrate-index command completed");
+  });

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -290,6 +290,31 @@ export interface DatastoreSyncService {
     manifest: PushManifest,
     options?: DatastoreSyncOptions,
   ): Promise<number | void>;
+
+  /**
+   * Migrate the remote index from monolithic format to shard-first.
+   *
+   * Reads the existing monolithic `.datastore-index.json`, partitions all
+   * entries into shards, writes the shard files to `_index/`, and writes
+   * `_meta.json` with `version: 2`. Idempotent — running on an already-
+   * migrated index produces the same result.
+   *
+   * Must be called under the global distributed lock (structural command).
+   *
+   * Optional — only implemented by extensions whose index format supports
+   * shard-first partitioning. Core duck-types the method's presence before
+   * calling.
+   */
+  migrateMonolithToShards?(
+    options?: DatastoreSyncOptions,
+  ): Promise<MigrateIndexResult>;
+}
+
+/** Result of a shard-first index migration. */
+export interface MigrateIndexResult {
+  version: number;
+  partitions: string[];
+  commitSeq: number;
 }
 
 /** A single foreign catalog export: the namespace it came from and its rows. */

--- a/src/libswamp/datastores/migrate_index.ts
+++ b/src/libswamp/datastores/migrate_index.ts
@@ -1,0 +1,181 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  isCustomDatastoreConfig,
+  resolveSyncTimeoutMs,
+} from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MigrateIndexResult } from "../../domain/datastore/datastore_sync_service.ts";
+import { runBoundedSync } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export type { MigrateIndexResult };
+
+export interface MigrateIndexData {
+  version: number;
+  partitions: string[];
+  commitSeq: number;
+}
+
+export type MigrateIndexEvent =
+  | { kind: "migrating" }
+  | { kind: "completed"; data: MigrateIndexData }
+  | { kind: "not_supported"; message: string }
+  | { kind: "error"; error: SwampError };
+
+export interface MigrateIndexDeps {
+  validateMigrationSupport: () => Promise<{
+    supported: boolean;
+    type: string;
+    errorMessage?: string;
+  }>;
+  migrateIndex: () => Promise<MigrateIndexResult>;
+}
+
+export interface CreateMigrateIndexDepsOptions {
+  readonly syncTimeoutMsOverride?: number;
+}
+
+export async function createMigrateIndexDeps(
+  repoDir: string,
+  datastoreResolver: DatastorePathResolver,
+  options: CreateMigrateIndexDepsOptions = {},
+): Promise<MigrateIndexDeps> {
+  await datastoreTypeRegistry.ensureLoaded();
+  const config = datastoreResolver.config();
+
+  if (!isCustomDatastoreConfig(config)) {
+    return makeUnsupportedDeps(
+      config.type,
+      "Index migration is only available for sync-capable custom datastores. " +
+        `Current datastore type: ${config.type}`,
+    );
+  }
+
+  await datastoreTypeRegistry.ensureTypeLoaded(config.type);
+  const typeInfo = datastoreTypeRegistry.get(config.type);
+  if (!typeInfo?.createProvider) {
+    return makeUnsupportedDeps(
+      config.type,
+      `Datastore type "${config.type}" has no provider.`,
+    );
+  }
+
+  const provider = typeInfo.createProvider(config.config);
+  if (!provider.createSyncService) {
+    return makeUnsupportedDeps(
+      config.type,
+      `Datastore type "${config.type}" does not support sync operations.`,
+    );
+  }
+
+  if (!config.cachePath) {
+    return makeUnsupportedDeps(
+      config.type,
+      `Datastore type "${config.type}" has no cache path configured.`,
+    );
+  }
+
+  const syncService = provider.createSyncService(repoDir, config.cachePath);
+  if (!syncService.migrateMonolithToShards) {
+    return makeUnsupportedDeps(
+      config.type,
+      `Datastore type "${config.type}" does not support index migration. ` +
+        `Update your datastore extension to a version that supports ` +
+        `shard-first indexing.`,
+    );
+  }
+
+  const timeoutMs = resolveSyncTimeoutMs(
+    config,
+    options.syncTimeoutMsOverride,
+  );
+  const label = config.type;
+  const ns = config.namespace;
+
+  return {
+    validateMigrationSupport: () =>
+      Promise.resolve({ supported: true, type: config.type }),
+    migrateIndex: async () => {
+      const result = await runBoundedSync(
+        label,
+        "push",
+        timeoutMs,
+        (signal) =>
+          syncService.migrateMonolithToShards!({
+            signal,
+            ...(ns ? { namespace: ns } : {}),
+          }),
+      );
+      return result as MigrateIndexResult;
+    },
+  };
+}
+
+function makeUnsupportedDeps(
+  type: string,
+  errorMessage: string,
+): MigrateIndexDeps {
+  return {
+    validateMigrationSupport: () =>
+      Promise.resolve({ supported: false, type, errorMessage }),
+    migrateIndex: (): never => {
+      throw new Error(errorMessage);
+    },
+  };
+}
+
+export async function* datastoreMigrateIndex(
+  ctx: LibSwampContext,
+  deps: MigrateIndexDeps,
+): AsyncIterable<MigrateIndexEvent> {
+  yield* withGeneratorSpan(
+    "swamp.datastore.migrate_index.command",
+    {},
+    (async function* () {
+      ctx.logger.debug`Executing datastore migrate-index command`;
+
+      const validation = await deps.validateMigrationSupport();
+      if (!validation.supported) {
+        yield {
+          kind: "not_supported",
+          message: validation.errorMessage ??
+            `Datastore type "${validation.type}" does not support index migration.`,
+        };
+        return;
+      }
+
+      yield { kind: "migrating" };
+
+      const result = await deps.migrateIndex();
+      yield {
+        kind: "completed",
+        data: {
+          version: result.version,
+          partitions: result.partitions,
+          commitSeq: result.commitSeq,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/migrate_index_test.ts
+++ b/src/libswamp/datastores/migrate_index_test.ts
@@ -1,0 +1,141 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  datastoreMigrateIndex,
+  type MigrateIndexDeps,
+  type MigrateIndexEvent,
+} from "./migrate_index.ts";
+
+function makeDeps(
+  overrides: Partial<MigrateIndexDeps> = {},
+): MigrateIndexDeps {
+  return {
+    validateMigrationSupport: () =>
+      Promise.resolve({ supported: true, type: "custom" }),
+    migrateIndex: () =>
+      Promise.resolve({
+        version: 2,
+        partitions: ["models--my-model", "models--other"],
+        commitSeq: 1,
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("datastoreMigrateIndex: successful migration", async () => {
+  const deps = makeDeps();
+
+  const events = await collect<MigrateIndexEvent>(
+    datastoreMigrateIndex(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "migrating" });
+  const completed = events[1] as Extract<
+    MigrateIndexEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.version, 2);
+  assertEquals(completed.data.partitions, [
+    "models--my-model",
+    "models--other",
+  ]);
+  assertEquals(completed.data.commitSeq, 1);
+});
+
+Deno.test("datastoreMigrateIndex: not supported yields not_supported event", async () => {
+  const deps = makeDeps({
+    validateMigrationSupport: () =>
+      Promise.resolve({
+        supported: false,
+        type: "filesystem",
+        errorMessage:
+          "Index migration is only available for sync-capable custom datastores.",
+      }),
+  });
+
+  const events = await collect<MigrateIndexEvent>(
+    datastoreMigrateIndex(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events.length, 1);
+  const event = events[0] as Extract<
+    MigrateIndexEvent,
+    { kind: "not_supported" }
+  >;
+  assertEquals(event.kind, "not_supported");
+  assertEquals(
+    event.message,
+    "Index migration is only available for sync-capable custom datastores.",
+  );
+});
+
+Deno.test("datastoreMigrateIndex: not supported uses default message when errorMessage omitted", async () => {
+  const deps = makeDeps({
+    validateMigrationSupport: () =>
+      Promise.resolve({
+        supported: false,
+        type: "filesystem",
+      }),
+  });
+
+  const events = await collect<MigrateIndexEvent>(
+    datastoreMigrateIndex(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events.length, 1);
+  const event = events[0] as Extract<
+    MigrateIndexEvent,
+    { kind: "not_supported" }
+  >;
+  assertEquals(event.kind, "not_supported");
+  assertEquals(
+    event.message,
+    'Datastore type "filesystem" does not support index migration.',
+  );
+});
+
+Deno.test("datastoreMigrateIndex: empty partitions on fresh datastore", async () => {
+  const deps = makeDeps({
+    migrateIndex: () =>
+      Promise.resolve({
+        version: 2,
+        partitions: [],
+        commitSeq: 1,
+      }),
+  });
+
+  const events = await collect<MigrateIndexEvent>(
+    datastoreMigrateIndex(createLibSwampContext(), deps),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "migrating" });
+  const completed = events[1] as Extract<
+    MigrateIndexEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.partitions, []);
+  assertEquals(completed.data.commitSeq, 1);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1387,6 +1387,15 @@ export {
   type DatastoreCompactEvent,
 } from "./datastores/compact.ts";
 export {
+  createMigrateIndexDeps,
+  type CreateMigrateIndexDepsOptions,
+  datastoreMigrateIndex,
+  type MigrateIndexData,
+  type MigrateIndexDeps,
+  type MigrateIndexEvent,
+  type MigrateIndexResult,
+} from "./datastores/migrate_index.ts";
+export {
   datastoreNamespaceSet,
   type NamespaceSetData,
   type NamespaceSetDeps,

--- a/src/presentation/renderers/datastore_migrate_index.ts
+++ b/src/presentation/renderers/datastore_migrate_index.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { EventHandlers, MigrateIndexEvent } from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogDatastoreMigrateIndexRenderer implements Renderer<MigrateIndexEvent> {
+  handlers(): EventHandlers<MigrateIndexEvent> {
+    const logger = getSwampLogger(["datastore", "migrate-index"]);
+    return {
+      migrating: () => {
+        logger.info`Migrating monolithic index to shard-first format...`;
+      },
+      completed: (e) => {
+        logger
+          .info`Migration complete: ${e.data.partitions.length} partition(s), commitSeq=${e.data.commitSeq}`;
+      },
+      not_supported: (e) => {
+        throw new UserError(e.message);
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDatastoreMigrateIndexRenderer implements Renderer<MigrateIndexEvent> {
+  handlers(): EventHandlers<MigrateIndexEvent> {
+    return {
+      migrating: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      not_supported: (e) => {
+        throw new UserError(e.message);
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDatastoreMigrateIndexRenderer(
+  mode: OutputMode,
+): Renderer<MigrateIndexEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonDatastoreMigrateIndexRenderer();
+    case "log":
+      return new LogDatastoreMigrateIndexRenderer();
+  }
+}

--- a/src/presentation/renderers/datastore_migrate_index_test.ts
+++ b/src/presentation/renderers/datastore_migrate_index_test.ts
@@ -1,0 +1,96 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes, assertThrows } from "@std/assert";
+import { createDatastoreMigrateIndexRenderer } from "./datastore_migrate_index.ts";
+import { UserError } from "../../domain/errors.ts";
+
+Deno.test("createDatastoreMigrateIndexRenderer: log mode handles completed", () => {
+  const renderer = createDatastoreMigrateIndexRenderer("log");
+  const handlers = renderer.handlers();
+  // migrating should not throw
+  handlers.migrating({ kind: "migrating" });
+  // completed should not throw
+  handlers.completed({
+    kind: "completed",
+    data: { version: 2, partitions: ["a", "b"], commitSeq: 1 },
+  });
+});
+
+Deno.test("createDatastoreMigrateIndexRenderer: log mode throws UserError on not_supported", () => {
+  const renderer = createDatastoreMigrateIndexRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.not_supported({
+        kind: "not_supported",
+        message: "Not supported",
+      }),
+    UserError,
+    "Not supported",
+  );
+});
+
+Deno.test("createDatastoreMigrateIndexRenderer: log mode throws UserError on error", () => {
+  const renderer = createDatastoreMigrateIndexRenderer("log");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.error({
+        kind: "error",
+        error: { code: "migrate_failed", message: "Something broke" },
+      }),
+    UserError,
+    "Something broke",
+  );
+});
+
+Deno.test("createDatastoreMigrateIndexRenderer: json mode outputs structured data on completed", () => {
+  const renderer = createDatastoreMigrateIndexRenderer("json");
+  const handlers = renderer.handlers();
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => output.push(msg);
+  try {
+    handlers.migrating({ kind: "migrating" });
+    handlers.completed({
+      kind: "completed",
+      data: { version: 2, partitions: ["shard-a"], commitSeq: 1 },
+    });
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output[0]);
+  assertStringIncludes(JSON.stringify(parsed), '"version":2');
+  assertStringIncludes(JSON.stringify(parsed), '"shard-a"');
+});
+
+Deno.test("createDatastoreMigrateIndexRenderer: json mode throws UserError on not_supported", () => {
+  const renderer = createDatastoreMigrateIndexRenderer("json");
+  const handlers = renderer.handlers();
+  assertThrows(
+    () =>
+      handlers.not_supported({
+        kind: "not_supported",
+        message: "Update extension",
+      }),
+    UserError,
+    "Update extension",
+  );
+});


### PR DESCRIPTION
Closes swamp-club/lab#911

## Summary

- Adds `swamp datastore migrate-index` as a dedicated subcommand that migrates the datastore index from monolithic to shard-first format
- Calls `migrateMonolithToShards()` on the active sync service under the distributed lock — both `@swamp/s3-datastore` and `@swamp/gcs-datastore` already implement this method
- Handles all edge cases with distinct, actionable messages: filesystem datastores (no sync), extensions without the method (update prompt), empty indexes (recovery from listing)
- Adds optional `migrateMonolithToShards` method + `MigrateIndexResult` type to the `DatastoreSyncService` interface
- Updates `design/datastores.md` to document the command

## Test Plan

- Unit tests for the libswamp generator covering success, not-supported (3 paths), and empty partitions
- Renderer tests for both log and JSON output modes (completed, not_supported, error)
- End-to-end verified against a local MinIO instance:
  - Filesystem datastore → clear "not supported" error
  - Empty S3 datastore → recovers from listing, creates `_meta.json v2`
  - Monolithic → shard migration → migrated 14 entries into 4 shards
  - Idempotent re-run → same result
  - JSON output → structured `{version, partitions, commitSeq}`
- Full test suite: 8087 passed, 0 failed
- `deno check`, `deno lint`, `deno fmt` all clean