### PR TITLE
fix(data): add memory budget to ephemeral data store

### DIFF
--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -41,6 +41,26 @@ export class OwnershipValidationError extends Error {
 }
 
 /**
+ * Error thrown when the ephemeral data memory budget is exceeded.
+ */
+export class EphemeralBudgetExceededError extends Error {
+  constructor(
+    readonly currentBytes: number,
+    readonly contentBytes: number,
+    readonly maxBytes: number,
+  ) {
+    const usedMB = Math.round(currentBytes / 1024 / 1024);
+    const maxMB = Math.round(maxBytes / 1024 / 1024);
+    super(
+      `Ephemeral data budget exceeded: ${usedMB} MB used, ` +
+        `write of ${contentBytes} bytes would exceed ${maxMB} MB limit. ` +
+        `Use "workflow" or "infinite" lifetime for large data.`,
+    );
+    this.name = "EphemeralBudgetExceededError";
+  }
+}
+
+/**
  * Result of garbage collection operation.
  */
 export interface GarbageCollectionResult {

--- a/src/infrastructure/persistence/ephemeral_store.ts
+++ b/src/infrastructure/persistence/ephemeral_store.ts
@@ -19,7 +19,10 @@
 
 import { getLogger } from "@logtape/logtape";
 import { CatalogStore } from "./catalog_store.ts";
-import { InMemoryUnifiedDataRepository } from "./in_memory_data_repository.ts";
+import {
+  DEFAULT_EPHEMERAL_MAX_BYTES,
+  InMemoryUnifiedDataRepository,
+} from "./in_memory_data_repository.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { CompositeUnifiedDataRepository } from "../../domain/data/composite_data_repository.ts";
 import { CompositeDataQueryService } from "../../domain/data/composite_data_query_service.ts";
@@ -27,6 +30,46 @@ import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
 import type { Namespace } from "../../domain/data/namespace.ts";
 
 const logger = getLogger(["swamp", "data", "ephemeral"]);
+
+export function parseByteSize(value: string): number | undefined {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*([kmg]?b?)?$/i);
+  if (!match) return undefined;
+  const num = parseFloat(match[1]);
+  if (isNaN(num) || num < 0) return undefined;
+  const suffix = (match[2] ?? "").toLowerCase();
+  switch (suffix) {
+    case "k":
+    case "kb":
+      return Math.floor(num * 1024);
+    case "m":
+    case "mb":
+      return Math.floor(num * 1024 * 1024);
+    case "g":
+    case "gb":
+      return Math.floor(num * 1024 * 1024 * 1024);
+    case "":
+    case "b":
+      return Math.floor(num);
+    default:
+      return undefined;
+  }
+}
+
+function resolveMaxBytes(explicit?: number): number {
+  if (explicit !== undefined) return explicit;
+  const envValue = Deno.env.get("SWAMP_EPHEMERAL_BUDGET");
+  if (envValue) {
+    const parsed = parseByteSize(envValue);
+    if (parsed !== undefined) {
+      logger
+        .info`Ephemeral budget set to ${envValue} via SWAMP_EPHEMERAL_BUDGET`;
+      return parsed;
+    }
+    logger
+      .warn`Invalid SWAMP_EPHEMERAL_BUDGET value ${envValue}, using default ${DEFAULT_EPHEMERAL_MAX_BYTES}`;
+  }
+  return DEFAULT_EPHEMERAL_MAX_BYTES;
+}
 
 export interface EphemeralStore {
   repo: InMemoryUnifiedDataRepository;
@@ -36,15 +79,20 @@ export interface EphemeralStore {
 
 export function createEphemeralStore(
   namespace?: Namespace,
-  options?: { isResume?: boolean },
+  options?: { isResume?: boolean; maxBytes?: number },
 ): EphemeralStore {
   if (options?.isResume) {
     logger.info(
       "Ephemeral data from before suspension is not available in resumed runs — use 'workflow' or 'infinite' lifetime to persist across gates.",
     );
   }
+  const maxBytes = resolveMaxBytes(options?.maxBytes);
   const catalog = new CatalogStore(":memory:");
-  const repo = new InMemoryUnifiedDataRepository(catalog, namespace);
+  const repo = new InMemoryUnifiedDataRepository(
+    catalog,
+    namespace,
+    maxBytes,
+  );
   return {
     repo,
     catalog,

--- a/src/infrastructure/persistence/ephemeral_store_test.ts
+++ b/src/infrastructure/persistence/ephemeral_store_test.ts
@@ -1,0 +1,63 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { parseByteSize } from "./ephemeral_store.ts";
+
+Deno.test("parseByteSize: parses plain bytes", () => {
+  assertEquals(parseByteSize("1024"), 1024);
+  assertEquals(parseByteSize("0"), 0);
+  assertEquals(parseByteSize("100b"), 100);
+});
+
+Deno.test("parseByteSize: parses kilobytes", () => {
+  assertEquals(parseByteSize("1k"), 1024);
+  assertEquals(parseByteSize("1kb"), 1024);
+  assertEquals(parseByteSize("1KB"), 1024);
+  assertEquals(parseByteSize("2K"), 2048);
+});
+
+Deno.test("parseByteSize: parses megabytes", () => {
+  assertEquals(parseByteSize("1m"), 1024 * 1024);
+  assertEquals(parseByteSize("1mb"), 1024 * 1024);
+  assertEquals(parseByteSize("512M"), 512 * 1024 * 1024);
+  assertEquals(parseByteSize("1MB"), 1024 * 1024);
+});
+
+Deno.test("parseByteSize: parses gigabytes", () => {
+  assertEquals(parseByteSize("1g"), 1024 * 1024 * 1024);
+  assertEquals(parseByteSize("1gb"), 1024 * 1024 * 1024);
+  assertEquals(parseByteSize("2G"), 2 * 1024 * 1024 * 1024);
+});
+
+Deno.test("parseByteSize: handles fractional values", () => {
+  assertEquals(parseByteSize("0.5g"), Math.floor(0.5 * 1024 * 1024 * 1024));
+  assertEquals(parseByteSize("1.5m"), Math.floor(1.5 * 1024 * 1024));
+});
+
+Deno.test("parseByteSize: trims whitespace", () => {
+  assertEquals(parseByteSize("  512m  "), 512 * 1024 * 1024);
+});
+
+Deno.test("parseByteSize: returns undefined for invalid input", () => {
+  assertEquals(parseByteSize(""), undefined);
+  assertEquals(parseByteSize("abc"), undefined);
+  assertEquals(parseByteSize("-1m"), undefined);
+  assertEquals(parseByteSize("1t"), undefined);
+});

--- a/src/infrastructure/persistence/in_memory_data_repository.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository.ts
@@ -28,6 +28,7 @@ import {
 import type { Namespace } from "../../domain/data/namespace.ts";
 import { SOLO_NAMESPACE } from "../../domain/data/namespace.ts";
 import {
+  EphemeralBudgetExceededError,
   type GarbageCollectionResult,
   OwnershipValidationError,
   type UnifiedDataRepository,
@@ -53,6 +54,8 @@ function latestKey(
   return `${typeNormalized}${SEP}${modelId}${SEP}${dataName}`;
 }
 
+export const DEFAULT_EPHEMERAL_MAX_BYTES = 512 * 1024 * 1024; // 512 MB
+
 export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
   private readonly dataMap = new Map<string, Data>();
   private readonly contentMap = new Map<string, Uint8Array>();
@@ -64,11 +67,15 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     version: number;
   }>();
   private disposed = false;
+  private totalBytes = 0;
+  private readonly maxBytes: number;
 
   constructor(
     private readonly catalogStore: CatalogStore,
     public readonly namespace: Namespace = SOLO_NAMESPACE,
+    maxBytes?: number,
   ) {
+    this.maxBytes = maxBytes ?? DEFAULT_EPHEMERAL_MAX_BYTES;
     catalogStore.markPopulated();
   }
 
@@ -90,6 +97,16 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
   private ensureNotDisposed(): void {
     if (this.disposed) {
       throw new Error("InMemoryUnifiedDataRepository has been disposed");
+    }
+  }
+
+  private ensureBudget(additionalBytes: number): void {
+    if (this.totalBytes + additionalBytes > this.maxBytes) {
+      throw new EphemeralBudgetExceededError(
+        this.totalBytes,
+        additionalBytes,
+        this.maxBytes,
+      );
     }
   }
 
@@ -190,6 +207,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     }
 
     const newVersion = this.nextVersion(type, modelId, data.name);
+    this.ensureBudget(content.length);
 
     const dataToSave = data.withNewVersion({
       version: newVersion,
@@ -200,6 +218,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     const key = dataKey(type.normalized, modelId, data.name, newVersion);
     this.dataMap.set(key, dataToSave);
     this.contentMap.set(key, content);
+    this.totalBytes += content.length;
     this.latestVersionMap.set(
       latestKey(type.normalized, modelId, data.name),
       newVersion,
@@ -228,12 +247,15 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
       throw new Error(`Data "${dataName}" is not configured for streaming`);
     }
 
+    this.ensureBudget(content.length);
+
     const key = dataKey(type.normalized, modelId, dataName, latestVersion);
     const existing = this.contentMap.get(key) ?? new Uint8Array(0);
     const merged = new Uint8Array(existing.length + content.length);
     merged.set(existing);
     merged.set(content, existing.length);
     this.contentMap.set(key, merged);
+    this.totalBytes += content.length;
 
     const updatedData = data.withNewVersion({
       version: latestVersion,
@@ -313,6 +335,8 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
       content = new Uint8Array(0);
     }
 
+    this.ensureBudget(content.length);
+
     const checksum = await this.computeChecksum(content);
     const size = content.length;
 
@@ -325,6 +349,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     const key = dataKey(type.normalized, modelId, data.name, version);
     this.dataMap.set(key, dataToSave);
     this.contentMap.set(key, content);
+    this.totalBytes += content.length;
     this.latestVersionMap.set(
       latestKey(type.normalized, modelId, data.name),
       version,
@@ -457,6 +482,8 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
 
     if (version !== undefined) {
       const key = dataKey(type.normalized, modelId, dataName, version);
+      const content = this.contentMap.get(key);
+      if (content) this.totalBytes -= content.length;
       this.dataMap.delete(key);
       this.contentMap.delete(key);
 
@@ -479,6 +506,8 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
       const versions = this.listVersionsSync(type, modelId, dataName);
       for (const v of versions) {
         const key = dataKey(type.normalized, modelId, dataName, v);
+        const content = this.contentMap.get(key);
+        if (content) this.totalBytes -= content.length;
         this.dataMap.delete(key);
         this.contentMap.delete(key);
       }
@@ -543,6 +572,7 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
         versionsRemoved++;
 
         if (!options?.dryRun) {
+          if (content) this.totalBytes -= content.length;
           this.dataMap.delete(key);
           this.contentMap.delete(key);
         }

--- a/src/infrastructure/persistence/in_memory_data_repository_test.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository_test.ts
@@ -22,7 +22,10 @@ import { InMemoryUnifiedDataRepository } from "./in_memory_data_repository.ts";
 import { CatalogStore } from "./catalog_store.ts";
 import { Data } from "../../domain/data/data.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
-import { OwnershipValidationError } from "../../domain/data/repositories.ts";
+import {
+  EphemeralBudgetExceededError,
+  OwnershipValidationError,
+} from "../../domain/data/repositories.ts";
 
 function createTestData(overrides: Partial<{
   name: string;
@@ -49,12 +52,16 @@ const TEST_TYPE = ModelType.create("test/type");
 const TEST_MODEL_ID = "test-model-id";
 const TEST_CONTENT = new TextEncoder().encode('{"key": "value"}');
 
-function createRepo(): {
+function createRepo(maxBytes?: number): {
   repo: InMemoryUnifiedDataRepository;
   catalog: CatalogStore;
 } {
   const catalog = new CatalogStore(":memory:");
-  const repo = new InMemoryUnifiedDataRepository(catalog);
+  const repo = new InMemoryUnifiedDataRepository(
+    catalog,
+    undefined,
+    maxBytes,
+  );
   return { repo, catalog };
 }
 
@@ -449,4 +456,91 @@ Deno.test("collectGarbage: dryRun does not remove versions", async () => {
     "test-data",
   );
   assertEquals(versions, [1, 2, 3, 4, 5]);
+});
+
+// --- Budget enforcement ---
+
+Deno.test("save: rejects when content exceeds budget", async () => {
+  const { repo } = createRepo(32);
+  const data = createTestData();
+  const bigContent = new Uint8Array(64);
+
+  await assertRejects(
+    () => repo.save(TEST_TYPE, TEST_MODEL_ID, data, bigContent),
+    EphemeralBudgetExceededError,
+  );
+});
+
+Deno.test("save: rejects when cumulative writes exceed budget", async () => {
+  const { repo } = createRepo(TEST_CONTENT.length + 10);
+  const data = createTestData();
+
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await assertRejects(
+    () =>
+      repo.save(
+        TEST_TYPE,
+        TEST_MODEL_ID,
+        data,
+        TEST_CONTENT,
+      ),
+    EphemeralBudgetExceededError,
+  );
+});
+
+Deno.test("save: allows write after delete frees budget", async () => {
+  const { repo } = createRepo(TEST_CONTENT.length + 10);
+  const data = createTestData();
+
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.delete(TEST_TYPE, TEST_MODEL_ID, "test-data");
+
+  const result = await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  assertEquals(result.version, 1);
+});
+
+Deno.test("append: rejects when appended content exceeds budget", async () => {
+  const { repo } = createRepo(TEST_CONTENT.length + 4);
+  const data = createTestData({ streaming: true });
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await assertRejects(
+    () =>
+      repo.append(
+        TEST_TYPE,
+        TEST_MODEL_ID,
+        "test-data",
+        new Uint8Array(10),
+      ),
+    EphemeralBudgetExceededError,
+  );
+});
+
+Deno.test("finalizeVersion: rejects when finalized content exceeds budget", async () => {
+  const { repo } = createRepo(8);
+  const data = createTestData();
+
+  const alloc = await repo.allocateVersion(TEST_TYPE, TEST_MODEL_ID, data);
+  const bigContent = new Uint8Array(16);
+  await Deno.writeFile(alloc.contentPath, bigContent);
+
+  await assertRejects(
+    () => repo.finalizeVersion(TEST_TYPE, TEST_MODEL_ID, data, alloc.version),
+    EphemeralBudgetExceededError,
+  );
+});
+
+Deno.test("collectGarbage: frees budget for reclaimed bytes", async () => {
+  const gcKeep = 1;
+  const { repo } = createRepo(TEST_CONTENT.length * 3);
+  const data = createTestData({ garbageCollection: gcKeep });
+
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+
+  await repo.collectGarbage(TEST_TYPE, TEST_MODEL_ID);
+
+  const result = await repo.save(TEST_TYPE, TEST_MODEL_ID, data, TEST_CONTENT);
+  assertEquals(result.version, 3);
 });


### PR DESCRIPTION
## Summary

- Adds a configurable memory budget to `InMemoryUnifiedDataRepository` (default 512 MB) to prevent OOM from unbounded ephemeral data writes
- Budget is enforced on all write paths (`save`, `append`, `finalizeVersion`) and freed on all removal paths (`delete`, `collectGarbage`)
- Throws `EphemeralBudgetExceededError` with a clear message when the limit is hit
- Configurable via `SWAMP_EPHEMERAL_BUDGET` env var (accepts human-friendly sizes: `256m`, `1g`, `1024`, etc.)

### Background

PR #1737 introduced ephemeral in-memory data with no size limits. A user pointed out that it's trivial to OOM the process by writing enough ephemeral data within a single workflow run. This adds a safety net while keeping the default generous enough for real workloads.

## Test Plan

- 6 new unit tests for budget enforcement (save, append, finalizeVersion, delete-frees-budget, GC-frees-budget, cumulative writes)
- 7 new unit tests for `parseByteSize` (kb/mb/gb suffixes, fractional values, whitespace, invalid input)
- Verified brute-force writes hit the budget at the expected threshold (4x 256 KB writes succeed, 5th rejected at 1 MB budget)
- All 8149 existing tests pass