### PR TITLE
fix(extensions): preserve source-mounted catalog rows in pruneUnreachableSources (swamp-club#928)

### DIFF
--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -1161,7 +1161,10 @@ export class ExtensionCatalogStore {
    * from prior container sessions (bind-mounted at a different path)
    * don't block catalog writes.
    */
-  pruneUnreachableSources(canonicalRepoRoot: string): string[] {
+  pruneUnreachableSources(
+    canonicalRepoRoot: string,
+    protectedPaths?: ReadonlySet<string>,
+  ): string[] {
     const prefix = canonicalRepoRoot.endsWith("/")
       ? canonicalRepoRoot
       : canonicalRepoRoot + "/";
@@ -1169,7 +1172,9 @@ export class ExtensionCatalogStore {
     const pruned: string[] = [];
     for (const row of rows) {
       if ((row.state ?? "Indexed") === "Tombstoned") continue;
-      if (!canonicalizePath(row.source_path).startsWith(prefix)) {
+      const canonical = canonicalizePath(row.source_path);
+      if (protectedPaths?.has(canonical)) continue;
+      if (!canonical.startsWith(prefix)) {
         this.removeBySourcePath(row.source_path);
         pruned.push(row.source_path);
       }

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -2053,6 +2053,47 @@ Deno.test("pruneUnreachableSources: preserves all rows under the repo root", () 
   store.close();
 });
 
+Deno.test("pruneUnreachableSources: preserves rows in protectedPaths even if outside repo root", () => {
+  const dbPath = makeTempDbPath();
+  const repoRoot = canonicalizePath(dirname(dirname(dbPath)));
+  const store = new ExtensionCatalogStore(dbPath);
+
+  const externalPath = "/external/repo/extensions/models/ext.ts";
+  const stalePath =
+    "/workspace/.swamp/pulled-extensions/@swamp/echo/models/echo.ts";
+
+  store.upsert(
+    makeRow({
+      source_path: join(repoRoot, "extensions", "models", "local.ts"),
+      type_normalized: "@test/local",
+      kind: "model",
+    }),
+  );
+  store.upsert(
+    makeRow({
+      source_path: externalPath,
+      type_normalized: "@test/ext",
+      kind: "model",
+    }),
+  );
+  store.upsert(
+    makeRow({
+      source_path: stalePath,
+      type_normalized: "@swamp/echo",
+      kind: "model",
+    }),
+  );
+
+  const protectedPaths = new Set([externalPath]);
+  const pruned = store.pruneUnreachableSources(repoRoot, protectedPaths);
+
+  assertEquals(pruned.length, 1);
+  assertEquals(pruned[0], stalePath);
+  assertEquals(store.findAll().length, 2);
+
+  store.close();
+});
+
 // ── resolveOriginConflicts ──────────────────────────────────────────
 
 Deno.test("resolveOriginConflicts: no-op when no pulled rows exist", () => {

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -220,10 +220,19 @@ export class ExtensionRepository {
    */
   saveAll(extensions: readonly Extension[]): void {
     this.catalog.runInTransaction(() => {
+      const protectedPaths = new Set<string>();
       for (const ext of extensions) {
+        for (const source of ext.sources.values()) {
+          if (source.state.tag !== "Tombstoned") {
+            protectedPaths.add(source.id.canonicalPath);
+          }
+        }
         this.applyDiffForExtension(ext);
       }
-      const pruned = this.catalog.pruneUnreachableSources(this.repoRoot);
+      const pruned = this.catalog.pruneUnreachableSources(
+        this.repoRoot,
+        protectedPaths,
+      );
       if (pruned.length > 0) {
         logger
           .info`Pruned ${pruned.length} catalog row(s) with unreachable source path(s)`;

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -989,3 +989,67 @@ Deno.test("ExtensionRepository: primary rows and ValidationFailed extension rows
     assertEquals(brokenRow.extends_type, "");
   });
 });
+
+// ===== saveAll preserves source-mounted extension rows =====
+Deno.test("ExtensionRepository: saveAll preserves source-mounted rows outside repo root", () => {
+  withRepository((repo, cat, repoRoot) => {
+    const externalSourcePath =
+      "/external/arch-cloud-init/extensions/models/arch_cloud_init.ts";
+    const bundlePath = join(
+      repoRoot,
+      ".swamp",
+      "bundles",
+      "a1b2c3d4",
+      "models",
+      "arch_cloud_init.js",
+    );
+
+    const localSource = makeSource({
+      id: makeSourceLocation(
+        join(repoRoot, "extensions", "models", "local.ts"),
+        repoRoot,
+      ),
+      kind: "model",
+      fingerprint: "fp-local",
+      state: {
+        tag: "Indexed",
+        type: "@test/local",
+        bundle: makeBundleLocation(
+          join(repoRoot, ".swamp", "bundles", "local.js"),
+          "fp-local",
+        ),
+      },
+      sourceMtime: "2026-01-15T10:00:00.000Z",
+    });
+
+    const sourceMountedSource = makeSource({
+      id: makeSourceLocation(externalSourcePath, repoRoot),
+      kind: "model",
+      fingerprint: "fp-ext",
+      state: {
+        tag: "Indexed",
+        type: "@test/ext-model",
+        bundle: makeBundleLocation(bundlePath, "fp-ext"),
+      },
+      sourceMtime: "2026-01-15T10:00:00.000Z",
+    });
+
+    const ext = makeExtension({
+      name: "@local/test",
+      version: "0.0.0",
+      origin: "local",
+      extensionRoot: repoRoot,
+      sources: [localSource, sourceMountedSource],
+    });
+
+    repo.saveAll([ext]);
+
+    const rows = cat.findAll();
+    assertEquals(rows.length, 2, "both local and source-mounted rows survive");
+    const sourcePaths = rows.map((r) => r.source_path).sort();
+    assert(
+      sourcePaths.some((p) => p === canonicalizePath(externalSourcePath)),
+      "source-mounted row preserved",
+    );
+  });
+});

--- a/src/libswamp/extensions/doctor_aggregate_test.ts
+++ b/src/libswamp/extensions/doctor_aggregate_test.ts
@@ -173,6 +173,52 @@ Deno.test("buildAggregateState: detects bundle orphans", async () => {
   });
 });
 
+Deno.test("buildAggregateState: source-mounted bundle not reported as orphan", async () => {
+  await withTempDir(async (dir) => {
+    // Create a bundle file under .swamp/bundles/ for a source-mounted
+    // extension (source path is outside the repo root).
+    const bundleDir = join(dir, ".swamp", "bundles", "a1b2c3d4", "models");
+    await ensureDir(bundleDir);
+    const bundleFile = join(bundleDir, "ext_model.js");
+    await Deno.writeTextFile(bundleFile, "// source-mounted bundle");
+
+    const bundle = makeBundleLocation(bundleFile, "fp-ext");
+
+    // The source file is outside the repo root — this simulates a
+    // source-mounted extension.
+    const externalSourcePath = "/external/repo/extensions/models/ext_model.ts";
+    const source = makeSource({
+      id: makeSourceLocation(externalSourcePath, dir),
+      kind: "model",
+      fingerprint: "fp-ext",
+      state: { tag: "Indexed", type: "@test/ext-model", bundle },
+      sourceMtime: "2026-01-01T00:00:00.000Z",
+    });
+
+    const ext = makeExtension({
+      name: "@local/test",
+      version: "0.0.0",
+      origin: "local",
+      extensionRoot: dir,
+      sources: [source],
+    });
+
+    const report = await buildAggregateState({
+      extensions: [ext],
+      repoDir: dir,
+    });
+
+    assertEquals(
+      report.bundleOrphans.length,
+      0,
+      "Source-mounted bundle should not be an orphan",
+    );
+    assertEquals(report.orphanBundleFileCount, 0);
+    assertEquals(report.totalSources, 1);
+    assertEquals(report.healthySources, 1);
+  });
+});
+
 Deno.test("buildAggregateState: all 7 RowState tags counted", async () => {
   await withTempDir(async (dir) => {
     const bundle = makeBundleLocation(


### PR DESCRIPTION
## Summary

- `pruneUnreachableSources` (added in ba6bb4b0 for swamp-club#574) deleted any
  catalog row whose `source_path` was outside the repo root. Source-mounted
  extensions legitimately have external source paths (from `.swamp-sources.yaml`),
  so their rows were immediately pruned after the reconcile wrote them — leaving
  bundle files orphaned on disk.
- Fix: `saveAll` now collects all non-Tombstoned source paths from the extensions
  being saved and passes them as a `protectedPaths` set to
  `pruneUnreachableSources`, which skips rows in the set even if they're outside
  the repo root. This preserves source-mounted rows while still cleaning up stale
  cross-mount artifacts.

Fixes swamp-club#928

## Test Plan

- Added unit test for `pruneUnreachableSources` with `protectedPaths` parameter
  — verifies protected external rows survive while unprotected stale rows are
  pruned
- Added `saveAll` integration test verifying source-mounted extension rows
  (outside repo root) survive the transaction
- Added `buildAggregateState` regression test with source-mounted-like extension
  — verifies bundle files referenced by external sources are not reported as
  orphans
- Verified with compiled binary against scratch repo with source-mounted
  extension: `doctor extensions --repair` + `doctor extensions --json` produces
  `bundleOrphans: 0` and is idempotent
- All existing tests pass (8093 passed, 1 pre-existing flaky SIGINT test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)