### PR TITLE
fix(cli): recognize scoped identifiers in --input values

### DIFF
--- a/design/inputs.md
+++ b/design/inputs.md
@@ -208,6 +208,33 @@ parsed value is used. If parsing fails or the result is a different JSON type
 (e.g. `null`, a number), the value remains as a string and downstream
 validation reports the mismatch.
 
+### File references via `@`
+
+Values starting with `@` are read as file paths:
+
+```sh
+swamp model method run my-model deploy --input cert=@/path/to/cert.pem
+swamp model method run my-model deploy --input token=@~/secrets/token.txt
+```
+
+To pass a literal `@`, escape it with `\`:
+
+```sh
+swamp model method run my-model search --input email=\@user
+```
+
+**Scoped identifiers** (`@namespace/name`) are recognized and passed through
+literally — they are not treated as file paths. This covers swamp type
+identifiers like `@hivemq/base-images` or `@swamp/aws/ec2/vpc`. The heuristic:
+if the value after `@` starts with a letter, contains at least one `/`, and has
+no `.` characters, it is a scoped identifier. File paths with extensions (e.g.
+`@path/to/file.txt`) are still read as files.
+
+```sh
+# Passes @hivemq/base-images as the literal value (not a file path)
+swamp model method run my-model check --input sourceType=@hivemq/base-images
+```
+
 ### JSON-typed values via `:json` suffix
 
 Append `:json` to the leaf segment of a key to parse the value as JSON

--- a/src/cli/input_parser.ts
+++ b/src/cli/input_parser.ts
@@ -77,6 +77,22 @@ export function setNestedValue(
   current[parts[parts.length - 1]] = value;
 }
 
+// Scoped identifier: @namespace/name with optional sub-segments.
+// Segments are alphanumeric + hyphens/underscores; no dots (which
+// would indicate a file extension). Distinguishes @hivemq/base-images
+// from @path/to/file.txt.
+const SCOPED_IDENTIFIER_RE =
+  /^@[a-zA-Z][a-zA-Z0-9_-]*\/[a-zA-Z0-9][a-zA-Z0-9_\/-]*$/;
+
+/**
+ * Returns true when the value looks like a scoped identifier
+ * (e.g. `@hivemq/base-images`, `@swamp/aws/ec2/vpc`) rather than
+ * a file path.
+ */
+export function isScopedIdentifier(value: string): boolean {
+  return SCOPED_IDENTIFIER_RE.test(value);
+}
+
 /**
  * Resolves a file reference value (prefixed with @) to its file contents.
  * Supports tilde expansion for home directory paths.
@@ -102,7 +118,8 @@ async function resolveFileValue(
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
       throw new UserError(
-        `Input file not found for key "${key}": ${resolvedPath}`,
+        `Input file not found for key "${key}": ${resolvedPath}` +
+          `. Values starting with @ are read as file paths; use \\@ for a literal @ or :json suffix to bypass`,
       );
     }
     const message = error instanceof Error ? error.message : String(error);
@@ -117,6 +134,7 @@ async function resolveFileValue(
  *
  * - Dot notation creates nested objects: `server.host=localhost`
  * - Values starting with `@` read file contents: `key=@path/to/file`
+ * - Scoped identifiers (`@scope/name`) pass through literally
  * - Escaped `@` with `\@` produces a literal `@`: `key=\@literal`
  * - Splits on first `=` only, so values can contain `=`
  * - `:json` suffix on the leaf segment of the key parses the value as
@@ -174,8 +192,8 @@ export async function parseKeyValueInputs(
     if (value.startsWith("\\@")) {
       // Escaped @ — use literal value without the backslash
       value = value.slice(1);
-    } else if (value.startsWith("@")) {
-      // File reference — read file contents
+    } else if (value.startsWith("@") && !isScopedIdentifier(value)) {
+      // File reference — read file contents (but not scoped identifiers)
       const filePath = value.slice(1);
       value = await resolveFileValue(key, filePath);
     }

--- a/src/cli/input_parser_test.ts
+++ b/src/cli/input_parser_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import {
   deepMerge,
+  isScopedIdentifier,
   mergeInputArgs,
   parseInputs,
   parseKeyValueInputs,
@@ -121,7 +122,7 @@ Deno.test("parseKeyValueInputs: @file reads file contents", async () => {
   }
 });
 
-Deno.test("parseKeyValueInputs: @file with missing file throws", async () => {
+Deno.test("parseKeyValueInputs: @file with missing file throws with escape hint", async () => {
   const err = await assertRejects(
     () => parseKeyValueInputs(["key=@/nonexistent/path/file.txt"]),
     Error,
@@ -129,6 +130,10 @@ Deno.test("parseKeyValueInputs: @file with missing file throws", async () => {
   assertStringIncludes(
     (err as Error).message,
     'Input file not found for key "key"',
+  );
+  assertStringIncludes(
+    (err as Error).message,
+    "\\@",
   );
 });
 
@@ -138,6 +143,83 @@ Deno.test("parseKeyValueInputs: @file with dot notation", async () => {
     await Deno.writeTextFile(tempFile, "cert-data");
     const result = await parseKeyValueInputs([`server.cert=@${tempFile}`]);
     assertEquals(result, { server: { cert: "cert-data" } });
+  } finally {
+    await Deno.remove(tempFile);
+  }
+});
+
+// --- isScopedIdentifier ---
+
+Deno.test("isScopedIdentifier: matches two-segment scoped type", () => {
+  assertEquals(isScopedIdentifier("@hivemq/base-images"), true);
+});
+
+Deno.test("isScopedIdentifier: matches multi-segment scoped type", () => {
+  assertEquals(isScopedIdentifier("@swamp/aws/ec2/vpc"), true);
+});
+
+Deno.test("isScopedIdentifier: matches reserved collectives", () => {
+  assertEquals(isScopedIdentifier("@swamp/echo"), true);
+  assertEquals(isScopedIdentifier("@swamp/issue-lifecycle"), true);
+});
+
+Deno.test("isScopedIdentifier: rejects bare @filename (no slash)", () => {
+  assertEquals(isScopedIdentifier("@myfile.txt"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects file path with extension", () => {
+  assertEquals(isScopedIdentifier("@path/to/file.txt"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects absolute path", () => {
+  assertEquals(isScopedIdentifier("@/absolute/path"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects relative path with dot prefix", () => {
+  assertEquals(isScopedIdentifier("@./relative/path"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects tilde path", () => {
+  assertEquals(isScopedIdentifier("@~/home/file"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects value without @", () => {
+  assertEquals(isScopedIdentifier("hivemq/base-images"), false);
+});
+
+Deno.test("isScopedIdentifier: rejects namespace-only (no slash)", () => {
+  assertEquals(isScopedIdentifier("@hivemq"), false);
+});
+
+// --- parseKeyValueInputs: scoped identifier passthrough ---
+
+Deno.test("parseKeyValueInputs: scoped identifier passes through literally", async () => {
+  const result = await parseKeyValueInputs([
+    "sourceType=@hivemq/base-images",
+  ]);
+  assertEquals(result, { sourceType: "@hivemq/base-images" });
+});
+
+Deno.test("parseKeyValueInputs: multi-segment scoped identifier passes through", async () => {
+  const result = await parseKeyValueInputs([
+    "type=@swamp/aws/ec2/vpc",
+  ]);
+  assertEquals(result, { type: "@swamp/aws/ec2/vpc" });
+});
+
+Deno.test("parseKeyValueInputs: scoped identifier with dot-notation key", async () => {
+  const result = await parseKeyValueInputs([
+    "config.type=@myorg/deployer",
+  ]);
+  assertEquals(result, { config: { type: "@myorg/deployer" } });
+});
+
+Deno.test("parseKeyValueInputs: @file with extension still reads file", async () => {
+  const tempFile = await Deno.makeTempFile({ suffix: ".txt" });
+  try {
+    await Deno.writeTextFile(tempFile, "from-file");
+    const result = await parseKeyValueInputs([`key=@${tempFile}`]);
+    assertEquals(result, { key: "from-file" });
   } finally {
     await Deno.remove(tempFile);
   }
@@ -211,6 +293,10 @@ Deno.test({
       assertStringIncludes(
         (caught as Error).message,
         "~/definitely-missing.txt",
+      );
+      assertStringIncludes(
+        (caught as Error).message,
+        "\\@",
       );
     } finally {
       if (originalHome !== undefined) {


### PR DESCRIPTION
## Summary

- `--input key=@value` now passes scoped identifiers (`@scope/name` pattern) through as literal values instead of treating them as file paths
- Fixes `Input file not found` errors when passing swamp type identifiers like `@hivemq/base-images` as input values
- Improves the file-not-found error message to mention the `\@` escape and `:json` suffix workarounds

Closes swamp-club/swamp-club#986

## Test Plan

- [x] 13 new unit tests for `isScopedIdentifier` and scoped identifier passthrough
- [x] Verified existing `@file` indirection still works for real file paths
- [x] Updated 2 existing error-message assertions to match improved message
- [x] Reproduced original bug in scratch repo, confirmed fix with compiled binary
- [x] Full test suite passes (8377 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)