### PR TITLE
feat(worker): hide disconnected workers by default, add --all flag

### DIFF
--- a/src/cli/commands/worker_list.ts
+++ b/src/cli/commands/worker_list.ts
@@ -52,11 +52,13 @@ export const workerListCommand = withRemoteOptions(
     .description(
       "List workers in the pool: status, labels, platform, and last seen",
     )
-    .example("List all workers", "swamp worker list")
+    .example("List connected workers", "swamp worker list")
+    .example("Include disconnected workers", "swamp worker list --all")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
-    ),
+    )
+    .option("--all", "Include disconnected workers"),
 ).action(async function (options: AnyOptions) {
   const cliCtx = createContext(options as GlobalOptions, [
     "worker",
@@ -69,11 +71,12 @@ export const workerListCommand = withRemoteOptions(
       server,
       options.token as string | undefined,
     );
+    const showAll = options.all ?? false;
     const response = await requestServerResponse<WorkerListResponse>(
       { server, token },
       {
         type: "worker.list",
-        payload: {},
+        payload: { showAll },
       },
     );
     renderWorkerList(
@@ -92,7 +95,9 @@ export const workerListCommand = withRemoteOptions(
   const deps = createWorkerListDeps(repoContext.dataQueryService);
 
   await consumeStream(
-    workerList(libCtx, deps),
+    workerList(libCtx, deps, {
+      includeDisconnected: options.all ?? false,
+    }),
     withDefaults<WorkerListEvent>({
       completed: (event) => {
         renderWorkerList(event.data, cliCtx.outputMode);

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -359,6 +359,7 @@ export {
   type WorkerListDeps,
   type WorkerListEvent,
   type WorkerListItem,
+  type WorkerListOptions,
   workerTokenList,
   type WorkerTokenListData,
   type WorkerTokenListEvent,

--- a/src/libswamp/worker/list.ts
+++ b/src/libswamp/worker/list.ts
@@ -96,6 +96,12 @@ export interface WorkerListItem {
 export interface WorkerListData {
   workers: WorkerListItem[];
   count: number;
+  filteredDisconnectedCount?: number;
+}
+
+/** Options for the worker list query. */
+export interface WorkerListOptions {
+  includeDisconnected?: boolean;
 }
 
 export type WorkerListEvent =
@@ -203,11 +209,15 @@ export async function* workerTokenList(
 }
 
 /**
- * Lists all workers known to the pool, sorted by name.
+ * Lists workers known to the pool, sorted by name.
+ *
+ * By default disconnected workers are excluded from the results.
+ * Pass `{ includeDisconnected: true }` to include them.
  */
 export async function* workerList(
   _ctx: LibSwampContext,
   deps: WorkerListDeps,
+  options?: WorkerListOptions,
 ): AsyncGenerator<WorkerListEvent> {
   yield* withGeneratorSpan(
     "swamp.worker.list",
@@ -219,12 +229,12 @@ export async function* workerList(
           `modelType == "${WORKER_MODEL_TYPE.normalized}" && ` +
             `name == "${WORKER_STATE_DATA_NAME}"`,
         );
-        const workers: WorkerListItem[] = [];
+        const allWorkers: WorkerListItem[] = [];
         for (const record of records) {
           const parsed = WorkerStateSchema.safeParse(record.attributes);
           if (!parsed.success) continue;
           const state = parsed.data;
-          workers.push({
+          allWorkers.push({
             name: state.name,
             status: state.status,
             labels: state.labels,
@@ -237,10 +247,23 @@ export async function* workerList(
             activeDispatchIds: state.activeDispatchIds ?? [],
           });
         }
-        workers.sort((a, b) => a.name.localeCompare(b.name));
+        allWorkers.sort((a, b) => a.name.localeCompare(b.name));
+
+        const includeDisconnected = options?.includeDisconnected ?? false;
+        const workers = includeDisconnected
+          ? allWorkers
+          : allWorkers.filter((w) => w.status !== "disconnected");
+        const filteredDisconnectedCount = allWorkers.length - workers.length;
+
         yield {
           kind: "completed" as const,
-          data: { workers, count: workers.length },
+          data: {
+            workers,
+            count: workers.length,
+            ...(filteredDisconnectedCount > 0
+              ? { filteredDisconnectedCount }
+              : {}),
+          },
         };
       } catch (error) {
         yield {

--- a/src/libswamp/worker/list_test.ts
+++ b/src/libswamp/worker/list_test.ts
@@ -26,6 +26,7 @@ import {
   workerList,
   type WorkerListDeps,
   type WorkerListEvent,
+  type WorkerListOptions,
   workerTokenList,
   type WorkerTokenListEvent,
 } from "./list.ts";
@@ -250,6 +251,87 @@ Deno.test("workerList: yields error when the query fails", async () => {
   const error = events[1] as Extract<WorkerListEvent, { kind: "error" }>;
   assertEquals(error.kind, "error");
   assertStringIncludes(error.error.message, "boom");
+});
+
+Deno.test("workerList: filters disconnected workers by default", async () => {
+  const deps = makeDeps([
+    makeRecord(
+      "worker-a",
+      "state-main",
+      workerAttributes("worker-a", { status: "idle" }),
+    ),
+    makeRecord(
+      "worker-b",
+      "state-main",
+      workerAttributes("worker-b", { status: "disconnected" }),
+    ),
+    makeRecord(
+      "worker-c",
+      "state-main",
+      workerAttributes("worker-c", { status: "busy" }),
+    ),
+  ]);
+  const events = await collect<WorkerListEvent>(
+    workerList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    WorkerListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.count, 2);
+  assertEquals(
+    completed.data.workers.map((w) => w.name),
+    ["worker-a", "worker-c"],
+  );
+  assertEquals(completed.data.filteredDisconnectedCount, 1);
+});
+
+Deno.test("workerList: includes disconnected workers with includeDisconnected", async () => {
+  const deps = makeDeps([
+    makeRecord(
+      "worker-a",
+      "state-main",
+      workerAttributes("worker-a", { status: "idle" }),
+    ),
+    makeRecord(
+      "worker-b",
+      "state-main",
+      workerAttributes("worker-b", { status: "disconnected" }),
+    ),
+  ]);
+  const options: WorkerListOptions = { includeDisconnected: true };
+  const events = await collect<WorkerListEvent>(
+    workerList(createLibSwampContext(), deps, options),
+  );
+  const completed = events[1] as Extract<
+    WorkerListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.count, 2);
+  assertEquals(
+    completed.data.workers.map((w) => w.name),
+    ["worker-a", "worker-b"],
+  );
+  assertEquals(completed.data.filteredDisconnectedCount, undefined);
+});
+
+Deno.test("workerList: omits filteredDisconnectedCount when no workers are disconnected", async () => {
+  const deps = makeDeps([
+    makeRecord(
+      "worker-a",
+      "state-main",
+      workerAttributes("worker-a", { status: "idle" }),
+    ),
+  ]);
+  const events = await collect<WorkerListEvent>(
+    workerList(createLibSwampContext(), deps),
+  );
+  const completed = events[1] as Extract<
+    WorkerListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.count, 1);
+  assertEquals(completed.data.filteredDisconnectedCount, undefined);
 });
 
 Deno.test("effectiveTokenState: live states past expiry display as expired", () => {

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -220,7 +220,7 @@ export function renderWorkerList(
   mode: OutputMode,
 ): void {
   if (mode === "json") {
-    console.log(JSON.stringify(data.workers, null, 2));
+    console.log(JSON.stringify(data, null, 2));
     return;
   }
   if (data.workers.length === 0) {
@@ -229,7 +229,9 @@ export function renderWorkerList(
         [
           "No connected workers found.",
           dim(
-            `${data.filteredDisconnectedCount} disconnected worker(s) hidden — use --all to show all.`,
+            `${data.filteredDisconnectedCount} disconnected ${
+              data.filteredDisconnectedCount === 1 ? "worker" : "workers"
+            } hidden — use --all to show all.`,
           ),
         ].join("\n"),
       );
@@ -265,7 +267,9 @@ export function renderWorkerList(
   if (data.filteredDisconnectedCount) {
     writeOutput(
       dim(
-        `${data.filteredDisconnectedCount} disconnected worker(s) hidden — use --all to show all.`,
+        `${data.filteredDisconnectedCount} disconnected ${
+          data.filteredDisconnectedCount === 1 ? "worker" : "workers"
+        } hidden — use --all to show all.`,
       ),
     );
   }

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -231,7 +231,7 @@ export function renderWorkerList(
           dim(
             `${data.filteredDisconnectedCount} disconnected ${
               data.filteredDisconnectedCount === 1 ? "worker" : "workers"
-            } hidden — use --all to show all.`,
+            } hidden — use 'swamp worker list --all' to show all.`,
           ),
         ].join("\n"),
       );
@@ -269,7 +269,7 @@ export function renderWorkerList(
       dim(
         `${data.filteredDisconnectedCount} disconnected ${
           data.filteredDisconnectedCount === 1 ? "worker" : "workers"
-        } hidden — use --all to show all.`,
+        } hidden — use 'swamp worker list --all' to show all.`,
       ),
     );
   }

--- a/src/presentation/output/worker_output.ts
+++ b/src/presentation/output/worker_output.ts
@@ -224,14 +224,25 @@ export function renderWorkerList(
     return;
   }
   if (data.workers.length === 0) {
-    writeOutput(
-      [
-        "No workers found.",
-        dim(
-          "Workers appear here after enrolling with: swamp worker token create <name> --duration 24h",
-        ),
-      ].join("\n"),
-    );
+    if (data.filteredDisconnectedCount) {
+      writeOutput(
+        [
+          "No connected workers found.",
+          dim(
+            `${data.filteredDisconnectedCount} disconnected worker(s) hidden — use --all to show all.`,
+          ),
+        ].join("\n"),
+      );
+    } else {
+      writeOutput(
+        [
+          "No workers found.",
+          dim(
+            "Workers appear here after enrolling with: swamp worker token create <name> --duration 24h",
+          ),
+        ].join("\n"),
+      );
+    }
     return;
   }
   const rows = data.workers.map((worker) => {
@@ -251,6 +262,13 @@ export function renderWorkerList(
     (column, value) => (column === 1 ? colorWorkerStatus(value) : value),
   );
   writeOutput(lines.join("\n"));
+  if (data.filteredDisconnectedCount) {
+    writeOutput(
+      dim(
+        `${data.filteredDisconnectedCount} disconnected worker(s) hidden — use --all to show all.`,
+      ),
+    );
+  }
   if (data.workers.some((w) => w.status === "unverified")) {
     writeOutput(
       dim(

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -262,7 +262,7 @@ Deno.test("renderWorkerList: log mode shows disconnected hint when all filtered"
   );
   assertStringIncludes(output, "No connected workers found.");
   assertStringIncludes(output, "3 disconnected workers hidden");
-  assertStringIncludes(output, "--all");
+  assertStringIncludes(output, "swamp worker list --all");
 });
 
 Deno.test("renderWorkerList: log mode shows disconnected hint after table", () => {
@@ -289,7 +289,7 @@ Deno.test("renderWorkerList: log mode shows disconnected hint after table", () =
   );
   assertStringIncludes(output, "live-worker");
   assertStringIncludes(output, "2 disconnected workers hidden");
-  assertStringIncludes(output, "--all");
+  assertStringIncludes(output, "swamp worker list --all");
 });
 
 Deno.test("renderWorkerList: json mode emits the full data envelope", () => {

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -261,7 +261,7 @@ Deno.test("renderWorkerList: log mode shows disconnected hint when all filtered"
     ),
   );
   assertStringIncludes(output, "No connected workers found.");
-  assertStringIncludes(output, "3 disconnected worker(s) hidden");
+  assertStringIncludes(output, "3 disconnected workers hidden");
   assertStringIncludes(output, "--all");
 });
 
@@ -288,17 +288,43 @@ Deno.test("renderWorkerList: log mode shows disconnected hint after table", () =
     captureLogs(() => renderWorkerList(data, "log")),
   );
   assertStringIncludes(output, "live-worker");
-  assertStringIncludes(output, "2 disconnected worker(s) hidden");
+  assertStringIncludes(output, "2 disconnected workers hidden");
   assertStringIncludes(output, "--all");
 });
 
-Deno.test("renderWorkerList: json mode emits the array of records", () => {
+Deno.test("renderWorkerList: json mode emits the full data envelope", () => {
   const output = captureLogs(() => renderWorkerList(workerListData, "json"));
-  const parsed = JSON.parse(output) as WorkerListData["workers"];
-  assertEquals(parsed.length, 2);
-  assertEquals(parsed[0].status, "busy");
-  assertEquals(parsed[0].labels, { os: "linux", gpu: "none" });
-  assertEquals(parsed[1].activeDispatchIds, []);
+  const parsed = JSON.parse(output) as WorkerListData;
+  assertEquals(parsed.workers.length, 2);
+  assertEquals(parsed.count, 2);
+  assertEquals(parsed.workers[0].status, "busy");
+  assertEquals(parsed.workers[0].labels, { os: "linux", gpu: "none" });
+  assertEquals(parsed.workers[1].activeDispatchIds, []);
+});
+
+Deno.test("renderWorkerList: json mode includes filteredDisconnectedCount when present", () => {
+  const data: WorkerListData = {
+    workers: [
+      {
+        name: "live-worker",
+        status: "idle",
+        labels: {},
+        platform: "linux",
+        arch: "x86_64",
+        instanceUuid: "uuid-1",
+        enrolledAt: "2026-06-09T00:00:00.000Z",
+        lastSeenAt: "2026-06-09T12:00:00.000Z",
+        capacity: 1,
+        activeDispatchIds: [],
+      },
+    ],
+    count: 1,
+    filteredDisconnectedCount: 2,
+  };
+  const output = captureLogs(() => renderWorkerList(data, "json"));
+  const parsed = JSON.parse(output) as WorkerListData;
+  assertEquals(parsed.count, 1);
+  assertEquals(parsed.filteredDisconnectedCount, 2);
 });
 
 Deno.test("renderWorkerStatus: dispatch lifecycle renders start and finish", () => {

--- a/src/presentation/output/worker_output_test.ts
+++ b/src/presentation/output/worker_output_test.ts
@@ -251,6 +251,47 @@ Deno.test("renderWorkerList: log mode shows empty-state hint", () => {
   assertStringIncludes(output, "No workers found.");
 });
 
+Deno.test("renderWorkerList: log mode shows disconnected hint when all filtered", () => {
+  const output = stripAnsiCode(
+    captureLogs(() =>
+      renderWorkerList(
+        { workers: [], count: 0, filteredDisconnectedCount: 3 },
+        "log",
+      )
+    ),
+  );
+  assertStringIncludes(output, "No connected workers found.");
+  assertStringIncludes(output, "3 disconnected worker(s) hidden");
+  assertStringIncludes(output, "--all");
+});
+
+Deno.test("renderWorkerList: log mode shows disconnected hint after table", () => {
+  const data: WorkerListData = {
+    workers: [
+      {
+        name: "live-worker",
+        status: "idle",
+        labels: {},
+        platform: "linux",
+        arch: "x86_64",
+        instanceUuid: "uuid-1",
+        enrolledAt: "2026-06-09T00:00:00.000Z",
+        lastSeenAt: "2026-06-09T12:00:00.000Z",
+        capacity: 1,
+        activeDispatchIds: [],
+      },
+    ],
+    count: 1,
+    filteredDisconnectedCount: 2,
+  };
+  const output = stripAnsiCode(
+    captureLogs(() => renderWorkerList(data, "log")),
+  );
+  assertStringIncludes(output, "live-worker");
+  assertStringIncludes(output, "2 disconnected worker(s) hidden");
+  assertStringIncludes(output, "--all");
+});
+
 Deno.test("renderWorkerList: json mode emits the array of records", () => {
   const output = captureLogs(() => renderWorkerList(workerListData, "json"));
   const parsed = JSON.parse(output) as WorkerListData["workers"];

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1480,6 +1480,7 @@ export function handleMessage(
         request.id,
         controller,
         principal,
+        request.payload,
       );
       break;
     case "worker.queue.list":

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -655,6 +655,9 @@ const VaultAnnotateRequestSchema = z.object({
 const WorkerListRequestSchema = z.object({
   type: z.literal("worker.list"),
   id: z.string().min(1).max(256),
+  payload: z.object({
+    showAll: z.boolean().optional(),
+  }).optional(),
 });
 
 const WorkerQueueListRequestSchema = z.object({

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -50,6 +50,7 @@ import type {
   ExtensionInfoPayload,
   ExtensionRmPayload,
   ExtensionSearchPayload,
+  WorkerListPayload,
   WorkerProbeResult,
   WorkerVerifyPayload,
 } from "../protocol.ts";
@@ -76,6 +77,7 @@ export async function handleWorkerList(
   requestId: string,
   controller: AbortController,
   principal: Principal | null,
+  payload?: WorkerListPayload,
 ): Promise<void> {
   if (
     !authorizeOrReject(socket, requestId, principal, "admin", {
@@ -91,7 +93,9 @@ export async function handleWorkerList(
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
-      workerList(libCtx, deps),
+      workerList(libCtx, deps, {
+        includeDisconnected: payload?.showAll ?? false,
+      }),
       {
         resolving: () => {},
         completed: (e) => {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -339,7 +339,9 @@ export interface VaultAnnotatePayload {
 
 // ── Server admin ─────────────────────────────────────────────────────
 
-export type WorkerListPayload = Record<string, never>;
+export interface WorkerListPayload {
+  showAll?: boolean;
+}
 
 export type WorkerQueueListPayload = Record<string, never>;
 


### PR DESCRIPTION
Closes swamp-club#1000

## Summary

- `swamp worker list` now hides disconnected workers by default — operators see only the live pool
- `--all` flag includes disconnected workers in the output
- Both local and remote (serve) paths support the flag via `WorkerListPayload.showAll`
- Empty-state and after-table hints tell users about `--all` when disconnected workers are filtered
- Filtering lives in the domain layer (`workerList`) so `count` and empty-state semantics are consistent across output modes

## Breaking Change

**`swamp worker list --json` output shape changed.** Previously emitted a bare JSON array of worker objects; now emits the full `WorkerListData` envelope:

```json
{
  "workers": [...],
  "count": 2,
  "filteredDisconnectedCount": 1
}
```

Scripts using `swamp worker list --json | jq '.[0]'` must update to `jq '.workers[0]'`. The envelope is necessary so JSON consumers can detect when disconnected workers were filtered — without it, the default filtering would silently reduce the result set with no signal.

## Test Plan

- [x] `deno check` — type check passes
- [x] `deno lint` — lint passes
- [x] `deno fmt --check` — formatting passes
- [x] Unit tests for domain filtering: default hides disconnected, `includeDisconnected: true` includes them, `filteredDisconnectedCount` omitted when zero
- [x] Presentation tests: empty-state hint when all workers are disconnected, footer hint when some are hidden, JSON envelope includes `filteredDisconnectedCount`
- [x] All existing tests pass (1 pre-existing flaky SIGINT signal test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>