### PR TITLE
feat(data): add swamp data prune to reclaim orphaned data (#1009)

### DIFF
--- a/.claude/skills/swamp/references/data/guide.md
+++ b/.claude/skills/swamp/references/data/guide.md
@@ -35,24 +35,26 @@ for the full list of queryable fields and predicate operators.
 
 ## Quick Reference
 
-| Task                   | Command                                               |
-| ---------------------- | ----------------------------------------------------- |
-| Query by model         | `swamp data query 'modelName == "my-model"'`          |
-| Query by type          | `swamp data query 'dataType == "resource"'`           |
-| Query with projection  | `swamp data query 'modelName == "x"' --select 'name'` |
-| Query by tags          | `swamp data query 'tags.env == "prod"'`               |
-| Query by content       | `swamp data query 'attributes.status == "failed"'`    |
-| List model data        | `swamp data list <model> --json`                      |
-| List workflow data     | `swamp data list --workflow <name> --json`            |
-| Get specific data      | `swamp data get <model> <name> --json`                |
-| Get metadata only      | `swamp data get <model> <name> --no-content --json`   |
-| Get data via workflow  | `swamp data get --workflow <name> <data_name> --json` |
-| View version history   | `swamp data versions <model> <name> --json`           |
-| Run garbage collection | `swamp data gc --json`                                |
-| Rename data instance   | `swamp data rename <model> <old> <new>`               |
-| Delete data artifact   | `swamp data delete <model> <name> --force`            |
-| Delete one version     | `swamp data delete <model> <name> --version 3`        |
-| Preview GC (dry run)   | `swamp data gc --dry-run --json`                      |
+| Task                    | Command                                               |
+| ----------------------- | ----------------------------------------------------- |
+| Query by model          | `swamp data query 'modelName == "my-model"'`          |
+| Query by type           | `swamp data query 'dataType == "resource"'`           |
+| Query with projection   | `swamp data query 'modelName == "x"' --select 'name'` |
+| Query by tags           | `swamp data query 'tags.env == "prod"'`               |
+| Query by content        | `swamp data query 'attributes.status == "failed"'`    |
+| List model data         | `swamp data list <model> --json`                      |
+| List workflow data      | `swamp data list --workflow <name> --json`            |
+| Get specific data       | `swamp data get <model> <name> --json`                |
+| Get metadata only       | `swamp data get <model> <name> --no-content --json`   |
+| Get data via workflow   | `swamp data get --workflow <name> <data_name> --json` |
+| View version history    | `swamp data versions <model> <name> --json`           |
+| Run garbage collection  | `swamp data gc --json`                                |
+| Prune orphaned data     | `swamp data prune --force --json`                     |
+| Preview prune (dry run) | `swamp data prune --dry-run --json`                   |
+| Rename data instance    | `swamp data rename <model> <old> <new>`               |
+| Delete data artifact    | `swamp data delete <model> <name> --force`            |
+| Delete one version      | `swamp data delete <model> <name> --version 3`        |
+| Preview GC (dry run)    | `swamp data gc --dry-run --json`                      |
 
 See [references/concepts.md](references/concepts.md) for lifetime types, tags,
 and version GC policies.

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -254,6 +254,45 @@ Two things are deliberately **not** namespaced:
   the namespace prefix cannot reach them — vaults stay repo-local by
   construction.
 
+#### Orphaned data reclamation (`swamp data prune`)
+
+**Orphaned data** is persisted data whose owning model definition no longer
+exists in its namespace — e.g. after the definition is deleted from the repo, or
+after a model instance is migrated to a different namespace leaving its
+historical data behind. Because the on-disk layout and the catalog `DELETE`
+predicate are keyed by model **type** (`{typeDir}/{modelId}/...` and
+`type_normalized`), and the type is normally re-derived by resolving the
+definition, both `swamp data delete` and `swamp data gc` fail on orphaned data:
+`delete` throws `Model not found`, and `gc` only enforces each item's frozen
+`lifetime`/`garbageCollection` policy (so `infinite`-lifetime orphans are never
+collected). The rows then accumulate in the catalog indefinitely, inflating
+index size and per-write sync cost.
+
+`swamp data prune` reclaims them. It walks the datastore data root
+(`findAllGlobal`), groups by `(type, modelId)`, and for each group asks a
+per-item predicate whether the owning model definition still exists. The
+predicate uses the definition repository's `findById` — which resolves **both**
+`models/` and `.swamp/auto-definitions/`, matching `swamp model get` — so
+auto-definition-backed models (auto-created model-run/workflow models, installed
+`@swamp/*` models) are correctly treated as live and never pruned. Groups with
+no live definition are reclaimed via the existing definition-free
+`delete(type, modelId, dataName)`, which removes all versions on disk and their
+catalog rows. Reclamation is irreversible and inferential (a definition can be
+transiently absent — a branch switch or an in-flight migration), so prune is
+opt-in per invocation, defaults to a confirmation prompt, supports `--dry-run`
+for a preview, and acquires the global datastore lock (via
+`requireInitializedRepo`) like `gc`/`delete`.
+
+This is distinct from two neighbouring concepts:
+
+- **`swamp data gc`** enforces the retention policy a model *declared*
+  (lifetime + version-cap). `prune` removes data whose model is *gone*. They are
+  deliberately separate commands; `gc` stays safe to run unattended, while
+  `prune` gates the inferential deletion behind its own verb.
+- **"Orphan recovery"** in `data_access_service.ts` is the *opposite* intent — a
+  read-time mechanism that keeps data reachable across a model's UUID change. It
+  never deletes anything.
+
 ## Remote Datastore Sync
 
 When a remote datastore (e.g., S3 via `@swamp/s3-datastore`) is configured,

--- a/integration/data_prune_test.ts
+++ b/integration/data_prune_test.ts
@@ -1,0 +1,218 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for orphaned-data reclamation (`swamp data prune`),
+ * reproducing swamp-club#1009.
+ *
+ * Exercises the full slice against a real FileSystemUnifiedDataRepository +
+ * CatalogStore + YamlDefinitionRepository:
+ * (a) data whose owning model definition is gone is reclaimed (disk + catalog)
+ * (b) a model with a live definition is never touched (no false positives)
+ * (c) a model whose definition lives ONLY in .swamp/auto-definitions/ is treated
+ *     as live and never pruned — the ADV-1 correctness crux: the predicate must
+ *     match `swamp model get` (findById covers models/ AND auto-definitions/),
+ *     not `model search` (which skips auto-definitions)
+ * (d) --dry-run reports the orphan but deletes nothing
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { Data } from "../src/domain/data/data.ts";
+import type { OwnerDefinition } from "../src/domain/data/data_metadata.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import {
+  createDefinitionId,
+  Definition,
+} from "../src/domain/definitions/definition.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import {
+  DefaultDataLifecycleService,
+  type IsModelLive,
+} from "../src/domain/data/data_lifecycle_service.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../src/infrastructure/persistence/paths.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-data-prune-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+function createOwner(ref: string): OwnerDefinition {
+  return { ownerType: "model-method", ownerRef: ref };
+}
+
+// A stub workflow-run repo — orphan reclamation never consults it.
+const stubWorkflowRunRepo = { findById: () => Promise.resolve(null) } as never;
+
+interface Harness {
+  service: DefaultDataLifecycleService;
+  dataRepo: FileSystemUnifiedDataRepository;
+  isModelLive: IsModelLive;
+  /** Definition repo scoped to models/ (primary). */
+  modelsRepo: YamlDefinitionRepository;
+  /** Definition repo scoped to .swamp/auto-definitions/ (secondary). */
+  autoDefsRepo: YamlDefinitionRepository;
+}
+
+async function wire(repoDir: string): Promise<Harness> {
+  await ensureDir(join(repoDir, ".swamp", "data"));
+  await ensureDir(join(repoDir, "models"));
+
+  const dataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    undefined,
+    new CatalogStore(join(repoDir, "_catalog.db")),
+  );
+  const service = new DefaultDataLifecycleService(
+    dataRepo,
+    stubWorkflowRunRepo,
+  );
+
+  // Predicate wired exactly like createDataPruneDeps: per-item findById on a
+  // repo that resolves BOTH models/ and .swamp/auto-definitions/.
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const isModelLive: IsModelLive = async (type, modelId) =>
+    (await definitionRepo.findById(type, createDefinitionId(modelId))) !== null;
+
+  const modelsRepo = new YamlDefinitionRepository(repoDir);
+  const autoDefsRepo = new YamlDefinitionRepository(
+    repoDir,
+    undefined,
+    swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions),
+  );
+
+  return { service, dataRepo, isModelLive, modelsRepo, autoDefsRepo };
+}
+
+async function writeData(
+  dataRepo: FileSystemUnifiedDataRepository,
+  type: ModelType,
+  modelId: string,
+  dataName: string,
+  versions: number,
+): Promise<void> {
+  const data = Data.create({
+    name: dataName,
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 10,
+    tags: { type: "state", modelName: "test-model" },
+    ownerDefinition: createOwner(`${type.toDirectoryPath()}:${modelId}`),
+  });
+  for (let i = 1; i <= versions; i++) {
+    await dataRepo.save(
+      type,
+      modelId,
+      data,
+      new TextEncoder().encode(JSON.stringify({ v: i })),
+    );
+  }
+}
+
+Deno.test("Data Prune: reclaims orphaned data, spares live and auto-definition models", async () => {
+  await withTempDir(async (repoDir) => {
+    const { service, dataRepo, isModelLive, modelsRepo, autoDefsRepo } =
+      await wire(repoDir);
+
+    const type = ModelType.create("test/prune");
+
+    // 1. LIVE model — definition saved to models/
+    const live = Definition.create({ name: "live-model" });
+    await modelsRepo.save(type, live);
+    await writeData(dataRepo, type, live.id, "state", 2);
+
+    // 2. AUTO-DEF model — definition saved ONLY to .swamp/auto-definitions/
+    const auto = Definition.create({ name: "auto-model" });
+    await autoDefsRepo.save(type, auto);
+    await writeData(dataRepo, type, auto.id, "state", 2);
+
+    // 3. ORPHAN model — data written, but NO definition anywhere
+    const orphanId = createDefinitionId(crypto.randomUUID());
+    await writeData(dataRepo, type, orphanId, "result", 3);
+
+    // findOrphanedData returns exactly the orphan.
+    const orphans = await service.findOrphanedData(isModelLive);
+    assertEquals(orphans.length, 1);
+    assertEquals(orphans[0].modelId, orphanId);
+    assertEquals(orphans[0].versionCount, 3);
+
+    // --dry-run: nothing deleted.
+    const dry = await service.deleteOrphanedData({ isModelLive, dryRun: true });
+    assertEquals(dry.modelsReclaimed, 1);
+    assertEquals(dry.dryRun, true);
+    assertEquals(
+      (await dataRepo.listVersions(type, orphanId, "result")).length,
+      3,
+    );
+
+    // Real prune: orphan gone, live + auto-def intact.
+    const result = await service.deleteOrphanedData({ isModelLive });
+    assertEquals(result.modelsReclaimed, 1);
+    assertEquals(result.dataEntriesReclaimed, 1);
+    assertEquals(result.versionsDeleted, 3);
+    assertEquals(result.bytesReclaimed > 0, true);
+
+    // Orphan removed from disk AND catalog.
+    assertEquals(await dataRepo.listVersions(type, orphanId, "result"), []);
+    assertEquals(await dataRepo.findByName(type, orphanId, "result"), null);
+
+    // Invariant (b): live model untouched.
+    assertEquals(
+      (await dataRepo.listVersions(type, live.id, "state")).length,
+      2,
+    );
+    // Invariant (c) — ADV-1: auto-definition-backed model untouched.
+    assertEquals(
+      (await dataRepo.listVersions(type, auto.id, "state")).length,
+      2,
+    );
+  });
+});
+
+Deno.test("Data Prune: no orphans when every model has a live definition", async () => {
+  await withTempDir(async (repoDir) => {
+    const { service, dataRepo, isModelLive, modelsRepo } = await wire(repoDir);
+    const type = ModelType.create("test/prune");
+
+    const live = Definition.create({ name: "live-only" });
+    await modelsRepo.save(type, live);
+    await writeData(dataRepo, type, live.id, "state", 2);
+
+    const result = await service.deleteOrphanedData({ isModelLive });
+    assertEquals(result.modelsReclaimed, 0);
+    assertEquals(
+      (await dataRepo.listVersions(type, live.id, "state")).length,
+      2,
+    );
+  });
+});

