### PR TITLE
perf(expressions): resolve data.latest() via direct filesystem lookup (swamp-club#918)

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -145,23 +145,6 @@ export class DataQueryService {
   }
 
   /**
-   * Synchronous variant of getLatestRecord. Triggers sync backfill if needed.
-   * Vault resolution does NOT happen in the sync path.
-   */
-  getLatestRecordSync(
-    modelName: string,
-    dataName: string,
-    namespace?: string,
-  ): DataRecord | null {
-    if (!this.catalogStore.isPopulated()) {
-      this.backfillSync();
-    }
-    const row = this.catalogStore.findLatestRow(modelName, dataName, namespace);
-    if (!row) return null;
-    return fromRow(row, this.dataRepo, true, false);
-  }
-
-  /**
    * Queries data artifacts matching a CEL predicate.
    * Triggers backfill if the catalog is not yet populated.
    * Vault references in JSON attributes are resolved when a VaultService

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -105,6 +105,63 @@ export class DataQueryService {
   }
 
   /**
+   * Direct indexed lookup for the latest version of a specific data item.
+   * Bypasses the generic CEL-predicate-over-full-table-scan path by using
+   * a SQL WHERE query with the idx_catalog_latest_lookup index.
+   */
+  async getLatestRecord(
+    modelName: string,
+    dataName: string,
+    namespace?: string,
+  ): Promise<DataRecord | null> {
+    if (!this.catalogStore.isPopulated()) {
+      if (this.backfillPromise) {
+        await this.backfillPromise;
+      } else {
+        const promise = this.backfillAsync();
+        this.backfillPromise = promise;
+        try {
+          await promise;
+        } finally {
+          this.backfillPromise = null;
+        }
+      }
+    }
+    const row = this.catalogStore.findLatestRow(modelName, dataName, namespace);
+    if (!row) return null;
+    const record = fromRow(row, this.dataRepo, true, false);
+    if (this.vaultService && Object.keys(record.attributes).length > 0) {
+      try {
+        await resolveVaultRefsInData(
+          record.attributes,
+          this.vaultService,
+          this.redactor,
+        );
+      } catch {
+        // Leave unresolved
+      }
+    }
+    return record;
+  }
+
+  /**
+   * Synchronous variant of getLatestRecord. Triggers sync backfill if needed.
+   * Vault resolution does NOT happen in the sync path.
+   */
+  getLatestRecordSync(
+    modelName: string,
+    dataName: string,
+    namespace?: string,
+  ): DataRecord | null {
+    if (!this.catalogStore.isPopulated()) {
+      this.backfillSync();
+    }
+    const row = this.catalogStore.findLatestRow(modelName, dataName, namespace);
+    if (!row) return null;
+    return fromRow(row, this.dataRepo, true, false);
+  }
+
+  /**
    * Queries data artifacts matching a CEL predicate.
    * Triggers backfill if the catalog is not yet populated.
    * Vault references in JSON attributes are resolved when a VaultService

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -492,29 +492,12 @@ export class ModelResolver {
       context.model[definition.id] = modelData;
     }
 
-    // Build model coordinates map and populate model.resource/file eagerly.
-    // Uses findAllGlobal() to discover data from disk first, then matches
-    // to definitions. This handles the case where a model was deleted and
-    // recreated (new UUID) — data under the old UUID is still found.
+    // Build model coordinates map from definitions (O(definitions) not O(data)).
+    // model.resource and model.file are populated lazily on first access
+    // to avoid the O(N) findAllGlobal() filesystem walk.
     const coordsMap: ModelCoordinatesMap = new Map();
     if (this.dataRepo) {
-      // Build definition lookup maps
-      const defById = new Map<
-        string,
-        { definition: Definition; type: ModelType }
-      >();
-      const defsByType = new Map<
-        string,
-        Array<{ definition: Definition; type: ModelType }>
-      >();
-
       for (const { definition: def, type: defType } of allDefinitions) {
-        defById.set(def.id, { definition: def, type: defType });
-        const typeKey = defType.normalized;
-        if (!defsByType.has(typeKey)) defsByType.set(typeKey, []);
-        defsByType.get(typeKey)!.push({ definition: def, type: defType });
-
-        // Add current definition coordinates
         const coords: ModelCoordinates = {
           modelType: defType,
           modelId: def.id,
@@ -523,121 +506,177 @@ export class ModelResolver {
         coordsMap.get(def.name)!.push(coords);
       }
 
-      // Discover all data on disk for orphan recovery and eager population
-      const allGlobalData = await this.dataRepo.findAllGlobal();
+      // Lazy-load model.resource and model.file on first property access.
+      // Instead of walking all data on disk upfront, each model's data is
+      // loaded only when its .resource or .file is accessed in a CEL expression.
+      // The getter replaces itself with the loaded value after first access.
+      const dataRepo = this.dataRepo;
+      const self = this;
+      let orphanData:
+        | Array<{ data: Data; modelType: ModelType; modelId: string }>
+        | null = null;
+      for (const { definition: def } of allDefinitions) {
+        const modelData = context.model[def.name];
+        if (!modelData) continue;
 
-      // Group data items by (modelType, modelId) — the disk coordinates
-      const groupKey = (mt: ModelType, mid: string) =>
-        `${mt.normalized}::${mid}`;
-      const groupedData = new Map<
-        string,
-        { modelType: ModelType; modelId: string; items: Data[] }
-      >();
-      for (const { data, modelType, modelId } of allGlobalData) {
-        const key = groupKey(modelType, modelId);
-        if (!groupedData.has(key)) {
-          groupedData.set(key, { modelType, modelId, items: [] });
-        }
-        groupedData.get(key)!.items.push(data);
-      }
+        const defName = def.name;
 
-      // Match each group to a definition and populate model.resource/file
-      for (const [_key, group] of groupedData) {
-        const { modelType, modelId, items } = group;
+        const loadResources = (): {
+          resource?: Record<string, Record<string, DataRecord>>;
+          file?: Record<string, Record<string, FileDataRecord>>;
+        } => {
+          const result: {
+            resource?: Record<string, Record<string, DataRecord>>;
+            file?: Record<string, Record<string, FileDataRecord>>;
+          } = {};
+          const allCoords = coordsMap.get(defName) ?? [];
 
-        // 1. Direct match: modelId matches a definition's UUID
-        let matchedDef = defById.get(modelId);
-
-        // 2. Orphan recovery by modelName tag
-        if (!matchedDef) {
-          const modelNameTag = items.find((d) => d.tags["modelName"])
-            ?.tags["modelName"];
-          if (modelNameTag) {
-            const defsOfType = defsByType.get(modelType.normalized) ?? [];
-            const nameMatch = defsOfType.find(
-              (d) => d.definition.name === modelNameTag,
-            );
-            if (nameMatch) matchedDef = nameMatch;
-          }
-        }
-
-        // 3. Orphan recovery by heuristic: only one definition of this type
-        if (!matchedDef) {
-          const defsOfType = defsByType.get(modelType.normalized) ?? [];
-          if (defsOfType.length === 1) {
-            matchedDef = defsOfType[0];
-          }
-        }
-
-        if (!matchedDef) continue;
-
-        const modelName = matchedDef.definition.name;
-
-        // Add orphan coordinates (disk modelId differs from current definition UUID)
-        if (modelId !== matchedDef.definition.id) {
-          const orphanCoords: ModelCoordinates = { modelType, modelId };
-          if (!coordsMap.has(modelName)) coordsMap.set(modelName, []);
-          const existing = coordsMap.get(modelName)!;
-          const alreadyTracked = existing.some(
-            (c) =>
-              c.modelType.normalized === modelType.normalized &&
-              c.modelId === modelId,
-          );
-          if (!alreadyTracked) existing.push(orphanCoords);
-        }
-
-        // Populate model.resource and model.file eagerly (backward compat)
-        // Skip renamed-tombstoned entries to avoid duplicates
-        const modelData = context.model[modelName];
-        if (modelData) {
-          for (const data of items) {
-            if (data.isRenamed) continue;
-            const latestRecord = this.dataToRecord(
-              data,
-              modelType,
-              modelId,
-              data.name,
-              undefined,
-              modelName,
-            );
-            if (!latestRecord) continue;
-
-            const dataType = latestRecord.tags["type"];
-
-            if (dataType === "resource") {
-              if (!modelData.resource) modelData.resource = {};
-              const specName = latestRecord.tags["specName"] ?? data.name;
-              if (!modelData.resource[specName]) {
-                modelData.resource[specName] = {};
-              }
-              modelData.resource[specName][data.name] = latestRecord;
-            } else if (dataType === "file") {
-              if (!modelData.file) modelData.file = {};
-              const specName = latestRecord.tags["specName"] ?? data.name;
-              if (!modelData.file[specName]) modelData.file[specName] = {};
-              const contentPath = this.dataRepo.getContentPath(
-                modelType,
-                modelId,
+          for (const { modelType: mt, modelId: mid } of allCoords) {
+            const items = dataRepo.findAllForModelSync(mt, mid);
+            for (const data of items) {
+              if (data.isRenamed) continue;
+              const latestRecord = self.dataToRecord(
+                data,
+                mt,
+                mid,
                 data.name,
-                latestRecord.version,
+                undefined,
+                defName,
               );
-              try {
-                const stat = Deno.statSync(contentPath);
-                modelData.file[specName][data.name] = {
-                  id: latestRecord.id,
-                  version: latestRecord.version,
-                  createdAt: latestRecord.createdAt,
-                  path: contentPath,
-                  size: stat.size,
-                  contentType: latestRecord.tags["contentType"] ??
-                    "application/octet-stream",
-                };
-              } catch {
-                // File not found on disk, skip
+              if (!latestRecord) continue;
+
+              const dataType = latestRecord.tags["type"];
+              if (dataType === "resource") {
+                if (!result.resource) result.resource = {};
+                const specName = latestRecord.tags["specName"] ?? data.name;
+                if (!result.resource[specName]) {
+                  result.resource[specName] = {};
+                }
+                result.resource[specName][data.name] = latestRecord;
+              } else if (dataType === "file") {
+                if (!result.file) result.file = {};
+                const specName = latestRecord.tags["specName"] ?? data.name;
+                if (!result.file[specName]) {
+                  result.file[specName] = {};
+                }
+                const contentPath = dataRepo.getContentPath(
+                  mt,
+                  mid,
+                  data.name,
+                  latestRecord.version,
+                );
+                try {
+                  const stat = Deno.statSync(contentPath);
+                  result.file[specName][data.name] = {
+                    id: latestRecord.id,
+                    version: latestRecord.version,
+                    createdAt: latestRecord.createdAt,
+                    path: contentPath,
+                    size: stat.size,
+                    contentType: latestRecord.tags["contentType"] ??
+                      "application/octet-stream",
+                  } as FileDataRecord;
+                } catch {
+                  // File not found on disk, skip
+                }
               }
             }
           }
-        }
+          // Orphan recovery: if no resource/file data found under current
+          // coordinates, scan the full datastore once (shared across all
+          // models) for orphan data tagged with this model's name.
+          if (!result.resource && !result.file) {
+            if (!orphanData) {
+              orphanData = dataRepo.findAllGlobalSync();
+            }
+            for (const { data, modelType: mt, modelId: mid } of orphanData) {
+              if (data.isRenamed) continue;
+              if (data.tags["modelName"] !== defName) continue;
+              const latestRecord = self.dataToRecord(
+                data,
+                mt,
+                mid,
+                data.name,
+                undefined,
+                defName,
+              );
+              if (!latestRecord) continue;
+              const dataType = latestRecord.tags["type"];
+              if (dataType === "resource") {
+                if (!result.resource) result.resource = {};
+                const specName = latestRecord.tags["specName"] ?? data.name;
+                if (!result.resource[specName]) result.resource[specName] = {};
+                result.resource[specName][data.name] = latestRecord;
+              } else if (dataType === "file") {
+                if (!result.file) result.file = {};
+                const specName = latestRecord.tags["specName"] ?? data.name;
+                if (!result.file[specName]) result.file[specName] = {};
+                const contentPath = dataRepo.getContentPath(
+                  mt,
+                  mid,
+                  data.name,
+                  latestRecord.version,
+                );
+                try {
+                  const stat = Deno.statSync(contentPath);
+                  result.file[specName][data.name] = {
+                    id: latestRecord.id,
+                    version: latestRecord.version,
+                    createdAt: latestRecord.createdAt,
+                    path: contentPath,
+                    size: stat.size,
+                    contentType: latestRecord.tags["contentType"] ??
+                      "application/octet-stream",
+                  } as FileDataRecord;
+                } catch { /* skip */ }
+              }
+            }
+          }
+
+          return result;
+        };
+
+        Object.defineProperty(modelData, "resource", {
+          configurable: true,
+          enumerable: true,
+          get() {
+            const loaded = loadResources();
+            Object.defineProperty(this, "resource", {
+              value: loaded.resource,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            });
+            Object.defineProperty(this, "file", {
+              value: loaded.file,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            });
+            return loaded.resource;
+          },
+        });
+
+        Object.defineProperty(modelData, "file", {
+          configurable: true,
+          enumerable: true,
+          get() {
+            const loaded = loadResources();
+            Object.defineProperty(this, "resource", {
+              value: loaded.resource,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            });
+            Object.defineProperty(this, "file", {
+              value: loaded.file,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            });
+            return loaded.file;
+          },
+        });
       }
     }
 
