### PR TITLE
feat(remote): elastic queueing — queue placed steps instead of failing (swamp-club#947)

### DIFF
--- a/integration/remote_execution_test.ts
+++ b/integration/remote_execution_test.ts
@@ -325,7 +325,11 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 }
 
 function remoteStepRequest(overrides?: {
-  placement?: { target?: string; labels?: Record<string, string> };
+  placement?: {
+    target?: string;
+    labels?: Record<string, string>;
+    queueTimeoutMs?: number;
+  };
   methodArgs?: Record<string, unknown>;
   signal?: AbortSignal;
 }) {
@@ -441,15 +445,17 @@ Deno.test({
         );
         assertEquals(after.priorWasNull, false);
 
-        // ── Scheduling ───────────────────────────────────────────────────
-        const unschedulable = await assertRejects(
+        // ── Scheduling: no-match placement queues then times out ────────
+        const queueTimeout = await assertRejects(
           () =>
             orchestrator.dispatchService.executeRemote(
-              remoteStepRequest({ placement: { target: "ghost" } }),
+              remoteStepRequest({
+                placement: { target: "ghost", queueTimeoutMs: 1_500 },
+              }),
             ),
           Error,
         );
-        assertStringIncludes(unschedulable.message, "No connected worker");
+        assertStringIncludes(queueTimeout.message, "target 'ghost'");
 
         const targeted = await orchestrator.dispatchService.executeRemote(
           remoteStepRequest({

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -238,6 +238,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.wsIdleTimeout) {
     args.push("--ws-idle-timeout", options.wsIdleTimeout as string);
   }
+  if (options.queueTimeout) {
+    args.push("--queue-timeout", options.queueTimeout as string);
+  }
   return args;
 }
 
@@ -470,6 +473,11 @@ export const serveCommand = new Command()
     "WebSocket idle timeout — how long the server waits for a pong before closing the connection (env: SWAMP_WS_IDLE_TIMEOUT). " +
       "Accepts seconds (30), explicit units (2m, 5m), or 0 to disable. Default: 30s",
   )
+  .option(
+    "--queue-timeout <duration:string>",
+    "How long a placed step queues for a matching worker before timing out. " +
+      "Accepts seconds (60), explicit units (2m, 10m), or 0 to wait forever. Default: 60s",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
@@ -531,6 +539,14 @@ export const serveCommand = new Command()
       }
     }
 
+    const queueTimeoutRaw = options.queueTimeout as string | undefined;
+    let queueTimeoutMs: number | undefined;
+    if (queueTimeoutRaw !== undefined) {
+      queueTimeoutMs = queueTimeoutRaw === "0"
+        ? 0
+        : parseTimeout(queueTimeoutRaw);
+    }
+
     const authConfig = buildServeAuthConfig({
       authMode: options.authMode as string | undefined,
       admins: options.admins as string | undefined,
@@ -584,6 +600,7 @@ export const serveCommand = new Command()
       repoContext,
       dispatches: dispatchRegistry,
       bundles: bundleRegistry,
+      queueTimeoutMs,
     });
     const workerGateway = new WorkerGateway({
       repoDir: resolvedRepoDir,
@@ -591,6 +608,8 @@ export const serveCommand = new Command()
       capabilityService,
       onWorkerIdle: (worker) => dispatchService.notifyWorkerIdle(worker),
       onGraceExpired: (worker) => dispatchService.notifyGraceExpired(worker),
+      onWorkerEnrolled: (worker) =>
+        dispatchService.notifyWorkerEnrolled(worker),
     });
     dispatchService.bindGateway(workerGateway);
     setRemoteStepDispatcher(dispatchService);

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -291,6 +291,7 @@ export interface MethodContext {
     target?: string;
     labels?: Record<string, string>;
     platform?: string;
+    queueTimeoutMs?: number;
   };
 
   /**

--- a/src/domain/remote/scheduler.ts
+++ b/src/domain/remote/scheduler.ts
@@ -36,6 +36,8 @@ export interface StepPlacement {
   labels?: Record<string, string>;
   /** Required platform, e.g. "linux" or "linux/x86_64". */
   platform?: string;
+  /** Per-step queue timeout in milliseconds; overrides the serve-level default. */
+  queueTimeoutMs?: number;
 }
 
 /** The slice of worker state scheduling looks at. */
@@ -51,8 +53,27 @@ export interface SchedulableWorker {
 
 export type ScheduleDecision =
   | { kind: "dispatch"; worker: SchedulableWorker }
-  | { kind: "queue" }
-  | { kind: "unschedulable"; reason: string };
+  | { kind: "queue" };
+
+/**
+ * Human-readable description of a placement requirement, for use in
+ * timeout errors and step_queued events.
+ */
+export function describePlacement(placement: StepPlacement): string {
+  if (placement.target !== undefined) {
+    return `target '${placement.target}'`;
+  }
+  const parts = [
+    placement.labels && Object.keys(placement.labels).length > 0
+      ? `labels ${
+        Object.entries(placement.labels).map(([k, v]) => `${k}=${v}`)
+          .join(",")
+      }`
+      : null,
+    placement.platform ? `platform '${placement.platform}'` : null,
+  ].filter((part) => part !== null).join(" and ");
+  return parts || "any worker";
+}
 
 /** True when a step declares any placement requirement at all. */
 export function hasPlacement(placement: StepPlacement | undefined): boolean {
@@ -114,9 +135,9 @@ export function eligibleWorkers(
 
 /**
  * Decide where a step goes right now. `dispatch` names an idle eligible
- * worker; `queue` means eligible workers exist but all are busy; and
- * `unschedulable` means no connected worker can ever satisfy the placement
- * (the step fails fast rather than queueing forever).
+ * worker; `queue` means every eligible worker is busy, or no connected
+ * worker matches the placement at all — the step waits for a pool change
+ * either way.
  */
 export function scheduleStep(
   placement: StepPlacement,
@@ -124,21 +145,7 @@ export function scheduleStep(
 ): ScheduleDecision {
   const eligible = eligibleWorkers(placement, pool);
   if (eligible.length === 0) {
-    const requirement = placement.target !== undefined
-      ? `target '${placement.target}'`
-      : [
-        placement.labels && Object.keys(placement.labels).length > 0
-          ? `labels ${
-            Object.entries(placement.labels).map(([k, v]) => `${k}=${v}`)
-              .join(",")
-          }`
-          : null,
-        placement.platform ? `platform '${placement.platform}'` : null,
-      ].filter((part) => part !== null).join(" and ") || "any worker";
-    return {
-      kind: "unschedulable",
-      reason: `No connected worker matches ${requirement}`,
-    };
+    return { kind: "queue" };
   }
   const idle = eligible
     .filter((worker) => worker.status === "idle")

--- a/src/domain/remote/scheduler_test.ts
+++ b/src/domain/remote/scheduler_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  describePlacement,
   eligibleWorkers,
   hasPlacement,
   type SchedulableWorker,
@@ -68,14 +69,10 @@ Deno.test("scheduleStep: direct target on a busy worker queues", () => {
   assertEquals(scheduleStep({ target: "a" }, pool).kind, "queue");
 });
 
-Deno.test("scheduleStep: direct target not connected is unschedulable", () => {
+Deno.test("scheduleStep: direct target not connected queues", () => {
   const pool = [worker({ name: "a", connected: false })];
   const decision = scheduleStep({ target: "a" }, pool);
-  assertEquals(decision.kind, "unschedulable");
-  assertStringIncludes(
-    decision.kind === "unschedulable" ? decision.reason : "",
-    "target 'a'",
-  );
+  assertEquals(decision.kind, "queue");
 });
 
 Deno.test("scheduleStep: label selectors require every entry to match", () => {
@@ -104,7 +101,7 @@ Deno.test("scheduleStep: platform matches 'os' and 'os/arch' forms", () => {
   assertEquals(armOnly.map((w) => w.name), ["lin-arm"]);
   assertEquals(
     scheduleStep({ platform: "windows" }, pool).kind,
-    "unschedulable",
+    "queue",
   );
 });
 
@@ -141,13 +138,30 @@ Deno.test("scheduleStep: disconnected workers never match", () => {
   );
 });
 
-Deno.test("scheduleStep: unschedulable reason names the requirement", () => {
+Deno.test("scheduleStep: no-match placement queues", () => {
   const decision = scheduleStep(
     { labels: { gpu: "true" }, platform: "linux/aarch64" },
     [worker({ name: "plain" })],
   );
-  assertEquals(decision.kind, "unschedulable");
-  const reason = decision.kind === "unschedulable" ? decision.reason : "";
-  assertStringIncludes(reason, "gpu=true");
-  assertStringIncludes(reason, "linux/aarch64");
+  assertEquals(decision.kind, "queue");
+});
+
+Deno.test("describePlacement: names target requirement", () => {
+  assertEquals(
+    describePlacement({ target: "my-worker" }),
+    "target 'my-worker'",
+  );
+});
+
+Deno.test("describePlacement: names labels and platform", () => {
+  const desc = describePlacement({
+    labels: { gpu: "true" },
+    platform: "linux/aarch64",
+  });
+  assertStringIncludes(desc, "gpu=true");
+  assertStringIncludes(desc, "linux/aarch64");
+});
+
+Deno.test("describePlacement: falls back to 'any worker'", () => {
+  assertEquals(describePlacement({}), "any worker");
 });

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -91,6 +91,7 @@ const StepObjectSchema = z.object({
   target: z.string().optional(),
   labels: z.record(z.string(), z.string()).optional(),
   platform: z.string().optional(),
+  queueTimeout: z.number().nonnegative().optional(),
 });
 
 /**
@@ -144,6 +145,7 @@ export interface CreateStepProps {
   target?: string;
   labels?: Record<string, string>;
   platform?: string;
+  queueTimeout?: number;
 }
 
 /**
@@ -171,6 +173,7 @@ export class Step {
     readonly target: string | undefined,
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
+    readonly queueTimeout: number | undefined,
   ) {}
 
   /**
@@ -193,6 +196,7 @@ export class Step {
       target: props.target,
       labels: props.labels,
       platform: props.platform,
+      queueTimeout: props.queueTimeout,
     });
 
     return Step.fromData(data);
@@ -237,6 +241,7 @@ export class Step {
       validated.target,
       validated.labels,
       validated.platform,
+      validated.queueTimeout,
     );
   }
 
@@ -298,6 +303,7 @@ export class Step {
       target: this.target,
       labels: this.labels,
       platform: this.platform,
+      queueTimeout: this.queueTimeout,
     };
   }
 
@@ -306,7 +312,12 @@ export class Step {
    * placement-free steps run on the loopback executor.
    */
   get placement():
-    | { target?: string; labels?: Record<string, string>; platform?: string }
+    | {
+      target?: string;
+      labels?: Record<string, string>;
+      platform?: string;
+      queueTimeoutMs?: number;
+    }
     | undefined {
     if (
       this.target === undefined && this.platform === undefined &&
@@ -318,6 +329,9 @@ export class Step {
       target: this.target,
       labels: this.labels,
       platform: this.platform,
+      queueTimeoutMs: this.queueTimeout !== undefined
+        ? this.queueTimeout * 1000
+        : undefined,
     };
   }
 }

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -416,7 +416,26 @@ Deno.test("Step placement: target, labels, and platform round-trip through toDat
     target: "ci-runner-3",
     labels: { gpu: "true", region: "us-east" },
     platform: "linux/x86_64",
+    queueTimeoutMs: undefined,
   });
   const restored = Step.fromData(step.toData());
   assertEquals(restored.placement, step.placement);
+});
+
+Deno.test("Step placement: queueTimeout converts seconds to milliseconds", () => {
+  const step = Step.fromData({
+    name: "queued",
+    task: {
+      type: "model_method",
+      modelIdOrName: "my-model",
+      methodName: "run",
+    },
+    target: "worker-1",
+    queueTimeout: 30,
+  });
+  assertEquals(step.placement?.queueTimeoutMs, 30_000);
+  assertEquals(step.queueTimeout, 30);
+  const restored = Step.fromData(step.toData());
+  assertEquals(restored.queueTimeout, 30);
+  assertEquals(restored.placement?.queueTimeoutMs, 30_000);
 });

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -52,6 +52,7 @@ import {
 } from "../domain/remote/protocol.ts";
 import { ChannelClosedError, RpcError } from "../domain/remote/rpc_channel.ts";
 import {
+  describePlacement,
   hasPlacement,
   type ScheduleDecision,
   scheduleStep,
@@ -75,7 +76,7 @@ const logger = getSwampLogger(["serve", "dispatch"]);
 export const BUILTIN_BUNDLE_PREFIX = "builtin:";
 
 /** Default ceiling on how long a step queues for a matching worker. */
-export const DEFAULT_QUEUE_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_QUEUE_TIMEOUT_MS = 60 * 1000;
 
 async function sha256Hex(text: string): Promise<string> {
   const digest = await crypto.subtle.digest(
@@ -158,6 +159,11 @@ export class DispatchService {
     this.#wakePoolWaiters();
   }
 
+  /** Gateway hook: a worker enrolled or re-enrolled — wake queued steps. */
+  notifyWorkerEnrolled(_worker: WorkerSnapshot): void {
+    this.#wakePoolWaiters();
+  }
+
   /**
    * Data-plane hook, awaited BEFORE the first durable write persists, so a
    * lease can never say "no writes" while a write exists. The converse
@@ -181,7 +187,11 @@ export class DispatchService {
     if (this.#gateway === null) {
       throw new Error("DispatchService has no gateway bound");
     }
-    const deadline = Date.now() + this.#queueTimeoutMs;
+    const effectiveTimeoutMs = request.placement.queueTimeoutMs ??
+      this.#queueTimeoutMs;
+    const deadline = effectiveTimeoutMs === 0
+      ? null
+      : Date.now() + effectiveTimeoutMs;
 
     while (true) {
       request.signal?.throwIfAborted();
@@ -216,7 +226,7 @@ export class DispatchService {
             { worker: workerName },
           );
           await this.#waitForPoolChange(
-            Math.max(deadline - Date.now(), 0),
+            deadline !== null ? Math.max(deadline - Date.now(), 0) : 60_000,
             request.signal,
           );
           continue;
@@ -364,11 +374,11 @@ export class DispatchService {
     }
   }
 
-  /** Schedule against the live pool, queueing while eligible workers are busy. */
+  /** Schedule against the live pool, queueing while eligible workers are busy or absent. */
   async #acquireWorker(
     placement: StepPlacement,
     signal: AbortSignal | undefined,
-    deadline: number,
+    deadline: number | null,
   ): Promise<string> {
     while (true) {
       signal?.throwIfAborted();
@@ -380,16 +390,19 @@ export class DispatchService {
         this.#reserved.add(decision.worker.name);
         return decision.worker.name;
       }
-      if (decision.kind === "unschedulable") {
-        throw new Error(decision.reason);
+      if (deadline !== null) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          throw new Error(
+            `Timed out waiting for a worker matching ${
+              describePlacement(placement)
+            } to become available`,
+          );
+        }
+        await this.#waitForPoolChange(remaining, signal);
+      } else {
+        await this.#waitForPoolChange(60_000, signal);
       }
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
-        throw new Error(
-          "Timed out waiting for a matching worker to become available",
-        );
-      }
-      await this.#waitForPoolChange(remaining, signal);
     }
   }
 

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -224,15 +224,36 @@ Deno.test("DispatchService: remote method error fails the lease and rethrows", a
   );
 });
 
-Deno.test("DispatchService: unschedulable placement fails fast", async () => {
-  const h = createHarness();
+Deno.test("DispatchService: no-match placement queues then times out", async () => {
+  const h = createHarness({ queueTimeoutMs: 100 });
   await assertRejects(
     () =>
       h.service.executeRemote(
-        stepRequest({ placement: { labels: { gpu: "true" } } }),
+        stepRequest({
+          placement: { labels: { gpu: "true" }, platform: "linux" },
+        }),
       ),
     Error,
-    "No connected worker matches",
+    "Timed out waiting for a worker matching",
+  );
+  assertEquals(h.transitions.length, 0);
+});
+
+Deno.test("DispatchService: per-step queueTimeout overrides serve-level default", async () => {
+  const h = createHarness({ queueTimeoutMs: 60_000 });
+  await assertRejects(
+    () =>
+      h.service.executeRemote(
+        stepRequest({
+          placement: {
+            labels: { gpu: "true" },
+            platform: "linux",
+            queueTimeoutMs: 100,
+          },
+        }),
+      ),
+    Error,
+    "Timed out waiting for a worker matching",
   );
   assertEquals(h.transitions.length, 0);
 });
@@ -432,6 +453,37 @@ Deno.test("DispatchService: worker_busy desync re-queues instead of failing the 
     h.transitions.map((t) => t.methodName),
     ["acquire", "expire", "acquire", "complete"],
   );
+});
+
+Deno.test("DispatchService: wake-on-enroll dispatches to newly enrolled worker", async () => {
+  const h = createHarness({ workers: [], queueTimeoutMs: 5_000 });
+  const pending = h.service.executeRemote(
+    stepRequest({ placement: { platform: "linux" } }),
+  );
+  await new Promise((r) => setTimeout(r, 30));
+  assertEquals(h.dispatchCalls.length, 0);
+
+  h.pool.set("new-worker", snapshot({ name: "new-worker" }));
+  h.service.notifyWorkerEnrolled(snapshot({ name: "new-worker" }));
+  const result = await pending;
+  assertEquals(h.dispatchCalls.length, 1);
+  assertEquals(h.dispatchCalls[0].name, "new-worker");
+  assertEquals(result.outputs.length, 1);
+});
+
+Deno.test("DispatchService: timeout error contains placement description", async () => {
+  const h = createHarness({ queueTimeoutMs: 100 });
+  const error = await assertRejects(
+    () =>
+      h.service.executeRemote(
+        stepRequest({
+          placement: { labels: { gpu: "true" }, platform: "linux/aarch64" },
+        }),
+      ),
+    Error,
+  );
+  assertStringIncludes(error.message, "gpu=true");
+  assertStringIncludes(error.message, "linux/aarch64");
 });
 
 Deno.test("DispatchService: forwards trace headers and reports the executing worker", async () => {

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -139,6 +139,8 @@ export interface WorkerGatewayOptions {
   onWorkerDisconnected?: (worker: WorkerSnapshot) => void;
   /** The grace window elapsed without reconnection; the worker is gone. */
   onGraceExpired?: (worker: WorkerSnapshot) => void;
+  /** A worker enrolled or re-enrolled (including within the grace window). */
+  onWorkerEnrolled?: (worker: WorkerSnapshot) => void;
   /** Test seam: overrides the modelMethodRun-backed transition runner. */
   runModelMethod?: ModelMethodRunner;
   /**
@@ -453,8 +455,10 @@ export class WorkerGateway {
         worker: name,
         mode: reconnecting ? "reconnect" : "first-connect",
       });
+      const snap = this.#snapshot(entry);
+      this.#options.onWorkerEnrolled?.(snap);
       if (entry.status === "idle") {
-        this.#options.onWorkerIdle?.(this.#snapshot(entry));
+        this.#options.onWorkerIdle?.(snap);
       }
       return {
         workerId: name,

--- a/tests/fleet-smoke/verify-queueing.sh
+++ b/tests/fleet-smoke/verify-queueing.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Elastic queueing smoke tests — exercises the compiled swamp binary
+# end-to-end with Docker containers acting as orchestrator and worker.
+#
+# Proves: --queue-timeout flag works, queue-on-empty waits for enroll,
+# timeout fires with placement description, per-step queueTimeout
+# overrides serve default, and wake-on-enroll is event-driven (not polled).
+#
+# Usage: ./tests/fleet-smoke/verify-queueing.sh
+# Requires: Docker, jq, the compiled swamp binary in the repo root.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMAGE="swamp-smoke:local"
+REPO_DIR=""
+ORCHESTRATOR_CID=""
+PASS=0
+FAIL=0
+
+# ── Cleanup ──────────────────────────────────────────────────────────
+cleanup() {
+  [ -n "${ORCHESTRATOR_CID:-}" ] && docker rm -f "$ORCHESTRATOR_CID" 2>/dev/null || true
+  [ -n "${REPO_DIR:-}" ] && rm -rf "$REPO_DIR" || true
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+stop_containers() {
+  if [ -n "${ORCHESTRATOR_CID:-}" ]; then
+    echo "  --- orchestrator logs ---"
+    docker logs "$ORCHESTRATOR_CID" 2>&1 | grep -v '^\[0m\[38;5;245' | tail -30
+    echo "  --- end logs ---"
+    docker rm -f "$ORCHESTRATOR_CID" 2>/dev/null || true
+  fi
+  ORCHESTRATOR_CID=""
+}
+
+wait_for_serve() {
+  local cid="$1"
+  local max_wait="${2:-15}"
+  local elapsed=0
+  until docker exec "$cid" \
+    swamp worker list --server ws://127.0.0.1:9090 --json 2>/dev/null; do
+    sleep 0.5
+    elapsed=$((elapsed + 1))
+    if [ "$elapsed" -ge "$((max_wait * 2))" ]; then
+      echo "  ERROR: orchestrator did not start within ${max_wait}s"
+      docker logs "$cid" 2>&1 | tail -20
+      return 1
+    fi
+  done
+  return 0
+}
+
+# ── Build ────────────────────────────────────────────────────────────
+# Detect the Docker platform's architecture for cross-compilation
+DOCKER_ARCH=$(docker info --format '{{.Architecture}}' 2>/dev/null || echo "x86_64")
+case "$DOCKER_ARCH" in
+  aarch64|arm64) DENO_TARGET="aarch64-unknown-linux-gnu" ;;
+  *)             DENO_TARGET="x86_64-unknown-linux-gnu" ;;
+esac
+
+echo "==> Compiling Linux binary (target: $DENO_TARGET)..."
+(cd "$REPO_ROOT" && deno task compile --target "$DENO_TARGET")
+
+echo "==> Building Docker image..."
+docker build -t "$IMAGE" "$REPO_ROOT"
+
+# Recompile for the host so we can bootstrap the repo locally
+echo "==> Recompiling host binary..."
+(cd "$REPO_ROOT" && deno task compile)
+
+# ── Bootstrap repo ───────────────────────────────────────────────────
+echo "==> Bootstrapping test repo..."
+REPO_DIR=$(mktemp -d)
+"$REPO_ROOT/swamp" init "$REPO_DIR" --quiet
+"$REPO_ROOT/swamp" vault create local_encryption local-enc \
+  --repo-dir "$REPO_DIR" --config '{"auto_generate": true}'
+
+# Create a shell model for the smoke tests
+"$REPO_ROOT/swamp" model create command/shell smoke-echo \
+  --repo-dir "$REPO_DIR" --json >/dev/null
+
+# Helper: create a workflow and return its YAML path
+create_workflow() {
+  local name="$1"
+  "$REPO_ROOT/swamp" workflow create "$name" \
+    --repo-dir "$REPO_DIR" --json | jq -r '.path'
+}
+
+# Workflow 1: placed step with labels
+WF1_PATH=$(create_workflow smoke-placed)
+WF1_ID=$(basename "$WF1_PATH" .yaml | sed 's/workflow-//')
+cat > "$REPO_DIR/workflows/$(basename "$WF1_PATH")" <<YAML
+id: $WF1_ID
+name: smoke-placed
+jobs:
+  - name: main
+    steps:
+      - name: echo-step
+        labels:
+          tier: smoke
+        task:
+          type: model_method
+          modelIdOrName: smoke-echo
+          methodName: execute
+          inputs:
+            run: "echo hello-from-worker"
+        dependsOn: []
+        weight: 0
+        allowFailure: false
+    dependsOn: []
+    weight: 0
+version: 1
+YAML
+
+# Workflow 2: unmatched labels (for timeout test)
+WF2_PATH=$(create_workflow smoke-unmatched)
+WF2_ID=$(basename "$WF2_PATH" .yaml | sed 's/workflow-//')
+cat > "$REPO_DIR/workflows/$(basename "$WF2_PATH")" <<YAML
+id: $WF2_ID
+name: smoke-unmatched
+jobs:
+  - name: main
+    steps:
+      - name: gpu-step
+        labels:
+          gpu: "true"
+        task:
+          type: model_method
+          modelIdOrName: smoke-echo
+          methodName: execute
+          inputs:
+            run: "echo should-not-run"
+        dependsOn: []
+        weight: 0
+        allowFailure: false
+    dependsOn: []
+    weight: 0
+version: 1
+YAML
+
+# Workflow 3: per-step queueTimeout override
+WF3_PATH=$(create_workflow smoke-step-timeout)
+WF3_ID=$(basename "$WF3_PATH" .yaml | sed 's/workflow-//')
+cat > "$REPO_DIR/workflows/$(basename "$WF3_PATH")" <<YAML
+id: $WF3_ID
+name: smoke-step-timeout
+jobs:
+  - name: main
+    steps:
+      - name: short-timeout-step
+        labels:
+          gpu: "true"
+        queueTimeout: 3
+        task:
+          type: model_method
+          modelIdOrName: smoke-echo
+          methodName: execute
+          inputs:
+            run: "echo should-not-run"
+        dependsOn: []
+        weight: 0
+        allowFailure: false
+    dependsOn: []
+    weight: 0
+version: 1
+YAML
+
+# Mint worker tokens (one per scenario that needs a worker)
+TOKEN=$("$REPO_ROOT/swamp" worker token create smoke-worker \
+  --duration 10m --repo-dir "$REPO_DIR" --json | jq -r '.token')
+TOKEN2=$("$REPO_ROOT/swamp" worker token create smoke-worker-2 \
+  --duration 10m --repo-dir "$REPO_DIR" --json | jq -r '.token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "ERROR: failed to mint worker token"
+  exit 1
+fi
+echo "  Tokens minted: ${TOKEN:0:20}... ${TOKEN2:0:20}..."
+
+# ── Scenario 1: queue-on-empty → enroll → complete ──────────────────
+echo ""
+echo "==> Scenario 1: queue-on-empty, dispatch on enroll"
+
+ORCHESTRATOR_CID=$(docker run -d --name "orch-s1-$$" \
+  -v "$REPO_DIR:/workspace" \
+  "$IMAGE" serve --port 9090 --queue-timeout 30s --no-schedule)
+
+wait_for_serve "$ORCHESTRATOR_CID" || { fail "orchestrator start"; stop_containers; exit 1; }
+
+# Submit workflow in background — it should queue, not fail
+docker exec "$ORCHESTRATOR_CID" \
+  swamp workflow run smoke-placed --server ws://127.0.0.1:9090 --log 2>&1 &
+RUN_PID=$!
+
+sleep 2
+if ! kill -0 "$RUN_PID" 2>/dev/null; then
+  fail "workflow exited before worker enrolled (old fail-fast behavior)"
+  stop_containers
+else
+  # Connect a worker (same container, loopback)
+  docker exec -d "$ORCHESTRATOR_CID" \
+    swamp worker connect ws://127.0.0.1:9090 \
+      --token "$TOKEN" --label tier=smoke
+
+  # Wait for the workflow to finish
+  RUN_EXIT=0
+  wait "$RUN_PID" 2>/dev/null || RUN_EXIT=$?
+
+  if [ "$RUN_EXIT" -eq 0 ]; then
+    pass "queue-on-empty then dispatch on enroll"
+  else
+    fail "workflow exited $RUN_EXIT after worker enrolled"
+  fi
+  stop_containers
+fi
+
+# ── Scenario 2: timeout with placement description ───────────────────
+echo ""
+echo "==> Scenario 2: timeout fires with placement description"
+
+ORCHESTRATOR_CID=$(docker run -d --name "orch-s2-$$" \
+  -v "$REPO_DIR:/workspace" \
+  "$IMAGE" serve --port 9090 --queue-timeout 5s --no-schedule)
+
+wait_for_serve "$ORCHESTRATOR_CID" || { fail "orchestrator start"; stop_containers; exit 1; }
+
+# Submit workflow targeting gpu: "true" — no worker will match
+TIMEOUT_START=$(date +%s)
+TIMEOUT_OUTPUT=$(docker exec "$ORCHESTRATOR_CID" \
+  swamp workflow run smoke-unmatched --server ws://127.0.0.1:9090 --log 2>&1 || true)
+TIMEOUT_END=$(date +%s)
+TIMEOUT_ELAPSED=$((TIMEOUT_END - TIMEOUT_START))
+
+# Should take ~5s (not instant — that was the old unschedulable behavior)
+if [ "$TIMEOUT_ELAPSED" -ge 3 ]; then
+  pass "timeout took ${TIMEOUT_ELAPSED}s (not instant)"
+else
+  fail "timeout took only ${TIMEOUT_ELAPSED}s — expected ≥3s"
+fi
+
+# Error should mention the placement requirement
+if echo "$TIMEOUT_OUTPUT" | grep -q "gpu=true"; then
+  pass "timeout error contains placement description 'gpu=true'"
+else
+  fail "timeout error missing placement description"
+  echo "  Output: $TIMEOUT_OUTPUT" | head -5
+fi
+
+stop_containers
+
+# ── Scenario 3: per-step queueTimeout overrides serve default ────────
+echo ""
+echo "==> Scenario 3: per-step queueTimeout overrides serve default"
+
+ORCHESTRATOR_CID=$(docker run -d --name "orch-s3-$$" \
+  -v "$REPO_DIR:/workspace" \
+  "$IMAGE" serve --port 9090 --queue-timeout 30s --no-schedule)
+
+wait_for_serve "$ORCHESTRATOR_CID" || { fail "orchestrator start"; stop_containers; exit 1; }
+
+STEP_START=$(date +%s)
+docker exec "$ORCHESTRATOR_CID" \
+  swamp workflow run smoke-step-timeout --server ws://127.0.0.1:9090 --log 2>&1 || true
+STEP_END=$(date +%s)
+STEP_ELAPSED=$((STEP_END - STEP_START))
+
+# Per-step queueTimeout is 3s; serve default is 30s. Should be ~3s not ~30s.
+if [ "$STEP_ELAPSED" -le 10 ]; then
+  pass "per-step timeout fired in ${STEP_ELAPSED}s (not serve default 30s)"
+else
+  fail "per-step timeout took ${STEP_ELAPSED}s — expected ≤10s"
+fi
+
+stop_containers
+
+# ── Scenario 4: wake-on-enroll is event-driven ───────────────────────
+echo ""
+echo "==> Scenario 4: wake-on-enroll timing (not polling)"
+
+ORCHESTRATOR_CID=$(docker run -d --name "orch-s4-$$" \
+  -v "$REPO_DIR:/workspace" \
+  "$IMAGE" serve --port 9090 --queue-timeout 30s --no-schedule)
+
+wait_for_serve "$ORCHESTRATOR_CID" || { fail "orchestrator start"; stop_containers; exit 1; }
+
+# Submit workflow in background
+docker exec "$ORCHESTRATOR_CID" \
+  swamp workflow run smoke-placed --server ws://127.0.0.1:9090 --log 2>&1 &
+WAKE_PID=$!
+
+sleep 1
+
+# Connect worker (same container) and measure time to completion
+ENROLL_START=$(date +%s)
+docker exec -d "$ORCHESTRATOR_CID" \
+  swamp worker connect ws://127.0.0.1:9090 \
+    --token "$TOKEN2" --label tier=smoke
+
+WAKE_EXIT=0
+wait "$WAKE_PID" 2>/dev/null || WAKE_EXIT=$?
+ENROLL_END=$(date +%s)
+ENROLL_ELAPSED=$((ENROLL_END - ENROLL_START))
+
+if [ "$WAKE_EXIT" -eq 0 ] && [ "$ENROLL_ELAPSED" -le 5 ]; then
+  pass "wake-on-enroll: completed ${ENROLL_ELAPSED}s after worker connected (event-driven)"
+elif [ "$WAKE_EXIT" -ne 0 ]; then
+  fail "workflow failed with exit code $WAKE_EXIT"
+else
+  fail "wake-on-enroll took ${ENROLL_ELAPSED}s — expected ≤5s (poll cycle is 5s)"
+fi
+
+stop_containers
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "==> Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Worker fleets phase 1, PR1: collapse `unschedulable` into `queue` so placed steps wait for a matching worker instead of failing immediately. Under fleets, an empty pool between scale-up events is the steady state — not a configuration mistake.

- **Scheduler:** delete `unschedulable` variant from `ScheduleDecision`, extract `describePlacement()` helper for reuse in timeout errors and `step_queued` events (PR2)
- **Step schema:** add `queueTimeout` field (seconds, `z.number().nonnegative().optional()`) threaded as `queueTimeoutMs` through `StepPlacement` → `MethodContext` → `RemoteStepRequest` → dispatch deadline
- **DispatchService:** layered timeout (per-step → serve-level → 60s default), null deadline for wait-forever (`queueTimeout: 0`), `describePlacement()` in timeout errors, `notifyWorkerEnrolled()` to wake queued steps
- **WorkerGateway:** new `onWorkerEnrolled` callback fired after enroll and re-enroll within grace window
- **serve CLI:** `--queue-timeout <duration>` flag parsed by `parseTimeout`, forwarded in daemon launcher args
- **Integration test:** existing unschedulable test updated to queue-then-timeout with 1.5s `queueTimeoutMs`, asserts error contains placement description

### Default timeout change

`DEFAULT_QUEUE_TIMEOUT_MS` changed from 600s to 60s. Existing users with workers that take >60s to appear will need `--queue-timeout 10m` to restore the old behavior. This is deliberate — phase 6 raises it once the queueing UX is proven.

### Invariants preserved

- `recordFirstWrite` ordering untouched
- Sole-writer `#transitionTail` chain untouched
- `#reserved` set logic unchanged (reservations only on `dispatch` decisions)
- Unplaced steps never enter the queueing path (`hasPlacement` gates)
- `forEach` sharing works automatically (queueTimeout is immutable on shared Step)

### What's next

- **PR2:** `step_queued` event pipeline, `pending_dispatch` bookkeeping model, queue introspection CLI (`swamp worker queue`)
- **PR3:** boot reconciliation, golden-path integration test, design doc updates

## Test plan

- `deno check` — all files pass (full project type check)
- `deno lint` — 1,651 files clean
- `deno fmt` — 1,776 files clean
- `deno run test` — 8,174 tests pass, 0 failures
- `deno run compile` — binary builds successfully
- **Docker smoke tests** (`tests/fleet-smoke/verify-queueing.sh`) — 5/5 scenarios pass:
  - Queue-on-empty → worker enrolls → workflow completes (15ms enroll-to-dispatch)
  - Timeout fires after 5s with `gpu=true` in error (not instant)
  - Per-step `queueTimeout: 3` overrides serve-level 30s default (fires in 3s)
  - Wake-on-enroll completes in 1s (event-driven, not 5s poll cycle)

Closes swamp-club#947

🤖 Generated with [Claude Code](https://claude.com/claude-code)