### PR TITLE
fix(remote): add --concurrency usage example to worker connect

### DIFF
--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -86,6 +86,10 @@ export const workerConnectCommand = new Command()
     "Auto-shutdown after 5 minutes of inactivity",
     "swamp worker connect wss://orch:4000 --token <token> --idle-timeout 5m",
   )
+  .example(
+    "Run up to one dispatch per CPU core",
+    "swamp worker connect wss://orch:4000 --token <token> --concurrency auto",
+  )
   .arguments("[url:string]")
   .option(
     "--token <token:string>",


### PR DESCRIPTION
## Summary

- Add `.example()` entry for `--concurrency auto` on `worker connect`, matching the pattern of `--max-dispatches` and `--idle-timeout`

## Test Plan

- Formatting and type check pass
- No behavioral change — CLI help text only