### PR TITLE
fix(serve): survive unhandled promise rejections from extension code

### DIFF
--- a/design/run-tracker.md
+++ b/design/run-tracker.md
@@ -73,6 +73,20 @@ are purged on startup.
 All commands support `--server` for querying a remote `swamp serve` instance and
 `--json` for structured output.
 
+### Unhandled Rejection Guard
+
+`swamp serve` installs a global `unhandledrejection` and `error` event handler
+at startup (`src/serve/unhandled_rejection_guard.ts`). This prevents detached
+rejecting promises or uncaught exceptions in extension code from terminating the
+server process. The handler logs the error and calls `preventDefault()` to keep
+the process alive.
+
+The guard cannot correlate a detached rejection with a specific active run
+because the rejection may fire after the run's async context has already exited.
+If the rejection does orphan a run (e.g. the rejection fires during execution
+and prevents the run from completing normally), the heartbeat reaper will mark
+it as stale after the 90-second TTL.
+
 ### Local-only
 
 The tracker DB is NOT synced to remote datastores. PIDs and heartbeats are

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -80,6 +80,7 @@ import {
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { sweepStaleRecords } from "../../serve/boot_reconciliation.ts";
+import { installUnhandledRejectionGuard } from "../../serve/unhandled_rejection_guard.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -641,6 +642,8 @@ export const serveCommand = new Command()
         h.length > 0
       )
       : undefined;
+
+    const rejectionGuard = installUnhandledRejectionGuard();
 
     ctx.logger.info`Initializing repository at ${repoDir}`;
 
@@ -1245,6 +1248,7 @@ export const serveCommand = new Command()
         await scheduledExecution.stop();
       }
       await policySnapshotLoader.dispose();
+      rejectionGuard.dispose();
       setRemoteStepDispatcher(null);
       ac.abort();
       if (isJson) {

--- a/src/serve/unhandled_rejection_guard.ts
+++ b/src/serve/unhandled_rejection_guard.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "unhandled-rejection-guard"]);
+
+export interface UnhandledRejectionGuard {
+  dispose(): void;
+}
+
+/**
+ * Installs global `unhandledrejection` and `error` event listeners that
+ * prevent the serve process from terminating when extension code produces
+ * detached rejecting promises or uncaught exceptions.
+ *
+ * Call `dispose()` during shutdown to deregister the listeners.
+ */
+export function installUnhandledRejectionGuard(): UnhandledRejectionGuard {
+  const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+    event.preventDefault();
+    const reason = event.reason;
+    const message = reason instanceof Error
+      ? reason.message
+      : String(reason ?? "unknown");
+    const stack = reason instanceof Error ? reason.stack : undefined;
+    logger.error`Unhandled promise rejection (process kept alive): ${message}`;
+    if (stack) {
+      logger.debug`${stack}`;
+    }
+  };
+
+  const onUncaughtError = (event: ErrorEvent): void => {
+    event.preventDefault();
+    const message = event.error instanceof Error
+      ? event.error.message
+      : String(event.message ?? "unknown");
+    const stack = event.error instanceof Error ? event.error.stack : undefined;
+    logger.error`Uncaught error (process kept alive): ${message}`;
+    if (stack) {
+      logger.debug`${stack}`;
+    }
+  };
+
+  globalThis.addEventListener("unhandledrejection", onUnhandledRejection);
+  globalThis.addEventListener("error", onUncaughtError);
+
+  return {
+    dispose() {
+      globalThis.removeEventListener(
+        "unhandledrejection",
+        onUnhandledRejection,
+      );
+      globalThis.removeEventListener("error", onUncaughtError);
+    },
+  };
+}

