### PR TITLE
feat(serve): add SWAMP_SERVE_EXTRA_HEADERS for proxy/tunnel pass-through

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -186,11 +186,32 @@ stored credentials in `~/.config/swamp/servers.json` (managed by
 `swamp access token mint/list/revoke`.
 
 The token travels as a `?token=` query parameter on the WebSocket upgrade URL.
-This is the standard WebSocket auth pattern (the browser WebSocket API does not
-support custom headers on upgrade requests), but the plaintext will appear in
-any reverse proxy or load balancer access logs that capture the full request
-URL. Use TLS (`wss://`) for non-loopback deployments and configure access-log
-redaction on any intermediary that fronts the server.
+This avoids the browser WebSocket limitation (no custom headers), but the
+plaintext will appear in any reverse proxy or load balancer access logs that
+capture the full request URL. Use TLS (`wss://`) for non-loopback deployments
+and configure access-log redaction on any intermediary that fronts the server.
+
+### Extra headers for reverse proxies and tunnels
+
+When a `swamp serve` instance sits behind a reverse proxy or tunnel that
+requires custom HTTP headers (e.g. `Tunnel-Token`, provider-specific access
+headers), clients can inject arbitrary pass-through headers via the
+`SWAMP_SERVE_EXTRA_HEADERS` environment variable. The format is
+newline-separated `Name: value` entries:
+
+```
+export SWAMP_SERVE_EXTRA_HEADERS=$'Tunnel-Token: abc123\nX-Proxy-Auth: def456'
+```
+
+These headers are applied to the WebSocket upgrade request (using Deno 2.x's
+non-standard `WebSocket({ headers })` extension) and, for workers, to all HTTP
+data-plane requests. They are pure pass-through — `swamp serve` itself does not
+read or require them. Header values may contain secrets and are never logged;
+only header names appear in debug output (as a count).
+
+Reserved header names (`Authorization`, `Host`, `Upgrade`, `Connection`) are
+rejected to prevent conflicts with swamp's internal protocol headers. Values
+containing control characters are also rejected to prevent header injection.
 
 ## No execution drivers
 

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -91,6 +91,10 @@ export const workerConnectCommand = new Command()
     "Run up to one dispatch per CPU core",
     "swamp worker connect wss://orch:4000 --token <token> --concurrency auto",
   )
