### PR TITLE
feat(extensions): accept --channel stable as valid no-op value

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -55,8 +55,8 @@ beta → rc → stable
 ```
 
 - **stable** — the default channel. All existing versions are stable. Omitting
-  `--channel` on push and pull means stable. Auto-resolve only considers
-  stable versions.
+  `--channel` or passing `--channel stable` on push and pull means stable.
+  Auto-resolve only considers stable versions.
 - **rc** — release candidate. Opt-in via `--channel rc`.
 - **beta** — early preview. Opt-in via `--channel beta`.
 

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -209,16 +209,19 @@ export const extensionPullCommand = new Command()
   .option("--force", "Overwrite existing files without prompting")
   .option(
     "--channel <channel:string>",
-    "Release channel: 'beta' or 'rc' (default: stable)",
+    "Release channel: 'beta', 'rc', or 'stable' (default: stable)",
   )
   .action(async function (options: AnyOptions, extension: string) {
-    const channel: string | undefined = options.channel;
+    let channel: string | undefined = options.channel;
     if (
-      channel !== undefined && !ReleaseChannel.isPrereleaseName(channel)
+      channel !== undefined && !ReleaseChannel.isValid(channel)
     ) {
       throw new UserError(
-        `Invalid channel: "${channel}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
+        `Invalid channel: "${channel}". Must be one of: beta, rc, stable.`,
       );
+    }
+    if (channel === "stable") {
+      channel = undefined;
     }
 
     const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -203,7 +203,7 @@ export const extensionPushCommand = new Command()
   )
   .option(
     "--channel <channel:string>",
-    "Release channel: 'beta' or 'rc' (default: stable)",
+    "Release channel: 'beta', 'rc', or 'stable' (default: stable)",
   )
   .option(
     "--version-suffix <type:string>",
@@ -212,11 +212,14 @@ export const extensionPushCommand = new Command()
   .action(async function (options: ExtensionPushOptions, manifestPath: string) {
     if (
       options.channel !== undefined &&
-      !ReleaseChannel.isPrereleaseName(options.channel)
+      !ReleaseChannel.isValid(options.channel)
     ) {
       throw new UserError(
-        `Invalid channel: "${options.channel}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
+        `Invalid channel: "${options.channel}". Must be one of: beta, rc, stable.`,
       );
+    }
+    if (options.channel === "stable") {
+      options.channel = undefined;
     }
     if (
       options.versionSuffix !== undefined &&

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -27,6 +27,7 @@ import {
 import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { UserError } from "../../domain/errors.ts";
+import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 import {
   ExtensionApiClient,
 } from "../../infrastructure/http/extension_api_client.ts";
@@ -88,7 +89,7 @@ export const extensionSearchCommand = withRemoteOptions(
     )
     .option(
       "--channel <channel:string>",
-      "Filter by release channel: 'beta' or 'rc' (default: stable only)",
+      "Filter by release channel: 'beta', 'rc', or 'stable' (default: stable only)",
       { collect: true },
     )
     .option("--per-page <perPage:number>", "Results per page", { default: 20 })
@@ -144,13 +145,15 @@ export const extensionSearchCommand = withRemoteOptions(
   }
 
   // Validate channel values
-  const validChannels = ["beta", "rc"];
   for (const ch of options.channel ?? []) {
-    if (!validChannels.includes(ch)) {
+    if (!ReleaseChannel.isValid(ch)) {
       throw new UserError(
-        `Invalid channel: "${ch}". Must be one of: beta, rc. Stable is the default; omit --channel to use it.`,
+        `Invalid channel: "${ch}". Must be one of: beta, rc, stable.`,
       );
     }
+  }
+  if (options.channel) {
+    options.channel = options.channel.filter((ch: string) => ch !== "stable");
   }
 
   // Validate sort option value


### PR DESCRIPTION
## Summary

Closes swamp-club#942.

- Accept `--channel stable` as a valid value in `extension push`, `pull`, and `search` commands — it resolves to the default (equivalent to omitting `--channel`)
- Previously, `stable` was rejected with an error telling the user to omit the flag, which forced CI/scripting to special-case the flag when the channel is a variable
- Updated `design/extension.md` to document the new behavior

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 8149 tests pass
- [x] `ReleaseChannel.isValid("stable")` already returns `true` — existing domain tests cover the validation
- [x] Verified `stable` is normalized to `undefined` in push/pull and filtered from the array in search, so downstream API calls are unchanged