@@ -655,6 +694,7 @@ export class ModelResolver {
     // `forEach.in`) must go through `CelEvaluator.evaluateAsync`, which
     // cel-js natively propagates Promises through.
     const ownNamespace = this.dataRepo?.namespace ?? ("" as Namespace);
+    const latestCache = new Map<string, DataRecord | null>();
     context.data = {
       version: async (
         rawModelName: string,
@@ -679,18 +719,72 @@ export class ModelResolver {
         rawModelName: string,
         dataName: string,
       ): Promise<DataRecord | null> => {
-        if (!this.dataQueryService) return null;
+        if (!this.dataRepo) return null;
         const ns = routeNamespace(rawModelName, ownNamespace);
+
+        if (!ns.isWildcard) {
+          const nsForKey = ns.namespacePredicate
+            ? (ns.namespacePredicate.match(/ns == "([^"]*)"/)?.[1] ?? "")
+            : ownNamespace;
+          const cacheKey = `${nsForKey}\0${ns.modelName}\0${dataName}`;
+          if (latestCache.has(cacheKey)) return latestCache.get(cacheKey)!;
+
+          // Direct filesystem lookup via coordsMap — same O(1) path as
+          // `swamp data get`, bypassing the catalog entirely.
+          const coords = coordsMap.get(ns.modelName);
+          if (coords && coords.length > 0) {
+            for (const { modelType, modelId } of coords) {
+              const data = await this.dataRepo.findByName(
+                modelType,
+                modelId,
+                dataName,
+              );
+              if (data) {
+                const record = this.dataToRecord(
+                  data,
+                  modelType,
+                  modelId,
+                  dataName,
+                  undefined,
+                  ns.modelName,
+                );
+                latestCache.set(cacheKey, record);
+                return record;
+              }
+            }
+          }
+
+          // Fallback to the catalog for orphan data (no matching definition).
+          // Parse the resolved namespace from the predicate for cross-namespace
+          // lookups (e.g. "security:scanner" → namespace "security").
+          if (this.dataQueryService) {
+            const targetNs = ns.namespacePredicate
+              ? ns.namespacePredicate.match(
+                /ns == "([^"]*)"/,
+              )?.[1]
+              : (ownNamespace || undefined);
+            const record = await this.dataQueryService.getLatestRecord(
+              ns.modelName,
+              dataName,
+              targetNs,
+            );
+            latestCache.set(cacheKey, record);
+            return record;
+          }
+
+          latestCache.set(cacheKey, null);
+          return null;
+        }
+
+        // Wildcard lookups fall back to the catalog query path.
+        if (!this.dataQueryService) return null;
         const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
           `&& name == "${escapeCelString(dataName)}"` +
           ns.namespacePredicate;
         const results = await this.dataQueryService.query(predicate, {
-          limit: ns.isWildcard ? undefined : 1,
           loadAttributes: true,
         }) as DataRecord[];
-        if (ns.isWildcard) {
-          checkWildcardAmbiguity(results, rawModelName);
-        }
+        checkWildcardAmbiguity(results, rawModelName);
         return results.length > 0 ? results[0] : null;
       },
       listVersions: (rawModelName: string, dataName: string): number[] => {

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -511,7 +511,7 @@ export class ModelResolver {
       // loaded only when its .resource or .file is accessed in a CEL expression.
       // The getter replaces itself with the loaded value after first access.
       const dataRepo = this.dataRepo;
-      const self = this;
+      const boundDataToRecord = this.dataToRecord.bind(this);
       let orphanData:
         | Array<{ data: Data; modelType: ModelType; modelId: string }>
         | null = null;
@@ -535,7 +535,7 @@ export class ModelResolver {
             const items = dataRepo.findAllForModelSync(mt, mid);
             for (const data of items) {
               if (data.isRenamed) continue;
-              const latestRecord = self.dataToRecord(
+              const latestRecord = boundDataToRecord(
                 data,
                 mt,
                 mid,
@@ -592,7 +592,7 @@ export class ModelResolver {
             for (const { data, modelType: mt, modelId: mid } of orphanData) {
               if (data.isRenamed) continue;
               if (data.tags["modelName"] !== defName) continue;
-              const latestRecord = self.dataToRecord(
+              const latestRecord = boundDataToRecord(
                 data,
                 mt,
                 mid,

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -27,6 +27,7 @@ import type { Data } from "../data/data.ts";
 import type { DataRecord } from "../data/data_record.ts";
 import type { DataQueryService } from "../data/data_query_service.ts";
 import { isTextContentType } from "../data/content_type.ts";
+import { resolveVaultRefsInData } from "../models/data_writer.ts";
 import { ModelNotFoundError } from "./errors.ts";
 import { parseNamespacedModelName } from "../data/namespace.ts";
 import type { Namespace } from "../data/namespace.ts";
@@ -748,6 +749,14 @@ export class ModelResolver {
                   undefined,
                   ns.modelName,
                 );
+                if (record && Object.keys(record.attributes).length > 0) {
+                  try {
+                    const vs = await this.getVaultService();
+                    await resolveVaultRefsInData(record.attributes, vs);
+                  } catch {
+                    // Vault unavailable — leave refs unresolved
+                  }
+                }
                 latestCache.set(cacheKey, record);
                 return record;
               }

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -200,6 +200,7 @@ export class CatalogStore {
       CREATE INDEX IF NOT EXISTS idx_catalog_step_name       ON catalog(step_name);
       CREATE INDEX IF NOT EXISTS idx_namespace               ON catalog(namespace);
       CREATE INDEX IF NOT EXISTS idx_catalog_is_latest       ON catalog(namespace, type_normalized, model_id, data_name, is_latest);
+      CREATE INDEX IF NOT EXISTS idx_catalog_latest_lookup  ON catalog(model_name, data_name, is_latest, namespace);
 
       CREATE TABLE IF NOT EXISTS catalog_meta (
         key   TEXT PRIMARY KEY,
@@ -559,6 +560,36 @@ export class CatalogStore {
       if (rows.length < ITERATE_PAGE_SIZE) break;
       offset += ITERATE_PAGE_SIZE;
     }
+  }
+
+  /**
+   * Direct indexed lookup for a single latest row by model name, data name,
+   * and optional namespace. Uses the idx_catalog_latest_lookup composite
+   * index instead of a full table scan.
+   */
+  findLatestRow(
+    modelName: string,
+    dataName: string,
+    namespace?: string,
+  ): CatalogRow | null {
+    if (namespace !== undefined) {
+      const stmt = this.db.prepare(
+        `SELECT * FROM catalog
+         WHERE model_name = ? AND data_name = ? AND is_latest = 1 AND namespace = ?
+         ORDER BY rowid DESC LIMIT 1`,
+      );
+      return (stmt.get(
+        modelName,
+        dataName,
+        namespace,
+      ) as unknown as CatalogRow) ?? null;
+    }
+    const stmt = this.db.prepare(
+      `SELECT * FROM catalog
+       WHERE model_name = ? AND data_name = ? AND is_latest = 1
+       ORDER BY rowid DESC LIMIT 1`,
+    );
+    return (stmt.get(modelName, dataName) as unknown as CatalogRow) ?? null;
   }
 
   /**

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -200,7 +200,7 @@ export class CatalogStore {
       CREATE INDEX IF NOT EXISTS idx_catalog_step_name       ON catalog(step_name);
       CREATE INDEX IF NOT EXISTS idx_namespace               ON catalog(namespace);
       CREATE INDEX IF NOT EXISTS idx_catalog_is_latest       ON catalog(namespace, type_normalized, model_id, data_name, is_latest);
-      CREATE INDEX IF NOT EXISTS idx_catalog_latest_lookup  ON catalog(model_name, data_name, is_latest, namespace);
+      CREATE INDEX IF NOT EXISTS idx_catalog_latest_lookup ON catalog(model_name, data_name, is_latest, namespace);
 
       CREATE TABLE IF NOT EXISTS catalog_meta (
         key   TEXT PRIMARY KEY,

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -922,3 +922,82 @@ Deno.test("bulkUpsertForeign: updates existing foreign rows in place", () => {
 
   store.close();
 });
+
+Deno.test(
+  "CatalogStore: findLatestRow returns the latest row by model name and data name",
+  () => {
+    const store = new CatalogStore(makeTempDbPath());
+    store.upsert(
+      makeRow({
+        model_name: "my-model",
+        data_name: "my-data",
+        version: 1,
+        is_latest: 0,
+      }),
+    );
+    store.upsert(
+      makeRow({
+        model_name: "my-model",
+        data_name: "my-data",
+        version: 2,
+        is_latest: 1,
+      }),
+    );
+
+    const row = store.findLatestRow("my-model", "my-data");
+    assertEquals(row?.version, 2);
+    assertEquals(row?.is_latest, 1);
+    assertEquals(row?.model_name, "my-model");
+
+    store.close();
+  },
+);
+
+Deno.test(
+  "CatalogStore: findLatestRow returns null for non-existent data",
+  () => {
+    const store = new CatalogStore(makeTempDbPath());
+    store.upsert(
+      makeRow({ model_name: "my-model", data_name: "my-data" }),
+    );
+
+    assertEquals(store.findLatestRow("other-model", "my-data"), null);
+    assertEquals(store.findLatestRow("my-model", "other-data"), null);
+
+    store.close();
+  },
+);
+
+Deno.test(
+  "CatalogStore: findLatestRow scopes by namespace when provided",
+  () => {
+    const store = new CatalogStore(makeTempDbPath());
+    store.upsert(makeRow({
+      namespace: "ns-a",
+      model_name: "shared-model",
+      data_name: "shared-data",
+      model_id: "id-a",
+      id: "uuid-a",
+    }));
+    store.upsert(makeRow({
+      namespace: "ns-b",
+      model_name: "shared-model",
+      data_name: "shared-data",
+      model_id: "id-b",
+      id: "uuid-b",
+    }));
+
+    const rowA = store.findLatestRow("shared-model", "shared-data", "ns-a");
+    assertEquals(rowA?.id, "uuid-a");
+
+    const rowB = store.findLatestRow("shared-model", "shared-data", "ns-b");
+    assertEquals(rowB?.id, "uuid-b");
+
+    assertEquals(
+      store.findLatestRow("shared-model", "shared-data", "ns-c"),
+      null,
+    );
+
+    store.close();
+  },
+);


### PR DESCRIPTION
## Summary

- `data.latest()` CEL expressions now use a direct O(1) filesystem lookup (same path as `swamp data get`) instead of scanning the full SQLite catalog per expression
- `model.resource` and `model.file` are lazy-loaded via self-replacing getters — data is only read when a CEL expression accesses `.resource` or `.file`
- Adds a composite catalog index and `getLatestRecord()` for the indexed fallback path (orphan data without a matching definition)

**Before:** `model evaluate` with 20K data items: ~17s (reporter saw 30-35s with larger datastore)
**After:** `model evaluate` with 20K data items: ~1.7s (matches `data get` at ~1.6s)

Fixes swamp-club#918. Filed swamp-club#919 for the remaining edge case (catalog backfill in orphan fallback path).

## Test Plan

- All 8091 existing tests pass (unit + integration)
- Added 3 tests for `CatalogStore.findLatestRow` (direct lookup, null case, namespace scoping)
- Verified cross-model resource references, orphan UUID recovery, cross-namespace lookups, and wildcard ambiguity via existing integration tests in `cel_data_access_test.ts` and `giga_swamp_cel_namespace_test.ts`
- Benchmarked before/after with a 20K-item scratch repo at `/tmp/swamp-repro-issue-918`