### PR TITLE
fix(issue-lifecycle): truncate lifecycle entry summaries exceeding API limit

### DIFF
--- a/extensions/models/_lib/swamp_club.ts
+++ b/extensions/models/_lib/swamp_club.ts
@@ -21,6 +21,8 @@
 import { join } from "@std/path";
 import type { IssueType } from "./schemas.ts";
 
+export const LIFECYCLE_SUMMARY_MAX_CHARS = 2000;
+
 export interface LifecycleEntryParams {
   step: string;
   targetStatus: string;
@@ -151,6 +153,10 @@ export class SwampClubClient {
     try {
       const url =
         `${this.baseUrl}/api/v1/lab/issues/${this.issueNumber}/lifecycle`;
+      let summary = params.summary;
+      if (summary.length > LIFECYCLE_SUMMARY_MAX_CHARS) {
+        summary = summary.slice(0, LIFECYCLE_SUMMARY_MAX_CHARS - 3) + "...";
+      }
       const res = await fetch(url, {
         method: "POST",
         headers: {
@@ -160,7 +166,7 @@ export class SwampClubClient {
         body: JSON.stringify({
           step: params.step,
           targetStatus: params.targetStatus,
-          summary: params.summary,
+          summary,
           emoji: params.emoji,
           payload: params.payload,
           body: params.body,

--- a/extensions/models/_lib/swamp_club_test.ts
+++ b/extensions/models/_lib/swamp_club_test.ts
@@ -1,0 +1,163 @@
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License version 3 as published by the Free
+// Software Foundation, with the Swamp Extension and Definition Exception (found in
+// the "COPYING-EXCEPTION" file).
+//
+// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { LIFECYCLE_SUMMARY_MAX_CHARS, SwampClubClient } from "./swamp_club.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface CapturedPost {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+function buildClientWithFetchStub(): {
+  client: SwampClubClient;
+  posts: CapturedPost[];
+  restore: () => void;
+} {
+  const posts: CapturedPost[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = ((
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+    if (init?.method === "POST" && init?.body) {
+      posts.push({
+        url,
+        body: JSON.parse(init.body as string),
+      });
+    }
+
+    return Promise.resolve(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+
+  const client = new SwampClubClient(
+    "https://fake.swamp.club",
+    "fake-key",
+    42,
+  );
+
+  return {
+    client,
+    posts,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// postLifecycleEntry summary truncation
+// ---------------------------------------------------------------------------
+
+Deno.test("postLifecycleEntry: sends summary unchanged when at the limit", async () => {
+  const { client, posts, restore } = buildClientWithFetchStub();
+  try {
+    const summary = "a".repeat(LIFECYCLE_SUMMARY_MAX_CHARS);
+    await client.postLifecycleEntry({
+      step: "test",
+      targetStatus: "open",
+      summary,
+      emoji: "\u{1F50D}",
+      payload: {},
+    });
+
+    assertEquals(posts.length, 1);
+    assertEquals(posts[0].body.summary, summary);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("postLifecycleEntry: sends summary unchanged when below the limit", async () => {
+  const { client, posts, restore } = buildClientWithFetchStub();
+  try {
+    const summary = "Short summary";
+    await client.postLifecycleEntry({
+      step: "test",
+      targetStatus: "open",
+      summary,
+      emoji: "\u{1F50D}",
+      payload: {},
+    });
+
+    assertEquals(posts.length, 1);
+    assertEquals(posts[0].body.summary, summary);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("postLifecycleEntry: truncates summary exceeding the limit with ellipsis", async () => {
+  const { client, posts, restore } = buildClientWithFetchStub();
+  try {
+    const summary = "x".repeat(LIFECYCLE_SUMMARY_MAX_CHARS + 500);
+    await client.postLifecycleEntry({
+      step: "test",
+      targetStatus: "open",
+      summary,
+      emoji: "\u{1F50D}",
+      payload: {},
+    });
+
+    assertEquals(posts.length, 1);
+    const sent = posts[0].body.summary as string;
+    assertEquals(sent.length, LIFECYCLE_SUMMARY_MAX_CHARS);
+    assertEquals(sent.endsWith("..."), true);
+    assertEquals(
+      sent,
+      "x".repeat(LIFECYCLE_SUMMARY_MAX_CHARS - 3) + "...",
+    );
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("postLifecycleEntry: truncates summary one char over the limit", async () => {
+  const { client, posts, restore } = buildClientWithFetchStub();
+  try {
+    const summary = "y".repeat(LIFECYCLE_SUMMARY_MAX_CHARS + 1);
+    await client.postLifecycleEntry({
+      step: "test",
+      targetStatus: "open",
+      summary,
+      emoji: "\u{1F50D}",
+      payload: {},
+    });
+
+    assertEquals(posts.length, 1);
+    const sent = posts[0].body.summary as string;
+    assertEquals(sent.length, LIFECYCLE_SUMMARY_MAX_CHARS);
+    assertEquals(sent.endsWith("..."), true);
+  } finally {
+    restore();
+  }
+});

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -73,7 +73,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.06.29.1",
+  version: "2026.07.05.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -152,6 +152,14 @@ export const model = {
         "against the approved plan. New codeConformanceReview resource, " +
         "code_conformance_review and justify_deviations methods, " +
         "code-conformance-clear check gating link_pr. " +
+        "No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.07.05.1",
+      description:
+        "Truncate lifecycle entry summaries to 2000 chars in postLifecycleEntry " +
+        "to prevent silent 400 rejections from the swamp-club API. " +
         "No globalArguments changes.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.06.29.1", () => {
-  assertEquals(model.version, "2026.06.29.1");
+Deno.test("model: version bumped to 2026.07.05.1", () => {
+  assertEquals(model.version, "2026.07.05.1");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `SwampClubClient.postLifecycleEntry()` now truncates the `summary` field to 2000 characters before posting to the swamp-club API, preventing silent 400 rejections that caused lifecycle entries to be dropped from the issue timeline
- When truncation occurs, the last 3 characters are replaced with `...` to indicate the summary was cut — the full data is always preserved in the `payload` field
- Added `LIFECYCLE_SUMMARY_MAX_CHARS` exported constant and a new `swamp_club_test.ts` with 4 unit tests covering boundary conditions
- Bumped model version to `2026.07.05.1` with upgrade migration

Fixes swamp-club#973

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test extensions/models/` — 60 tests pass (4 new + 56 existing)
- [x] `deno check` — type check passes
- [x] New tests verify: summary at limit (unchanged), below limit (unchanged), 500 chars over limit (truncated with ellipsis), 1 char over limit (truncated with ellipsis)