### PR TITLE
fix(agent): suggest repo upgrade in already initialized repos

### DIFF
--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -36,6 +36,9 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { RepoService } from "../../domain/repo/repo_service.ts";
+import { VERSION } from "./version.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -220,6 +223,13 @@ Some tools need a header like this to auto-load rules:
 
     await addCustomTool(repoDir, def);
 
+    const repoPath = RepoPath.create(repoDir);
+    const repoService = new RepoService(VERSION);
+    const isInitialized = await repoService.isInitialized(repoPath);
+    const setupCommand = isInitialized
+      ? `swamp repo upgrade --tool ${name}`
+      : `swamp repo init --tool ${name}`;
+
     await Deno.stdout.write(encoder.encode(`
 Custom agent "${name}" configured:
   Skills:        ${def.skillsDir}/
@@ -229,7 +239,7 @@ Custom agent "${name}" configured:
   Frontmatter:   ${def.frontmatter ? "yes" : "none"}
 
 Saved to .swamp-custom-tools.yaml
-Run \`swamp repo init --tool ${name}\` to set up this repo.
+Run \`${setupCommand}\` to set up this repo.
 `));
 
     cliCtx.logger.debug`Agent setup completed for ${name}`;


### PR DESCRIPTION
## Summary

- `swamp agent setup` now detects whether the current directory is already an initialized swamp repository
- If initialized: suggests `swamp repo upgrade --tool <name>` instead of `swamp repo init --tool <name>`
- If not initialized: continues to suggest `swamp repo init --tool <name>` (unchanged behavior)

Fixes swamp-club#931

## Test Plan

- `deno check` — passes
- `deno lint` — passes
- `deno fmt --check` — passes
- `deno run test` — all 8094 tests pass
- Manual verification: `swamp agent setup` in an initialized repo shows `repo upgrade`; in an uninitialized directory shows `repo init`