### PR TITLE
feat(serve): add --trusted-hosts flag for Docker/Kubernetes worker connections

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -147,6 +147,7 @@ export function validateWebSocketOrigin(
   hostHeader: string | null,
   bindHost: string,
   tlsEnabled: boolean,
+  trustedHosts?: readonly string[],
 ): { allowed: boolean; reason?: string } {
   if (origin) {
     const TRUSTED_ORIGINS = new Set([
@@ -193,6 +194,11 @@ export function validateWebSocketOrigin(
       "::1",
       bindHost.toLowerCase(),
     ]);
+    if (trustedHosts) {
+      for (const h of trustedHosts) {
+        TRUSTED_HOSTS.add(h.toLowerCase());
+      }
+    }
     if (!TRUSTED_HOSTS.has(hostName)) {
       return { allowed: false, reason: `untrusted host: ${hostHeader}` };
     }
@@ -247,6 +253,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   }
   if (options.verifyOnEnroll) {
     args.push("--verify-on-enroll");
+  }
+  if (options.trustedHosts) {
+    args.push("--trusted-hosts", options.trustedHosts as string);
   }
   return args;
 }
@@ -325,6 +334,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--verify-on-enroll",
     "Run a fleet probe on each enrolling worker before it becomes schedulable",
+  )
+  .option(
+    "--trusted-hosts <hosts:string>",
+    "Comma-separated hostnames to trust for Host header validation (env: SWAMP_TRUSTED_HOSTS)",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -511,6 +524,13 @@ export const serveCommand = new Command()
     "--verify-on-enroll",
     "Run a fleet probe on each enrolling worker before it becomes schedulable — workers that fail are marked unverified (env: SWAMP_VERIFY_ON_ENROLL)",
   )
+  .option(
+    "--trusted-hosts <hosts:string>",
+    "Comma-separated hostnames to trust for Host header validation when binding off-loopback " +
+      "(e.g. host.docker.internal,host.minikube.internal). " +
+      "Preserves the DNS rebinding defense while allowing Docker/Kubernetes worker connections " +
+      "(env: SWAMP_TRUSTED_HOSTS)",
+  )
   .example(
     "Enable TLS",
     "swamp serve --cert-file server.crt --key-file server.key",
@@ -531,6 +551,11 @@ export const serveCommand = new Command()
     "Webhook with a provider scheme",
     "swamp serve --webhook '/hooks/linear:my-workflow:@env=LINEAR_SECRET:linear' " +
       "--webhook '/hooks/custom:my-workflow:@env=CUSTOM_SECRET:generic:X-Signature:sha256='",
+  )
+  .example(
+    "Docker workers",
+    "swamp serve --host 0.0.0.0 --trusted-hosts host.docker.internal " +
+      "--cert-file server.crt --key-file server.key --auth-mode token",
   )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["serve"]);
@@ -608,6 +633,14 @@ export const serveCommand = new Command()
     }
 
     assertOffLoopbackSecurity(host, tlsEnabled, authConfig.mode);
+
+    const trustedHostsRaw = (options.trustedHosts as string | undefined) ??
+      Deno.env.get("SWAMP_TRUSTED_HOSTS") ?? undefined;
+    const trustedHosts = trustedHostsRaw
+      ? trustedHostsRaw.split(",").map((h) => h.trim()).filter((h) =>
+        h.length > 0
+      )
+      : undefined;
 
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
@@ -1003,6 +1036,7 @@ export const serveCommand = new Command()
             req.headers.get("host"),
             host,
             tlsEnabled,
+            trustedHosts,
           );
           if (!originCheck.allowed) {
             logger.warn(

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -19,7 +19,11 @@
 
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
-import { assertOffLoopbackSecurity, validateWebSocketOrigin } from "./serve.ts";
+import {
+  assertOffLoopbackSecurity,
+  collectServeExtraArgs,
+  validateWebSocketOrigin,
+} from "./serve.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // Initialize logging for tests
@@ -279,4 +283,101 @@ Deno.test("validateWebSocketOrigin: rejects malformed origin", () => {
   );
   assertEquals(result.allowed, false);
   assertStringIncludes(result.reason!, "malformed origin");
+});
+
+// --- Trusted hosts ---
+
+Deno.test("validateWebSocketOrigin: accepts trusted host on off-loopback bind", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "host.docker.internal:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal"],
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: rejects untrusted host even with other trusted hosts", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "evil.com:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal"],
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted host");
+});
+
+Deno.test("validateWebSocketOrigin: trusted hosts are case-insensitive", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "Host.Docker.Internal:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal"],
+  );
+  assertEquals(result.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: multiple trusted hosts", () => {
+  const result1 = validateWebSocketOrigin(
+    null,
+    "host.docker.internal:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal", "host.minikube.internal"],
+  );
+  assertEquals(result1.allowed, true);
+
+  const result2 = validateWebSocketOrigin(
+    null,
+    "host.minikube.internal:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal", "host.minikube.internal"],
+  );
+  assertEquals(result2.allowed, true);
+});
+
+Deno.test("validateWebSocketOrigin: trusted hosts do not affect origin validation", () => {
+  const result = validateWebSocketOrigin(
+    "http://host.docker.internal",
+    "host.docker.internal:9090",
+    "0.0.0.0",
+    true,
+    ["host.docker.internal"],
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted origin");
+});
+
+Deno.test("validateWebSocketOrigin: empty trusted hosts array has no effect", () => {
+  const result = validateWebSocketOrigin(
+    null,
+    "evil.com:9090",
+    "0.0.0.0",
+    true,
+    [],
+  );
+  assertEquals(result.allowed, false);
+  assertStringIncludes(result.reason!, "untrusted host");
+});
+
+// --- collectServeExtraArgs ---
+
+Deno.test("collectServeExtraArgs: forwards --trusted-hosts", () => {
+  const args = collectServeExtraArgs({
+    trustedHosts: "host.docker.internal,host.minikube.internal",
+  });
+  assertEquals(args, [
+    "--trusted-hosts",
+    "host.docker.internal,host.minikube.internal",
+  ]);
+});
+
+Deno.test("collectServeExtraArgs: omits --trusted-hosts when not set", () => {
+  const args = collectServeExtraArgs({});
+  assertEquals(args, []);
 });


### PR DESCRIPTION
## Summary

- Add `--trusted-hosts` flag (and `SWAMP_TRUSTED_HOSTS` env var) to `swamp serve` that lets operators whitelist additional hostnames for Host header validation when binding off-loopback
- Enables Docker/Kubernetes workers to connect via platform-specific hostnames like `host.docker.internal` while preserving the DNS rebinding defense
- Forwards the flag through `collectServeExtraArgs` for daemon mode and adds it to `daemonEnableCommand`

## Test Plan

- 8 new unit tests covering: trusted host accepted, untrusted host still rejected, case-insensitive matching, multiple trusted hosts, trusted hosts don't affect origin validation, empty array no effect, `collectServeExtraArgs` forwarding (set and unset)
- All 8394 existing tests pass
- `deno check`, `deno lint`, `deno fmt` all clean

Closes swamp-club/lab#994

🤖 Generated with [Claude Code](https://claude.com/claude-code)