--- a/src/serve/unhandled_rejection_guard_test.ts
+++ b/src/serve/unhandled_rejection_guard_test.ts
@@ -1,0 +1,101 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { installUnhandledRejectionGuard } from "./unhandled_rejection_guard.ts";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+Deno.test("installUnhandledRejectionGuard: prevents process termination on unhandled rejection", async () => {
+  const guard = installUnhandledRejectionGuard();
+  try {
+    const events: PromiseRejectionEvent[] = [];
+    const spy = (e: PromiseRejectionEvent) => events.push(e);
+    globalThis.addEventListener("unhandledrejection", spy);
+
+    try {
+      // Create a detached rejecting promise — the guard should catch it
+      const _detached = Promise.reject(
+        new Error("simulated extension crash"),
+      );
+
+      // Let the microtask queue drain so the rejection event fires
+      await new Promise((r) => setTimeout(r, 10));
+
+      assertEquals(events.length, 1);
+      assertEquals(events[0].defaultPrevented, true);
+    } finally {
+      globalThis.removeEventListener("unhandledrejection", spy);
+    }
+  } finally {
+    guard.dispose();
+  }
+});
+
+Deno.test("installUnhandledRejectionGuard: handles non-Error rejection reasons", async () => {
+  const guard = installUnhandledRejectionGuard();
+  try {
+    const events: PromiseRejectionEvent[] = [];
+    const spy = (e: PromiseRejectionEvent) => events.push(e);
+    globalThis.addEventListener("unhandledrejection", spy);
+
+    try {
+      const _detached = Promise.reject("string rejection reason");
+      await new Promise((r) => setTimeout(r, 10));
+
+      assertEquals(events.length, 1);
+      assertEquals(events[0].defaultPrevented, true);
+    } finally {
+      globalThis.removeEventListener("unhandledrejection", spy);
+    }
+  } finally {
+    guard.dispose();
+  }
+});
+
+Deno.test("installUnhandledRejectionGuard: dispose removes listeners", async () => {
+  const guard = installUnhandledRejectionGuard();
+  guard.dispose();
+
+  // After disposal, unhandled rejections should NOT be caught by our guard.
+  // We verify by checking that a subsequent rejection event is NOT
+  // defaultPrevented (unless some other handler catches it).
+  const events: PromiseRejectionEvent[] = [];
+  const catcher = (e: PromiseRejectionEvent) => {
+    events.push(e);
+    // Prevent the test runner from crashing
+    e.preventDefault();
+  };
+  globalThis.addEventListener("unhandledrejection", catcher);
+
+  try {
+    const _detached = Promise.reject(new Error("after disposal"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    assertEquals(events.length, 1);
+    // The guard was disposed, so it didn't call preventDefault() — our
+    // test catcher is the only handler. The event should NOT have been
+    // prevented before our catcher ran. We can't directly observe this
+    // because our catcher calls preventDefault(), but we verify the guard
+    // didn't interfere by confirming exactly 1 event was caught.
+  } finally {
+    globalThis.removeEventListener("unhandledrejection", catcher);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1001.

- Install a global `unhandledrejection` and `error` event handler at `swamp serve` startup that calls `preventDefault()` to keep the process alive when extension code produces detached rejecting promises
- Log the error at `error` level for extension authors to diagnose, with stack trace at `debug` level
- Deregister the handler during graceful shutdown to prevent dangling listeners
- Document the guard and its tradeoffs (no per-run correlation, relies on heartbeat reaper) in `design/run-tracker.md`

## Root cause

Extension code runs in-process via `InProcessExecutor` with no isolation boundary. The `try/catch` catches errors from the awaited promise chain, but detached promises (created but not awaited by extension code) escape entirely. Deno terminates the process on unhandled rejections, crashing the server and orphaning all active runs.

## Reproduction

Created a synthetic extension (`@stack72/bad-extension`) with a method that creates a detached `setTimeout`-based rejecting promise. Before the fix, `swamp serve` crashed with `Uncaught (in promise) Error`. After the fix, the server logs the error and stays alive.

## Test plan

- [x] Unit tests for the guard: Error rejections, non-Error rejections, disposal cleanup
- [x] Type check, lint, format pass
- [x] Reproduction confirmed crash before fix
- [x] Reproduction confirmed server survives after fix
- [ ] Full test suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Jean-Philippe Evrard <evrardjp@users.noreply.github.com>