### PR TITLE
fix(extensions): exclude skill dir entries from legacy layout warning (swamp-club#920)

### DIFF
--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -24,7 +24,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import {
   createExtensionListDeps,
   createLibSwampContext,
@@ -39,6 +39,8 @@ import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import {
   createExtensionListRenderer,
   type EnrichedExtensionListEntry,
@@ -151,9 +153,15 @@ export const extensionListCommand = withRemoteOptions(
   const modelsDir = resolveModelsDir(marker);
   const absoluteModelsDir = resolve(repoDir, modelsDir);
   const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const tool = resolvePrimaryTool(marker);
+  const skillsDirRelative = relative(
+    repoDir,
+    resolveSkillsDir(repoDir, tool),
+  );
   await warnLegacyExtensionLayout(
     lockfilePath,
     (msg) => cliCtx.logger.warn(msg),
+    skillsDirRelative,
   );
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -19,7 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import type { Logger } from "@logtape/logtape";
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import type { DenoRuntime } from "../../domain/runtime/deno_runtime.ts";
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
@@ -239,20 +239,14 @@ export const extensionPullCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    // 5. Warn if any extensions are still in a legacy layout. We don't
-    // block — the lockfile tolerates mixed generations and the new pull
-    // writes to the per-extension subtree regardless.
+    const tool = resolvePrimaryTool(marker);
+    const skillsDir = resolveSkillsDir(repoDir, tool);
+    const skillsDirRelative = relative(repoDir, skillsDir);
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => ctx.logger.warn(msg),
+      skillsDirRelative,
     );
-
-    // 6. Resolve skills destination (tool-aware). Per-extension
-    // models/workflows/vaults/drivers/datastores/reports destinations
-    // are derived inside installExtension from `ref.name` — the CLI
-    // doesn't need to compute them.
-    const tool = resolvePrimaryTool(marker);
-    const skillsDir = resolveSkillsDir(repoDir, tool);
 
     // 7. Construct W2 service deps (denoRuntime + ExtensionRepository)
     // so phase 8 fires synchronously at install time. Both are required

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
@@ -26,6 +26,8 @@ import {
 } from "../context.ts";
 import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
+import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import {
   consumeStream,
   createExtensionRmDeps,
@@ -120,11 +122,15 @@ export const extensionRemoveCommand = withRemoteOptions(
   const absoluteModelsDir = resolve(repoDir, modelsDir);
   const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-  // Warn if any extensions are still in a legacy layout. rm follows
-  // the lockfile's tracked paths so it works against either generation.
+  const tool = resolvePrimaryTool(marker);
+  const skillsDirRelative = relative(
+    repoDir,
+    resolveSkillsDir(repoDir, tool),
+  );
   await warnLegacyExtensionLayout(
     lockfilePath,
     (msg) => ctx.logger.warn(msg),
+    skillsDirRelative,
   );
 
   // Create libswamp context, deps, renderer.

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
@@ -260,11 +260,14 @@ export const extensionSearchCommand = withRemoteOptions(
       "upstream_extensions.json",
     );
 
-    // Warn (don't block) on legacy layout. The pull that follows writes
-    // to the per-extension subtree regardless of existing layout state.
+    const skillsDirRelative = relative(
+      repoDir,
+      resolveSkillsDir(repoDir, resolvePrimaryTool(marker)),
+    );
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => ctx.logger.warn(msg),
+      skillsDirRelative,
     );
 
     const lockfileRepository = await LockfileRepository.create(lockfilePath);

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { join, resolve } from "@std/path";
+import { join, relative, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
@@ -86,12 +86,11 @@ export const extensionUpdateCommand = new Command()
     const tool = resolvePrimaryTool(marker);
     const skillsDir = resolveSkillsDir(repoDir, tool);
 
-    // 3. Warn (don't block) on legacy layout. update pulls new versions
-    // which write to the per-extension subtree, migrating each extension
-    // as it goes.
+    const skillsDirRelative = relative(repoDir, skillsDir);
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => cliCtx.logger.warn(msg),
+      skillsDirRelative,
     );
 
     // 4. Parse extension name if given

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -248,10 +248,19 @@ export function extractTopLevelRoot(
  * Returns a flat list of legacy entries (both gen-1 and gen-2) with their
  * generation tag so the upgrade migrator can branch.
  *
+ * `skillsDirRelative` (when provided, repo-relative) filters skill
+ * directory entries out of legacy classification — they are always
+ * considered current-layout regardless of physical location. Without
+ * this filter, the `tool=none` fallback at
+ * `.swamp/pulled-extensions/skills/<name>` is structurally identical to
+ * a gen-2 path and would be falsely flagged as legacy.
+ *
  * @param lockfilePath Full path to upstream_extensions.json
+ * @param skillsDirRelative Repo-relative skills directory path
  */
 export async function detectLegacyExtensionLayout(
   lockfilePath: string,
+  skillsDirRelative?: string,
 ): Promise<LegacyFileEntry[]> {
   const repo = await LockfileRepository.create(lockfilePath);
   const upstream = repo.getAllEntries();
@@ -260,6 +269,9 @@ export async function detectLegacyExtensionLayout(
   for (const [name, entry] of Object.entries(upstream)) {
     if (!entry.files) continue;
     for (const file of entry.files) {
+      if (isSkillDirEntry(file, skillsDirRelative)) {
+        continue;
+      }
       const generation = classifyExtensionFile(file);
       if (generation === "gen-1" || generation === "gen-2") {
         legacy.push({ extensionName: name, file, generation });
@@ -320,13 +332,21 @@ export function summariseLegacyLayout(
  * @param warn Invoked with a short human-readable message when legacy
  *   entries exist. Callers typically wire this to their logger's warn
  *   channel.
+ * @param skillsDirRelative Repo-relative skills directory path; filters
+ *   skill dir entries out of legacy classification so the `tool=none`
+ *   fallback at `.swamp/pulled-extensions/skills/<name>` is not falsely
+ *   flagged as gen-2.
  * @returns The legacy summary, or `undefined` if everything is current.
  */
 export async function warnLegacyExtensionLayout(
   lockfilePath: string,
   warn: (message: string) => void,
+  skillsDirRelative?: string,
 ): Promise<LegacyLayoutSummary | undefined> {
-  const legacy = await detectLegacyExtensionLayout(lockfilePath);
+  const legacy = await detectLegacyExtensionLayout(
+    lockfilePath,
+    skillsDirRelative,
+  );
   if (legacy.length === 0) return undefined;
   const summary = summariseLegacyLayout(legacy);
   warn(

--- a/src/libswamp/extensions/layout_test.ts
+++ b/src/libswamp/extensions/layout_test.ts
@@ -285,6 +285,72 @@ Deno.test("detectLegacyExtensionLayout: mixed generations in one lockfile", asyn
   }
 });
 
+Deno.test("detectLegacyExtensionLayout: excludes skill dir entries when skillsDirRelative provided", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@magistr/good-planning": {
+          version: "2026.06.12.1",
+          pulledAt: "2026-06-12T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/@magistr/good-planning/models/plan.ts",
+            ".swamp/pulled-extensions/skills/good-planning",
+          ],
+        },
+      }),
+    );
+
+    const withFilter = await detectLegacyExtensionLayout(
+      lockfilePath,
+      ".swamp/pulled-extensions/skills",
+    );
+    assertEquals(withFilter, []);
+
+    const withoutFilter = await detectLegacyExtensionLayout(lockfilePath);
+    assertEquals(withoutFilter.length, 1);
+    assertEquals(
+      withoutFilter[0].file,
+      ".swamp/pulled-extensions/skills/good-planning",
+    );
+    assertEquals(withoutFilter[0].generation, "gen-2");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("detectLegacyExtensionLayout: skill filter does not hide real gen-2 entries", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@scope/ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/models/foo.ts",
+            ".swamp/pulled-extensions/skills/good-planning",
+          ],
+        },
+      }),
+    );
+
+    const legacy = await detectLegacyExtensionLayout(
+      lockfilePath,
+      ".swamp/pulled-extensions/skills",
+    );
+    assertEquals(legacy.length, 1);
+    assertEquals(legacy[0].file, ".swamp/pulled-extensions/models/foo.ts");
+    assertEquals(legacy[0].generation, "gen-2");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("detectLegacyExtensionLayout: returns empty when lockfile missing", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
   try {
@@ -346,6 +412,45 @@ Deno.test("warnLegacyExtensionLayout: warns on legacy, returns summary", async (
       messages[0],
       "1 extension(s) pending migration. Run 'swamp repo upgrade' to complete.",
     );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("warnLegacyExtensionLayout: silent when all legacy-looking entries are skill dirs", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@magistr/good-planning": {
+          version: "2026.06.12.1",
+          pulledAt: "2026-06-12T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/@magistr/good-planning/models/plan.ts",
+            ".swamp/pulled-extensions/skills/good-planning",
+          ],
+        },
+        "@magistr/fc-agent-proxy": {
+          version: "2026.06.12.1",
+          pulledAt: "2026-06-12T00:00:00Z",
+          files: [
+            ".swamp/pulled-extensions/@magistr/fc-agent-proxy/models/proxy.ts",
+            ".swamp/pulled-extensions/skills/fc-agent-proxy",
+          ],
+        },
+      }),
+    );
+
+    const messages: string[] = [];
+    const summary = await warnLegacyExtensionLayout(
+      lockfilePath,
+      (msg) => messages.push(msg),
+      ".swamp/pulled-extensions/skills",
+    );
+    assertEquals(summary, undefined);
+    assertEquals(messages, []);
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

Closes swamp-club#920.

- `detectLegacyExtensionLayout` and `warnLegacyExtensionLayout` now accept an optional `skillsDirRelative` parameter and filter skill dir entries via `isSkillDirEntry` before classification — matching the existing install flow in `needsInstallOrMigration`
- All 5 CLI callers (`extension rm`, `extension search`, `extension update`, `extension list`, `extension pull`) compute and pass `skillsDirRelative`
- Skill paths at `.swamp/pulled-extensions/skills/<name>` (the fallback for unrecognized tools like `pi`) are no longer falsely flagged as gen-2 legacy

### Root cause

PR #1279 added `isSkillDirEntry` filtering to `needsInstallOrMigration` and `sweepLegacyPaths` to prevent destructive sweep of skill directories during migration, but did not add the same filter to `detectLegacyExtensionLayout` which drives the warning. The `tool=none`/unrecognized-tool fallback path `.swamp/pulled-extensions/skills/<name>` is structurally identical to a gen-2 path, so the warning misclassified it as legacy while the install flow correctly treated it as current.

## Test Plan

- Added 3 new unit tests in `layout_test.ts`:
  - `detectLegacyExtensionLayout` excludes skill dir entries when `skillsDirRelative` provided
  - Skill filter does not hide real gen-2 entries
  - `warnLegacyExtensionLayout` stays silent when all legacy-looking entries are skill dirs
- Verified against reproduction: created a `tools: ["pi"]` repo with `.swamp/pulled-extensions/skills/good-planning` in the lockfile — production binary warns falsely, fixed binary does not
- Full test suite passes (8094 tests)