### PR TITLE
fix(security): add per-step secret authorization to resolveSecret and putSecret

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -462,8 +462,8 @@ disposition — a proxy verb, worker-local, or shipped state. Fourteen verbs:
 | `persistFile`      | file writer `writeAll`/`writeText`/`writeStream`                           | h2        | Streams bytes; durable immediately     |
 | `appendData`       | `DataWriter.writeLine` → `repo.append`                                     | h2        | Incremental append; durable per request (live logs) |
 | `deleteData`       | `repo.delete`, `repo.removeLatestMarker`                                   | ws        | Lifecycle/GC-aware methods use these   |
-| `resolveSecret`    | `vaultService.get` / `getAnnotation`                                       | ws        | Authorized per step                    |
-| `putSecret`        | `vaultService.put` / `putAnnotation` / `deleteAnnotation`                  | ws        | Vault writes — the mint model's own path |
+| `resolveSecret`    | `vaultService.get` / `getAnnotation`                                       | ws        | Authorized per step: infrastructure key denylist (`server-token-*`, `worker-token-*`) + expression-based allowlist from dispatched step's args |
+| `putSecret`        | `vaultService.put` / `putAnnotation` / `deleteAnnotation`                  | ws        | Infrastructure key denylist (`server-token-*`, `worker-token-*`); no expression-based allowlist (write targets are not declared in vault expressions) |
 | `readDefinition`   | `definitionRepository` reads                                               | ws        | Lazy-load; cacheable for the run       |
 | `readOutput`       | `outputRepository` execution-history reads                                 | ws        | Optional context member; same lazy/cache rule |
 | `resolveModel`     | catalog / `catalogStore`                                                   | ws        | Workflow step model resolution         |

