### PR TITLE
feat(worker): add --server-token flag for authenticated orchestrator connections

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -110,6 +110,25 @@ swamp worker token create ci-runner-3 --duration 1h    # on/near the orchestrato
 swamp worker connect wss://orchestrator.internal:4000 --token <token>   # on the worker
 ```
 
+When the orchestrator runs with `--auth-mode token`, the worker must also
+provide a server access token to authenticate the WebSocket upgrade. The
+`--server-token` flag (or `SWAMP_SERVER_TOKEN` env var) passes this separately
+from the enrollment token — the server token authenticates the transport
+connection, while the enrollment token authenticates the worker's identity
+inside the RPC handshake:
+
+```bash
+swamp worker connect wss://orch:9090 \
+  --server-token admin.secret \
+  --token worker-pool.enrollment-secret \
+  --label tier=ci
+```
+
+The CLI appends the server token as a `?token=` query parameter to the
+WebSocket URL before connecting, using the same `appendTokenToUrl` helper as
+`--server` commands. This avoids leaking the token in `SWAMP_ORCHESTRATOR_URL`
+environment dumps or process listings.
+
 ### A symmetric control protocol, two handler registries
 
 Today `src/serve/` couples two roles: the websocket *server* is also the

--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -34,6 +34,7 @@ import { VERSION } from "./version.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { resolveExtraHeaders } from "../../domain/auth/extra_headers.ts";
+import { appendTokenToUrl } from "../remote_run.ts";
 
 // Import models barrel so built-in models resolve from the worker's own
 // registry when a `builtin:` bundle fingerprint is dispatched.
@@ -92,6 +93,10 @@ export const workerConnectCommand = new Command()
     "swamp worker connect wss://orch:4000 --token <token> --concurrency auto",
   )
   .example(
+    "Connect to a token-authenticated orchestrator",
+    "swamp worker connect wss://orch:9090 --server-token admin.secret --token worker-pool.enrollment-secret",
+  )
+  .example(
     "Connect through a reverse-proxy that requires a tunnel token",
     "SWAMP_SERVE_EXTRA_HEADERS=$'Tunnel-Token: abc123' swamp worker connect wss://orch.internal:4000 --token tok.secret",
   )
@@ -99,6 +104,10 @@ export const workerConnectCommand = new Command()
   .option(
     "--token <token:string>",
     "Enrollment token (<name>.<secret>) (env: SWAMP_WORKER_TOKEN)",
+  )
+  .option(
+    "--server-token <token:string>",
+    "Server access token for authenticating the WebSocket connection (<name>.<secret>) (env: SWAMP_SERVER_TOKEN)",
   )
   .option(
     "--label <label:string>",
@@ -144,6 +153,9 @@ export const workerConnectCommand = new Command()
         `Orchestrator URL must start with ws:// or wss:// (got '${url}')`,
       );
     }
+
+    const serverToken = (options.serverToken as string | undefined) ??
+      Deno.env.get("SWAMP_SERVER_TOKEN");
 
     const token = (options.token as string | undefined) ??
       Deno.env.get("SWAMP_WORKER_TOKEN");
