### PR TITLE
fix(expressions): defer data.query and data.findByTag as step-output dependencies

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -436,6 +436,20 @@ inputs:
 `data.query()` results have the same `DataRecord[]` shape as the shortcuts
 — anything you can do with a shortcut result, you can do with a query result.
 
+### Step-output deferral in workflows
+
+All `data.*` functions (`data.latest`, `data.version`, `data.listVersions`,
+`data.findBySpec`, `data.query`, `data.findByTag`) are classified as
+step-output dependencies. In workflow step `task.inputs`, they are **deferred**
+past workflow evaluation and resolved at step execution time — after upstream
+steps have run and their data is available. This enables patterns where step 1
+produces ephemeral data and step 2 consumes it via `data.findBySpec()` or
+`data.query()`.
+
+The `--last-evaluated` flag preserves this behavior: deferred expressions saved
+as raw `${{ }}` in the evaluated workflow are resolved at step execution time
+against the current data store.
+
 ## Sensitive Data
 
 You should be able to access sensitive data by referencing the storage keys they

--- a/src/domain/expressions/dependency_extractor.ts
+++ b/src/domain/expressions/dependency_extractor.ts
@@ -259,10 +259,11 @@ export function extractDataFunctionDependencies(expression: string): string[] {
  * Checks if an expression has any data function calls.
  *
  * @param expression - The CEL expression to check
- * @returns True if the expression contains data.version, data.latest, or data.listVersions
+ * @returns True if the expression contains any data.* function call
  */
 export function hasDataFunctionDependency(expression: string): boolean {
-  return /data\.(version|latest|listVersions|findBySpec)\s*\(/.test(expression);
+  return /data\.(version|latest|listVersions|findBySpec|query|findByTag)\s*\(/
+    .test(expression);
 }
 
 /**

--- a/src/domain/expressions/dependency_extractor_test.ts
+++ b/src/domain/expressions/dependency_extractor_test.ts
@@ -214,6 +214,22 @@ Deno.test("hasDataFunctionDependency returns true for data.listVersions", () => 
   );
 });
 
+Deno.test("hasDataFunctionDependency returns true for data.query", () => {
+  assertEquals(
+    hasDataFunctionDependency(
+      'data.query(\'modelName == "fleet" && specName == "host"\')',
+    ),
+    true,
+  );
+});
+
+Deno.test("hasDataFunctionDependency returns true for data.findByTag", () => {
+  assertEquals(
+    hasDataFunctionDependency("data.findByTag('env', 'prod')"),
+    true,
+  );
+});
+
 Deno.test("hasDataFunctionDependency returns false for other expressions", () => {
   assertEquals(hasDataFunctionDependency("model.foo.data.bar"), false);
   assertEquals(hasDataFunctionDependency("self.name"), false);
@@ -333,6 +349,22 @@ Deno.test("hasStepOutputDependency returns true for data function calls", () => 
 Deno.test("hasStepOutputDependency returns true for file.contents calls", () => {
   assertEquals(
     hasStepOutputDependency("file.contents('my-model', 'report')"),
+    true,
+  );
+});
+
+Deno.test("hasStepOutputDependency returns true for data.query calls", () => {
+  assertEquals(
+    hasStepOutputDependency(
+      "data.query('modelName == \"scanner\"')",
+    ),
+    true,
+  );
+});
+
+Deno.test("hasStepOutputDependency returns true for data.findByTag calls", () => {
+  assertEquals(
+    hasStepOutputDependency("data.findByTag('env', 'prod')"),
     true,
   );
 });

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -682,22 +682,63 @@ export class ModelResolver {
       }
     }
 
-    // Create data namespace — every helper delegates to DataQueryService.
-    // The query service owns the implicit `isLatest == true` injection, so
-    // helpers compose predicates as if the catalog exposed history directly.
-    //
-    // Point-lookup helpers (latest, version, findBySpec, findByTag,
-    // listVersions) default to own-namespace scoping. Cross-namespace access
-    // uses "ns:model" prefix syntax; wildcard "*:model" queries all namespaces
-    // with an ambiguity check. data.query() spans all namespaces by default.
-    //
-    // Most helpers are async because the query path resolves vault
-    // references in result attributes. Callers in sync CEL contexts (e.g.
-    // `forEach.in`) must go through `CelEvaluator.evaluateAsync`, which
-    // cel-js natively propagates Promises through.
     const ownNamespace = this.dataRepo?.namespace ?? ("" as Namespace);
+    context.data = this.buildDataNamespace(ownNamespace, coordsMap);
+
+    // Create file namespace for lazy-loading file contents
+    context.file = {
+      contents: (modelName: string, specName: string): string | null => {
+        const modelData = context.model[modelName];
+        if (!modelData?.file?.[specName]) return null;
+        // Get the first instance under the spec
+        const instances = modelData.file[specName];
+        const firstKey = Object.keys(instances)[0];
+        if (!firstKey) return null;
+        const filePath = instances[firstKey].path;
+        try {
+          return Deno.readTextFileSync(filePath);
+        } catch {
+          return null;
+        }
+      },
+    };
+
+    // Build self context if provided
+    if (selfDefinition && selfType) {
+      context.self = {
+        id: selfDefinition.id,
+        name: selfDefinition.name,
+        version: selfDefinition.version,
+        tags: selfDefinition.tags,
+        globalArguments: selfDefinition.globalArguments,
+      };
+    }
+
+    return context;
+  }
+
+  /**
+   * Builds a lightweight expression context with only the data and env
+   * namespaces — no definition loading, no model data, no file namespace.
+   * Used by --last-evaluated where definitions are already cached and only
+   * deferred data.* expressions need resolution at step execution time.
+   */
+  buildLightContext(): ExpressionContext {
+    const ownNamespace = this.dataRepo?.namespace ?? ("" as Namespace);
+    const context: ExpressionContext = {
+      model: {},
+      env: buildEnvContext(),
+    };
+    context.data = this.buildDataNamespace(ownNamespace, new Map());
+    return context;
+  }
+
+  private buildDataNamespace(
+    ownNamespace: Namespace,
+    coordsMap: ModelCoordinatesMap,
+  ): DataNamespace {
     const latestCache = new Map<string, DataRecord | null>();
-    context.data = {
+    return {
       version: async (
         rawModelName: string,
         dataName: string,
@@ -731,8 +772,6 @@ export class ModelResolver {
           const cacheKey = `${nsForKey}\0${ns.modelName}\0${dataName}`;
           if (latestCache.has(cacheKey)) return latestCache.get(cacheKey)!;
 
-          // Direct filesystem lookup via coordsMap — same O(1) path as
-          // `swamp data get`, bypassing the catalog entirely.
           const coords = coordsMap.get(ns.modelName);
           if (coords && coords.length > 0) {
             for (const { modelType, modelId } of coords) {
@@ -764,9 +803,6 @@ export class ModelResolver {
             }
           }
 
-          // Fallback to the catalog for orphan data (no matching definition).
-          // Parse the resolved namespace from the predicate for cross-namespace
-          // lookups (e.g. "security:scanner" → namespace "security").
           if (this.dataQueryService) {
             const targetNs = ns.namespacePredicate
               ? ns.namespacePredicate.match(
@@ -786,7 +822,6 @@ export class ModelResolver {
           return null;
         }
 
-        // Wildcard lookups fall back to the catalog query path.
         if (!this.dataQueryService) return null;
         const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
           `&& name == "${escapeCelString(dataName)}"` +
@@ -800,16 +835,10 @@ export class ModelResolver {
       listVersions: (rawModelName: string, dataName: string): number[] => {
         if (!this.dataQueryService) return [];
         const ns = routeNamespace(rawModelName, ownNamespace);
-        // `version >= 0` is the history opt-in: it suppresses the implicit
-        // `isLatest == true` injection so every version of this data item
-        // is returned. The select projection extracts just the version
-        // numbers. querySync is used so this helper can be called from
-        // synchronous CEL contexts.
         const predicate = `modelName == "${escapeCelString(ns.modelName)}" ` +
           `&& name == "${escapeCelString(dataName)}" && version >= 0` +
           ns.namespacePredicate;
         if (ns.isWildcard) {
-          // Can't check ambiguity on projected number[], so query records first.
           const records = this.dataQueryService.querySync(
             predicate,
           ) as DataRecord[];
@@ -860,37 +889,6 @@ export class ModelResolver {
         return await this.dataQueryService.query(predicate, { select });
       },
     };
-
-    // Create file namespace for lazy-loading file contents
-    context.file = {
-      contents: (modelName: string, specName: string): string | null => {
-        const modelData = context.model[modelName];
-        if (!modelData?.file?.[specName]) return null;
-        // Get the first instance under the spec
-        const instances = modelData.file[specName];
-        const firstKey = Object.keys(instances)[0];
-        if (!firstKey) return null;
-        const filePath = instances[firstKey].path;
-        try {
-          return Deno.readTextFileSync(filePath);
-        } catch {
-          return null;
-        }
-      },
-    };
-
-    // Build self context if provided
-    if (selfDefinition && selfType) {
-      context.self = {
-        id: selfDefinition.id,
-        name: selfDefinition.name,
-        version: selfDefinition.version,
-        tags: selfDefinition.tags,
-        globalArguments: selfDefinition.globalArguments,
-      };
-    }
-
-    return context;
   }
 
   /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -89,7 +89,6 @@ import type { MethodResult, ModelDefinition } from "../models/model.ts";
 import { ExpressionEvaluationService } from "../expressions/expression_evaluation_service.ts";
 import { resolveAvailableExpressions } from "../expressions/available_expression_resolver.ts";
 import {
-  buildEnvContext,
   type DataRecord,
   type ExpressionContext,
   type FileDataRecord,
@@ -602,8 +601,15 @@ export class DefaultStepExecutor implements StepExecutor {
       }
       evaluatedDefinition = lastEvaluated;
 
-      // Values are already resolved in the pre-evaluated workflow
-      if (task.inputs) {
+      // Resolve deferred expressions (data.*, file.contents) that were
+      // skipped during workflow evaluate.  evaluateData only touches
+      // remaining ${{ }} markers; already-resolved values pass through.
+      if (task.inputs && ctx.expressionContext) {
+        stepInputs = await expressionEvaluator.evaluateData(
+          task.inputs,
+          ctx.expressionContext,
+        ) as Record<string, unknown>;
+      } else if (task.inputs) {
         stepInputs = task.inputs;
       }
     } else if (ctx.expressionContext) {
@@ -1461,13 +1467,10 @@ export class WorkflowExecutionService {
           // Use the fully evaluated workflow (forEach expanded, expressions resolved)
           workflow = lastEvaluated;
 
-          // Build a minimal expression context so step outputs can be tracked
-          // and deferred expressions (e.g. model.previous.resource.*) can be
-          // evaluated at step execution time.
-          expressionContext = {
-            model: {},
-            env: buildEnvContext(),
-          };
+          // Build a lightweight context with only data.* and env so
+          // deferred data expressions can be resolved at step execution
+          // time without the cost of loading all definitions from disk.
+          expressionContext = this.modelResolver.buildLightContext();
           if (options?.inputs) {
             expressionContext.inputs = options.inputs;
           }


### PR DESCRIPTION
## Summary

- Add `data.query()` and `data.findByTag()` to the step-output dependency detection in `hasDataFunctionDependency()` — these were missing from the regex, causing them to be eagerly evaluated during workflow evaluation instead of deferred to step execution time. This broke the pattern where step 1 produces ephemeral data and step 2 consumes it via `data.query()`.
- Fix `--last-evaluated` workflow runs to resolve deferred data expressions at step execution time. Adds `buildLightContext()` to `ModelResolver` — a lightweight context with only the `data.*` namespace (no definition loading from disk) — and uses `evaluateData()` on task inputs instead of passing them through as-is.
- Extract `buildDataNamespace()` as a shared private method on `ModelResolver`, used by both `buildContext()` and `buildLightContext()` to avoid duplication.

Closes swamp-club#487

Note: The extension-side changes for `@swamp/ssh` to use dynamic host discovery via ephemeral data belong in the swamp-extensions repo as a follow-up.

## Test Plan

- Unit tests for `hasDataFunctionDependency` and `hasStepOutputDependency` returning true for `data.query()` and `data.findByTag()` — 4 new tests, all 57 dependency extractor tests pass
- Full test suite: 8177 passed, 0 failed
- End-to-end CLI verification in a scratch repo with a local `@test/producer` extension writing ephemeral data and a `@test/consumer` reading it:
  - `workflow run`: deferred `data.findBySpec()` and `data.query()` resolve at step execution time — consumer receives all 3 host records
  - `workflow evaluate`: both expressions remain as raw `${{ }}` strings (properly deferred)
  - `workflow run --last-evaluated`: deferred expressions resolve at step execution time — consumer receives actual data records, not raw strings