--- a/src/cli/commands/data.ts
+++ b/src/cli/commands/data.ts
@@ -24,6 +24,7 @@ import { dataListCommand } from "./data_list.ts";
 import { dataSearchCommand } from "./data_search.ts";
 import { dataVersionsCommand } from "./data_versions.ts";
 import { dataGcCommand } from "./data_gc.ts";
+import { dataPruneCommand } from "./data_prune.ts";
 import { dataRenameCommand } from "./data_rename.ts";
 import { dataDeleteCommand } from "./data_delete.ts";
 import { dataQueryCommand } from "./data_query.ts";
@@ -38,5 +39,6 @@ export const dataCommand = new Command()
   .command("query", dataQueryCommand)
   .command("versions", dataVersionsCommand)
   .command("gc", dataGcCommand)
+  .command("prune", dataPruneCommand)
   .command("rename", dataRenameCommand)
   .command("delete", dataDeleteCommand);

--- a/src/cli/commands/data_prune.ts
+++ b/src/cli/commands/data_prune.ts
@@ -1,0 +1,121 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createDataPruneDeps,
+  createLibSwampContext,
+  dataPrune,
+  dataPrunePreview,
+} from "../../libswamp/mod.ts";
+import {
+  createDataPruneRenderer,
+  renderDataPruneCancelled,
+  renderDataPrunePreview,
+} from "../../presentation/renderers/data_prune.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  requireInitializedRepo,
+  requireInitializedRepoReadOnly,
+} from "../repo_context.ts";
+
+async function promptConfirmation(message: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
+
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return false;
+
+  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
+  return response === "y" || response === "yes";
+}
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const dataPruneCommand = new Command()
+  .name("prune")
+  .description(
+    "Reclaim orphaned data whose owning model definition no longer exists.\n" +
+      "Unlike `data gc` (which enforces each model's declared lifetime and\n" +
+      "version-cap), prune removes data left behind when a model definition is\n" +
+      "deleted or migrated away. Deletion is irreversible; use --dry-run first.",
+  )
+  .example(
+    "Preview orphaned data that would be reclaimed",
+    "swamp data prune --dry-run",
+  )
+  .example("Reclaim orphaned data", "swamp data prune --force")
+  .example(
+    "Run non-interactively in JSON mode (no prompt, structured output)",
+    "swamp data prune --json",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--dry-run", "Show what would be reclaimed without deleting")
+  .option("-f, --force", "Skip confirmation prompt")
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, ["data", "prune"]);
+
+    const repoOpts = {
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    };
+    const { repoDir, datastoreResolver } = options.dryRun
+      ? await requireInitializedRepoReadOnly(repoOpts)
+      : await requireInitializedRepo(repoOpts);
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createDataPruneDeps(repoDir, datastoreResolver);
+
+    // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
+    if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {
+      const preview = await dataPrunePreview(ctx, deps);
+      if (preview.items.length === 0) {
+        console.log("No orphaned data to reclaim.");
+        return;
+      }
+
+      renderDataPrunePreview(preview, cliCtx.outputMode);
+      const confirmed = await promptConfirmation(
+        "Reclaim this orphaned data?",
+      );
+      if (!confirmed) {
+        renderDataPruneCancelled(cliCtx.outputMode);
+        return;
+      }
+    }
+
+    // Phase 2: Execute prune
+    const renderer = createDataPruneRenderer(cliCtx.outputMode);
+    await consumeStream(
+      dataPrune(ctx, deps, { dryRun: !!options.dryRun }),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/data_prune_test.ts
+++ b/src/cli/commands/data_prune_test.ts
@@ -1,0 +1,76 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("dataPruneCommand - has correct name", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  assertEquals(dataPruneCommand.getName(), "prune");
+});
+
+Deno.test("dataPruneCommand - description mentions orphaned data", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const description = dataPruneCommand.getDescription().toLowerCase();
+  assertStringIncludes(description, "orphaned");
+});
+
+Deno.test("dataPruneCommand - description distinguishes it from gc", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const description = dataPruneCommand.getDescription().toLowerCase();
+  assertStringIncludes(description, "gc");
+});
+
+Deno.test("dataPruneCommand - has repo-dir option", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const options = dataPruneCommand.getOptions();
+  const repoDir = options.find((opt) => opt.name === "repo-dir");
+  assertEquals(repoDir !== undefined, true);
+});
+
+Deno.test("dataPruneCommand - has dry-run option", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const options = dataPruneCommand.getOptions();
+  const dryRun = options.find((opt) => opt.name === "dry-run");
+  assertEquals(dryRun !== undefined, true);
+});
+
+Deno.test("dataPruneCommand - has force option", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const options = dataPruneCommand.getOptions();
+  const force = options.find((opt) => opt.name === "force");
+  assertEquals(force !== undefined, true);
+});
+
+Deno.test("dataPruneCommand - help text includes a --json non-interactive example", async () => {
+  const { dataPruneCommand } = await import("./data_prune.ts");
+  const examples = dataPruneCommand.getExamples().map((e) => e.description);
+  const hasJsonExample = examples.some((d) => d.toLowerCase().includes("json"));
+  assertEquals(hasJsonExample, true, `examples were: ${examples.join(" | ")}`);
+});
+
+Deno.test("data command registers the prune subcommand", async () => {
+  await import("../../domain/models/models.ts");
+  const { dataCommand } = await import("./data.ts");
+  const prune = dataCommand.getCommand("prune");
+  assertEquals(prune !== undefined, true);
+});

