### PR TITLE
feat(remote): capacity slots and concurrent dispatch (phase 4b)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -508,8 +508,10 @@ running on the orchestrator host would. Scoping the snapshot (allowlists per
 token or per label) is a later refinement; v1 chooses single-host fidelity over
 introducing a new partial-environment failure mode.
 
-Workers execute dispatches serially (one in flight per worker; an overlapping
-dispatch is rejected with `worker_busy`).
+Workers accept up to `capacity` concurrent dispatches (configured via
+`--concurrency N` on `worker connect`, default 1). When all slots are full, an
+overlapping dispatch is rejected with `worker_busy` and re-queued by the
+orchestrator.
 
 ### Dispatch runners (phase 4a)
 
@@ -525,12 +527,15 @@ that the orchestrator–worker control socket uses. A capability bridge forwards
 the 9 metadata-RPC capability verbs (`getData`, `queryData`, `listVersions`,
 `deleteData`, `resolveSecret`, `putSecret`, `readDefinition`, `readOutput`,
 `resolveModel`) from the runner to the orchestrator. Data-plane HTTP operations
-go directly from the runner to the orchestrator using the session credential.
+go directly from the runner to the orchestrator using a per-dispatch credential.
 
 The runner receives bootstrap parameters as its first stdin frame:
-`RunnerBootstrapParams` carrying the session credential, data-plane URL, cache
-directory path, and the full `DispatchParams`. The session credential is a
-static snapshot — safe at capacity 1 where dispatches are serial.
+`RunnerBootstrapParams` carrying a per-dispatch session credential, data-plane
+URL, cache directory path, and the full `DispatchParams`. Each dispatch gets its
+own credential (issued by `SessionCredentialService.issueForDispatch`) that
+encodes the `dispatchId`; session refreshes on the control channel do not
+invalidate dispatch credentials. The data plane cross-checks
+`credential.dispatchId` against the authenticated dispatch to prevent spoofing.
 
 **Cancel propagation** is nested: the orchestrator's `CANCEL_GRACE_MS` (30 s)
 bounds the supervisor, which forwards `rpc.cancel` to the runner immediately
@@ -540,9 +545,29 @@ not respond. This leaves ~20 s for cleanup and the response frame.
 **Crash isolation**: a runner crash (non-zero exit or stdio channel close) fails
 only that dispatch — the worker stays enrolled and accepts the next dispatch.
 
-Phase 4a ships at capacity 1 — identical behavior to the prior in-process path,
-plus crash isolation and clean environment handling. Phase 4b adds `--concurrency
-N` slots, where the supervisor manages N concurrent runners.
+Phase 4a shipped at capacity 1 — identical behavior to the prior in-process
+path, plus crash isolation and clean environment handling.
+
+### Concurrent dispatch (phase 4b)
+
+Phase 4b adds `--concurrency N` (or `"auto"` for CPU count) to `worker connect`.
+The worker advertises its capacity via `resourceLimits.capacity` at enrollment
+(protocol version 4). The scheduler picks the worker with the most free slots
+(least-loaded tiebreak, then name for determinism). The `DispatchRegistry`
+tracks N active dispatches per worker keyed by `(workerName, dispatchId)`.
+
+**Per-dispatch credentials**: each runner receives its own credential from
+`SessionCredentialService.issueForDispatch(workerId, dispatchId)`. This
+credential is independent of the control-channel credential — session refreshes
+do not invalidate in-flight runners. Credentials are revoked when the dispatch
+completes. The capability bridge injects `dispatchId` into every RPC verb so
+the `CapabilityService` can resolve the correct dispatch for model-type scope
+isolation.
+
+**Idle semantics**: a worker is "idle" when `activeDispatchIds.length === 0`.
+The idle timeout starts only when all slots are empty. `maxDispatches` counts
+total completed dispatches, not concurrent ones. Drain waits for all active
+runners to finish (`activeRunners === 0`).
 
 ## Shipping extension code
 

--- a/integration/dispatch_runner_test.ts
+++ b/integration/dispatch_runner_test.ts
@@ -225,6 +225,7 @@ Deno.test("capability bridge: orchestrator error message propagates to runner", 
   bridgeCapabilityVerbs({
     childChannel: runnerPair.b,
     orchestratorChannel: orchPair.a,
+    dispatchId: "test-dispatch",
     signal: AbortSignal.timeout(5_000),
   });
 

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -113,6 +113,10 @@ export const workerConnectCommand = new Command()
     "--idle-timeout <duration:string>",
     "Drain and exit 0 after being continuously idle for this duration (e.g. 30s, 5m, 1h) (env: SWAMP_WORKER_IDLE_TIMEOUT)",
   )
