### PR TITLE
fix(auth): suppress login nudge banner after auth commands (swamp-club#961)

### DIFF
--- a/integration/auth_nudge_test.ts
+++ b/integration/auth_nudge_test.ts
@@ -211,6 +211,32 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "auth nudge: exit banner suppressed for auth commands even when unauthenticated",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    await withTempDir(async (repoDir) => {
+      await withTempDir(async (configDir) => {
+        await initializeTestRepo(repoDir);
+
+        const result = await runCliCommand(
+          ["auth", "whoami", "--no-telemetry"],
+          repoDir,
+          { XDG_CONFIG_HOME: configDir, NO_COLOR: "1" },
+        );
+
+        const combined = result.stdout + result.stderr;
+        assertEquals(
+          combined.includes(AUTH_NUDGE_MESSAGE),
+          false,
+          "nudge should not appear after auth commands",
+        );
+      });
+    });
+  },
+});
+
+Deno.test({
   name: "auth nudge: exit banner suppressed in --json mode",
   ignore: Deno.build.os === "windows",
   fn: async () => {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1508,15 +1508,17 @@ export async function runCli(args: string[]): Promise<void> {
 
       // Auth nudge banner (throttled to once per day, suppressed once logged in).
       // Skip for commands whose renderers already include their own inline
-      // nudge to avoid showing it twice. If you add an inline nudge to a
-      // new renderer, add the command here too.
+      // nudge to avoid showing it twice, and for auth commands (which handle
+      // authentication directly — showing "please log in" after a successful
+      // login is confusing).
       //   - repo init/upgrade: src/presentation/renderers/repo_init.ts
       //   - model method run: src/presentation/renderers/model_method_run.ts
       //   - workflow run/resume: src/presentation/renderers/workflow_run.ts
       //   - access grant/group: via model_method_run renderer
+      //   - auth *: authentication commands manage login state directly
       {
         const outputMode = getOutputModeFromArgs(args);
-        const hasInlineNudge = (commandInfo.command === "repo" &&
+        const skipNudge = (commandInfo.command === "repo" &&
           (commandInfo.subcommand === "init" ||
             commandInfo.subcommand === "upgrade")) ||
           (commandInfo.command === "model" &&
@@ -1524,8 +1526,9 @@ export async function runCli(args: string[]): Promise<void> {
           (commandInfo.command === "workflow" &&
             (commandInfo.subcommand === "run" ||
               commandInfo.subcommand === "resume")) ||
-          commandInfo.command === "access";
-        if (outputMode === "log" && !isAuthenticated() && !hasInlineNudge) {
+          commandInfo.command === "access" ||
+          commandInfo.command === "auth";
+        if (outputMode === "log" && !isAuthenticated() && !skipNudge) {
           try {
             const nudgeRepo = new AuthNudgeRepository();
             const nudgeState = await nudgeRepo.read();


### PR DESCRIPTION
## Summary

- Suppress the auth nudge banner ("Tip: Join & participate...swamp auth login") for all `auth` subcommands by adding `commandInfo.command === "auth"` to the nudge exclusion predicate in `src/cli/mod.ts`
- The nudge was shown after successful `swamp auth login` because `isAuthenticated()` is set once at CLI startup and the `auth` command family wasn't excluded
- Renamed `hasInlineNudge` → `skipNudge` to reflect that the predicate now covers two exclusion reasons (inline nudge and auth commands)

Closes swamp-club/lab#961

## Test Plan

- [x] Added integration test verifying nudge is suppressed for unauthenticated users running `auth whoami`
- [x] All 8211 existing tests pass
- [x] `deno fmt`, `deno lint`, `deno check` all pass