### PR TITLE
feat(daemon): add --user flag for per-user service units

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -48,7 +48,7 @@ import {
   renderDaemonDisabled,
   renderDaemonEnabled,
   renderDaemonStatus,
-  type ServiceMode,
+  toServiceMode,
 } from "../../presentation/output/serve_daemon_output.ts";
 import { groupCommandAction } from "../group_action.ts";
 import { ScheduledExecutionService } from "../../libswamp/mod.ts";
@@ -357,10 +357,7 @@ const daemonEnableCommand = new Command()
       extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
     });
 
-    const svcMode: ServiceMode = mode === "agent"
-      ? "user service"
-      : "system service";
-    renderDaemonEnabled(ctx.outputMode, svcMode);
+    renderDaemonEnabled(ctx.outputMode, toServiceMode(mode));
   });
 
 const daemonDisableCommand = new Command()
@@ -384,10 +381,7 @@ const daemonDisableCommand = new Command()
 
     await scheduler.disable();
 
-    const svcMode: ServiceMode = mode === "agent"
-      ? "user service"
-      : "system service";
-    renderDaemonDisabled(ctx.outputMode, svcMode);
+    renderDaemonDisabled(ctx.outputMode, toServiceMode(mode));
   });
 
 const daemonStatusCommand = new Command()
@@ -411,7 +405,7 @@ const daemonStatusCommand = new Command()
 
     const status = await scheduler.status();
 
-    renderDaemonStatus(status, ctx.outputMode);
+    renderDaemonStatus(status, ctx.outputMode, toServiceMode(mode));
   });
 
 const daemonCommand = new Command()

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -48,6 +48,7 @@ import {
   renderDaemonDisabled,
   renderDaemonEnabled,
   renderDaemonStatus,
+  type ServiceMode,
 } from "../../presentation/output/serve_daemon_output.ts";
 import { groupCommandAction } from "../group_action.ts";
 import { ScheduledExecutionService } from "../../libswamp/mod.ts";
@@ -253,6 +254,10 @@ const daemonEnableCommand = new Command()
   .name("enable")
   .description("Enable swamp serve as a system daemon (launchd/systemd)")
   .option(
+    "--user",
+    "Install as a per-user service (systemd --user / launchd agent)",
+  )
+  .option(
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
@@ -336,7 +341,9 @@ const daemonEnableCommand = new Command()
       "enable",
     ]);
     const repoDir = resolveRepoDir(options.repoDir as string | undefined);
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createServiceScheduler({ mode });
     const extraArgs = collectServeExtraArgs(options);
 
@@ -350,12 +357,19 @@ const daemonEnableCommand = new Command()
       extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
     });
 
-    renderDaemonEnabled(ctx.outputMode);
+    const svcMode: ServiceMode = mode === "agent"
+      ? "user service"
+      : "system service";
+    renderDaemonEnabled(ctx.outputMode, svcMode);
   });
 
 const daemonDisableCommand = new Command()
   .name("disable")
   .description("Disable and remove the swamp serve daemon")
+  .option(
+    "--user",
+    "Target the per-user service (systemd --user / launchd agent)",
+  )
   .example("Disable daemon", "swamp serve daemon disable")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, [
@@ -363,17 +377,26 @@ const daemonDisableCommand = new Command()
       "daemon",
       "disable",
     ]);
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createServiceScheduler({ mode });
 
     await scheduler.disable();
 
-    renderDaemonDisabled(ctx.outputMode);
+    const svcMode: ServiceMode = mode === "agent"
+      ? "user service"
+      : "system service";
+    renderDaemonDisabled(ctx.outputMode, svcMode);
   });
 
 const daemonStatusCommand = new Command()
   .name("status")
   .description("Show the status of the swamp serve daemon")
+  .option(
+    "--user",
+    "Target the per-user service (systemd --user / launchd agent)",
+  )
   .example("Check daemon status", "swamp serve daemon status")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, [
@@ -381,7 +404,9 @@ const daemonStatusCommand = new Command()
       "daemon",
       "status",
     ]);
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createServiceScheduler({ mode });
 
     const status = await scheduler.status();

