### PR TITLE
feat(data): implement ephemeral data as in-memory repository (swamp-club#663)

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -643,3 +643,54 @@ CatalogStore  CelEvaluator
 
 Both `CatalogStore` and `DataQueryService` are wired through
 `RepositoryContext` via `createRepositoryContext()`.
+
+## Ephemeral Data
+
+Data with `lifetime: "ephemeral"` lives only in memory for the duration of a
+workflow run or method run. It uses a parallel in-memory stack:
+
+- **`InMemoryUnifiedDataRepository`** — `Map`-based storage, no disk I/O.
+  `allocateVersion` creates a temp file for `DataWriter` compatibility;
+  `finalizeVersion` reads it into memory and deletes it.
+- **`:memory:` `CatalogStore`** — a separate SQLite instance so queries work
+  transparently. Marked as pre-populated to skip filesystem backfill.
+- **`CompositeUnifiedDataRepository`** — wraps the filesystem and in-memory
+  repos. Writes route by `data.lifetime === "ephemeral"`. Reads check ephemeral
+  first, fall back to persistent. `data.latest()` resolves transparently.
+- **`CompositeDataQueryService`** — merges query results from both catalogs
+  with deduplication.
+
+### Lifecycle scoping
+
+The ephemeral store is created at the start of each execution and disposed in
+the `finally` block:
+
+- **Workflow runs** — `workflowRun()` creates the store, passes it through
+  `createExecutionService` → `WorkflowExecutionService` constructor. All steps
+  share the same store so downstream steps can read upstream ephemeral data.
+- **Standalone method runs** — `modelMethodRun()` creates and disposes its own
+  store.
+- **Workflow resume** — a fresh store is created. Ephemeral data from before
+  suspension is lost (by design — use `"workflow"` or `"infinite"` lifetime for
+  data that must survive suspension).
+
+### Definition-level overrides
+
+Definitions can override a model type's default resource lifetime:
+
+```yaml
+resources:
+  result:
+    lifetime: ephemeral
+    garbageCollection: 3
+```
+
+These are converted to `dataOutputOverrides` and merged with any workflow step
+overrides (step wins).
+
+### Remote execution
+
+Each `ActiveDispatch` carries the per-execution composite repo. The data plane
+resolves `dispatch.dataRepo` for each worker's reads and writes, so remote
+workers transparently access ephemeral data through the same composite as local
+steps.

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -84,7 +84,8 @@ function isTracingImport(filePath: string, importPath: string): boolean {
 // the domain layer when the catalog gets fully replaced (W4).
 // W4: +2 net (5 user_*_loader.ts deleted, 7 KindAdapter + ExtensionLoader
 // files added — adapters require ExtensionTypeRow + SWAMP_SUBDIRS imports).
-const KNOWN_DOMAIN_INFRA_VIOLATIONS = 25;
+// +1 for CompositeDataQueryService extending DataQueryService (same CatalogStore import)
+const KNOWN_DOMAIN_INFRA_VIOLATIONS = 26;
 
 Deno.test(
   "domain layer must not add new infrastructure imports (ratchet)",

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -53,8 +53,7 @@ import {
   mapWorkflowExecutionEvent,
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
-import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
 import { GIT_SHA } from "./version.ts";
 import {
   deepMerge,
@@ -330,10 +329,9 @@ export const workflowResumeCommand = withRemoteOptions(
       };
     };
 
-    const ephemeralCatalog = new CatalogStore(":memory:");
-    const ephemeralRepo = new InMemoryUnifiedDataRepository(
-      ephemeralCatalog,
+    const ephemeral = createEphemeralStore(
       repoContext.unifiedDataRepo.namespace,
+      { isResume: true },
     );
 
     const service = new WorkflowExecutionService(
@@ -348,8 +346,8 @@ export const workflowResumeCommand = withRemoteOptions(
       repoContext.unifiedDataRepo.namespace,
       stepLockHook,
       RunTrackerStore.fromSwampDir(swampPath(repoDir)),
-      ephemeralRepo,
-      ephemeralCatalog,
+      ephemeral.repo,
+      ephemeral.catalog,
     );
 
     const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
@@ -371,7 +369,11 @@ export const workflowResumeCommand = withRemoteOptions(
       }
     };
 
-    await consumeStream(resumeGenerator(), renderer.handlers());
+    try {
+      await consumeStream(resumeGenerator(), renderer.handlers());
+    } finally {
+      ephemeral.dispose();
+    }
 
     if (renderer.workflowFailed()) {
       Deno.exitCode = 1;

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -53,6 +53,8 @@ import {
   mapWorkflowExecutionEvent,
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
 import { GIT_SHA } from "./version.ts";
 import {
   deepMerge,
@@ -328,6 +330,12 @@ export const workflowResumeCommand = withRemoteOptions(
       };
     };
 
+    const ephemeralCatalog = new CatalogStore(":memory:");
+    const ephemeralRepo = new InMemoryUnifiedDataRepository(
+      ephemeralCatalog,
+      repoContext.unifiedDataRepo.namespace,
+    );
+
     const service = new WorkflowExecutionService(
       workflowRepo,
       runRepo,
@@ -340,6 +348,8 @@ export const workflowResumeCommand = withRemoteOptions(
       repoContext.unifiedDataRepo.namespace,
       stepLockHook,
       RunTrackerStore.fromSwampDir(swampPath(repoDir)),
+      ephemeralRepo,
+      ephemeralCatalog,
     );
 
     const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -53,7 +53,7 @@ import {
   mapWorkflowExecutionEvent,
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
-import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
+import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import { GIT_SHA } from "./version.ts";
 import {
   deepMerge,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -276,7 +276,14 @@ export const workflowRunCommand = new Command()
           return await repo.findByName(idOrName) ??
             await repo.findById(createWorkflowId(idOrName));
         },
-        createExecutionService: (wfRepo, rnRepo, dir, catalogStore) => {
+        createExecutionService: (
+          wfRepo,
+          rnRepo,
+          dir,
+          catalogStore,
+          ephRepo,
+          ephCatalog,
+        ) => {
           const directResolver: DirectTypeResolver = async (
             typeArg,
             defName,
@@ -356,6 +363,8 @@ export const workflowRunCommand = new Command()
             repoContext.unifiedDataRepo.namespace,
             stepLockHook,
             tracker,
+            ephRepo,
+            ephCatalog,
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/domain/data/composite_data_query_service.ts
+++ b/src/domain/data/composite_data_query_service.ts
@@ -23,6 +23,8 @@ import {
   DataQueryService,
   type ForeignContentFetcher,
 } from "./data_query_service.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import type { UnifiedDataRepository } from "./repositories.ts";
 import type { VaultService } from "../vaults/vault_service.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
 
@@ -50,24 +52,11 @@ export class CompositeDataQueryService extends DataQueryService {
   private readonly ephemeralQueryService: DataQueryService;
 
   constructor(
-    persistentQueryService: DataQueryService,
+    persistentCatalog: CatalogStore,
+    persistentRepo: UnifiedDataRepository,
     ephemeralQueryService: DataQueryService,
   ) {
-    // Inherit the persistent query service's catalog and repo via accessing
-    // its internal state is not possible, so we use a delegation pattern.
-    // We extend DataQueryService but override query/querySync to merge.
-    // The super constructor is called but we won't use its catalog — we
-    // delegate all calls to the two backing services.
-    //
-    // NOTE: We need access to the persistent service's catalog and repo for
-    // the super() call. Since DataQueryService doesn't expose these, we use
-    // the persistent service directly and override the query methods.
-    super(
-      // deno-lint-ignore no-explicit-any
-      (persistentQueryService as any).catalogStore,
-      // deno-lint-ignore no-explicit-any
-      (persistentQueryService as any).dataRepo,
-    );
+    super(persistentCatalog, persistentRepo);
     this.ephemeralQueryService = ephemeralQueryService;
   }
 
@@ -93,6 +82,7 @@ export class CompositeDataQueryService extends DataQueryService {
       this.ephemeralQueryService.query(predicate, options),
     ]);
 
+    // Projections (select) return opaque values — dedup is not possible
     if (options?.select) {
       return [
         ...(ephemeralResults as unknown[]),

--- a/src/domain/data/composite_data_query_service.ts
+++ b/src/domain/data/composite_data_query_service.ts
@@ -1,0 +1,131 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { DataRecord } from "./data_record.ts";
+import {
+  type DataQueryOptions,
+  DataQueryService,
+  type ForeignContentFetcher,
+} from "./data_query_service.ts";
+import type { VaultService } from "../vaults/vault_service.ts";
+import type { SecretRedactor } from "../secrets/mod.ts";
+
+function deduplicateRecords(
+  ephemeral: DataRecord[],
+  persistent: DataRecord[],
+): DataRecord[] {
+  const seen = new Set<string>();
+  const results: DataRecord[] = [];
+
+  for (const r of ephemeral) {
+    const key = `${r.modelType}:${r.modelId}:${r.name}:${r.version}`;
+    seen.add(key);
+    results.push(r);
+  }
+  for (const r of persistent) {
+    const key = `${r.modelType}:${r.modelId}:${r.name}:${r.version}`;
+    if (!seen.has(key)) results.push(r);
+  }
+
+  return results;
+}
+
+export class CompositeDataQueryService extends DataQueryService {
+  private readonly ephemeralQueryService: DataQueryService;
+
+  constructor(
+    persistentQueryService: DataQueryService,
+    ephemeralQueryService: DataQueryService,
+  ) {
+    // Inherit the persistent query service's catalog and repo via accessing
+    // its internal state is not possible, so we use a delegation pattern.
+    // We extend DataQueryService but override query/querySync to merge.
+    // The super constructor is called but we won't use its catalog — we
+    // delegate all calls to the two backing services.
+    //
+    // NOTE: We need access to the persistent service's catalog and repo for
+    // the super() call. Since DataQueryService doesn't expose these, we use
+    // the persistent service directly and override the query methods.
+    super(
+      // deno-lint-ignore no-explicit-any
+      (persistentQueryService as any).catalogStore,
+      // deno-lint-ignore no-explicit-any
+      (persistentQueryService as any).dataRepo,
+    );
+    this.ephemeralQueryService = ephemeralQueryService;
+  }
+
+  override setVaultService(
+    vaultService: VaultService,
+    redactor?: SecretRedactor,
+  ): void {
+    super.setVaultService(vaultService, redactor);
+    this.ephemeralQueryService.setVaultService(vaultService, redactor);
+  }
+
+  override setForeignContentFetcher(fetcher: ForeignContentFetcher): void {
+    super.setForeignContentFetcher(fetcher);
+    this.ephemeralQueryService.setForeignContentFetcher(fetcher);
+  }
+
+  override async query(
+    predicate: string,
+    options?: DataQueryOptions,
+  ): Promise<DataRecord[] | unknown[]> {
+    const [persistentResults, ephemeralResults] = await Promise.all([
+      super.query(predicate, options),
+      this.ephemeralQueryService.query(predicate, options),
+    ]);
+
+    if (options?.select) {
+      return [
+        ...(ephemeralResults as unknown[]),
+        ...(persistentResults as unknown[]),
+      ];
+    }
+
+    return deduplicateRecords(
+      ephemeralResults as DataRecord[],
+      persistentResults as DataRecord[],
+    );
+  }
+
+  override querySync(
+    predicate: string,
+    options?: DataQueryOptions,
+  ): DataRecord[] | unknown[] {
+    const persistentResults = super.querySync(predicate, options);
+    const ephemeralResults = this.ephemeralQueryService.querySync(
+      predicate,
+      options,
+    );
+
+    if (options?.select) {
+      return [
+        ...(ephemeralResults as unknown[]),
+        ...(persistentResults as unknown[]),
+      ];
+    }
+
+    return deduplicateRecords(
+      ephemeralResults as DataRecord[],
+      persistentResults as DataRecord[],
+    );
+  }
+}

--- a/src/domain/data/composite_data_query_service_test.ts
+++ b/src/domain/data/composite_data_query_service_test.ts
@@ -1,0 +1,203 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { CompositeDataQueryService } from "./composite_data_query_service.ts";
+import { DataQueryService } from "./data_query_service.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { Data } from "./data.ts";
+import { ModelType } from "../models/model_type.ts";
+import type { DataRecord } from "./data_record.ts";
+
+function createTestData(overrides: Partial<{
+  name: string;
+  lifetime: string;
+  ownerRef: string;
+}> = {}): Data {
+  return Data.create({
+    name: overrides.name ?? "test-data",
+    contentType: "application/json",
+    lifetime: overrides.lifetime ?? "ephemeral",
+    garbageCollection: 5,
+    streaming: false,
+    tags: { type: "resource", specName: "test", modelName: "test-model" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: overrides.ownerRef ?? "test-ref",
+    },
+  });
+}
+
+const TEST_TYPE = ModelType.create("test/type");
+const TEST_MODEL_ID = "test-model-id";
+
+function createCompositeQueryService(): {
+  composite: CompositeDataQueryService;
+  persistentRepo: InMemoryUnifiedDataRepository;
+  ephemeralRepo: InMemoryUnifiedDataRepository;
+} {
+  const persistentCatalog = new CatalogStore(":memory:");
+  const ephemeralCatalog = new CatalogStore(":memory:");
+  const persistentRepo = new InMemoryUnifiedDataRepository(persistentCatalog);
+  const ephemeralRepo = new InMemoryUnifiedDataRepository(ephemeralCatalog);
+  const ephemeralQueryService = new DataQueryService(
+    ephemeralCatalog,
+    ephemeralRepo,
+  );
+  const composite = new CompositeDataQueryService(
+    persistentCatalog,
+    persistentRepo,
+    ephemeralQueryService,
+  );
+  return { composite, persistentRepo, ephemeralRepo };
+}
+
+Deno.test("CompositeDataQueryService: query returns results from both stores merged", async () => {
+  const { composite, persistentRepo, ephemeralRepo } =
+    createCompositeQueryService();
+
+  const ephData = createTestData({ name: "eph-data", ownerRef: "eph" });
+  const persData = createTestData({ name: "pers-data", ownerRef: "pers" });
+
+  await ephemeralRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    ephData,
+    new TextEncoder().encode('{"source": "ephemeral"}'),
+  );
+  await persistentRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    persData,
+    new TextEncoder().encode('{"source": "persistent"}'),
+  );
+
+  const results = (await composite.query("true")) as DataRecord[];
+
+  assertEquals(results.length, 2);
+  const names = results.map((r) => r.name).sort();
+  assertEquals(names, ["eph-data", "pers-data"]);
+});
+
+Deno.test("CompositeDataQueryService: query deduplicates when same record exists in both stores", async () => {
+  const { composite, persistentRepo, ephemeralRepo } =
+    createCompositeQueryService();
+
+  // Same name saved to both stores — ephemeral should win
+  const ephData = createTestData({ name: "shared", ownerRef: "eph" });
+  const persData = createTestData({ name: "shared", ownerRef: "pers" });
+
+  await ephemeralRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    ephData,
+    new TextEncoder().encode('{"source": "ephemeral"}'),
+  );
+  await persistentRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    persData,
+    new TextEncoder().encode('{"source": "persistent"}'),
+  );
+
+  const results = (await composite.query("true")) as DataRecord[];
+
+  assertEquals(results.length, 1);
+  assertEquals(results[0].name, "shared");
+  assertEquals(results[0].ownerRef, "eph");
+});
+
+Deno.test("CompositeDataQueryService: querySync returns merged and deduplicated results", () => {
+  const { composite, persistentRepo, ephemeralRepo } =
+    createCompositeQueryService();
+
+  // Use synchronous save by calling the sync-populated repos directly.
+  // InMemoryUnifiedDataRepository.save is async, but the catalog is already
+  // populated after construction, so querySync works once data is present.
+  // We need to save data first, then query synchronously.
+  const ephData = createTestData({ name: "shared", ownerRef: "eph" });
+  const persData = createTestData({ name: "shared", ownerRef: "pers" });
+  const persOnly = createTestData({ name: "pers-only", ownerRef: "pers" });
+
+  // Save all data then query synchronously
+  const setup = Promise.all([
+    ephemeralRepo.save(
+      TEST_TYPE,
+      TEST_MODEL_ID,
+      ephData,
+      new TextEncoder().encode('{"source": "ephemeral"}'),
+    ),
+    persistentRepo.save(
+      TEST_TYPE,
+      TEST_MODEL_ID,
+      persData,
+      new TextEncoder().encode('{"source": "persistent"}'),
+    ),
+    persistentRepo.save(
+      TEST_TYPE,
+      TEST_MODEL_ID,
+      persOnly,
+      new TextEncoder().encode('{"source": "persistent-only"}'),
+    ),
+  ]);
+
+  return setup.then(() => {
+    const results = composite.querySync("true") as DataRecord[];
+
+    assertEquals(results.length, 2);
+    const names = results.map((r) => r.name).sort();
+    assertEquals(names, ["pers-only", "shared"]);
+
+    // "shared" should come from the ephemeral store
+    const shared = results.find((r) => r.name === "shared");
+    assertEquals(shared?.ownerRef, "eph");
+  });
+});
+
+Deno.test("CompositeDataQueryService: query with select concatenates without deduplication", async () => {
+  const { composite, persistentRepo, ephemeralRepo } =
+    createCompositeQueryService();
+
+  // Same name in both stores. When using `select`, the results are opaque
+  // projected values (not DataRecords), so deduplication by composite key
+  // is not possible — both projected values are returned as-is.
+  const ephData = createTestData({ name: "shared", ownerRef: "eph" });
+  const persData = createTestData({ name: "shared", ownerRef: "pers" });
+
+  await ephemeralRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    ephData,
+    new TextEncoder().encode('{"source": "ephemeral"}'),
+  );
+  await persistentRepo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    persData,
+    new TextEncoder().encode('{"source": "persistent"}'),
+  );
+
+  const results = await composite.query("true", { select: "name" });
+
+  // Both projected values are included — no dedup on projections
+  assertEquals(results.length, 2);
+  assertEquals(results[0], "shared");
+  assertEquals(results[1], "shared");
+});

--- a/src/domain/data/composite_data_repository.ts
+++ b/src/domain/data/composite_data_repository.ts
@@ -1,0 +1,421 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Data } from "./data.ts";
+import type { DataId } from "./data_id.ts";
+import type { ModelType, ModelTypeInput } from "../models/model_type.ts";
+import { coerceModelType } from "../models/model_type.ts";
+import type { Namespace } from "./namespace.ts";
+import type {
+  GarbageCollectionResult,
+  UnifiedDataRepository,
+} from "./repositories.ts";
+
+export class CompositeUnifiedDataRepository implements UnifiedDataRepository {
+  readonly namespace: Namespace;
+
+  constructor(
+    private readonly persistent: UnifiedDataRepository,
+    private readonly ephemeral: UnifiedDataRepository,
+  ) {
+    this.namespace = persistent.namespace;
+  }
+
+  private routeWrite(data: Data): UnifiedDataRepository {
+    return data.lifetime === "ephemeral" ? this.ephemeral : this.persistent;
+  }
+
+  // --- Write Operations ---
+
+  save(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<{ version: number }> {
+    return this.routeWrite(data).save(type, modelId, data, content);
+  }
+
+  append(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    content: Uint8Array,
+  ): Promise<void> {
+    return this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null
+      ? this.ephemeral.append(type, modelId, dataName, content)
+      : this.persistent.append(type, modelId, dataName, content);
+  }
+
+  allocateVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+  ): Promise<{ version: number; contentPath: string }> {
+    return this.routeWrite(data).allocateVersion(type, modelId, data);
+  }
+
+  finalizeVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+  ): Promise<{ size: number; checksum: string }> {
+    return this.routeWrite(data).finalizeVersion(
+      type,
+      modelId,
+      data,
+      version,
+    );
+  }
+
+  delete(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<void> {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null) {
+      return this.ephemeral.delete(type, modelId, dataName, version);
+    }
+    return this.persistent.delete(type, modelId, dataName, version);
+  }
+
+  removeLatestMarker(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<void> {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null) {
+      return this.ephemeral.removeLatestMarker(type, modelId, dataName);
+    }
+    return this.persistent.removeLatestMarker(type, modelId, dataName);
+  }
+
+  collectGarbage(
+    type: ModelType,
+    modelId: string,
+    options?: { dryRun?: boolean },
+  ): Promise<GarbageCollectionResult> {
+    return this.persistent.collectGarbage(type, modelId, options);
+  }
+
+  rename(
+    type: ModelType,
+    modelId: string,
+    oldName: string,
+    newName: string,
+  ): Promise<
+    {
+      oldName: string;
+      newName: string;
+      copiedVersion: number;
+      newVersion: number;
+    }
+  > {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, oldName) !== null) {
+      return this.ephemeral.rename(type, modelId, oldName, newName);
+    }
+    return this.persistent.rename(type, modelId, oldName, newName);
+  }
+
+  // --- Read Operations (ephemeral-first fallback) ---
+
+  async findByName(
+    type: ModelTypeInput,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Data | null> {
+    const ephResult = await this.ephemeral.findByName(
+      type,
+      modelId,
+      dataName,
+      version,
+    );
+    if (ephResult) return ephResult;
+    return this.persistent.findByName(type, modelId, dataName, version);
+  }
+
+  async findById(
+    type: ModelType,
+    modelId: string,
+    dataId: DataId,
+    version?: number,
+  ): Promise<Data | null> {
+    const ephResult = await this.ephemeral.findById(
+      type,
+      modelId,
+      dataId,
+      version,
+    );
+    if (ephResult) return ephResult;
+    return this.persistent.findById(type, modelId, dataId, version);
+  }
+
+  async listVersions(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<number[]> {
+    const ephVersions = await this.ephemeral.listVersions(
+      type,
+      modelId,
+      dataName,
+    );
+    if (ephVersions.length > 0) return ephVersions;
+    return this.persistent.listVersions(type, modelId, dataName);
+  }
+
+  async findAllForModel(
+    type: ModelTypeInput,
+    modelId: string,
+  ): Promise<Data[]> {
+    const coerced = coerceModelType(type);
+    const [ephResults, persResults] = await Promise.all([
+      this.ephemeral.findAllForModel(coerced, modelId),
+      this.persistent.findAllForModel(coerced, modelId),
+    ]);
+
+    const seen = new Set<string>();
+    const merged: Data[] = [];
+    for (const data of ephResults) {
+      seen.add(data.name);
+      merged.push(data);
+    }
+    for (const data of persResults) {
+      if (!seen.has(data.name)) merged.push(data);
+    }
+    return merged;
+  }
+
+  async findAllForType(
+    type: ModelTypeInput,
+  ): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > {
+    const coerced = coerceModelType(type);
+    const [ephResults, persResults] = await Promise.all([
+      this.ephemeral.findAllForType(coerced),
+      this.persistent.findAllForType(coerced),
+    ]);
+
+    const seen = new Set<string>();
+    const merged: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+    for (const item of ephResults) {
+      seen.add(`${item.modelId}:${item.data.name}`);
+      merged.push(item);
+    }
+    for (const item of persResults) {
+      if (!seen.has(`${item.modelId}:${item.data.name}`)) merged.push(item);
+    }
+    return merged;
+  }
+
+  async findAllGlobal(): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > {
+    const [ephResults, persResults] = await Promise.all([
+      this.ephemeral.findAllGlobal(),
+      this.persistent.findAllGlobal(),
+    ]);
+
+    const seen = new Set<string>();
+    const merged: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+    for (const item of ephResults) {
+      seen.add(
+        `${item.modelType.normalized}:${item.modelId}:${item.data.name}`,
+      );
+      merged.push(item);
+    }
+    for (const item of persResults) {
+      const key =
+        `${item.modelType.normalized}:${item.modelId}:${item.data.name}`;
+      if (!seen.has(key)) merged.push(item);
+    }
+    return merged;
+  }
+
+  async getContent(
+    type: ModelTypeInput,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Uint8Array | null> {
+    const ephContent = await this.ephemeral.getContent(
+      type,
+      modelId,
+      dataName,
+      version,
+    );
+    if (ephContent) return ephContent;
+    return this.persistent.getContent(type, modelId, dataName, version);
+  }
+
+  async *stream(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): AsyncIterable<Uint8Array> {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null) {
+      yield* this.ephemeral.stream(type, modelId, dataName, version);
+      return;
+    }
+    yield* this.persistent.stream(type, modelId, dataName, version);
+  }
+
+  // --- Path Operations ---
+
+  getPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null) {
+      return this.ephemeral.getPath(type, modelId, dataName, version);
+    }
+    return this.persistent.getPath(type, modelId, dataName, version);
+  }
+
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    if (this.ephemeral.getLatestVersionSync(type, modelId, dataName) !== null) {
+      return this.ephemeral.getContentPath(type, modelId, dataName, version);
+    }
+    return this.persistent.getContentPath(type, modelId, dataName, version);
+  }
+
+  // --- Identity ---
+
+  nextId(): DataId {
+    return this.persistent.nextId();
+  }
+
+  // --- Sync Read Methods ---
+
+  getLatestVersionSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number | null {
+    const ephVersion = this.ephemeral.getLatestVersionSync(
+      type,
+      modelId,
+      dataName,
+    );
+    if (ephVersion !== null) return ephVersion;
+    return this.persistent.getLatestVersionSync(type, modelId, dataName);
+  }
+
+  findByNameSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Data | null {
+    const ephResult = this.ephemeral.findByNameSync(
+      type,
+      modelId,
+      dataName,
+      version,
+    );
+    if (ephResult) return ephResult;
+    return this.persistent.findByNameSync(type, modelId, dataName, version);
+  }
+
+  listVersionsSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number[] {
+    const ephVersions = this.ephemeral.listVersionsSync(
+      type,
+      modelId,
+      dataName,
+    );
+    if (ephVersions.length > 0) return ephVersions;
+    return this.persistent.listVersionsSync(type, modelId, dataName);
+  }
+
+  getContentSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Uint8Array | null {
+    const ephContent = this.ephemeral.getContentSync(
+      type,
+      modelId,
+      dataName,
+      version,
+    );
+    if (ephContent) return ephContent;
+    return this.persistent.getContentSync(type, modelId, dataName, version);
+  }
+
+  findAllForModelSync(type: ModelType, modelId: string): Data[] {
+    const ephResults = this.ephemeral.findAllForModelSync(type, modelId);
+    const persResults = this.persistent.findAllForModelSync(type, modelId);
+
+    const seen = new Set<string>();
+    const merged: Data[] = [];
+    for (const data of ephResults) {
+      seen.add(data.name);
+      merged.push(data);
+    }
+    for (const data of persResults) {
+      if (!seen.has(data.name)) merged.push(data);
+    }
+    return merged;
+  }
+
+  findAllGlobalSync(): Array<
+    { data: Data; modelType: ModelType; modelId: string }
+  > {
+    const ephResults = this.ephemeral.findAllGlobalSync();
+    const persResults = this.persistent.findAllGlobalSync();
+
+    const seen = new Set<string>();
+    const merged: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+    for (const item of ephResults) {
+      seen.add(
+        `${item.modelType.normalized}:${item.modelId}:${item.data.name}`,
+      );
+      merged.push(item);
+    }
+    for (const item of persResults) {
+      const key =
+        `${item.modelType.normalized}:${item.modelId}:${item.data.name}`;
+      if (!seen.has(key)) merged.push(item);
+    }
+    return merged;
+  }
+}

--- a/src/domain/data/composite_data_repository_test.ts
+++ b/src/domain/data/composite_data_repository_test.ts
@@ -1,0 +1,297 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { CompositeUnifiedDataRepository } from "./composite_data_repository.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { Data } from "./data.ts";
+import { ModelType } from "../models/model_type.ts";
+
+function createTestData(overrides: Partial<{
+  name: string;
+  lifetime: string;
+  streaming: boolean;
+  ownerRef: string;
+}> = {}): Data {
+  return Data.create({
+    name: overrides.name ?? "test-data",
+    contentType: "application/json",
+    lifetime: overrides.lifetime ?? "ephemeral",
+    garbageCollection: 5,
+    streaming: overrides.streaming ?? false,
+    tags: { type: "resource", specName: "test", modelName: "test-model" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: overrides.ownerRef ?? "test-ref",
+    },
+  });
+}
+
+const TEST_TYPE = ModelType.create("test/type");
+const TEST_MODEL_ID = "test-model-id";
+const TEST_CONTENT = new TextEncoder().encode('{"key": "value"}');
+
+function createCompositeRepo(): {
+  composite: CompositeUnifiedDataRepository;
+  persistent: InMemoryUnifiedDataRepository;
+  ephemeral: InMemoryUnifiedDataRepository;
+} {
+  const persistentCatalog = new CatalogStore(":memory:");
+  const ephemeralCatalog = new CatalogStore(":memory:");
+  const persistent = new InMemoryUnifiedDataRepository(persistentCatalog);
+  const ephemeral = new InMemoryUnifiedDataRepository(ephemeralCatalog);
+  const composite = new CompositeUnifiedDataRepository(persistent, ephemeral);
+  return { composite, persistent, ephemeral };
+}
+
+Deno.test("CompositeUnifiedDataRepository: save routes ephemeral lifetime to ephemeral repo", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+  const data = createTestData({ lifetime: "ephemeral" });
+
+  await composite.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const ephResult = await ephemeral.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  const persResult = await persistent.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(ephResult?.name, "test-data");
+  assertEquals(persResult, null);
+});
+
+Deno.test("CompositeUnifiedDataRepository: save routes non-ephemeral lifetime to persistent repo", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+  const data = createTestData({ lifetime: "infinite" });
+
+  await composite.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const persResult = await persistent.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  const ephResult = await ephemeral.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(persResult?.name, "test-data");
+  assertEquals(ephResult, null);
+});
+
+Deno.test("CompositeUnifiedDataRepository: findByName returns ephemeral data when it exists", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+  const ephData = createTestData({ lifetime: "ephemeral", ownerRef: "eph" });
+  const persData = createTestData({ lifetime: "infinite", ownerRef: "pers" });
+
+  // Save to both stores with different owner refs so content differs
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, ephData, TEST_CONTENT);
+  await persistent.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    persData,
+    new TextEncoder().encode('{"key": "persistent"}'),
+  );
+
+  const found = await composite.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  // Ephemeral shadows persistent — the result should come from the ephemeral store
+  assertEquals(found?.ownerDefinition.ownerRef, "eph");
+});
+
+Deno.test("CompositeUnifiedDataRepository: findByName falls back to persistent when ephemeral has no match", async () => {
+  const { composite, persistent } = createCompositeRepo();
+  const persData = createTestData({ lifetime: "infinite" });
+
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persData, TEST_CONTENT);
+
+  const found = await composite.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(found?.name, "test-data");
+});
+
+Deno.test("CompositeUnifiedDataRepository: findAllForModel merges results, ephemeral shadows persistent by name", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+
+  // "shared" exists in both stores — ephemeral should win
+  const sharedEph = createTestData({
+    name: "shared",
+    lifetime: "ephemeral",
+    ownerRef: "eph",
+  });
+  const sharedPers = createTestData({
+    name: "shared",
+    lifetime: "infinite",
+    ownerRef: "pers",
+  });
+  const onlyPers = createTestData({
+    name: "only-persistent",
+    lifetime: "infinite",
+  });
+  const onlyEph = createTestData({
+    name: "only-ephemeral",
+    lifetime: "ephemeral",
+  });
+
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, sharedEph, TEST_CONTENT);
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, onlyEph, TEST_CONTENT);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, sharedPers, TEST_CONTENT);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, onlyPers, TEST_CONTENT);
+
+  const results = await composite.findAllForModel(TEST_TYPE, TEST_MODEL_ID);
+
+  assertEquals(results.length, 3);
+  const names = results.map((d) => d.name).sort();
+  assertEquals(names, ["only-ephemeral", "only-persistent", "shared"]);
+
+  // The "shared" entry should be from ephemeral
+  const shared = results.find((d) => d.name === "shared");
+  assertEquals(shared?.ownerDefinition.ownerRef, "eph");
+});
+
+Deno.test("CompositeUnifiedDataRepository: findAllGlobal merges results with deduplication", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+
+  const ephData = createTestData({
+    name: "global-data",
+    lifetime: "ephemeral",
+    ownerRef: "eph",
+  });
+  const persData = createTestData({
+    name: "global-data",
+    lifetime: "infinite",
+    ownerRef: "pers",
+  });
+  const persOnly = createTestData({
+    name: "pers-only",
+    lifetime: "infinite",
+  });
+
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, ephData, TEST_CONTENT);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persData, TEST_CONTENT);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persOnly, TEST_CONTENT);
+
+  const results = await composite.findAllGlobal();
+
+  assertEquals(results.length, 2);
+  const names = results.map((r) => r.data.name).sort();
+  assertEquals(names, ["global-data", "pers-only"]);
+
+  // The "global-data" entry should be from ephemeral
+  const globalData = results.find((r) => r.data.name === "global-data");
+  assertEquals(globalData?.data.ownerDefinition.ownerRef, "eph");
+});
+
+Deno.test("CompositeUnifiedDataRepository: getContent returns ephemeral content when available", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+
+  const ephContent = new TextEncoder().encode('{"from": "ephemeral"}');
+  const persContent = new TextEncoder().encode('{"from": "persistent"}');
+
+  const ephData = createTestData({ ownerRef: "eph" });
+  const persData = createTestData({ ownerRef: "pers" });
+
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, ephData, ephContent);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persData, persContent);
+
+  const content = await composite.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(new TextDecoder().decode(content!), '{"from": "ephemeral"}');
+});
+
+Deno.test("CompositeUnifiedDataRepository: getContentSync returns ephemeral content with fallback", async () => {
+  const { composite, persistent, ephemeral } = createCompositeRepo();
+
+  const ephContent = new TextEncoder().encode('{"from": "ephemeral"}');
+  const persContent = new TextEncoder().encode('{"from": "persistent"}');
+
+  // Both stores have the same data name
+  const ephData = createTestData({ name: "both", ownerRef: "eph" });
+  const persData = createTestData({ name: "both", ownerRef: "pers" });
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, ephData, ephContent);
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persData, persContent);
+
+  const content = composite.getContentSync(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "both",
+  );
+  assertEquals(new TextDecoder().decode(content!), '{"from": "ephemeral"}');
+
+  // Only persistent has "pers-only"
+  const persOnly = createTestData({ name: "pers-only" });
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, persOnly, persContent);
+
+  const fallbackContent = composite.getContentSync(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "pers-only",
+  );
+  assertEquals(
+    new TextDecoder().decode(fallbackContent!),
+    '{"from": "persistent"}',
+  );
+});
+
+Deno.test("CompositeUnifiedDataRepository: delete deletes from ephemeral when data exists there", async () => {
+  const { composite, ephemeral } = createCompositeRepo();
+
+  const data = createTestData({ lifetime: "ephemeral" });
+  await ephemeral.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await composite.delete(TEST_TYPE, TEST_MODEL_ID, "test-data");
+
+  const found = await ephemeral.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(found, null);
+});
+
+Deno.test("CompositeUnifiedDataRepository: delete deletes from persistent when data only exists there", async () => {
+  const { composite, persistent } = createCompositeRepo();
+
+  const data = createTestData({ lifetime: "infinite" });
+  await persistent.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await composite.delete(TEST_TYPE, TEST_MODEL_ID, "test-data");
+
+  const found = await persistent.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(found, null);
+});