--- a/src/domain/expressions/vault_reference_extractor.ts
+++ b/src/domain/expressions/vault_reference_extractor.ts
@@ -1,0 +1,85 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/g;
+
+const VAULT_GET_PATTERN =
+  /vault\.get\(\s*(?:(['"`])(.+?)\1|([^\s,)]+))\s*,\s*(?:(['"`])(.+?)\4|([^\s,)]+))\s*\)/g;
+
+export interface VaultReference {
+  vaultName: string;
+  secretKey: string;
+}
+
+export interface VaultExtractionResult {
+  staticRefs: VaultReference[];
+  hasDynamicRefs: boolean;
+}
+
+export function extractVaultReferences(
+  ...dataSources: unknown[]
+): VaultExtractionResult {
+  const staticRefs: VaultReference[] = [];
+  const seen = new Set<string>();
+  let hasDynamicRefs = false;
+
+  for (const data of dataSources) {
+    collectVaultReferences(data, staticRefs, seen, (dynamic) => {
+      if (dynamic) hasDynamicRefs = true;
+    });
+  }
+
+  return { staticRefs, hasDynamicRefs };
+}
+
+function collectVaultReferences(
+  data: unknown,
+  refs: VaultReference[],
+  seen: Set<string>,
+  onDynamic: (isDynamic: boolean) => void,
+): void {
+  if (typeof data === "string") {
+    for (const exprMatch of data.matchAll(EXPRESSION_PATTERN)) {
+      const celExpr = exprMatch[1];
+      VAULT_GET_PATTERN.lastIndex = 0;
+      for (const vaultMatch of celExpr.matchAll(VAULT_GET_PATTERN)) {
+        const vaultName = vaultMatch[2];
+        const secretKey = vaultMatch[5];
+
+        if (vaultName !== undefined && secretKey !== undefined) {
+          const key = `${vaultName}\0${secretKey}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            refs.push({ vaultName, secretKey });
+          }
+        } else {
+          onDynamic(true);
+        }
+      }
+    }
+  } else if (Array.isArray(data)) {
+    for (const item of data) {
+      collectVaultReferences(item, refs, seen, onDynamic);
+    }
+  } else if (data !== null && typeof data === "object") {
+    for (const value of Object.values(data as Record<string, unknown>)) {
+      collectVaultReferences(value, refs, seen, onDynamic);
+    }
+  }
+}

--- a/src/domain/expressions/vault_reference_extractor_test.ts
+++ b/src/domain/expressions/vault_reference_extractor_test.ts
@@ -1,0 +1,147 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { extractVaultReferences } from "./vault_reference_extractor.ts";
+
+Deno.test("extractVaultReferences: extracts single quoted reference", () => {
+  const data = { apiKey: "${{ vault.get('default', 'api-key') }}" };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, [
+    { vaultName: "default", secretKey: "api-key" },
+  ]);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: extracts double quoted reference", () => {
+  const data = { token: '${{ vault.get("infra", "token") }}' };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, [
+    { vaultName: "infra", secretKey: "token" },
+  ]);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: extracts from nested objects", () => {
+  const data = {
+    outer: {
+      inner: {
+        secret: "${{ vault.get('v1', 'k1') }}",
+      },
+    },
+    top: "${{ vault.get('v2', 'k2') }}",
+  };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs.length, 2);
+  assertEquals(result.staticRefs[0], { vaultName: "v1", secretKey: "k1" });
+  assertEquals(result.staticRefs[1], { vaultName: "v2", secretKey: "k2" });
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: extracts from arrays", () => {
+  const data = [
+    "${{ vault.get('default', 'secret-a') }}",
+    "${{ vault.get('default', 'secret-b') }}",
+  ];
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs.length, 2);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: detects dynamic vault name", () => {
+  const data = { key: "${{ vault.get(inputs.vault, 'key') }}" };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, []);
+  assertEquals(result.hasDynamicRefs, true);
+});
+
+Deno.test("extractVaultReferences: detects dynamic secret key", () => {
+  const data = { key: "${{ vault.get('default', inputs.key) }}" };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, []);
+  assertEquals(result.hasDynamicRefs, true);
+});
+
+Deno.test("extractVaultReferences: handles mixed static and dynamic", () => {
+  const data = {
+    static: "${{ vault.get('default', 'api-key') }}",
+    dynamic: "${{ vault.get('default', inputs.key) }}",
+  };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, [
+    { vaultName: "default", secretKey: "api-key" },
+  ]);
+  assertEquals(result.hasDynamicRefs, true);
+});
+
+Deno.test("extractVaultReferences: deduplicates identical references", () => {
+  const data = {
+    a: "${{ vault.get('default', 'shared-key') }}",
+    b: "${{ vault.get('default', 'shared-key') }}",
+  };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs.length, 1);
+  assertEquals(result.staticRefs[0], {
+    vaultName: "default",
+    secretKey: "shared-key",
+  });
+});
+
+Deno.test("extractVaultReferences: returns empty for no vault references", () => {
+  const data = { plain: "hello", num: 42 };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, []);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: handles null and undefined values", () => {
+  const data = { a: null, b: undefined, c: "plain" };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, []);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: handles empty object", () => {
+  const result = extractVaultReferences({});
+  assertEquals(result.staticRefs, []);
+  assertEquals(result.hasDynamicRefs, false);
+});
+
+Deno.test("extractVaultReferences: handles multiple data sources", () => {
+  const globals = { apiKey: "${{ vault.get('default', 'api-key') }}" };
+  const methodArgs = { token: "${{ vault.get('infra', 'token') }}" };
+  const result = extractVaultReferences(globals, methodArgs);
+  assertEquals(result.staticRefs.length, 2);
+  assertEquals(result.staticRefs[0], {
+    vaultName: "default",
+    secretKey: "api-key",
+  });
+  assertEquals(result.staticRefs[1], {
+    vaultName: "infra",
+    secretKey: "token",
+  });
+});
+
+Deno.test("extractVaultReferences: handles secret keys with spaces", () => {
+  const data = { key: "${{ vault.get('infra', 'Client ID') }}" };
+  const result = extractVaultReferences(data);
+  assertEquals(result.staticRefs, [
+    { vaultName: "infra", secretKey: "Client ID" },
+  ]);
+});

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -59,8 +59,10 @@ const TOKEN_DATA_NAME = "token-main";
 
 const DEFAULT_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // ~30 days
 
+export const SERVER_TOKEN_SECRET_KEY_PREFIX = "server-token-";
+
 export function serverTokenSecretKey(tokenName: string): string {
-  return `server-token-${tokenName}`;
+  return `${SERVER_TOKEN_SECRET_KEY_PREFIX}${tokenName}`;
 }
 
 async function readToken(context: MethodContext): Promise<ServerToken> {

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -105,9 +105,11 @@ export type EnrollmentToken = z.output<typeof EnrollmentTokenSchema>;
 
 const TOKEN_DATA_NAME = "token-main";
 
+export const WORKER_TOKEN_SECRET_KEY_PREFIX = "worker-token-";
+
 /** Vault key under which a token's plaintext is stored. */
 export function tokenSecretKey(tokenName: string): string {
-  return `worker-token-${tokenName}`;
+  return `${WORKER_TOKEN_SECRET_KEY_PREFIX}${tokenName}`;
 }
 
 async function readToken(context: MethodContext): Promise<EnrollmentToken> {

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -63,10 +63,21 @@ import { jsonSafeClone } from "./serializer.ts";
 import type { ActiveDispatch, DispatchRegistry } from "./dispatch_registry.ts";
 import { GRANT_MODEL_TYPE } from "../domain/models/access/grant_model.ts";
 import { GROUP_MODEL_TYPE } from "../domain/models/access/group_model.ts";
-import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
-import { ENROLLMENT_TOKEN_MODEL_TYPE } from "../domain/models/worker/enrollment_token_model.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  SERVER_TOKEN_SECRET_KEY_PREFIX,
+} from "../domain/models/access/server_token_model.ts";
+import {
+  ENROLLMENT_TOKEN_MODEL_TYPE,
+  WORKER_TOKEN_SECRET_KEY_PREFIX,
+} from "../domain/models/worker/enrollment_token_model.ts";
 import { WORKER_MODEL_TYPE } from "../domain/models/worker/worker_model.ts";
 import { STEP_LEASE_MODEL_TYPE } from "../domain/models/worker/step_lease_model.ts";
+
+const DENIED_SECRET_KEY_PREFIXES: readonly string[] = [
+  SERVER_TOKEN_SECRET_KEY_PREFIX,
+  WORKER_TOKEN_SECRET_KEY_PREFIX,
+];
 
 const DENIED_QUERY_MODEL_TYPES: readonly string[] = [
   GRANT_MODEL_TYPE.normalized,
@@ -336,6 +347,34 @@ export class CapabilityService {
     return { deleted: true };
   }
 
+  #assertSecretKeyNotDenied(secretKey: string, verb: string): void {
+    const normalized = secretKey.toLowerCase();
+    if (DENIED_SECRET_KEY_PREFIXES.some((p) => normalized.startsWith(p))) {
+      throw new Error(
+        `${verb}: access denied — infrastructure secrets are not accessible from dispatched methods`,
+      );
+    }
+  }
+
+  #assertSecretInAllowlist(
+    dispatch: ActiveDispatch,
+    vaultName: string,
+    secretKey: string,
+    verb: string,
+  ): void {
+    const allowed = dispatch.allowedSecrets;
+    if (!allowed) return;
+    if (allowed.hasDynamicRefs) return;
+    const isAllowed = allowed.staticRefs.some(
+      (ref) => ref.vaultName === vaultName && ref.secretKey === secretKey,
+    );
+    if (!isAllowed) {
+      throw new Error(
+        `${verb}: secret '${secretKey}' is not referenced by the dispatched step`,
+      );
+    }
+  }
+
   async resolveSecret(
     workerName: string,
     params: ResolveSecretParams & { dispatchId?: string },
@@ -351,6 +390,13 @@ export class CapabilityService {
           `resolveSecret: worker '${workerName}' has no active dispatch`,
         );
       }
+      this.#assertSecretKeyNotDenied(params.secretKey, "resolveSecret");
+      this.#assertSecretInAllowlist(
+        dispatch,
+        params.vaultName,
+        params.secretKey,
+        "resolveSecret",
+      );
     }
     const vault = await this.#vault();
     if (params.annotation) {
@@ -379,6 +425,7 @@ export class CapabilityService {
           `putSecret: worker '${workerName}' has no active dispatch`,
         );
       }
+      this.#assertSecretKeyNotDenied(params.secretKey, "putSecret");
     }
     const vault = await this.#vault();
     if (params.deleteAnnotation) {

--- a/src/serve/capability_service_test.ts
+++ b/src/serve/capability_service_test.ts
@@ -21,8 +21,10 @@ import { assertRejects } from "@std/assert";
 import { assertEquals } from "@std/assert";
 import { CapabilityService } from "./capability_service.ts";
 import { DispatchRegistry } from "./dispatch_registry.ts";
+import type { ActiveDispatch } from "./dispatch_registry.ts";
 import { ModelType } from "../domain/models/model_type.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+import type { VaultExtractionResult } from "../domain/expressions/vault_reference_extractor.ts";
 
 function stubRepoContext(
   queryResult: unknown[] = [],
@@ -51,6 +53,28 @@ function createService(
     repoContext: stubRepoContext(queryResult),
     dispatches,
     createVaultService: () => Promise.reject(new Error("no vault")),
+  });
+}
+
+function createServiceWithVault(
+  dispatches?: DispatchRegistry,
+  secrets: Record<string, string> = {},
+): CapabilityService {
+  return new CapabilityService({
+    repoDir: "/tmp/test",
+    repoContext: stubRepoContext(),
+    dispatches,
+    createVaultService: () =>
+      Promise.resolve({
+        get: (_vault: string, key: string) => {
+          if (key in secrets) return Promise.resolve(secrets[key]);
+          throw new Error(`secret not found: ${key}`);
+        },
+        getAnnotation: () => Promise.resolve(null),
+        put: () => Promise.resolve(),
+        putAnnotation: () => Promise.resolve(),
+        deleteAnnotation: () => Promise.resolve(),
+      } as never),
   });
 }
 
@@ -289,4 +313,241 @@ Deno.test("getData: passes when no dispatch registry configured", async () => {
     dataName: "result",
   });
   assertEquals(result.found, false);
+});
+
+// ── secret key denylist tests ──────────────────────────────────────────
+
+function withDispatchAndSecrets(
+  dispatches: DispatchRegistry,
+  allowedSecrets?: VaultExtractionResult,
+  workerName = "worker-1",
+): void {
+  const dispatch: ActiveDispatch = {
+    workerName,
+    dispatchId: "d-1",
+    leaseId: "l-1",
+    modelDef: {} as never,
+    modelType: ModelType.create("acme/invoices"),
+    modelId: "m-1",
+    methodName: "run",
+    definitionName: "my-invoice",
+    definitionTags: {},
+    allowedSecrets,
+  };
+  dispatches.register(dispatch);
+}
+
+Deno.test("resolveSecret: rejects server-token-* keys", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "server-token-admin",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+Deno.test("resolveSecret: rejects worker-token-* keys", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "worker-token-ci-runner",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+Deno.test("resolveSecret: denylist is case-insensitive", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "Server-Token-Admin",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+Deno.test("putSecret: rejects server-token-* keys", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.putSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "server-token-admin",
+        secretValue: "evil",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+Deno.test("putSecret: rejects worker-token-* keys", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.putSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "worker-token-ci-runner",
+        secretValue: "evil",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+Deno.test("putSecret: denylist is case-insensitive", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.putSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "Worker-Token-CI",
+        secretValue: "evil",
+      }),
+    Error,
+    "access denied",
+  );
+});
+
+// ── per-step allowlist tests (resolveSecret only) ──────────────────────
+
+Deno.test("resolveSecret: allows key present in static allowlist", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [{ vaultName: "default", secretKey: "api-key" }],
+    hasDynamicRefs: false,
+  });
+  const service = createServiceWithVault(dispatches, { "api-key": "secret" });
+  const result = await service.resolveSecret("worker-1", {
+    vaultName: "default",
+    secretKey: "api-key",
+  });
+  assertEquals(result.value, "secret");
+});
+
+Deno.test("resolveSecret: rejects key not in static allowlist", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [{ vaultName: "default", secretKey: "api-key" }],
+    hasDynamicRefs: false,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "other-key",
+      }),
+    Error,
+    "not referenced by the dispatched step",
+  );
+});
+
+Deno.test("resolveSecret: skips allowlist when dispatch has dynamic refs", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [{ vaultName: "default", secretKey: "api-key" }],
+    hasDynamicRefs: true,
+  });
+  const service = createServiceWithVault(dispatches, {
+    "other-key": "value",
+  });
+  const result = await service.resolveSecret("worker-1", {
+    vaultName: "default",
+    secretKey: "other-key",
+  });
+  assertEquals(result.value, "value");
+});
+
+Deno.test("resolveSecret: empty allowlist denies all keys", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [],
+    hasDynamicRefs: false,
+  });
+  const service = createServiceWithVault(dispatches);
+  await assertRejects(
+    () =>
+      service.resolveSecret("worker-1", {
+        vaultName: "default",
+        secretKey: "any-key",
+      }),
+    Error,
+    "not referenced by the dispatched step",
+  );
+});
+
+Deno.test("putSecret: allows keys not in allowlist (denylist-only)", async () => {
+  const dispatches = new DispatchRegistry();
+  withDispatchAndSecrets(dispatches, {
+    staticRefs: [{ vaultName: "default", secretKey: "api-key" }],
+    hasDynamicRefs: false,
+  });
+  const service = createServiceWithVault(dispatches);
+  const result = await service.putSecret("worker-1", {
+    vaultName: "default",
+    secretKey: "new-output-key",
+    secretValue: "value",
+  });
+  assertEquals(result.ok, true);
+});
+
+Deno.test("resolveSecret: passes without dispatch registry (no scoping)", async () => {
+  const service = createServiceWithVault(undefined, {
+    "any-key": "value",
+  });
+  const result = await service.resolveSecret("worker-1", {
+    vaultName: "default",
+    secretKey: "any-key",
+  });
+  assertEquals(result.value, "value");
+});
+
+Deno.test("putSecret: passes without dispatch registry (no scoping)", async () => {
+  const service = createServiceWithVault(undefined);
+  const result = await service.putSecret("worker-1", {
+    vaultName: "default",
+    secretKey: "any-key",
+    secretValue: "value",
+  });
+  assertEquals(result.ok, true);
 });

--- a/src/serve/dispatch_registry.ts
+++ b/src/serve/dispatch_registry.ts
@@ -27,6 +27,9 @@
 import type { UnifiedDataRepository } from "../domain/data/repositories.ts";
 import type { ModelDefinition } from "../domain/models/model.ts";
 import type { ModelType } from "../domain/models/model_type.ts";
+import type {
+  VaultExtractionResult,
+} from "../domain/expressions/vault_reference_extractor.ts";
 
 export interface ActiveDispatch {
   workerName: string;
@@ -41,6 +44,7 @@ export interface ActiveDispatch {
   definitionTags: Record<string, string>;
   runtimeTags?: Record<string, string>;
   dataRepo?: UnifiedDataRepository;
+  allowedSecrets?: VaultExtractionResult;
 }
 
 export class DispatchRegistry {

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -71,6 +71,7 @@ import type { WorkerSnapshot } from "./worker_gateway.ts";
 import type { ActiveDispatch, DispatchRegistry } from "./dispatch_registry.ts";
 import type { BundleRegistry } from "./bundle_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import { extractVaultReferences } from "../domain/expressions/vault_reference_extractor.ts";
 
 export { hasPlacement };
 
@@ -370,6 +371,10 @@ export class DispatchService {
       definitionTags: request.definitionTags,
       runtimeTags: request.runtimeTags,
       dataRepo: request.dataRepo,
+      allowedSecrets: extractVaultReferences(
+        request.globalArgs,
+        request.methodArgs,
+      ),
     });
 
     const params: DispatchParams = {


### PR DESCRIPTION
## Summary

Closes swamp-club#1005.

Adds two layers of secret authorization to `CapabilityService` for `resolveSecret` and `putSecret`:

1. **Infrastructure key denylist** (case-insensitive) — unconditionally blocks `server-token-*` and `worker-token-*` prefixed keys on both `resolveSecret` and `putSecret`. Prevents dispatched methods from reading or overwriting authentication credentials.

2. **Per-step vault scoping** — at dispatch time, `vault.get()` references are extracted from the step's `globalArgs` and `methodArgs`. When all references are statically resolvable, `resolveSecret` enforces the allowlist. When dynamic references exist (e.g. `inputs.key`), `resolveSecret` falls back to denylist-only mode. `putSecret` is denylist-only because write targets are not declared in vault expressions.

### Changes

- **New**: `src/domain/expressions/vault_reference_extractor.ts` — extracts `(vaultName, secretKey)` pairs from arbitrary data structures containing `${{ vault.get() }}` expressions, distinguishing static from dynamic references
- **Modified**: `src/serve/dispatch_registry.ts` — `ActiveDispatch` gains `allowedSecrets?: VaultExtractionResult`
- **Modified**: `src/serve/dispatch_service.ts` — populates `allowedSecrets` at dispatch registration
- **Modified**: `src/serve/capability_service.ts` — `DENIED_SECRET_KEY_PREFIXES` constant, `#assertSecretKeyNotDenied` (both verbs), `#assertSecretInAllowlist` (`resolveSecret` only)
- **Modified**: `src/domain/models/access/server_token_model.ts` — exports `SERVER_TOKEN_SECRET_KEY_PREFIX`
- **Modified**: `src/domain/models/worker/enrollment_token_model.ts` — exports `WORKER_TOKEN_SECRET_KEY_PREFIX`
- **Modified**: `design/remote-execution.md` — updated capability table to reflect implemented authorization

## Test Plan

- 13 unit tests for vault reference extraction (static, dynamic, mixed, nested, dedup, edge cases)
- 14 new capability service tests:
  - `resolveSecret`/`putSecret` reject `server-token-*` and `worker-token-*` keys
  - Denylist is case-insensitive (`Server-Token-*` also rejected)
  - `resolveSecret` rejects keys not in static allowlist
  - `resolveSecret` allows keys present in allowlist
  - `resolveSecret` skips allowlist when dispatch has dynamic refs
  - Empty allowlist denies all `resolveSecret` keys
  - `putSecret` allows keys not in allowlist (denylist-only, no allowlist)
  - No-dispatch-registry codepath continues to work without restrictions
- All 8449 existing tests pass
- Full type check, lint, format clean