--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -28,7 +28,7 @@ import {
   renderWorkerDaemonEnabled,
   renderWorkerDaemonStatus,
 } from "../../presentation/output/worker_daemon_output.ts";
-import type { ServiceMode } from "../../presentation/output/serve_daemon_output.ts";
+import { toServiceMode } from "../../presentation/output/serve_daemon_output.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -157,10 +157,7 @@ const daemonEnableCommand = new Command()
       cacheDir: options.cacheDir as string | undefined,
     });
 
-    const svcMode: ServiceMode = mode === "agent"
-      ? "user service"
-      : "system service";
-    renderWorkerDaemonEnabled(ctx.outputMode, svcMode);
+    renderWorkerDaemonEnabled(ctx.outputMode, toServiceMode(mode));
   });
 
 const daemonDisableCommand = new Command()
@@ -184,10 +181,7 @@ const daemonDisableCommand = new Command()
 
     await scheduler.disable();
 
-    const svcMode: ServiceMode = mode === "agent"
-      ? "user service"
-      : "system service";
-    renderWorkerDaemonDisabled(ctx.outputMode, svcMode);
+    renderWorkerDaemonDisabled(ctx.outputMode, toServiceMode(mode));
   });
 
 const daemonStatusCommand = new Command()
@@ -211,7 +205,7 @@ const daemonStatusCommand = new Command()
 
     const status = await scheduler.status();
 
-    renderWorkerDaemonStatus(status, ctx.outputMode);
+    renderWorkerDaemonStatus(status, ctx.outputMode, toServiceMode(mode));
   });
 
 export const workerDaemonCommand = new Command()

--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -28,6 +28,7 @@ import {
   renderWorkerDaemonEnabled,
   renderWorkerDaemonStatus,
 } from "../../presentation/output/worker_daemon_output.ts";
+import type { ServiceMode } from "../../presentation/output/serve_daemon_output.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -84,6 +85,10 @@ const daemonEnableCommand = new Command()
   .description("Enable swamp worker as a system daemon (launchd/systemd)")
   .arguments("[url:string]")
   .option(
+    "--user",
+    "Install as a per-user service (systemd --user / launchd agent)",
+  )
+  .option(
     "--token <token:string>",
     "Enrollment token (<name>.<secret>)",
   )
@@ -138,7 +143,9 @@ const daemonEnableCommand = new Command()
     }
 
     const resolvedOptions = { ...options, url: urlArg };
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createWorkerDaemonScheduler({ mode });
     const extraArgs = collectWorkerExtraArgs(options);
     const env = collectWorkerEnv(resolvedOptions);
@@ -150,12 +157,19 @@ const daemonEnableCommand = new Command()
       cacheDir: options.cacheDir as string | undefined,
     });
 
-    renderWorkerDaemonEnabled(ctx.outputMode);
+    const svcMode: ServiceMode = mode === "agent"
+      ? "user service"
+      : "system service";
+    renderWorkerDaemonEnabled(ctx.outputMode, svcMode);
   });
 
 const daemonDisableCommand = new Command()
   .name("disable")
   .description("Disable and remove the swamp worker daemon")
+  .option(
+    "--user",
+    "Target the per-user service (systemd --user / launchd agent)",
+  )
   .example("Disable worker daemon", "swamp worker daemon disable")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, [
@@ -163,17 +177,26 @@ const daemonDisableCommand = new Command()
       "daemon",
       "disable",
     ]);
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createWorkerDaemonScheduler({ mode });
 
     await scheduler.disable();
 
-    renderWorkerDaemonDisabled(ctx.outputMode);
+    const svcMode: ServiceMode = mode === "agent"
+      ? "user service"
+      : "system service";
+    renderWorkerDaemonDisabled(ctx.outputMode, svcMode);
   });
 
 const daemonStatusCommand = new Command()
   .name("status")
   .description("Show the status of the swamp worker daemon")
+  .option(
+    "--user",
+    "Target the per-user service (systemd --user / launchd agent)",
+  )
   .example("Check worker daemon status", "swamp worker daemon status")
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, [
@@ -181,7 +204,9 @@ const daemonStatusCommand = new Command()
       "daemon",
       "status",
     ]);