--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -134,8 +134,8 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
     }
 
     if (lifetime === "ephemeral") {
-      // Not implemented yet - requires tracking execution context
-      logger.warn("Ephemeral lifetime is not yet implemented");
+      // Ephemeral data is routed to the in-memory repository by
+      // CompositeUnifiedDataRepository and never reaches persistent storage.
       return null;
     }
 

--- a/src/domain/data/ephemeral_store.ts
+++ b/src/domain/data/ephemeral_store.ts
@@ -1,0 +1,76 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { DataQueryService } from "./data_query_service.ts";
+
+const logger = getLogger(["swamp", "data", "ephemeral"]);
+import { CompositeUnifiedDataRepository } from "./composite_data_repository.ts";
+import { CompositeDataQueryService } from "./composite_data_query_service.ts";
+import type { UnifiedDataRepository } from "./repositories.ts";
+import type { Namespace } from "./namespace.ts";
+
+export interface EphemeralStore {
+  repo: InMemoryUnifiedDataRepository;
+  catalog: CatalogStore;
+  dispose(): void;
+}
+
+export function createEphemeralStore(
+  namespace?: Namespace,
+  options?: { isResume?: boolean },
+): EphemeralStore {
+  if (options?.isResume) {
+    logger.info(
+      "Ephemeral data from before suspension is not available in resumed runs — use 'workflow' or 'infinite' lifetime to persist across gates.",
+    );
+  }
+  const catalog = new CatalogStore(":memory:");
+  const repo = new InMemoryUnifiedDataRepository(catalog, namespace);
+  return {
+    repo,
+    catalog,
+    dispose() {
+      repo.dispose();
+    },
+  };
+}
+
+export function wrapWithEphemeral(
+  persistentRepo: UnifiedDataRepository,
+  persistentCatalog: CatalogStore,
+  store: EphemeralStore,
+): {
+  dataRepo: CompositeUnifiedDataRepository;
+  dataQueryService: CompositeDataQueryService;
+} {
+  return {
+    dataRepo: new CompositeUnifiedDataRepository(
+      persistentRepo,
+      store.repo,
+    ),
+    dataQueryService: new CompositeDataQueryService(
+      persistentCatalog,
+      persistentRepo,
+      new DataQueryService(store.catalog, store.repo),
+    ),
+  };
+}

