### PR TITLE
fix(serve): wire datastore resolver into all serve data paths

### DIFF
--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -40,6 +40,7 @@ import { StepTask } from "../src/domain/workflows/step_task.ts";
 import { YamlWorkflowRepository } from "../src/infrastructure/persistence/yaml_workflow_repository.ts";
 import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
 import { handleConnection } from "../src/serve/connection.ts";
+import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/default_datastore_path_resolver.ts";
 import { runWorkflowOverServer } from "../src/cli/remote_run.ts";
 import { createWorkflowRunRenderer } from "../src/presentation/renderers/workflow_run.ts";
 import type { WorkflowRunEvent } from "../src/libswamp/mod.ts";
@@ -101,6 +102,10 @@ async function withServeRepo(
       repoDir: resolvedRepoDir,
       repoContext,
       datastoreConfig,
+      datastoreResolver: new DefaultDatastorePathResolver(
+        resolvedRepoDir,
+        datastoreConfig,
+      ),
       syncService,
       authConfig: {
         mode: "none" as const,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -77,6 +77,7 @@ import {
   RunTrackerStore,
 } from "../../infrastructure/persistence/run_tracker_store.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { sweepStaleRecords } from "../../serve/boot_reconciliation.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -779,11 +780,16 @@ export const serveCommand = new Command()
       );
     }
 
+    const datastoreResolver = new DefaultDatastorePathResolver(
+      resolvedRepoDir,
+      datastoreConfig,
+    );
     const connectionCtx: import("../../serve/connection.ts").ConnectionContext =
       {
         repoDir: resolvedRepoDir,
         repoContext,
         datastoreConfig,
+        datastoreResolver,
         syncService,
         workerGateway,
         policySnapshotLoader,

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -64,11 +64,13 @@ import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../domain/reports/report_registry.ts";
 import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
 
 export async function createWorkflowRunDeps(
   repoDir: string,
   repoContext: RepositoryContext,
+  datastoreConfig: DatastoreConfig,
   stepLockHook?: StepLockHook,
   runTracker?: RunTrackerRepository,
 ): Promise<WorkflowRunDeps> {
@@ -151,12 +153,13 @@ export async function createWorkflowRunDeps(
           routedMethodInputs: result.routedInputs.methodArguments,
         };
       };
+      const resolver = new DefaultDatastorePathResolver(dir, datastoreConfig);
       return new WorkflowExecutionService(
         wfRepo,
         rnRepo,
         dir,
         undefined,
-        undefined,
+        resolver.resolvePath(SWAMP_SUBDIRS.data),
         catalogStore,
         directResolver,
         repoContext.markDirty,
@@ -308,6 +311,7 @@ export async function executeWorkflowWithLocks(
   const deps = await createWorkflowRunDeps(
     repoDir,
     repoContext,
+    datastoreConfig,
     stepLockHook,
     runTracker,
   );

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -427,7 +427,7 @@ export async function handleDataDelete(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createDataDeleteDeps(ctx.repoDir);
+    const deps = createDataDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -486,7 +486,7 @@ export async function handleDataRename(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createDataRenameDeps(ctx.repoDir);
+    const deps = createDataRenameDeps(ctx.repoDir, ctx.datastoreResolver);
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -486,7 +486,7 @@ export async function handleModelDelete(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelDeleteDeps(ctx.repoDir);
+    const deps = createModelDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
 
     const preview = await modelDeletePreview(
       libCtx,
@@ -622,7 +622,7 @@ export async function handleModelOutputData(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelOutputDataDeps(ctx.repoDir);
+    const deps = createModelOutputDataDeps(ctx.repoDir, ctx.datastoreResolver);
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -682,7 +682,7 @@ export async function handleModelOutputLogs(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelOutputLogsDeps(ctx.repoDir);
+    const deps = createModelOutputLogsDeps(ctx.repoDir, ctx.datastoreResolver);
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -23,6 +23,7 @@
 
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync_service.ts";
 import type { RunCancelRegistry } from "../run_cancel_registry.ts";
 import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
@@ -75,6 +76,7 @@ export interface ConnectionContext {
   repoDir: string;
   repoContext: RepositoryContext;
   datastoreConfig: DatastoreConfig;
+  datastoreResolver: DatastorePathResolver;
   /**
    * Shared sync service instance. Same one the repo context's markDirty hook
    * references — see `design/datastores.md`. Undefined for filesystem

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -71,6 +71,8 @@ import {
   principalToString,
 } from "../../domain/access/principal.ts";
 import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
+import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -735,7 +737,12 @@ export async function handleWorkflowResume(
 
     // Ensure model/vault/report registries are loaded (mirrors
     // createWorkflowRunDeps).
-    await createWorkflowRunDeps(ctx.repoDir, ctx.repoContext, stepLockHook);
+    await createWorkflowRunDeps(
+      ctx.repoDir,
+      ctx.repoContext,
+      ctx.datastoreConfig,
+      stepLockHook,
+    );
 
     const resumeInputs = payload.inputs ?? {};
     const ephemeral = createEphemeralStore(
@@ -743,12 +750,16 @@ export async function handleWorkflowResume(
       { isResume: true },
     );
 
+    const resolver = new DefaultDatastorePathResolver(
+      ctx.repoDir,
+      ctx.datastoreConfig,
+    );
     const service = new WorkflowExecutionService(
       workflowRepo,
       runRepo,
       ctx.repoDir,
       undefined,
-      undefined,
+      resolver.resolvePath(SWAMP_SUBDIRS.data),
       ctx.repoContext.catalogStore,
       undefined,
       ctx.repoContext.markDirty,


### PR DESCRIPTION
## Summary

- Wire `datastoreResolver` into all seven serve code paths that bypassed it, causing `FileSystemUnifiedDataRepository` to fall back to local `.swamp/data/` instead of the configured datastore path when a non-default datastore (S3, MongoDB, etc.) was configured
- Add `datastoreResolver` field to `ConnectionContext`, constructed once at serve startup from `repoDir` + `datastoreConfig`
- Thread `datastoreConfig` into `createWorkflowRunDeps` and resolve `dataBaseDir` for `WorkflowExecutionService` (bugs in `deps.ts` and `workflow_handlers.ts`)
- Pass `ctx.datastoreResolver` to five libswamp factory functions that already accept it: `createModelDeleteDeps`, `createModelOutputDataDeps`, `createModelOutputLogsDeps`, `createDataDeleteDeps`, `createDataRenameDeps`

Closes swamp-club#974

## Test Plan

- [x] `deno check` — all types pass
- [x] `deno lint` — clean
- [x] `deno fmt --check` — clean
- [x] `deno run test` — 8345 passed, 0 failed
- [x] `deno run compile` — binary compiled and verified
- [x] Compiled binary: `swamp serve` boots cleanly with resolver wiring
- [x] Compiled binary: workflow runs end-to-end over serve WebSocket, produces data artifacts, no errors
- [x] Verified `DefaultDatastorePathResolver` produces correct paths for both filesystem (local fallback, no behavior change) and custom datastores (cache path, the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)