### PR TITLE
fix(serve): resolve vault-backed sensitive fields in remote worker readResource (swamp-club#914)

### DIFF
--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -45,6 +45,7 @@ import type { DefinitionRepository } from "../domain/definitions/repositories.ts
 import type { OutputRepository } from "../domain/models/repositories.ts";
 import type { DataQueryService } from "../domain/data/data_query_service.ts";
 import type { VaultService } from "../domain/vaults/vault_service.ts";
+import { resolveVaultRefsInData } from "../domain/models/data_writer.ts";
 import { SecretRedactor } from "../domain/secrets/mod.ts";
 import { createExtensionCelEnvironment } from "../infrastructure/cel/cel_evaluator.ts";
 import type { RpcChannel } from "../domain/remote/rpc_channel.ts";
@@ -505,6 +506,8 @@ export function createRemoteMethodContext(
       }, { signal }),
   } as unknown as DataQueryService;
 
+  const redactor = new SecretRedactor();
+
   const readResource = async (
     instanceName: string,
     version?: number,
@@ -518,10 +521,12 @@ export function createRemoteMethodContext(
     if (content === null) {
       return null;
     }
-    return JSON.parse(new TextDecoder().decode(content)) as Record<
+    const data = JSON.parse(new TextDecoder().decode(content)) as Record<
       string,
       unknown
     >;
+    await resolveVaultRefsInData(data, vaultService, redactor);
+    return data;
   };
 
   const deleteResource = async (instanceName: string): Promise<void> => {
@@ -556,7 +561,7 @@ export function createRemoteMethodContext(
     definitionRepository,
     outputRepository,
     vaultService,
-    redactor: new SecretRedactor(),
+    redactor,
     dataQueryService,
     writeResource: writers.writeResource,
     readResource,

--- a/src/worker/remote_method_context_test.ts
+++ b/src/worker/remote_method_context_test.ts
@@ -68,7 +68,11 @@ interface StubCall {
   params: unknown;
 }
 
-function harness(scratchDir: string, extensionFilesDir?: string) {
+function harness(
+  scratchDir: string,
+  extensionFilesDir?: string,
+  artifactContent?: Record<string, unknown>,
+) {
   const calls: StubCall[] = [];
   // The orchestrator side of the control socket, with stub verb handlers.
   const worker: RpcChannel = new RpcChannel({
@@ -118,7 +122,9 @@ function harness(scratchDir: string, extensionFilesDir?: string) {
     readArtifact: (contentPath: string) => {
       calls.push({ method: "readArtifact", params: contentPath });
       return Promise.resolve(
-        new TextEncoder().encode(JSON.stringify({ loaded: true })),
+        new TextEncoder().encode(
+          JSON.stringify(artifactContent ?? { loaded: true }),
+        ),
       );
     },
     writeResource: (
@@ -215,6 +221,22 @@ Deno.test("remote context: readResource resolves metadata then fetches bytes", a
     const value = await h.context.readResource!("state-main");
     assertEquals(value, { loaded: true });
     assertEquals(h.calls.map((c) => c.method), ["getData", "readArtifact"]);
+  });
+});
+
+Deno.test("remote context: readResource resolves vault references in sensitive fields", async () => {
+  await withScratch(async (dir) => {
+    const h = harness(dir, undefined, {
+      username: "alice",
+      refreshToken: "${{ vault.get('my-vault', 'refresh-tok') }}",
+    });
+    const value = await h.context.readResource!("state-main");
+    assertEquals(value, { username: "alice", refreshToken: "s3cret" });
+    const resolveCall = h.calls.find((c) => c.method === "resolveSecret");
+    assertEquals(resolveCall?.params, {
+      vaultName: "my-vault",
+      secretKey: "refresh-tok",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- `readResource` in the remote worker context (`remote_method_context.ts`) returned raw `${{ vault.get(...) }}` reference strings instead of resolving them to actual secret values. This caused vault-backed sensitive fields (e.g. OAuth refresh tokens) to resolve empty when a model method ran under `swamp serve` — either via the internal scheduler or a `--server` client.
- Added a call to `resolveVaultRefsInData` (the same function the in-process executor uses via `createResourceReader`) using the already-available `vaultService` and `redactor`, so sensitive fields now resolve correctly in both execution paths.
- Shared the `SecretRedactor` instance between `readResource` and the `MethodContext` so secrets resolved during resource reads are also redacted from log output.

Closes swamp-club#914

## Test Plan

- [x] Added unit test: `readResource resolves vault references in sensitive fields` — returns resource JSON containing a vault reference, asserts it resolves to the secret value via the `resolveSecret` RPC verb
- [x] All existing `remote_method_context_test.ts` tests pass (13/13)
- [x] Full test suite passes (8088 passed, 0 failed)
- [x] `deno check`, `deno lint`, `deno fmt` all clean
- [x] Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)