### PR TITLE
feat(remote): add swamp worker daemon enable/disable/status

### DIFF
--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -27,6 +27,7 @@ import { workerListCommand } from "./worker_list.ts";
 import { workerConnectCommand } from "./worker_connect.ts";
 import { workerQueueCommand } from "./worker_queue.ts";
 import { workerVerifyCommand } from "./worker_verify.ts";
+import { workerDaemonCommand } from "./worker_daemon.ts";
 
 export const workerTokenCommand = new Command()
   .name("token")
@@ -46,4 +47,5 @@ export const workerCommand = new Command()
   .command("list", workerListCommand)
   .command("queue", workerQueueCommand)
   .command("connect", workerConnectCommand)
-  .command("verify", workerVerifyCommand);
+  .command("verify", workerVerifyCommand)
+  .command("daemon", workerDaemonCommand);

--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -1,0 +1,198 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { groupCommandAction } from "../group_action.ts";
+import { UserError } from "../../domain/errors.ts";
+import { resolveServiceMode } from "../../infrastructure/daemon/service_scheduler_factory.ts";
+import { createWorkerDaemonScheduler } from "../../infrastructure/daemon/worker_daemon_scheduler_factory.ts";
+import {
+  renderWorkerDaemonDisabled,
+  renderWorkerDaemonEnabled,
+  renderWorkerDaemonStatus,
+} from "../../presentation/output/worker_daemon_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export function collectWorkerExtraArgs(options: AnyOptions): string[] {
+  const args: string[] = [];
+  if (options.dataPlaneUrl) {
+    args.push("--data-plane-url", options.dataPlaneUrl as string);
+  }
+  if (options.reconnect === false) {
+    args.push("--no-reconnect");
+  }
+  return args;
+}
+
+function collectWorkerEnv(options: AnyOptions): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  const url = options.url as string | undefined;
+  if (url) {
+    env["SWAMP_ORCHESTRATOR_URL"] = url;
+  }
+
+  const token = options.token as string | undefined;
+  if (token) {
+    env["SWAMP_WORKER_TOKEN"] = token;
+  }
+
+  const labels = options.label as string[] | undefined;
+  if (labels && labels.length > 0) {
+    env["SWAMP_WORKER_LABELS"] = labels.join(",");
+  }
+
+  const cacheDir = options.cacheDir as string | undefined;
+  if (cacheDir) {
+    env["SWAMP_WORKER_CACHE_DIR"] = cacheDir;
+  }
+
+  const maxDispatches = options.maxDispatches as number | undefined;
+  if (maxDispatches !== undefined) {
+    env["SWAMP_WORKER_MAX_DISPATCHES"] = String(maxDispatches);
+  }
+
+  const idleTimeout = options.idleTimeout as string | undefined;
+  if (idleTimeout) {
+    env["SWAMP_WORKER_IDLE_TIMEOUT"] = idleTimeout;
+  }
+
+  return env;
+}
+
+const daemonEnableCommand = new Command()
+  .name("enable")
+  .description("Enable swamp worker as a system daemon (launchd/systemd)")
+  .arguments("[url:string]")
+  .option(
+    "--token <token:string>",
+    "Enrollment token (<name>.<secret>)",
+  )
+  .option(
+    "--label <label:string>",
+    "Scheduling label key=value (repeatable)",
+    { collect: true },
+  )
+  .option(
+    "--cache-dir <dir:string>",
+    "Bundle/asset cache directory; also stores the machine id",
+  )
+  .option(
+    "--data-plane-url <url:string>",
+    "Override the data-plane base URL",
+  )
+  .option(
+    "--max-dispatches <n:number>",
+    "Drain and exit 0 after N dispatches complete",
+  )
+  .option(
+    "--idle-timeout <duration:string>",
+    "Drain and exit 0 after being continuously idle for this duration (e.g. 30s, 5m, 1h)",
+  )
+  .option("--no-reconnect", "Exit when the control socket closes")
+  .example(
+    "Enable worker daemon",
+    "swamp worker daemon enable wss://orch:9090 --token tok.secret --label tier=ci --cache-dir /var/lib/swamp-worker",
+  )
+  .example(
+    "Enable with lifecycle policies",
+    "swamp worker daemon enable wss://orch:9090 --token tok.secret --max-dispatches 100 --idle-timeout 30m",
+  )
+  .action(async function (options: AnyOptions, urlArg?: string) {
+    const ctx = createContext(options as GlobalOptions, [
+      "worker",
+      "daemon",
+      "enable",
+    ]);
+
+    if (!urlArg) {
+      throw new UserError(
+        "Missing orchestrator URL — pass it as a positional argument:\n\n" +
+          "  swamp worker daemon enable wss://orchestrator:9090 --token <token>",
+      );
+    }
+    if (!options.token) {
+      throw new UserError(
+        "Missing enrollment token — pass --token:\n\n" +
+          "  swamp worker daemon enable wss://orchestrator:9090 --token <name>.<secret>",
+      );
+    }
+
+    const resolvedOptions = { ...options, url: urlArg };
+    const mode = await resolveServiceMode();
+    const scheduler = await createWorkerDaemonScheduler({ mode });
+    const extraArgs = collectWorkerExtraArgs(options);
+    const env = collectWorkerEnv(resolvedOptions);
+
+    await scheduler.enable({
+      binaryPath: Deno.execPath(),
+      extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
+      env: Object.keys(env).length > 0 ? env : undefined,
+      cacheDir: options.cacheDir as string | undefined,
+    });
+
+    renderWorkerDaemonEnabled(ctx.outputMode);
+  });
+
+const daemonDisableCommand = new Command()
+  .name("disable")
+  .description("Disable and remove the swamp worker daemon")
+  .example("Disable worker daemon", "swamp worker daemon disable")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "worker",
+      "daemon",
+      "disable",
+    ]);
+    const mode = await resolveServiceMode();
+    const scheduler = await createWorkerDaemonScheduler({ mode });
+
+    await scheduler.disable();
+
+    renderWorkerDaemonDisabled(ctx.outputMode);
+  });
+
+const daemonStatusCommand = new Command()
+  .name("status")
+  .description("Show the status of the swamp worker daemon")
+  .example("Check worker daemon status", "swamp worker daemon status")
+  .action(async function (options: AnyOptions) {
+    const ctx = createContext(options as GlobalOptions, [
+      "worker",
+      "daemon",
+      "status",
+    ]);
+    const mode = await resolveServiceMode();
+    const scheduler = await createWorkerDaemonScheduler({ mode });
+
+    const status = await scheduler.status();
+
+    renderWorkerDaemonStatus(status, ctx.outputMode);
+  });
+
+export const workerDaemonCommand = new Command()
+  .name("daemon")
+  .description("Manage swamp worker as a system daemon (EXPERIMENTAL)")
+  .action(groupCommandAction)
+  .command("enable", daemonEnableCommand)
+  .command("disable", daemonDisableCommand)
+  .command("status", daemonStatusCommand);

