### PR TITLE
fix(data): resolve model names in dataRepository methods

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -332,9 +332,10 @@ Users can bypass checks at runtime using CLI flags on `model method run`:
 1. **Value/policy validation** — inspect `context.globalArgs` for invalid or
    disallowed values. No I/O. Always fast.
 
-2. **Cross-model validation** — use `context.dataRepository` to read stored
-   state from another model instance and verify a dependency exists or is in
-   the right state.
+2. **Cross-model validation** — use `context.readModelData(modelName)` to read
+   stored state from another model instance by name and verify a dependency
+   exists or is in the right state. Note: `context.dataRepository` methods
+   (`findAllForModel`, `getContent`) require a UUID, not a model name.
 
 3. **Live API checks** — call an external API to verify quota, existence, or
    reachability. Label these `live` so users can skip them in offline

--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -308,6 +308,7 @@ export function createModelTestContext(
     writeResource,
     readResource,
     createFileWriter,
+    readModelData: () => Promise.resolve([]),
     createCelEnvironment: createExtensionCelEnvironment,
     onEvent,
   };

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -138,6 +138,38 @@ export interface MethodExecutionEvent {
 }
 
 /**
+ * Record returned by cross-model data reads.
+ * Represents a single version of a named data item with parsed content.
+ */
+export interface DataRecord {
+  id: string;
+  name: string;
+  version: number;
+  isLatest: boolean;
+  createdAt: string;
+  namespace: string;
+  attributes: Record<string, unknown>;
+  tags: Record<string, string>;
+  modelName: string;
+  modelId: string;
+  modelType: string;
+  specName: string;
+  dataType: string;
+  contentType: string;
+  lifetime: string;
+  ownerType: string;
+  streaming: boolean;
+  size: number;
+  content: string;
+  ownerRef: string;
+  workflowRunId: string;
+  workflowName: string;
+  jobName: string;
+  stepName: string;
+  source: string;
+}
+
+/**
  * The context object passed to extension model `execute` functions.
  *
  * This is the extension-author-facing subset of swamp's internal MethodContext.
@@ -180,6 +212,16 @@ export interface MethodContext<TGlobalArgs = Record<string, unknown>> {
   ) => Promise<Record<string, unknown> | null>;
   /** Create a file writer for binary/streaming content. */
   createFileWriter: (specName: string, name: string) => DataWriter;