--- a/src/domain/data/workflow_data_service.ts
+++ b/src/domain/data/workflow_data_service.ts
@@ -20,7 +20,7 @@
 import type { Data } from "./data.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { WorkflowRun } from "../workflows/workflow_run.ts";
-import type { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { UnifiedDataRepository } from "./repositories.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { createDefinitionId } from "../definitions/definition.ts";
 
@@ -50,7 +50,7 @@ export interface WorkflowDataItem {
 export class WorkflowDataService {
   constructor(
     private readonly definitionRepo: YamlDefinitionRepository,
-    private readonly dataRepo: FileSystemUnifiedDataRepository,
+    private readonly dataRepo: UnifiedDataRepository,
   ) {}
 
   /**

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -18,6 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { z } from "zod";
+import {
+  GarbageCollectionSchema,
+  LifetimeSchema,
+} from "../data/data_metadata.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
 import {
   type ReportSelection,
@@ -138,6 +142,15 @@ export type CheckSelection = {
   skip?: string[];
 };
 
+const ResourceOverrideSchema = z.object({
+  lifetime: LifetimeSchema.optional(),
+  garbageCollection: GarbageCollectionSchema.optional(),
+});
+
+export type ResourceOverride = z.infer<typeof ResourceOverrideSchema>;
+
+export type ResourceOverrides = Record<string, ResourceOverride>;
+
 const DefinitionObjectSchema = z.object({
   type: z.string().optional(),
   typeVersion: z.preprocess(
@@ -168,6 +181,7 @@ const DefinitionObjectSchema = z.object({
   inputs: InputsSchemaSchema,
   checks: CheckSelectionSchema,
   reports: ReportSelectionSchema,
+  resources: z.record(z.string(), ResourceOverrideSchema).optional(),
 });
 
 /**
@@ -207,6 +221,7 @@ export interface CreateDefinitionProps {
   inputs?: InputsSchema;
   checks?: CheckSelection;
   reports?: ReportSelection;
+  resources?: ResourceOverrides;
 }
 
 /**
@@ -231,6 +246,7 @@ export class Definition {
     private _inputs: InputsSchema | undefined,
     private _checks: CheckSelection | undefined,
     private _reports: ReportSelection | undefined,
+    private _resources: ResourceOverrides | undefined,
   ) {}
 
   /**
@@ -255,6 +271,7 @@ export class Definition {
       inputs: props.inputs,
       checks: props.checks,
       reports: props.reports,
+      resources: props.resources,
     });
 
     return new Definition(
@@ -269,6 +286,7 @@ export class Definition {
       validated.inputs,
       validated.checks,
       validated.reports,
+      validated.resources,
     );
   }
 
@@ -292,6 +310,7 @@ export class Definition {
       validated.inputs,
       validated.checks,
       validated.reports,
+      validated.resources,
     );
   }
 
@@ -321,6 +340,7 @@ export class Definition {
       original._inputs ? structuredClone(original._inputs) : undefined,
       original._checks ? structuredClone(original._checks) : undefined,
       original._reports ? structuredClone(original._reports) : undefined,
+      original._resources ? structuredClone(original._resources) : undefined,
     );
   }
 
@@ -437,6 +457,10 @@ export class Definition {
   /**
    * Converts the definition to a plain data object for persistence.
    */
+  get resources(): ResourceOverrides | undefined {
+    return this._resources;
+  }
+
   toData(): DefinitionData {
     return {
       type: this.type,
@@ -450,6 +474,7 @@ export class Definition {
       inputs: this._inputs ? structuredClone(this._inputs) : undefined,
       checks: this._checks ? structuredClone(this._checks) : undefined,
       reports: this._reports ? structuredClone(this._reports) : undefined,
+      resources: this._resources ? structuredClone(this._resources) : undefined,
     };
   }
 

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -263,6 +263,7 @@ Deno.test("Definition.toData returns correct structure", () => {
     },
     checks: undefined,
     reports: undefined,
+    resources: undefined,
   });
 });
 

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -367,6 +367,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         jobName: context.tagOverrides?.job,
         stepName: context.tagOverrides?.step,
         signal: context.signal,
+        dataRepo: context.dataRepository,
         onEvent: context.onEvent
           ? (event: RpcStreamEvent) => {
             if (event.kind === "method_event" && "event" in event) {

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -27,6 +27,7 @@
  * orchestrator fails with a clear error instead of silently running locally.
  */
 
+import type { UnifiedDataRepository } from "../data/repositories.ts";
 import type { ModelDefinition } from "../models/model.ts";
 import type { ModelType } from "../models/model_type.ts";
 import type { StepPlacement } from "./scheduler.ts";
@@ -58,6 +59,7 @@ export interface RemoteStepRequest {
   stepName?: string;
   signal?: AbortSignal;
   onEvent?: (event: RpcStreamEvent) => void;
+  dataRepo?: UnifiedDataRepository;
 }
 
 export interface RemoteStepResult {

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -410,7 +410,8 @@ export class DefaultStepExecutor implements StepExecutor {
     const dataQueryService: DataQueryService =
       opts.ephemeralRepo && opts.ephemeralCatalog
         ? new CompositeDataQueryService(
-          persistentQueryService,
+          opts.catalogStore,
+          fsDataRepo,
           new DataQueryService(opts.ephemeralCatalog, opts.ephemeralRepo),
         )
         : persistentQueryService;
@@ -1378,7 +1379,8 @@ export class WorkflowExecutionService {
     );
     const dataQueryService: DataQueryService = ephemeralRepo && ephemeralCatalog
       ? new CompositeDataQueryService(
-        persistentQueryService,
+        catalogStore,
+        fsDataRepo,
         new DataQueryService(ephemeralCatalog, ephemeralRepo),
       )
       : persistentQueryService;

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -61,6 +61,10 @@ import { type Namespace, SOLO_NAMESPACE } from "../data/namespace.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import type { MarkDirtyHook } from "../datastore/datastore_sync_service.ts";
 import { DataQueryService } from "../data/data_query_service.ts";
+import { CompositeUnifiedDataRepository } from "../data/composite_data_repository.ts";
+import { CompositeDataQueryService } from "../data/composite_data_query_service.ts";
+import type { ResourceOverrides } from "../definitions/definition.ts";
+import type { DataOutputOverride } from "../models/data_output_override.ts";
 import {
   fromFileHandle,
   fromResourceHandle,
@@ -144,6 +148,33 @@ export class WorkflowSuspendedError extends Error {
   }
 }
 
+function mergeDataOutputOverrides(
+  definitionResources: ResourceOverrides | undefined,
+  stepOverrides: DataOutputOverride[] | undefined,
+): DataOutputOverride[] | undefined {
+  const defOverrides: DataOutputOverride[] = definitionResources
+    ? Object.entries(definitionResources).map(([specName, override]) => ({
+      specName,
+      lifetime: override.lifetime,
+      garbageCollection: override.garbageCollection,
+    }))
+    : [];
+
+  if (defOverrides.length === 0) return stepOverrides;
+  if (!stepOverrides || stepOverrides.length === 0) return defOverrides;
+
+  const merged = [...defOverrides];
+  for (const stepOvr of stepOverrides) {
+    const idx = merged.findIndex((o) => o.specName === stepOvr.specName);
+    if (idx >= 0) {
+      merged[idx] = stepOvr;
+    } else {
+      merged.push(stepOvr);
+    }
+  }
+  return merged;
+}
+
 /**
  * Context for step execution.
  */
@@ -205,6 +236,8 @@ export interface StepExecutionContext {
    */
   namespace?: Namespace;
   runTracker?: RunTrackerRepository;
+  ephemeralRepo?: UnifiedDataRepository;
+  ephemeralCatalog?: CatalogStore;
 }
 
 /**
@@ -335,6 +368,8 @@ export class DefaultStepExecutor implements StepExecutor {
       catalogStore: ctx.catalogStore,
       markDirty: this.markDirty,
       namespace: ctx.namespace,
+      ephemeralRepo: ctx.ephemeralRepo,
+      ephemeralCatalog: ctx.ephemeralCatalog,
     });
     if (this._directTypeResolver) {
       deps.directTypeResolver = this._directTypeResolver;
@@ -352,10 +387,12 @@ export class DefaultStepExecutor implements StepExecutor {
       catalogStore: CatalogStore;
       markDirty?: MarkDirtyHook;
       namespace?: Namespace;
+      ephemeralRepo?: UnifiedDataRepository;
+      ephemeralCatalog?: CatalogStore;
     },
   ): Promise<StepExecutorDeps> {
     const definitionRepo = new YamlDefinitionRepository(repoDir);
-    const unifiedDataRepo = new FileSystemUnifiedDataRepository(
+    const fsDataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       opts.dataBaseDir,
       opts.catalogStore,
@@ -363,10 +400,20 @@ export class DefaultStepExecutor implements StepExecutor {
       undefined,
       opts.namespace ?? SOLO_NAMESPACE,
     );
-    const dataQueryService = new DataQueryService(
+    const unifiedDataRepo: UnifiedDataRepository = opts.ephemeralRepo
+      ? new CompositeUnifiedDataRepository(fsDataRepo, opts.ephemeralRepo)
+      : fsDataRepo;
+    const persistentQueryService = new DataQueryService(
       opts.catalogStore,
-      unifiedDataRepo,
+      fsDataRepo,
     );
+    const dataQueryService: DataQueryService =
+      opts.ephemeralRepo && opts.ephemeralCatalog
+        ? new CompositeDataQueryService(
+          persistentQueryService,
+          new DataQueryService(opts.ephemeralCatalog, opts.ephemeralRepo),
+        )
+        : persistentQueryService;
     return {
       definitionRepo,
       unifiedDataRepo,
@@ -928,7 +975,10 @@ export class DefaultStepExecutor implements StepExecutor {
           logger: runLogger,
           tagOverrides: workflowTagOverrides,
           runtimeTags: ctx.runtimeTags,
-          dataOutputOverrides: stepDataOutputOverrides,
+          dataOutputOverrides: mergeDataOutputOverrides(
+            evaluatedDefinition.resources,
+            stepDataOutputOverrides,
+          ),
           vaultSecrets: secretBag,
           placement: ctx.step?.placement,
           skipCheckNames: ctx.skipCheckNames,
@@ -1274,7 +1324,7 @@ export class WorkflowExecutionService {
   private readonly definitionRepo: YamlDefinitionRepository;
   private readonly evaluatedDefRepo: YamlEvaluatedDefinitionRepository;
   private readonly modelResolver: ModelResolver;
-  private readonly dataRepo: FileSystemUnifiedDataRepository;
+  private readonly dataRepo: UnifiedDataRepository;
   private readonly dataBaseDir?: string;
   private readonly catalogStore: CatalogStore;
   private readonly workflowReportRunner = new WorkflowReportRunner();
@@ -1293,6 +1343,8 @@ export class WorkflowExecutionService {
     private readonly namespace: Namespace = SOLO_NAMESPACE,
     stepLockHook?: StepLockHook,
     private readonly runTracker?: RunTrackerRepository,
+    private readonly ephemeralRepo?: UnifiedDataRepository,
+    private readonly ephemeralCatalog?: CatalogStore,
   ) {
     this.executor = executor ??
       new DefaultStepExecutor(
@@ -1309,7 +1361,7 @@ export class WorkflowExecutionService {
       undefined,
       markDirty,
     );
-    this.dataRepo = new FileSystemUnifiedDataRepository(
+    const fsDataRepo = new FileSystemUnifiedDataRepository(
       repoDir,
       dataBaseDir,
       catalogStore,
@@ -1317,7 +1369,19 @@ export class WorkflowExecutionService {
       undefined,
       namespace,
     );
-    const dataQueryService = new DataQueryService(catalogStore, this.dataRepo);
+    this.dataRepo = ephemeralRepo
+      ? new CompositeUnifiedDataRepository(fsDataRepo, ephemeralRepo)
+      : fsDataRepo;
+    const persistentQueryService = new DataQueryService(
+      catalogStore,
+      fsDataRepo,
+    );
+    const dataQueryService: DataQueryService = ephemeralRepo && ephemeralCatalog
+      ? new CompositeDataQueryService(
+        persistentQueryService,
+        new DataQueryService(ephemeralCatalog, ephemeralRepo),
+      )
+      : persistentQueryService;
     this.modelResolver = new ModelResolver(this.definitionRepo, {
       repoDir,
       dataRepo: this.dataRepo,
@@ -2434,6 +2498,8 @@ export class WorkflowExecutionService {
           catalogStore: this.catalogStore,
           namespace: this.namespace,
           runTracker: this.runTracker,
+          ephemeralRepo: this.ephemeralRepo,
+          ephemeralCatalog: this.ephemeralCatalog,
         };
         return this.executor.execute(step, ctx);
       });
@@ -2673,6 +2739,8 @@ export class WorkflowExecutionService {
       this.namespace,
       undefined,
       this.runTracker,
+      this.ephemeralRepo,
+      this.ephemeralCatalog,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/infrastructure/persistence/ephemeral_store.ts
+++ b/src/infrastructure/persistence/ephemeral_store.ts
@@ -18,15 +18,15 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getLogger } from "@logtape/logtape";
-import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
-import { DataQueryService } from "./data_query_service.ts";
+import { CatalogStore } from "./catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "./in_memory_data_repository.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { CompositeUnifiedDataRepository } from "../../domain/data/composite_data_repository.ts";
+import { CompositeDataQueryService } from "../../domain/data/composite_data_query_service.ts";
+import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
+import type { Namespace } from "../../domain/data/namespace.ts";
 
 const logger = getLogger(["swamp", "data", "ephemeral"]);
-import { CompositeUnifiedDataRepository } from "./composite_data_repository.ts";
-import { CompositeDataQueryService } from "./composite_data_query_service.ts";
-import type { UnifiedDataRepository } from "./repositories.ts";
-import type { Namespace } from "./namespace.ts";
 
 export interface EphemeralStore {
   repo: InMemoryUnifiedDataRepository;

--- a/src/infrastructure/persistence/in_memory_data_repository.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository.ts
@@ -1,0 +1,763 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Data, isReservedDataName } from "../../domain/data/data.ts";
+import type { DataId } from "../../domain/data/data_id.ts";
+import { generateDataId } from "../../domain/data/data_id.ts";
+import {
+  coerceModelType,
+  ModelType,
+  type ModelTypeInput,
+} from "../../domain/models/model_type.ts";
+import type { Namespace } from "../../domain/data/namespace.ts";
+import { SOLO_NAMESPACE } from "../../domain/data/namespace.ts";
+import {
+  type GarbageCollectionResult,
+  OwnershipValidationError,
+  type UnifiedDataRepository,
+} from "../../domain/data/repositories.ts";
+import type { CatalogStore } from "./catalog_store.ts";
+
+function dataKey(
+  typeNormalized: string,
+  modelId: string,
+  dataName: string,
+  version: number,
+): string {
+  return `${typeNormalized}:${modelId}:${dataName}:${version}`;
+}
+
+function latestKey(
+  typeNormalized: string,
+  modelId: string,
+  dataName: string,
+): string {
+  return `${typeNormalized}:${modelId}:${dataName}`;
+}
+
+export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
+  private readonly dataMap = new Map<string, Data>();
+  private readonly contentMap = new Map<string, Uint8Array>();
+  private readonly latestVersionMap = new Map<string, number>();
+  private readonly allocatedPaths = new Map<string, {
+    typeNormalized: string;
+    modelId: string;
+    data: Data;
+    version: number;
+  }>();
+  private disposed = false;
+
+  constructor(
+    private readonly catalogStore: CatalogStore,
+    public readonly namespace: Namespace = SOLO_NAMESPACE,
+  ) {
+    catalogStore.markPopulated();
+  }
+
+  dispose(): void {
+    this.dataMap.clear();
+    this.contentMap.clear();
+    this.latestVersionMap.clear();
+    this.allocatedPaths.clear();
+    this.disposed = true;
+  }
+
+  private ensureNotDisposed(): void {
+    if (this.disposed) {
+      throw new Error("InMemoryUnifiedDataRepository has been disposed");
+    }
+  }
+
+  private catalogUpsert(type: ModelType, modelId: string, data: Data): void {
+    this.catalogStore.upsertNewVersion({
+      namespace: this.namespace,
+      type_normalized: type.normalized,
+      model_id: modelId,
+      data_name: data.name,
+      id: data.id,
+      version: data.version,
+      is_latest: 1,
+      model_name: data.tags["modelName"] ?? "",
+      spec_name: data.tags["specName"] ?? "",
+      data_type: data.tags["type"] ?? "",
+      content_type: data.contentType,
+      lifetime: data.lifetime,
+      owner_type: data.ownerDefinition.ownerType,
+      streaming: data.streaming ? 1 : 0,
+      size: data.size ?? 0,
+      created_at: data.createdAt.toISOString(),
+      tags: JSON.stringify(data.tags),
+      owner_ref: data.ownerDefinition.ownerRef,
+      workflow_run_id: data.ownerDefinition.workflowRunId ?? "",
+      workflow_name: data.ownerDefinition.workflowName ?? "",
+      job_name: data.ownerDefinition.jobName ?? "",
+      step_name: data.ownerDefinition.stepName ?? "",
+      source: data.ownerDefinition.source ?? "",
+    });
+  }
+
+  private catalogRemove(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): void {
+    this.catalogStore.remove(
+      this.namespace,
+      type.normalized,
+      modelId,
+      dataName,
+    );
+  }
+
+  private getLatestVersionNumber(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number | null {
+    const key = latestKey(type.normalized, modelId, dataName);
+    return this.latestVersionMap.get(key) ?? null;
+  }
+
+  private nextVersion(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number {
+    const current = this.getLatestVersionNumber(type, modelId, dataName);
+    return (current ?? 0) + 1;
+  }
+
+  private async computeChecksum(content: Uint8Array): Promise<string> {
+    const buffer = new ArrayBuffer(content.length);
+    new Uint8Array(buffer).set(content);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = new Uint8Array(hashBuffer);
+    return Array.from(hashArray)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  // --- Write Operations ---
+
+  async save(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<{ version: number }> {
+    this.ensureNotDisposed();
+
+    if (isReservedDataName(data.name)) {
+      throw new Error(
+        `Data name '${data.name}' is reserved for internal use. Use a different name.`,
+      );
+    }
+
+    const existing = this.findByNameSync(type, modelId, data.name);
+    if (existing) {
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition,
+          data.ownerDefinition,
+        );
+      }
+    }
+
+    const newVersion = this.nextVersion(type, modelId, data.name);
+
+    const dataToSave = data.withNewVersion({
+      version: newVersion,
+      size: content.length,
+      checksum: await this.computeChecksum(content),
+    });
+
+    const key = dataKey(type.normalized, modelId, data.name, newVersion);
+    this.dataMap.set(key, dataToSave);
+    this.contentMap.set(key, content);
+    this.latestVersionMap.set(
+      latestKey(type.normalized, modelId, data.name),
+      newVersion,
+    );
+
+    this.catalogUpsert(type, modelId, dataToSave);
+
+    return { version: newVersion };
+  }
+
+  async append(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    content: Uint8Array,
+  ): Promise<void> {
+    this.ensureNotDisposed();
+
+    const latestVersion = this.getLatestVersionNumber(type, modelId, dataName);
+    if (latestVersion === null) {
+      throw new Error(`No existing data found for "${dataName}"`);
+    }
+
+    const data = this.findByNameSync(type, modelId, dataName, latestVersion);
+    if (!data?.streaming) {
+      throw new Error(`Data "${dataName}" is not configured for streaming`);
+    }
+
+    const key = dataKey(type.normalized, modelId, dataName, latestVersion);
+    const existing = this.contentMap.get(key) ?? new Uint8Array(0);
+    const merged = new Uint8Array(existing.length + content.length);
+    merged.set(existing);
+    merged.set(content, existing.length);
+    this.contentMap.set(key, merged);
+
+    const updatedData = data.withNewVersion({
+      version: latestVersion,
+      size: merged.length,
+      checksum: await this.computeChecksum(merged),
+    });
+    this.dataMap.set(key, updatedData);
+    this.catalogUpsert(type, modelId, updatedData);
+  }
+
+  async allocateVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+  ): Promise<{ version: number; contentPath: string }> {
+    this.ensureNotDisposed();
+
+    if (isReservedDataName(data.name)) {
+      throw new Error(
+        `Data name '${data.name}' is reserved for internal use. Use a different name.`,
+      );
+    }
+
+    const existing = this.findByNameSync(type, modelId, data.name);
+    if (existing) {
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition,
+          data.ownerDefinition,
+        );
+      }
+    }
+
+    const newVersion = this.nextVersion(type, modelId, data.name);
+    const contentPath = await Deno.makeTempFile({
+      prefix: "swamp-ephemeral-",
+    });
+
+    this.allocatedPaths.set(contentPath, {
+      typeNormalized: type.normalized,
+      modelId,
+      data,
+      version: newVersion,
+    });
+
+    return { version: newVersion, contentPath };
+  }
+
+  async finalizeVersion(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+  ): Promise<{ size: number; checksum: string }> {
+    this.ensureNotDisposed();
+
+    let tempPath: string | undefined;
+    for (const [path, alloc] of this.allocatedPaths) {
+      if (
+        alloc.typeNormalized === type.normalized &&
+        alloc.modelId === modelId &&
+        alloc.version === version
+      ) {
+        tempPath = path;
+        break;
+      }
+    }
+
+    let content: Uint8Array;
+    if (tempPath) {
+      content = await Deno.readFile(tempPath);
+      await Deno.remove(tempPath).catch(() => {});
+      this.allocatedPaths.delete(tempPath);
+    } else {
+      content = new Uint8Array(0);
+    }
+
+    const checksum = await this.computeChecksum(content);
+    const size = content.length;
+
+    const dataToSave = data.withNewVersion({
+      version,
+      size,
+      checksum,
+    });
+
+    const key = dataKey(type.normalized, modelId, data.name, version);
+    this.dataMap.set(key, dataToSave);
+    this.contentMap.set(key, content);
+    this.latestVersionMap.set(
+      latestKey(type.normalized, modelId, data.name),
+      version,
+    );
+
+    this.catalogUpsert(type, modelId, dataToSave);
+
+    return { size, checksum };
+  }
+
+  // --- Read Operations ---
+
+  findAllGlobal(): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > {
+    this.ensureNotDisposed();
+    return Promise.resolve(this.findAllGlobalSync());
+  }
+
+  findAllForType(
+    type: ModelTypeInput,
+  ): Promise<
+    Array<{ data: Data; modelType: ModelType; modelId: string }>
+  > {
+    this.ensureNotDisposed();
+    type = coerceModelType(type);
+    const results: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+
+    for (const [key, version] of this.latestVersionMap) {
+      const parts = key.split(":");
+      if (parts[0] !== type.normalized) continue;
+      const dKey = dataKey(parts[0], parts[1], parts[2], version);
+      const data = this.dataMap.get(dKey);
+      if (data && !data.isDeleted) {
+        results.push({
+          data,
+          modelType: type,
+          modelId: parts[1],
+        });
+      }
+    }
+
+    return Promise.resolve(results);
+  }
+
+  findByName(
+    type: ModelTypeInput,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Data | null> {
+    this.ensureNotDisposed();
+    return Promise.resolve(
+      this.findByNameSync(coerceModelType(type), modelId, dataName, version),
+    );
+  }
+
+  findById(
+    _type: ModelType,
+    _modelId: string,
+    dataId: DataId,
+    version?: number,
+  ): Promise<Data | null> {
+    this.ensureNotDisposed();
+
+    for (const data of this.dataMap.values()) {
+      if (data.id === dataId) {
+        if (version !== undefined && data.version !== version) continue;
+        return Promise.resolve(data);
+      }
+    }
+    return Promise.resolve(null);
+  }
+
+  listVersions(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<number[]> {
+    this.ensureNotDisposed();
+    return Promise.resolve(this.listVersionsSync(type, modelId, dataName));
+  }
+
+  findAllForModel(
+    type: ModelTypeInput,
+    modelId: string,
+  ): Promise<Data[]> {
+    this.ensureNotDisposed();
+    return Promise.resolve(
+      this.findAllForModelSync(coerceModelType(type), modelId),
+    );
+  }
+
+  getContent(
+    type: ModelTypeInput,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<Uint8Array | null> {
+    this.ensureNotDisposed();
+    return Promise.resolve(
+      this.getContentSync(coerceModelType(type), modelId, dataName, version),
+    );
+  }
+
+  async *stream(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): AsyncIterable<Uint8Array> {
+    this.ensureNotDisposed();
+    const content = this.getContentSync(type, modelId, dataName, version);
+    if (content) {
+      yield content;
+    }
+  }
+
+  // --- Delete Operations ---
+
+  delete(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Promise<void> {
+    this.ensureNotDisposed();
+
+    if (version !== undefined) {
+      const key = dataKey(type.normalized, modelId, dataName, version);
+      this.dataMap.delete(key);
+      this.contentMap.delete(key);
+
+      const latest = this.getLatestVersionNumber(type, modelId, dataName);
+      if (latest === version) {
+        const remaining = this.listVersionsSync(type, modelId, dataName);
+        if (remaining.length > 0) {
+          this.latestVersionMap.set(
+            latestKey(type.normalized, modelId, dataName),
+            remaining[remaining.length - 1],
+          );
+        } else {
+          this.latestVersionMap.delete(
+            latestKey(type.normalized, modelId, dataName),
+          );
+          this.catalogRemove(type, modelId, dataName);
+        }
+      }
+    } else {
+      const versions = this.listVersionsSync(type, modelId, dataName);
+      for (const v of versions) {
+        const key = dataKey(type.normalized, modelId, dataName, v);
+        this.dataMap.delete(key);
+        this.contentMap.delete(key);
+      }
+      this.latestVersionMap.delete(
+        latestKey(type.normalized, modelId, dataName),
+      );
+      this.catalogRemove(type, modelId, dataName);
+    }
+    return Promise.resolve();
+  }
+
+  removeLatestMarker(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): Promise<void> {
+    this.ensureNotDisposed();
+    this.latestVersionMap.delete(
+      latestKey(type.normalized, modelId, dataName),
+    );
+    return Promise.resolve();
+  }
+
+  collectGarbage(
+    type: ModelType,
+    modelId: string,
+    options?: { dryRun?: boolean },
+  ): Promise<GarbageCollectionResult> {
+    this.ensureNotDisposed();
+    let versionsRemoved = 0;
+    let bytesReclaimed = 0;
+
+    const toProcess = new Map<string, number[]>();
+    for (const [key] of this.dataMap) {
+      const parts = key.split(":");
+      if (parts[0] !== type.normalized || parts[1] !== modelId) continue;
+      const dataName = parts[2];
+      const version = parseInt(parts[3], 10);
+      if (!toProcess.has(dataName)) toProcess.set(dataName, []);
+      toProcess.get(dataName)!.push(version);
+    }
+
+    for (const [dataName, versions] of toProcess) {
+      versions.sort((a, b) => a - b);
+      const latest = this.getLatestVersionNumber(type, modelId, dataName);
+      const latestData = latest
+        ? this.dataMap.get(
+          dataKey(type.normalized, modelId, dataName, latest),
+        )
+        : undefined;
+      if (!latestData) continue;
+
+      const keep = latestData.garbageCollection;
+      if (typeof keep !== "number") continue;
+      if (versions.length <= keep) continue;
+
+      const toRemove = versions.slice(0, versions.length - keep);
+      for (const v of toRemove) {
+        const key = dataKey(type.normalized, modelId, dataName, v);
+        const content = this.contentMap.get(key);
+        bytesReclaimed += content?.length ?? 0;
+        versionsRemoved++;
+
+        if (!options?.dryRun) {
+          this.dataMap.delete(key);
+          this.contentMap.delete(key);
+        }
+      }
+    }
+
+    return Promise.resolve({ versionsRemoved, bytesReclaimed });
+  }
+
+  rename(
+    type: ModelType,
+    modelId: string,
+    oldName: string,
+    newName: string,
+  ): Promise<{
+    oldName: string;
+    newName: string;
+    copiedVersion: number;
+    newVersion: number;
+  }> {
+    this.ensureNotDisposed();
+
+    const latest = this.getLatestVersionNumber(type, modelId, oldName);
+    if (latest === null) {
+      throw new Error(`No existing data found for "${oldName}"`);
+    }
+
+    const oldKey = dataKey(type.normalized, modelId, oldName, latest);
+    const oldData = this.dataMap.get(oldKey);
+    const oldContent = this.contentMap.get(oldKey);
+    if (!oldData || !oldContent) {
+      throw new Error(`No existing data found for "${oldName}"`);
+    }
+
+    const newVersion = this.nextVersion(type, modelId, newName);
+    const newData = Data.create({
+      id: oldData.id,
+      name: newName,
+      version: newVersion,
+      contentType: oldData.contentType,
+      lifetime: oldData.lifetime,
+      garbageCollection: oldData.garbageCollection,
+      streaming: oldData.streaming,
+      tags: oldData.tags,
+      ownerDefinition: oldData.ownerDefinition,
+      size: oldData.size,
+      checksum: oldData.checksum,
+    });
+
+    const newKey = dataKey(type.normalized, modelId, newName, newVersion);
+    this.dataMap.set(newKey, newData);
+    this.contentMap.set(newKey, oldContent);
+    this.latestVersionMap.set(
+      latestKey(type.normalized, modelId, newName),
+      newVersion,
+    );
+
+    const tombstoneVersion = latest + 1;
+    const tombstone = oldData.withRenameMarker({
+      version: tombstoneVersion,
+      renamedTo: newName,
+    });
+    const tombstoneKey = dataKey(
+      type.normalized,
+      modelId,
+      oldName,
+      tombstoneVersion,
+    );
+    this.dataMap.set(tombstoneKey, tombstone);
+    this.contentMap.set(tombstoneKey, new TextEncoder().encode("{}"));
+    this.latestVersionMap.set(
+      latestKey(type.normalized, modelId, oldName),
+      tombstoneVersion,
+    );
+
+    this.catalogUpsert(type, modelId, newData);
+
+    return Promise.resolve({
+      oldName,
+      newName,
+      copiedVersion: latest,
+      newVersion,
+    });
+  }
+
+  // --- Path Operations ---
+
+  getPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    return `ephemeral://${type.normalized}/${modelId}/${dataName}/${version}`;
+  }
+
+  getContentPath(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number,
+  ): string {
+    return `ephemeral://${type.normalized}/${modelId}/${dataName}/${version}/raw`;
+  }
+
+  // --- Identity ---
+
+  nextId(): DataId {
+    return generateDataId();
+  }
+
+  // --- Sync Read Methods (for CEL) ---
+
+  getLatestVersionSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number | null {
+    this.ensureNotDisposed();
+    return this.getLatestVersionNumber(type, modelId, dataName);
+  }
+
+  findByNameSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Data | null {
+    this.ensureNotDisposed();
+
+    const v = version ?? this.getLatestVersionNumber(type, modelId, dataName);
+    if (v === null) return null;
+
+    const key = dataKey(type.normalized, modelId, dataName, v);
+    const data = this.dataMap.get(key);
+    if (!data) return null;
+
+    if (data.isRenamed && data.renamedTo) {
+      return this.findByNameSync(type, modelId, data.renamedTo);
+    }
+
+    return data;
+  }
+
+  listVersionsSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+  ): number[] {
+    this.ensureNotDisposed();
+    const prefix = `${type.normalized}:${modelId}:${dataName}:`;
+    const versions: number[] = [];
+
+    for (const key of this.dataMap.keys()) {
+      if (key.startsWith(prefix)) {
+        const v = parseInt(key.slice(prefix.length), 10);
+        if (!isNaN(v)) versions.push(v);
+      }
+    }
+
+    return versions.sort((a, b) => a - b);
+  }
+
+  getContentSync(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version?: number,
+  ): Uint8Array | null {
+    this.ensureNotDisposed();
+
+    const v = version ?? this.getLatestVersionNumber(type, modelId, dataName);
+    if (v === null) return null;
+
+    const key = dataKey(type.normalized, modelId, dataName, v);
+    return this.contentMap.get(key) ?? null;
+  }
+
+  findAllForModelSync(type: ModelType, modelId: string): Data[] {
+    this.ensureNotDisposed();
+    const results: Data[] = [];
+    const seen = new Set<string>();
+
+    for (const [key, version] of this.latestVersionMap) {
+      const parts = key.split(":");
+      if (parts[0] !== type.normalized || parts[1] !== modelId) continue;
+      const dataName = parts[2];
+      if (seen.has(dataName)) continue;
+
+      const dKey = dataKey(type.normalized, modelId, dataName, version);
+      const data = this.dataMap.get(dKey);
+      if (data && !data.isDeleted) {
+        seen.add(dataName);
+        results.push(data);
+      }
+    }
+
+    return results;
+  }
+
+  findAllGlobalSync(): Array<
+    { data: Data; modelType: ModelType; modelId: string }
+  > {
+    this.ensureNotDisposed();
+    const results: Array<
+      { data: Data; modelType: ModelType; modelId: string }
+    > = [];
+
+    for (const [key, version] of this.latestVersionMap) {
+      const parts = key.split(":");
+      const typeNorm = parts[0];
+      const modelId = parts[1];
+      const dataName = parts[2];
+
+      const dKey = dataKey(typeNorm, modelId, dataName, version);
+      const data = this.dataMap.get(dKey);
+      if (data && !data.isDeleted) {
+        results.push({
+          data,
+          modelType: ModelType.create(typeNorm),
+          modelId,
+        });
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/infrastructure/persistence/in_memory_data_repository.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository.ts
@@ -34,13 +34,15 @@ import {
 } from "../../domain/data/repositories.ts";
 import type { CatalogStore } from "./catalog_store.ts";
 
+const SEP = "\0";
+
 function dataKey(
   typeNormalized: string,
   modelId: string,
   dataName: string,
   version: number,
 ): string {
-  return `${typeNormalized}:${modelId}:${dataName}:${version}`;
+  return `${typeNormalized}${SEP}${modelId}${SEP}${dataName}${SEP}${version}`;
 }
 
 function latestKey(
@@ -48,7 +50,7 @@ function latestKey(
   modelId: string,
   dataName: string,
 ): string {
-  return `${typeNormalized}:${modelId}:${dataName}`;
+  return `${typeNormalized}${SEP}${modelId}${SEP}${dataName}`;
 }
 
 export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
@@ -71,6 +73,13 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   dispose(): void {
+    for (const path of this.allocatedPaths.keys()) {
+      try {
+        Deno.removeSync(path);
+      } catch {
+        // Best-effort cleanup — file may already be gone
+      }
+    }
     this.dataMap.clear();
     this.contentMap.clear();
     this.latestVersionMap.clear();
@@ -287,6 +296,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
       if (
         alloc.typeNormalized === type.normalized &&
         alloc.modelId === modelId &&
+        alloc.data.name === data.name &&
         alloc.version === version
       ) {
         tempPath = path;
@@ -346,7 +356,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     > = [];
 
     for (const [key, version] of this.latestVersionMap) {
-      const parts = key.split(":");
+      const parts = key.split(SEP);
       if (parts[0] !== type.normalized) continue;
       const dKey = dataKey(parts[0], parts[1], parts[2], version);
       const data = this.dataMap.get(dKey);
@@ -503,7 +513,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
 
     const toProcess = new Map<string, number[]>();
     for (const [key] of this.dataMap) {
-      const parts = key.split(":");
+      const parts = key.split(SEP);
       if (parts[0] !== type.normalized || parts[1] !== modelId) continue;
       const dataName = parts[2];
       const version = parseInt(parts[3], 10);
@@ -662,7 +672,16 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     version?: number,
   ): Data | null {
     this.ensureNotDisposed();
+    return this.findByNameWithDepth(type, modelId, dataName, version, 0);
+  }
 
+  private findByNameWithDepth(
+    type: ModelType,
+    modelId: string,
+    dataName: string,
+    version: number | undefined,
+    depth: number,
+  ): Data | null {
     const v = version ?? this.getLatestVersionNumber(type, modelId, dataName);
     if (v === null) return null;
 
@@ -671,7 +690,14 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     if (!data) return null;
 
     if (data.isRenamed && data.renamedTo) {
-      return this.findByNameSync(type, modelId, data.renamedTo);
+      if (depth >= 5) return null;
+      return this.findByNameWithDepth(
+        type,
+        modelId,
+        data.renamedTo,
+        undefined,
+        depth + 1,
+      );
     }
 
     return data;
@@ -683,7 +709,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     dataName: string,
   ): number[] {
     this.ensureNotDisposed();
-    const prefix = `${type.normalized}:${modelId}:${dataName}:`;
+    const prefix = `${type.normalized}${SEP}${modelId}${SEP}${dataName}${SEP}`;
     const versions: number[] = [];
 
     for (const key of this.dataMap.keys()) {
@@ -717,7 +743,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     const seen = new Set<string>();
 
     for (const [key, version] of this.latestVersionMap) {
-      const parts = key.split(":");
+      const parts = key.split(SEP);
       if (parts[0] !== type.normalized || parts[1] !== modelId) continue;
       const dataName = parts[2];
       if (seen.has(dataName)) continue;
@@ -742,7 +768,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     > = [];
 
     for (const [key, version] of this.latestVersionMap) {
-      const parts = key.split(":");
+      const parts = key.split(SEP);
       const typeNorm = parts[0];
       const modelId = parts[1];
       const dataName = parts[2];

--- a/src/infrastructure/persistence/in_memory_data_repository_test.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository_test.ts
@@ -1,0 +1,452 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { InMemoryUnifiedDataRepository } from "./in_memory_data_repository.ts";
+import { CatalogStore } from "./catalog_store.ts";
+import { Data } from "../../domain/data/data.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+import { OwnershipValidationError } from "../../domain/data/repositories.ts";
+
+function createTestData(overrides: Partial<{
+  name: string;
+  lifetime: string;
+  streaming: boolean;
+  garbageCollection: number;
+  ownerRef: string;
+}> = {}): Data {
+  return Data.create({
+    name: overrides.name ?? "test-data",
+    contentType: "application/json",
+    lifetime: overrides.lifetime ?? "ephemeral",
+    garbageCollection: overrides.garbageCollection ?? 5,
+    streaming: overrides.streaming ?? false,
+    tags: { type: "resource", specName: "test", modelName: "test-model" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: overrides.ownerRef ?? "test-ref",
+    },
+  });
+}
+
+const TEST_TYPE = ModelType.create("test/type");
+const TEST_MODEL_ID = "test-model-id";
+const TEST_CONTENT = new TextEncoder().encode('{"key": "value"}');
+
+function createRepo(): {
+  repo: InMemoryUnifiedDataRepository;
+  catalog: CatalogStore;
+} {
+  const catalog = new CatalogStore(":memory:");
+  const repo = new InMemoryUnifiedDataRepository(catalog);
+  return { repo, catalog };
+}
+
+Deno.test("save: stores data and returns version", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+
+  const result = await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  assertEquals(result.version, 1);
+});
+
+Deno.test("save: increments version on subsequent saves", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+
+  const r1 = await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  const r2 = await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  assertEquals(r1.version, 1);
+  assertEquals(r2.version, 2);
+});
+
+Deno.test("save: rejects reserved data names", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ name: "latest" });
+
+  await assertRejects(
+    () => repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT),
+    Error,
+    "reserved for internal use",
+  );
+});
+
+Deno.test("save: validates ownership", async () => {
+  const { repo } = createRepo();
+  const data1 = createTestData({ ownerRef: "owner-1" });
+  const data2 = createTestData({ ownerRef: "owner-2" });
+
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data1, TEST_CONTENT);
+
+  await assertRejects(
+    () => repo.save(TEST_TYPE, TEST_MODEL_ID, data2, TEST_CONTENT),
+    OwnershipValidationError,
+  );
+});
+
+Deno.test("findByName: retrieves saved data", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const found = await repo.findByName(TEST_TYPE, TEST_MODEL_ID, "test-data");
+
+  assertEquals(found?.name, "test-data");
+  assertEquals(found?.version, 1);
+});
+
+Deno.test("findByName: returns null for missing data", async () => {
+  const { repo } = createRepo();
+
+  const found = await repo.findByName(TEST_TYPE, TEST_MODEL_ID, "missing");
+
+  assertEquals(found, null);
+});
+
+Deno.test("findByName: retrieves specific version", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    data,
+    new TextEncoder().encode("v2"),
+  );
+
+  const found = await repo.findByName(TEST_TYPE, TEST_MODEL_ID, "test-data", 1);
+
+  assertEquals(found?.version, 1);
+});
+
+Deno.test("getContent: retrieves saved content", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const content = await repo.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+
+  assertEquals(content, TEST_CONTENT);
+});
+
+Deno.test("getContent: returns null for missing data", async () => {
+  const { repo } = createRepo();
+
+  const content = await repo.getContent(TEST_TYPE, TEST_MODEL_ID, "missing");
+
+  assertEquals(content, null);
+});
+
+Deno.test("listVersions: returns sorted versions", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const versions = await repo.listVersions(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+
+  assertEquals(versions, [1, 2, 3]);
+});
+
+Deno.test("delete: removes all versions", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await repo.delete(TEST_TYPE, TEST_MODEL_ID, "test-data");
+
+  const found = await repo.findByName(TEST_TYPE, TEST_MODEL_ID, "test-data");
+  assertEquals(found, null);
+  const versions = await repo.listVersions(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(versions, []);
+});
+
+Deno.test("delete: removes specific version", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await repo.delete(TEST_TYPE, TEST_MODEL_ID, "test-data", 1);
+
+  const versions = await repo.listVersions(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(versions, [2]);
+});
+
+Deno.test("append: appends to streaming data", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ streaming: true });
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const appendContent = new TextEncoder().encode("\nmore data");
+  await repo.append(TEST_TYPE, TEST_MODEL_ID, "test-data", appendContent);
+
+  const content = await repo.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(content?.length, TEST_CONTENT.length + appendContent.length);
+});
+
+Deno.test("append: rejects non-streaming data", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ streaming: false });
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await assertRejects(
+    () =>
+      repo.append(
+        TEST_TYPE,
+        TEST_MODEL_ID,
+        "test-data",
+        new TextEncoder().encode("more"),
+      ),
+    Error,
+    "not configured for streaming",
+  );
+});
+
+Deno.test("allocateVersion: creates temp file and finalizeVersion reads it into memory", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+
+  const alloc = await repo.allocateVersion(TEST_TYPE, TEST_MODEL_ID, data);
+  assertEquals(typeof alloc.version, "number");
+  assertEquals(typeof alloc.contentPath, "string");
+
+  await Deno.writeFile(alloc.contentPath, TEST_CONTENT);
+
+  const result = await repo.finalizeVersion(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    data,
+    alloc.version,
+  );
+
+  assertEquals(result.size, TEST_CONTENT.length);
+  assertEquals(typeof result.checksum, "string");
+
+  const content = await repo.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(content, TEST_CONTENT);
+
+  // Temp file should be cleaned up
+  await assertRejects(
+    () => Deno.stat(alloc.contentPath),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("findAllForModel: returns latest versions", async () => {
+  const { repo } = createRepo();
+  const data1 = createTestData({ name: "data-1" });
+  const data2 = createTestData({ name: "data-2" });
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data1, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data2, TEST_CONTENT);
+
+  const results = await repo.findAllForModel(TEST_TYPE, TEST_MODEL_ID);
+
+  assertEquals(results.length, 2);
+  const names = results.map((d) => d.name).sort();
+  assertEquals(names, ["data-1", "data-2"]);
+});
+
+Deno.test("findAllGlobal: returns all data across models", async () => {
+  const { repo } = createRepo();
+  const data1 = createTestData({ name: "data-1" });
+  const data2 = createTestData({ name: "data-2" });
+  await repo.save(TEST_TYPE, "model-a", data1, TEST_CONTENT);
+  await repo.save(TEST_TYPE, "model-b", data2, TEST_CONTENT);
+
+  const results = await repo.findAllGlobal();
+
+  assertEquals(results.length, 2);
+});
+
+Deno.test("rename: creates new entry and tombstones old", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ name: "old-name" });
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const result = await repo.rename(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "old-name",
+    "new-name",
+  );
+
+  assertEquals(result.oldName, "old-name");
+  assertEquals(result.newName, "new-name");
+
+  const newData = await repo.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "new-name",
+  );
+  assertEquals(newData?.name, "new-name");
+
+  const content = await repo.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "new-name",
+  );
+  assertEquals(content, TEST_CONTENT);
+});
+
+Deno.test("getPath: returns synthetic ephemeral path", () => {
+  const { repo } = createRepo();
+
+  const path = repo.getPath(TEST_TYPE, TEST_MODEL_ID, "data-1", 1);
+
+  assertEquals(path, "ephemeral://test/type/test-model-id/data-1/1");
+});
+
+Deno.test("getContentPath: returns synthetic ephemeral path", () => {
+  const { repo } = createRepo();
+
+  const path = repo.getContentPath(TEST_TYPE, TEST_MODEL_ID, "data-1", 1);
+
+  assertEquals(path, "ephemeral://test/type/test-model-id/data-1/1/raw");
+});
+
+Deno.test("dispose: clears all data and prevents further operations", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  repo.dispose();
+
+  assertThrows(
+    () => repo.findByNameSync(TEST_TYPE, TEST_MODEL_ID, "test-data"),
+    Error,
+    "disposed",
+  );
+});
+
+Deno.test("sync methods: match async counterparts", async () => {
+  const { repo } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  const syncData = repo.findByNameSync(TEST_TYPE, TEST_MODEL_ID, "test-data");
+  const asyncData = await repo.findByName(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(syncData?.id, asyncData?.id);
+
+  const syncContent = repo.getContentSync(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  const asyncContent = await repo.getContent(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(syncContent, asyncContent);
+
+  const syncLatest = repo.getLatestVersionSync(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(syncLatest, 1);
+});
+
+Deno.test("catalog integration: indexes data for search", async () => {
+  const { repo, catalog } = createRepo();
+  const data = createTestData();
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  let rowCount = 0;
+  for (const _row of catalog.iterate()) {
+    rowCount++;
+  }
+
+  assertEquals(rowCount, 1);
+});
+
+Deno.test("collectGarbage: removes excess versions", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ garbageCollection: 2 });
+
+  for (let i = 0; i < 5; i++) {
+    await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  }
+
+  const result = await repo.collectGarbage(TEST_TYPE, TEST_MODEL_ID);
+
+  assertEquals(result.versionsRemoved, 3);
+
+  const versions = await repo.listVersions(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(versions, [4, 5]);
+});
+
+Deno.test("collectGarbage: dryRun does not remove versions", async () => {
+  const { repo } = createRepo();
+  const data = createTestData({ garbageCollection: 2 });
+
+  for (let i = 0; i < 5; i++) {
+    await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  }
+
+  const result = await repo.collectGarbage(TEST_TYPE, TEST_MODEL_ID, {
+    dryRun: true,
+  });
+
+  assertEquals(result.versionsRemoved, 3);
+
+  const versions = await repo.listVersions(
+    TEST_TYPE,
+    TEST_MODEL_ID,
+    "test-data",
+  );
+  assertEquals(versions, [1, 2, 3, 4, 5]);
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -39,12 +39,16 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import type { ModelDefinition } from "../../domain/models/model.ts";
 import type { MethodExecutionService } from "../../domain/models/method_execution_service.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { VaultService } from "../../domain/vaults/vault_service.ts";
 import type { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
-import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { DataQueryService } from "../../domain/data/data_query_service.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { CompositeUnifiedDataRepository } from "../../domain/data/composite_data_repository.ts";
+import { CompositeDataQueryService } from "../../domain/data/composite_data_query_service.ts";
 import { buildMethodContext } from "../../domain/models/method_context.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import type {
@@ -240,6 +244,23 @@ export async function* modelMethodRun(
       "method.name": input.methodName,
     },
     (async function* () {
+      const ephemeralCatalog = new CatalogStore(":memory:");
+      const ephemeralRepo = new InMemoryUnifiedDataRepository(
+        ephemeralCatalog,
+        deps.dataRepo.namespace,
+      );
+      deps = {
+        ...deps,
+        dataRepo: new CompositeUnifiedDataRepository(
+          deps.dataRepo,
+          ephemeralRepo,
+        ),
+        dataQueryService: new CompositeDataQueryService(
+          deps.dataQueryService,
+          new DataQueryService(ephemeralCatalog, ephemeralRepo),
+        ),
+      };
+
       // --- Validate inputs phase ---
       yield { kind: "validating_inputs" };
 
@@ -659,6 +680,15 @@ export async function* modelMethodRun(
                     methodName: input.methodName,
                     logger: getRunLogger(definition.name, input.methodName),
                     runtimeTags: input.runtimeTags,
+                    dataOutputOverrides: evaluatedDefinition.resources
+                      ? Object.entries(
+                        evaluatedDefinition.resources,
+                      ).map(([specName, override]) => ({
+                        specName,
+                        lifetime: override.lifetime,
+                        garbageCollection: override.garbageCollection,
+                      }))
+                      : undefined,
                     vaultSecrets: secretBag,
                     skipCheckNames: input.skipCheckNames,
                     skipCheckLabels: input.skipCheckLabels,
@@ -1050,6 +1080,7 @@ export async function* modelMethodRun(
         }
       } finally {
         runLog.cleanup();
+        ephemeralRepo.dispose();
       }
     })(),
   );

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -49,7 +49,7 @@ import type { CatalogStore } from "../../infrastructure/persistence/catalog_stor
 import {
   createEphemeralStore,
   wrapWithEphemeral,
-} from "../../domain/data/ephemeral_store.ts";
+} from "../../infrastructure/persistence/ephemeral_store.ts";
 import { buildMethodContext } from "../../domain/models/method_context.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import type {

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -44,11 +44,12 @@ import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { VaultService } from "../../domain/vaults/vault_service.ts";
 import type { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
-import { DataQueryService } from "../../domain/data/data_query_service.ts";
-import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
-import { CompositeUnifiedDataRepository } from "../../domain/data/composite_data_repository.ts";
-import { CompositeDataQueryService } from "../../domain/data/composite_data_query_service.ts";
+import type { DataQueryService } from "../../domain/data/data_query_service.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import {
+  createEphemeralStore,
+  wrapWithEphemeral,
+} from "../../domain/data/ephemeral_store.ts";
 import { buildMethodContext } from "../../domain/models/method_context.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import type {
@@ -187,9 +188,9 @@ export interface ModelMethodRunDeps {
   createExecutionService: () => MethodExecutionService;
   createVaultService: () => Promise<VaultService>;
   dataRepo: UnifiedDataRepository;
+  catalogStore?: CatalogStore;
   definitionRepo: YamlDefinitionRepository;
   outputRepo: OutputRepository;
-  /** Data query service — the executor derives context.queryData from this. */
   dataQueryService: DataQueryService;
   createRunLog: (
     modelType: ModelType,
@@ -244,22 +245,15 @@ export async function* modelMethodRun(
       "method.name": input.methodName,
     },
     (async function* () {
-      const ephemeralCatalog = new CatalogStore(":memory:");
-      const ephemeralRepo = new InMemoryUnifiedDataRepository(
-        ephemeralCatalog,
-        deps.dataRepo.namespace,
-      );
-      deps = {
-        ...deps,
-        dataRepo: new CompositeUnifiedDataRepository(
+      const ephemeral = createEphemeralStore(deps.dataRepo.namespace);
+      if (deps.catalogStore) {
+        const wrapped = wrapWithEphemeral(
           deps.dataRepo,
-          ephemeralRepo,
-        ),
-        dataQueryService: new CompositeDataQueryService(
-          deps.dataQueryService,
-          new DataQueryService(ephemeralCatalog, ephemeralRepo),
-        ),
-      };
+          deps.catalogStore,
+          ephemeral,
+        );
+        deps = { ...deps, ...wrapped };
+      }
 
       // --- Validate inputs phase ---
       yield { kind: "validating_inputs" };
@@ -1080,7 +1074,7 @@ export async function* modelMethodRun(
         }
       } finally {
         runLog.cleanup();
-        ephemeralRepo.dispose();
+        ephemeral.dispose();
       }
     })(),
   );

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -50,7 +50,7 @@ import {
 } from "../../domain/inputs/mod.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
-import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
+import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -48,8 +48,9 @@ import {
   type InputValidationError,
   InputValidationService,
 } from "../../domain/inputs/mod.ts";
-import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import type { UnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
@@ -231,6 +232,8 @@ export interface WorkflowRunDeps {
     runRepo: WorkflowRunRepository,
     repoDir: string,
     catalogStore: CatalogStore,
+    ephemeralRepo?: UnifiedDataRepository,
+    ephemeralCatalog?: CatalogStore,
   ) => WorkflowExecutionService;
   catalogStore: CatalogStore;
   dataRepo?: UnifiedDataRepository;
@@ -468,6 +471,10 @@ export async function* workflowRun(
     "swamp.workflow.run.command",
     { "workflow.id_or_name": input.workflowIdOrName },
     (async function* () {
+      const ephemeralCatalog = new CatalogStore(":memory:");
+      const ephemeralRepo = new InMemoryUnifiedDataRepository(
+        ephemeralCatalog,
+      );
       let resolvedInput = input;
 
       yield { kind: "validating_inputs" };
@@ -520,6 +527,8 @@ export async function* workflowRun(
         deps.runRepo,
         deps.repoDir,
         deps.catalogStore,
+        ephemeralRepo,
+        ephemeralCatalog,
       );
 
       // Per-method-invocation telemetry bridge. Constructed once per
@@ -619,6 +628,7 @@ export async function* workflowRun(
         if (telemetryBridge) {
           await telemetryBridge.finalize();
         }
+        ephemeralRepo.dispose();
       }
     })(),
   );

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -48,9 +48,9 @@ import {
   type InputValidationError,
   InputValidationService,
 } from "../../domain/inputs/mod.ts";
-import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
+import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
@@ -471,10 +471,7 @@ export async function* workflowRun(
     "swamp.workflow.run.command",
     { "workflow.id_or_name": input.workflowIdOrName },
     (async function* () {
-      const ephemeralCatalog = new CatalogStore(":memory:");
-      const ephemeralRepo = new InMemoryUnifiedDataRepository(
-        ephemeralCatalog,
-      );
+      const ephemeral = createEphemeralStore();
       let resolvedInput = input;
 
       yield { kind: "validating_inputs" };
@@ -527,8 +524,8 @@ export async function* workflowRun(
         deps.runRepo,
         deps.repoDir,
         deps.catalogStore,
-        ephemeralRepo,
-        ephemeralCatalog,
+        ephemeral.repo,
+        ephemeral.catalog,
       );
 
       // Per-method-invocation telemetry bridge. Constructed once per
@@ -628,7 +625,7 @@ export async function* workflowRun(
         if (telemetryBridge) {
           await telemetryBridge.finalize();
         }
-        ephemeralRepo.dispose();
+        ephemeral.dispose();
       }
     })(),
   );

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -29,6 +29,7 @@
 
 import { ModelType } from "../domain/models/model_type.ts";
 import type { Data } from "../domain/data/data.ts";
+import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
 import { createDataId } from "../domain/data/data_id.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { VaultService } from "../domain/vaults/vault_service.ts";
@@ -163,9 +164,7 @@ export class CapabilityService {
     }
   }
 
-  #repoForWorker(
-    workerName: string,
-  ): import("../domain/data/repositories.ts").UnifiedDataRepository {
+  #repoForWorker(workerName: string): UnifiedDataRepository {
     const dispatch = this.#dispatches?.forWorker(workerName);
     return dispatch?.dataRepo ?? this.#repoContext.unifiedDataRepo;
   }

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -163,22 +163,30 @@ export class CapabilityService {
     }
   }
 
+  #repoForWorker(
+    workerName: string,
+  ): import("../domain/data/repositories.ts").UnifiedDataRepository {
+    const dispatch = this.#dispatches?.forWorker(workerName);
+    return dispatch?.dataRepo ?? this.#repoContext.unifiedDataRepo;
+  }
+
   async getData(
     workerName: string,
     params: GetDataParams,
   ): Promise<GetDataResult> {
     this.#assertDispatchScope(workerName, params.modelType, "getData");
     const type = ModelType.create(params.modelType);
+    const repo = this.#repoForWorker(workerName);
     let data: Data | null = null;
     if (params.dataId !== undefined) {
-      data = await this.#repoContext.unifiedDataRepo.findById(
+      data = await repo.findById(
         type,
         params.modelId,
         createDataId(params.dataId),
         params.version,
       );
     } else if (params.dataName !== undefined) {
-      data = await this.#repoContext.unifiedDataRepo.findByName(
+      data = await repo.findByName(
         type,
         params.modelId,
         params.dataName,
@@ -244,8 +252,12 @@ export class CapabilityService {
     return records.map((record) => jsonSafeClone(record));
   }
 
-  listVersions(params: ListVersionsParams): Promise<number[]> {
-    return this.#repoContext.unifiedDataRepo.listVersions(
+  listVersions(
+    workerName: string,
+    params: ListVersionsParams,
+  ): Promise<number[]> {
+    const repo = this.#repoForWorker(workerName);
+    return repo.listVersions(
       ModelType.create(params.modelType),
       params.modelId,
       params.dataName,
@@ -258,14 +270,15 @@ export class CapabilityService {
   ): Promise<{ deleted: boolean }> {
     this.#assertDispatchScope(workerName, params.modelType, "deleteData");
     const type = ModelType.create(params.modelType);
+    const repo = this.#repoForWorker(workerName);
     if (params.removeLatestMarkerOnly) {
-      await this.#repoContext.unifiedDataRepo.removeLatestMarker(
+      await repo.removeLatestMarker(
         type,
         params.modelId,
         params.dataName,
       );
     } else {
-      await this.#repoContext.unifiedDataRepo.delete(
+      await repo.delete(
         type,
         params.modelId,
         params.dataName,
@@ -419,7 +432,7 @@ export class CapabilityService {
     channel.register(
       RemoteMethod.listVersions,
       safe((params) =>
-        this.listVersions(ListVersionsParamsSchema.parse(params))
+        this.listVersions(workerName, ListVersionsParamsSchema.parse(params))
       ),
     );
     channel.register(

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -212,6 +212,13 @@ export class DataPlane {
     return this.#vaultService;
   }
 
+  #repoForWorker(
+    workerName: string,
+  ): import("../domain/data/repositories.ts").UnifiedDataRepository {
+    const dispatch = this.#options.dispatches.forWorker(workerName);
+    return dispatch?.dataRepo ?? this.#options.repoContext.unifiedDataRepo;
+  }
+
   // ── /data routes ───────────────────────────────────────────────────────
 
   async #handleData(
@@ -220,7 +227,7 @@ export class DataPlane {
     workerName: string,
   ): Promise<Response> {
     if (req.method === "GET" && segments.length === 5) {
-      return await this.#readArtifact(req, segments);
+      return await this.#readArtifact(req, segments, workerName);
     }
     if (req.method === "POST" && segments[1] === "resource") {
       return await this.#writeResource(req, workerName);
@@ -244,7 +251,11 @@ export class DataPlane {
     return errorResponse(404, "Unknown data-plane route");
   }
 
-  async #readArtifact(req: Request, segments: string[]): Promise<Response> {
+  async #readArtifact(
+    req: Request,
+    segments: string[],
+    workerName: string,
+  ): Promise<Response> {
     const [, rawType, rawModelId, rawDataName, rawVersion] = segments;
     const type = ModelType.create(decodeURIComponent(rawType));
     const modelId = decodeURIComponent(rawModelId);
@@ -254,7 +265,8 @@ export class DataPlane {
       return errorResponse(400, `Invalid version '${rawVersion}'`);
     }
 
-    const data = await this.#options.repoContext.unifiedDataRepo.findByName(
+    const repo = this.#repoForWorker(workerName);
+    const data = await repo.findByName(
       type,
       modelId,
       dataName,
@@ -271,7 +283,7 @@ export class DataPlane {
       return new Response(null, { status: 304, headers: { etag } });
     }
 
-    const stream = this.#options.repoContext.unifiedDataRepo.stream(
+    const stream = repo.stream(
       type,
       modelId,
       dataName,
@@ -299,8 +311,9 @@ export class DataPlane {
       return errorResponse(400, "Expected { specName, name, data }");
     }
 
+    const repo = this.#repoForWorker(workerName);
     const { writeResource } = createResourceWriter(
-      this.#options.repoContext.unifiedDataRepo,
+      repo,
       dispatch.modelType,
       dispatch.modelId,
       dispatch.modelDef.resources ?? {},
@@ -337,7 +350,8 @@ export class DataPlane {
     }
 
     try {
-      await this.#options.repoContext.unifiedDataRepo.delete(
+      const repo = this.#repoForWorker(workerName);
+      await repo.delete(
         dispatch.modelType,
         dispatch.modelId,
         body.name,
@@ -358,8 +372,9 @@ export class DataPlane {
       return errorResponse(400, "Expected { specName, name }");
     }
 
+    const repo = this.#repoForWorker(workerName);
     const { createFileWriter } = createFileWriterFactory(
-      this.#options.repoContext.unifiedDataRepo,
+      repo,
       dispatch.modelType,
       dispatch.modelId,
       dispatch.modelDef.files ?? {},

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -53,6 +53,7 @@ import { VaultService } from "../domain/vaults/vault_service.ts";
 import type { ActiveDispatch, DispatchRegistry } from "./dispatch_registry.ts";
 import type { BundleRegistry } from "./bundle_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
 
 const logger = getSwampLogger(["serve", "data-plane"]);
 
@@ -212,9 +213,7 @@ export class DataPlane {
     return this.#vaultService;
   }
 
-  #repoForWorker(
-    workerName: string,
-  ): import("../domain/data/repositories.ts").UnifiedDataRepository {
+  #repoForWorker(workerName: string): UnifiedDataRepository {
     const dispatch = this.#options.dispatches.forWorker(workerName);
     return dispatch?.dataRepo ?? this.#options.repoContext.unifiedDataRepo;
   }

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -85,7 +85,14 @@ export async function createWorkflowRunDeps(
       return await repo.findByName(idOrName) ??
         await repo.findById(createWorkflowId(idOrName));
     },
-    createExecutionService: (wfRepo, rnRepo, dir, catalogStore) => {
+    createExecutionService: (
+      wfRepo,
+      rnRepo,
+      dir,
+      catalogStore,
+      ephRepo,
+      ephCatalog,
+    ) => {
       // Direct type execution (auto-create-then-run steps) must work over
       // serve exactly as it does locally — serve is the only way to run
       // workflows with worker placement. Mirrors the CLI's resolver in
@@ -156,6 +163,8 @@ export async function createWorkflowRunDeps(
         repoContext.unifiedDataRepo.namespace,
         stepLockHook,
         runTracker,
+        ephRepo,
+        ephCatalog,
       );
     },
     catalogStore: repoContext.catalogStore,

--- a/src/serve/dispatch_registry.ts
+++ b/src/serve/dispatch_registry.ts
@@ -26,6 +26,7 @@
  * design/remote-execution.md, "Authenticating the data plane").
  */
 
+import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
 import type { ModelDefinition } from "../domain/models/model.ts";
 import type { ModelType } from "../domain/models/model_type.ts";
 
@@ -41,6 +42,7 @@ export interface ActiveDispatch {
   definitionName: string;
   definitionTags: Record<string, string>;
   runtimeTags?: Record<string, string>;
+  dataRepo?: UnifiedDataRepository;
 }
 
 export class DispatchRegistry {

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -262,6 +262,7 @@ export class DispatchService {
       definitionName: request.definitionName,
       definitionTags: request.definitionTags,
       runtimeTags: request.runtimeTags,
+      dataRepo: request.dataRepo,
     });
 
     const params: DispatchParams = {

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -70,7 +70,7 @@ import {
   type Principal,
   principalToString,
 } from "../../domain/access/principal.ts";
-import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
+import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -70,6 +70,8 @@ import {
   type Principal,
   principalToString,
 } from "../../domain/access/principal.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -737,6 +739,12 @@ export async function handleWorkflowResume(
     await createWorkflowRunDeps(ctx.repoDir, ctx.repoContext, stepLockHook);
 
     const resumeInputs = payload.inputs ?? {};
+    const ephemeralCatalog = new CatalogStore(":memory:");
+    const ephemeralRepo = new InMemoryUnifiedDataRepository(
+      ephemeralCatalog,
+      ctx.repoContext.unifiedDataRepo.namespace,
+    );
+
     const service = new WorkflowExecutionService(
       workflowRepo,
       runRepo,
@@ -749,6 +757,8 @@ export async function handleWorkflowResume(
       ctx.repoContext.unifiedDataRepo.namespace,
       stepLockHook,
       ctx.runTracker,
+      ephemeralRepo,
+      ephemeralCatalog,
     );
 
     const resumeGenerator = async function* (): AsyncGenerator<

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -70,8 +70,7 @@ import {
   type Principal,
   principalToString,
 } from "../../domain/access/principal.ts";
-import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "../../infrastructure/persistence/in_memory_data_repository.ts";
+import { createEphemeralStore } from "../../domain/data/ephemeral_store.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -739,10 +738,9 @@ export async function handleWorkflowResume(
     await createWorkflowRunDeps(ctx.repoDir, ctx.repoContext, stepLockHook);
 
     const resumeInputs = payload.inputs ?? {};
-    const ephemeralCatalog = new CatalogStore(":memory:");
-    const ephemeralRepo = new InMemoryUnifiedDataRepository(
-      ephemeralCatalog,
+    const ephemeral = createEphemeralStore(
       ctx.repoContext.unifiedDataRepo.namespace,
+      { isResume: true },
     );
 
     const service = new WorkflowExecutionService(
@@ -757,8 +755,8 @@ export async function handleWorkflowResume(
       ctx.repoContext.unifiedDataRepo.namespace,
       stepLockHook,
       ctx.runTracker,
-      ephemeralRepo,
-      ephemeralCatalog,
+      ephemeral.repo,
+      ephemeral.catalog,
     );
 
     const resumeGenerator = async function* (): AsyncGenerator<
@@ -774,12 +772,16 @@ export async function handleWorkflowResume(
       }
     };
 
-    for await (const event of resumeGenerator()) {
-      if (socket.readyState !== WebSocket.OPEN) break;
-      const serialized = serializeEvent(
-        event as { kind: string; [key: string]: unknown },
-      );
-      send(socket, { type: "event", id: requestId, event: serialized });
+    try {
+      for await (const event of resumeGenerator()) {
+        if (socket.readyState !== WebSocket.OPEN) break;
+        const serialized = serializeEvent(
+          event as { kind: string; [key: string]: unknown },
+        );
+        send(socket, { type: "event", id: requestId, event: serialized });
+      }
+    } finally {
+      ephemeral.dispose();
     }
     send(socket, { type: "done", id: requestId });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Implements `lifetime: "ephemeral"` as a global in-memory store that never writes to disk and is scoped to execution lifetime
- Ephemeral data is indexed for search via `:memory:` SQLite catalog, so `data.latest()`, `data.query()`, and `data.search()` all work transparently
- Definition YAML now supports `resources.<name>.lifetime: ephemeral` to override model type defaults
- Remote workers access ephemeral data through dispatch-scoped composite repos on both the data plane (HTTP) and capability service (WebSocket)

### New components

| Component | Location | Role |
|-----------|----------|------|
| `InMemoryUnifiedDataRepository` | `src/infrastructure/persistence/` | Map-based storage with `:memory:` CatalogStore, temp file strategy for `allocateVersion`/`finalizeVersion` |
| `CompositeUnifiedDataRepository` | `src/domain/data/` | Routes writes by `data.lifetime === "ephemeral"`, reads with ephemeral-first fallback |
| `CompositeDataQueryService` | `src/domain/data/` | Merges query results from persistent and ephemeral catalogs with deduplication |

### Execution lifecycle

- **Workflow runs**: `workflowRun()` creates ephemeral store, passes through `WorkflowExecutionService` constructor. All steps share the same store so downstream steps read upstream ephemeral data via `data.latest()`.
- **Standalone method runs**: `modelMethodRun()` creates and disposes its own store.
- **Workflow resume**: Fresh store created (ephemeral data from before suspension is intentionally lost).
- **Sub-workflows**: Share parent's ephemeral store.
- **Remote execution**: `ActiveDispatch` carries the composite repo; `DataPlane` and `CapabilityService` resolve per-worker.

### Known limitation

- Suspend/resume: ephemeral data from before suspension is lost by design (option 3 from the design doc). Use `"workflow"` or `"infinite"` lifetime for data that must survive suspension.

Closes swamp-club#663

## Test plan

- 25 unit tests for `InMemoryUnifiedDataRepository` (save, read, delete, versions, append, allocateVersion/finalizeVersion round-trip, GC, rename, dispose, catalog integration)
- End-to-end verified with compiled binary:
  - [x] Standalone method run with definition-level `resources.result.lifetime: ephemeral` — data at `ephemeral://` path, gone after run
  - [x] Workflow with `dataOutputOverrides` ephemeral — data gone, persistent unaffected
  - [x] Multi-step workflow — step B reads step A's ephemeral data via `data.latest()` CEL expression
  - [x] Workflow resume — fresh ephemeral store, post-gate steps produce/consume ephemeral correctly
  - [x] Backwards compatibility — old definitions without `resources` field load fine, invalid lifetimes rejected by Zod
- All 282 serve tests + 14 capability service tests + 30 dispatch service tests pass
- 8116 total tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)