### PR TITLE
feat(remote): drain state machine, lifecycle policies, signal handling

### DIFF
--- a/integration/remote_execution_test.ts
+++ b/integration/remote_execution_test.ts
@@ -54,7 +54,7 @@ import { DispatchService } from "../src/serve/dispatch_service.ts";
 import { DispatchRegistry } from "../src/serve/dispatch_registry.ts";
 import { BundleRegistry } from "../src/serve/bundle_registry.ts";
 import { DataPlane } from "../src/serve/data_plane.ts";
-import { runWorker } from "../src/worker/connect.ts";
+import { runWorker, type WorkerExitResult } from "../src/worker/connect.ts";
 import {
   ENROLLMENT_TOKEN_MODEL_TYPE,
   tokenSecretKey,
@@ -387,7 +387,7 @@ Deno.test({
     await withTempDir(async (dir) => {
       const orchestrator = await startOrchestrator(dir);
       const workerStop = new AbortController();
-      let workerDone: Promise<void> | null = null;
+      let workerDone: Promise<WorkerExitResult> | null = null;
       try {
         const token = await orchestrator.mintToken("it-worker");
 
@@ -546,7 +546,7 @@ Deno.test({
     await withTempDir(async (dir) => {
       const orchestrator = await startOrchestrator(dir);
       const workerStop = new AbortController();
-      let workerDone: Promise<void> | null = null;
+      let workerDone: Promise<WorkerExitResult> | null = null;
       try {
         const token = await orchestrator.mintToken("queue-worker");
 
@@ -593,7 +593,7 @@ Deno.test({
     await withTempDir(async (dir) => {
       let orchestrator = await startOrchestrator(dir);
       const workerStop = new AbortController();
-      let workerDone: Promise<void> | null = null;
+      let workerDone: Promise<WorkerExitResult> | null = null;
       try {
         const token = await orchestrator.mintToken("recon-worker");
 
@@ -687,7 +687,7 @@ Deno.test({
     await withTempDir(async (dir) => {
       const orchestrator = await startOrchestrator(dir);
       const stops: AbortController[] = [];
-      const dones: Promise<void>[] = [];
+      const dones: Promise<WorkerExitResult>[] = [];
       try {
         const token = await orchestrator.mintToken("fleet-pool", {
           maxEnrollments: 3,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -627,6 +627,8 @@ export const serveCommand = new Command()
       onGraceExpired: (worker) => dispatchService.notifyGraceExpired(worker),
       onWorkerEnrolled: (worker) =>
         dispatchService.notifyWorkerEnrolled(worker),
+      onWorkerDraining: (worker) =>
+        dispatchService.notifyWorkerDraining(worker),
       verifyOnEnroll,
       verifyWorker: verifyOnEnroll
         ? async (workerName) => {

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -28,10 +28,11 @@ import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseLabels } from "./worker_shared.ts";
-import { runWorker } from "../../worker/connect.ts";
+import { runWorker, type WorkerExitReason } from "../../worker/connect.ts";
 import { renderWorkerStatus } from "../../presentation/output/worker_output.ts";
 import { VERSION } from "./version.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
+import { parseTimeout } from "../duration_parser.ts";
 
 // Import models barrel so built-in models resolve from the worker's own
 // registry when a `builtin:` bundle fingerprint is dispatched.
@@ -96,6 +97,14 @@ export const workerConnectCommand = new Command()
     "Bundle/asset cache directory; also stores the machine id the enrollment token binds to — set a stable directory so the worker can re-enroll after a restart (defaults to a fresh temp dir) (env: SWAMP_WORKER_CACHE_DIR)",
   )
   .option("--no-reconnect", "Exit when the control socket closes")
+  .option(
+    "--max-dispatches <n:number>",
+    "Drain and exit 0 after N dispatches complete (env: SWAMP_WORKER_MAX_DISPATCHES)",
+  )
+  .option(
+    "--idle-timeout <duration:string>",
+    "Drain and exit 0 after being continuously idle for this duration (env: SWAMP_WORKER_IDLE_TIMEOUT)",
+  )
   .action(async function (options: AnyOptions, urlArg?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "worker",
@@ -133,15 +142,44 @@ export const workerConnectCommand = new Command()
     const cacheDir = (options.cacheDir as string | undefined) ??
       Deno.env.get("SWAMP_WORKER_CACHE_DIR");
 
+    const maxDispatchesRaw = (options.maxDispatches as number | undefined) ??
+      (() => {
+        const env = Deno.env.get("SWAMP_WORKER_MAX_DISPATCHES");
+        return env !== undefined ? parseInt(env, 10) : undefined;
+      })();
+    if (
+      maxDispatchesRaw !== undefined &&
+      (isNaN(maxDispatchesRaw) || maxDispatchesRaw < 1)
+    ) {
+      throw new UserError(
+        "--max-dispatches must be a positive integer",
+      );
+    }
+
+    const idleTimeoutRaw = (options.idleTimeout as string | undefined) ??
+      Deno.env.get("SWAMP_WORKER_IDLE_TIMEOUT");
+    const idleTimeoutMs = idleTimeoutRaw !== undefined
+      ? parseTimeout(idleTimeoutRaw)
+      : undefined;
+
+    let requestDrain: ((reason: WorkerExitReason) => void) | null = null;
+    let signalCount = 0;
     const ac = new AbortController();
-    registerShutdownHandler({
+    const shutdownHandle = registerShutdownHandler({
       handler: () => {
-        ac.abort();
+        signalCount++;
+        if (signalCount === 1 && requestDrain) {
+          requestDrain("signal");
+        } else if (signalCount === 1) {
+          ac.abort();
+        } else {
+          Deno.exit(1);
+        }
       },
     });
 
     try {
-      await runWorker({
+      const result = await runWorker({
         url,
         token,
         labels,
@@ -149,12 +187,26 @@ export const workerConnectCommand = new Command()
         dataPlaneUrl: options.dataPlaneUrl,
         cacheDir,
         reconnect: options.reconnect !== false,
+        maxDispatches: maxDispatchesRaw,
+        idleTimeoutMs,
         signal: ac.signal,
-        onStatus: (event) => renderWorkerStatus(event, cliCtx.outputMode),
+        onStatus: (event) => {
+          renderWorkerStatus(event, cliCtx.outputMode);
+        },
+        onDrainAvailable: (drain) => {
+          requestDrain = drain;
+        },
       });
+
+      const policyComplete = result.reason !== "error";
+      if (!policyComplete) {
+        Deno.exit(1);
+      }
     } catch (error) {
       throw new UserError(
         error instanceof Error ? error.message : String(error),
       );
+    } finally {
+      shutdownHandle.dispose();
     }
   });

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -103,7 +103,7 @@ export const workerConnectCommand = new Command()
   )
   .option(
     "--idle-timeout <duration:string>",
-    "Drain and exit 0 after being continuously idle for this duration (env: SWAMP_WORKER_IDLE_TIMEOUT)",
+    "Drain and exit 0 after being continuously idle for this duration (e.g. 30s, 5m, 1h) (env: SWAMP_WORKER_IDLE_TIMEOUT)",
   )
   .action(async function (options: AnyOptions, urlArg?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -159,7 +159,7 @@ export const workerConnectCommand = new Command()
     const idleTimeoutRaw = (options.idleTimeout as string | undefined) ??
       Deno.env.get("SWAMP_WORKER_IDLE_TIMEOUT");
     const idleTimeoutMs = idleTimeoutRaw !== undefined
-      ? parseTimeout(idleTimeoutRaw)
+      ? parseTimeout(idleTimeoutRaw, "--idle-timeout")
       : undefined;
 
     let requestDrain: ((reason: WorkerExitReason) => void) | null = null;

--- a/src/domain/models/worker/worker_model.ts
+++ b/src/domain/models/worker/worker_model.ts
@@ -44,6 +44,7 @@ export const WorkerStatusSchema = z.enum([
   "busy",
   "disconnected",
   "unverified",
+  "draining",
 ]);
 
 export type WorkerStatus = z.infer<typeof WorkerStatusSchema>;
@@ -155,7 +156,7 @@ async function setStatus(
  */
 export const workerModel: ModelDefinition = defineModel({
   type: WORKER_MODEL_TYPE,
-  version: "2026.07.04.1",
+  version: "2026.07.05.1",
   resources: {
     "state": {
       description:
@@ -176,7 +177,7 @@ export const workerModel: ModelDefinition = defineModel({
     },
     set_status: {
       description:
-        "Record a worker status change (idle/busy/disconnected/unverified)",
+        "Record a worker status change (idle/busy/disconnected/unverified/draining)",
       kind: "update",
       arguments: SetStatusArgsSchema,
       execute: setStatus,

--- a/src/domain/remote/protocol.ts
+++ b/src/domain/remote/protocol.ts
@@ -39,7 +39,7 @@ import { z } from "zod";
  * dispatch, never mid-run. Also pins the capability-verb inventory — any
  * change to the verbs below requires a version bump.
  */
-export const REMOTE_PROTOCOL_VERSION = 2;
+export const REMOTE_PROTOCOL_VERSION = 3;
 
 // ── RPC framing ──────────────────────────────────────────────────────────
 
@@ -139,6 +139,8 @@ export const RemoteMethod = {
   enroll: "worker.enroll",
   /** Sliding-window refresh of the data-plane session credential. */
   sessionRefresh: "worker.session.refresh",
+  /** Worker notifies orchestrator it is draining (no new dispatches). */
+  drain: "worker.drain",
 
   // Capability verbs (metadata half — bytes ride the data plane).
   getData: "capability.getData",

--- a/src/domain/remote/scheduler.ts
+++ b/src/domain/remote/scheduler.ts
@@ -47,7 +47,7 @@ export interface SchedulableWorker {
   labels: Record<string, string>;
   platform: string;
   arch: string;
-  status: "idle" | "busy" | "unverified";
+  status: "idle" | "busy" | "unverified" | "draining";
   connected: boolean;
 }
 
@@ -115,10 +115,11 @@ export function eligibleWorkers(
       return false;
     }
     if (placement.target !== undefined) {
+      if (worker.status === "draining") return false;
       return worker.name === placement.target ||
         worker.instanceUuid === placement.target;
     }
-    if (worker.status === "unverified") {
+    if (worker.status === "unverified" || worker.status === "draining") {
       return false;
     }
     if (

--- a/src/domain/remote/scheduler_test.ts
+++ b/src/domain/remote/scheduler_test.ts
@@ -193,3 +193,24 @@ Deno.test("scheduleStep: targeted dispatch to unverified worker queues", () => {
   const decision = scheduleStep({ target: "a" }, pool);
   assertEquals(decision.kind, "queue");
 });
+
+Deno.test("eligibleWorkers: draining workers excluded from non-targeted placement", () => {
+  const pool = [
+    worker({ name: "a", status: "draining" }),
+    worker({ name: "b", status: "idle" }),
+  ];
+  const eligible = eligibleWorkers({}, pool);
+  assertEquals(eligible.length, 1);
+  assertEquals(eligible[0].name, "b");
+});
+
+Deno.test("eligibleWorkers: targeted placement excludes draining worker", () => {
+  const pool = [worker({ name: "drain-target", status: "draining" })];
+  const eligible = eligibleWorkers({ target: "drain-target" }, pool);
+  assertEquals(eligible.length, 0);
+});
+
+Deno.test("scheduleStep: draining workers are not scheduled", () => {
+  const pool = [worker({ name: "a", status: "draining" })];
+  assertEquals(scheduleStep({}, pool).kind, "queue");
+});

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -88,6 +88,8 @@ function colorWorkerStatus(status: string): string {
       return status.replace(trimmed, red(trimmed));
     case "unverified":
       return status.replace(trimmed, yellow(trimmed));
+    case "draining":
+      return status.replace(trimmed, yellow(trimmed));
     default:
       return status;
   }
@@ -309,6 +311,14 @@ export function renderWorkerStatus(
       break;
     case "stopped":
       writeOutput(dim(`Worker stopped: ${event.reason}`));
+      break;
+    case "draining":
+      writeOutput(
+        yellow(`Draining (${event.reason}) — finishing in-flight work...`),
+      );
+      break;
+    case "drain_complete":
+      writeOutput(dim("Drain complete — disconnecting"));
       break;
     case "dispatch_started": {
       const where = event.workflowName

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -38,6 +38,19 @@ import type { OutputMode } from "./output.ts";
 
 const checkmark = "\u2713"; // ✓
 
+function humanStopReason(reason: string): string {
+  switch (reason) {
+    case "max-dispatches":
+      return "reached max dispatches";
+    case "idle-timeout":
+      return "idle timeout elapsed";
+    case "signal":
+      return "received shutdown signal";
+    default:
+      return reason;
+  }
+}
+
 /** Pads each cell to its column width and joins with two spaces. */
 function tableLines(
   headers: string[],
@@ -87,7 +100,6 @@ function colorWorkerStatus(status: string): string {
     case "disconnected":
       return status.replace(trimmed, red(trimmed));
     case "unverified":
-      return status.replace(trimmed, yellow(trimmed));
     case "draining":
       return status.replace(trimmed, yellow(trimmed));
     default:
@@ -242,6 +254,13 @@ export function renderWorkerList(
       ),
     );
   }
+  if (data.workers.some((w) => w.status === "draining")) {
+    writeOutput(
+      dim(
+        "Some workers are draining — they will exit once their current dispatch completes.",
+      ),
+    );
+  }
 }
 
 function formatAge(ms: number): string {
@@ -310,7 +329,7 @@ export function renderWorkerStatus(
       writeOutput(dim(`Reconnecting in ${Math.round(event.delayMs / 1000)}s`));
       break;
     case "stopped":
-      writeOutput(dim(`Worker stopped: ${event.reason}`));
+      writeOutput(dim(`Worker stopped: ${humanStopReason(event.reason)}`));
       break;
     case "draining":
       writeOutput(

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -177,6 +177,11 @@ export class DispatchService {
     this.#wakePoolWaiters();
   }
 
+  /** Gateway hook: a worker started draining — wake queued steps to re-evaluate. */
+  notifyWorkerDraining(_worker: WorkerSnapshot): void {
+    this.#wakePoolWaiters();
+  }
+
   /**
    * Data-plane hook, awaited BEFORE the first durable write persists, so a
    * lease can never say "no writes" while a write exists. The converse
@@ -283,13 +288,14 @@ export class DispatchService {
             });
             continue;
           }
-          if (error instanceof RpcError && error.code === "worker_busy") {
-            // Transient orchestrator/worker view desync (e.g. a cancel grace
-            // period elapsed before the worker freed its serial slot). The
-            // worker IS busy — treat it like any busy worker and re-queue.
+          if (
+            error instanceof RpcError &&
+            (error.code === "worker_busy" ||
+              error.code === "worker_draining")
+          ) {
             logger.warn(
-              "Worker {worker} reported busy on dispatch; re-queueing step",
-              { worker: workerName },
+              "Worker {worker} reported {code} on dispatch; re-queueing step",
+              { worker: workerName, code: error.code },
             );
             endQueue("mark_dispatched", {
               dispatchId: lastDispatchId ?? "unknown",

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -513,3 +513,31 @@ Deno.test("DispatchService: forwards trace headers and reports the executing wor
   );
   assertEquals(result.workerName, "w1");
 });
+
+Deno.test("DispatchService: worker_draining re-queues instead of failing the run", async () => {
+  const h = createHarness();
+  let attempts = 0;
+  h.setBehavior(() => {
+    attempts++;
+    if (attempts === 1) {
+      queueMicrotask(() =>
+        h.service.notifyWorkerIdle(snapshot({ name: "w1" }))
+      );
+      return Promise.reject(
+        new RpcError({
+          code: "worker_draining",
+          message: "Worker is draining — no new dispatches accepted",
+        }),
+      );
+    }
+    return Promise.resolve({
+      status: "success",
+      outputs: [],
+      logs: [],
+      durationMs: 1,
+    });
+  });
+  const result = await h.service.executeRemote(stepRequest());
+  assertEquals(result.durationMs, 1);
+  assertEquals(attempts, 2);
+});

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -297,6 +297,9 @@ export class WorkerGateway {
     if (entry.status === "unverified" && !params.probeMarker) {
       throw new Error(`Worker '${name}' is unverified`);
     }
+    if (entry.status === "draining") {
+      throw new Error(`Worker '${name}' is draining`);
+    }
 
     logger.info(
       "Dispatching {modelType}.{methodName} (step {step}) to worker {worker} [{dispatchId}]",
@@ -347,6 +350,8 @@ export class WorkerGateway {
       return result;
     } finally {
       entry.dispatchId = null;
+      // Cast: TS narrows status to "busy" from the assignment above, but
+      // #handleDrain may have changed it to "draining" across the await.
       const currentStatus = entry.status as string;
       if (entry.channel === null || entry.channel.closed) {
         // The socket dropped mid-dispatch. The in-memory status returns to

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -112,7 +112,7 @@ export interface WorkerSnapshot {
   platform: string;
   arch: string;
   swampVersion: string;
-  status: "idle" | "busy" | "unverified";
+  status: "idle" | "busy" | "unverified" | "draining";
   connected: boolean;
   dispatchId: string | null;
   verifyFailureReason?: string;
@@ -130,7 +130,7 @@ interface WorkerEntry {
   channel: RpcChannel | null;
   /** Force-closes the current control socket (absent for test transports). */
   closeSocket: (() => void) | null;
-  status: "idle" | "busy" | "unverified";
+  status: "idle" | "busy" | "unverified" | "draining";
   dispatchId: string | null;
   verifyFailureReason?: string;
   graceTimer?: ReturnType<typeof setTimeout>;
@@ -164,6 +164,8 @@ export interface WorkerGatewayOptions {
   onGraceExpired?: (worker: WorkerSnapshot) => void;
   /** A worker enrolled or re-enrolled (including within the grace window). */
   onWorkerEnrolled?: (worker: WorkerSnapshot) => void;
+  /** A worker announced it is draining (no longer schedulable). */
+  onWorkerDraining?: (worker: WorkerSnapshot) => void;
   /**
    * When true, dispatch a fleet probe to each enrolling worker before it
    * becomes schedulable. Workers that fail the probe are marked `unverified`.
@@ -345,12 +347,13 @@ export class WorkerGateway {
       return result;
     } finally {
       entry.dispatchId = null;
+      const currentStatus = entry.status as string;
       if (entry.channel === null || entry.channel.closed) {
         // The socket dropped mid-dispatch. The in-memory status returns to
         // idle so a reconnect within the grace window is schedulable again;
         // the durable record already says "disconnected".
         entry.status = "idle";
-      } else {
+      } else if (currentStatus !== "draining") {
         entry.status = "idle";
         await this.#recordTransition(() =>
           this.#runModelMethod({
@@ -529,6 +532,10 @@ export class WorkerGateway {
         RemoteMethod.sessionRefresh,
         () => this.#handleSessionRefresh(workerName),
       );
+      state.channel.register(
+        RemoteMethod.drain,
+        () => this.#handleDrain(workerName),
+      );
 
       const session = this.#sessions.issue(workerName);
       logger.info("Worker {worker} enrolled ({mode})", {
@@ -571,6 +578,22 @@ export class WorkerGateway {
     });
   }
 
+  async #handleDrain(workerName: string): Promise<void> {
+    const entry = this.#workers.get(workerName);
+    if (!entry) return;
+    logger.info("Worker {worker} is draining", { worker: workerName });
+    entry.status = "draining";
+    await this.#recordTransition(() =>
+      this.#runModelMethod({
+        typeArg: WORKER_MODEL_TYPE.normalized,
+        definitionName: workerDefinitionName(workerName),
+        methodName: "set_status",
+        inputs: { status: "draining" },
+      })
+    );
+    this.#options.onWorkerDraining?.(this.#snapshot(entry));
+  }
+
   #handleSocketClosed(state: SocketState): void {
     state.channel.close("control socket closed");
     const name = state.workerName;
@@ -602,6 +625,20 @@ export class WorkerGateway {
         },
       );
     });
+
+    if (entry.status === "draining") {
+      if (entry.expiryTimer !== undefined) {
+        clearTimeout(entry.expiryTimer);
+        entry.expiryTimer = undefined;
+      }
+      this.#workers.delete(name);
+      this.#sessions.revokeForWorker(name);
+      logger.info("Draining worker {worker} disconnected — removed from pool", {
+        worker: name,
+      });
+      this.#options.onWorkerDisconnected?.(snapshot);
+      return;
+    }
 
     entry.graceTimer = setTimeout(() => {
       entry.graceTimer = undefined;

--- a/src/serve/worker_gateway_test.ts
+++ b/src/serve/worker_gateway_test.ts
@@ -694,3 +694,45 @@ Deno.test("WorkerGateway: without verifyOnEnroll — worker becomes idle immedia
   assertEquals(h.idle.length, 1);
   assertEquals(enrolled.length, 1);
 });
+
+Deno.test("WorkerGateway: worker.drain sets status to draining", async () => {
+  const draining: WorkerSnapshot[] = [];
+  const h = createHarness({
+    onWorkerDraining: (w) => draining.push(w),
+  });
+  const { workerChannel } = connectWorkerSocket(h.gateway);
+  await enroll(workerChannel);
+
+  await workerChannel.call(RemoteMethod.drain, {});
+  const workers = h.gateway.workers();
+  assertEquals(workers[0].status, "draining");
+  assertEquals(draining.length, 1);
+  assertEquals(draining[0].status, "draining");
+  const setStatusCalls = h.transitions.filter(
+    (t) => t.methodName === "set_status",
+  );
+  assertEquals(
+    setStatusCalls.some((t) => t.inputs.status === "draining"),
+    true,
+  );
+});
+
+Deno.test("WorkerGateway: draining worker disconnect skips grace window", async () => {
+  const h = createHarness({
+    graceWindowMs: 60_000,
+    onWorkerDraining: () => {},
+  });
+  const { workerChannel, dropSocket } = connectWorkerSocket(h.gateway);
+  await enroll(workerChannel);
+
+  await workerChannel.call(RemoteMethod.drain, {});
+  assertEquals(h.gateway.workers()[0].status, "draining");
+
+  dropSocket();
+  await new Promise((r) => setTimeout(r, 10));
+
+  assertEquals(h.gateway.workers().length, 0);
+  assertEquals(h.gateway.pendingGraceWindows, 0);
+  assertEquals(h.graceExpired.length, 0);
+  assertEquals(h.disconnected.length, 1);
+});

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -208,6 +208,10 @@ export async function runWorker(
           currentDrainHandle = handle;
           currentChannel = channel;
           currentCloseConnection = close;
+          if (drainReason !== null) {
+            close();
+            return;
+          }
           startIdleTimer();
         },
         onDispatchStarted: () => {
@@ -224,7 +228,6 @@ export async function runWorker(
             startIdleTimer();
           }
         },
-        drainReason: () => drainReason,
       });
       options.onStatus?.({ kind: "disconnected", reason: outcome });
       delayMs = RECONNECT_BASE_DELAY_MS;
@@ -319,7 +322,6 @@ interface ConnectOnceArgs {
   ) => void;
   onDispatchStarted: () => void;
   onDispatchFinished: () => void;
-  drainReason: () => WorkerExitReason | null;
 }
 
 /** One socket lifetime: connect, enroll, serve dispatches until close. */

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -44,6 +44,7 @@ import {
 } from "./data_plane_client.ts";
 import { WorkerBundleCache } from "./bundle_cache.ts";
 import {
+  type DispatchHandlerHandle,
   registerDispatchHandler,
   type WorkerDispatchEvent,
 } from "./dispatch_handler.ts";
@@ -64,7 +65,20 @@ export type WorkerStatusEvent =
   | { kind: "disconnected"; reason: string }
   | { kind: "retrying"; delayMs: number }
   | { kind: "stopped"; reason: string }
+  | { kind: "draining"; reason: WorkerExitReason }
+  | { kind: "drain_complete" }
   | WorkerDispatchEvent;
+
+export type WorkerExitReason =
+  | "signal"
+  | "max-dispatches"
+  | "idle-timeout"
+  | "shutdown"
+  | "error";
+
+export interface WorkerExitResult {
+  reason: WorkerExitReason;
+}
 
 export interface RunWorkerOptions {
   /** Orchestrator control-socket URL (ws:// or wss://). */
@@ -83,6 +97,16 @@ export interface RunWorkerOptions {
   onStatus?: (event: WorkerStatusEvent) => void;
   /** Reconnect on socket loss (default true). */
   reconnect?: boolean;
+  /** Drain and exit 0 after N dispatches complete. */
+  maxDispatches?: number;
+  /** Drain and exit 0 after being continuously idle for this many ms. */
+  idleTimeoutMs?: number;
+  /**
+   * Called once during setup with a function that triggers drain from
+   * outside (e.g. signal handler). The caller can store this and invoke
+   * it when a signal arrives.
+   */
+  onDrainAvailable?: (requestDrain: (reason: WorkerExitReason) => void) => void;
   /** Test seam: WebSocket factory. */
   createSocket?: (url: string) => WebSocket;
 }
@@ -94,9 +118,12 @@ interface SessionState {
 
 /**
  * Run the worker until the signal aborts, enrollment is permanently
- * rejected, or (with reconnect disabled) the socket closes.
+ * rejected, a lifecycle policy triggers drain, or (with reconnect
+ * disabled) the socket closes.
  */
-export async function runWorker(options: RunWorkerOptions): Promise<void> {
+export async function runWorker(
+  options: RunWorkerOptions,
+): Promise<WorkerExitResult> {
   const instanceUuid = crypto.randomUUID();
   const session: SessionState = { credential: "", expiresAtMs: 0 };
   const dataPlaneUrl = options.dataPlaneUrl ??
@@ -110,9 +137,63 @@ export async function runWorker(options: RunWorkerOptions): Promise<void> {
   const machineId = await loadOrCreateMachineId(cacheDir);
   const bundleCache = new WorkerBundleCache(join(cacheDir, "bundles"), client);
 
+  let drainReason: WorkerExitReason | null = null;
+  let dispatchCount = 0;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let currentDrainHandle: DispatchHandlerHandle | null = null;
+  let currentChannel: RpcChannel | null = null;
+  let currentCloseConnection: (() => void) | null = null;
+
+  const startIdleTimer = () => {
+    if (options.idleTimeoutMs === undefined || drainReason !== null) return;
+    clearIdleTimer();
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      triggerDrain("idle-timeout");
+    }, options.idleTimeoutMs);
+  };
+
+  const clearIdleTimer = () => {
+    if (idleTimer !== undefined) {
+      clearTimeout(idleTimer);
+      idleTimer = undefined;
+    }
+  };
+
+  const triggerDrain = (reason: WorkerExitReason) => {
+    if (drainReason !== null) return;
+    drainReason = reason;
+    clearIdleTimer();
+    options.onStatus?.({ kind: "draining", reason });
+
+    const handle = currentDrainHandle;
+    const channel = currentChannel;
+    const close = currentCloseConnection;
+    if (handle) {
+      handle.drain().then(() => {
+        options.onStatus?.({ kind: "drain_complete" });
+        if (!channel) {
+          close?.();
+          return;
+        }
+        return channel.call(RemoteMethod.drain, {}).then(() => {
+          close?.();
+        }).catch(() => {
+          close?.();
+        });
+      }).catch(() => {
+        close?.();
+      });
+    } else {
+      close?.();
+    }
+  };
+
+  options.onDrainAvailable?.(triggerDrain);
+
   let attempt = 0;
   let delayMs = RECONNECT_BASE_DELAY_MS;
-  while (!(options.signal?.aborted ?? false)) {
+  while (!(options.signal?.aborted ?? false) && drainReason === null) {
     attempt++;
     options.onStatus?.({ kind: "connecting", url: options.url, attempt });
     try {
@@ -123,6 +204,27 @@ export async function runWorker(options: RunWorkerOptions): Promise<void> {
         session,
         client,
         bundleCache,
+        onDispatchHandlerRegistered: (handle, channel, close) => {
+          currentDrainHandle = handle;
+          currentChannel = channel;
+          currentCloseConnection = close;
+          startIdleTimer();
+        },
+        onDispatchStarted: () => {
+          clearIdleTimer();
+        },
+        onDispatchFinished: () => {
+          dispatchCount++;
+          if (
+            options.maxDispatches !== undefined &&
+            dispatchCount >= options.maxDispatches
+          ) {
+            triggerDrain("max-dispatches");
+          } else {
+            startIdleTimer();
+          }
+        },
+        drainReason: () => drainReason,
       });
       options.onStatus?.({ kind: "disconnected", reason: outcome });
       delayMs = RECONNECT_BASE_DELAY_MS;
@@ -134,14 +236,21 @@ export async function runWorker(options: RunWorkerOptions): Promise<void> {
       }
       options.onStatus?.({ kind: "disconnected", reason: message });
     }
-    if (options.reconnect === false || (options.signal?.aborted ?? false)) {
+    if (
+      options.reconnect === false || (options.signal?.aborted ?? false) ||
+      drainReason !== null
+    ) {
       break;
     }
     options.onStatus?.({ kind: "retrying", delayMs });
     await abortableDelay(delayMs, options.signal);
     delayMs = Math.min(delayMs * 2, RECONNECT_MAX_DELAY_MS);
   }
-  options.onStatus?.({ kind: "stopped", reason: "shutdown" });
+
+  clearIdleTimer();
+  const reason = drainReason ?? "shutdown";
+  options.onStatus?.({ kind: "stopped", reason });
+  return { reason };
 }
 
 const MACHINE_ID_FILE = "machine-id";
@@ -203,6 +312,14 @@ interface ConnectOnceArgs {
   session: SessionState;
   client: DataPlaneClient;
   bundleCache: WorkerBundleCache;
+  onDispatchHandlerRegistered: (
+    handle: DispatchHandlerHandle,
+    channel: RpcChannel,
+    closeConnection: () => void,
+  ) => void;
+  onDispatchStarted: () => void;
+  onDispatchFinished: () => void;
+  drainReason: () => WorkerExitReason | null;
 }
 
 /** One socket lifetime: connect, enroll, serve dispatches until close. */
@@ -278,12 +395,24 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
         enrolled = true;
         session.credential = result.sessionCredential;
         session.expiresAtMs = result.sessionExpiresAtMs;
-        registerDispatchHandler({
+        const handle = registerDispatchHandler({
           channel,
           client: args.client,
           bundleCache: args.bundleCache,
-          onDispatch: (event) => options.onStatus?.(event),
+          onDispatch: (event) => {
+            if (event.kind === "dispatch_started") {
+              args.onDispatchStarted();
+            } else if (event.kind === "dispatch_finished") {
+              args.onDispatchFinished();
+            }
+            options.onStatus?.(event);
+          },
         });
+        args.onDispatchHandlerRegistered(
+          handle,
+          channel,
+          () => finish("drained"),
+        );
         scheduleRefresh();
         logger.info("Enrolled as {workerId}", { workerId: result.workerId });
         options.onStatus?.({

--- a/src/worker/dispatch_handler.ts
+++ b/src/worker/dispatch_handler.ts
@@ -141,12 +141,26 @@ export interface DispatchHandlerOptions {
   executor?: Pick<DefaultMethodExecutionService, "execute">;
 }
 
+export interface DispatchHandlerHandle {
+  /** Signal the handler to reject new dispatches and resolve when in-flight work completes. */
+  drain: () => Promise<void>;
+}
+
 /** Registers the dispatch handler on an enrolled worker channel. */
 export function registerDispatchHandler(
   options: DispatchHandlerOptions,
-): void {
+): DispatchHandlerHandle {
   let busy = false;
+  let draining = false;
+  let onDrainComplete: (() => void) | null = null;
+
   options.channel.register(WorkerMethod.dispatch, async (rawParams, ctx) => {
+    if (draining) {
+      throw new RpcError({
+        code: "worker_draining",
+        message: "Worker is draining — no new dispatches accepted",
+      });
+    }
     if (busy) {
       throw new RpcError({
         code: "worker_busy",
@@ -159,8 +173,21 @@ export function registerDispatchHandler(
       return await handleDispatch(rawParams, ctx, options);
     } finally {
       busy = false;
+      if (draining && onDrainComplete) {
+        onDrainComplete();
+      }
     }
   });
+
+  return {
+    drain: () => {
+      draining = true;
+      if (!busy) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        onDrainComplete = resolve;
+      });
+    },
+  };
 }
 
 async function handleDispatch(

--- a/src/worker/dispatch_handler_test.ts
+++ b/src/worker/dispatch_handler_test.ts
@@ -334,3 +334,108 @@ Deno.test("dispatch handler: trace context applies during the method and restore
   assertEquals(seenTraceparent, "00-abc123-def456-01");
   assertEquals(Deno.env.get("TRACEPARENT"), undefined);
 });
+
+Deno.test("dispatch handler: draining rejects with worker_draining", async () => {
+  const { worker, orchestrator } = channelPair();
+  const { client } = stubClient();
+  const handle = registerDispatchHandler({
+    channel: worker,
+    client,
+    bundleCache,
+  });
+  methodBehavior = () => Promise.resolve();
+
+  await handle.drain();
+
+  let drainError: RpcError | null = null;
+  try {
+    await orchestrator.call<DispatchResult>(
+      WorkerMethod.dispatch,
+      dispatchParams(),
+      { timeoutMs: null },
+    );
+  } catch (error) {
+    drainError = error as RpcError;
+  }
+  assertEquals(drainError?.code, "worker_draining");
+});
+
+Deno.test("dispatch handler: drain() resolves immediately when idle", async () => {
+  const { worker } = channelPair();
+  const { client } = stubClient();
+  const handle = registerDispatchHandler({
+    channel: worker,
+    client,
+    bundleCache,
+  });
+  methodBehavior = () => Promise.resolve();
+
+  await handle.drain();
+});
+
+Deno.test("dispatch handler: drain() resolves after in-flight dispatch completes", async () => {
+  const { worker, orchestrator } = channelPair();
+  const { client } = stubClient();
+  const handle = registerDispatchHandler({
+    channel: worker,
+    client,
+    bundleCache,
+  });
+
+  let gate: { resolve: () => void };
+  methodBehavior = () =>
+    new Promise<void>((resolve) => {
+      gate = { resolve };
+    });
+
+  const dispatchDone = orchestrator.call<DispatchResult>(
+    WorkerMethod.dispatch,
+    dispatchParams(),
+    { timeoutMs: null },
+  );
+  await new Promise((r) => setTimeout(r, 20));
+
+  let drained = false;
+  const drainDone = handle.drain().then(() => {
+    drained = true;
+  });
+
+  assertEquals(drained, false);
+  gate!.resolve();
+  await drainDone;
+  assertEquals(drained, true);
+
+  const result = await dispatchDone;
+  assertEquals(result.status, "success");
+});
+
+Deno.test("dispatch handler: in-flight dispatch completes normally during drain", async () => {
+  const { worker, orchestrator } = channelPair();
+  const { client, resourceWrites } = stubClient();
+  const handle = registerDispatchHandler({
+    channel: worker,
+    client,
+    bundleCache,
+  });
+
+  let gate: { resolve: () => void };
+  methodBehavior = () =>
+    new Promise<void>((resolve) => {
+      gate = { resolve };
+    });
+
+  const dispatchDone = orchestrator.call<DispatchResult>(
+    WorkerMethod.dispatch,
+    dispatchParams(),
+    { timeoutMs: null },
+  );
+  await new Promise((r) => setTimeout(r, 20));
+
+  const drainDone = handle.drain();
+  gate!.resolve();
+  await drainDone;
+
+  const result = await dispatchDone;
+  assertEquals(result.status, "success");
+  assertEquals(resourceWrites.length, 1);
+});


### PR DESCRIPTION
## Summary

Worker fleets phase 3 PR1 (swamp-club#976). Workers currently die immediately on SIGTERM — after this change they drain gracefully:

- **Drain state machine**: worker-side `busy`+`draining` flags in the dispatch handler reject new dispatches with `worker_draining`. The `drain()` handle returns a promise that resolves when in-flight work completes. The worker sends `worker.drain` to the orchestrator, which sets pool status to `draining` and skips the grace window on disconnect.
- **Lifecycle policies**: `--max-dispatches N` drains after N dispatches complete. `--idle-timeout <duration>` drains after continuous idleness. Both have env var fallbacks (`SWAMP_WORKER_MAX_DISPATCHES`, `SWAMP_WORKER_IDLE_TIMEOUT`).
- **Signal handling**: first SIGTERM/SIGINT triggers drain (finish work → notify orchestrator → close socket → exit 0). Second signal force-exits with code 1.

Protocol: `REMOTE_PROTOCOL_VERSION` bumped 2→3 (`worker.drain` added to `RemoteMethod`). Scheduler excludes draining workers from all placement including targeted. Dispatch service re-queues `worker_draining` errors (never fails the step).

**Files changed (15):** domain model, protocol, scheduler, dispatch handler, gateway, dispatch service, CLI, connect loop, presentation, serve wiring, integration test type updates.

**Tests added (10):** dispatch handler drain (4), scheduler drain exclusion (3), gateway drain + disconnect (2), dispatch service re-queue (1).

Closes swamp-club#976

## Test Plan

- `deno check` — passes
- `deno lint` — passes
- `deno fmt --check` — passes
- `deno run test` — 8293 passed, 0 failed
- Verified drain lifecycle end-to-end with `--max-dispatches 1`: worker connects, receives one dispatch, completes it, drains, sends `worker.drain`, closes socket, exits 0
- Verified draining worker disconnect skips grace window (unit test)
- Verified `worker_draining` RPC error re-queues step (unit test)
- Verified draining workers excluded from all scheduler placement (unit test)