### PR TITLE
fix(security): explicitly override child-injected dispatchId in runner bridge

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -600,7 +600,7 @@ tracks N active dispatches per worker keyed by `(workerName, dispatchId)`.
 `SessionCredentialService.issueForDispatch(workerId, dispatchId)`. This
 credential is independent of the control-channel credential — session refreshes
 do not invalidate in-flight runners. Credentials are revoked when the dispatch
-completes. The capability bridge injects `dispatchId` into every RPC verb so
+completes. The capability bridge overrides `dispatchId` in every RPC verb so
 the `CapabilityService` can resolve the correct dispatch for model-type scope
 isolation.
 

--- a/src/worker/runner_bridge.ts
+++ b/src/worker/runner_bridge.ts
@@ -74,7 +74,9 @@ export function bridgeCapabilityVerbs(
       async (params: unknown, ctx: RpcHandlerContext) => {
         logger.debug("Bridging {verb} from runner to orchestrator", { verb });
         const combinedSignal = AbortSignal.any([signal, ctx.signal]);
-        const wrapped = { ...(params as Record<string, unknown>), dispatchId };
+        const { dispatchId: _childDispatchId, ...childParams } =
+          params as Record<string, unknown>;
+        const wrapped = { ...childParams, dispatchId };
         return await orchestratorChannel.call(verb, wrapped, {
           signal: combinedSignal,
           timeoutMs: null,

--- a/src/worker/runner_bridge_test.ts
+++ b/src/worker/runner_bridge_test.ts
@@ -151,6 +151,60 @@ Deno.test("bridgeCapabilityVerbs: cancel signal aborts bridged call", async () =
   );
 });
 
+Deno.test("bridgeCapabilityVerbs: child-injected dispatchId is overwritten by supervisor value", async () => {
+  const runnerPair = channelPair();
+  const orchPair = channelPair();
+
+  orchPair.b.register(
+    RemoteMethod.getData,
+    (params) => Promise.resolve({ data: params }),
+  );
+
+  bridgeCapabilityVerbs({
+    childChannel: runnerPair.b,
+    orchestratorChannel: orchPair.a,
+    dispatchId: "supervisor-dispatch",
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  const result = await runnerPair.a.call<{ data: Record<string, unknown> }>(
+    RemoteMethod.getData,
+    {
+      modelType: "test",
+      modelId: "m1",
+      dataName: "out",
+      dispatchId: "malicious-dispatch",
+    },
+  );
+
+  assertEquals(result.data.dispatchId, "supervisor-dispatch");
+});
+
+Deno.test("bridgeCapabilityVerbs: params without dispatchId get supervisor value injected", async () => {
+  const runnerPair = channelPair();
+  const orchPair = channelPair();
+
+  orchPair.b.register(
+    RemoteMethod.deleteData,
+    (params) => Promise.resolve({ data: params }),
+  );
+
+  bridgeCapabilityVerbs({
+    childChannel: runnerPair.b,
+    orchestratorChannel: orchPair.a,
+    dispatchId: "supervisor-dispatch",
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  const result = await runnerPair.a.call<{ data: Record<string, unknown> }>(
+    RemoteMethod.deleteData,
+    { modelType: "test", modelId: "m1", dataName: "out" },
+  );
+
+  assertEquals(result.data.dispatchId, "supervisor-dispatch");
+  assertEquals(result.data.modelType, "test");
+});
+
 Deno.test("bridgeCapabilityVerbs: exactly 9 verbs are bridged", () => {
   assertEquals(BRIDGED_VERBS.length, 9);
 });


### PR DESCRIPTION
## Summary

- Hardens the runner bridge's `dispatchId` enforcement by explicitly destructuring and discarding the child's value before spreading params — the prior code relied on implicit JS spread-order semantics which, while correct, was fragile against accidental refactoring
- Adds two tests verifying the adversarial case (child-injected dispatchId is overwritten) and the normal case (params without dispatchId get the supervisor's value)
- Updates design/remote-execution.md to clarify the bridge *overrides* (not just injects) `dispatchId`

Closes swamp-club#1007

## Test Plan

- [x] New test: child-injected `dispatchId` is overwritten by supervisor value
- [x] New test: params without `dispatchId` get supervisor value injected
- [x] All 8433 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean