### PR TITLE
feat(remote): fleet tokens (--max-enrollments, bindings, worker naming)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -54,7 +54,7 @@ Three properties drove the design:
 | **Worker**           | A disposable swamp process that dials the orchestrator, enrolls, and executes dispatched steps with a remote `MethodContext`. |
 | **Executor**         | What a dispatch actually runs on: the **local loopback** (in-process on the orchestrator, no socket) or a **remote worker**. Either way, methods run in-process. |
 | **Enrollment**       | The first-connect handshake: redeem the token, bind it to the worker instance UUID, exchange version/labels, issue a session credential, admit the worker into the pool. |
-| **Enrollment token** | A named, time-boxed credential that enrolls exactly one worker once, then re-authenticates that same instance for the rest of its lifetime. A built-in model. |
+| **Enrollment token** | A named, time-boxed credential that enrolls one or more workers (controlled by `maxEnrollments`), then re-authenticates each bound instance for the rest of its lifetime. A built-in model. |
 | **Session credential** | The short-lived credential issued at enrollment that authenticates the worker's HTTP/2 data-plane requests.                |
 | **Dispatch**         | The orchestrator → worker request to run one `ExecutionRequest`. The unit of fan-out.                                       |
 | **Capability**       | A side-effecting function a running method reaches through its context, proxied back to the orchestrator. A finite, closed set. |
@@ -255,10 +255,14 @@ system. Each token is:
 - **Time-boxed** — a `--duration` lifetime that is a *hard deadline*: it bounds
   enrollment and reconnection, and when it elapses the orchestrator actively
   disconnects a connected worker. Continuing past it means minting a new token.
-- **One machine** — it enrolls exactly one machine. The first connect binds it
-  to the worker's `machineId` (a durable id persisted in the worker's cache
-  directory); an *enrollment* attempt from a different machine is rejected.
-- **Reconnect-for-lifetime** — after enrollment, the *bound machine* may
+- **Controlled enrollment** — `maxEnrollments` (default `1`) controls how many
+  distinct machines a token can bind. A single-enrollment token behaves as
+  before: first connect binds it to a `machineId`; a different machine is
+  rejected. A fleet token (`maxEnrollments > 1` or `"unlimited"`) accepts
+  multiple machines, each appended to a `bindings` list until the allowance is
+  exhausted. Each fleet member gets a distinct pool name
+  (`<tokenName>-<suffix>`) derived from a stable hash of its `machineId`.
+- **Reconnect-for-lifetime** — after enrollment, any *bound machine* may
   re-authenticate by presenting `{token, machineId}` as many times as needed
   until the lifetime expires. This is what survives a broken control socket
   *and* a process restart or reboot: the worker comes back as the same pool
@@ -266,8 +270,8 @@ system. Each token is:
 
 The token is a built-in **enrollment-token** model whose instances are swamp data,
 with states `unused → enrolled → expired`; the `unused → enrolled` transition
-records the bound `machineId`, and two workers cannot race to claim one
-token. The datastore itself provides no compare-and-swap — concurrent saves to
+appends a binding (`machineId` + `enrolledAt`) to the token's `bindings` list,
+and concurrent enrollment attempts are serialized by the orchestrator. The datastore itself provides no compare-and-swap — concurrent saves to
 one data item simply land as successive versions — so atomicity comes from the
 **orchestrator process serializing all token and lease transitions in memory**:
 it is the sole writer of these models, and enrollment for a given token is a