--- a/src/cli/commands/worker_daemon_test.ts
+++ b/src/cli/commands/worker_daemon_test.ts
@@ -1,0 +1,50 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collectWorkerExtraArgs } from "./worker_daemon.ts";
+
+Deno.test("collectWorkerExtraArgs: includes data-plane-url when provided", () => {
+  const args = collectWorkerExtraArgs({
+    dataPlaneUrl: "https://dp.internal",
+  });
+  assertEquals(args, ["--data-plane-url", "https://dp.internal"]);
+});
+
+Deno.test("collectWorkerExtraArgs: includes no-reconnect when false", () => {
+  const args = collectWorkerExtraArgs({ reconnect: false });
+  assertEquals(args, ["--no-reconnect"]);
+});
+
+Deno.test("collectWorkerExtraArgs: returns empty when no relevant options", () => {
+  const args = collectWorkerExtraArgs({});
+  assertEquals(args, []);
+});
+
+Deno.test("collectWorkerExtraArgs: combines multiple options", () => {
+  const args = collectWorkerExtraArgs({
+    dataPlaneUrl: "https://dp.internal",
+    reconnect: false,
+  });
+  assertEquals(args, [
+    "--data-plane-url",
+    "https://dp.internal",
+    "--no-reconnect",
+  ]);
+});

--- a/src/domain/worker/worker_daemon_config.ts
+++ b/src/domain/worker/worker_daemon_config.ts
@@ -1,0 +1,25 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface WorkerDaemonConfig {
+  readonly binaryPath: string;
+  readonly extraArgs?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly cacheDir?: string;
+}

--- a/src/domain/worker/worker_daemon_scheduler.ts
+++ b/src/domain/worker/worker_daemon_scheduler.ts
@@ -1,0 +1,33 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { WorkerDaemonConfig } from "./worker_daemon_config.ts";
+
+export interface WorkerDaemonStatus {
+  readonly enabled: boolean;
+  readonly running: boolean;
+  readonly pid?: number;
+  readonly logPath?: string;
+}
+
+export interface WorkerDaemonScheduler {
+  enable(config: WorkerDaemonConfig): Promise<void>;
+  disable(): Promise<void>;
+  status(): Promise<WorkerDaemonStatus>;
+}

--- a/src/infrastructure/daemon/has_systemctl.ts
+++ b/src/infrastructure/daemon/has_systemctl.ts
@@ -1,0 +1,32 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export async function hasSystemctl(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("systemctl", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    return result.success;
+  } catch {
+    return false;
+  }
+}

