### PR TITLE
fix(security): reject select projections in capability service queryData (swamp-club#1004)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -456,7 +456,7 @@ disposition — a proxy verb, worker-local, or shipped state. Fourteen verbs:
 | Verb               | Backed by                                                                  | Transport | Notes                                  |
 | ------------------ | -------------------------------------------------------------------------- | --------- | -------------------------------------- |
 | `getData`          | repo reads (`findByName`/`findById`/`getContent`/`stream`), `context.readResource`, `readModelData` | ws + h2   | ws resolves `latest`→version; h2 streams bytes |
-| `queryData`        | `dataQueryService` / `context.queryData`, incl. `select` projection and attribute loading | ws        | CEL predicate over the catalog; always live |
+| `queryData`        | `dataQueryService` / `context.queryData`, attribute loading (`select` projection rejected — bypasses denylist) | ws        | CEL predicate over the catalog; always live |
 | `listVersions`     | `repo.listVersions`, `findAllGlobal`/`findAllForModel` enumeration         | ws        | Version-history and cross-model enumeration |
 | `persistResource`  | resource writer (`writeResource`)                                          | h2        | Streams bytes; durable immediately     |
 | `persistFile`      | file writer `writeAll`/`writeText`/`writeStream`                           | h2        | Streams bytes; durable immediately     |

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -253,6 +253,11 @@ export class CapabilityService {
     workerName: string,
     params: QueryDataParams & { dispatchId?: string },
   ): Promise<unknown[]> {
+    if (params.options?.select) {
+      throw new Error(
+        "Select projections are not permitted from workers",
+      );
+    }
     if (params.predicate.length > MAX_CAPABILITY_PREDICATE_LENGTH) {
       throw new Error("Query predicate exceeds maximum length");
     }

--- a/src/serve/capability_service_test.ts
+++ b/src/serve/capability_service_test.ts
@@ -137,6 +137,21 @@ Deno.test("queryData: allows results without modelType field", async () => {
   assertEquals(result.length, 1);
 });
 
+Deno.test("queryData: rejects when select projection is provided", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatch(dispatches);
+  const service = createService(dispatches);
+  await assertRejects(
+    () =>
+      service.queryData("worker-1", {
+        predicate: "true",
+        options: { select: "attributes.secretKey" },
+      }),
+    Error,
+    "not permitted from workers",
+  );
+});
+
 Deno.test("queryData: rejects predicate exceeding max length", async () => {
   const dispatches = new DispatchRegistry();
   withDispatch(dispatches);


### PR DESCRIPTION
## Summary

The capability service's `queryData` post-query denylist filter checks
`rec.modelType` on each result, but CEL `select` projections return plain
objects without `modelType` — letting all projected values through and
bypassing the infrastructure model denylist (`DENIED_QUERY_MODEL_TYPES`).

A dispatched worker method could call `context.queryData` with a `select`
projection targeting denied model types (e.g. `swamp/enrollment-token`) to
extract sensitive fields like vault references.

**Fix:** Reject `options.select` at the capability service boundary before the
query executes. Workers have no legitimate need for CEL projections through the
capability RPC — projections are a CLI/workflow convenience.

- Added guard in `CapabilityService.queryData()` that throws before query execution
- Added unit test for the new rejection
- Updated `design/remote-execution.md` verb table to reflect select is rejected

Closes swamp-club#1004

## Test Plan

- [x] New test: `queryData: rejects when select projection is provided`
- [x] Existing denylist tests still pass (swamp/grant, swamp/server-token, denormalized types)
- [x] Existing "allows results without modelType field" test still passes (non-projection path)
- [x] Full test suite passes (8425 passed, 0 failed)