--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -76,6 +76,61 @@ export interface LifecycleGCResult {
 }
 
 /**
+ * Predicate answering whether a model definition still exists for the given
+ * (type, modelId). Injected as a port so the lifecycle service stays decoupled
+ * from the definition repository — the libswamp layer wires this using the same
+ * definition lookup that `swamp model get` uses (covering both `models/` and
+ * `.swamp/auto-definitions/`).
+ */
+export type IsModelLive = (
+  type: ModelType,
+  modelId: string,
+) => Promise<boolean>;
+
+/**
+ * A model's orphaned data — data whose owning model definition no longer exists
+ * in its namespace. Aggregated per (type, modelId); every data name under an
+ * orphaned model is orphaned together.
+ */
+export interface OrphanedDataInfo {
+  type: ModelType;
+  modelId: string;
+  /** Human-readable model name, from the data tags (may be absent on old data). */
+  modelName?: string;
+  /** Distinct data names owned by the orphaned model. */
+  dataNames: string[];
+  /** Total versions across all data names. */
+  versionCount: number;
+  /** Bytes on disk across all versions. */
+  bytesReclaimed: number;
+}
+
+/**
+ * Result of orphaned-data reclamation.
+ */
+export interface OrphanReclamationResult {
+  /** Number of orphaned models whose data was reclaimed. */
+  modelsReclaimed: number;
+  /** Number of data entries (distinct data names) reclaimed. */
+  dataEntriesReclaimed: number;
+  /** Number of versions hard-deleted. */
+  versionsDeleted: number;
+  /** Bytes reclaimed. */
+  bytesReclaimed: number;
+  /** Whether this was a dry run. */
+  dryRun: boolean;
+  /** The orphaned models that were (or would be) reclaimed. */
+  reclaimedModels: Array<{
+    type: string;
+    modelId: string;
+    modelName?: string;
+    dataNames: string[];
+    versionCount: number;
+    bytesReclaimed: number;
+  }>;
+}
+
+/**
  * Service for managing data lifecycle and garbage collection.
  */
 export interface DataLifecycleService {
@@ -100,6 +155,25 @@ export interface DataLifecycleService {
   deleteExpiredData(options?: {
     dryRun?: boolean;
   }): Promise<LifecycleGCResult>;
+
+  /**
+   * Finds all orphaned data — data whose owning model definition no longer
+   * exists, per the injected `isModelLive` predicate. Results are aggregated
+   * per (type, modelId).
+   */
+  findOrphanedData(isModelLive: IsModelLive): Promise<OrphanedDataInfo[]>;
+
+  /**
+   * Reclaims orphaned data (all versions of every data name owned by a model
+   * with no live definition).
+   *
+   * @param options - The `isModelLive` predicate and an optional `dryRun` flag
+   * @returns Statistics about the operation
+   */
+  deleteOrphanedData(options: {
+    isModelLive: IsModelLive;
+    dryRun?: boolean;
+  }): Promise<OrphanReclamationResult>;
 
   /**
    * Checks if a data entry has expired.
@@ -390,6 +464,115 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
       bytesReclaimed,
       dryRun,
       expiredEntries,
+    };
+  }
+
+  async findOrphanedData(
+    isModelLive: IsModelLive,
+  ): Promise<OrphanedDataInfo[]> {
+    const allData = await this.dataRepo.findAllGlobal();
+
+    // Group by (type, modelId) — the consistency boundary for a model's data.
+    const groups = new Map<
+      string,
+      { type: ModelType; modelId: string; items: Data[] }
+    >();
+    for (const { data, modelType, modelId } of allData) {
+      if (data.isDeleted) continue;
+      const key = `${modelType.toDirectoryPath()}/${modelId}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { type: modelType, modelId, items: [] };
+        groups.set(key, group);
+      }
+      group.items.push(data);
+    }
+
+    const orphans: OrphanedDataInfo[] = [];
+    for (const group of groups.values()) {
+      // A model is orphaned iff its definition no longer exists. This check
+      // matches `swamp model get` semantics (models/ AND auto-definitions/).
+      if (await isModelLive(group.type, group.modelId)) continue;
+
+      const dataNames = [...new Set(group.items.map((d) => d.name))];
+      let versionCount = 0;
+      let bytesReclaimed = 0;
+      for (const name of dataNames) {
+        const versions = await this.dataRepo.listVersions(
+          group.type,
+          group.modelId,
+          name,
+        );
+        versionCount += versions.length;
+        for (const version of versions) {
+          const contentPath = this.dataRepo.getContentPath(
+            group.type,
+            group.modelId,
+            name,
+            version,
+          );
+          try {
+            const stat = await Deno.stat(contentPath);
+            bytesReclaimed += stat.size;
+          } catch {
+            // Ignore stat errors for missing files
+          }
+        }
+      }
+
+      orphans.push({
+        type: group.type,
+        modelId: group.modelId,
+        modelName: group.items[0]?.tags.modelName,
+        dataNames,
+        versionCount,
+        bytesReclaimed,
+      });
+    }
+
+    return orphans;
+  }
+
+  async deleteOrphanedData(options: {
+    isModelLive: IsModelLive;
+    dryRun?: boolean;
+  }): Promise<OrphanReclamationResult> {
+    const dryRun = options.dryRun ?? false;
+    const orphans = await this.findOrphanedData(options.isModelLive);
+
+    let versionsDeleted = 0;
+    let bytesReclaimed = 0;
+    let dataEntriesReclaimed = 0;
+    const reclaimedModels: OrphanReclamationResult["reclaimedModels"] = [];
+
+    for (const orphan of orphans) {
+      versionsDeleted += orphan.versionCount;
+      bytesReclaimed += orphan.bytesReclaimed;
+      dataEntriesReclaimed += orphan.dataNames.length;
+
+      if (!dryRun) {
+        for (const name of orphan.dataNames) {
+          await this.dataRepo.delete(orphan.type, orphan.modelId, name);
+        }
+      }
+
+      reclaimedModels.push({
+        type: orphan.type.toDirectoryPath(),
+        modelId: orphan.modelId,
+        modelName: orphan.modelName,
+        dataNames: orphan.dataNames,
+        versionCount: orphan.versionCount,
+        bytesReclaimed: orphan.bytesReclaimed,
+      });
+    }
+
+    return {
+      modelsReclaimed: orphans.length,
+      dataEntriesReclaimed,
+      versionsDeleted,
+      bytesReclaimed,
+      dryRun,
+      reclaimedModels,
     };
   }
 }

--- a/src/domain/data/data_lifecycle_service_test.ts
+++ b/src/domain/data/data_lifecycle_service_test.ts
@@ -657,3 +657,199 @@ Deno.test("previewVersionGarbage - returns empty when no prunes pending", async 
 
   assertEquals(previews.length, 0);
 });
+
+// --- Orphaned-data reclamation ---
+
+/** Predicate factory: models in `liveIds` are live, everything else orphaned. */
+function isModelLiveFor(liveIds: string[]) {
+  return (_type: ModelType, modelId: string) =>
+    Promise.resolve(liveIds.includes(modelId));
+}
+
+Deno.test("findOrphanedData - returns only models with no live definition", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  // infinite lifetime so nothing is "expired" — orphaning is independent of TTL
+  const orphanData = createMockData({ name: "d1", lifetime: "infinite" });
+  const liveData = createMockData({ name: "d2", lifetime: "infinite" });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: orphanData, modelType, modelId: "orphan" },
+      { data: liveData, modelType, modelId: "live" },
+    ]);
+  mockRepo.listVersions = () => Promise.resolve([1, 2]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor(["live"]));
+
+  assertEquals(orphans.length, 1);
+  assertEquals(orphans[0].modelId, "orphan");
+  assertEquals(orphans[0].dataNames, ["d1"]);
+  assertEquals(orphans[0].versionCount, 2);
+});
+
+Deno.test("findOrphanedData - aggregates multiple data names under one model", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const d1 = createMockData({ name: "result", lifetime: "infinite" });
+  const d2 = createMockData({ name: "log", lifetime: "infinite" });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: d1, modelType, modelId: "orphan" },
+      { data: d2, modelType, modelId: "orphan" },
+    ]);
+  mockRepo.listVersions = () => Promise.resolve([1]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor([]));
+
+  assertEquals(orphans.length, 1);
+  assertEquals(orphans[0].dataNames.sort(), ["log", "result"]);
+  assertEquals(orphans[0].versionCount, 2);
+});
+
+Deno.test("findOrphanedData - skips deletion markers", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const deletedData = Data.create({
+    name: "gone",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+    lifecycle: "deleted",
+  });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: deletedData, modelType, modelId: "orphan" },
+    ]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor([]));
+
+  assertEquals(orphans.length, 0);
+});
+
+Deno.test("findOrphanedData - surfaces modelName from data tags", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const named = Data.create({
+    name: "d1",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test", modelName: "my-model" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+  });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([{ data: named, modelType, modelId: "orphan" }]);
+  mockRepo.listVersions = () => Promise.resolve([1]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor([]));
+
+  assertEquals(orphans[0].modelName, "my-model");
+});
+
+Deno.test("deleteOrphanedData - hard-deletes orphaned data, leaves live untouched", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const orphanData = createMockData({ name: "d1", lifetime: "infinite" });
+  const liveData = createMockData({ name: "d2", lifetime: "infinite" });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: orphanData, modelType, modelId: "orphan" },
+      { data: liveData, modelType, modelId: "live" },
+    ]);
+  mockRepo.listVersions = () => Promise.resolve([1, 2, 3]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const result = await service.deleteOrphanedData({
+    isModelLive: isModelLiveFor(["live"]),
+  });
+
+  // Only the orphaned model's data is deleted (all versions, no version arg).
+  assertEquals(mockRepo.deleteCalls.length, 1);
+  assertEquals(mockRepo.deleteCalls[0].modelId, "orphan");
+  assertEquals(mockRepo.deleteCalls[0].dataName, "d1");
+  assertEquals(mockRepo.deleteCalls[0].version, undefined);
+
+  assertEquals(result.modelsReclaimed, 1);
+  assertEquals(result.dataEntriesReclaimed, 1);
+  assertEquals(result.versionsDeleted, 3);
+  assertEquals(result.reclaimedModels[0].modelId, "orphan");
+});
+
+Deno.test("deleteOrphanedData - dry run does not call delete()", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const orphanData = createMockData({ name: "d1", lifetime: "infinite" });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([{ data: orphanData, modelType, modelId: "orphan" }]);
+  mockRepo.listVersions = () => Promise.resolve([1, 2]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const result = await service.deleteOrphanedData({
+    isModelLive: isModelLiveFor([]),
+    dryRun: true,
+  });
+
+  assertEquals(mockRepo.deleteCalls.length, 0);
+  assertEquals(result.dryRun, true);
+  assertEquals(result.modelsReclaimed, 1);
+  assertEquals(result.versionsDeleted, 2);
+});
+
+Deno.test("deleteOrphanedData - no orphans when all models live", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const liveData = createMockData({ name: "d1", lifetime: "infinite" });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([{ data: liveData, modelType, modelId: "live" }]);
+  mockRepo.listVersions = () => Promise.resolve([1]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const result = await service.deleteOrphanedData({
+    isModelLive: isModelLiveFor(["live"]),
+  });
+
+  assertEquals(mockRepo.deleteCalls.length, 0);
+  assertEquals(result.modelsReclaimed, 0);
+  assertEquals(result.reclaimedModels.length, 0);
+});