+  .option(
+    "--concurrency <n:string>",
+    'Number of concurrent dispatch slots ("auto" = CPU count, min 1). Default: 1 (env: SWAMP_WORKER_CONCURRENCY)',
+  )
   .action(async function (options: AnyOptions, urlArg?: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "worker",
@@ -171,6 +175,23 @@ export const workerConnectCommand = new Command()
       ? parseTimeout(idleTimeoutRaw, "--idle-timeout")
       : undefined;
 
+    const concurrencyRaw = (options.concurrency as string | undefined) ??
+      Deno.env.get("SWAMP_WORKER_CONCURRENCY");
+    let concurrency = 1;
+    if (concurrencyRaw !== undefined) {
+      if (concurrencyRaw === "auto") {
+        concurrency = Math.max(1, navigator.hardwareConcurrency ?? 1);
+      } else {
+        const parsed = Number(concurrencyRaw);
+        if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 1) {
+          throw new UserError(
+            '--concurrency must be a positive integer or "auto"',
+          );
+        }
+        concurrency = parsed;
+      }
+    }
+
     let requestDrain: ((reason: WorkerExitReason) => void) | null = null;
     let signalCount = 0;
     const ac = new AbortController();
@@ -198,6 +219,7 @@ export const workerConnectCommand = new Command()
         reconnect: options.reconnect !== false,
         maxDispatches: maxDispatchesRaw,
         idleTimeoutMs,
+        concurrency,
         signal: ac.signal,
         onStatus: (event) => {
           renderWorkerStatus(event, cliCtx.outputMode);

--- a/src/domain/models/worker/worker_model.ts
+++ b/src/domain/models/worker/worker_model.ts
@@ -62,8 +62,14 @@ export const WorkerStateSchema = z.object({
   enrolledAt: z.string().datetime(),
   lastSeenAt: z.string().datetime(),
   disconnectedAt: z.string().datetime().optional(),
-  currentDispatchId: z.string().nullable().describe(
-    "Dispatch in flight on this worker, or null when idle",
+  capacity: z.number().int().min(1).default(1).describe(
+    "Maximum concurrent dispatch slots advertised at enrollment",
+  ),
+  activeDispatchIds: z.array(z.string()).default([]).describe(
+    "Dispatches currently in flight on this worker",
+  ),
+  currentDispatchId: z.string().nullable().optional().describe(
+    "Deprecated: migration fallback from pre-4b single-dispatch state",
   ),
   verifyFailureReason: z.string().optional().describe(
     "Why the enrollment verification probe failed (present only when status is 'unverified')",
@@ -98,6 +104,7 @@ const EnrollArgsSchema = z.object({
   arch: z.string(),
   swampVersion: z.string(),
   protocolVersion: z.number().int(),
+  capacity: z.number().int().min(1).default(1),
 });
 
 async function enroll(
@@ -117,7 +124,8 @@ async function enroll(
     protocolVersion: args.protocolVersion,
     enrolledAt: now,
     lastSeenAt: now,
-    currentDispatchId: null,
+    capacity: args.capacity,
+    activeDispatchIds: [],
   };
   const handle = await context.writeResource!("state", STATE_DATA_NAME, state);
   return { dataHandles: [handle] };
@@ -126,6 +134,7 @@ async function enroll(
 const SetStatusArgsSchema = z.object({
   status: WorkerStatusSchema,
   dispatchId: z.string().optional(),
+  activeDispatchIds: z.array(z.string()).optional(),
   verifyFailureReason: z.string().optional(),
 });
 
@@ -135,13 +144,14 @@ async function setStatus(
 ): Promise<MethodResult> {
   const current = await readState(context);
   const now = new Date().toISOString();
+  const dispatchIds = args.activeDispatchIds ?? current.activeDispatchIds ?? [];
   const state: WorkerState = {
     ...current,
     status: args.status,
     lastSeenAt: now,
-    currentDispatchId: args.status === "busy"
-      ? (args.dispatchId ?? null)
-      : null,
+    activeDispatchIds: args.status === "idle" || args.status === "disconnected"
+      ? []
+      : dispatchIds,
     ...(args.status === "disconnected" ? { disconnectedAt: now } : {}),
     verifyFailureReason: args.status === "unverified"
       ? args.verifyFailureReason
@@ -156,7 +166,7 @@ async function setStatus(
  */
 export const workerModel: ModelDefinition = defineModel({
   type: WORKER_MODEL_TYPE,
-  version: "2026.07.05.1",
+  version: "2026.07.06.1",
   resources: {
     "state": {
       description:

--- a/src/domain/models/worker/worker_model_test.ts
+++ b/src/domain/models/worker/worker_model_test.ts
@@ -29,6 +29,7 @@ const enrollArgs = {
   arch: "x86_64",
   swampVersion: "1.0.0",
   protocolVersion: 1,
+  capacity: 1,
 };
 
 Deno.test("workerModel: enroll records an idle worker", async () => {
@@ -42,7 +43,8 @@ Deno.test("workerModel: enroll records an idle worker", async () => {
   assertEquals(state.status, "idle");
   assertEquals(state.name, "ci-runner-3");
   assertEquals(state.instanceUuid, "uuid-1");
-  assertEquals(state.currentDispatchId, null);
+  assertEquals(state.capacity, 1);
+  assertEquals(state.activeDispatchIds, []);
   assertEquals((state.labels as Record<string, string>).region, "us-east");
 });
 
@@ -53,12 +55,12 @@ Deno.test("workerModel: set_status busy records the dispatch id", async () => {
   );
   await workerModel.methods.enroll.execute(enrollArgs, context);
   await workerModel.methods.set_status.execute(
-    { status: "busy", dispatchId: "d-42" },
+    { status: "busy", activeDispatchIds: ["d-42"] },
     context,
   );
   const state = store.get("state-main")!;
   assertEquals(state.status, "busy");
-  assertEquals(state.currentDispatchId, "d-42");
+  assertEquals(state.activeDispatchIds, ["d-42"]);
 });
 
 Deno.test("workerModel: set_status idle clears the dispatch id", async () => {
@@ -68,13 +70,13 @@ Deno.test("workerModel: set_status idle clears the dispatch id", async () => {
   );
   await workerModel.methods.enroll.execute(enrollArgs, context);
   await workerModel.methods.set_status.execute(
-    { status: "busy", dispatchId: "d-42" },
+    { status: "busy", activeDispatchIds: ["d-42"] },
     context,
   );
   await workerModel.methods.set_status.execute({ status: "idle" }, context);
   const state = store.get("state-main")!;
   assertEquals(state.status, "idle");
-  assertEquals(state.currentDispatchId, null);
+  assertEquals(state.activeDispatchIds, []);
 });
 
 Deno.test("workerModel: set_status disconnected stamps disconnectedAt", async () => {

--- a/src/domain/remote/protocol.ts
+++ b/src/domain/remote/protocol.ts
@@ -39,7 +39,7 @@ import { z } from "zod";
  * dispatch, never mid-run. Also pins the capability-verb inventory — any
  * change to the verbs below requires a version bump.
  */
-export const REMOTE_PROTOCOL_VERSION = 3;
+export const REMOTE_PROTOCOL_VERSION = 4;
 
 // ── RPC framing ──────────────────────────────────────────────────────────
 

--- a/src/domain/remote/scheduler.ts
+++ b/src/domain/remote/scheduler.ts
@@ -49,6 +49,8 @@ export interface SchedulableWorker {
   arch: string;
   status: "idle" | "busy" | "unverified" | "draining";
   connected: boolean;
+  capacity: number;
+  activeDispatchIds: string[];
 }
 
 export type ScheduleDecision =
@@ -138,10 +140,10 @@ export function eligibleWorkers(
 }
 
 /**
- * Decide where a step goes right now. `dispatch` names an idle eligible
- * worker; `queue` means every eligible worker is busy, or no connected
- * worker matches the placement at all — the step waits for a pool change
- * either way.
+ * Decide where a step goes right now. `dispatch` names an eligible worker
+ * with available capacity; `queue` means every eligible worker is at
+ * capacity, or no connected worker matches the placement at all.
+ * Tiebreak: most free slots first, then name for determinism.
  */
 export function scheduleStep(
   placement: StepPlacement,
@@ -151,11 +153,16 @@ export function scheduleStep(
   if (eligible.length === 0) {
     return { kind: "queue" };
   }
-  const idle = eligible
-    .filter((worker) => worker.status === "idle")
-    .sort((a, b) => a.name.localeCompare(b.name));
-  if (idle.length === 0) {
+  const schedulable = eligible
+    .filter((worker) => worker.activeDispatchIds.length < worker.capacity)
+    .sort((a, b) => {
+      const freeA = a.capacity - a.activeDispatchIds.length;
+      const freeB = b.capacity - b.activeDispatchIds.length;
+      if (freeA !== freeB) return freeB - freeA;
+      return a.name.localeCompare(b.name);
+    });
+  if (schedulable.length === 0) {
     return { kind: "queue" };
   }
-  return { kind: "dispatch", worker: idle[0] };
+  return { kind: "dispatch", worker: schedulable[0] };
 }

--- a/src/domain/remote/scheduler.ts
+++ b/src/domain/remote/scheduler.ts
@@ -154,7 +154,10 @@ export function scheduleStep(
     return { kind: "queue" };
   }
   const schedulable = eligible
-    .filter((worker) => worker.activeDispatchIds.length < worker.capacity)
+    .filter((worker) =>
+      worker.status !== "unverified" &&
+      worker.activeDispatchIds.length < worker.capacity
+    )
     .sort((a, b) => {
       const freeA = a.capacity - a.activeDispatchIds.length;
       const freeB = b.capacity - b.activeDispatchIds.length;

--- a/src/domain/remote/scheduler_test.ts
+++ b/src/domain/remote/scheduler_test.ts
@@ -36,6 +36,8 @@ function worker(
     arch: "x86_64",
     status: "idle",
     connected: true,
+    capacity: 1,
+    activeDispatchIds: [],
     ...overrides,
   };
 }
@@ -65,7 +67,14 @@ Deno.test("scheduleStep: direct target matches by name or instance uuid", () => 
 });
 
 Deno.test("scheduleStep: direct target on a busy worker queues", () => {
-  const pool = [worker({ name: "a", status: "busy" })];
+  const pool = [
+    worker({
+      name: "a",
+      status: "busy",
+      activeDispatchIds: ["d1"],
+      capacity: 1,
+    }),
+  ];
   assertEquals(scheduleStep({ target: "a" }, pool).kind, "queue");
 });
 
@@ -107,8 +116,20 @@ Deno.test("scheduleStep: platform matches 'os' and 'os/arch' forms", () => {
 
 Deno.test("scheduleStep: all-busy eligible pool queues rather than failing", () => {
   const pool = [
-    worker({ name: "a", status: "busy", labels: { gpu: "true" } }),
-    worker({ name: "b", status: "busy", labels: { gpu: "true" } }),
+    worker({
+      name: "a",
+      status: "busy",
+      labels: { gpu: "true" },
+      activeDispatchIds: ["d1"],
+      capacity: 1,
+    }),
+    worker({
+      name: "b",
+      status: "busy",
+      labels: { gpu: "true" },
+      activeDispatchIds: ["d2"],
+      capacity: 1,
+    }),
   ];
   assertEquals(scheduleStep({ labels: { gpu: "true" } }, pool).kind, "queue");
 });
@@ -189,7 +210,14 @@ Deno.test("eligibleWorkers: targeted placement reaches unverified worker", () =>
 });
 
 Deno.test("scheduleStep: targeted dispatch to unverified worker queues", () => {
-  const pool = [worker({ name: "a", status: "unverified" })];
+  const pool = [
+    worker({
+      name: "a",
+      status: "unverified",
+      activeDispatchIds: ["d1"],
+      capacity: 1,
+    }),
+  ];
   const decision = scheduleStep({ target: "a" }, pool);
   assertEquals(decision.kind, "queue");
 });
@@ -213,4 +241,79 @@ Deno.test("eligibleWorkers: targeted placement excludes draining worker", () => 
 Deno.test("scheduleStep: draining workers are not scheduled", () => {
   const pool = [worker({ name: "a", status: "draining" })];
   assertEquals(scheduleStep({}, pool).kind, "queue");
+});
+
+Deno.test("scheduleStep: least-loaded tiebreak picks worker with most free slots", () => {
+  const pool = [
+    worker({
+      name: "heavy",
+      status: "busy",
+      capacity: 8,
+      activeDispatchIds: ["d1", "d2", "d3", "d4", "d5", "d6"],
+    }),
+    worker({
+      name: "light",
+      status: "busy",
+      capacity: 8,
+      activeDispatchIds: ["d1", "d2"],
+    }),
+  ];
+  const decision = scheduleStep({}, pool);
+  assertEquals(decision.kind, "dispatch");
+  assertEquals(
+    decision.kind === "dispatch" ? decision.worker.name : "",
+    "light",
+  );
+});
+
+Deno.test("scheduleStep: equal free slots breaks on name", () => {
+  const pool = [
+    worker({
+      name: "zulu",
+      status: "busy",
+      capacity: 8,
+      activeDispatchIds: ["d1", "d2", "d3", "d4"],
+    }),
+    worker({
+      name: "alpha",
+      status: "busy",
+      capacity: 8,
+      activeDispatchIds: ["d1", "d2", "d3", "d4"],
+    }),
+  ];
+  const decision = scheduleStep({}, pool);
+  assertEquals(decision.kind, "dispatch");
+  assertEquals(
+    decision.kind === "dispatch" ? decision.worker.name : "",
+    "alpha",
+  );
+});
+
+Deno.test("scheduleStep: worker at capacity is not schedulable", () => {
+  const pool = [
+    worker({
+      name: "full",
+      status: "busy",
+      capacity: 4,
+      activeDispatchIds: ["d1", "d2", "d3", "d4"],
+    }),
+  ];
+  assertEquals(scheduleStep({}, pool).kind, "queue");
+});
+
+Deno.test("scheduleStep: multi-capacity worker with available slots dispatches", () => {
+  const pool = [
+    worker({
+      name: "partial",
+      status: "busy",
+      capacity: 4,
+      activeDispatchIds: ["d1", "d2"],
+    }),
+  ];
+  const decision = scheduleStep({}, pool);
+  assertEquals(decision.kind, "dispatch");
+  assertEquals(
+    decision.kind === "dispatch" ? decision.worker.name : "",
+    "partial",
+  );
 });

--- a/src/domain/remote/session_credential.ts
+++ b/src/domain/remote/session_credential.ts
@@ -31,6 +31,8 @@ export interface SessionCredentialRecord {
   workerId: string;
   /** Epoch ms after which the credential no longer verifies. */
   expiresAtMs: number;
+  /** When set, this credential is scoped to a specific dispatch. */
+  dispatchId?: string;
 }
 
 /** Default credential lifetime: 15 minutes, refreshed well before expiry. */
@@ -64,8 +66,9 @@ export class SessionCredentialService {
   }
 
   /**
-   * Issue a fresh credential for a worker, revoking any prior one — a worker
-   * holds exactly one valid session credential at a time.
+   * Issue a fresh control-channel credential for a worker, revoking any
+   * prior control-channel credential. Per-dispatch credentials are not
+   * affected by this call.
    */
   issue(workerId: string): SessionCredentialRecord {
     this.revokeForWorker(workerId);
@@ -80,10 +83,31 @@ export class SessionCredentialService {
   }
 
   /**
-   * Verify a presented credential. Returns the worker id it authenticates,
-   * or null when unknown or expired. Expired records are pruned on sight.
+   * Issue a per-dispatch credential. These are independent of the
+   * control-channel credential and are not revoked by `issue()` or
+   * `refresh()`. They are revoked explicitly via `revokeDispatch()`.
    */
-  verify(credential: string): string | null {
+  issueForDispatch(
+    workerId: string,
+    dispatchId: string,
+  ): SessionCredentialRecord {
+    const record: SessionCredentialRecord = {
+      credential: generateOpaqueToken(),
+      workerId,
+      expiresAtMs: this.#now() + this.#ttlMs,
+      dispatchId,
+    };
+    this.#byCredential.set(record.credential, record);
+    return record;
+  }
+
+  /**
+   * Verify a presented credential. Returns the worker id and optional
+   * dispatch id it authenticates, or null when unknown or expired.
+   */
+  verify(
+    credential: string,
+  ): { workerId: string; dispatchId?: string } | null {
     const record = this.#byCredential.get(credential);
     if (!record) {
       return null;
@@ -95,28 +119,54 @@ export class SessionCredentialService {
       }
       return null;
     }
-    return record.workerId;
+    return {
+      workerId: record.workerId,
+      dispatchId: record.dispatchId,
+    };
   }
 
   /**
-   * Slide the window forward: re-issue against a currently valid credential.
-   * Returns null when the presented credential is not valid, in which case
-   * the worker must re-enroll.
+   * Slide the window forward: re-issue against a currently valid
+   * control-channel credential. Does not affect dispatch credentials.
    */
   refresh(credential: string): SessionCredentialRecord | null {
-    const workerId = this.verify(credential);
-    if (workerId === null) {
+    const result = this.verify(credential);
+    if (result === null) {
       return null;
     }
-    return this.issue(workerId);
+    if (result.dispatchId) {
+      return null;
+    }
+    return this.issue(result.workerId);
   }
 
-  /** Revoke the worker's current credential, if any. */
+  /** Revoke the worker's control-channel credential, if any. */
   revokeForWorker(workerId: string): void {
     const credential = this.#byWorker.get(workerId);
     if (credential !== undefined) {
       this.#byCredential.delete(credential);
       this.#byWorker.delete(workerId);
+    }
+  }
+
+  /** Revoke all credentials for a worker (control + dispatch). */
+  revokeAllForWorker(workerId: string): void {
+    this.revokeForWorker(workerId);
+    for (const [cred, record] of this.#byCredential) {
+      if (record.workerId === workerId) {
+        this.#byCredential.delete(cred);
+      }
+    }
+  }
+
+  /** Revoke a specific dispatch credential by dispatch id. */
+  revokeDispatch(workerId: string, dispatchId: string): void {
+    for (const [cred, record] of this.#byCredential) {
+      if (
+        record.workerId === workerId && record.dispatchId === dispatchId
+      ) {
+        this.#byCredential.delete(cred);
+      }
     }
   }
 }

--- a/src/domain/remote/session_credential_test.ts
+++ b/src/domain/remote/session_credential_test.ts
@@ -96,3 +96,66 @@ Deno.test("SessionCredentialService: credentials are distinct per worker", () =>
   assertEquals(service.verify(a.credential)?.workerId, "worker-a");
   assertEquals(service.verify(b.credential)?.workerId, "worker-b");
 });
+
+Deno.test("SessionCredentialService: issueForDispatch creates a credential with workerId and dispatchId", () => {
+  const clock = { nowMs: 0 };
+  const service = serviceAt(clock);
+  const record = service.issueForDispatch("worker-1", "dispatch-42");
+  assertEquals(service.verify(record.credential), {
+    workerId: "worker-1",
+    dispatchId: "dispatch-42",
+  });
+});
+
+Deno.test("SessionCredentialService: revokeDispatch revokes only the targeted dispatch credential", () => {
+  const clock = { nowMs: 0 };
+  const service = serviceAt(clock);
+  const control = service.issue("worker-1");
+  const d1 = service.issueForDispatch("worker-1", "dispatch-1");
+  const d2 = service.issueForDispatch("worker-1", "dispatch-2");
+
+  service.revokeDispatch("worker-1", "dispatch-1");
+
+  assertEquals(service.verify(d1.credential), null);
+  assertEquals(service.verify(d2.credential)?.dispatchId, "dispatch-2");
+  assertEquals(service.verify(control.credential)?.workerId, "worker-1");
+});
+
+Deno.test("SessionCredentialService: revokeAllForWorker revokes control and dispatch credentials", () => {
+  const clock = { nowMs: 0 };
+  const service = serviceAt(clock);
+  const control = service.issue("worker-1");
+  const d1 = service.issueForDispatch("worker-1", "dispatch-1");
+  const d2 = service.issueForDispatch("worker-1", "dispatch-2");
+  const other = service.issue("worker-2");
+
+  service.revokeAllForWorker("worker-1");
+
+  assertEquals(service.verify(control.credential), null);
+  assertEquals(service.verify(d1.credential), null);
+  assertEquals(service.verify(d2.credential), null);
+  assertEquals(service.verify(other.credential)?.workerId, "worker-2");
+});
+
+Deno.test("SessionCredentialService: refresh returns null for dispatch credentials", () => {
+  const clock = { nowMs: 0 };
+  const service = serviceAt(clock);
+  const dispatch = service.issueForDispatch("worker-1", "dispatch-1");
+  assertEquals(service.refresh(dispatch.credential), null);
+  assertEquals(
+    service.verify(dispatch.credential)?.dispatchId,
+    "dispatch-1",
+  );
+});
+
+Deno.test("SessionCredentialService: control-channel issue does not revoke dispatch credentials", () => {
+  const clock = { nowMs: 0 };
+  const service = serviceAt(clock);
+  const d1 = service.issueForDispatch("worker-1", "dispatch-1");
+  const first = service.issue("worker-1");
+  const second = service.issue("worker-1");
+
+  assertEquals(service.verify(first.credential), null);
+  assertEquals(service.verify(second.credential)?.workerId, "worker-1");
+  assertEquals(service.verify(d1.credential)?.dispatchId, "dispatch-1");
+});

--- a/src/domain/remote/session_credential_test.ts
+++ b/src/domain/remote/session_credential_test.ts
@@ -28,7 +28,10 @@ Deno.test("SessionCredentialService: issue then verify returns the worker id", (
   const clock = { nowMs: 0 };
   const service = serviceAt(clock);
   const record = service.issue("worker-1");
-  assertEquals(service.verify(record.credential), "worker-1");
+  assertEquals(service.verify(record.credential), {
+    workerId: "worker-1",
+    dispatchId: undefined,
+  });
   assertEquals(record.expiresAtMs, 1000);
 });
 
@@ -56,7 +59,7 @@ Deno.test("SessionCredentialService: refresh slides the window with a new creden
   assertEquals(second!.expiresAtMs, 1900);
   // The old credential is revoked by the refresh.
   assertEquals(service.verify(first.credential), null);
-  assertEquals(service.verify(second!.credential), "worker-1");
+  assertEquals(service.verify(second!.credential)?.workerId, "worker-1");
 });
 
 Deno.test("SessionCredentialService: refresh of an expired credential fails", () => {
@@ -73,7 +76,7 @@ Deno.test("SessionCredentialService: issue revokes the worker's prior credential
   const first = service.issue("worker-1");
   const second = service.issue("worker-1");
   assertEquals(service.verify(first.credential), null);
-  assertEquals(service.verify(second.credential), "worker-1");
+  assertEquals(service.verify(second.credential)?.workerId, "worker-1");
 });
 
 Deno.test("SessionCredentialService: revokeForWorker invalidates the credential", () => {
@@ -90,6 +93,6 @@ Deno.test("SessionCredentialService: credentials are distinct per worker", () =>
   const a = service.issue("worker-a");
   const b = service.issue("worker-b");
   assertNotEquals(a.credential, b.credential);
-  assertEquals(service.verify(a.credential), "worker-a");
-  assertEquals(service.verify(b.credential), "worker-b");
+  assertEquals(service.verify(a.credential)?.workerId, "worker-a");
+  assertEquals(service.verify(b.credential)?.workerId, "worker-b");
 });

--- a/src/libswamp/worker/list.ts
+++ b/src/libswamp/worker/list.ts
@@ -88,7 +88,8 @@ export interface WorkerListItem {
   instanceUuid: string;
   enrolledAt: string;
   lastSeenAt: string;
-  currentDispatchId: string | null;
+  capacity: number;
+  activeDispatchIds: string[];
 }
 
 /** Data payload for the worker list completed event. */
@@ -232,7 +233,8 @@ export async function* workerList(
             instanceUuid: state.instanceUuid,
             enrolledAt: state.enrolledAt,
             lastSeenAt: state.lastSeenAt,
-            currentDispatchId: state.currentDispatchId,
+            capacity: state.capacity ?? 1,
+            activeDispatchIds: state.activeDispatchIds ?? [],
           });
         }
         workers.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/libswamp/worker/list_test.ts
+++ b/src/libswamp/worker/list_test.ts
@@ -95,7 +95,8 @@ function workerAttributes(
     protocolVersion: 1,
     enrolledAt: "2026-06-09T00:00:00.000Z",
     lastSeenAt: "2026-06-09T01:00:00.000Z",
-    currentDispatchId: null,
+    capacity: 1,
+    activeDispatchIds: [],
     ...overrides,
   };
 }
@@ -197,7 +198,8 @@ Deno.test("workerList: yields completed with mapped workers sorted by name", asy
       "state-main",
       workerAttributes("worker-a", {
         status: "busy",
-        currentDispatchId: "dispatch-7",
+        capacity: 1,
+        activeDispatchIds: ["dispatch-7"],
       }),
     ),
   ]);
@@ -216,7 +218,7 @@ Deno.test("workerList: yields completed with mapped workers sorted by name", asy
     ["worker-a", "worker-b"],
   );
   assertEquals(completed.data.workers[0].status, "busy");
-  assertEquals(completed.data.workers[0].currentDispatchId, "dispatch-7");
+  assertEquals(completed.data.workers[0].activeDispatchIds, ["dispatch-7"]);
   assertEquals(completed.data.workers[1].labels, { os: "linux" });
   assertEquals(completed.data.workers[1].platform, "linux");
   assertEquals(completed.data.workers[1].arch, "x86_64");

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -234,15 +234,19 @@ export function renderWorkerList(
     );
     return;
   }
-  const rows = data.workers.map((worker) => [
-    worker.name,
-    worker.status,
-    formatLabels(worker.labels),
-    `${worker.platform}/${worker.arch}`,
-    worker.lastSeenAt,
-  ]);
+  const rows = data.workers.map((worker) => {
+    const load = `${worker.activeDispatchIds.length}/${worker.capacity}`;
+    return [
+      worker.name,
+      worker.status,
+      load,
+      formatLabels(worker.labels),
+      `${worker.platform}/${worker.arch}`,
+      worker.lastSeenAt,
+    ];
+  });
   const lines = tableLines(
-    ["NAME", "STATUS", "LABELS", "PLATFORM/ARCH", "LAST SEEN"],
+    ["NAME", "STATUS", "SLOTS", "LABELS", "PLATFORM/ARCH", "LAST SEEN"],
     rows,
     (column, value) => (column === 1 ? colorWorkerStatus(value) : value),
   );

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -197,7 +197,8 @@ const workerListData: WorkerListData = {
       instanceUuid: "uuid-42",
       enrolledAt: "2026-06-09T00:00:00.000Z",
       lastSeenAt: "2026-06-09T12:00:00.000Z",
-      currentDispatchId: "dispatch-7",
+      capacity: 1,
+      activeDispatchIds: ["dispatch-7"],
     },
     {
       name: "mac-builder",
@@ -208,7 +209,8 @@ const workerListData: WorkerListData = {
       instanceUuid: "uuid-43",
       enrolledAt: "2026-06-09T00:00:00.000Z",
       lastSeenAt: "2026-06-09T11:00:00.000Z",
-      currentDispatchId: null,
+      capacity: 1,
+      activeDispatchIds: [],
     },
   ],
   count: 2,
@@ -255,7 +257,7 @@ Deno.test("renderWorkerList: json mode emits the array of records", () => {
   assertEquals(parsed.length, 2);
   assertEquals(parsed[0].status, "busy");
   assertEquals(parsed[0].labels, { os: "linux", gpu: "none" });
-  assertEquals(parsed[1].currentDispatchId, null);
+  assertEquals(parsed[1].activeDispatchIds, []);
 });
 
 Deno.test("renderWorkerStatus: dispatch lifecycle renders start and finish", () => {

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -60,7 +60,7 @@ import {
 } from "../domain/remote/protocol.ts";
 import type { RpcChannel } from "../domain/remote/rpc_channel.ts";
 import { jsonSafeClone } from "./serializer.ts";
-import type { DispatchRegistry } from "./dispatch_registry.ts";
+import type { ActiveDispatch, DispatchRegistry } from "./dispatch_registry.ts";
 import { GRANT_MODEL_TYPE } from "../domain/models/access/grant_model.ts";
 import { GROUP_MODEL_TYPE } from "../domain/models/access/group_model.ts";
 import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
@@ -146,11 +146,12 @@ export class CapabilityService {
 
   #assertDispatchScope(
     workerName: string,
+    dispatchId: string | undefined,
     paramModelType: string,
     verb: string,
   ): void {
     if (!this.#dispatches) return;
-    const dispatch = this.#dispatches.forWorker(workerName);
+    const dispatch = this.#resolveDispatch(workerName, dispatchId, verb);
     if (!dispatch) {
       throw new Error(
         `${verb}: worker '${workerName}' has no active dispatch`,
@@ -164,18 +165,52 @@ export class CapabilityService {
     }
   }
 
-  #repoForWorker(workerName: string): UnifiedDataRepository {
-    const dispatch = this.#dispatches?.forWorker(workerName);
-    return dispatch?.dataRepo ?? this.#repoContext.unifiedDataRepo;
+  #resolveDispatch(
+    workerName: string,
+    dispatchId: string | undefined,
+    verb: string,
+  ): ActiveDispatch | null {
+    if (!this.#dispatches) return null;
+    if (dispatchId) {
+      return this.#dispatches.forDispatch(workerName, dispatchId);
+    }
+    const dispatches = this.#dispatches.forWorker(workerName);
+    if (dispatches.length === 1) return dispatches[0];
+    if (dispatches.length === 0) return null;
+    throw new Error(
+      `${verb}: worker '${workerName}' has ${dispatches.length} active dispatches — dispatchId is required`,
+    );
+  }
+
+  #repoForWorker(
+    workerName: string,
+    dispatchId?: string,
+  ): UnifiedDataRepository {
+    if (this.#dispatches && dispatchId) {
+      const dispatch = this.#dispatches.forDispatch(workerName, dispatchId);
+      if (dispatch?.dataRepo) return dispatch.dataRepo;
+    }
+    if (this.#dispatches) {
+      const dispatches = this.#dispatches.forWorker(workerName);
+      if (dispatches.length === 1 && dispatches[0].dataRepo) {
+        return dispatches[0].dataRepo;
+      }
+    }
+    return this.#repoContext.unifiedDataRepo;
   }
 
   async getData(
     workerName: string,
-    params: GetDataParams,
+    params: GetDataParams & { dispatchId?: string },
   ): Promise<GetDataResult> {
-    this.#assertDispatchScope(workerName, params.modelType, "getData");
+    this.#assertDispatchScope(
+      workerName,
+      params.dispatchId,
+      params.modelType,
+      "getData",
+    );
     const type = ModelType.create(params.modelType);
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, params.dispatchId);
     let data: Data | null = null;
     if (params.dataId !== undefined) {
       data = await repo.findById(
@@ -216,13 +251,17 @@ export class CapabilityService {
 
   async queryData(
     workerName: string,
-    params: QueryDataParams,
+    params: QueryDataParams & { dispatchId?: string },
   ): Promise<unknown[]> {
     if (params.predicate.length > MAX_CAPABILITY_PREDICATE_LENGTH) {
       throw new Error("Query predicate exceeds maximum length");
     }
     if (this.#dispatches) {
-      const dispatch = this.#dispatches.forWorker(workerName);
+      const dispatch = this.#resolveDispatch(
+        workerName,
+        params.dispatchId,
+        "queryData",
+      );
       if (!dispatch) {
         throw new Error(
           `queryData: worker '${workerName}' has no active dispatch`,
@@ -253,9 +292,9 @@ export class CapabilityService {
 
   listVersions(
     workerName: string,
-    params: ListVersionsParams,
+    params: ListVersionsParams & { dispatchId?: string },
   ): Promise<number[]> {
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, params.dispatchId);
     return repo.listVersions(
       ModelType.create(params.modelType),
       params.modelId,
@@ -265,11 +304,16 @@ export class CapabilityService {
 
   async deleteData(
     workerName: string,
-    params: DeleteDataParams,
+    params: DeleteDataParams & { dispatchId?: string },
   ): Promise<{ deleted: boolean }> {
-    this.#assertDispatchScope(workerName, params.modelType, "deleteData");
+    this.#assertDispatchScope(
+      workerName,
+      params.dispatchId,
+      params.modelType,
+      "deleteData",
+    );
     const type = ModelType.create(params.modelType);
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, params.dispatchId);
     if (params.removeLatestMarkerOnly) {
       await repo.removeLatestMarker(
         type,
@@ -289,12 +333,14 @@ export class CapabilityService {
 
   async resolveSecret(
     workerName: string,
-    params: ResolveSecretParams,
+    params: ResolveSecretParams & { dispatchId?: string },
   ): Promise<{ value: unknown }> {
-    // Secrets are not model-type-scoped (any method may reference a vault
-    // secret), so we verify only that the worker has an active dispatch.
     if (this.#dispatches) {
-      const dispatch = this.#dispatches.forWorker(workerName);
+      const dispatch = this.#resolveDispatch(
+        workerName,
+        params.dispatchId,
+        "resolveSecret",
+      );
       if (!dispatch) {
         throw new Error(
           `resolveSecret: worker '${workerName}' has no active dispatch`,
@@ -315,15 +361,14 @@ export class CapabilityService {
 
   async putSecret(
     workerName: string,
-    params: PutSecretParams,
+    params: PutSecretParams & { dispatchId?: string },
   ): Promise<{ ok: boolean }> {
-    // Secrets are not model-type-scoped: any method may write to any vault
-    // key via context.vaultService.put, so we verify only that the worker
-    // has an active dispatch (not that the vault key relates to the
-    // dispatched model type). deleteData uses the stricter
-    // #assertDispatchScope because data artifacts are model-type-addressed.
     if (this.#dispatches) {
-      const dispatch = this.#dispatches.forWorker(workerName);
+      const dispatch = this.#resolveDispatch(
+        workerName,
+        params.dispatchId,
+        "putSecret",
+      );
       if (!dispatch) {
         throw new Error(
           `putSecret: worker '${workerName}' has no active dispatch`,

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -461,43 +461,63 @@ export class CapabilityService {
       }
     };
 
+    const extractDispatchId = (params: unknown): string | undefined =>
+      (params as Record<string, unknown> | null)?.dispatchId as
+        | string
+        | undefined;
+
     channel.register(
       RemoteMethod.getData,
       safe((params) =>
-        this.getData(workerName, GetDataParamsSchema.parse(params))
+        this.getData(workerName, {
+          ...GetDataParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(
       RemoteMethod.queryData,
       safe((params) =>
-        this.queryData(workerName, QueryDataParamsSchema.parse(params))
+        this.queryData(workerName, {
+          ...QueryDataParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(
       RemoteMethod.listVersions,
       safe((params) =>
-        this.listVersions(workerName, ListVersionsParamsSchema.parse(params))
+        this.listVersions(workerName, {
+          ...ListVersionsParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(
       RemoteMethod.deleteData,
       safe((params) =>
-        this.deleteData(workerName, DeleteDataParamsSchema.parse(params))
+        this.deleteData(workerName, {
+          ...DeleteDataParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(
       RemoteMethod.resolveSecret,
       safe((params) =>
-        this.resolveSecret(
-          workerName,
-          ResolveSecretParamsSchema.parse(params),
-        )
+        this.resolveSecret(workerName, {
+          ...ResolveSecretParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(
       RemoteMethod.putSecret,
       safe((params) =>
-        this.putSecret(workerName, PutSecretParamsSchema.parse(params))
+        this.putSecret(workerName, {
+          ...PutSecretParamsSchema.parse(params),
+          dispatchId: extractDispatchId(params),
+        })
       ),
     );
     channel.register(

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -248,7 +248,17 @@ export class DataPlane {
     return this.#vaultService;
   }
 
-  #repoForWorker(workerName: string): UnifiedDataRepository {
+  #repoForWorker(
+    workerName: string,
+    dispatchId?: string,
+  ): UnifiedDataRepository {
+    if (dispatchId) {
+      const dispatch = this.#options.dispatches.forDispatch(
+        workerName,
+        dispatchId,
+      );
+      if (dispatch?.dataRepo) return dispatch.dataRepo;
+    }
     const dispatches = this.#options.dispatches.forWorker(workerName);
     if (dispatches.length === 1 && dispatches[0].dataRepo) {
       return dispatches[0].dataRepo;
@@ -265,7 +275,7 @@ export class DataPlane {
     dispatchId?: string,
   ): Promise<Response> {
     if (req.method === "GET" && segments.length === 5) {
-      return await this.#readArtifact(req, segments, workerName);
+      return await this.#readArtifact(req, segments, workerName, dispatchId);
     }
     if (req.method === "POST" && segments[1] === "resource") {
       return await this.#writeResource(req, workerName, dispatchId);
@@ -293,6 +303,7 @@ export class DataPlane {
     req: Request,
     segments: string[],
     workerName: string,
+    dispatchId?: string,
   ): Promise<Response> {
     const [, rawType, rawModelId, rawDataName, rawVersion] = segments;
     const type = ModelType.create(decodeURIComponent(rawType));
@@ -303,7 +314,7 @@ export class DataPlane {
       return errorResponse(400, `Invalid version '${rawVersion}'`);
     }
 
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, dispatchId);
     const data = await repo.findByName(
       type,
       modelId,

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -364,7 +364,7 @@ export class DataPlane {
       return errorResponse(400, "Expected { specName, name, data }");
     }
 
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, dispatchId);
     const { writeResource } = createResourceWriter(
       repo,
       dispatch.modelType,
@@ -407,7 +407,7 @@ export class DataPlane {
     }
 
     try {
-      const repo = this.#repoForWorker(workerName);
+      const repo = this.#repoForWorker(workerName, dispatchId);
       await repo.delete(
         dispatch.modelType,
         dispatch.modelId,

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -433,7 +433,7 @@ export class DataPlane {
       return errorResponse(400, "Expected { specName, name }");
     }
 
-    const repo = this.#repoForWorker(workerName);
+    const repo = this.#repoForWorker(workerName, dispatchId);
     const { createFileWriter } = createFileWriterFactory(
       repo,
       dispatch.modelType,
@@ -466,7 +466,7 @@ export class DataPlane {
     if (!session || session.workerName !== workerName) {
       return errorResponse(404, `Unknown writer '${writerId}'`);
     }
-    const dispatch = this.#activeDispatch(workerName);
+    const dispatch = this.#activeDispatch(workerName, session.dispatchId);
     if (dispatch.dispatchId !== session.dispatchId) {
       return errorResponse(409, "Writer belongs to a finished dispatch");
     }

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -60,7 +60,11 @@ const logger = getSwampLogger(["serve", "data-plane"]);
 export interface DataPlaneOptions {
   repoDir: string;
   repoContext: RepositoryContext;
-  sessions: { verify(credential: string): string | null };
+  sessions: {
+    verify(
+      credential: string,
+    ): { workerId: string; dispatchId?: string } | null;
+  };
   dispatches: DispatchRegistry;
   bundles: BundleRegistry;
   /** Fired on a dispatch's first durable write (drives lease.mark_writes). */
@@ -151,8 +155,8 @@ export class DataPlane {
       return null;
     }
 
-    const workerName = this.#authenticate(req);
-    if (workerName === null) {
+    const auth = this.#authenticate(req);
+    if (auth === null) {
       return errorResponse(401, "Missing or invalid session credential");
     }
 
@@ -160,7 +164,12 @@ export class DataPlane {
       if (root === "bundle") {
         return this.#handleBundle(req, segments);
       }
-      return await this.#handleData(req, segments, workerName);
+      return await this.#handleData(
+        req,
+        segments,
+        auth.workerName,
+        auth.dispatchId,
+      );
     } catch (error) {
       if (error instanceof DataPlaneError) {
         return errorResponse(error.status, error.message);
@@ -175,23 +184,49 @@ export class DataPlane {
     }
   }
 
-  #authenticate(req: Request): string | null {
+  #authenticate(
+    req: Request,
+  ): { workerName: string; dispatchId?: string } | null {
     const header = req.headers.get("authorization");
     if (header === null || !header.startsWith("Bearer ")) {
       return null;
     }
-    return this.#options.sessions.verify(header.slice("Bearer ".length));
+    const result = this.#options.sessions.verify(
+      header.slice("Bearer ".length),
+    );
+    if (result === null) return null;
+    return { workerName: result.workerId, dispatchId: result.dispatchId };
   }
 
-  #activeDispatch(workerName: string): ActiveDispatch {
-    const dispatch = this.#options.dispatches.forWorker(workerName);
-    if (dispatch === null) {
+  #activeDispatch(
+    workerName: string,
+    dispatchId?: string,
+  ): ActiveDispatch {
+    if (dispatchId) {
+      const dispatch = this.#options.dispatches.forDispatch(
+        workerName,
+        dispatchId,
+      );
+      if (dispatch === null) {
+        throw new DataPlaneError(
+          400,
+          `Dispatch '${dispatchId}' not found for worker '${workerName}'`,
+        );
+      }
+      return dispatch;
+    }
+    const dispatches = this.#options.dispatches.forWorker(workerName);
+    if (dispatches.length === 0) {
       throw new DataPlaneError(
         400,
         `Worker '${workerName}' has no active dispatch — writes are lease-scoped`,
       );
     }
-    return dispatch;
+    if (dispatches.length === 1) return dispatches[0];
+    throw new DataPlaneError(
+      400,
+      `Worker '${workerName}' has ${dispatches.length} active dispatches — dispatch credential required`,
+    );
   }
 
   async #recordWrite(dispatch: ActiveDispatch): Promise<void> {
@@ -214,8 +249,11 @@ export class DataPlane {
   }
 
   #repoForWorker(workerName: string): UnifiedDataRepository {
-    const dispatch = this.#options.dispatches.forWorker(workerName);
-    return dispatch?.dataRepo ?? this.#options.repoContext.unifiedDataRepo;
+    const dispatches = this.#options.dispatches.forWorker(workerName);
+    if (dispatches.length === 1 && dispatches[0].dataRepo) {
+      return dispatches[0].dataRepo;
+    }
+    return this.#options.repoContext.unifiedDataRepo;
   }
 
   // ── /data routes ───────────────────────────────────────────────────────
@@ -224,19 +262,20 @@ export class DataPlane {
     req: Request,
     segments: string[],
     workerName: string,
+    dispatchId?: string,
   ): Promise<Response> {
     if (req.method === "GET" && segments.length === 5) {
       return await this.#readArtifact(req, segments, workerName);
     }
     if (req.method === "POST" && segments[1] === "resource") {
-      return await this.#writeResource(req, workerName);
+      return await this.#writeResource(req, workerName, dispatchId);
     }
     if (req.method === "DELETE" && segments[1] === "resource") {
-      return await this.#deleteResource(req, workerName);
+      return await this.#deleteResource(req, workerName, dispatchId);
     }
     if (req.method === "POST" && segments[1] === "writers") {
       if (segments.length === 2) {
-        return await this.#openWriter(req, workerName);
+        return await this.#openWriter(req, workerName, dispatchId);
       }
       if (segments.length === 4) {
         return await this.#writerAction(
@@ -299,8 +338,12 @@ export class DataPlane {
     return new Response(ReadableStream.from(stream), { headers });
   }
 
-  async #writeResource(req: Request, workerName: string): Promise<Response> {
-    const dispatch = this.#activeDispatch(workerName);
+  async #writeResource(
+    req: Request,
+    workerName: string,
+    dispatchId?: string,
+  ): Promise<Response> {
+    const dispatch = this.#activeDispatch(workerName, dispatchId);
     const body = await req.json() as {
       specName?: string;
       name?: string;
@@ -341,8 +384,12 @@ export class DataPlane {
     return json(handleToJson(handle));
   }
 
-  async #deleteResource(req: Request, workerName: string): Promise<Response> {
-    const dispatch = this.#activeDispatch(workerName);
+  async #deleteResource(
+    req: Request,
+    workerName: string,
+    dispatchId?: string,
+  ): Promise<Response> {
+    const dispatch = this.#activeDispatch(workerName, dispatchId);
     const body = await req.json() as { name?: string };
     if (!body.name) {
       return errorResponse(400, "Expected { name }");
@@ -364,8 +411,12 @@ export class DataPlane {
     return new Response(null, { status: 204 });
   }
 
-  async #openWriter(req: Request, workerName: string): Promise<Response> {
-    const dispatch = this.#activeDispatch(workerName);
+  async #openWriter(
+    req: Request,
+    workerName: string,
+    dispatchId?: string,
+  ): Promise<Response> {
+    const dispatch = this.#activeDispatch(workerName, dispatchId);
     const body = await req.json() as { specName?: string; name?: string };
     if (!body.specName || !body.name) {
       return errorResponse(400, "Expected { specName, name }");

--- a/src/serve/data_plane_test.ts
+++ b/src/serve/data_plane_test.ts
@@ -204,7 +204,9 @@ async function withHarness(
     const plane = new DataPlane({
       repoDir: tempDir,
       repoContext: { unifiedDataRepo: repo } as unknown as RepositoryContext,
-      sessions: { verify: (c) => (c === "good-credential" ? "w1" : null) },
+      sessions: {
+        verify: (c) => c === "good-credential" ? { workerId: "w1" } : null,
+      },
       dispatches,
       bundles,
       onFirstWrite: (d) => {

--- a/src/serve/dispatch_registry.ts
+++ b/src/serve/dispatch_registry.ts
@@ -18,12 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Registry of in-flight dispatches, keyed by worker name. The dispatcher
- * registers a dispatch before sending it and unregisters it when the result
- * (or failure) lands; the data plane consults it to authorize and shape a
- * worker's writes — a worker may only write through the declared output
- * specs of the model method it is currently leased to run (see
- * design/remote-execution.md, "Authenticating the data plane").
+ * Registry of in-flight dispatches, keyed by (worker name, dispatch id).
+ * A worker may have up to its capacity in concurrent active dispatches.
+ * The data plane and capability service consult this to authorize and
+ * scope a worker's operations to the correct dispatch.
  */
 
 import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
@@ -46,25 +44,37 @@ export interface ActiveDispatch {
 }
 
 export class DispatchRegistry {
-  readonly #byWorker = new Map<string, ActiveDispatch>();
+  readonly #byWorker = new Map<string, Map<string, ActiveDispatch>>();
 
   register(dispatch: ActiveDispatch): void {
-    if (this.#byWorker.has(dispatch.workerName)) {
-      throw new Error(
-        `Worker '${dispatch.workerName}' already has an active dispatch`,
-      );
+    let dispatches = this.#byWorker.get(dispatch.workerName);
+    if (!dispatches) {
+      dispatches = new Map();
+      this.#byWorker.set(dispatch.workerName, dispatches);
     }
-    this.#byWorker.set(dispatch.workerName, dispatch);
+    dispatches.set(dispatch.dispatchId, dispatch);
   }
 
   unregister(workerName: string, dispatchId: string): void {
-    const active = this.#byWorker.get(workerName);
-    if (active && active.dispatchId === dispatchId) {
-      this.#byWorker.delete(workerName);
+    const dispatches = this.#byWorker.get(workerName);
+    if (dispatches) {
+      dispatches.delete(dispatchId);
+      if (dispatches.size === 0) {
+        this.#byWorker.delete(workerName);
+      }
     }
   }
 
-  forWorker(workerName: string): ActiveDispatch | null {
-    return this.#byWorker.get(workerName) ?? null;
+  forDispatch(workerName: string, dispatchId: string): ActiveDispatch | null {
+    return this.#byWorker.get(workerName)?.get(dispatchId) ?? null;
+  }
+
+  forWorker(workerName: string): ActiveDispatch[] {
+    const dispatches = this.#byWorker.get(workerName);
+    return dispatches ? [...dispatches.values()] : [];
+  }
+
+  activeCount(workerName: string): number {
+    return this.#byWorker.get(workerName)?.size ?? 0;
   }
 }

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -135,8 +135,8 @@ export class DispatchService {
   readonly #captureEnvironment: () => Record<string, string>;
   #gateway: DispatchGateway | null = null;
   #onDispatchEnd: ((dispatchId: string) => void) | null = null;
-  /** Workers picked by a queued step but not yet marked busy. */
-  readonly #reserved = new Set<string>();
+  /** Per-worker reservation count for queued steps not yet dispatched. */
+  readonly #reserved = new Map<string, number>();
   /** Dispatches that performed at least one durable write. */
   readonly #writesByDispatch = new Set<string>();
   /** Steps waiting for the pool to change (a worker idled or expired). */
@@ -310,7 +310,12 @@ export class DispatchService {
           }
           throw error;
         } finally {
-          this.#reserved.delete(workerName);
+          const count = this.#reserved.get(workerName) ?? 0;
+          if (count <= 1) {
+            this.#reserved.delete(workerName);
+          } else {
+            this.#reserved.set(workerName, count - 1);
+          }
         }
       }
     } catch (error) {
@@ -482,7 +487,8 @@ export class DispatchService {
         this.#poolSnapshot(),
       );
       if (decision.kind === "dispatch") {
-        this.#reserved.add(decision.worker.name);
+        const current = this.#reserved.get(decision.worker.name) ?? 0;
+        this.#reserved.set(decision.worker.name, current + 1);
         return decision.worker.name;
       }
       onQueued?.();
@@ -502,13 +508,23 @@ export class DispatchService {
     }
   }
 
-  /** The live pool with steps' not-yet-busy reservations applied. */
+  /** The live pool with reservation counts overlaid onto active dispatch counts. */
   #poolSnapshot(): WorkerSnapshot[] {
-    return this.#gateway!.workers().map((worker) =>
-      this.#reserved.has(worker.name) && worker.status === "idle"
-        ? { ...worker, status: "busy" as const }
-        : worker
-    );
+    return this.#gateway!.workers().map((worker) => {
+      const reservations = this.#reserved.get(worker.name) ?? 0;
+      if (reservations === 0) return worker;
+      const virtualIds = [
+        ...worker.activeDispatchIds,
+        ...Array.from({ length: reservations }, (_, i) => `__reserved_${i}`),
+      ];
+      return {
+        ...worker,
+        activeDispatchIds: virtualIds,
+        status: virtualIds.length >= worker.capacity
+          ? "busy" as const
+          : worker.status,
+      };
+    });
   }
 
   #wakePoolWaiters(): void {

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -64,7 +64,8 @@ function snapshot(
     swampVersion: "1.0.0",
     status: "idle",
     connected: true,
-    dispatchId: null,
+    capacity: 1,
+    activeDispatchIds: [],
     ...overrides,
   };
 }
@@ -192,7 +193,7 @@ Deno.test("DispatchService: dispatches a step and completes its lease", async ()
     ["acquire", "complete"],
   );
   // The dispatch registry is empty again after completion.
-  assertEquals(h.dispatches.forWorker("w1"), null);
+  assertEquals(h.dispatches.forWorker("w1"), []);
 });
 
 Deno.test("DispatchService: extension bundles register by content fingerprint", async () => {
@@ -308,7 +309,14 @@ Deno.test("DispatchService: queues while eligible workers are busy", async () =>
 
 Deno.test("DispatchService: queue wait times out with a clear error", async () => {
   const h = createHarness({
-    workers: [snapshot({ name: "w1", status: "busy" })],
+    workers: [
+      snapshot({
+        name: "w1",
+        status: "busy",
+        activeDispatchIds: ["d-existing"],
+        capacity: 1,
+      }),
+    ],
     queueTimeoutMs: 50,
   });
   await assertRejects(
@@ -404,7 +412,14 @@ Deno.test("DispatchService: recordFirstWrite marks the lease exactly once", asyn
 
 Deno.test("DispatchService: abort during queue wait rejects", async () => {
   const h = createHarness({
-    workers: [snapshot({ name: "w1", status: "busy" })],
+    workers: [
+      snapshot({
+        name: "w1",
+        status: "busy",
+        activeDispatchIds: ["d-existing"],
+        capacity: 1,
+      }),
+    ],
   });
   const controller = new AbortController();
   const pending = h.service.executeRemote(

--- a/src/serve/worker_gateway.ts
+++ b/src/serve/worker_gateway.ts
@@ -114,7 +114,8 @@ export interface WorkerSnapshot {
   swampVersion: string;
   status: "idle" | "busy" | "unverified" | "draining";
   connected: boolean;
-  dispatchId: string | null;
+  capacity: number;
+  activeDispatchIds: string[];
   verifyFailureReason?: string;
 }
 
@@ -131,7 +132,8 @@ interface WorkerEntry {
   /** Force-closes the current control socket (absent for test transports). */
   closeSocket: (() => void) | null;
   status: "idle" | "busy" | "unverified" | "draining";
-  dispatchId: string | null;
+  capacity: number;
+  activeDispatchIds: string[];
   verifyFailureReason?: string;
   graceTimer?: ReturnType<typeof setTimeout>;
   /** Fires at the token's `expiresAt` to disconnect the worker. */
@@ -291,8 +293,8 @@ export class WorkerGateway {
     if (entry.channel === null) {
       throw new Error(`Worker '${name}' is disconnected`);
     }
-    if (entry.status === "busy") {
-      throw new Error(`Worker '${name}' is busy`);
+    if (entry.activeDispatchIds.length >= entry.capacity) {
+      throw new Error(`Worker '${name}' is at capacity`);
     }
     if (entry.status === "unverified" && !params.probeMarker) {
       throw new Error(`Worker '${name}' is unverified`);
@@ -312,28 +314,37 @@ export class WorkerGateway {
       },
     );
     const dispatchStart = performance.now();
+    entry.activeDispatchIds.push(params.dispatchId);
     entry.status = "busy";
-    entry.dispatchId = params.dispatchId;
     await this.#recordTransition(() =>
       this.#runModelMethod({
         typeArg: WORKER_MODEL_TYPE.normalized,
         definitionName: workerDefinitionName(name),
         methodName: "set_status",
-        inputs: { status: "busy", dispatchId: params.dispatchId },
+        inputs: {
+          status: "busy",
+          activeDispatchIds: [...entry.activeDispatchIds],
+        },
       })
     );
 
+    const dispatchCredential = this.#sessions.issueForDispatch(
+      name,
+      params.dispatchId,
+    );
+
     try {
+      const dispatchParams = {
+        ...params,
+        dispatchCredential: dispatchCredential.credential,
+      };
       const raw = await entry.channel.call(
         WorkerMethod.dispatch,
-        params,
+        dispatchParams,
         {
           timeoutMs: null,
           signal: options?.signal,
           onStream: options?.onEvent,
-          // A cancelled dispatch must stay pending until the worker's
-          // serial slot has actually freed — otherwise the next dispatch
-          // races the worker's busy guard.
           waitForPeerOnCancel: true,
         },
       );
@@ -349,32 +360,54 @@ export class WorkerGateway {
       );
       return result;
     } finally {
-      entry.dispatchId = null;
-      // Cast: TS narrows status to "busy" from the assignment above, but
-      // #handleDrain may have changed it to "draining" across the await.
+      entry.activeDispatchIds = entry.activeDispatchIds.filter(
+        (id) => id !== params.dispatchId,
+      );
+      this.#sessions.revokeDispatch(name, params.dispatchId);
       const currentStatus = entry.status as string;
       if (entry.channel === null || entry.channel.closed) {
-        // The socket dropped mid-dispatch. The in-memory status returns to
-        // idle so a reconnect within the grace window is schedulable again;
-        // the durable record already says "disconnected".
-        if (currentStatus !== "draining") {
+        if (
+          currentStatus !== "draining" && entry.activeDispatchIds.length === 0
+        ) {
           entry.status = "idle";
         }
       } else if (currentStatus !== "draining") {
-        entry.status = "idle";
-        await this.#recordTransition(() =>
-          this.#runModelMethod({
-            typeArg: WORKER_MODEL_TYPE.normalized,
-            definitionName: workerDefinitionName(name),
-            methodName: "set_status",
-            inputs: { status: "idle" },
-          })
-        ).catch((error: unknown) => {
-          logger.warn("Failed to record idle status for {worker}: {error}", {
-            worker: name,
-            error: error instanceof Error ? error.message : String(error),
+        if (entry.activeDispatchIds.length === 0) {
+          entry.status = "idle";
+          await this.#recordTransition(() =>
+            this.#runModelMethod({
+              typeArg: WORKER_MODEL_TYPE.normalized,
+              definitionName: workerDefinitionName(name),
+              methodName: "set_status",
+              inputs: { status: "idle" },
+            })
+          ).catch((error: unknown) => {
+            logger.warn("Failed to record idle status for {worker}: {error}", {
+              worker: name,
+              error: error instanceof Error ? error.message : String(error),
+            });
           });
-        });
+        } else {
+          await this.#recordTransition(() =>
+            this.#runModelMethod({
+              typeArg: WORKER_MODEL_TYPE.normalized,
+              definitionName: workerDefinitionName(name),
+              methodName: "set_status",
+              inputs: {
+                status: "busy",
+                activeDispatchIds: [...entry.activeDispatchIds],
+              },
+            })
+          ).catch((error: unknown) => {
+            logger.warn(
+              "Failed to record dispatch-end status for {worker}: {error}",
+              {
+                worker: name,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          });
+        }
         this.#options.onWorkerIdle?.(this.#snapshot(entry));
       }
     }
@@ -468,14 +501,20 @@ export class WorkerGateway {
         }
       }
 
+      const capacity = (params.resourceLimits?.capacity as number) ?? 1;
+
       if (reconnecting) {
         existing.channel = state.channel;
+        existing.capacity = capacity;
         await this.#runModelMethod({
           typeArg: WORKER_MODEL_TYPE.normalized,
           definitionName: workerDefinitionName(workerName),
           methodName: "set_status",
-          inputs: existing.status === "busy"
-            ? { status: "busy", dispatchId: existing.dispatchId ?? undefined }
+          inputs: existing.activeDispatchIds.length > 0
+            ? {
+              status: "busy",
+              activeDispatchIds: [...existing.activeDispatchIds],
+            }
             : { status: "idle" },
         });
       } else {
@@ -492,6 +531,7 @@ export class WorkerGateway {
             arch: params.arch,
             swampVersion: params.swampVersion,
             protocolVersion: params.protocolVersion,
+            capacity,
           },
         });
       }
@@ -513,7 +553,8 @@ export class WorkerGateway {
         channel: state.channel,
         closeSocket: state.closeSocket,
         status: initialStatus,
-        dispatchId: null,
+        capacity,
+        activeDispatchIds: [],
       };
       if (reconnecting && this.#options.verifyOnEnroll) {
         entry.status = "unverified";
@@ -639,7 +680,7 @@ export class WorkerGateway {
         entry.expiryTimer = undefined;
       }
       this.#workers.delete(name);
-      this.#sessions.revokeForWorker(name);
+      this.#sessions.revokeAllForWorker(name);
       logger.info("Draining worker {worker} disconnected — removed from pool", {
         worker: name,
       });
@@ -654,7 +695,7 @@ export class WorkerGateway {
         entry.expiryTimer = undefined;
       }
       this.#workers.delete(name);
-      this.#sessions.revokeForWorker(name);
+      this.#sessions.revokeAllForWorker(name);
       logger.info("Reconnection grace window expired for {worker}", {
         worker: name,
       });
@@ -808,7 +849,8 @@ export class WorkerGateway {
       swampVersion: entry.swampVersion,
       status: entry.status,
       connected: entry.channel !== null,
-      dispatchId: entry.dispatchId,
+      capacity: entry.capacity,
+      activeDispatchIds: [...entry.activeDispatchIds],
       verifyFailureReason: entry.verifyFailureReason,
     };
   }

--- a/src/serve/worker_gateway_test.ts
+++ b/src/serve/worker_gateway_test.ts
@@ -143,7 +143,7 @@ Deno.test("WorkerGateway: enrollment redeems the token, records the worker, issu
   assertEquals(result.protocolVersion, REMOTE_PROTOCOL_VERSION);
   assertEquals(typeof result.sessionCredential, "string");
   assertEquals(
-    h.gateway.sessions.verify(result.sessionCredential),
+    h.gateway.sessions.verify(result.sessionCredential)?.workerId,
     "ci-runner-3",
   );
 
@@ -214,7 +214,7 @@ Deno.test("WorkerGateway: session refresh issues a fresh sliding credential", as
     { sessionCredential: string; sessionExpiresAtMs: number }
   >(RemoteMethod.sessionRefresh, {});
   assertEquals(
-    h.gateway.sessions.verify(refreshed.sessionCredential),
+    h.gateway.sessions.verify(refreshed.sessionCredential)?.workerId,
     "ci-runner-3",
   );
   assertEquals(h.gateway.sessions.verify(first.sessionCredential), null);
@@ -287,7 +287,7 @@ Deno.test("WorkerGateway: dispatch to a busy worker rejects", async () => {
   await assertRejects(
     () => h.gateway.dispatch("ci-runner-3", dispatchParams("d-2")),
     Error,
-    "busy",
+    "at capacity",
   );
   gate.resolve();
   await first;

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -97,6 +97,8 @@ export interface RunWorkerOptions {
   maxDispatches?: number;
   /** Drain and exit 0 after being continuously idle for this many ms. */
   idleTimeoutMs?: number;
+  /** Number of concurrent dispatch slots (default 1). */
+  concurrency?: number;
   /**
    * Called once during setup with a function that triggers drain from
    * outside (e.g. signal handler). The caller can store this and invoke
@@ -130,8 +132,10 @@ export async function runWorker(
     await Deno.makeTempDir({ prefix: "swamp-worker-cache-" });
   const machineId = await loadOrCreateMachineId(cacheDir);
 
+  const concurrency = options.concurrency ?? 1;
   let drainReason: WorkerExitReason | null = null;
   let dispatchCount = 0;
+  let activeDispatches = 0;
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
   let currentDrainHandle: DispatchHandlerHandle | null = null;
   let currentChannel: RpcChannel | null = null;
@@ -198,6 +202,7 @@ export async function runWorker(
         session,
         dataPlaneUrl,
         cacheDirPath: join(cacheDir, "bundles"),
+        concurrency,
         onDispatchHandlerRegistered: (handle, channel, close) => {
           currentDrainHandle = handle;
           currentChannel = channel;
@@ -209,16 +214,18 @@ export async function runWorker(
           startIdleTimer();
         },
         onDispatchStarted: () => {
+          activeDispatches++;
           clearIdleTimer();
         },
         onDispatchFinished: () => {
+          activeDispatches--;
           dispatchCount++;
           if (
             options.maxDispatches !== undefined &&
             dispatchCount >= options.maxDispatches
           ) {
             triggerDrain("max-dispatches");
-          } else {
+          } else if (activeDispatches === 0) {
             startIdleTimer();
           }
         },
@@ -309,6 +316,7 @@ interface ConnectOnceArgs {
   session: SessionState;
   dataPlaneUrl: string;
   cacheDirPath: string;
+  concurrency: number;
   onDispatchHandlerRegistered: (
     handle: DispatchHandlerHandle,
     channel: RpcChannel,
@@ -387,6 +395,7 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
         platform: Deno.build.os,
         arch: Deno.build.arch,
         labels: options.labels ?? {},
+        resourceLimits: { capacity: args.concurrency },
       }).then((result) => {
         enrolled = true;
         session.credential = result.sessionCredential;
@@ -396,6 +405,7 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
           sessionCredential: () => session.credential,
           dataPlaneUrl: args.dataPlaneUrl,
           cacheDirPath: args.cacheDirPath,
+          capacity: args.concurrency,
           runnerCommand: options.runnerCommand,
           onDispatch: (event) => {
             if (event.kind === "dispatch_started") {

--- a/src/worker/dispatch_handler.ts
+++ b/src/worker/dispatch_handler.ts
@@ -26,8 +26,9 @@
  * capability RPCs between the child and the orchestrator over a
  * StdioTransport. A runner crash fails only that dispatch, not the worker.
  *
- * Dispatches execute SERIALLY — capacity 1, same as before. Phase 4b adds
- * concurrency slots on top.
+ * Each dispatch spawns one runner. The handler accepts up to `capacity`
+ * concurrent dispatches, rejecting with `worker_busy` when all slots are full.
+ * Capacity 1 is byte-for-byte identical to the prior serial behavior.
  */
 
 import { overlayEnvironment } from "../domain/remote/environment_snapshot.ts";
@@ -81,6 +82,8 @@ export interface DispatchHandlerOptions {
   dataPlaneUrl: string;
   /** Path to the shared bundle cache directory. */
   cacheDirPath: string;
+  /** Maximum concurrent dispatches (default 1). */
+  capacity: number;
   /** Receives dispatch start/finish notifications (connect-mode output). */
   onDispatch?: (event: WorkerDispatchEvent) => void;
   /** Override the runner command + args (test seam). */
@@ -96,7 +99,8 @@ export interface DispatchHandlerHandle {
 export function registerDispatchHandler(
   options: DispatchHandlerOptions,
 ): DispatchHandlerHandle {
-  let busy = false;
+  let activeRunners = 0;
+  const capacity = options.capacity;
   let draining = false;
   let onDrainComplete: (() => void) | null = null;
 
@@ -107,19 +111,19 @@ export function registerDispatchHandler(
         message: "Worker is draining — no new dispatches accepted",
       });
     }
-    if (busy) {
+    if (activeRunners >= capacity) {
       throw new RpcError({
         code: "worker_busy",
         message:
-          "Worker is already executing a dispatch (v1 dispatches are serial)",
+          `Worker is at capacity (${activeRunners}/${capacity} slots in use)`,
       });
     }
-    busy = true;
+    activeRunners++;
     try {
       return await handleDispatch(rawParams, ctx, options);
     } finally {
-      busy = false;
-      if (draining && onDrainComplete) {
+      activeRunners--;
+      if (draining && activeRunners === 0 && onDrainComplete) {
         onDrainComplete();
       }
     }
@@ -128,7 +132,7 @@ export function registerDispatchHandler(
   return {
     drain: () => {
       draining = true;
-      if (!busy) return Promise.resolve();
+      if (activeRunners === 0) return Promise.resolve();
       return new Promise<void>((resolve) => {
         onDrainComplete = resolve;
       });
@@ -176,8 +180,12 @@ async function handleDispatch(
     spawnEnv = overlayEnvironment(spawnEnv, traceSnapshot);
   }
 
+  const rawParams2 = rawParams as Record<string, unknown>;
+  const dispatchCredential = rawParams2.dispatchCredential as
+    | string
+    | undefined;
   const bootstrapParams: RunnerBootstrapParams = {
-    sessionCredential: options.sessionCredential(),
+    sessionCredential: dispatchCredential ?? options.sessionCredential(),
     dataPlaneUrl: options.dataPlaneUrl,
     cacheDirPath: options.cacheDirPath,
     dispatch: params,
@@ -200,6 +208,7 @@ async function handleDispatch(
   bridgeCapabilityVerbs({
     childChannel,
     orchestratorChannel: options.channel,
+    dispatchId: params.dispatchId,
     signal: cancelController.signal,
   });
 

--- a/src/worker/dispatch_handler_test.ts
+++ b/src/worker/dispatch_handler_test.ts
@@ -99,6 +99,7 @@ Deno.test("registerDispatchHandler: draining rejects with worker_draining", asyn
     sessionCredential: () => "test-cred",
     dataPlaneUrl: "http://localhost:0",
     cacheDirPath: "/tmp/test-cache",
+    capacity: 1,
   });
 
   await handle.drain();
@@ -123,6 +124,7 @@ Deno.test("registerDispatchHandler: drain() resolves immediately when idle", asy
     sessionCredential: () => "test-cred",
     dataPlaneUrl: "http://localhost:0",
     cacheDirPath: "/tmp/test-cache",
+    capacity: 1,
   });
 
   await handle.drain();

--- a/src/worker/runner_bridge.ts
+++ b/src/worker/runner_bridge.ts
@@ -49,6 +49,8 @@ export interface RunnerBridgeOptions {
   childChannel: RpcChannel;
   /** RPC channel to the orchestrator (over WebSocket). */
   orchestratorChannel: RpcChannel;
+  /** Dispatch ID injected into every bridged call for dispatch-scoped auth. */
+  dispatchId: string;
   /** Signal to abort all bridged calls (e.g. dispatch cancelled). */
   signal: AbortSignal;
   /** Receives stream events from the child to forward to the orchestrator. */
@@ -64,7 +66,7 @@ export interface RunnerBridgeOptions {
 export function bridgeCapabilityVerbs(
   options: RunnerBridgeOptions,
 ): void {
-  const { childChannel, orchestratorChannel, signal } = options;
+  const { childChannel, orchestratorChannel, dispatchId, signal } = options;
 
   for (const verb of BRIDGED_VERBS) {
     childChannel.register(
@@ -72,7 +74,8 @@ export function bridgeCapabilityVerbs(
       async (params: unknown, ctx: RpcHandlerContext) => {
         logger.debug("Bridging {verb} from runner to orchestrator", { verb });
         const combinedSignal = AbortSignal.any([signal, ctx.signal]);
-        return await orchestratorChannel.call(verb, params, {
+        const wrapped = { ...(params as Record<string, unknown>), dispatchId };
+        return await orchestratorChannel.call(verb, wrapped, {
           signal: combinedSignal,
           timeoutMs: null,
           onStream: options.onChildStream

--- a/src/worker/runner_bridge_test.ts
+++ b/src/worker/runner_bridge_test.ts
@@ -44,6 +44,7 @@ Deno.test("bridgeCapabilityVerbs: forwards getData from runner to orchestrator",
   bridgeCapabilityVerbs({
     childChannel: runnerPair.b,
     orchestratorChannel: orchPair.a,
+    dispatchId: "test-dispatch",
     signal: AbortSignal.timeout(5_000),
   });
 
@@ -57,6 +58,7 @@ Deno.test("bridgeCapabilityVerbs: forwards getData from runner to orchestrator",
     modelType: "test",
     modelId: "m1",
     dataName: "out",
+    dispatchId: "test-dispatch",
   });
 });
 
@@ -75,6 +77,7 @@ Deno.test("bridgeCapabilityVerbs: forwards all 9 capability verbs", async () => 
   bridgeCapabilityVerbs({
     childChannel: runnerPair.b,
     orchestratorChannel: orchPair.a,
+    dispatchId: "test-dispatch",
     signal: AbortSignal.timeout(5_000),
   });
 
@@ -97,6 +100,7 @@ Deno.test("bridgeCapabilityVerbs: propagates orchestrator errors to runner", asy
   bridgeCapabilityVerbs({
     childChannel: runnerPair.b,
     orchestratorChannel: orchPair.a,
+    dispatchId: "test-dispatch",
     signal: AbortSignal.timeout(5_000),
   });
 
@@ -129,6 +133,7 @@ Deno.test("bridgeCapabilityVerbs: cancel signal aborts bridged call", async () =
   bridgeCapabilityVerbs({
     childChannel: runnerPair.b,
     orchestratorChannel: orchPair.a,
+    dispatchId: "test-dispatch",
     signal: controller.signal,
   });
 

--- a/src/worker/runner_protocol.ts
+++ b/src/worker/runner_protocol.ts
@@ -25,11 +25,9 @@ import { DispatchParamsSchema } from "../domain/remote/protocol.ts";
  * dispatch runner. The runner reads this to set up its data-plane client,
  * bundle cache, and RPC channel before executing the dispatch.
  *
- * The session credential is a static snapshot taken at spawn time. At
- * capacity 1 (phase 4a) this is safe — dispatches are serial and the
- * credential TTL exceeds any single dispatch duration. Phase 4b must add
- * a credential refresh forwarding mechanism for concurrent long-running
- * dispatches.
+ * Each runner receives a per-dispatch credential that is independent of
+ * the control-channel credential. Session refreshes on the control
+ * channel do not invalidate dispatch credentials.
  */
 export const RunnerBootstrapParamsSchema = z.object({
   /** Bearer credential for the HTTP data plane (static at spawn time). */


### PR DESCRIPTION
## Summary

- Add `--concurrency N` flag to `worker connect` (integer ≥ 1, or `"auto"` for CPU count; env `SWAMP_WORKER_CONCURRENCY`)
- Bump `REMOTE_PROTOCOL_VERSION` 3→4; worker advertises capacity via `resourceLimits.capacity` at enrollment
- Replace the binary `busy` boolean in the dispatch handler with an `activeRunners` counter against `capacity`
- `DispatchRegistry` now tracks N active dispatches per worker: `Map<workerName, Map<dispatchId, ActiveDispatch>>`
- Per-dispatch credentials via `SessionCredentialService.issueForDispatch(workerId, dispatchId)` — session refreshes on the control channel do not invalidate in-flight runner credentials; the data plane uses the credential's `dispatchId` for dispatch-scoped authorization
- Capability bridge injects `dispatchId` into every bridged RPC verb so `CapabilityService` resolves the correct dispatch for model-type scope isolation
- Scheduler uses slot-aware eligibility (`activeDispatchIds.length < capacity`) with least-loaded tiebreak (most free slots first, then name for determinism)
- Dispatch service reservation mechanism: `Set<string>` → `Map<string, number>` (per-worker reservation count)
- Worker model schema: `capacity` + `activeDispatchIds` replace `currentDispatchId`; model version bump
- Idle timeout starts only when all slots are empty; drain waits for all active runners
- `swamp worker list` shows a `SLOTS` column (e.g. `2/8`)
- Design doc updated with phase 4b semantics

Capacity 1 (the default) is byte-for-byte identical to pre-4b behavior.

## Test Plan

- 4 new scheduler tests: least-loaded tiebreak, equal-free-slots name tiebreak, at-capacity exclusion, multi-capacity dispatch
- All existing tests updated for new type shapes (28 files, 8361 tests pass)
- `deno check`, `deno lint`, `deno fmt`, `deno run test`, `deno run compile` all pass

Closes #989