-    const mode = await resolveServiceMode();
+    const mode = await resolveServiceMode({
+      user: options.user as boolean | undefined,
+    });
     const scheduler = await createWorkerDaemonScheduler({ mode });
 
     const status = await scheduler.status();

--- a/src/infrastructure/daemon/service_scheduler_factory.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory.ts
@@ -25,7 +25,13 @@ import { LaunchdServiceScheduler } from "./launchd_service_scheduler.ts";
 import { SystemdServiceScheduler } from "./systemd_service_scheduler.ts";
 import { hasSystemctl } from "./has_systemctl.ts";
 
-export async function resolveServiceMode(): Promise<LaunchdMode> {
+export async function resolveServiceMode(
+  options?: { user?: boolean },
+): Promise<LaunchdMode> {
+  if (options?.user) {
+    return "agent";
+  }
+
   let currentUid: number | null = null;
   let binaryUid: number | null = null;
   try {

--- a/src/infrastructure/daemon/service_scheduler_factory_test.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory_test.ts
@@ -25,7 +25,7 @@ Deno.test("resolveServiceMode: returns agent when user flag is true", async () =
   assertEquals(mode, "agent");
 });
 
-Deno.test("resolveServiceMode: returns agent when user flag is undefined", async () => {
+Deno.test("resolveServiceMode: user undefined behaves same as no options", async () => {
   const mode = await resolveServiceMode({ user: undefined });
   assertEquals(mode, await resolveServiceMode());
 });

--- a/src/infrastructure/daemon/service_scheduler_factory_test.ts
+++ b/src/infrastructure/daemon/service_scheduler_factory_test.ts
@@ -1,0 +1,36 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { resolveServiceMode } from "./service_scheduler_factory.ts";
+
+Deno.test("resolveServiceMode: returns agent when user flag is true", async () => {
+  const mode = await resolveServiceMode({ user: true });
+  assertEquals(mode, "agent");
+});
+
+Deno.test("resolveServiceMode: returns agent when user flag is undefined", async () => {
+  const mode = await resolveServiceMode({ user: undefined });
+  assertEquals(mode, await resolveServiceMode());
+});
+
+Deno.test("resolveServiceMode: returns agent when options are undefined", async () => {
+  const mode = await resolveServiceMode();
+  assertEquals(typeof mode, "string");
+});

--- a/src/infrastructure/daemon/systemd_service_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler.ts
@@ -133,10 +133,12 @@ export class SystemdServiceScheduler implements ServiceScheduler {
     } catch (err: unknown) {
       if (err instanceof Deno.errors.PermissionDenied) {
         const dir = systemdUnitDir(this.mode);
+        const hint = this.mode === "agent"
+          ? `  Check permissions on ${dir} and its parent directories`
+          : `  Option 1: Run with sudo for a system-wide service\n` +
+            `  Option 2: Use --user to install as a per-user service`;
         throw new UserError(
-          `Permission denied writing to ${dir}.\n\n` +
-            `  Option 1: Run with sudo for a system-wide service\n` +
-            `  Option 2: Use --user to install as a per-user service`,
+          `Permission denied writing to ${dir}.\n\n${hint}`,
         );
       }
       throw err;

--- a/src/infrastructure/daemon/systemd_service_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_service_scheduler.ts
@@ -23,6 +23,7 @@ import type {
   ServiceScheduler,
   ServiceStatus,
 } from "../../domain/serve/service_scheduler.ts";
+import { UserError } from "../../domain/errors.ts";
 import type { LaunchdMode } from "../update/launchd_scheduler.ts";
 import {
   escapeSystemdPath,
@@ -120,14 +121,26 @@ export class SystemdServiceScheduler implements ServiceScheduler {
   async enable(config: ServiceConfig): Promise<void> {
     await this.disable();
 
-    const dir = systemdUnitDir(this.mode);
-    await Deno.mkdir(dir, { recursive: true });
+    try {
+      const dir = systemdUnitDir(this.mode);
+      await Deno.mkdir(dir, { recursive: true });
 
-    await atomicWriteTextFile(
-      servicePath(this.mode),
-      buildServeService(config, this.mode),
-      { mode: 0o600 },
-    );
+      await atomicWriteTextFile(
+        servicePath(this.mode),
+        buildServeService(config, this.mode),
+        { mode: 0o600 },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Deno.errors.PermissionDenied) {
+        const dir = systemdUnitDir(this.mode);
+        throw new UserError(
+          `Permission denied writing to ${dir}.\n\n` +
+            `  Option 1: Run with sudo for a system-wide service\n` +
+            `  Option 2: Use --user to install as a per-user service`,
+        );
+      }
+      throw err;
+    }
 
     await systemctl(this.mode, "daemon-reload");
     const result = await systemctl(

--- a/src/infrastructure/daemon/systemd_worker_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_worker_scheduler.ts
@@ -126,10 +126,12 @@ export class SystemdWorkerScheduler implements WorkerDaemonScheduler {
     } catch (err: unknown) {
       if (err instanceof Deno.errors.PermissionDenied) {
         const dir = systemdUnitDir(this.mode);
+        const hint = this.mode === "agent"
+          ? `  Check permissions on ${dir} and its parent directories`
+          : `  Option 1: Run with sudo for a system-wide service\n` +
+            `  Option 2: Use --user to install as a per-user service`;
         throw new UserError(
-          `Permission denied writing to ${dir}.\n\n` +
-            `  Option 1: Run with sudo for a system-wide service\n` +
-            `  Option 2: Use --user to install as a per-user service`,
+          `Permission denied writing to ${dir}.\n\n${hint}`,
         );
       }
       throw err;

--- a/src/infrastructure/daemon/systemd_worker_scheduler.ts
+++ b/src/infrastructure/daemon/systemd_worker_scheduler.ts
@@ -23,6 +23,7 @@ import type {
   WorkerDaemonScheduler,
   WorkerDaemonStatus,
 } from "../../domain/worker/worker_daemon_scheduler.ts";
+import { UserError } from "../../domain/errors.ts";
 import type { LaunchdMode } from "../update/launchd_scheduler.ts";
 import {
   escapeSystemdPath,
@@ -113,14 +114,26 @@ export class SystemdWorkerScheduler implements WorkerDaemonScheduler {
   async enable(config: WorkerDaemonConfig): Promise<void> {
     await this.disable();
 
-    const dir = systemdUnitDir(this.mode);
-    await Deno.mkdir(dir, { recursive: true });
+    try {
+      const dir = systemdUnitDir(this.mode);
+      await Deno.mkdir(dir, { recursive: true });
 
-    await atomicWriteTextFile(
-      servicePath(this.mode),
-      buildWorkerService(config, this.mode),
-      { mode: 0o600 },
-    );
+      await atomicWriteTextFile(
+        servicePath(this.mode),
+        buildWorkerService(config, this.mode),
+        { mode: 0o600 },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Deno.errors.PermissionDenied) {
+        const dir = systemdUnitDir(this.mode);
+        throw new UserError(
+          `Permission denied writing to ${dir}.\n\n` +
+            `  Option 1: Run with sudo for a system-wide service\n` +
+            `  Option 2: Use --user to install as a per-user service`,
+        );
+      }
+      throw err;
+    }
 
     await systemctl(this.mode, "daemon-reload");
     const result = await systemctl(

--- a/src/presentation/output/serve_daemon_output.ts
+++ b/src/presentation/output/serve_daemon_output.ts
@@ -22,23 +22,47 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { ServiceStatus } from "../../domain/serve/service_scheduler.ts";
 import type { OutputMode } from "./output.ts";
 
-export function renderDaemonEnabled(mode: OutputMode): void {
+export type ServiceMode = "user service" | "system service";
+
+export function renderDaemonEnabled(
+  mode: OutputMode,
+  serviceMode: ServiceMode,
+): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify({ enabled: true }, null, 2));
+    console.log(
+      JSON.stringify(
+        { enabled: true, serviceMode },
+        null,
+        2,
+      ),
+    );
   } else {
     writeOutput(
-      `${green("✓")} Daemon enabled — swamp serve will start automatically`,
+      `${
+        green("✓")
+      } Daemon enabled as ${serviceMode} — swamp serve will start automatically`,
     );
   }
 }
 
-export function renderDaemonDisabled(mode: OutputMode): void {
+export function renderDaemonDisabled(
+  mode: OutputMode,
+  serviceMode: ServiceMode,
+): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify({ enabled: false }, null, 2));
+    console.log(
+      JSON.stringify(
+        { enabled: false, serviceMode },
+        null,
+        2,
+      ),
+    );
   } else {
-    writeOutput(`${green("✓")} Daemon disabled — service definition removed`);
+    writeOutput(
+      `${green("✓")} Daemon disabled — ${serviceMode} definition removed`,
+    );
   }
 }
 

--- a/src/presentation/output/serve_daemon_output.ts
+++ b/src/presentation/output/serve_daemon_output.ts
@@ -22,7 +22,15 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { ServiceStatus } from "../../domain/serve/service_scheduler.ts";
 import type { OutputMode } from "./output.ts";
 
-export type ServiceMode = "user service" | "system service";
+export type ServiceMode = "user" | "system";
+
+export function serviceModeLabel(serviceMode: ServiceMode): string {
+  return serviceMode === "user" ? "user service" : "system service";
+}
+
+export function toServiceMode(launchdMode: "agent" | "daemon"): ServiceMode {
+  return launchdMode === "agent" ? "user" : "system";
+}
 
 export function renderDaemonEnabled(
   mode: OutputMode,
@@ -38,10 +46,11 @@ export function renderDaemonEnabled(
       ),
     );
   } else {
+    const label = serviceModeLabel(serviceMode);
     writeOutput(
       `${
         green("✓")
-      } Daemon enabled as ${serviceMode} — swamp serve will start automatically`,
+      } Daemon enabled as ${label} — swamp serve will start automatically`,
     );
   }
 }
@@ -60,8 +69,9 @@ export function renderDaemonDisabled(
       ),
     );
   } else {
+    const label = serviceModeLabel(serviceMode);
     writeOutput(
-      `${green("✓")} Daemon disabled — ${serviceMode} definition removed`,
+      `${green("✓")} Daemon disabled — ${label} definition removed`,
     );
   }
 }
@@ -69,15 +79,20 @@ export function renderDaemonDisabled(
 export function renderDaemonStatus(
   status: ServiceStatus,
   mode: OutputMode,
+  serviceMode: ServiceMode,
 ): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify(status, null, 2));
+    console.log(JSON.stringify({ ...status, serviceMode }, null, 2));
     return;
   }
 
+  const label = serviceModeLabel(serviceMode);
+
   if (!status.enabled) {
-    writeOutput(`${dim("Status:")} ${dim("not configured")}`);
+    writeOutput(
+      `${dim(`Status (${label}):`)} ${dim("not configured")}`,
+    );
     writeOutput(
       `${dim("Run")} ${bold("swamp serve daemon enable")} ${
         dim("to set up the daemon")
@@ -88,7 +103,7 @@ export function renderDaemonStatus(
 
   const stateLabel = status.running ? green("running") : red("stopped");
 
-  writeOutput(`${dim("Status:")}  ${stateLabel}`);
+  writeOutput(`${dim(`Status (${label}):`)}  ${stateLabel}`);
   writeOutput(`${dim("Enabled:")} ${green("yes")}`);
   if (status.pid !== undefined) {
     writeOutput(`${dim("PID:")}     ${String(status.pid)}`);

--- a/src/presentation/output/worker_daemon_output.ts
+++ b/src/presentation/output/worker_daemon_output.ts
@@ -21,7 +21,7 @@ import { bold, dim, green, red } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { WorkerDaemonStatus } from "../../domain/worker/worker_daemon_scheduler.ts";
 import type { OutputMode } from "./output.ts";
-import type { ServiceMode } from "./serve_daemon_output.ts";
+import { type ServiceMode, serviceModeLabel } from "./serve_daemon_output.ts";
 
 export function renderWorkerDaemonEnabled(
   mode: OutputMode,
@@ -37,10 +37,11 @@ export function renderWorkerDaemonEnabled(
       ),
     );
   } else {
+    const label = serviceModeLabel(serviceMode);
     writeOutput(
       `${
         green("✓")
-      } Worker daemon enabled as ${serviceMode} — swamp worker connect will start automatically`,
+      } Worker daemon enabled as ${label} — swamp worker connect will start automatically`,
     );
   }
 }
@@ -59,10 +60,9 @@ export function renderWorkerDaemonDisabled(
       ),
     );
   } else {
+    const label = serviceModeLabel(serviceMode);
     writeOutput(
-      `${
-        green("✓")
-      } Worker daemon disabled — ${serviceMode} definition removed`,
+      `${green("✓")} Worker daemon disabled — ${label} definition removed`,
     );
   }
 }
@@ -70,15 +70,20 @@ export function renderWorkerDaemonDisabled(
 export function renderWorkerDaemonStatus(
   status: WorkerDaemonStatus,
   mode: OutputMode,
+  serviceMode: ServiceMode,
 ): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify(status, null, 2));
+    console.log(JSON.stringify({ ...status, serviceMode }, null, 2));
     return;
   }
 
+  const label = serviceModeLabel(serviceMode);
+
   if (!status.enabled) {
-    writeOutput(`${dim("Status:")} ${dim("not configured")}`);
+    writeOutput(
+      `${dim(`Status (${label}):`)} ${dim("not configured")}`,
+    );
     writeOutput(
       `${dim("Run")} ${bold("swamp worker daemon enable")} ${
         dim("to set up the daemon")
@@ -89,7 +94,7 @@ export function renderWorkerDaemonStatus(
 
   const stateLabel = status.running ? green("running") : red("stopped");
 
-  writeOutput(`${dim("Status:")}  ${stateLabel}`);
+  writeOutput(`${dim(`Status (${label}):`)}  ${stateLabel}`);
   writeOutput(`${dim("Enabled:")} ${green("yes")}`);
   if (status.pid !== undefined) {
     writeOutput(`${dim("PID:")}     ${String(status.pid)}`);

--- a/src/presentation/output/worker_daemon_output.ts
+++ b/src/presentation/output/worker_daemon_output.ts
@@ -21,27 +21,48 @@ import { bold, dim, green, red } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { WorkerDaemonStatus } from "../../domain/worker/worker_daemon_scheduler.ts";
 import type { OutputMode } from "./output.ts";
+import type { ServiceMode } from "./serve_daemon_output.ts";
 
-export function renderWorkerDaemonEnabled(mode: OutputMode): void {
+export function renderWorkerDaemonEnabled(
+  mode: OutputMode,
+  serviceMode: ServiceMode,
+): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify({ enabled: true }, null, 2));
+    console.log(
+      JSON.stringify(
+        { enabled: true, serviceMode },
+        null,
+        2,
+      ),
+    );
   } else {
     writeOutput(
       `${
         green("✓")
-      } Worker daemon enabled — swamp worker connect will start automatically`,
+      } Worker daemon enabled as ${serviceMode} — swamp worker connect will start automatically`,
     );
   }
 }
 
-export function renderWorkerDaemonDisabled(mode: OutputMode): void {
+export function renderWorkerDaemonDisabled(
+  mode: OutputMode,
+  serviceMode: ServiceMode,
+): void {
   if (mode === "json") {
     // deno-lint-ignore no-console
-    console.log(JSON.stringify({ enabled: false }, null, 2));
+    console.log(
+      JSON.stringify(
+        { enabled: false, serviceMode },
+        null,
+        2,
+      ),
+    );
   } else {
     writeOutput(
-      `${green("✓")} Worker daemon disabled — service definition removed`,
+      `${
+        green("✓")
+      } Worker daemon disabled — ${serviceMode} definition removed`,
     );
   }
 }

--- a/src/presentation/output/worker_daemon_output_test.ts
+++ b/src/presentation/output/worker_daemon_output_test.ts
@@ -38,65 +38,59 @@ function captureLogs(run: () => void): string {
   return logs.join("\n");
 }
 
-Deno.test("renderWorkerDaemonEnabled: json mode outputs enabled true with user service", () => {
-  const output = captureLogs(() =>
-    renderWorkerDaemonEnabled("json", "user service")
-  );
+Deno.test("renderWorkerDaemonEnabled: json mode outputs enabled true with service mode", () => {
+  const output = captureLogs(() => renderWorkerDaemonEnabled("json", "user"));
   const parsed = JSON.parse(output);
-  assertEquals(parsed, { enabled: true, serviceMode: "user service" });
+  assertEquals(parsed, { enabled: true, serviceMode: "user" });
 });
 
 Deno.test("renderWorkerDaemonEnabled: json mode system service", () => {
-  const output = captureLogs(() =>
-    renderWorkerDaemonEnabled("json", "system service")
-  );
+  const output = captureLogs(() => renderWorkerDaemonEnabled("json", "system"));
   const parsed = JSON.parse(output);
-  assertEquals(parsed, { enabled: true, serviceMode: "system service" });
+  assertEquals(parsed, { enabled: true, serviceMode: "system" });
 });
 
 Deno.test("renderWorkerDaemonEnabled: log mode mentions worker daemon", () => {
-  const output = captureLogs(() =>
-    renderWorkerDaemonEnabled("log", "user service")
-  );
+  const output = captureLogs(() => renderWorkerDaemonEnabled("log", "user"));
   assertStringIncludes(stripAnsiCode(output), "Worker daemon enabled");
   assertStringIncludes(stripAnsiCode(output), "user service");
 });
 
 Deno.test("renderWorkerDaemonDisabled: json mode outputs enabled false with service mode", () => {
-  const output = captureLogs(() =>
-    renderWorkerDaemonDisabled("json", "user service")
-  );
+  const output = captureLogs(() => renderWorkerDaemonDisabled("json", "user"));
   const parsed = JSON.parse(output);
-  assertEquals(parsed, { enabled: false, serviceMode: "user service" });
+  assertEquals(parsed, { enabled: false, serviceMode: "user" });
 });
 
 Deno.test("renderWorkerDaemonDisabled: log mode mentions disabled", () => {
-  const output = captureLogs(() =>
-    renderWorkerDaemonDisabled("log", "system service")
-  );
+  const output = captureLogs(() => renderWorkerDaemonDisabled("log", "system"));
   const stripped = stripAnsiCode(output);
   assertStringIncludes(stripped, "Worker daemon disabled");
   assertStringIncludes(stripped, "system service");
 });
 
-Deno.test("renderWorkerDaemonStatus: json mode outputs full status", () => {
+Deno.test("renderWorkerDaemonStatus: json mode outputs full status with service mode", () => {
   const status: WorkerDaemonStatus = {
     enabled: true,
     running: true,
     pid: 1234,
     logPath: "/var/log/swamp",
   };
-  const output = captureLogs(() => renderWorkerDaemonStatus(status, "json"));
+  const output = captureLogs(() =>
+    renderWorkerDaemonStatus(status, "json", "user")
+  );
   const parsed = JSON.parse(output);
-  assertEquals(parsed, status);
+  assertEquals(parsed, { ...status, serviceMode: "user" });
 });
 
 Deno.test("renderWorkerDaemonStatus: log mode shows not configured when disabled", () => {
   const status: WorkerDaemonStatus = { enabled: false, running: false };
-  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const output = captureLogs(() =>
+    renderWorkerDaemonStatus(status, "log", "user")
+  );
   const stripped = stripAnsiCode(output);
   assertStringIncludes(stripped, "not configured");
-  assertStringIncludes(stripped, "swamp worker daemon enable");
+  assertStringIncludes(stripped, "user service");
 });
 
 Deno.test("renderWorkerDaemonStatus: log mode shows running when enabled and running", () => {
@@ -105,15 +99,20 @@ Deno.test("renderWorkerDaemonStatus: log mode shows running when enabled and run
     running: true,
     pid: 5678,
   };
-  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const output = captureLogs(() =>
+    renderWorkerDaemonStatus(status, "log", "system")
+  );
   const stripped = stripAnsiCode(output);
   assertStringIncludes(stripped, "running");
   assertStringIncludes(stripped, "5678");
+  assertStringIncludes(stripped, "system service");
 });
 
 Deno.test("renderWorkerDaemonStatus: log mode shows stopped when enabled but not running", () => {
   const status: WorkerDaemonStatus = { enabled: true, running: false };
-  const output = captureLogs(() => renderWorkerDaemonStatus(status, "log"));
+  const output = captureLogs(() =>
+    renderWorkerDaemonStatus(status, "log", "user")
+  );
   const stripped = stripAnsiCode(output);
   assertStringIncludes(stripped, "stopped");
 });

--- a/src/presentation/output/worker_daemon_output_test.ts
+++ b/src/presentation/output/worker_daemon_output_test.ts
@@ -38,26 +38,45 @@ function captureLogs(run: () => void): string {
   return logs.join("\n");
 }
 
-Deno.test("renderWorkerDaemonEnabled: json mode outputs enabled true", () => {
-  const output = captureLogs(() => renderWorkerDaemonEnabled("json"));
+Deno.test("renderWorkerDaemonEnabled: json mode outputs enabled true with user service", () => {
+  const output = captureLogs(() =>
+    renderWorkerDaemonEnabled("json", "user service")
+  );
   const parsed = JSON.parse(output);
-  assertEquals(parsed, { enabled: true });
+  assertEquals(parsed, { enabled: true, serviceMode: "user service" });
+});
+
+Deno.test("renderWorkerDaemonEnabled: json mode system service", () => {
+  const output = captureLogs(() =>
+    renderWorkerDaemonEnabled("json", "system service")
+  );
+  const parsed = JSON.parse(output);
+  assertEquals(parsed, { enabled: true, serviceMode: "system service" });
 });
 
 Deno.test("renderWorkerDaemonEnabled: log mode mentions worker daemon", () => {
-  const output = captureLogs(() => renderWorkerDaemonEnabled("log"));
+  const output = captureLogs(() =>
+    renderWorkerDaemonEnabled("log", "user service")
+  );
   assertStringIncludes(stripAnsiCode(output), "Worker daemon enabled");
+  assertStringIncludes(stripAnsiCode(output), "user service");
 });
 
-Deno.test("renderWorkerDaemonDisabled: json mode outputs enabled false", () => {
-  const output = captureLogs(() => renderWorkerDaemonDisabled("json"));
+Deno.test("renderWorkerDaemonDisabled: json mode outputs enabled false with service mode", () => {
+  const output = captureLogs(() =>
+    renderWorkerDaemonDisabled("json", "user service")
+  );
   const parsed = JSON.parse(output);
-  assertEquals(parsed, { enabled: false });
+  assertEquals(parsed, { enabled: false, serviceMode: "user service" });
 });
 
 Deno.test("renderWorkerDaemonDisabled: log mode mentions disabled", () => {
-  const output = captureLogs(() => renderWorkerDaemonDisabled("log"));
-  assertStringIncludes(stripAnsiCode(output), "Worker daemon disabled");
+  const output = captureLogs(() =>
+    renderWorkerDaemonDisabled("log", "system service")
+  );
+  const stripped = stripAnsiCode(output);
+  assertStringIncludes(stripped, "Worker daemon disabled");
+  assertStringIncludes(stripped, "system service");
 });
 
 Deno.test("renderWorkerDaemonStatus: json mode outputs full status", () => {


### PR DESCRIPTION
## Summary

- Add `--user` flag to `serve daemon enable/disable/status` and `worker daemon enable/disable/status` commands for installing per-user systemd units (`systemctl --user`) or launchd agents without root
- Wrap `PermissionDenied` errors during unit file creation with an actionable `UserError` suggesting `--user` or `sudo`
- Update output renderers to show "user service" vs "system service" in enabled/disabled messages

Closes #988

## Test Plan

- [x] New `service_scheduler_factory_test.ts` verifying `resolveServiceMode({ user: true })` returns `"agent"`
- [x] Updated `worker_daemon_output_test.ts` for new `ServiceMode` parameter
- [x] `deno check` passes (no type errors)
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Full test suite: 8360 passed (1 pre-existing failure in `http_update_checker_test.ts` due to missing `tar` — unrelated)
- [x] DDD layer rules integration test passes (presentation layer uses `ServiceMode` type, not infrastructure `LaunchdMode`)

## Documentation

Manual docs at `swamp-club/swamp-club` `content/manual/reference/swamp-serve/daemon.md` need updating for the new `--user` flag (issues are disabled on that repo — noting here for follow-up).