### PR TITLE
fix(data): hydrate attributes in query results regardless of predicate (swamp-club#985)

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -378,6 +378,8 @@ export class DataQueryService {
     // CEL reserves "namespace" as an identifier, so we expose an "ns" alias
     // via a prototype-chain overlay — the record itself is not mutated.
     const results: DataRecord[] = [];
+    const needsHydration = !needsAttributes && !selectParsed;
+    const matchedRows: CatalogRow[] = [];
     for (const row of this.catalogStore.iterate()) {
       const record = this.rowToRecord(row, needsAttributes, needsContent);
       const ctx = Object.create(
@@ -388,6 +390,7 @@ export class DataQueryService {
         const match = parsed(ctx);
         if (match === true) {
           results.push(record);
+          if (needsHydration) matchedRows.push(row);
           if (results.length >= limit) break;
         }
       } catch (error) {
@@ -395,6 +398,15 @@ export class DataQueryService {
           .debug`Query predicate skipped row ${row.model_name}/${row.data_name}: ${
           String(error)
         }`;
+      }
+    }
+
+    // Hydrate matched records with attributes when the predicate didn't
+    // require them for filtering. Only applies to non-projected results —
+    // projections handle attribute loading via AST analysis above.
+    if (needsHydration) {
+      for (let i = 0; i < results.length; i++) {
+        results[i] = this.rowToRecord(matchedRows[i], true, needsContent);
       }
     }
 

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -299,15 +299,66 @@ Deno.test("DataQueryService: attributes filter with content on disk", () => {
   catalog.close();
 });
 
-Deno.test("DataQueryService: no-attributes predicate skips content", () => {
+Deno.test("DataQueryService: no-attributes predicate hydrates matched results", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-hydrate-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "my-data",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(
+    join(dataDir, "raw"),
+    JSON.stringify({ status: "ok", count: 7 }),
+  );
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "my-data",
+      id: "00000000-0000-1000-8000-000000000001",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "my-data", "latest"),
+    "1",
+  );
+
+  catalog.upsert(makeRow());
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  const results = service.querySync('modelName == "ingest"') as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].attributes["status"], "ok");
+  assertEquals(results[0].attributes["count"], 7);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: select projection skips hydration", () => {
   const { catalog, service } = setupTest();
   catalog.upsert(makeRow({ content_type: "application/json" }));
 
-  // This predicate doesn't reference attributes, so content should not be loaded
-  const results = service.querySync('modelName == "ingest"') as DataRecord[];
+  const results = service.querySync('modelName == "ingest"', {
+    select: "name",
+  }) as string[];
   assertEquals(results.length, 1);
-  // attributes should be empty since content was not loaded
-  assertEquals(results[0].attributes, {});
+  assertEquals(results[0], "my-data");
   catalog.close();
 });
 


### PR DESCRIPTION
## Summary

- `data.query` returned records with `attributes: {}` and `content: ""` when the CEL predicate didn't reference those fields, because the AST-based lazy-loading optimization skipped disk reads for non-referenced fields
- This was inconsistent with `data.latest`, `data.version`, `data.findByTag`, and `data.findBySpec` which always populate attributes
- Adds a post-filter hydration pass in `executeQuery()` that re-reads content from disk for matched records only — preserving the fast SQLite-first catalog filtering while ensuring returned `DataRecord` objects are complete

Closes swamp-club#985

## Test Plan

- Updated unit test to verify attributes are populated in query results even when the predicate doesn't reference them
- Added unit test verifying select projections skip hydration (projected results don't need it)
- Verified existing predicate-based attribute filtering test still passes (regression guard)
- Full test suite: 8363 passed, 0 new failures
- Binary verification against reproduction repo:
  - **Before**: `swamp data query 'modelName == "bug-repro"' --json` → `attributes: {}`
  - **After**: same query → `attributes: {"exitCode": 0, "command": "echo hello world", ...}`