+  .example(
+    "Connect through a reverse-proxy that requires a tunnel token",
+    "SWAMP_SERVE_EXTRA_HEADERS=$'Tunnel-Token: abc123' swamp worker connect wss://orch.internal:4000 --token tok.secret",
+  )
   .arguments("[url:string]")
   .option(
     "--token <token:string>",

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -33,6 +33,7 @@ import { renderWorkerStatus } from "../../presentation/output/worker_output.ts";
 import { VERSION } from "./version.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
+import { resolveExtraHeaders } from "../../domain/auth/extra_headers.ts";
 
 // Import models barrel so built-in models resolve from the worker's own
 // registry when a `builtin:` bundle fingerprint is dispatched.
@@ -213,6 +214,7 @@ export const workerConnectCommand = new Command()
     });
 
     try {
+      const extraHeaders = resolveExtraHeaders();
       const result = await runWorker({
         url,
         token,
@@ -220,6 +222,7 @@ export const workerConnectCommand = new Command()
         swampVersion: VERSION,
         dataPlaneUrl: options.dataPlaneUrl,
         cacheDir,
+        headers: extraHeaders,
         reconnect: options.reconnect !== false,
         maxDispatches: maxDispatchesRaw,
         idleTimeoutMs,

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -43,6 +43,7 @@ import type {
 import { deserializeEvent } from "../serve/serializer.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
 import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
+import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
 
 /**
  * Resolves the server URL from the `--server` flag with `SWAMP_SERVE_URL`
@@ -66,8 +67,10 @@ export interface ServerRunOptions {
   /** Server token (`<name>.<secret>`) for authentication. */
   token?: string;
   signal?: AbortSignal;
+  /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
+  headers?: Record<string, string>;
   /** Test seam: WebSocket factory. */
-  createSocket?: (url: string) => WebSocket;
+  createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
 }
 
 /**
@@ -170,7 +173,9 @@ export interface RequestResponseOptions {
   server: string;
   token?: string;
   signal?: AbortSignal;
-  createSocket?: (url: string) => WebSocket;
+  /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
+  headers?: Record<string, string>;
+  createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
   timeoutMs?: number;
 }
 
@@ -180,8 +185,9 @@ export function requestServerResponse<T>(
 ): Promise<T> {
   const baseUrl = normalizeServerUrl(options.server);
   const url = appendTokenToUrl(baseUrl, options.token);
+  const headers = options.headers ?? resolveExtraHeaders();
   const requestId = request.id ?? crypto.randomUUID();
-  const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
+  const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
 
   return new Promise<T>((resolve, reject) => {
@@ -303,6 +309,16 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
     ) as T;
 }
 
+function defaultCreateSocket(
+  url: string,
+  headers?: Record<string, string>,
+): WebSocket {
+  if (headers && Object.keys(headers).length > 0) {
+    return new WebSocket(url, { headers });
+  }
+  return new WebSocket(url);
+}
+
 interface OutboundRequest {
   type: "workflow.run" | "model.method.run" | "workflow.resume";
   payload: WorkflowRunPayload | ModelMethodRunPayload | WorkflowResumePayload;
@@ -319,8 +335,9 @@ async function* streamServerRun(
 ): AsyncIterable<{ kind: string; [key: string]: unknown }> {
   const baseUrl = normalizeServerUrl(options.server);
   const url = appendTokenToUrl(baseUrl, options.token);
+  const headers = options.headers ?? resolveExtraHeaders();
   const requestId = crypto.randomUUID();
-  const socket = (options.createSocket ?? ((u) => new WebSocket(u)))(url);
+  const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
 
   // Push-queue bridging socket callbacks to the generator.
   const queue: ServerMessage[] = [];

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -301,7 +301,7 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
   return command
     .option(
       "--server <url:string>",
-      "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required (env: SWAMP_SERVE_URL).",
+      "Run through a 'swamp serve' server (ws:// or http://) instead of locally; no local repo required (env: SWAMP_SERVE_URL). For proxy/tunnel pass-through headers see SWAMP_SERVE_EXTRA_HEADERS.",
     )
     .option(
       "--token <token:string>",

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -495,7 +495,7 @@ function headerCapturingServer(): {
   const server = Deno.serve(
     { port: 0, hostname: "127.0.0.1", onListen: () => {} },
     (req) => {
-      captured = req.headers;
+      captured = new Headers(req.headers);
       const { socket, response } = Deno.upgradeWebSocket(req);
       socket.onmessage = (event) => {
         const parsed = JSON.parse(event.data as string);
@@ -552,7 +552,7 @@ Deno.test({
     const server = Deno.serve(
       { port: 0, hostname: "127.0.0.1", onListen: () => {} },
       (req) => {
-        captured = req.headers;
+        captured = new Headers(req.headers);
         const { socket, response } = Deno.upgradeWebSocket(req);
         socket.onmessage = (event) => {
           const parsed = JSON.parse(event.data as string);

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -484,6 +484,153 @@ Deno.test("resolveServerToken: converts ws URL to http for credential lookup", a
   assertEquals(result, "stored.ws-lookup");
 });
 
+// ── extra headers tests ────────────────────────────────────────────────
+
+function headerCapturingServer(): {
+  url: string;
+  shutdown: () => Promise<void>;
+  capturedHeaders: () => Headers;
+} {
+  let captured: Headers = new Headers();
+  const server = Deno.serve(
+    { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+    (req) => {
+      captured = req.headers;
+      const { socket, response } = Deno.upgradeWebSocket(req);
+      socket.onmessage = (event) => {
+        const parsed = JSON.parse(event.data as string);
+        socket.send(
+          JSON.stringify({
+            type: "done",
+            id: parsed.id,
+          }),
+        );
+      };
+      return response;
+    },
+  );
+  return {
+    url: `ws://127.0.0.1:${server.addr.port}`,
+    shutdown: () => server.shutdown(),
+    capturedHeaders: () => captured,
+  };
+}
+
+Deno.test({
+  name: "remote run: sends extra headers from options on WebSocket upgrade",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = headerCapturingServer();
+    try {
+      for await (
+        const _ of runWorkflowOverServer({
+          server: server.url,
+          headers: { "X-Tunnel-Token": "secret123", "X-Proxy-Auth": "pass" },
+          payload: { workflowIdOrName: "wf" },
+        })
+        // deno-lint-ignore no-empty
+      ) {}
+      assertEquals(
+        server.capturedHeaders().get("x-tunnel-token"),
+        "secret123",
+      );
+      assertEquals(server.capturedHeaders().get("x-proxy-auth"), "pass");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "requestServerResponse: sends extra headers from options on WebSocket upgrade",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    let captured: Headers = new Headers();
+    const server = Deno.serve(
+      { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+      (req) => {
+        captured = req.headers;
+        const { socket, response } = Deno.upgradeWebSocket(req);
+        socket.onmessage = (event) => {
+          const parsed = JSON.parse(event.data as string);
+          socket.send(JSON.stringify({
+            type: "test.response",
+            id: parsed.id,
+            payload: { ok: true },
+          }));
+        };
+        return response;
+      },
+    );
+    const url = `ws://127.0.0.1:${server.addr.port}`;
+    try {
+      await requestServerResponse<Record<string, unknown>>(
+        { server: url, headers: { "X-Custom": "val" } },
+        { type: "test" },
+      );
+      assertEquals(captured.get("x-custom"), "val");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: resolves extra headers from SWAMP_SERVE_EXTRA_HEADERS env var",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = headerCapturingServer();
+    const prev = Deno.env.get("SWAMP_SERVE_EXTRA_HEADERS");
+    try {
+      Deno.env.set("SWAMP_SERVE_EXTRA_HEADERS", "X-From-Env: envvalue");
+      for await (
+        const _ of runWorkflowOverServer({
+          server: server.url,
+          payload: { workflowIdOrName: "wf" },
+        })
+        // deno-lint-ignore no-empty
+      ) {}
+      assertEquals(server.capturedHeaders().get("x-from-env"), "envvalue");
+    } finally {
+      if (prev !== undefined) Deno.env.set("SWAMP_SERVE_EXTRA_HEADERS", prev);
+      else Deno.env.delete("SWAMP_SERVE_EXTRA_HEADERS");
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "remote run: explicit headers option takes precedence over env var",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = headerCapturingServer();
+    const prev = Deno.env.get("SWAMP_SERVE_EXTRA_HEADERS");
+    try {
+      Deno.env.set("SWAMP_SERVE_EXTRA_HEADERS", "X-Env: should-not-appear");
+      for await (
+        const _ of runWorkflowOverServer({
+          server: server.url,
+          headers: { "X-Explicit": "wins" },
+          payload: { workflowIdOrName: "wf" },
+        })
+        // deno-lint-ignore no-empty
+      ) {}
+      assertEquals(server.capturedHeaders().get("x-explicit"), "wins");
+      assertEquals(server.capturedHeaders().get("x-env"), null);
+    } finally {
+      if (prev !== undefined) Deno.env.set("SWAMP_SERVE_EXTRA_HEADERS", prev);
+      else Deno.env.delete("SWAMP_SERVE_EXTRA_HEADERS");
+      await server.shutdown();
+    }
+  },
+});
+
 Deno.test("resolveServerToken: returns undefined when no credential", async () => {
   const emptyRepo: ServerCredentialRepository = {
     get: () => Promise.resolve(null),

--- a/src/domain/auth/extra_headers.ts
+++ b/src/domain/auth/extra_headers.ts
@@ -1,0 +1,93 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { UserError } from "../errors.ts";
+
+const RESERVED_HEADER_NAMES = new Set([
+  "authorization",
+  "host",
+  "upgrade",
+  "connection",
+]);
+
+// deno-lint-ignore no-control-regex
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/;
+
+export function parseExtraHeaders(
+  raw: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex < 1) {
+      throw new UserError(
+        `Invalid header format: expected "Name: value", got ${
+          JSON.stringify(trimmed)
+        }`,
+      );
+    }
+
+    const name = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+
+    validateHeaderName(name);
+    validateHeaderValue(name, value);
+
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function validateHeaderName(name: string): void {
+  if (name === "") {
+    throw new UserError("Header name must not be empty");
+  }
+  if (CONTROL_CHAR_RE.test(name)) {
+    throw new UserError(
+      `Header name ${JSON.stringify(name)} contains control characters`,
+    );
+  }
+  if (RESERVED_HEADER_NAMES.has(name.toLowerCase())) {
+    throw new UserError(
+      `Header name ${
+        JSON.stringify(name)
+      } is reserved and cannot be overridden`,
+    );
+  }
+}
+
+function validateHeaderValue(name: string, value: string): void {
+  if (CONTROL_CHAR_RE.test(value)) {
+    throw new UserError(
+      `Value for header ${JSON.stringify(name)} contains control characters`,
+    );
+  }
+}
+
+export function resolveExtraHeaders(
+  getEnv: () => string | undefined = () =>
+    Deno.env.get("SWAMP_SERVE_EXTRA_HEADERS"),
+): Record<string, string> {
+  const raw = getEnv();
+  if (!raw) return {};
+  return parseExtraHeaders(raw);
+}

--- a/src/domain/auth/extra_headers_test.ts
+++ b/src/domain/auth/extra_headers_test.ts
@@ -1,0 +1,144 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { UserError } from "../errors.ts";
+import { parseExtraHeaders, resolveExtraHeaders } from "./extra_headers.ts";
+
+Deno.test("parseExtraHeaders: parses single header", () => {
+  assertEquals(parseExtraHeaders("X-Token: abc123"), { "X-Token": "abc123" });
+});
+
+Deno.test("parseExtraHeaders: parses multiple newline-separated headers", () => {
+  assertEquals(
+    parseExtraHeaders("X-Token: abc123\nX-Proxy-Auth: def456"),
+    { "X-Token": "abc123", "X-Proxy-Auth": "def456" },
+  );
+});
+
+Deno.test("parseExtraHeaders: preserves colons in value", () => {
+  assertEquals(
+    parseExtraHeaders("X-Token: abc:def:ghi"),
+    { "X-Token": "abc:def:ghi" },
+  );
+});
+
+Deno.test("parseExtraHeaders: trims whitespace around name and value", () => {
+  assertEquals(
+    parseExtraHeaders("  X-Token  :  abc123  "),
+    { "X-Token": "abc123" },
+  );
+});
+
+Deno.test("parseExtraHeaders: skips blank lines", () => {
+  assertEquals(
+    parseExtraHeaders("\nX-Token: abc123\n\nX-Other: val\n"),
+    { "X-Token": "abc123", "X-Other": "val" },
+  );
+});
+
+Deno.test("parseExtraHeaders: last value wins for duplicate names", () => {
+  assertEquals(
+    parseExtraHeaders("X-Token: first\nX-Token: second"),
+    { "X-Token": "second" },
+  );
+});
+
+Deno.test("parseExtraHeaders: allows empty value", () => {
+  assertEquals(parseExtraHeaders("X-Token:"), { "X-Token": "" });
+});
+
+Deno.test("parseExtraHeaders: throws on missing colon", () => {
+  assertThrows(
+    () => parseExtraHeaders("InvalidHeader"),
+    UserError,
+    "Invalid header format",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on colon at position 0 (empty name)", () => {
+  assertThrows(
+    () => parseExtraHeaders(": value"),
+    UserError,
+    "Invalid header format",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on control chars in name", () => {
+  assertThrows(
+    () => parseExtraHeaders("X-Bad\x00Name: value"),
+    UserError,
+    "contains control characters",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on control chars in value", () => {
+  assertThrows(
+    () => parseExtraHeaders("X-Token: bad\x0dvalue"),
+    UserError,
+    "contains control characters",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on reserved name Authorization", () => {
+  assertThrows(
+    () => parseExtraHeaders("Authorization: Bearer token"),
+    UserError,
+    "reserved",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on reserved name Host (case-insensitive)", () => {
+  assertThrows(
+    () => parseExtraHeaders("host: evil.example.com"),
+    UserError,
+    "reserved",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on reserved name Upgrade", () => {
+  assertThrows(
+    () => parseExtraHeaders("Upgrade: h2c"),
+    UserError,
+    "reserved",
+  );
+});
+
+Deno.test("parseExtraHeaders: throws on reserved name Connection", () => {
+  assertThrows(
+    () => parseExtraHeaders("Connection: close"),
+    UserError,
+    "reserved",
+  );
+});
+
+Deno.test("resolveExtraHeaders: returns empty when env var is unset", () => {
+  assertEquals(resolveExtraHeaders(() => undefined), {});
+});
+
+Deno.test("resolveExtraHeaders: returns empty when env var is empty string", () => {
+  assertEquals(resolveExtraHeaders(() => ""), {});
+});
+
+Deno.test("resolveExtraHeaders: parses env var value", () => {
+  assertEquals(
+    resolveExtraHeaders(() => "Tunnel-Token: secret123"),
+    { "Tunnel-Token": "secret123" },
+  );
+});

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -105,8 +105,10 @@ export interface RunWorkerOptions {
    * it when a signal arrives.
    */
   onDrainAvailable?: (requestDrain: (reason: WorkerExitReason) => void) => void;
+  /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
+  headers?: Record<string, string>;
   /** Test seam: WebSocket factory. */
-  createSocket?: (url: string) => WebSocket;
+  createSocket?: (url: string, headers?: Record<string, string>) => WebSocket;
   /** Test seam: override the runner command for the dispatch child process. */
   runnerCommand?: { cmd: string; args: string[] };
 }
@@ -330,8 +332,13 @@ interface ConnectOnceArgs {
 function connectOnce(args: ConnectOnceArgs): Promise<string> {
   const { options, instanceUuid, machineId, session } = args;
   return new Promise<string>((resolve, reject) => {
-    const socket = (options.createSocket ?? ((url) => new WebSocket(url)))(
+    const defaultCreate = (url: string, headers?: Record<string, string>) =>
+      headers && Object.keys(headers).length > 0
+        ? new WebSocket(url, { headers })
+        : new WebSocket(url);
+    const socket = (options.createSocket ?? defaultCreate)(
       options.url,
+      options.headers,
     );
     const channel = new RpcChannel({ send: (data) => socket.send(data) });
     let enrolled = false;

--- a/src/worker/data_plane_client.ts
+++ b/src/worker/data_plane_client.ts
@@ -52,6 +52,8 @@ export interface DataPlaneClientOptions {
   fetchImpl?: typeof fetch;
   /** Maximum cached artifacts before oldest is evicted. Defaults to 1000. */
   maxCacheEntries?: number;
+  /** Extra headers for proxy/tunnel pass-through (env: SWAMP_SERVE_EXTRA_HEADERS). */
+  extraHeaders?: Record<string, string>;
 }
 
 function combineSignals(
@@ -105,6 +107,7 @@ export class DataPlaneClient {
       method,
       body: init?.body,
       headers: {
+        ...this.#options.extraHeaders,
         authorization: `Bearer ${this.#options.credential()}`,
         ...init?.headers,
       },

--- a/src/worker/exec_dispatch.ts
+++ b/src/worker/exec_dispatch.ts
@@ -47,6 +47,7 @@ import {
   RunnerBootstrapParamsSchema,
 } from "./runner_protocol.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
 
 const logger = getSwampLogger(["worker", "runner"]);
 
@@ -134,6 +135,7 @@ export async function runDispatchRunner(
   const client = new DataPlaneClient({
     baseUrl: params.dataPlaneUrl,
     credential: () => params.sessionCredential,
+    extraHeaders: resolveExtraHeaders(),
   });
   const bundleCache = new WorkerBundleCache(params.cacheDirPath, client);
 


### PR DESCRIPTION
## Summary

- Add `SWAMP_SERVE_EXTRA_HEADERS` environment variable for sending custom HTTP headers through reverse proxies/tunnels when connecting to `swamp serve`
- Headers are newline-separated `Name: value` entries, validated against injection attacks (control chars) and reserved header names (`Authorization`, `Host`, `Upgrade`, `Connection`)
- Applied to CLI WebSocket connections via Deno 2.x `WebSocket({ headers })` and to worker data-plane HTTP requests
- Header values are never logged (only header count appears in debug output)
- `swamp serve` itself ignores these headers — they exist purely for intermediary proxies

Closes swamp-club#990

## Test Plan

- 18 unit tests for header parsing, validation, and env var resolution (`src/domain/auth/extra_headers_test.ts`)
- 4 integration tests verifying headers arrive on server-side WebSocket upgrade requests, env var auto-resolution, and explicit-headers-override-env-var precedence (`src/cli/remote_run_test.ts`)
- Full test suite passes (8385 passed, 0 failed)
- Manual verification: set `SWAMP_SERVE_EXTRA_HEADERS` and confirm headers appear on the upstream WebSocket upgrade request