### PR TITLE
fix(serve): correct stale comment referencing non-existent context.putSecret API

### DIFF
--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -318,7 +318,7 @@ export class CapabilityService {
     params: PutSecretParams,
   ): Promise<{ ok: boolean }> {
     // Secrets are not model-type-scoped: any method may write to any vault
-    // key via the context.putSecret API, so we verify only that the worker
+    // key via context.vaultService.put, so we verify only that the worker
     // has an active dispatch (not that the vault key relates to the
     // dispatched model type). deleteData uses the stricter
     // #assertDispatchScope because data artifacts are model-type-addressed.


### PR DESCRIPTION
## Summary

- Fixes a stale comment in `src/serve/capability_service.ts` that referenced a non-existent `context.putSecret` API. The actual vault-write path is `context.vaultService.put`. Updated the comment to match the real API surface.

Fixes swamp-club#984

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes  
- [x] `deno run test` passes (8357 tests, 0 failures)
- [x] Comment-only change — no behavioral impact