@@ -792,8 +796,8 @@ provisioning credentials and extensions onto workers:
   the step that needs them (consistent with the out-of-process resolution pattern
   in [execution-drivers.md](./execution-drivers.md#vault-secret-resolution)).
 
-- The **enrollment token** is named, time-boxed for first redemption, and
-  enrolls exactly one machine, binding to the worker's durable `machineId`. The
+- The **enrollment token** is named, time-boxed, and enrolls up to
+  `maxEnrollments` machines, each binding to the worker's durable `machineId`. The
   `{token, machineId}` pair is a *bearer* reconnection secret rather than
   proof-of-possession — the machine id is client-asserted, so the binding
   contains *accidental* token reuse (pasting one token onto a second box),
@@ -843,7 +847,7 @@ provisioning credentials and extensions onto workers:
 In scope:
 
 - Worker dial-home + enrollment over `wss://` with a named, time-boxed token that
-  enrolls once and reconnects the same `{token, instanceUuid}` for its lifetime;
+  enrolls one or more machines and reconnects each `{token, machineId}` for its lifetime;
   `swamp worker token` commands and a built-in mint model that writes the token to
   a vault.
 - Drivers removed: in-process execution everywhere, isolation as a worker

--- a/integration/remote_execution_test.ts
+++ b/integration/remote_execution_test.ts
@@ -153,7 +153,10 @@ interface Orchestrator {
   dispatchService: DispatchService;
   serverUrl: string;
   shutdown: () => Promise<void>;
-  mintToken: (name: string) => Promise<string>;
+  mintToken: (
+    name: string,
+    opts?: { maxEnrollments?: number | "unlimited" },
+  ) => Promise<string>;
   runModelMethod: (input: {
     typeArg: string;
     definitionName: string;
@@ -286,12 +289,21 @@ async function startOrchestrator(
   );
   const port = server.addr.port;
 
-  const mintToken = async (name: string): Promise<string> => {
+  const mintToken = async (
+    name: string,
+    opts?: { maxEnrollments?: number | "unlimited" },
+  ): Promise<string> => {
     await runModelMethod({
       typeArg: ENROLLMENT_TOKEN_MODEL_TYPE.normalized,
       definitionName: name,
       methodName: "mint",
-      inputs: { durationMs: 10 * 60 * 1000, vaultName: "local" },
+      inputs: {
+        durationMs: 10 * 60 * 1000,
+        vaultName: "local",
+        ...(opts?.maxEnrollments !== undefined
+          ? { maxEnrollments: opts.maxEnrollments }
+          : {}),
+      },
     });
     const vault = await VaultService.fromRepository(repoDir);
     const plaintext = await vault.get("local", tokenSecretKey(name));
@@ -660,6 +672,76 @@ Deno.test({
         assertStringIncludes(error.message, "does not match");
         assertEquals(orchestrator.gateway.workers().length, 0);
       } finally {
+        await orchestrator.shutdown();
+      }
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "remote execution: fleet token enrolls two workers with distinct pool identities, both dispatchable",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const orchestrator = await startOrchestrator(dir);
+      const stops: AbortController[] = [];
+      const dones: Promise<void>[] = [];
+      try {
+        const token = await orchestrator.mintToken("fleet-pool", {
+          maxEnrollments: 3,
+        });
+
+        for (const i of [1, 2]) {
+          const stop = new AbortController();
+          stops.push(stop);
+          dones.push(runWorker({
+            url: orchestrator.serverUrl,
+            token,
+            labels: { tier: "it", idx: String(i) },
+            swampVersion: "test",
+            cacheDir: join(dir, `worker-cache-${i}`),
+            signal: stop.signal,
+          }));
+        }
+        await waitFor(
+          () => orchestrator.gateway.workers().length === 2,
+          "two fleet workers enrolled",
+        );
+
+        const workers = orchestrator.gateway.workers();
+        assertEquals(workers.length, 2);
+        const names = workers.map((w) => w.name).sort();
+        assertEquals(names[0].startsWith("fleet-pool-"), true);
+        assertEquals(names[1].startsWith("fleet-pool-"), true);
+        assertEquals(names[0] !== names[1], true);
+
+        for (const worker of workers) {
+          assertEquals(worker.labels.fleet, "fleet-pool");
+          assertEquals(worker.status, "idle");
+          assertEquals(worker.connected, true);
+        }
+
+        // Both fleet members are dispatchable.
+        const result1 = await orchestrator.dispatchService.executeRemote(
+          remoteStepRequest({
+            placement: { target: names[0] },
+            methodArgs: { echo: "worker-1" },
+          }),
+        );
+        assertEquals(result1.outputs.length > 0, true);
+
+        const result2 = await orchestrator.dispatchService.executeRemote(
+          remoteStepRequest({
+            placement: { target: names[1] },
+            methodArgs: { echo: "worker-2" },
+          }),
+        );
+        assertEquals(result2.outputs.length > 0, true);
+      } finally {
+        for (const stop of stops) stop.abort();
+        await Promise.allSettled(dones);
         await orchestrator.shutdown();
       }
     });

--- a/src/cli/commands/worker_token_create.ts
+++ b/src/cli/commands/worker_token_create.ts
@@ -28,12 +28,12 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
-import type { MaxEnrollments } from "../../domain/models/worker/enrollment_token_model.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   consumeStream,
   createLibSwampContext,
   createWorkerTokenCreateDeps,
+  type MaxEnrollments,
   parseDuration,
   withDefaults,
   workerTokenCreate,
@@ -57,6 +57,10 @@ export const workerTokenCreateCommand = new Command()
   .example(
     "Choose the vault that stores the plaintext",
     "swamp worker token create ci-runner-3 --duration 7d --vault prod-vault",
+  )
+  .example(
+    "Mint a fleet token for 3 machines",
+    "swamp worker token create ci-fleet --duration 24h --max-enrollments 3",
   )
   .arguments("<name:string>")
   .option(

--- a/src/cli/commands/worker_token_create.ts
+++ b/src/cli/commands/worker_token_create.ts
@@ -28,6 +28,7 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import type { MaxEnrollments } from "../../domain/models/worker/enrollment_token_model.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   consumeStream,
@@ -71,6 +72,10 @@ export const workerTokenCreateCommand = new Command()
     "--vault <vault:string>",
     "Vault that stores the token plaintext (defaults to the sole configured vault)",
   )
+  .option(
+    "--max-enrollments <n:string>",
+    'Maximum machines this token can enroll (positive integer or "unlimited"). Default: 1',
+  )
   .action(async function (options: AnyOptions, name: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "worker",
@@ -83,6 +88,22 @@ export const workerTokenCreateCommand = new Command()
       throw new UserError(
         `Invalid --duration value "${options.duration}": must be positive`,
       );
+    }
+
+    let maxEnrollments: MaxEnrollments = 1;
+    if (options.maxEnrollments !== undefined) {
+      const raw = options.maxEnrollments as string;
+      if (raw === "unlimited") {
+        maxEnrollments = "unlimited";
+      } else {
+        const parsed = Number(raw);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new UserError(
+            `Invalid --max-enrollments value "${raw}": must be a positive integer or "unlimited"`,
+          );
+        }
+        maxEnrollments = parsed;
+      }
     }
 
     const { repoDir, repoContext, datastoreConfig, syncService } =
@@ -131,6 +152,7 @@ export const workerTokenCreateCommand = new Command()
           name,
           durationMs,
           vaultName: options.vault as string | undefined,
+          maxEnrollments,
         }),
         withDefaults<WorkerTokenCreateEvent>({
           completed: (event) => {

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -24,12 +24,13 @@
  * One model instance per token, named by the token name. The token's
  * plaintext only ever lives in a vault — the resource records the vault
  * reference and the lifecycle state machine `unused → enrolled → expired`
- * (plus `revoked`). First redemption binds the token to the presenting
- * machine id; the bound machine may redeem again (worker restarts and
- * reboots) until the lifetime expires, while any other machine is rejected.
- * The datastore provides no compare-and-swap, so the `unused → enrolled`
- * transition is made atomic by the orchestrator process serializing all
- * token transitions in memory — it is the sole writer of this model.
+ * (plus `revoked`). A token's `maxEnrollments` controls how many distinct
+ * machines may bind: `1` (the default) gives single-machine semantics,
+ * a higher number or `"unlimited"` creates a fleet token. Each bound
+ * machine may redeem again (worker restarts and reboots) until the
+ * lifetime expires. The datastore provides no compare-and-swap, so
+ * transitions are made atomic by the orchestrator process serializing
+ * all token transitions in memory — it is the sole writer of this model.
  */
 
 import { z } from "zod";
@@ -56,6 +57,20 @@ export const TokenStateSchema = z.enum([
 
 export type TokenState = z.infer<typeof TokenStateSchema>;
 
+export const MaxEnrollmentsSchema = z.union([
+  z.number().int().positive(),
+  z.literal("unlimited"),
+]);
+
+export type MaxEnrollments = z.infer<typeof MaxEnrollmentsSchema>;
+
+const BindingSchema = z.object({
+  machineId: z.string(),
+  enrolledAt: z.string().datetime(),
+});
+
+export type Binding = z.infer<typeof BindingSchema>;
+
 export const EnrollmentTokenSchema = z.object({
   name: z.string().describe("Token name; the worker's pool-addressable handle"),
   state: TokenStateSchema,
@@ -65,13 +80,28 @@ export const EnrollmentTokenSchema = z.object({
   /** Vault reference to the token plaintext — never the secret itself. */
   vaultName: z.string(),
   secretKey: z.string(),
-  /** Durable machine id bound on first redemption. */
+  maxEnrollments: MaxEnrollmentsSchema.default(1),
+  bindings: z.array(BindingSchema).default([]),
+  /** @deprecated Legacy field — kept so Zod parses old records. */
   boundMachineId: z.string().optional(),
+  /** @deprecated Legacy field — kept so Zod parses old records. */
   enrolledAt: z.string().datetime().optional(),
   revokedAt: z.string().datetime().optional(),
+}).transform((token) => {
+  const { boundMachineId, enrolledAt, ...rest } = token;
+  if (boundMachineId && rest.bindings.length === 0) {
+    return {
+      ...rest,
+      bindings: [{
+        machineId: boundMachineId,
+        enrolledAt: enrolledAt ?? rest.createdAt,
+      }],
+    };
+  }
+  return rest;
 });
 
-export type EnrollmentToken = z.infer<typeof EnrollmentTokenSchema>;
+export type EnrollmentToken = z.output<typeof EnrollmentTokenSchema>;
 
 const TOKEN_DATA_NAME = "token-main";
 
@@ -101,6 +131,7 @@ const MintArgsSchema = z.object({
   vaultName: z.string().min(1).describe(
     "Vault that stores the token plaintext",
   ),
+  maxEnrollments: MaxEnrollmentsSchema.default(1),
 });
 
 async function mint(
@@ -123,13 +154,15 @@ async function mint(
   await context.vaultService.put(args.vaultName, secretKey, plaintext);
 
   const now = Date.now();
-  const token: EnrollmentToken = {
+  const token = {
     name,
-    state: "unused",
+    state: "unused" as const,
     createdAt: new Date(now).toISOString(),
     expiresAt: new Date(now + args.durationMs).toISOString(),
     vaultName: args.vaultName,
     secretKey,
+    maxEnrollments: args.maxEnrollments,
+    bindings: [] as Binding[],
   };
   const handle = await context.writeResource!("token", TOKEN_DATA_NAME, token);
   return { dataHandles: [handle] };
@@ -141,11 +174,12 @@ const RedeemArgsSchema = z.object({
 });
 
 /**
- * Redeem the token at enrollment, or re-authenticate the bound machine on
- * reconnect or restart. First redemption transitions `unused → enrolled` and
- * binds the machine id (a new resource version); a matching re-redemption
- * validates without writing. Expiry is a hard deadline for both: past
- * `expiresAt` even the bound machine is rejected. Every failure throws.
+ * Redeem the token at enrollment, or re-authenticate a bound machine on
+ * reconnect or restart. First redemption transitions `unused → enrolled`;
+ * subsequent machines are appended to the bindings list until the
+ * `maxEnrollments` allowance is exhausted. A known machineId re-auths
+ * without writing. Expiry is a hard deadline: past `expiresAt` every
+ * machine is rejected. Every failure throws.
  */
 async function redeem(
   args: z.infer<typeof RedeemArgsSchema>,
@@ -172,39 +206,34 @@ async function redeem(
     throw new Error(`Enrollment token '${name}' does not match`);
   }
 
-  if (token.state === "enrolled") {
-    if (token.boundMachineId === args.machineId) {
-      // Re-authentication of the bound machine: valid, no state change.
-      return { dataHandles: [] };
-    }
-    if (token.boundMachineId !== undefined) {
-      throw new Error(
-        `Enrollment token '${name}' is already bound to another machine`,
-      );
-    }
-    // Enrolled before machine binding existed: adopt the presenting machine.
-    const adopted: EnrollmentToken = {
-      ...token,
-      boundMachineId: args.machineId,
-    };
-    const handle = await context.writeResource!(
-      "token",
-      TOKEN_DATA_NAME,
-      adopted,
-    );
-    return { dataHandles: [handle] };
+  const existingBinding = token.bindings.find(
+    (b) => b.machineId === args.machineId,
+  );
+  if (existingBinding) {
+    return { dataHandles: [] };
   }
 
-  const enrolled: EnrollmentToken = {
+  if (
+    token.maxEnrollments !== "unlimited" &&
+    token.bindings.length >= token.maxEnrollments
+  ) {
+    throw new Error(
+      `Enrollment token '${name}': enrollment allowance exhausted`,
+    );
+  }
+
+  const updated = {
     ...token,
-    state: "enrolled",
-    boundMachineId: args.machineId,
-    enrolledAt: new Date().toISOString(),
+    state: "enrolled" as const,
+    bindings: [
+      ...token.bindings,
+      { machineId: args.machineId, enrolledAt: new Date().toISOString() },
+    ],
   };
   const handle = await context.writeResource!(
     "token",
     TOKEN_DATA_NAME,
-    enrolled,
+    updated,
   );
   return { dataHandles: [handle] };
 }
@@ -255,7 +284,7 @@ async function expire(
  */
 export const enrollmentTokenModel: ModelDefinition = defineModel({
   type: ENROLLMENT_TOKEN_MODEL_TYPE,
-  version: "2026.06.11.1",
+  version: "2026.07.04.1",
   resources: {
     "token": {
       description:
@@ -275,7 +304,7 @@ export const enrollmentTokenModel: ModelDefinition = defineModel({
     },
     redeem: {
       description:
-        "Redeem at enrollment (unused → enrolled, binds machine id) or re-authenticate the bound machine",
+        "Redeem at enrollment (appends a binding) or re-authenticate a bound machine",
       kind: "action",
       arguments: RedeemArgsSchema,
       execute: redeem,

--- a/src/domain/models/worker/enrollment_token_model_test.ts
+++ b/src/domain/models/worker/enrollment_token_model_test.ts
@@ -24,14 +24,32 @@ import {
   assertStringIncludes,
 } from "@std/assert";
 import {
+  type Binding,
   ENROLLMENT_TOKEN_MODEL_TYPE,
   enrollmentTokenModel,
+  type MaxEnrollments,
   tokenSecretKey,
 } from "./enrollment_token_model.ts";
 import { timingSafeEqual } from "../../crypto/timing_safe_equal.ts";
 import { createInMemoryWorkerContext } from "./worker_test_helpers.ts";
 
-const mintArgs = { durationMs: 60_000, vaultName: "local" };
+const mintArgs = {
+  durationMs: 60_000,
+  vaultName: "local",
+  maxEnrollments: 1 as const,
+};
+
+function tokenBindings(
+  store: Map<string, Record<string, unknown>>,
+): Binding[] {
+  return store.get("token-main")!.bindings as Binding[];
+}
+
+function tokenMaxEnrollments(
+  store: Map<string, Record<string, unknown>>,
+): MaxEnrollments {
+  return store.get("token-main")!.maxEnrollments as MaxEnrollments;
+}
 
 async function mintToken(name = "ci-runner-3") {
   const harness = createInMemoryWorkerContext(
@@ -49,9 +67,10 @@ Deno.test("enrollmentTokenModel: mint writes the secret to the vault, never to d
   assertEquals(token.state, "unused");
   assertEquals(token.vaultName, "local");
   assertEquals(token.secretKey, tokenSecretKey("ci-runner-3"));
+  assertEquals(tokenMaxEnrollments(store), 1);
+  assertEquals(tokenBindings(store), []);
   assertEquals(typeof plaintext, "string");
   assertEquals(plaintext.length, 64);
-  // The plaintext must not appear anywhere in the persisted record.
   assertEquals(JSON.stringify(token).includes(plaintext), false);
 });
 
@@ -72,8 +91,10 @@ Deno.test("enrollmentTokenModel: redeem transitions unused → enrolled and bind
   );
   const token = store.get("token-main")!;
   assertEquals(token.state, "enrolled");
-  assertEquals(token.boundMachineId, "machine-1");
-  assertEquals(typeof token.enrolledAt, "string");
+  const bindings = tokenBindings(store);
+  assertEquals(bindings.length, 1);
+  assertEquals(bindings[0].machineId, "machine-1");
+  assertEquals(typeof bindings[0].enrolledAt, "string");
 });
 
 Deno.test("enrollmentTokenModel: redeem with a wrong token fails", async () => {
@@ -103,7 +124,7 @@ Deno.test("enrollmentTokenModel: re-auth of the bound machine succeeds without a
   assertEquals(versions.get("token-main"), versionsAfterEnroll);
 });
 
-Deno.test("enrollmentTokenModel: a second machine cannot claim an enrolled token", async () => {
+Deno.test("enrollmentTokenModel: a second machine cannot claim a single-enrollment token", async () => {
   const { context, plaintext } = await mintToken();
   await enrollmentTokenModel.methods.redeem.execute(
     { presentedToken: plaintext, machineId: "machine-1" },
@@ -117,7 +138,7 @@ Deno.test("enrollmentTokenModel: a second machine cannot claim an enrolled token
       ),
     Error,
   );
-  assertStringIncludes(error.message, "already bound");
+  assertStringIncludes(error.message, "allowance exhausted");
 });
 
 Deno.test("enrollmentTokenModel: redeem of an expired unused token fails", async () => {
@@ -163,20 +184,40 @@ Deno.test("enrollmentTokenModel: even the bound machine cannot redeem past the t
   );
 });
 
-Deno.test("enrollmentTokenModel: an enrolled token without a bound machine adopts the presenter", async () => {
-  // Records written before machine binding existed have state "enrolled"
-  // but no boundMachineId — the next redemption adopts that machine.
-  const { context, store, plaintext } = await mintToken();
-  await enrollmentTokenModel.methods.redeem.execute(
-    { presentedToken: plaintext, machineId: "machine-1" },
-    context,
+Deno.test("enrollmentTokenModel: legacy record with boundMachineId migrates to bindings on read", async () => {
+  const harness = createInMemoryWorkerContext(
+    ENROLLMENT_TOKEN_MODEL_TYPE,
+    "legacy",
   );
-  delete store.get("token-main")!.boundMachineId;
+  // Simulate a legacy record with boundMachineId instead of bindings.
+  const legacyRecord = {
+    name: "legacy",
+    state: "enrolled",
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    vaultName: "local",
+    secretKey: "worker-token-legacy",
+    boundMachineId: "machine-1",
+    enrolledAt: "2026-06-01T00:00:00.000Z",
+  };
+  harness.store.set("token-main", legacyRecord as Record<string, unknown>);
+  harness.vault.set("local/worker-token-legacy", "test-secret");
+
+  // Re-auth of the migrated machine should work.
   await enrollmentTokenModel.methods.redeem.execute(
-    { presentedToken: plaintext, machineId: "machine-2" },
-    context,
+    { presentedToken: "test-secret", machineId: "machine-1" },
+    harness.context,
   );
-  assertEquals(store.get("token-main")!.boundMachineId, "machine-2");
+  // The second machine is rejected (maxEnrollments defaults to 1).
+  const error = await assertRejects(
+    () =>
+      enrollmentTokenModel.methods.redeem.execute(
+        { presentedToken: "test-secret", machineId: "machine-2" },
+        harness.context,
+      ),
+    Error,
+  );
+  assertStringIncludes(error.message, "allowance exhausted");
 });
 
 Deno.test("enrollmentTokenModel: revoke blocks subsequent redemption", async () => {
@@ -212,6 +253,108 @@ Deno.test("enrollmentTokenModel: minted tokens are unique", async () => {
   const a = await mintToken("a");
   const b = await mintToken("b");
   assertNotEquals(a.plaintext, b.plaintext);
+});
+
+async function mintFleetToken(
+  name = "pool",
+  maxEnrollments: number | "unlimited" = 3,
+) {
+  const harness = createInMemoryWorkerContext(
+    ENROLLMENT_TOKEN_MODEL_TYPE,
+    name,
+  );
+  await enrollmentTokenModel.methods.mint.execute(
+    { durationMs: 60_000, vaultName: "local", maxEnrollments },
+    harness.context,
+  );
+  const plaintext = harness.vault.get(`local/${tokenSecretKey(name)}`)!;
+  return { ...harness, plaintext };
+}
+
+Deno.test("enrollmentTokenModel: maxEnrollments: 3 allows three machines, rejects the fourth", async () => {
+  const { context, store, plaintext } = await mintFleetToken("pool", 3);
+  assertEquals(tokenMaxEnrollments(store), 3);
+
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m1" },
+    context,
+  );
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m2" },
+    context,
+  );
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m3" },
+    context,
+  );
+  assertEquals(tokenBindings(store).length, 3);
+
+  const error = await assertRejects(
+    () =>
+      enrollmentTokenModel.methods.redeem.execute(
+        { presentedToken: plaintext, machineId: "m4" },
+        context,
+      ),
+    Error,
+  );
+  assertStringIncludes(error.message, "allowance exhausted");
+});
+
+Deno.test("enrollmentTokenModel: maxEnrollments: unlimited allows N machines", async () => {
+  const { context, store, plaintext } = await mintFleetToken(
+    "fleet",
+    "unlimited",
+  );
+  assertEquals(tokenMaxEnrollments(store), "unlimited");
+
+  for (let i = 0; i < 10; i++) {
+    await enrollmentTokenModel.methods.redeem.execute(
+      { presentedToken: plaintext, machineId: `m${i}` },
+      context,
+    );
+  }
+  assertEquals(tokenBindings(store).length, 10);
+});
+
+Deno.test("enrollmentTokenModel: re-auth of a known machine does not append a duplicate binding", async () => {
+  const { context, store, plaintext, versions } = await mintFleetToken(
+    "pool2",
+    3,
+  );
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m1" },
+    context,
+  );
+  const versionsAfterEnroll = versions.get("token-main");
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m1" },
+    context,
+  );
+  assertEquals(versions.get("token-main"), versionsAfterEnroll);
+  assertEquals(tokenBindings(store).length, 1);
+});
+
+Deno.test("enrollmentTokenModel: revoke disconnects all bindings", async () => {
+  const { context, store, plaintext } = await mintFleetToken("pool3", 3);
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m1" },
+    context,
+  );
+  await enrollmentTokenModel.methods.redeem.execute(
+    { presentedToken: plaintext, machineId: "m2" },
+    context,
+  );
+  await enrollmentTokenModel.methods.revoke.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "revoked");
+  await assertRejects(
+    () =>
+      enrollmentTokenModel.methods.redeem.execute(
+        { presentedToken: plaintext, machineId: "m1" },
+        context,
+      ),
+    Error,
+    "revoked",
+  );
 });
 
 Deno.test("timingSafeEqual: equal and unequal strings", () => {

--- a/src/domain/models/worker/worker_model.ts
+++ b/src/domain/models/worker/worker_model.ts
@@ -83,6 +83,7 @@ export function workerDefinitionName(workerName: string): string {
 const EnrollArgsSchema = z.object({
   instanceUuid: z.string().min(1),
   tokenName: z.string().min(1),
+  workerName: z.string().min(1).optional(),
   labels: z.record(z.string(), z.string()).default({}),
   platform: z.string(),
   arch: z.string(),
@@ -96,10 +97,7 @@ async function enroll(
 ): Promise<MethodResult> {
   const now = new Date().toISOString();
   const state: WorkerState = {
-    // The pool-addressable name is the token name; the definition instance
-    // is prefixed (worker-<name>) so it cannot collide with the token's own
-    // instance in the shared definition-name namespace.
-    name: args.tokenName,
+    name: args.workerName ?? args.tokenName,
     instanceUuid: args.instanceUuid,
     tokenName: args.tokenName,
     status: "idle",

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -372,6 +372,7 @@ export {
   type WorkerTokenCreateEvent,
   type WorkerTokenCreateInput,
 } from "./worker/token_create.ts";
+export type { MaxEnrollments } from "./worker/token_create.ts";
 export {
   createWorkerTokenRevokeDeps,
   workerTokenRevoke,

--- a/src/libswamp/worker/list.ts
+++ b/src/libswamp/worker/list.ts
@@ -32,8 +32,10 @@ import type { DataRecord } from "../../domain/data/data_record.ts";
 import type { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import {
+  type Binding,
   ENROLLMENT_TOKEN_MODEL_TYPE,
   EnrollmentTokenSchema,
+  type MaxEnrollments,
   type TokenState,
 } from "../../domain/models/worker/enrollment_token_model.ts";
 import {
@@ -58,7 +60,9 @@ export interface WorkerTokenListItem {
   effectiveState: TokenState;
   createdAt: string;
   expiresAt: string;
-  boundMachineId?: string;
+  maxEnrollments: MaxEnrollments;
+  bindingCount: number;
+  bindings: Binding[];
   vaultName: string;
   secretKey: string;
 }
@@ -172,7 +176,9 @@ export async function* workerTokenList(
             ),
             createdAt: token.createdAt,
             expiresAt: token.expiresAt,
-            boundMachineId: token.boundMachineId,
+            maxEnrollments: token.maxEnrollments,
+            bindingCount: token.bindings.length,
+            bindings: token.bindings,
             vaultName: token.vaultName,
             secretKey: token.secretKey,
           });

--- a/src/libswamp/worker/list_test.ts
+++ b/src/libswamp/worker/list_test.ts
@@ -153,7 +153,8 @@ Deno.test("workerTokenList: overlays expired display state on stale live tokens"
   >;
   assertEquals(completed.data.tokens[0].state, "enrolled");
   assertEquals(completed.data.tokens[0].effectiveState, "expired");
-  assertEquals(completed.data.tokens[0].boundMachineId, "machine-9");
+  assertEquals(completed.data.tokens[0].bindingCount, 1);
+  assertEquals(completed.data.tokens[0].bindings[0].machineId, "machine-9");
 });
 
 Deno.test("workerTokenList: skips malformed records and sorts by name", async () => {

--- a/src/libswamp/worker/token_create.ts
+++ b/src/libswamp/worker/token_create.ts
@@ -38,6 +38,8 @@ import {
   ENROLLMENT_TOKEN_MODEL_TYPE,
   type MaxEnrollments,
 } from "../../domain/models/worker/enrollment_token_model.ts";
+
+export type { MaxEnrollments } from "../../domain/models/worker/enrollment_token_model.ts";
 import { createWorkerModelRunDeps } from "./run_deps.ts";
 
 /** Data payload for the completed event. */
@@ -46,6 +48,7 @@ export interface WorkerTokenCreateData {
   /** Token plaintext — shown once, never persisted outside the vault. */
   token: string;
   expiresAt: string;
+  maxEnrollments: MaxEnrollments;
   vaultRef: { vaultName: string; secretKey: string };
 }
 
@@ -221,6 +224,7 @@ export async function* workerTokenCreate(
           // splitEnrollmentToken in src/serve/worker_gateway.ts).
           token: `${input.name}.${plaintext}`,
           expiresAt: tokenRecord.expiresAt,
+          maxEnrollments: (tokenRecord.maxEnrollments as MaxEnrollments) ?? 1,
           vaultRef: { vaultName, secretKey },
         },
       };

--- a/src/libswamp/worker/token_create.ts
+++ b/src/libswamp/worker/token_create.ts
@@ -34,7 +34,10 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
-import { ENROLLMENT_TOKEN_MODEL_TYPE } from "../../domain/models/worker/enrollment_token_model.ts";
+import {
+  ENROLLMENT_TOKEN_MODEL_TYPE,
+  type MaxEnrollments,
+} from "../../domain/models/worker/enrollment_token_model.ts";
 import { createWorkerModelRunDeps } from "./run_deps.ts";
 
 /** Data payload for the completed event. */
@@ -56,13 +59,19 @@ export interface WorkerTokenCreateInput {
   durationMs: number;
   /** Omit to use the repo's sole configured vault. */
   vaultName?: string;
+  maxEnrollments?: MaxEnrollments;
 }
 
 /** Dependencies for the worker token create operation. */
 export interface WorkerTokenCreateDeps {
   listVaultNames: () => Promise<string[]>;
   runMint: (
-    input: { name: string; durationMs: number; vaultName: string },
+    input: {
+      name: string;
+      durationMs: number;
+      vaultName: string;
+      maxEnrollments?: MaxEnrollments;
+    },
   ) => AsyncIterable<ModelMethodRunEvent>;
   readSecret: (vaultName: string, secretKey: string) => Promise<string>;
 }
@@ -84,6 +93,9 @@ export async function createWorkerTokenCreateDeps(
         inputs: {
           durationMs: input.durationMs,
           vaultName: input.vaultName,
+          ...(input.maxEnrollments !== undefined
+            ? { maxEnrollments: input.maxEnrollments }
+            : {}),
         },
         lastEvaluated: false,
         typeArg: ENROLLMENT_TOKEN_MODEL_TYPE.normalized,
@@ -166,6 +178,7 @@ export async function* workerTokenCreate(
           name: input.name,
           durationMs: input.durationMs,
           vaultName,
+          maxEnrollments: input.maxEnrollments,
         })
       ) {
         if (event.kind === "error") {

--- a/src/libswamp/worker/token_create_test.ts
+++ b/src/libswamp/worker/token_create_test.ts
@@ -101,6 +101,7 @@ Deno.test("workerTokenCreate: mints and yields the plaintext once", async () => 
     name: "ci-runner-3",
     token: "ci-runner-3.plaintext-token",
     expiresAt: EXPIRES_AT,
+    maxEnrollments: 1,
     vaultRef: {
       vaultName: "main-vault",
       secretKey: "worker-token-ci-runner-3",

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -105,6 +105,7 @@ export function renderWorkerTokenCreate(
   const lines = [
     `${bold(cyan("Token:"))} ${bold(data.name)}`,
     `${bold(cyan("Expires:"))} ${data.expiresAt}`,
+    `${bold(cyan("Max enrollments:"))} ${data.maxEnrollments}`,
     `${bold(cyan("Vault:"))} ${data.vaultRef.vaultName} ${
       dim(`(key ${data.vaultRef.secretKey})`)
     }`,

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -138,14 +138,19 @@ export function renderWorkerTokenList(
     );
     return;
   }
-  const rows = data.tokens.map((token) => [
-    token.name,
-    token.effectiveState,
-    token.expiresAt,
-    token.boundMachineId ?? "-",
-  ]);
+  const rows = data.tokens.map((token) => {
+    const allowance = token.maxEnrollments === "unlimited"
+      ? "unlimited"
+      : String(token.maxEnrollments);
+    return [
+      token.name,
+      token.effectiveState,
+      token.expiresAt,
+      `${token.bindingCount} / ${allowance}`,
+    ];
+  });
   const lines = tableLines(
-    ["NAME", "STATE", "EXPIRES", "BOUND MACHINE"],
+    ["NAME", "STATE", "EXPIRES", "ENROLLMENTS"],
     rows,
     (column, value) => (column === 1 ? colorTokenState(value) : value),
   );

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -86,7 +86,12 @@ const tokenListData: WorkerTokenListData = {
       effectiveState: "enrolled",
       createdAt: "2026-06-09T00:00:00.000Z",
       expiresAt: "2026-06-10T00:00:00.000Z",
-      boundMachineId: "machine-42",
+      maxEnrollments: 1,
+      bindingCount: 1,
+      bindings: [{
+        machineId: "machine-42",
+        enrolledAt: "2026-06-09T01:00:00.000Z",
+      }],
       vaultName: "main-vault",
       secretKey: "worker-token-ci-runner-3",
     },
@@ -96,6 +101,9 @@ const tokenListData: WorkerTokenListData = {
       effectiveState: "expired",
       createdAt: "2026-06-01T00:00:00.000Z",
       expiresAt: "2026-06-02T00:00:00.000Z",
+      maxEnrollments: 1,
+      bindingCount: 0,
+      bindings: [],
       vaultName: "main-vault",
       secretKey: "worker-token-stale",
     },
@@ -110,10 +118,10 @@ Deno.test("renderWorkerTokenList: log mode renders the table with display state"
   assertStringIncludes(output, "NAME");
   assertStringIncludes(output, "STATE");
   assertStringIncludes(output, "EXPIRES");
-  assertStringIncludes(output, "BOUND MACHINE");
+  assertStringIncludes(output, "ENROLLMENTS");
   assertStringIncludes(output, "ci-runner-3");
   assertStringIncludes(output, "enrolled");
-  assertStringIncludes(output, "machine-42");
+  assertStringIncludes(output, "1 / 1");
   // Display-level expiry overlay
   assertStringIncludes(output, "expired");
 });

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -51,6 +51,7 @@ const createData: WorkerTokenCreateData = {
   name: "ci-runner-3",
   token: "swamp-token-plaintext",
   expiresAt: "2026-06-10T00:00:00.000Z",
+  maxEnrollments: 1,
   vaultRef: { vaultName: "main-vault", secretKey: "worker-token-ci-runner-3" },
 };
 

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -88,8 +88,11 @@ export function splitEnrollmentToken(
 }
 
 /**
- * Stable 4-hex-char suffix derived from a machineId, used to give each
+ * Stable 8-hex-char suffix derived from a machineId, used to give each
  * fleet member a distinct worker name: `<tokenName>-<suffix>`.
+ *
+ * 4 bytes → ~4 billion values; birthday-paradox collision is negligible
+ * for any practical fleet size.
  */
 export async function fleetMemberSuffix(machineId: string): Promise<string> {
   const digest = await crypto.subtle.digest(
@@ -97,7 +100,7 @@ export async function fleetMemberSuffix(machineId: string): Promise<string> {
     new TextEncoder().encode(machineId),
   );
   return Array.from(new Uint8Array(digest))
-    .slice(0, 2)
+    .slice(0, 4)
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 }
@@ -116,6 +119,8 @@ export interface WorkerSnapshot {
 
 interface WorkerEntry {
   name: string;
+  /** The enrollment-token model instance name (differs from `name` for fleet workers). */
+  tokenName: string;
   instanceUuid: string;
   labels: Record<string, string>;
   platform: string;
@@ -468,6 +473,7 @@ export class WorkerGateway {
       // enrollment leaves no orphaned state behind.
       const entry: WorkerEntry = reconnecting ? existing : {
         name: workerName,
+        tokenName: name,
         instanceUuid: params.instanceUuid,
         labels,
         platform: params.platform,
@@ -602,27 +608,27 @@ export class WorkerGateway {
    * worker's re-enrollment attempt is rejected as expired, so it cannot
    * return on this token.
    */
-  #handleTokenExpired(name: string): void {
-    const entry = this.#workers.get(name);
+  #handleTokenExpired(workerName: string): void {
+    const entry = this.#workers.get(workerName);
     if (!entry) {
       return;
     }
     entry.expiryTimer = undefined;
     logger.info("Enrollment token for {worker} expired — disconnecting", {
-      worker: name,
+      worker: workerName,
     });
     // Bookkeeping only: redeem independently rejects on time, so a failure
     // here just delays the durable record catching up.
     this.#recordTransition(() =>
       this.#runModelMethod({
         typeArg: ENROLLMENT_TOKEN_MODEL_TYPE.normalized,
-        definitionName: name,
+        definitionName: entry.tokenName,
         methodName: "expire",
         inputs: {},
       })
     ).catch((error: unknown) => {
       logger.warn("Failed to record token expiry for {worker}: {error}", {
-        worker: name,
+        worker: workerName,
         error: error instanceof Error ? error.message : String(error),
       });
     });

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -57,6 +57,7 @@ import {
 import {
   ENROLLMENT_TOKEN_MODEL_TYPE,
   EnrollmentTokenSchema,
+  type MaxEnrollments,
 } from "../domain/models/worker/enrollment_token_model.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
@@ -84,6 +85,21 @@ export function splitEnrollmentToken(
     return null;
   }
   return { name: presented.slice(0, dot), secret: presented.slice(dot + 1) };
+}
+
+/**
+ * Stable 4-hex-char suffix derived from a machineId, used to give each
+ * fleet member a distinct worker name: `<tokenName>-<suffix>`.
+ */
+export async function fleetMemberSuffix(machineId: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(machineId),
+  );
+  return Array.from(new Uint8Array(digest))
+    .slice(0, 2)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 export interface WorkerSnapshot {
@@ -148,6 +164,13 @@ export interface WorkerGatewayOptions {
    * expiry enforcement for that worker. Defaults to a datastore query.
    */
   readTokenExpiresAt?: (tokenName: string) => Promise<string | null>;
+  /**
+   * Test seam: reads a token's `maxEnrollments` after redemption for fleet
+   * naming. Defaults to a datastore query.
+   */
+  readTokenMaxEnrollments?: (
+    tokenName: string,
+  ) => Promise<MaxEnrollments | null>;
 }
 
 /** Tracks one attached control socket before/after enrollment. */
@@ -164,6 +187,9 @@ export class WorkerGateway {
   readonly #graceWindowMs: number;
   readonly #runModelMethod: ModelMethodRunner;
   readonly #readTokenExpiresAt: (tokenName: string) => Promise<string | null>;
+  readonly #readTokenMaxEnrollments: (
+    tokenName: string,
+  ) => Promise<MaxEnrollments | null>;
   /** Serializes every token/worker/lease transition (sole-writer rule). */
   #transitionTail: Promise<unknown> = Promise.resolve();
 
@@ -176,6 +202,8 @@ export class WorkerGateway {
       ((input) => this.#defaultRunModelMethod(input));
     this.#readTokenExpiresAt = options.readTokenExpiresAt ??
       ((tokenName) => this.#defaultReadTokenExpiresAt(tokenName));
+    this.#readTokenMaxEnrollments = options.readTokenMaxEnrollments ??
+      ((tokenName) => this.#defaultReadTokenMaxEnrollments(tokenName));
   }
 
   /** The credential service the data plane authenticates against. */
@@ -349,21 +377,10 @@ export class WorkerGateway {
     const { name, secret } = split;
 
     return await this.#recordTransition<EnrollResult>(async () => {
-      const existing = this.#workers.get(name);
-      if (
-        existing && existing.channel !== null &&
-        existing.instanceUuid !== params.instanceUuid
-      ) {
-        throw new RpcError({
-          code: "already_connected",
-          message: `Worker '${name}' is already connected`,
-        });
-      }
-
-      // Redeem validates state, expiry, the secret, and machine binding —
-      // and performs the unused → enrolled transition on first redemption.
-      // The bound machine may redeem again (restart, reboot); any other
-      // machine is rejected.
+      // Redeem validates state, expiry, the secret, and allowance — and
+      // appends a binding on first enrollment or re-auths a known machine.
+      // Must happen before the already-connected check because the worker
+      // name depends on maxEnrollments (fleet vs single-machine).
       await this.#runModelMethod({
         typeArg: ENROLLMENT_TOKEN_MODEL_TYPE.normalized,
         definitionName: name,
@@ -373,6 +390,22 @@ export class WorkerGateway {
           machineId: params.machineId,
         },
       });
+
+      const maxEnrollments = await this.#readTokenMaxEnrollments(name) ?? 1;
+      const workerName = maxEnrollments === 1
+        ? name
+        : `${name}-${await fleetMemberSuffix(params.machineId)}`;
+
+      const existing = this.#workers.get(workerName);
+      if (
+        existing && existing.channel !== null &&
+        existing.instanceUuid !== params.instanceUuid
+      ) {
+        throw new RpcError({
+          code: "already_connected",
+          message: `Worker '${workerName}' is already connected`,
+        });
+      }
 
       const reconnecting = existing !== undefined &&
         existing.instanceUuid === params.instanceUuid;
@@ -389,11 +422,24 @@ export class WorkerGateway {
         existing.expiryTimer = undefined;
       }
 
+      // Auto-inject fleet label for multi-machine tokens.
+      const labels = { ...params.labels };
+      if (maxEnrollments !== 1) {
+        if (labels.fleet !== undefined) {
+          logger.warn(
+            "Worker {worker} supplies its own fleet label {fleet}; keeping it instead of auto-injecting {tokenName}",
+            { worker: workerName, fleet: labels.fleet, tokenName: name },
+          );
+        } else {
+          labels.fleet = name;
+        }
+      }
+
       if (reconnecting) {
         existing.channel = state.channel;
         await this.#runModelMethod({
           typeArg: WORKER_MODEL_TYPE.normalized,
-          definitionName: workerDefinitionName(name),
+          definitionName: workerDefinitionName(workerName),
           methodName: "set_status",
           inputs: existing.status === "busy"
             ? { status: "busy", dispatchId: existing.dispatchId ?? undefined }
@@ -402,12 +448,13 @@ export class WorkerGateway {
       } else {
         await this.#runModelMethod({
           typeArg: WORKER_MODEL_TYPE.normalized,
-          definitionName: workerDefinitionName(name),
+          definitionName: workerDefinitionName(workerName),
           methodName: "enroll",
           inputs: {
             instanceUuid: params.instanceUuid,
             tokenName: name,
-            labels: params.labels,
+            workerName,
+            labels,
             platform: params.platform,
             arch: params.arch,
             swampVersion: params.swampVersion,
@@ -420,9 +467,9 @@ export class WorkerGateway {
       // the capability handlers, and issue the credential, so a failed
       // enrollment leaves no orphaned state behind.
       const entry: WorkerEntry = reconnecting ? existing : {
-        name,
+        name: workerName,
         instanceUuid: params.instanceUuid,
-        labels: params.labels,
+        labels,
         platform: params.platform,
         arch: params.arch,
         swampVersion: params.swampVersion,
@@ -433,8 +480,8 @@ export class WorkerGateway {
       };
       entry.channel = state.channel;
       entry.closeSocket = state.closeSocket;
-      this.#workers.set(name, entry);
-      state.workerName = name;
+      this.#workers.set(workerName, entry);
+      state.workerName = workerName;
 
       // The token lifetime is a hard deadline: when it elapses, disconnect
       // the worker. Re-enrollment is then rejected as expired, so the
@@ -444,15 +491,18 @@ export class WorkerGateway {
         this.#scheduleTokenExpiry(entry, Date.parse(expiresAt));
       }
 
-      this.#options.capabilityService.registerHandlers(state.channel, name);
+      this.#options.capabilityService.registerHandlers(
+        state.channel,
+        workerName,
+      );
       state.channel.register(
         RemoteMethod.sessionRefresh,
-        () => this.#handleSessionRefresh(name),
+        () => this.#handleSessionRefresh(workerName),
       );
 
-      const session = this.#sessions.issue(name);
+      const session = this.#sessions.issue(workerName);
       logger.info("Worker {worker} enrolled ({mode})", {
-        worker: name,
+        worker: workerName,
         mode: reconnecting ? "reconnect" : "first-connect",
       });
       const snap = this.#snapshot(entry);
@@ -461,7 +511,7 @@ export class WorkerGateway {
         this.#options.onWorkerIdle?.(snap);
       }
       return {
-        workerId: name,
+        workerId: workerName,
         sessionCredential: session.credential,
         sessionExpiresAtMs: session.expiresAtMs,
         protocolVersion: REMOTE_PROTOCOL_VERSION,
@@ -646,6 +696,44 @@ export class WorkerGateway {
         worker: tokenName,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+    return null;
+  }
+
+  async #defaultReadTokenMaxEnrollments(
+    tokenName: string,
+  ): Promise<MaxEnrollments | null> {
+    try {
+      const dataItems = await this.#options.repoContext.unifiedDataRepo
+        .findAllForType(ENROLLMENT_TOKEN_MODEL_TYPE);
+      for (const { data, modelType, modelId } of dataItems) {
+        if (data.isRenamed || data.isDeleted) continue;
+        if (data.name !== TOKEN_DATA_NAME) continue;
+        const content = await this.#options.repoContext.unifiedDataRepo
+          .getContent(modelType, modelId, data.name);
+        if (!content) continue;
+        let attrs: Record<string, unknown>;
+        try {
+          attrs = JSON.parse(new TextDecoder().decode(content)) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          continue;
+        }
+        const parsed = EnrollmentTokenSchema.safeParse(attrs);
+        if (parsed.success && parsed.data.name === tokenName) {
+          return parsed.data.maxEnrollments;
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        "Failed to read token maxEnrollments for {worker}: {error}",
+        {
+          worker: tokenName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
     return null;
   }

--- a/src/serve/worker_gateway_test.ts
+++ b/src/serve/worker_gateway_test.ts
@@ -475,15 +475,13 @@ Deno.test("WorkerGateway: a cancelled dispatch frees the worker only after it un
 
 // ── Fleet token tests ──────────────────────────────────────────────────
 
-Deno.test("fleetMemberSuffix: returns a stable 4-char hex suffix", async () => {
+Deno.test("fleetMemberSuffix: returns a stable 8-char hex suffix", async () => {
   const a = await fleetMemberSuffix("machine-1");
-  assertEquals(a.length, 4);
-  assertEquals(/^[0-9a-f]{4}$/.test(a), true);
-  // Stable across calls.
+  assertEquals(a.length, 8);
+  assertEquals(/^[0-9a-f]{8}$/.test(a), true);
   assertEquals(await fleetMemberSuffix("machine-1"), a);
-  // Different machines get different suffixes.
   const b = await fleetMemberSuffix("machine-2");
-  assertEquals(b.length, 4);
+  assertEquals(b.length, 8);
   assertEquals(a === b, false);
 });
 
@@ -581,4 +579,25 @@ Deno.test("WorkerGateway: null readTokenMaxEnrollments defaults to single-machin
   const { workerChannel } = connectWorkerSocket(h.gateway);
   const result = await enroll(workerChannel);
   assertEquals(result.workerId, "ci-runner-3");
+});
+
+Deno.test("WorkerGateway: fleet token expiry records expire on the token name, not the worker name", async () => {
+  const h = createHarness({
+    graceWindowMs: 20,
+    readTokenExpiresAt: () =>
+      Promise.resolve(new Date(Date.now() + 30).toISOString()),
+    readTokenMaxEnrollments: () => Promise.resolve(3),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  const result = await enroll(workerChannel);
+  const suffix = await fleetMemberSuffix("machine-1");
+  assertEquals(result.workerId, `ci-runner-3-${suffix}`);
+
+  await new Promise((r) => setTimeout(r, 100));
+  const expires = h.transitions.filter((t) => t.methodName === "expire");
+  assertEquals(expires.length, 1);
+  assertEquals(expires[0].typeArg, "swamp/enrollment-token");
+  assertEquals(expires[0].definitionName, "ci-runner-3");
+  assertEquals(h.graceExpired.length, 1);
+  assertEquals(h.gateway.workers().length, 0);
 });

--- a/src/serve/worker_gateway_test.ts
+++ b/src/serve/worker_gateway_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import {
+  fleetMemberSuffix,
   splitEnrollmentToken,
   WorkerGateway,
   type WorkerGatewayOptions,
@@ -470,4 +471,114 @@ Deno.test("WorkerGateway: a cancelled dispatch frees the worker only after it un
     dispatchParams("d-n"),
   );
   assertEquals(followUp.status, "success");
+});
+
+// ── Fleet token tests ──────────────────────────────────────────────────
+
+Deno.test("fleetMemberSuffix: returns a stable 4-char hex suffix", async () => {
+  const a = await fleetMemberSuffix("machine-1");
+  assertEquals(a.length, 4);
+  assertEquals(/^[0-9a-f]{4}$/.test(a), true);
+  // Stable across calls.
+  assertEquals(await fleetMemberSuffix("machine-1"), a);
+  // Different machines get different suffixes.
+  const b = await fleetMemberSuffix("machine-2");
+  assertEquals(b.length, 4);
+  assertEquals(a === b, false);
+});
+
+Deno.test("WorkerGateway: fleet token (maxEnrollments > 1) names workers with suffix", async () => {
+  const h = createHarness({
+    readTokenMaxEnrollments: () => Promise.resolve(3),
+  });
+  const { workerChannel: w1 } = connectWorkerSocket(h.gateway);
+  const result1 = await enroll(w1, {
+    ...enrollParams,
+    machineId: "machine-1",
+    instanceUuid: "uuid-1",
+  });
+  const suffix1 = await fleetMemberSuffix("machine-1");
+  assertEquals(result1.workerId, `ci-runner-3-${suffix1}`);
+
+  const { workerChannel: w2 } = connectWorkerSocket(h.gateway);
+  const result2 = await enroll(w2, {
+    ...enrollParams,
+    machineId: "machine-2",
+    instanceUuid: "uuid-2",
+  });
+  const suffix2 = await fleetMemberSuffix("machine-2");
+  assertEquals(result2.workerId, `ci-runner-3-${suffix2}`);
+
+  const workers = h.gateway.workers();
+  assertEquals(workers.length, 2);
+  const names = workers.map((w) => w.name).sort();
+  assertEquals(
+    names,
+    [`ci-runner-3-${suffix1}`, `ci-runner-3-${suffix2}`].sort(),
+  );
+});
+
+Deno.test("WorkerGateway: single-enrollment token (maxEnrollments === 1) uses plain token name", async () => {
+  const h = createHarness({
+    readTokenMaxEnrollments: () => Promise.resolve(1),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  const result = await enroll(workerChannel);
+  assertEquals(result.workerId, "ci-runner-3");
+});
+
+Deno.test("WorkerGateway: fleet token auto-injects fleet label", async () => {
+  const h = createHarness({
+    readTokenMaxEnrollments: () => Promise.resolve(5),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  await enroll(workerChannel);
+  const enrollTransition = h.transitions.find((t) => t.methodName === "enroll");
+  const labels = enrollTransition?.inputs.labels as Record<string, string>;
+  assertEquals(labels.fleet, "ci-runner-3");
+  assertEquals(labels.region, "us-east");
+});
+
+Deno.test("WorkerGateway: worker-supplied fleet label wins over auto-injection", async () => {
+  const h = createHarness({
+    readTokenMaxEnrollments: () => Promise.resolve(5),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  await enroll(workerChannel, {
+    ...enrollParams,
+    labels: { region: "us-east", fleet: "custom-fleet" },
+  });
+  const enrollTransition = h.transitions.find((t) => t.methodName === "enroll");
+  const labels = enrollTransition?.inputs.labels as Record<string, string>;
+  assertEquals(labels.fleet, "custom-fleet");
+});
+
+Deno.test("WorkerGateway: fleet worker naming is stable across reconnects", async () => {
+  const h = createHarness({
+    graceWindowMs: 200,
+    readTokenMaxEnrollments: () => Promise.resolve(3),
+  });
+  const first = connectWorkerSocket(h.gateway);
+  const result1 = await enroll(first.workerChannel);
+  const suffix = await fleetMemberSuffix("machine-1");
+  assertEquals(result1.workerId, `ci-runner-3-${suffix}`);
+
+  first.dropSocket();
+  await new Promise((r) => setTimeout(r, 5));
+
+  const second = connectWorkerSocket(h.gateway);
+  const result2 = await enroll(second.workerChannel);
+  assertEquals(result2.workerId, `ci-runner-3-${suffix}`);
+  assertEquals(h.gateway.workers().length, 1);
+  second.dropSocket();
+  await new Promise((r) => setTimeout(r, 250));
+});
+
+Deno.test("WorkerGateway: null readTokenMaxEnrollments defaults to single-machine naming", async () => {
+  const h = createHarness({
+    readTokenMaxEnrollments: () => Promise.resolve(null),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  const result = await enroll(workerChannel);
+  assertEquals(result.workerId, "ci-runner-3");
 });


### PR DESCRIPTION
## Summary

Closes swamp-club#966

- **Fleet tokens**: `swamp worker token create pool --max-enrollments 3` mints a token that enrolls up to 3 machines. Each fleet member gets a distinct pool name (`pool-<hash>`) and an auto-injected `fleet=pool` label.
- **Schema migration**: `EnrollmentTokenSchema` extended with `maxEnrollments` (default 1) and `bindings[]` array. Legacy `boundMachineId`/`enrolledAt` fields kept in the Zod input schema; a transform migrates them to `bindings` on read. No data rewrite needed.
- **Gateway restructuring**: `#handleEnroll` reordered to redeem first, then read `maxEnrollments` from the datastore (same pattern as `#defaultReadTokenExpiresAt`), compute fleet worker name, then check for existing workers. Worker-supplied `fleet` label wins over auto-injection.
- **Worker model**: Added optional `workerName` field to `EnrollArgsSchema` so fleet-suffixed names are stored correctly in the persisted worker record.
- **CLI**: `--max-enrollments <n>` flag on `worker token create` (positive integer or `"unlimited"`).
- **Output**: Token list column changed from `BOUND MACHINE` to `ENROLLMENTS` showing `used / allowance` (e.g. `3 / 3`, `1 / 1`, `8 / unlimited`).
- **Design docs**: Updated `design/remote-execution.md` in 4 locations from "exactly one machine" to fleet token semantics.
- No protocol version bump — fleet behavior is entirely orchestrator-internal; `EnrollParamsSchema` and `EnrollResult` wire types are unchanged.

## Test Plan

- **Enrollment token model** (18 tests): multi-enrollment allowance boundary, unlimited bindings, re-auth no-duplicate, allowance exhaustion error, legacy `boundMachineId` migration via Zod transform, revoke-all, single-machine identical to pre-change
- **Worker gateway** (24 tests, 7 new): `fleetMemberSuffix` stability, fleet naming with suffix, single-machine naming without suffix, auto-injected fleet label, worker-supplied label wins, reconnect stability, null-maxEnrollments fallback
- **Libswamp list** (8 tests): updated assertions for `bindingCount`/`bindings` replacing `boundMachineId`
- **Presentation output** (19 tests): `ENROLLMENTS` column rendering, `used / allowance` format
- **Integration test** (5 tests, 1 new): two workers enrolled on one fleet token with distinct pool identities, both dispatchable end-to-end
- **Binary verification**: 6 scenarios against compiled binary — fleet enrollment (3 workers), allowance boundary (4th rejected), single-machine unchanged, fleet dispatch, legacy token upgrade path (old-binary token → new-binary reconnect)
- `deno check`, `deno lint`, `deno fmt`, `deno run test` (8235 passed), `deno run compile` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)