+  /**
+   * Read data from another model by name.
+   * Resolves the model name, reads all data items, parses JSON content,
+   * and resolves vault references. Optionally filter by spec name.
+   * Returns an empty array if the model doesn't exist or has no data.
+   */
+  readModelData: (
+    modelName: string,
+    specName?: string,
+  ) => Promise<DataRecord[]>;
   /**
    * Build a fresh, isolated cel-js `Environment` seeded with swamp's
    * baseline arithmetic-overload registrations. Use this to evaluate

--- a/src/domain/models/method_context.ts
+++ b/src/domain/models/method_context.ts
@@ -23,6 +23,10 @@
 
 import type { MethodContext } from "./model.ts";
 import { resolveExtensionFile } from "../extensions/extension_file_resolver.ts";
+import { isUuid } from "./model_lookup.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+import type { ModelTypeInput } from "./model_type.ts";
 
 /**
  * Startup-scoped dependencies shared across every method invocation in a
@@ -110,7 +114,10 @@ export function buildMethodContext(
     definition: invocation.definition,
     methodName: invocation.methodName,
     logger: invocation.logger,
-    dataRepository: common.dataRepository,
+    dataRepository: withNameResolution(
+      common.dataRepository,
+      common.definitionRepository,
+    ),
     definitionRepository: common.definitionRepository,
     outputRepository: common.outputRepository,
     vaultService: common.vaultService,
@@ -135,4 +142,39 @@ export function buildMethodContext(
     extensionFile: (relPath: string) => resolveExtensionFile(root, relPath),
     createCelEnvironment: common.createCelEnvironment,
   };
+}
+
+async function resolveModelId(
+  definitionRepo: DefinitionRepository,
+  modelId: string,
+): Promise<string> {
+  if (isUuid(modelId)) return modelId;
+  const result = await definitionRepo.findByNameGlobal(modelId);
+  if (result) return result.definition.id;
+  return modelId;
+}
+
+function withNameResolution(
+  repo: UnifiedDataRepository,
+  definitionRepo: DefinitionRepository,
+): UnifiedDataRepository {
+  return Object.create(repo, {
+    findAllForModel: {
+      value: async (type: ModelTypeInput, modelId: string) => {
+        const resolved = await resolveModelId(definitionRepo, modelId);
+        return repo.findAllForModel(type, resolved);
+      },
+    },
+    getContent: {
+      value: async (
+        type: ModelTypeInput,
+        modelId: string,
+        dataName: string,
+        version?: number,
+      ) => {
+        const resolved = await resolveModelId(definitionRepo, modelId);
+        return repo.getContent(type, resolved, dataName, version);
+      },
+    },
+  });
 }

--- a/src/domain/models/method_context_test.ts
+++ b/src/domain/models/method_context_test.ts
@@ -81,7 +81,9 @@ Deno.test("buildMethodContext: passes through required common deps", () => {
     makeInvocation(),
   );
 
-  assertStrictEquals(ctx.dataRepository, dataRepository);
+  // dataRepository is wrapped with name resolution — verify the wrapper
+  // delegates to the original via prototype chain
+  assertEquals(Object.getPrototypeOf(ctx.dataRepository), dataRepository);
   assertStrictEquals(ctx.definitionRepository, definitionRepository);
 });
 

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -39,10 +39,13 @@ import type {
 
 import type {
   DataHandle as TestingDataHandle,
+  DataRecord as TestingDataRecord,
   DataWriter as TestingDataWriter,
   MethodContext as TestingMethodContext,
   MethodResult as TestingMethodResult,
 } from "../../../packages/testing/types.ts";
+
+import type { DataRecord as CanonicalDataRecord } from "../data/data_record.ts";
 
 import type {
   MethodDefinition as TestingMethodDefinition,
@@ -87,8 +90,73 @@ function _checkContextFields(ctx: TestingMethodContext) {
   const _defVersion: number = ctx.definition.version;
   const _defTags: Record<string, string> = ctx.definition.tags;
 
+  // readModelData return type uses the testing DataRecord
+  const _readModelData: (
+    modelName: string,
+    specName?: string,
+  ) => Promise<TestingDataRecord[]> = ctx.readModelData;
+
   void [_signal, _repoDir, _globalArgs, _methodName, _createCelEnvironment];
-  void [_defName, _defId, _defVersion, _defTags];
+  void [_defName, _defId, _defVersion, _defTags, _readModelData];
+}
+
+// DataRecord: verify every testing field has a compatible canonical field type.
+function _checkDataRecordFields(record: TestingDataRecord) {
+  const _id: CanonicalDataRecord["id"] = record.id;
+  const _name: CanonicalDataRecord["name"] = record.name;
+  const _version: CanonicalDataRecord["version"] = record.version;
+  const _isLatest: CanonicalDataRecord["isLatest"] = record.isLatest;
+  const _createdAt: CanonicalDataRecord["createdAt"] = record.createdAt;
+  const _namespace: CanonicalDataRecord["namespace"] = record.namespace;
+  const _attributes: CanonicalDataRecord["attributes"] = record.attributes;
+  const _tags: CanonicalDataRecord["tags"] = record.tags;
+  const _modelName: CanonicalDataRecord["modelName"] = record.modelName;
+  const _modelId: CanonicalDataRecord["modelId"] = record.modelId;
+  const _modelType: CanonicalDataRecord["modelType"] = record.modelType;
+  const _specName: CanonicalDataRecord["specName"] = record.specName;
+  const _dataType: CanonicalDataRecord["dataType"] = record.dataType;
+  const _contentType: CanonicalDataRecord["contentType"] = record.contentType;
+  const _lifetime: CanonicalDataRecord["lifetime"] = record.lifetime;
+  const _ownerType: CanonicalDataRecord["ownerType"] = record.ownerType;
+  const _streaming: CanonicalDataRecord["streaming"] = record.streaming;
+  const _size: CanonicalDataRecord["size"] = record.size;
+  const _content: CanonicalDataRecord["content"] = record.content;
+  const _ownerRef: CanonicalDataRecord["ownerRef"] = record.ownerRef;
+  const _workflowRunId: CanonicalDataRecord["workflowRunId"] =
+    record.workflowRunId;
+  const _workflowName: CanonicalDataRecord["workflowName"] =
+    record.workflowName;
+  const _jobName: CanonicalDataRecord["jobName"] = record.jobName;
+  const _stepName: CanonicalDataRecord["stepName"] = record.stepName;
+  const _source: CanonicalDataRecord["source"] = record.source;
+
+  void [
+    _id,
+    _name,
+    _version,
+    _isLatest,
+    _createdAt,
+    _namespace,
+    _attributes,
+    _tags,
+    _modelName,
+    _modelId,
+    _modelType,
+    _specName,
+    _dataType,
+    _contentType,
+    _lifetime,
+    _ownerType,
+    _streaming,
+    _size,
+    _content,
+    _ownerRef,
+    _workflowRunId,
+    _workflowName,
+    _jobName,
+    _stepName,
+    _source,
+  ];
 }
 
 // DataHandle: verify field-by-field.
@@ -218,6 +286,7 @@ Deno.test("testing package types: compile-time compatibility check", () => {
   void [
     _checkContextFields,
     _checkDataHandleFields,
+    _checkDataRecordFields,
     _checkDataWriterFields,
     _checkMethodResultFields,
     _checkMethodDefinitionFields,

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -37,6 +37,7 @@ import {
   ModelType,
   type ModelTypeInput,
 } from "../../domain/models/model_type.ts";
+import { isUuid } from "../../domain/models/model_lookup.ts";
 import type {
   HydrateFileHook,
   MarkDirtyHook,
@@ -522,6 +523,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     type: ModelTypeInput,
     modelId: string,
   ): Promise<Data[]> {
+    if (!isUuid(modelId)) {
+      logger
+        .warn`findAllForModel called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
+    }
     type = coerceModelType(type);
     const dataDir = this.getModelDataDir(type, modelId);
     const results: Data[] = [];
@@ -724,6 +729,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     dataName: string,
     version?: number,
   ): Promise<Uint8Array | null> {
+    if (!isUuid(modelId)) {
+      logger
+        .warn`getContent called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
+    }
     type = coerceModelType(type);
     const versionToRead = version ??
       await this.getLatestVersion(type, modelId, dataName);

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -94,6 +94,50 @@ Deno.test("listVersions rejects dataName with path traversal", async () => {
   );
 });
 
+Deno.test("findAllForModel: warns and returns empty for model name instead of UUID", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    const result = await repo.findAllForModel(testType, "my-model-name");
+    assertEquals(result, []);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("getContent: warns and returns null for model name instead of UUID", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+    const result = await repo.getContent(
+      testType,
+      "my-model-name",
+      "some-data",
+    );
+    assertEquals(result, null);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
 const owner = {
   ownerType: "model-method" as const,
   ownerRef: "test/model:test-method",


### PR DESCRIPTION
## Summary

Fixes swamp-club#987.

- Wrap `dataRepository` in `buildMethodContext` with name resolution — `findAllForModel` and `getContent` now resolve model names to UUIDs via `DefinitionRepository.findByNameGlobal()` before delegating, matching the CLI (`swamp data get`) and CEL (`data.latest()`) behavior
- Add warning log in `FileSystemUnifiedDataRepository` when a non-UUID `modelId` is passed (safety net for direct repository usage outside method context)
- Surface `readModelData` and `DataRecord` in the extension-facing `MethodContext` type (`packages/testing/types.ts`) so extension authors discover the higher-level API via autocomplete
- Update `design/models.md` cross-model validation pattern to recommend `readModelData()` over raw `dataRepository`

## Test Plan

- [x] Reproduced the bug in a scratch repo: `findAllForModel('@repro/writer', 'my-writer')` returned 0 entries
- [x] Verified the fix: same call now returns 3 entries after name resolution
- [x] Warning log fires for direct repository usage with a model name
- [x] Write path (save, findByName, getPath) works through the wrapper
- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` passes (8358 passed, 0 new failures)
- [x] `deno run compile` succeeds
- [x] Structural compatibility test verifies `DataRecord` and `readModelData` match canonical types

🤖 Generated with [Claude Code](https://claude.com/claude-code)