### PR TITLE
fix(update): sync global skills to enrolled directories only (swamp-club#943)

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -114,14 +114,46 @@ Today these commands copy skills into the repo. Under the new model:
 Global skills are synced automatically in three places:
 
 1. **`swamp update`** — after the binary is updated (interactive and background),
-   skills are written to all global tool directories. This is the primary sync
-   path and requires no repo context.
+   skills are written to existing global tool directories. For built-in tools,
+   only directories that already exist on disk are synced — `swamp update` does
+   not create new directories. For custom tools, directories registered in
+   `custom-tool-skill-dirs.json` are synced (see below). Stale registry entries
+   for deleted directories are pruned automatically.
 2. **`swamp repo init`** — writes global skills as part of first-time setup.
+   Creates built-in tool directories and custom tool global directories.
 3. **`swamp repo upgrade`** — writes global skills as part of the upgrade flow.
+   Creates built-in tool directories and custom tool global directories.
 
 The bundled skill files in the binary are the source of truth. The sync is
 idempotent — writing the same content is harmless. Failures during sync (e.g.,
 permissions, disk full) log a warning and do not block the update or command.
+
+### Custom Tool Global Skills
+
+Custom tools (defined via `swamp agent setup` / `.swamp-custom-tools.yaml`) with
+a home-relative `skillsDir` (starting with `~/`) are treated as global skill
+directories. During `repo init` and `repo upgrade`, swamp expands the `~/`
+prefix, copies bundled skills to the resolved path, and registers the absolute
+path in `~/.config/swamp/custom-tool-skill-dirs.json`.
+
+This registry bridges the gap between repo-scoped custom tool configuration and
+the repo-less `swamp update` command. Without it, `swamp update` has no way to
+discover custom tool directories.
+
+The registry is a simple JSON array of absolute directory paths:
+
+```json
+["/home/user/.pi/agent/skills", "/home/user/.foo/skills"]
+```
+
+Custom tools with repo-relative `skillsDir` (not `~/`-prefixed) are not
+registered — those are project-local directories, not global skill targets.
+
+> **Note:** The original design proposed a separate `globalSkillsDir` field on
+> `CustomToolDefinition`. The current implementation infers global intent from
+> the `~/` prefix on the existing `skillsDir` field instead. This is simpler and
+> covers the common case. The `globalSkillsDir` field can be added later if
+> finer-grained control is needed.
 
 ## Migration: Local to Global
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -85,8 +85,14 @@ async function syncGlobalSkills(
     return;
   }
 
-  const customToolRepo = new CustomToolSkillDirsRepository();
-  const customDirs = await customToolRepo.read();
+  let customToolRepo: CustomToolSkillDirsRepository | null = null;
+  let customDirs: string[] = [];
+  try {
+    customToolRepo = new CustomToolSkillDirsRepository();
+    customDirs = await customToolRepo.read();
+  } catch {
+    // Config dir not available (e.g. HOME not set on Windows) — skip custom dirs
+  }
 
   const skillAssets = new SkillAssets();
 
@@ -101,6 +107,8 @@ async function syncGlobalSkills(
     logger.info`Synced global skills to ${dir}`;
   }
 
+  if (customDirs.length === 0) return;
+
   const survivingCustomDirs: string[] = [];
   for (const dir of customDirs) {
     if (!await dirExists(dir)) {
@@ -113,7 +121,7 @@ async function syncGlobalSkills(
     survivingCustomDirs.push(dir);
   }
 
-  if (survivingCustomDirs.length !== customDirs.length) {
+  if (survivingCustomDirs.length !== customDirs.length && customToolRepo) {
     try {
       await customToolRepo.write(survivingCustomDirs);
     } catch {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -58,6 +58,8 @@ import {
 } from "../../domain/repo/skill_dirs.ts";
 import { removeSupersededSkills } from "../../domain/repo/superseded_skills.ts";
 import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
+import { resolve, SEPARATOR } from "@std/path";
+import { homeDirectory } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -109,15 +111,30 @@ async function syncGlobalSkills(
 
   if (customDirs.length === 0) return;
 
+  let home: string | null = null;
+  try {
+    home = homeDirectory();
+  } catch {
+    // Can't validate containment — skip custom dirs entirely
+  }
+  if (!home) return;
+
   const survivingCustomDirs: string[] = [];
   for (const dir of customDirs) {
-    if (!await dirExists(dir)) {
+    const resolved = resolve(dir);
+    if (
+      !resolved.startsWith(home + SEPARATOR) && resolved !== home
+    ) {
+      logger.debug`Skipping custom tool skill dir outside home: ${dir}`;
+      continue;
+    }
+    if (!await dirExists(resolved)) {
       logger.debug`Removing stale custom tool skill dir from registry: ${dir}`;
       continue;
     }
-    await skillAssets.copySkillsTo(dir);
-    await removeSupersededSkills(dir);
-    logger.info`Synced global skills to ${dir}`;
+    await skillAssets.copySkillsTo(resolved);
+    await removeSupersededSkills(resolved);
+    logger.info`Synced global skills to ${resolved}`;
     survivingCustomDirs.push(dir);
   }
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -57,11 +57,21 @@ import {
   resolveUniqueGlobalSkillsDirs,
 } from "../../domain/repo/skill_dirs.ts";
 import { removeSupersededSkills } from "../../domain/repo/superseded_skills.ts";
+import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
 const BACKGROUND_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const stat = await Deno.stat(path);
+    return stat.isDirectory;
+  } catch {
+    return false;
+  }
+}
 
 async function syncGlobalSkills(
   logger: ReturnType<typeof getSwampLogger>,
@@ -74,13 +84,41 @@ async function syncGlobalSkills(
     logger.warn`Skipping global skill sync: home directory not available`;
     return;
   }
-  if (globalDirs.length === 0) return;
+
+  const customToolRepo = new CustomToolSkillDirsRepository();
+  const customDirs = await customToolRepo.read();
 
   const skillAssets = new SkillAssets();
+
   for (const dir of globalDirs) {
+    if (!await dirExists(dir)) {
+      logger
+        .debug`Skipping global skill sync for ${dir}: directory does not exist`;
+      continue;
+    }
     await skillAssets.copySkillsTo(dir);
     await removeSupersededSkills(dir);
     logger.info`Synced global skills to ${dir}`;
+  }
+
+  const survivingCustomDirs: string[] = [];
+  for (const dir of customDirs) {
+    if (!await dirExists(dir)) {
+      logger.debug`Removing stale custom tool skill dir from registry: ${dir}`;
+      continue;
+    }
+    await skillAssets.copySkillsTo(dir);
+    await removeSupersededSkills(dir);
+    logger.info`Synced global skills to ${dir}`;
+    survivingCustomDirs.push(dir);
+  }
+
+  if (survivingCustomDirs.length !== customDirs.length) {
+    try {
+      await customToolRepo.write(survivingCustomDirs);
+    } catch {
+      logger.warn`Failed to update custom tool skill dirs registry`;
+    }
   }
 }
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { join, resolve, SEPARATOR } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
@@ -572,19 +572,30 @@ export class RepoService {
     }
 
     for (const config of customConfigs) {
-      let globalDir: string;
+      let home: string;
       try {
-        globalDir = homeDirectory() + config.skillsDir.slice(1);
+        home = homeDirectory();
       } catch {
         logger
           .warn`Skipping global skill install for ${config.name}: home directory not available`;
         continue;
       }
 
+      const globalDir = resolve(
+        join(home, config.skillsDir.slice(2)),
+      );
+      if (
+        !globalDir.startsWith(home + SEPARATOR) && globalDir !== home
+      ) {
+        logger
+          .warn`Skipping global skill install for ${config.name}: path escapes home directory`;
+        continue;
+      }
+
       try {
         await this.skillAssets.copySkillsTo(globalDir);
         await removeSupersededSkills(globalDir);
-        logger.info`Installed global skills to ${globalDir}`;
+        logger.info`Synced global skills to ${globalDir}`;
         await customToolDirsRepo.addDir(globalDir);
       } catch (err) {
         logger

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -557,11 +557,21 @@ export class RepoService {
   private async installCustomToolGlobalSkills(
     configs: readonly ToolConfig[],
   ): Promise<void> {
-    const customToolDirsRepo = new CustomToolSkillDirsRepository();
-    for (const config of configs) {
-      if (config.isBuiltIn) continue;
-      if (!config.skillsDir.startsWith("~/")) continue;
+    const customConfigs = configs.filter((c) =>
+      !c.isBuiltIn && c.skillsDir.startsWith("~/")
+    );
+    if (customConfigs.length === 0) return;
 
+    let customToolDirsRepo: CustomToolSkillDirsRepository;
+    try {
+      customToolDirsRepo = new CustomToolSkillDirsRepository();
+    } catch {
+      logger
+        .warn`Skipping custom tool global skill install: config directory not available`;
+      return;
+    }
+
+    for (const config of customConfigs) {
       let globalDir: string;
       try {
         globalDir = homeDirectory() + config.skillsDir.slice(1);

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -24,6 +24,7 @@ import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_wri
 import { defaultCommandResolver } from "../../infrastructure/process/resolve_command.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
+  homeDirectory,
   SWAMP_SUBDIRS,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
@@ -44,6 +45,7 @@ import { removeSupersededSkills } from "./superseded_skills.ts";
 import { assertPathContained, type ToolConfig } from "./custom_tool.ts";
 import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
+import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
 
 const logger = getLogger(["swamp", "repo", "service"]);
 
@@ -334,6 +336,9 @@ export class RepoService {
       settingsCreated = settingsCreated || r.settingsChanged;
     }
 
+    // Install skills for custom tools with global (~/prefixed) skillsDir
+    await this.installCustomToolGlobalSkills(resolvedConfigs);
+
     // Always manage .gitignore on init (single call with resolved configs)
     const gitignoreAction = await this.ensureGitignoreSection(
       repoPath,
@@ -447,6 +452,9 @@ export class RepoService {
       changedFiles.push(...r.changedFiles);
     }
 
+    // Install skills for custom tools with global (~/prefixed) skillsDir
+    await this.installCustomToolGlobalSkills(resolvedConfigs);
+
     // Determine gitignore management: CLI flag > marker preference > default off
     const shouldManageGitignore = options.includeGitignore ??
       existingMarker.gitignoreManaged ?? false;
@@ -539,6 +547,42 @@ export class RepoService {
       logger.info`Installed global skills to ${dir}`;
     }
     return this.skillAssets.getSkillNames();
+  }
+
+  /**
+   * Installs bundled skills to global directories for custom tools whose
+   * skillsDir starts with ~/ (home-relative). Registers each directory
+   * in custom-tool-skill-dirs.json so swamp update can discover them.
+   */
+  private async installCustomToolGlobalSkills(
+    configs: readonly ToolConfig[],
+  ): Promise<void> {
+    const customToolDirsRepo = new CustomToolSkillDirsRepository();
+    for (const config of configs) {
+      if (config.isBuiltIn) continue;
+      if (!config.skillsDir.startsWith("~/")) continue;
+
+      let globalDir: string;
+      try {
+        globalDir = homeDirectory() + config.skillsDir.slice(1);
+      } catch {
+        logger
+          .warn`Skipping global skill install for ${config.name}: home directory not available`;
+        continue;
+      }
+
+      try {
+        await this.skillAssets.copySkillsTo(globalDir);
+        await removeSupersededSkills(globalDir);
+        logger.info`Installed global skills to ${globalDir}`;
+        await customToolDirsRepo.addDir(globalDir);
+      } catch (err) {
+        logger
+          .warn`Failed to install global skills for custom tool ${config.name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+      }
+    }
   }
 
   /**

--- a/src/infrastructure/persistence/custom_tool_skill_dirs_repository.ts
+++ b/src/infrastructure/persistence/custom_tool_skill_dirs_repository.ts
@@ -1,0 +1,62 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+import { getSwampConfigDir } from "./paths.ts";
+
+const CUSTOM_TOOL_SKILL_DIRS_FILE = "custom-tool-skill-dirs.json";
+
+export class CustomToolSkillDirsRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ??
+      join(getSwampConfigDir(), CUSTOM_TOOL_SKILL_DIRS_FILE);
+  }
+
+  async read(): Promise<string[]> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      const parsed = JSON.parse(content);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((entry): entry is string =>
+        typeof entry === "string"
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  async write(dirs: string[]): Promise<void> {
+    const unique = [...new Set(dirs)];
+    await Deno.mkdir(dirname(this.filePath), { recursive: true });
+    await atomicWriteTextFile(
+      this.filePath,
+      JSON.stringify(unique, null, 2) + "\n",
+    );
+  }
+
+  async addDir(dir: string): Promise<void> {
+    const existing = await this.read();
+    if (existing.includes(dir)) return;
+    existing.push(dir);
+    await this.write(existing);
+  }
+}

--- a/src/infrastructure/persistence/custom_tool_skill_dirs_repository_test.ts
+++ b/src/infrastructure/persistence/custom_tool_skill_dirs_repository_test.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { CustomToolSkillDirsRepository } from "./custom_tool_skill_dirs_repository.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("CustomToolSkillDirsRepository: read returns empty array when file does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(
+      join(dir, "nonexistent.json"),
+    );
+    const result = await repo.read();
+    assertEquals(result, []);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: write and read round-trips", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.pi/agent/skills", "/home/user/.foo/skills"]);
+    const result = await repo.read();
+    assertEquals(result, [
+      "/home/user/.pi/agent/skills",
+      "/home/user/.foo/skills",
+    ]);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: write deduplicates entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.pi/skills", "/home/user/.pi/skills"]);
+    const result = await repo.read();
+    assertEquals(result, ["/home/user/.pi/skills"]);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: addDir appends new entry", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.pi/skills"]);
+    await repo.addDir("/home/user/.foo/skills");
+    const result = await repo.read();
+    assertEquals(result, ["/home/user/.pi/skills", "/home/user/.foo/skills"]);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: addDir is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.pi/skills"]);
+    await repo.addDir("/home/user/.pi/skills");
+    const result = await repo.read();
+    assertEquals(result, ["/home/user/.pi/skills"]);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: read filters out non-string entries", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "dirs.json");
+    await Deno.writeTextFile(
+      filePath,
+      JSON.stringify(["/valid", 42, null, "/also-valid"]),
+    );
+    const repo = new CustomToolSkillDirsRepository(filePath);
+    const result = await repo.read();
+    assertEquals(result, ["/valid", "/also-valid"]);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: read returns empty for malformed JSON", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "dirs.json");
+    await Deno.writeTextFile(filePath, "not json");
+    const repo = new CustomToolSkillDirsRepository(filePath);
+    const result = await repo.read();
+    assertEquals(result, []);
+  });
+});
+
+Deno.test("CustomToolSkillDirsRepository: addDir creates file when none exists", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new CustomToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.addDir("/home/user/.pi/skills");
+    const result = await repo.read();
+    assertEquals(result, ["/home/user/.pi/skills"]);
+  });
+});


### PR DESCRIPTION
## Summary

- `syncGlobalSkills` in `update.ts` now checks directory existence before syncing — only writes to built-in tool directories that already exist on disk, preventing creation of unwanted `~/.agents/skills` or `~/.kiro/skills` for unenrolled tools
- New `CustomToolSkillDirsRepository` at `~/.config/swamp/custom-tool-skill-dirs.json` tracks global skill directories registered by custom tools
- New `installCustomToolGlobalSkills` in `RepoService` expands `~/`-prefixed `skillsDir` for custom tools, syncs bundled skills there, and registers the path in the registry — called during both `repo init` and `repo upgrade`
- `syncGlobalSkills` reads the custom tool registry so `swamp update` keeps custom tool directories current, and prunes stale entries for deleted directories
- Updated `design/global-skills.md` documenting existence-check behavior and custom tool registry

Closes swamp-club#943

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt` passes
- [x] `deno run test` — 8157 tests pass
- [x] `deno run compile` — binary compiles
- [x] DDD layer rules pass
- [x] Verified with scratch repo: `swamp repo init --tool repro-pi` syncs skills to `~/.repro-pi-test/agent/skills` and registers in `custom-tool-skill-dirs.json`
- [x] Verified `swamp repo upgrade` refreshes custom tool skills
- [x] No unwanted built-in directories created for unenrolled tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)