@@ -219,8 +231,9 @@ export const workerConnectCommand = new Command()
 
     try {
       const extraHeaders = resolveExtraHeaders();
+      const authenticatedUrl = appendTokenToUrl(url, serverToken);
       const result = await runWorker({
-        url,
+        url: authenticatedUrl,
         token,
         labels,
         swampVersion: VERSION,

--- a/src/cli/commands/worker_connect_test.ts
+++ b/src/cli/commands/worker_connect_test.ts
@@ -59,3 +59,11 @@ Deno.test("workerConnectCommand: --label option is collectible", async () => {
   assertEquals(labelOpt !== undefined, true);
   assertEquals(labelOpt?.collect, true);
 });
+
+Deno.test("workerConnectCommand: --server-token option exists", async () => {
+  const { workerConnectCommand } = await import("./worker_connect.ts");
+  const options = workerConnectCommand.getOptions();
+  const serverTokenOpt = options.find((o) => o.name === "server-token");
+  assertEquals(serverTokenOpt !== undefined, true);
+  assertEquals(serverTokenOpt?.required ?? false, false);
+});

--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -44,7 +44,7 @@ export function collectWorkerExtraArgs(options: AnyOptions): string[] {
   return args;
 }
 
-function collectWorkerEnv(options: AnyOptions): Record<string, string> {
+export function collectWorkerEnv(options: AnyOptions): Record<string, string> {
   const env: Record<string, string> = {};
 
   const url = options.url as string | undefined;
@@ -55,6 +55,11 @@ function collectWorkerEnv(options: AnyOptions): Record<string, string> {
   const token = options.token as string | undefined;
   if (token) {
     env["SWAMP_WORKER_TOKEN"] = token;
+  }
+
+  const serverToken = options.serverToken as string | undefined;
+  if (serverToken) {
+    env["SWAMP_SERVER_TOKEN"] = serverToken;
   }
 
   const labels = options.label as string[] | undefined;
@@ -93,6 +98,10 @@ const daemonEnableCommand = new Command()
     "Enrollment token (<name>.<secret>)",
   )
   .option(
+    "--server-token <token:string>",
+    "Server access token for authenticating the WebSocket connection (<name>.<secret>)",
+  )
+  .option(
     "--label <label:string>",
     "Scheduling label key=value (repeatable)",
     { collect: true },
@@ -117,6 +126,10 @@ const daemonEnableCommand = new Command()
   .example(
     "Enable worker daemon",
     "swamp worker daemon enable wss://orch:9090 --token tok.secret --label tier=ci --cache-dir /var/lib/swamp-worker",
+  )
+  .example(
+    "Enable with a token-authenticated orchestrator",
+    "swamp worker daemon enable wss://orch:9090 --token tok.secret --server-token admin.secret --label tier=ci",
   )
   .example(
     "Enable with lifecycle policies",

--- a/src/cli/commands/worker_daemon_test.ts
+++ b/src/cli/commands/worker_daemon_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { collectWorkerExtraArgs } from "./worker_daemon.ts";
+import { collectWorkerEnv, collectWorkerExtraArgs } from "./worker_daemon.ts";
 
 Deno.test("collectWorkerExtraArgs: includes data-plane-url when provided", () => {
   const args = collectWorkerExtraArgs({
@@ -47,4 +47,29 @@ Deno.test("collectWorkerExtraArgs: combines multiple options", () => {
     "https://dp.internal",
     "--no-reconnect",
   ]);
+});
+
+Deno.test("collectWorkerEnv: includes SWAMP_SERVER_TOKEN when provided", () => {
+  const env = collectWorkerEnv({
+    url: "wss://orch:9090",
+    token: "tok.secret",
+    serverToken: "admin.secret",
+  });
+  assertEquals(env["SWAMP_SERVER_TOKEN"], "admin.secret");
+  assertEquals(env["SWAMP_WORKER_TOKEN"], "tok.secret");
+  assertEquals(env["SWAMP_ORCHESTRATOR_URL"], "wss://orch:9090");
+});
+
+Deno.test("collectWorkerEnv: omits SWAMP_SERVER_TOKEN when not provided", () => {
+  const env = collectWorkerEnv({
+    url: "wss://orch:9090",
+    token: "tok.secret",
+  });
+  assertEquals(env["SWAMP_SERVER_TOKEN"], undefined);
+  assertEquals(env["SWAMP_WORKER_TOKEN"], "tok.secret");
+});
+
+Deno.test("collectWorkerEnv: returns empty when no options", () => {
+  const env = collectWorkerEnv({});
+  assertEquals(Object.keys(env).length, 0);
 });


### PR DESCRIPTION
## Summary

- Add `--server-token` flag (env: `SWAMP_SERVER_TOKEN`) to `swamp worker connect` and `swamp worker daemon enable`
- Workers connecting to orchestrators with `--auth-mode token` can now pass the server access token separately from the enrollment token, avoiding leaking it in the orchestrator URL
- The CLI layer uses the existing `appendTokenToUrl` helper to bake the token into the WebSocket URL before passing it to `runWorker` — no changes to `connect.ts` or `RunWorkerOptions`

## Test Plan

- [x] `--server-token` option exists on `workerConnectCommand` (unit test)
- [x] `collectWorkerEnv` includes `SWAMP_SERVER_TOKEN` when provided (unit test)
- [x] `collectWorkerEnv` omits `SWAMP_SERVER_TOKEN` when not provided (unit test)
- [x] `collectWorkerEnv` returns empty when no options (unit test)
- [x] URL construction covered by existing `appendTokenToUrl` tests in `remote_run_test.ts`
- [x] All 8420 tests pass
- [x] `deno check`, `deno lint`, `deno fmt` pass
- [x] Binary compiles successfully

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)