### PR TITLE
feat(serve): raise default queue timeout to 10 minutes

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -505,7 +505,7 @@ export const serveCommand = new Command()
   .option(
     "--queue-timeout <duration:string>",
     "How long a placed step queues for a matching worker before timing out (env: SWAMP_QUEUE_TIMEOUT). " +
-      "Accepts seconds (60), explicit units (2m, 10m), or 0 to disable. Default: 60s",
+      "Accepts seconds (60), explicit units (2m, 10m), or 0 to disable. Default: 10m",
   )
   .option(
     "--verify-on-enroll",

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -80,7 +80,7 @@ const logger = getSwampLogger(["serve", "dispatch"]);
 export const BUILTIN_BUNDLE_PREFIX = "builtin:";
 
 /** Default ceiling on how long a step queues for a matching worker. */
-export const DEFAULT_QUEUE_TIMEOUT_MS = 60 * 1000;
+export const DEFAULT_QUEUE_TIMEOUT_MS = 600 * 1000;
 
 /**
  * Cap on a single #waitForPoolChange call when the deadline is null


### PR DESCRIPTION
## Summary

- Raise `DEFAULT_QUEUE_TIMEOUT_MS` from 60s to 10 minutes in `dispatch_service.ts` to match realistic cold-start times for autoscaled fleets (ASG scale-up, k8s scale-from-zero)
- Update `--queue-timeout` help text default display from `60s` to `10m` in `serve.ts`

Worker fleets phase 6: now that fleets, lifecycle, verification, and capacity slots are all in place, the conservative 60-second default is no longer needed.

Closes #992

## Test Plan

- All 17 `dispatch_service_test.ts` tests pass — they use explicit `queueTimeoutMs` overrides, not the default constant
- `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass
- `--queue-timeout <value>` and per-step `queueTimeout` overrides are unaffected