--- a/src/infrastructure/daemon/launchd_worker_scheduler.ts
+++ b/src/infrastructure/daemon/launchd_worker_scheduler.ts
@@ -1,0 +1,224 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type { WorkerDaemonConfig } from "../../domain/worker/worker_daemon_config.ts";
+import type {
+  WorkerDaemonScheduler,
+  WorkerDaemonStatus,
+} from "../../domain/worker/worker_daemon_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import { escapeXml } from "../update/launchd_scheduler.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+import { homeDirectory } from "../persistence/paths.ts";
+
+const LABEL = "club.swamp.worker";
+
+function agentPlistPath(): string {
+  return join(homeDirectory(), "Library", "LaunchAgents", `${LABEL}.plist`);
+}
+
+function daemonPlistPath(): string {
+  return join("/Library", "LaunchDaemons", `${LABEL}.plist`);
+}
+
+function plistPathForMode(mode: LaunchdMode): string {
+  return mode === "agent" ? agentPlistPath() : daemonPlistPath();
+}
+
+export function workerLogDir(mode: LaunchdMode = "agent"): string {
+  if (mode === "daemon") {
+    return join("/var", "log", "swamp");
+  }
+  return join(homeDirectory(), "Library", "Logs", "swamp");
+}
+
+export function buildWorkerPlist(
+  config: WorkerDaemonConfig,
+  mode: LaunchdMode = "agent",
+): string {
+  const escapedBinary = escapeXml(config.binaryPath);
+  const logDir = workerLogDir(mode);
+  const stdoutLog = escapeXml(join(logDir, "worker.stdout.log"));
+  const stderrLog = escapeXml(join(logDir, "worker.stderr.log"));
+
+  const userNameEntry = mode === "daemon"
+    ? `\n  <key>UserName</key>\n  <string>root</string>`
+    : "";
+
+  const args = [
+    `    <string>${escapedBinary}</string>`,
+    `    <string>worker</string>`,
+    `    <string>connect</string>`,
+  ];
+
+  if (config.extraArgs) {
+    for (const arg of config.extraArgs) {
+      args.push(`    <string>${escapeXml(arg)}</string>`);
+    }
+  }
+
+  let envBlock = "";
+  if (config.env && Object.keys(config.env).length > 0) {
+    const entries = Object.entries(config.env)
+      .map(
+        ([k, v]) =>
+          `    <key>${escapeXml(k)}</key>\n    <string>${
+            escapeXml(v)
+          }</string>`,
+      )
+      .join("\n");
+    envBlock =
+      `\n  <key>EnvironmentVariables</key>\n  <dict>\n${entries}\n  </dict>`;
+  }
+
+  const workingDirBlock = config.cacheDir
+    ? `\n  <key>WorkingDirectory</key>\n  <string>${
+      escapeXml(config.cacheDir)
+    }</string>`
+    : "";
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.join("\n")}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>${workingDirBlock}${userNameEntry}${envBlock}
+  <key>StandardOutPath</key>
+  <string>${stdoutLog}</string>
+  <key>StandardErrorPath</key>
+  <string>${stderrLog}</string>
+</dict>
+</plist>
+`;
+}
+
+async function getUid(): Promise<string> {
+  const cmd = new Deno.Command("id", {
+    args: ["-u"],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+export class LaunchdWorkerScheduler implements WorkerDaemonScheduler {
+  readonly mode: LaunchdMode;
+
+  constructor(mode: LaunchdMode = "agent") {
+    this.mode = mode;
+  }
+
+  async enable(config: WorkerDaemonConfig): Promise<void> {
+    await this.disable();
+
+    const path = plistPathForMode(this.mode);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.mkdir(workerLogDir(this.mode), { recursive: true });
+    await atomicWriteTextFile(path, buildWorkerPlist(config, this.mode), {
+      mode: 0o600,
+    });
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["bootstrap", domain, path],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    if (!result.success) {
+      throw new Error(
+        `launchctl bootstrap failed with exit code ${result.code}`,
+      );
+    }
+  }
+
+  async disable(): Promise<void> {
+    const path = plistPathForMode(this.mode);
+    try {
+      await Deno.stat(path);
+    } catch {
+      return;
+    }
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["bootout", `${domain}/${LABEL}`],
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+
+    await Deno.remove(path).catch(() => {});
+  }
+
+  async status(): Promise<WorkerDaemonStatus> {
+    const path = plistPathForMode(this.mode);
+    try {
+      await Deno.stat(path);
+    } catch {
+      return { enabled: false, running: false };
+    }
+
+    const domain = await this.launchctlDomain();
+    const cmd = new Deno.Command("launchctl", {
+      args: ["print", `${domain}/${LABEL}`],
+      stdout: "piped",
+      stderr: "null",
+    });
+    const result = await cmd.output();
+    const output = new TextDecoder().decode(result.stdout);
+
+    const running = result.success;
+    let pid: number | undefined;
+    const pidMatch = output.match(/pid\s*=\s*(\d+)/);
+    if (pidMatch) {
+      pid = parseInt(pidMatch[1], 10);
+    }
+
+    return {
+      enabled: true,
+      running,
+      pid,
+      logPath: workerLogDir(this.mode),
+    };
+  }
+
+  private async launchctlDomain(): Promise<string> {
+    if (this.mode === "daemon") {
+      return "system";
+    }
+    const uid = await getUid();
+    return `gui/${uid}`;
+  }
+}

--- a/src/infrastructure/daemon/launchd_worker_scheduler_test.ts
+++ b/src/infrastructure/daemon/launchd_worker_scheduler_test.ts
@@ -1,0 +1,150 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { assertFalse } from "@std/assert/false";
+import { buildWorkerPlist } from "./launchd_worker_scheduler.ts";
+import type { WorkerDaemonConfig } from "../../domain/worker/worker_daemon_config.ts";
+
+const baseConfig: WorkerDaemonConfig = {
+  binaryPath: "/usr/local/bin/swamp",
+};
+
+Deno.test("buildWorkerPlist: includes label club.swamp.worker", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "<string>club.swamp.worker</string>");
+});
+
+Deno.test("buildWorkerPlist: includes worker connect in ProgramArguments", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "<string>worker</string>");
+  assertStringIncludes(plist, "<string>connect</string>");
+});
+
+Deno.test("buildWorkerPlist: uses KeepAlive conditional dict with SuccessfulExit false", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "<key>KeepAlive</key>");
+  assertStringIncludes(plist, "<key>SuccessfulExit</key>");
+  assertStringIncludes(plist, "<false/>");
+});
+
+Deno.test("buildWorkerPlist: does not use simple KeepAlive true", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  const keepAliveIndex = plist.indexOf("<key>KeepAlive</key>");
+  const afterKeepAlive = plist.slice(keepAliveIndex + 20, keepAliveIndex + 60);
+  assertFalse(afterKeepAlive.includes("<true/>"));
+});
+
+Deno.test("buildWorkerPlist: includes RunAtLoad", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "<key>RunAtLoad</key>");
+  assertStringIncludes(plist, "<true/>");
+});
+
+Deno.test("buildWorkerPlist: includes ThrottleInterval", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "<key>ThrottleInterval</key>");
+  assertStringIncludes(plist, "<integer>10</integer>");
+});
+
+Deno.test("buildWorkerPlist: includes environment variables when provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    env: {
+      SWAMP_ORCHESTRATOR_URL: "wss://orch:9090",
+      SWAMP_WORKER_TOKEN: "tok.secret",
+    },
+  };
+  const plist = buildWorkerPlist(config);
+  assertStringIncludes(plist, "<key>EnvironmentVariables</key>");
+  assertStringIncludes(plist, "<key>SWAMP_ORCHESTRATOR_URL</key>");
+  assertStringIncludes(plist, "<string>wss://orch:9090</string>");
+  assertStringIncludes(plist, "<key>SWAMP_WORKER_TOKEN</key>");
+  assertStringIncludes(plist, "<string>tok.secret</string>");
+});
+
+Deno.test("buildWorkerPlist: omits env block when no env vars", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertFalse(plist.includes("EnvironmentVariables"));
+});
+
+Deno.test("buildWorkerPlist: includes WorkingDirectory when cacheDir provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    cacheDir: "/var/lib/swamp-worker",
+  };
+  const plist = buildWorkerPlist(config);
+  assertStringIncludes(plist, "<key>WorkingDirectory</key>");
+  assertStringIncludes(plist, "<string>/var/lib/swamp-worker</string>");
+});
+
+Deno.test("buildWorkerPlist: omits WorkingDirectory when no cacheDir", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertFalse(plist.includes("WorkingDirectory"));
+});
+
+Deno.test("buildWorkerPlist: daemon mode includes UserName root", () => {
+  const plist = buildWorkerPlist(baseConfig, "daemon");
+  assertStringIncludes(plist, "<key>UserName</key>");
+  assertStringIncludes(plist, "<string>root</string>");
+});
+
+Deno.test("buildWorkerPlist: agent mode omits UserName", () => {
+  const plist = buildWorkerPlist(baseConfig, "agent");
+  assertFalse(plist.includes("UserName"));
+});
+
+Deno.test("buildWorkerPlist: includes extraArgs when provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    extraArgs: ["--data-plane-url", "https://dp.internal"],
+  };
+  const plist = buildWorkerPlist(config);
+  assertStringIncludes(plist, "<string>--data-plane-url</string>");
+  assertStringIncludes(plist, "<string>https://dp.internal</string>");
+});
+
+Deno.test("buildWorkerPlist: omits extraArgs when not provided", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertFalse(plist.includes("--data-plane-url"));
+});
+
+Deno.test("buildWorkerPlist: escapes XML special characters", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    binaryPath: '/path/to/swamp "quoted" & <special>',
+  };
+  const plist = buildWorkerPlist(config);
+  assertStringIncludes(plist, "&amp;");
+  assertStringIncludes(plist, "&lt;special&gt;");
+  assertStringIncludes(plist, "&quot;quoted&quot;");
+});
+
+Deno.test("buildWorkerPlist: does not include serve-specific args", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertFalse(plist.includes("--repo-dir"));
+  assertFalse(plist.includes("--port"));
+  assertFalse(plist.includes("--host"));
+});
+
+Deno.test("buildWorkerPlist: uses worker log filenames", () => {
+  const plist = buildWorkerPlist(baseConfig);
+  assertStringIncludes(plist, "worker.stdout.log");
+  assertStringIncludes(plist, "worker.stderr.log");
+});

--- a/src/infrastructure/daemon/service_scheduler_factory.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory.ts
@@ -23,20 +23,7 @@ import { UserError } from "../../domain/errors.ts";
 import { detectBinaryOwnership } from "../update/scheduler_factory.ts";
 import { LaunchdServiceScheduler } from "./launchd_service_scheduler.ts";
 import { SystemdServiceScheduler } from "./systemd_service_scheduler.ts";
-
-async function hasSystemctl(): Promise<boolean> {
-  try {
-    const cmd = new Deno.Command("systemctl", {
-      args: ["--version"],
-      stdout: "null",
-      stderr: "null",
-    });
-    const result = await cmd.output();
-    return result.success;
-  } catch {
-    return false;
-  }
-}
+import { hasSystemctl } from "./has_systemctl.ts";
 
 export async function resolveServiceMode(): Promise<LaunchdMode> {
   let currentUid: number | null = null;

--- a/src/infrastructure/daemon/systemd_worker_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_worker_scheduler.ts
@@ -1,0 +1,186 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { WorkerDaemonConfig } from "../../domain/worker/worker_daemon_config.ts";
+import type {
+  WorkerDaemonScheduler,
+  WorkerDaemonStatus,
+} from "../../domain/worker/worker_daemon_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import {
+  escapeSystemdPath,
+  systemdUnitDir,
+} from "../update/systemd_scheduler.ts";
+import { atomicWriteTextFile } from "../persistence/atomic_write.ts";
+
+const UNIT_NAME = "swamp-worker";
+
+function servicePath(mode: LaunchdMode = "agent"): string {
+  return join(systemdUnitDir(mode), `${UNIT_NAME}.service`);
+}
+
+export function buildWorkerService(
+  config: WorkerDaemonConfig,
+  mode: LaunchdMode = "agent",
+): string {
+  const escapedBinary = escapeSystemdPath(config.binaryPath);
+
+  const args = [
+    `"${escapedBinary}"`,
+    "worker",
+    "connect",
+  ];
+
+  if (config.extraArgs) {
+    for (const arg of config.extraArgs) {
+      args.push(`"${escapeSystemdPath(arg)}"`);
+    }
+  }
+
+  const envLines: string[] = [];
+  if (config.env) {
+    for (const [k, v] of Object.entries(config.env)) {
+      envLines.push(
+        `Environment="${escapeSystemdPath(k)}=${escapeSystemdPath(v)}"`,
+      );
+    }
+  }
+  const envBlock = envLines.length > 0 ? "\n" + envLines.join("\n") : "";
+
+  const workingDirLine = config.cacheDir
+    ? `\nWorkingDirectory=${escapeSystemdPath(config.cacheDir)}`
+    : "";
+
+  return `[Unit]
+Description=Swamp worker daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${args.join(" ")}
+KillSignal=SIGTERM
+TimeoutStopSec=300
+Restart=on-failure
+RestartSec=10${workingDirLine}${envBlock}
+
+[Install]
+WantedBy=${mode === "daemon" ? "multi-user.target" : "default.target"}
+`;
+}
+
+async function systemctl(
+  mode: LaunchdMode,
+  ...args: string[]
+): Promise<{ success: boolean; stdout: string }> {
+  const modeArgs = mode === "agent" ? ["--user"] : [];
+  const cmd = new Deno.Command("systemctl", {
+    args: [...modeArgs, ...args],
+    stdout: "piped",
+    stderr: "null",
+  });
+  const result = await cmd.output();
+  return {
+    success: result.success,
+    stdout: new TextDecoder().decode(result.stdout).trim(),
+  };
+}
+
+export class SystemdWorkerScheduler implements WorkerDaemonScheduler {
+  readonly mode: LaunchdMode;
+
+  constructor(mode: LaunchdMode = "agent") {
+    this.mode = mode;
+  }
+
+  async enable(config: WorkerDaemonConfig): Promise<void> {
+    await this.disable();
+
+    const dir = systemdUnitDir(this.mode);
+    await Deno.mkdir(dir, { recursive: true });
+
+    await atomicWriteTextFile(
+      servicePath(this.mode),
+      buildWorkerService(config, this.mode),
+      { mode: 0o600 },
+    );
+
+    await systemctl(this.mode, "daemon-reload");
+    const result = await systemctl(
+      this.mode,
+      "enable",
+      "--now",
+      `${UNIT_NAME}.service`,
+    );
+    if (!result.success) {
+      throw new Error(
+        `Failed to enable systemd service ${UNIT_NAME}.service`,
+      );
+    }
+  }
+
+  async disable(): Promise<void> {
+    await systemctl(this.mode, "disable", "--now", `${UNIT_NAME}.service`);
+    await systemctl(this.mode, "daemon-reload");
+
+    await Deno.remove(servicePath(this.mode)).catch(() => {});
+  }
+
+  async status(): Promise<WorkerDaemonStatus> {
+    try {
+      await Deno.stat(servicePath(this.mode));
+    } catch {
+      return { enabled: false, running: false };
+    }
+
+    const isActive = await systemctl(
+      this.mode,
+      "is-active",
+      `${UNIT_NAME}.service`,
+    );
+    const running = isActive.stdout === "active";
+
+    let pid: number | undefined;
+    const showPid = await systemctl(
+      this.mode,
+      "show",
+      "--property=MainPID",
+      `${UNIT_NAME}.service`,
+    );
+    const pidMatch = showPid.stdout.match(/MainPID=(\d+)/);
+    if (pidMatch) {
+      const parsed = parseInt(pidMatch[1], 10);
+      if (parsed > 0) {
+        pid = parsed;
+      }
+    }
+
+    const logHint = this.mode === "agent"
+      ? `journalctl --user -u ${UNIT_NAME}`
+      : `journalctl -u ${UNIT_NAME}`;
+
+    return {
+      enabled: true,
+      running,
+      pid,
+      logPath: logHint,
+    };
+  }
+}

--- a/src/infrastructure/daemon/systemd_worker_scheduler_test.ts
+++ b/src/infrastructure/daemon/systemd_worker_scheduler_test.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import { assertFalse } from "@std/assert/false";
+import { buildWorkerService } from "./systemd_worker_scheduler.ts";
+import type { WorkerDaemonConfig } from "../../domain/worker/worker_daemon_config.ts";
+
+const baseConfig: WorkerDaemonConfig = {
+  binaryPath: "/usr/local/bin/swamp",
+};
+
+Deno.test("buildWorkerService: includes Restart=on-failure", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "Restart=on-failure");
+});
+
+Deno.test("buildWorkerService: does not use Restart=always", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertFalse(unit.includes("Restart=always"));
+});
+
+Deno.test("buildWorkerService: includes KillSignal=SIGTERM", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "KillSignal=SIGTERM");
+});
+
+Deno.test("buildWorkerService: includes TimeoutStopSec=300", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "TimeoutStopSec=300");
+});
+
+Deno.test("buildWorkerService: includes RestartSec", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "RestartSec=10");
+});
+
+Deno.test("buildWorkerService: includes Type=simple", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "Type=simple");
+});
+
+Deno.test("buildWorkerService: includes ExecStart with worker connect", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "ExecStart=");
+  assertStringIncludes(unit, "worker");
+  assertStringIncludes(unit, "connect");
+});
+
+Deno.test("buildWorkerService: includes environment variables when provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    env: {
+      SWAMP_ORCHESTRATOR_URL: "wss://orch:9090",
+      SWAMP_WORKER_TOKEN: "tok.secret",
+    },
+  };
+  const unit = buildWorkerService(config);
+  assertStringIncludes(
+    unit,
+    'Environment="SWAMP_ORCHESTRATOR_URL=wss://orch:9090"',
+  );
+  assertStringIncludes(unit, 'Environment="SWAMP_WORKER_TOKEN=tok.secret"');
+});
+
+Deno.test("buildWorkerService: omits env block when no env vars", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertFalse(unit.includes("Environment="));
+});
+
+Deno.test("buildWorkerService: includes WorkingDirectory when cacheDir provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    cacheDir: "/var/lib/swamp-worker",
+  };
+  const unit = buildWorkerService(config);
+  assertStringIncludes(unit, "WorkingDirectory=/var/lib/swamp-worker");
+});
+
+Deno.test("buildWorkerService: omits WorkingDirectory when no cacheDir", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertFalse(unit.includes("WorkingDirectory="));
+});
+
+Deno.test("buildWorkerService: includes network ordering", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "After=network-online.target");
+  assertStringIncludes(unit, "Wants=network-online.target");
+});
+
+Deno.test("buildWorkerService: agent mode uses default.target", () => {
+  const unit = buildWorkerService(baseConfig, "agent");
+  assertStringIncludes(unit, "[Install]");
+  assertStringIncludes(unit, "WantedBy=default.target");
+});
+
+Deno.test("buildWorkerService: daemon mode uses multi-user.target", () => {
+  const unit = buildWorkerService(baseConfig, "daemon");
+  assertStringIncludes(unit, "WantedBy=multi-user.target");
+});
+
+Deno.test("buildWorkerService: includes extraArgs when provided", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    extraArgs: ["--data-plane-url", "https://dp.internal"],
+  };
+  const unit = buildWorkerService(config);
+  assertStringIncludes(unit, '"--data-plane-url" "https://dp.internal"');
+});
+
+Deno.test("buildWorkerService: omits extraArgs when not provided", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertFalse(unit.includes("--data-plane-url"));
+});
+
+Deno.test("buildWorkerService: does not include serve-specific args", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertFalse(unit.includes("--repo-dir"));
+  assertFalse(unit.includes("--port"));
+  assertFalse(unit.includes("--host"));
+});
+
+Deno.test("buildWorkerService: description mentions worker", () => {
+  const unit = buildWorkerService(baseConfig);
+  assertStringIncludes(unit, "Description=Swamp worker daemon");
+});
+
+Deno.test("buildWorkerService: escapes percent specifiers in env values", () => {
+  const config: WorkerDaemonConfig = {
+    ...baseConfig,
+    env: { MY_VAR: "value%nwith%%percents" },
+  };
+  const unit = buildWorkerService(config);
+  assertStringIncludes(unit, "value%%nwith%%%%percents");
+});

--- a/src/infrastructure/daemon/worker_daemon_scheduler_factory.ts
+++ b/src/infrastructure/daemon/worker_daemon_scheduler_factory.ts
@@ -1,0 +1,52 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { WorkerDaemonScheduler } from "../../domain/worker/worker_daemon_scheduler.ts";
+import type { LaunchdMode } from "../update/launchd_scheduler.ts";
+import { UserError } from "../../domain/errors.ts";
+import { LaunchdWorkerScheduler } from "./launchd_worker_scheduler.ts";
+import { SystemdWorkerScheduler } from "./systemd_worker_scheduler.ts";
+import { hasSystemctl } from "./has_systemctl.ts";
+
+export interface WorkerDaemonSchedulerOptions {
+  mode?: LaunchdMode;
+}
+
+export async function createWorkerDaemonScheduler(
+  options?: WorkerDaemonSchedulerOptions,
+): Promise<WorkerDaemonScheduler> {
+  const mode = options?.mode ?? "agent";
+  switch (Deno.build.os) {
+    case "darwin":
+      return new LaunchdWorkerScheduler(mode);
+    case "linux":
+      if (await hasSystemctl()) {
+        return new SystemdWorkerScheduler(mode);
+      }
+      throw new UserError(
+        "swamp worker daemon currently requires systemd on Linux, but systemctl was not found.\n" +
+          "If you need support for your init system, please file a feature request:\n\n" +
+          "  swamp issue feature",
+      );
+    default:
+      throw new UserError(
+        `swamp worker daemon is not yet supported on ${Deno.build.os}`,
+      );
+  }
+}

--- a/src/presentation/output/worker_daemon_output.ts
+++ b/src/presentation/output/worker_daemon_output.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { WorkerDaemonStatus } from "../../domain/worker/worker_daemon_scheduler.ts";
+import type { OutputMode } from "./output.ts";
+
+export function renderWorkerDaemonEnabled(mode: OutputMode): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify({ enabled: true }, null, 2));
+  } else {
+    writeOutput(
+      `${
+        green("✓")
+      } Worker daemon enabled — swamp worker connect will start automatically`,
+    );
+  }
+}
+
+export function renderWorkerDaemonDisabled(mode: OutputMode): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify({ enabled: false }, null, 2));
+  } else {
+    writeOutput(
+      `${green("✓")} Worker daemon disabled — service definition removed`,
+    );
+  }
+}
+
+export function renderWorkerDaemonStatus(
+  status: WorkerDaemonStatus,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    // deno-lint-ignore no-console
+    console.log(JSON.stringify(status, null, 2));
+    return;
+  }
+
+  if (!status.enabled) {
+    writeOutput(`${dim("Status:")} ${dim("not configured")}`);
+    writeOutput(
+      `${dim("Run")} ${bold("swamp worker daemon enable")} ${
+        dim("to set up the daemon")
+      }`,
+    );
+    return;
+  }
+
+  const stateLabel = status.running ? green("running") : red("stopped");
+
+  writeOutput(`${dim("Status:")}  ${stateLabel}`);
+  writeOutput(`${dim("Enabled:")} ${green("yes")}`);
+  if (status.pid !== undefined) {
+    writeOutput(`${dim("PID:")}     ${String(status.pid)}`);
+  }
+  if (status.logPath) {
+    writeOutput(`${dim("Logs:")}    ${status.logPath}`);
+  }
+}

--- a/src/presentation/output/worker_daemon_output_test.ts
+++ b/src/presentation/output/worker_daemon_output_test.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import type { WorkerDaemonStatus } from "../../domain/worker/worker_daemon_scheduler.ts";
+import {
+  renderWorkerDaemonDisabled,
+  renderWorkerDaemonEnabled,
+  renderWorkerDaemonStatus,
+} from "./worker_daemon_output.ts";
+
+function captureLogs(run: () => void): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+  return logs.join("\n");
+}
+
+Deno.test("renderWorkerDaemonEnabled: json mode outputs enabled true", () => {
+  const output = captureLogs(() => renderWorkerDaemonEnabled("json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed, { enabled: true });
+});
+
+Deno.test("renderWorkerDaemonEnabled: log mode mentions worker daemon", () => {
+  const output = captureLogs(() => renderWorkerDaemonEnabled("log"));
+  assertStringIncludes(stripAnsiCode(output), "Worker daemon enabled");
+});
+
+Deno.test("renderWorkerDaemonDisabled: json mode outputs enabled false", () => {
+  const output = captureLogs(() => renderWorkerDaemonDisabled("json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed, { enabled: false });
+});
+
+Deno.test("renderWorkerDaemonDisabled: log mode mentions disabled", () => {
+  const output = captureLogs(() => renderWorkerDaemonDisabled("log"));
+  assertStringIncludes(stripAnsiCode(output), "Worker daemon disabled");
+});
+
+Deno.test("renderWorkerDaemonStatus: json mode outputs full status", () => {
+  const status: WorkerDaemonStatus = {
+    enabled: true,
+    running: true,
+    pid: 1234,
+    logPath: "/var/log/swamp",
+  };
+  const output = captureLogs(() => renderWorkerDaemonStatus(status, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed, status);
+});
+
+Deno.test("renderWorkerDaemonStatus: log mode shows not configured when disabled", () => {
+  const status: WorkerDaemonStatus = { enabled: false, running: false };
+  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const stripped = stripAnsiCode(output);
+  assertStringIncludes(stripped, "not configured");
+  assertStringIncludes(stripped, "swamp worker daemon enable");
+});
+
+Deno.test("renderWorkerDaemonStatus: log mode shows running when enabled and running", () => {
+  const status: WorkerDaemonStatus = {
+    enabled: true,
+    running: true,
+    pid: 5678,
+  };
+  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const stripped = stripAnsiCode(output);
+  assertStringIncludes(stripped, "running");
+  assertStringIncludes(stripped, "5678");
+});
+
+Deno.test("renderWorkerDaemonStatus: log mode shows stopped when enabled but not running", () => {
+  const status: WorkerDaemonStatus = { enabled: true, running: false };
+  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const stripped = stripAnsiCode(output);
+  assertStringIncludes(stripped, "stopped");
+});


### PR DESCRIPTION
## Summary

Adds `swamp worker daemon enable/disable/status` CLI commands that generate systemd (Linux) and launchd (macOS) service units for the `swamp worker connect` process, mirroring the existing `swamp serve daemon` pattern.

Closes swamp-club#979

### Key design decisions

- **Restart policy**: `Restart=on-failure` (systemd) / `KeepAlive:{SuccessfulExit:false}` (launchd) — restarts on crash but not on intentional exit 0 from drain/max-dispatches/idle-timeout
- **Signal handling**: `KillSignal=SIGTERM` triggers graceful drain from PR1; `TimeoutStopSec=300` gives 5 minutes for in-flight work to complete
- **Token security**: Enrollment token goes in `EnvironmentVariables` (launchd) / `Environment=` (systemd), never in `ProgramArguments`/`ExecStart`. Unit files written with mode `0o600`
- **Domain decoupling**: `WorkerDaemonConfig` and `WorkerDaemonStatus` defined independently in `src/domain/worker/` — no imports from the serve domain
- **WorkingDirectory**: Set to `--cache-dir` when provided (the only stable path a worker owns), omitted otherwise

### New files (12)

| Layer | File | Purpose |
|-------|------|---------|
| Domain | `src/domain/worker/worker_daemon_config.ts` | `WorkerDaemonConfig` value object |
| Domain | `src/domain/worker/worker_daemon_scheduler.ts` | `WorkerDaemonScheduler` interface + `WorkerDaemonStatus` |
| Infra | `src/infrastructure/daemon/has_systemctl.ts` | Shared `hasSystemctl()` helper (extracted from serve factory) |
| Infra | `src/infrastructure/daemon/launchd_worker_scheduler.ts` | macOS launchd scheduler (`club.swamp.worker`) |
| Infra | `src/infrastructure/daemon/systemd_worker_scheduler.ts` | Linux systemd scheduler (`swamp-worker`) |
| Infra | `src/infrastructure/daemon/worker_daemon_scheduler_factory.ts` | Platform-specific factory |
| Presentation | `src/presentation/output/worker_daemon_output.ts` | Renderers for both log/json modes |
| CLI | `src/cli/commands/worker_daemon.ts` | `enable`/`disable`/`status` commands |
| Tests | 4 test files | 48 tests covering all new code |

### Modified files (2)

- `src/cli/commands/worker.ts` — register `daemon` subcommand
- `src/infrastructure/daemon/service_scheduler_factory.ts` — import shared `hasSystemctl`

## Test Plan

- [x] 48 new unit tests covering:
  - `buildWorkerPlist`: KeepAlive conditional dict, env vars, WorkingDirectory, XML escaping, worker log filenames, no serve-specific args
  - `buildWorkerService`: Restart=on-failure (not always), KillSignal=SIGTERM, TimeoutStopSec=300, Environment lines, WorkingDirectory, no serve-specific args
  - `collectWorkerExtraArgs`: data-plane-url, no-reconnect, combinations
  - Output renderers: both json and log modes for enabled/disabled/status
- [x] Full test suite passes (8345 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all pass
- [x] `deno run compile` succeeds
- [x] Existing serve daemon tests unaffected by `hasSystemctl` extraction

🤖 Generated with [Claude Code](https://claude.ai/code)