--- a/src/libswamp/data/prune.ts
+++ b/src/libswamp/data/prune.ts
@@ -1,0 +1,190 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  DefaultDataLifecycleService,
+  type IsModelLive,
+  type OrphanedDataInfo,
+  type OrphanReclamationResult,
+} from "../../domain/data/data_lifecycle_service.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { createDefinitionId } from "../../domain/definitions/definition.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import {
+  createCatalogStore,
+  namespaceFromResolver,
+} from "../../infrastructure/persistence/repository_factory.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/** Preview item for a single orphaned model whose data would be reclaimed. */
+export interface DataPrunePreviewItem {
+  type: string;
+  modelId: string;
+  modelName?: string;
+  dataNames: string[];
+  versionCount: number;
+  bytesReclaimed: number;
+}
+
+/** Preview data returned before confirmation. */
+export interface DataPrunePreview {
+  items: DataPrunePreviewItem[];
+}
+
+/** Data structure for the data prune completed event. */
+export interface DataPruneData {
+  modelsReclaimed: number;
+  dataEntriesReclaimed: number;
+  versionsDeleted: number;
+  bytesReclaimed: number;
+  dryRun: boolean;
+  reclaimedModels: Array<{
+    type: string;
+    modelId: string;
+    modelName?: string;
+    dataNames: string[];
+    versionCount: number;
+    bytesReclaimed: number;
+  }>;
+  walPagesTotal: number;
+  walPagesCheckpointed: number;
+}
+
+export type DataPruneEvent =
+  | { kind: "collecting" }
+  | { kind: "completed"; data: DataPruneData }
+  | { kind: "error"; error: SwampError };
+
+/** Input for the data prune operation. */
+export interface DataPruneInput {
+  dryRun: boolean;
+}
+
+/** Dependencies for the data prune operation. */
+export interface DataPruneDeps {
+  findOrphanedData: () => Promise<OrphanedDataInfo[]>;
+  deleteOrphanedData: (opts: {
+    dryRun: boolean;
+  }) => Promise<OrphanReclamationResult>;
+  /** Checkpoints the catalog WAL. Omit in tests that don't need compaction. */
+  compactCatalog?: () => {
+    walPagesTotal: number;
+    walPagesCheckpointed: number;
+  };
+}
+
+/** Wires real infrastructure into DataPruneDeps. */
+export function createDataPruneDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+): DataPruneDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
+  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
+  const unifiedDataRepo = new FileSystemUnifiedDataRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.data),
+    catalogStore,
+    undefined,
+    undefined,
+    namespaceFromResolver(datastoreResolver),
+  );
+  const workflowRunRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+  );
+  const service = new DefaultDataLifecycleService(
+    unifiedDataRepo,
+    workflowRunRepo,
+  );
+
+  // The definition repository resolves models from BOTH models/ and
+  // .swamp/auto-definitions/ (the constructor default), matching what
+  // `swamp model get <id>` reports. isModelLive MUST use this per-item lookup —
+  // NOT model search / findAllGlobal, which skip auto-definitions and would
+  // falsely flag every auto-definition-backed model as orphaned.
+  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const isModelLive: IsModelLive = async (type, modelId) =>
+    (await definitionRepo.findById(type, createDefinitionId(modelId))) !== null;
+
+  return {
+    findOrphanedData: () => service.findOrphanedData(isModelLive),
+    deleteOrphanedData: (opts) =>
+      service.deleteOrphanedData({ isModelLive, dryRun: opts.dryRun }),
+    compactCatalog: () => catalogStore.checkpoint(),
+  };
+}
+
+/** Gathers preview info for the data prune operation. */
+export async function dataPrunePreview(
+  ctx: LibSwampContext,
+  deps: DataPruneDeps,
+): Promise<DataPrunePreview> {
+  ctx.logger.debug`Finding orphaned data`;
+  const orphans = await deps.findOrphanedData();
+  return {
+    items: orphans.map((item) => ({
+      type: item.type.toDirectoryPath(),
+      modelId: item.modelId,
+      modelName: item.modelName,
+      dataNames: item.dataNames,
+      versionCount: item.versionCount,
+      bytesReclaimed: item.bytesReclaimed,
+    })),
+  };
+}
+
+/** Reclaims orphaned data whose owning model definition no longer exists. */
+export async function* dataPrune(
+  _ctx: LibSwampContext,
+  deps: DataPruneDeps,
+  input: DataPruneInput,
+): AsyncIterable<DataPruneEvent> {
+  yield* withGeneratorSpan(
+    "swamp.data.prune",
+    { "prune.dry_run": input.dryRun },
+    (async function* () {
+      yield { kind: "collecting" } as const;
+
+      const result = await deps.deleteOrphanedData({ dryRun: input.dryRun });
+
+      const compact = !input.dryRun ? deps.compactCatalog?.() : undefined;
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          modelsReclaimed: result.modelsReclaimed,
+          dataEntriesReclaimed: result.dataEntriesReclaimed,
+          versionsDeleted: result.versionsDeleted,
+          bytesReclaimed: result.bytesReclaimed,
+          dryRun: result.dryRun,
+          reclaimedModels: result.reclaimedModels,
+          walPagesTotal: compact?.walPagesTotal ?? 0,
+          walPagesCheckpointed: compact?.walPagesCheckpointed ?? 0,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/data/prune_test.ts
+++ b/src/libswamp/data/prune_test.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  dataPrune,
+  type DataPruneDeps,
+  type DataPruneEvent,
+  dataPrunePreview,
+} from "./prune.ts";
+import type { OrphanReclamationResult } from "../../domain/data/data_lifecycle_service.ts";
+
+function emptyResult(
+  overrides: Partial<OrphanReclamationResult> = {},
+): OrphanReclamationResult {
+  return {
+    modelsReclaimed: 0,
+    dataEntriesReclaimed: 0,
+    versionsDeleted: 0,
+    bytesReclaimed: 0,
+    dryRun: false,
+    reclaimedModels: [],
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<DataPruneDeps> = {}): DataPruneDeps {
+  return {
+    findOrphanedData: () => Promise.resolve([]),
+    deleteOrphanedData: () => Promise.resolve(emptyResult()),
+    ...overrides,
+  };
+}
+
+Deno.test("dataPrunePreview: returns empty preview when no orphaned data", async () => {
+  const preview = await dataPrunePreview(createLibSwampContext(), makeDeps());
+
+  assertEquals(preview.items.length, 0);
+});
+
+Deno.test("dataPrunePreview: maps orphaned models into preview items", async () => {
+  const deps = makeDeps({
+    findOrphanedData: () =>
+      Promise.resolve([
+        {
+          type: { toDirectoryPath: () => "command/shell" },
+          modelId: "m1",
+          modelName: "hello",
+          dataNames: ["result", "log"],
+          versionCount: 4,
+          bytesReclaimed: 2048,
+        },
+      ] as unknown as import("../../domain/data/data_lifecycle_service.ts").OrphanedDataInfo[]),
+  });
+
+  const preview = await dataPrunePreview(createLibSwampContext(), deps);
+
+  assertEquals(preview.items.length, 1);
+  assertEquals(preview.items[0].type, "command/shell");
+  assertEquals(preview.items[0].modelId, "m1");
+  assertEquals(preview.items[0].modelName, "hello");
+  assertEquals(preview.items[0].dataNames, ["result", "log"]);
+  assertEquals(preview.items[0].versionCount, 4);
+  assertEquals(preview.items[0].bytesReclaimed, 2048);
+});
+
+Deno.test("dataPrune: yields completed with reclamation results", async () => {
+  const deps = makeDeps({
+    deleteOrphanedData: () =>
+      Promise.resolve(emptyResult({
+        modelsReclaimed: 2,
+        dataEntriesReclaimed: 5,
+        versionsDeleted: 9,
+        bytesReclaimed: 4096,
+      })),
+  });
+
+  const events = await collect<DataPruneEvent>(
+    dataPrune(createLibSwampContext(), deps, { dryRun: false }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "collecting");
+  const completed = events[1] as Extract<
+    DataPruneEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.modelsReclaimed, 2);
+  assertEquals(completed.data.dataEntriesReclaimed, 5);
+  assertEquals(completed.data.versionsDeleted, 9);
+  assertEquals(completed.data.bytesReclaimed, 4096);
+  assertEquals(completed.data.dryRun, false);
+});
+
+Deno.test("dataPrune: calls compactCatalog and includes WAL stats", async () => {
+  let compactCalled = false;
+  const deps = makeDeps({
+    compactCatalog: () => {
+      compactCalled = true;
+      return { walPagesTotal: 12, walPagesCheckpointed: 12 };
+    },
+  });
+
+  const events = await collect<DataPruneEvent>(
+    dataPrune(createLibSwampContext(), deps, { dryRun: false }),
+  );
+
+  assertEquals(compactCalled, true);
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    DataPruneEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.walPagesTotal, 12);
+  assertEquals(completed.data.walPagesCheckpointed, 12);
+});
+
+Deno.test("dataPrune: skips compactCatalog on dry-run", async () => {
+  let compactCalled = false;
+  const deps = makeDeps({
+    compactCatalog: () => {
+      compactCalled = true;
+      return { walPagesTotal: 12, walPagesCheckpointed: 12 };
+    },
+  });
+
+  await collect<DataPruneEvent>(
+    dataPrune(createLibSwampContext(), deps, { dryRun: true }),
+  );
+
+  assertEquals(compactCalled, false);
+});
+
+Deno.test("dataPrune: passes dryRun flag through to deleteOrphanedData", async () => {
+  let receivedDryRun = false;
+  const deps = makeDeps({
+    deleteOrphanedData: (opts) => {
+      receivedDryRun = opts.dryRun;
+      return Promise.resolve(emptyResult({ dryRun: true }));
+    },
+  });
+
+  await collect<DataPruneEvent>(
+    dataPrune(createLibSwampContext(), deps, { dryRun: true }),
+  );
+
+  assertEquals(receivedDryRun, true);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1046,6 +1046,19 @@ export {
   type VersionGcPreviewItem,
 } from "./data/gc.ts";
 
+// Data prune (orphaned-data reclamation)
+export {
+  createDataPruneDeps,
+  dataPrune,
+  type DataPruneData,
+  type DataPruneDeps,
+  type DataPruneEvent,
+  type DataPruneInput,
+  type DataPrunePreview,
+  dataPrunePreview,
+  type DataPrunePreviewItem,
+} from "./data/prune.ts";
+
 // Model create operations
 export {
   createModelCreateDeps,

--- a/src/presentation/renderers/data_prune.ts
+++ b/src/presentation/renderers/data_prune.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  DataPruneEvent,
+  DataPrunePreview,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogDataPruneRenderer implements Renderer<DataPruneEvent> {
+  handlers(): EventHandlers<DataPruneEvent> {
+    const logger = getSwampLogger(["data", "prune"]);
+    return {
+      collecting: () => {},
+      completed: (e) => {
+        if (e.data.dryRun) {
+          logger
+            .info`Prune dry run: would reclaim ${e.data.modelsReclaimed} orphaned model(s), ${e.data.dataEntriesReclaimed} data entries, ${e.data.versionsDeleted} versions (${e.data.bytesReclaimed} bytes)`;
+          return;
+        }
+        logger
+          .info`Prune complete: reclaimed ${e.data.modelsReclaimed} orphaned model(s), ${e.data.dataEntriesReclaimed} data entries, ${e.data.versionsDeleted} versions (${e.data.bytesReclaimed} bytes)`;
+        if (
+          e.data.walPagesTotal > 0 &&
+          e.data.walPagesCheckpointed < e.data.walPagesTotal
+        ) {
+          logger
+            .info`WAL partial checkpoint: ${e.data.walPagesCheckpointed}/${e.data.walPagesTotal} pages (active readers present)`;
+        } else if (e.data.walPagesTotal > 0) {
+          logger.info`WAL checkpointed and truncated`;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDataPruneRenderer implements Renderer<DataPruneEvent> {
+  handlers(): EventHandlers<DataPruneEvent> {
+    return {
+      collecting: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(
+          {
+            modelsReclaimed: e.data.modelsReclaimed,
+            dataEntriesReclaimed: e.data.dataEntriesReclaimed,
+            versionsDeleted: e.data.versionsDeleted,
+            bytesReclaimed: e.data.bytesReclaimed,
+            dryRun: e.data.dryRun,
+            reclaimedModels: e.data.reclaimedModels,
+            walPagesTotal: e.data.walPagesTotal,
+            walPagesCheckpointed: e.data.walPagesCheckpointed,
+          },
+          null,
+          2,
+        ));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDataPruneRenderer(
+  mode: OutputMode,
+): Renderer<DataPruneEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonDataPruneRenderer();
+    case "log":
+      return new LogDataPruneRenderer();
+  }
+}
+
+/** Renders the preview of orphaned data before confirmation. */
+export function renderDataPrunePreview(
+  preview: DataPrunePreview,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    const totalVersions = preview.items.reduce(
+      (sum, item) => sum + item.versionCount,
+      0,
+    );
+    const totalBytes = preview.items.reduce(
+      (sum, item) => sum + item.bytesReclaimed,
+      0,
+    );
+    console.log(JSON.stringify(
+      {
+        orphanedModelCount: preview.items.length,
+        orphanedVersionCount: totalVersions,
+        orphanedBytes: totalBytes,
+        orphanedModels: preview.items,
+      },
+      null,
+      2,
+    ));
+  } else {
+    const logger = getSwampLogger(["data", "prune"]);
+    logger
+      .info`Prune preview: ${preview.items.length} orphaned model(s) with no live definition`;
+    for (const item of preview.items) {
+      const name = item.modelName ? `${item.modelName} ` : "";
+      logger
+        .info`  ${name}(${item.type}/${item.modelId}): ${item.dataNames.length} data entries, ${item.versionCount} versions, ${item.bytesReclaimed} bytes`;
+    }
+  }
+}
+
+/** Renders cancellation when user declines the prompt. */
+export function renderDataPruneCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ cancelled: true }, null, 2));
+  } else {
+    const logger = getSwampLogger(["data", "prune"]);
+    logger.info("Prune cancelled.");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes swamp-club lab #1009 — orphaned data (whose owning model definition no longer exists) could be neither GC'd nor deleted.

Both `swamp data delete` and `swamp data gc` resolve the model **definition** to obtain the `ModelType` (needed for the on-disk path `{typeDir}/{modelId}/...` and the catalog `type_normalized` predicate). Once the definition is gone — deleted from the repo, or the model migrated to a different namespace leaving historical data behind — the type is unrecoverable via the definition repo, so `delete` throws `Model not found` and `gc` only enforces each item's frozen `lifetime`/version-cap (never reclaiming `infinite`-lifetime orphans). The rows then accumulate in the catalog indefinitely, inflating index size and per-write sync cost.

This adds an **orphaned-data reclamation** domain operation and a new **`swamp data prune`** command:

- `DefaultDataLifecycleService.findOrphanedData` / `deleteOrphanedData` enumerate data via the existing `findAllGlobal` walk, group by `(type, modelId)`, and reclaim groups with no live definition via the existing definition-free `delete(type, modelId, dataName)` (removes all versions on disk + catalog rows).
- The model-existence check is injected as a port (`IsModelLive`); the libswamp layer wires it to a **per-item `YamlDefinitionRepository.findById`**, which resolves both `models/` **and** `.swamp/auto-definitions/` — matching `swamp model get`. This is the correctness crux: auto-definition-backed models (auto-created model-run/workflow models, installed `@swamp/*` models) are treated as **live** and never pruned. Using `model search` / `findAllGlobal` here would skip auto-definitions and mass-delete their data.
- Safe by default: `--dry-run` preview, `-f/--force` to skip the confirmation prompt, `--json`, and the global datastore lock via `requireInitializedRepo` (read-only lock for dry-run) — mirroring `data gc`/`delete`. No per-model locks.

Kept deliberately **separate from `data gc`** (which enforces declared retention policy) so `gc` stays safe to run unattended, while the inferential, irreversible orphan deletion is gated behind its own verb. `design/datastores.md` documents the concept and contrasts it with the read-time "orphan recovery" in `data_access_service.ts` (opposite intent).

## Test Plan

- **Domain unit tests** (`data_lifecycle_service_test.ts`): find/delete orphaned data, dry-run is a no-op, live models untouched, modelName surfaced, deletion markers skipped.
- **libswamp unit tests** (`prune_test.ts`): event stream, WAL compaction on real run / skipped on dry-run, dryRun passthrough.
- **CLI tests** (`data_prune_test.ts`): command wiring, options, help, subcommand registration.
- **Integration test** (`integration/data_prune_test.ts`): full reproduction against a real repo + catalog, asserting orphan reclaimed (disk + catalog) and two safety invariants — (b) a **live** model's data is untouched, and (c) a model whose definition lives **only** in `.swamp/auto-definitions/` is never pruned.
- **End-to-end**: rebuilt the binary and re-ran the original reproduction — `swamp data prune --force` reclaimed all 4 orphaned `command/shell` entries that previously survived both `gc` and `delete` (catalog rows → 0, on-disk dirs gone); a live model in the same repo was left untouched.
- Gates: `deno check`, `deno lint`, `deno fmt --check`, affected-area tests (106 passed / 0 failed, no regressions in existing `gc`/`delete`/`search`/`versions`/`rename`), `deno run compile`.

## Follow-ups

- UAT gap filed: swamp-club/swamp-uat#293 (CLI test for `data prune`).
- Manual-docs gap: could not be filed — GitHub issues are disabled on `swamp-club/swamp-club`. `content/manual/reference/data.md` should gain a `swamp data prune` entry; tracking needed via the lab issue system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)