### PR TITLE
fix(install): point post-install "Learn more" link to swamp-club/swamp

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ main() {
   info "  3. Join the community:"
   info "       https://discord.gg/swamp-club"
   info ""
-  info "Learn more: https://github.com/systeminit/swamp"
+  info "Learn more: https://github.com/swamp-club/swamp"
 }
 
 parse_cli_args() {


### PR DESCRIPTION
## Summary

The curl installer's post-install "Next steps" banner still linked to the old `github.com/systeminit/swamp` repository. Sibling URLs (the artifact host and Discord invite) were migrated during the org move to `swamp-club`, but this GitHub "Learn more" link was left behind. This is a one-line string change in `scripts/install.sh`.

```diff
-  info "Learn more: https://github.com/systeminit/swamp"
+  info "Learn more: https://github.com/swamp-club/swamp"
```

Fixes swamp-club lab issue #983 (reported by @evrardjp).

## Test Plan

- `sh -n scripts/install.sh` — script still parses.
- `grep systeminit scripts/install.sh` — no remaining stale references.
- Confirmed the published installer at `https://swamp-club.com/install.sh` and `https://artifacts.swamp-club.com/install.sh` are byte-for-byte identical (matching SHA-256) to the repo's committed `scripts/install.sh`, so the repo is the source of truth and merging this updates the live link on next publish. No out-of-band edits exist on the artifact store.
- Change is shell-only; no TypeScript surface, so `deno lint` passes and the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)