### PR TITLE
feat(serve-auth): implement OAuth device grant flow (#1016)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -204,6 +204,55 @@ stored credentials in `~/.config/swamp/servers.json` (managed by
 `swamp auth server-login`). Token management is through
 `swamp access token mint/list/revoke`.
 
+When `--auth-mode oauth` is active, users authenticate via the OAuth device
+grant flow (RFC 8628) against swamp-club. The server acts as an OAuth client
+relay — it holds client credentials (auto-registered on first start or
+supplied via `--oauth-client-id`) and proxies the device authorization flow.
+The flow:
+
+1. User runs `swamp auth login --server <url>`
+2. CLI calls `GET /auth/info` on the serve instance to discover auth mode
+3. CLI calls `POST /auth/device` — serve starts a device grant against
+   swamp-club, returns a user code and verification URL
+4. User visits the URL, signs in to swamp-club, enters the code, approves
+5. CLI polls `POST /auth/device/token` — serve polls swamp-club's token
+   endpoint, gets an access token, calls the userinfo endpoint to retrieve
+   `sub`, `email`, `name`, and `collectives`
+6. Serve applies the admission policy: the user must be in
+   `--allowed-collectives` or `--allowed-users`; otherwise admission is
+   rejected
+7. On admission, serve mints a `swamp/server-token` with the user's
+   collectives snapshotted on the token record and returns
+   `<name>.<secret>` to the CLI
+8. CLI stores the server token via `ServerCredentialRepository` — subsequent
+   commands authenticate with it automatically
+
+After the device flow, OAuth-minted tokens are indistinguishable from
+manually-minted tokens. The WebSocket upgrade, cancel endpoint, and all
+handler authorization use the same `?token=<name>.<secret>` +
+`authenticateServerToken` path for both modes. The only difference is
+collectives: the `authorizeOrReject` function reads collectives from the
+token record (via a per-connection WeakMap set at upgrade time), enabling
+`idp-group:` grants to match for OAuth-authenticated users.
+
+Auto-registration: on first start with `--auth-mode oauth`, if no client
+credentials are stored, the serve instance reads the admin's swamp-club API
+key from `~/.config/swamp/auth.json`, calls
+`POST /api/auth/oauth2/register`, and stores the returned `client_id` and
+`client_secret` in the vault (keys: `oauth-client-id`,
+`oauth-client-secret`). Subsequent starts read from the vault. If the admin
+hasn't run `swamp auth login`, the server refuses to start. If no vault is
+initialized, the server refuses to start.
+
+Collectives are snapshotted at login time and become stale if the user's
+collective membership changes in swamp-club. Refresh is a later phase.
+
+v1 is swamp-club-specific: the OAuth client endpoint paths
+(`/api/auth/device/code`, `/api/auth/device/token`,
+`/api/auth/oauth2/userinfo`, `/api/auth/oauth2/register`) are hardcoded.
+The `--oauth-provider` flag accepts a custom URL but only swamp-club is
+tested.
+
 The token travels as a `?token=` query parameter on the WebSocket upgrade URL.
 This avoids the browser WebSocket limitation (no custom headers), but the
 plaintext will appear in any reverse proxy or load balancer access logs that

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -25,10 +25,7 @@ import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
 import { splitServerToken } from "../../serve/token_auth.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { bold, green, yellow } from "@std/fmt/colors";
-import {
-  createServerLoginDeps,
-  serverLogin,
-} from "../../libswamp/auth/server_login.ts";
+import { createServerLoginDeps, serverLogin } from "../../libswamp/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -173,7 +170,12 @@ async function handleOAuthFlow(
         }
         break;
       case "browser_open_failed":
-        if (cliCtx.outputMode !== "json") {
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({
+            status: "browser_open_failed",
+            message: event.message,
+          }));
+        } else {
           writeOutput(yellow(event.message));
         }
         break;
@@ -184,6 +186,7 @@ async function handleOAuthFlow(
         if (cliCtx.outputMode === "json") {
           console.log(JSON.stringify({
             status: "authenticated",
+            serverUrl: rawUrl,
             principalId: event.data.principalId,
             principalEmail: event.data.principalEmail,
             displayName: event.data.displayName,

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -130,7 +130,17 @@ async function handleOAuthFlow(
   options: AnyOptions,
   cliCtx: { outputMode: string },
 ): Promise<void> {
-  const rawUrl = options.server as string;
+  let rawUrl = options.server as string;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol === "ws:") parsed.protocol = "http:";
+    else if (parsed.protocol === "wss:") parsed.protocol = "https:";
+    rawUrl = parsed.href;
+  } catch {
+    throw new UserError(
+      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+    );
+  }
   const normalizedUrl = normalizeServerUrl(rawUrl);
   const deps = createServerLoginDeps();
   const input = { serverUrl: rawUrl, signal: AbortSignal.timeout(300_000) };

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -24,7 +24,11 @@ import { FileServerCredentialRepository } from "../../infrastructure/persistence
 import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
 import { splitServerToken } from "../../serve/token_auth.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import { bold, green } from "@std/fmt/colors";
+import { bold, green, yellow } from "@std/fmt/colors";
+import {
+  createServerLoginDeps,
+  serverLogin,
+} from "../../libswamp/auth/server_login.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -32,11 +36,15 @@ type AnyOptions = any;
 export const authServerLoginCommand = new Command()
   .name("server-login")
   .description(
-    "Store a server token for a swamp serve instance — subsequent " +
-      "--server commands use it automatically",
+    "Authenticate with a swamp serve instance — uses OAuth device flow " +
+      "when available, or store a static token with --token",
   )
   .example(
-    "Save a token",
+    "OAuth login",
+    "swamp auth server-login --server wss://swamp.acme.internal:9090",
+  )
+  .example(
+    "Save a static token",
     "swamp auth server-login --server wss://swamp.acme.internal:9090 --token adam-token.a1b2c3...",
   )
   .option(
@@ -46,8 +54,7 @@ export const authServerLoginCommand = new Command()
   )
   .option(
     "--token <token:string>",
-    "Server token in <name>.<secret> format",
-    { required: true },
+    "Server token in <name>.<secret> format (skips OAuth flow)",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -55,54 +62,143 @@ export const authServerLoginCommand = new Command()
       "server-login",
     ]);
 
-    const token = options.token as string;
-    const split = splitServerToken(token);
-    if (split === null) {
-      throw new UserError(
-        `Invalid --token value: expected <name>.<secret> format`,
-      );
-    }
+    const token = options.token as string | undefined;
 
-    let rawUrl = options.server as string;
-    try {
-      const parsed = new URL(rawUrl);
-      if (parsed.protocol === "ws:") parsed.protocol = "http:";
-      else if (parsed.protocol === "wss:") parsed.protocol = "https:";
-      rawUrl = parsed.href;
-    } catch {
-      throw new UserError(
-        `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
-      );
-    }
-    let serverUrl: string;
-    try {
-      serverUrl = normalizeServerUrl(rawUrl);
-    } catch {
-      throw new UserError(
-        `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
-      );
-    }
-
-    const repo = new FileServerCredentialRepository();
-    await repo.save({
-      serverUrl,
-      tokenName: split.name,
-      token,
-      principalId: "",
-      obtainedAt: new Date().toISOString(),
-    });
-
-    if (cliCtx.outputMode === "json") {
-      console.log(JSON.stringify({
-        serverUrl,
-        tokenName: split.name,
-        stored: true,
-      }));
+    if (token) {
+      // Static token flow (unchanged)
+      await handleStaticToken(options, cliCtx, token);
     } else {
-      writeOutput(
-        `${green("✓")} Token ${bold(split.name)} stored for ${bold(serverUrl)}`,
-      );
+      // OAuth device flow
+      await handleOAuthFlow(options, cliCtx);
     }
 
     cliCtx.logger.debug("Server login command completed");
   });
+
+async function handleStaticToken(
+  options: AnyOptions,
+  cliCtx: { outputMode: string },
+  token: string,
+): Promise<void> {
+  const split = splitServerToken(token);
+  if (split === null) {
+    throw new UserError(
+      `Invalid --token value: expected <name>.<secret> format`,
+    );
+  }
+
+  let rawUrl = options.server as string;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol === "ws:") parsed.protocol = "http:";
+    else if (parsed.protocol === "wss:") parsed.protocol = "https:";
+    rawUrl = parsed.href;
+  } catch {
+    throw new UserError(
+      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+    );
+  }
+  let serverUrl: string;
+  try {
+    serverUrl = normalizeServerUrl(rawUrl);
+  } catch {
+    throw new UserError(
+      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+    );
+  }
+
+  const repo = new FileServerCredentialRepository();
+  await repo.save({
+    serverUrl,
+    tokenName: split.name,
+    token,
+    principalId: "",
+    obtainedAt: new Date().toISOString(),
+  });
+
+  if (cliCtx.outputMode === "json") {
+    console.log(JSON.stringify({
+      serverUrl,
+      tokenName: split.name,
+      stored: true,
+    }));
+  } else {
+    writeOutput(
+      `${green("✓")} Token ${bold(split.name)} stored for ${bold(serverUrl)}`,
+    );
+  }
+}
+
+async function handleOAuthFlow(
+  options: AnyOptions,
+  cliCtx: { outputMode: string },
+): Promise<void> {
+  const rawUrl = options.server as string;
+  const deps = createServerLoginDeps();
+  const input = { serverUrl: rawUrl, signal: AbortSignal.timeout(300_000) };
+
+  for await (const event of serverLogin(deps, input)) {
+    switch (event.kind) {
+      case "discovering":
+        if (cliCtx.outputMode !== "json") {
+          writeOutput("Discovering server auth mode...");
+        }
+        break;
+      case "device_verification":
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({
+            status: "device_verification",
+            userCode: event.userCode,
+            verificationUri: event.verificationUri,
+            verificationUriComplete: event.verificationUriComplete,
+          }));
+        } else {
+          writeOutput(
+            `\nYour verification code: ${bold(event.userCode)}\n`,
+          );
+          if (event.verificationUriComplete) {
+            writeOutput(
+              `Open: ${bold(event.verificationUriComplete)}`,
+            );
+          } else {
+            writeOutput(
+              `Visit: ${bold(event.verificationUri)}`,
+            );
+          }
+        }
+        break;
+      case "opening_browser":
+        if (cliCtx.outputMode !== "json") {
+          writeOutput("Opening browser...");
+        }
+        break;
+      case "browser_open_failed":
+        if (cliCtx.outputMode !== "json") {
+          writeOutput(yellow(event.message));
+        }
+        break;
+      case "polling":
+        // Quiet in both modes — no spam
+        break;
+      case "completed":
+        if (cliCtx.outputMode === "json") {
+          console.log(JSON.stringify({
+            status: "authenticated",
+            principalId: event.data.principalId,
+            principalEmail: event.data.principalEmail,
+            displayName: event.data.displayName,
+            collectives: event.data.collectives,
+          }));
+        } else {
+          writeOutput(
+            `\n${green("✓")} Authenticated as ${
+              bold(event.data.displayName || event.data.principalEmail)
+            }`,
+          );
+        }
+        break;
+      case "error":
+        throw event.error;
+    }
+  }
+}

--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -131,6 +131,7 @@ async function handleOAuthFlow(
   cliCtx: { outputMode: string },
 ): Promise<void> {
   const rawUrl = options.server as string;
+  const normalizedUrl = normalizeServerUrl(rawUrl);
   const deps = createServerLoginDeps();
   const input = { serverUrl: rawUrl, signal: AbortSignal.timeout(300_000) };
 
@@ -159,7 +160,9 @@ async function handleOAuthFlow(
             );
           } else {
             writeOutput(
-              `Visit: ${bold(event.verificationUri)}`,
+              `Visit ${bold(event.verificationUri)} and enter code ${
+                bold(event.userCode)
+              }`,
             );
           }
         }
@@ -180,13 +183,12 @@ async function handleOAuthFlow(
         }
         break;
       case "polling":
-        // Quiet in both modes — no spam
         break;
       case "completed":
         if (cliCtx.outputMode === "json") {
           console.log(JSON.stringify({
             status: "authenticated",
-            serverUrl: rawUrl,
+            serverUrl: normalizedUrl,
             principalId: event.data.principalId,
             principalEmail: event.data.principalEmail,
             displayName: event.data.displayName,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -28,6 +28,13 @@ import { UserError } from "../../domain/errors.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
 import { handleConnection } from "../../serve/connection.ts";
+import { setConnectionCollectives } from "../../serve/handlers/shared.ts";
+import {
+  createDeviceAuthDeps,
+  handleDeviceAuth,
+} from "../../serve/device_auth_handler.ts";
+import { resolveOAuthClientCredentials } from "../../serve/oauth_registration.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { authenticateServerToken } from "../../serve/token_auth.ts";
 import { parsePrincipal } from "../../domain/access/principal.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
@@ -756,6 +763,197 @@ export const serveCommand = new Command()
       );
     }
 
+    let oauthClientSecret = "";
+    if (authConfig.mode === "oauth") {
+      const vaultService = await VaultService.fromRepository(resolvedRepoDir);
+      const vaultNames = vaultService.getVaultNames();
+      if (vaultNames.length === 0) {
+        throw new UserError(
+          "oauth mode requires a vault — run 'swamp vault create local default' first",
+        );
+      }
+      const vaultName = vaultNames[0];
+      const credentials = await resolveOAuthClientCredentials(
+        {
+          getVaultSecret: async (v, k) => {
+            try {
+              return await vaultService.get(v, k);
+            } catch {
+              return null;
+            }
+          },
+          putVaultSecret: (v, k, val) => vaultService.put(v, k, val),
+          registerClient: async (providerUrl, signal) => {
+            const { startDeviceGrant, pollForToken } = await import(
+              "../../serve/oauth_client.ts"
+            );
+            const { BOOTSTRAP_CLIENT_ID } = await import(
+              "../../serve/oauth_registration.ts"
+            );
+            const { DeviceGrantPollError } = await import(
+              "../../serve/oauth_client.ts"
+            );
+
+            const grant = await startDeviceGrant(
+              providerUrl,
+              BOOTSTRAP_CLIENT_ID,
+              signal,
+            );
+
+            logger.info(
+              "First-time OAuth setup — visit {uri} and enter code: {code}",
+              { uri: grant.verificationUri, code: grant.userCode },
+            );
+            console.log("");
+            console.log(
+              `  Visit ${
+                grant.verificationUriComplete || grant.verificationUri
+              }`,
+            );
+            console.log(`  Verify code: ${grant.userCode}`);
+            console.log("");
+
+            const intervalMs = (grant.interval || 5) * 1000;
+            const deadline = Date.now() + grant.expiresIn * 1000;
+            let tokenResponse;
+            while (Date.now() < deadline) {
+              try {
+                tokenResponse = await pollForToken(
+                  providerUrl,
+                  BOOTSTRAP_CLIENT_ID,
+                  "",
+                  grant.deviceCode,
+                  signal,
+                );
+                break;
+              } catch (err) {
+                if (
+                  err instanceof DeviceGrantPollError &&
+                  (err.code === "authorization_pending" ||
+                    err.code === "slow_down")
+                ) {
+                  await new Promise((resolve) =>
+                    setTimeout(resolve, intervalMs)
+                  );
+                  continue;
+                }
+                throw err;
+              }
+            }
+            if (!tokenResponse) {
+              throw new Error("Bootstrap device grant timed out");
+            }
+
+            const resp = await fetch(
+              `${providerUrl}/api/auth/oauth2/register`,
+              {
+                method: "POST",
+                headers: {
+                  "content-type": "application/json",
+                  "authorization": `Bearer ${tokenResponse.accessToken}`,
+                },
+                body: JSON.stringify({
+                  client_name: `swamp-serve-${crypto.randomUUID().slice(0, 8)}`,
+                  redirect_uris: ["http://localhost"],
+                  grant_types: ["authorization_code"],
+                  scope: "openid profile email collectives",
+                }),
+                signal,
+              },
+            );
+            if (!resp.ok) {
+              const body = await resp.text().catch(() => "");
+              throw new Error(
+                `OAuth client registration failed: ${resp.status} ${resp.statusText}${
+                  body ? ` — ${body}` : ""
+                }`,
+              );
+            }
+            const data = await resp.json();
+            return {
+              clientId: data.client_id as string,
+              clientSecret: data.client_secret as string,
+              accessToken: tokenResponse.accessToken,
+            };
+          },
+        },
+        authConfig.oauthProvider,
+        vaultName,
+        authConfig.oauthClientId,
+        AbortSignal.timeout(300_000),
+      );
+      authConfig.oauthClientId = credentials.clientId;
+      oauthClientSecret = credentials.clientSecret;
+      logger.info(
+        "OAuth client credentials resolved (clientId: {clientId})",
+        { clientId: credentials.clientId },
+      );
+
+      if (credentials.accessToken) {
+        const { resolveUsername } = await import(
+          "../../serve/oauth_client.ts"
+        );
+        const { storeResolvedAdmins } = await import(
+          "../../serve/oauth_registration.ts"
+        );
+        const resolvedMap: Record<string, string> = {};
+        for (let i = 0; i < authConfig.admins.length; i++) {
+          const admin = authConfig.admins[i];
+          const username = admin.startsWith("user:") ? admin.slice(5) : admin;
+          try {
+            const sub = await resolveUsername(
+              authConfig.oauthProvider,
+              username,
+              credentials.accessToken,
+              AbortSignal.timeout(10_000),
+            );
+            authConfig.admins[i] = `user:${sub}`;
+            resolvedMap[username] = sub;
+            logger.info("Resolved admin {username} to user:{sub}", {
+              username,
+              sub,
+            });
+          } catch (err) {
+            throw new UserError(
+              `Failed to resolve admin '${admin}': ${
+                err instanceof Error ? err.message : String(err)
+              }. Ensure the username exists on ${authConfig.oauthProvider}.`,
+            );
+          }
+        }
+        await storeResolvedAdmins(
+          { putVaultSecret: (v, k, val) => vaultService.put(v, k, val) },
+          vaultName,
+          resolvedMap,
+        );
+      } else if (credentials.resolvedAdmins) {
+        for (let i = 0; i < authConfig.admins.length; i++) {
+          const admin = authConfig.admins[i];
+          const username = admin.startsWith("user:") ? admin.slice(5) : admin;
+          const cachedSub = credentials.resolvedAdmins[username];
+          if (cachedSub) {
+            authConfig.admins[i] = `user:${cachedSub}`;
+            logger.info(
+              "Using cached admin resolution: {username} → user:{sub}",
+              { username, sub: cachedSub },
+            );
+          } else {
+            throw new UserError(
+              `Admin '${admin}' not found in cached resolutions. ` +
+                "Clear stored credentials to re-register: " +
+                `swamp vault delete ${vaultName} oauth-client-id`,
+            );
+          }
+        }
+      } else {
+        throw new UserError(
+          "Cannot resolve admin usernames — no access token and no cached resolutions. " +
+            "Clear stored credentials to re-register: " +
+            `swamp vault delete ${vaultName} oauth-client-id`,
+        );
+      }
+    }
+
     const autoDefRepo = new YamlDefinitionRepository(
       resolvedRepoDir,
       undefined,
@@ -1053,13 +1251,6 @@ export const serveCommand = new Command()
           }
 
           if (authConfig.mode !== "none") {
-            if (authConfig.mode !== "token") {
-              return new Response(
-                "WebSocket authentication is not supported for this server configuration",
-                { status: 501 },
-              );
-            }
-
             if (!checkRateLimit(remoteAddr)) {
               logger.warn("WebSocket auth rate-limited from {ip}", {
                 ip: remoteAddr,
@@ -1097,6 +1288,7 @@ export const serveCommand = new Command()
               req,
               wsUpgradeOpts,
             );
+            setConnectionCollectives(socket, result.collectives);
             handleConnection(socket, connectionCtx, principal);
             return response;
           }
@@ -1195,6 +1387,34 @@ export const serveCommand = new Command()
             }
             return Response.json({ status: "cancelled", count });
           }
+        }
+
+        // Device authorization endpoints (OAuth mode only)
+        if (authConfig.mode === "oauth" && authConfig.oauthClientId) {
+          const deviceAuthDeps = createDeviceAuthDeps(
+            authConfig,
+            oauthClientSecret,
+            resolvedRepoDir,
+            repoContext,
+          );
+          const deviceAuthResponse = await handleDeviceAuth(
+            req,
+            deviceAuthDeps,
+          );
+          if (deviceAuthResponse) return deviceAuthResponse;
+        }
+
+        // Auth discovery (unauthenticated — mode is not sensitive)
+        if (
+          req.method === "GET" && new URL(req.url).pathname === "/auth/info"
+        ) {
+          const info: Record<string, string> = { mode: authConfig.mode };
+          if (authConfig.mode === "oauth") {
+            info.verificationBaseUri = authConfig.oauthProvider;
+          }
+          return new Response(JSON.stringify(info), {
+            headers: { "content-type": "application/json" },
+          });
         }
 
         // Health check endpoint

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -321,7 +321,7 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--allowed-users <list:string>",
-    "Comma-separated user identifiers for OAuth admission policy",
+    "Comma-separated swamp-club usernames or user:<sub> subjects for OAuth admission policy",
   )
   .option(
     "--oauth-provider <url:string>",
@@ -329,7 +329,7 @@ const daemonEnableCommand = new Command()
   )
   .option(
     "--oauth-client-id <id:string>",
-    "OAuth client ID (required for oauth mode)",
+    "OAuth client ID — auto-registered on first start if omitted",
   )
   .option(
     "--groups-field <field:string>",
@@ -500,7 +500,7 @@ export const serveCommand = new Command()
   )
   .option(
     "--allowed-users <list:string>",
-    "Comma-separated user identifiers for OAuth admission policy",
+    "Comma-separated swamp-club usernames or user:<sub> subjects for OAuth admission policy",
   )
   .option(
     "--oauth-provider <url:string>",
@@ -508,7 +508,7 @@ export const serveCommand = new Command()
   )
   .option(
     "--oauth-client-id <id:string>",
-    "OAuth client ID (required for oauth mode)",
+    "OAuth client ID — auto-registered on first start if omitted",
   )
   .option(
     "--groups-field <field:string>",
@@ -800,18 +800,12 @@ export const serveCommand = new Command()
               signal,
             );
 
+            const verifyUrl = grant.verificationUriComplete ||
+              grant.verificationUri;
             logger.info(
-              "First-time OAuth setup — visit {uri} and enter code: {code}",
-              { uri: grant.verificationUri, code: grant.userCode },
+              "First-time OAuth setup — visit {uri} and verify code: {code}",
+              { uri: verifyUrl, code: grant.userCode },
             );
-            console.log("");
-            console.log(
-              `  Visit ${
-                grant.verificationUriComplete || grant.verificationUri
-              }`,
-            );
-            console.log(`  Verify code: ${grant.userCode}`);
-            console.log("");
 
             const intervalMs = (grant.interval || 5) * 1000;
             const deadline = Date.now() + grant.expiresIn * 1000;
@@ -1389,8 +1383,28 @@ export const serveCommand = new Command()
           }
         }
 
-        // Device authorization endpoints (OAuth mode only)
+        // Device authorization endpoints (OAuth mode only, rate-limited)
         if (authConfig.mode === "oauth" && authConfig.oauthClientId) {
+          const url = new URL(req.url);
+          if (
+            url.pathname === "/auth/device" ||
+            url.pathname === "/auth/device/token"
+          ) {
+            const deviceRemoteAddr = trustProxy
+              ? (req.headers.get("x-forwarded-for")
+                ?.split(",")[0]?.trim() ??
+                info.remoteAddr.hostname)
+              : info.remoteAddr.hostname;
+            if (!checkRateLimit(deviceRemoteAddr)) {
+              return new Response(
+                JSON.stringify({ error: "Too Many Requests" }),
+                {
+                  status: 429,
+                  headers: { "content-type": "application/json" },
+                },
+              );
+            }
+          }
           const deviceAuthDeps = createDeviceAuthDeps(
             authConfig,
             oauthClientSecret,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -807,7 +807,7 @@ export const serveCommand = new Command()
               { uri: verifyUrl, code: grant.userCode },
             );
 
-            const intervalMs = (grant.interval || 5) * 1000;
+            let currentIntervalMs = (grant.interval || 5) * 1000;
             const deadline = Date.now() + grant.expiresIn * 1000;
             let tokenResponse;
             while (Date.now() < deadline) {
@@ -821,15 +821,19 @@ export const serveCommand = new Command()
                 );
                 break;
               } catch (err) {
-                if (
-                  err instanceof DeviceGrantPollError &&
-                  (err.code === "authorization_pending" ||
-                    err.code === "slow_down")
-                ) {
-                  await new Promise((resolve) =>
-                    setTimeout(resolve, intervalMs)
-                  );
-                  continue;
+                if (err instanceof DeviceGrantPollError) {
+                  if (err.code === "slow_down") {
+                    currentIntervalMs += 5000;
+                  }
+                  if (
+                    err.code === "authorization_pending" ||
+                    err.code === "slow_down"
+                  ) {
+                    await new Promise((resolve) =>
+                      setTimeout(resolve, currentIntervalMs)
+                    );
+                    continue;
+                  }
                 }
                 throw err;
               }
@@ -915,6 +919,30 @@ export const serveCommand = new Command()
             );
           }
         }
+        for (let i = 0; i < authConfig.allowedUsers.length; i++) {
+          const entry = authConfig.allowedUsers[i];
+          const username = entry.startsWith("user:") ? entry.slice(5) : entry;
+          try {
+            const sub = await resolveUsername(
+              authConfig.oauthProvider,
+              username,
+              credentials.accessToken,
+              AbortSignal.timeout(10_000),
+            );
+            authConfig.allowedUsers[i] = sub;
+            resolvedMap[`allowed:${username}`] = sub;
+            logger.info("Resolved allowed-user {username} to {sub}", {
+              username,
+              sub,
+            });
+          } catch (err) {
+            throw new UserError(
+              `Failed to resolve allowed-user '${entry}': ${
+                err instanceof Error ? err.message : String(err)
+              }. Ensure the username exists on ${authConfig.oauthProvider}.`,
+            );
+          }
+        }
         await storeResolvedAdmins(
           { putVaultSecret: (v, k, val) => vaultService.put(v, k, val) },
           vaultName,
@@ -939,9 +967,27 @@ export const serveCommand = new Command()
             );
           }
         }
+        for (let i = 0; i < authConfig.allowedUsers.length; i++) {
+          const entry = authConfig.allowedUsers[i];
+          const username = entry.startsWith("user:") ? entry.slice(5) : entry;
+          const cachedSub = credentials.resolvedAdmins[`allowed:${username}`];
+          if (cachedSub) {
+            authConfig.allowedUsers[i] = cachedSub;
+            logger.info(
+              "Using cached allowed-user resolution: {username} → {sub}",
+              { username, sub: cachedSub },
+            );
+          } else {
+            throw new UserError(
+              `Allowed-user '${entry}' not found in cached resolutions. ` +
+                "Clear stored credentials to re-register: " +
+                `swamp vault delete ${vaultName} oauth-client-id`,
+            );
+          }
+        }
       } else {
         throw new UserError(
-          "Cannot resolve admin usernames — no access token and no cached resolutions. " +
+          "Cannot resolve usernames — no access token and no cached resolutions. " +
             "Clear stored credentials to re-register: " +
             `swamp vault delete ${vaultName} oauth-client-id`,
         );
@@ -1405,8 +1451,12 @@ export const serveCommand = new Command()
               );
             }
           }
+          const oauthConfig = {
+            ...authConfig,
+            oauthClientId: authConfig.oauthClientId!,
+          };
           const deviceAuthDeps = createDeviceAuthDeps(
-            authConfig,
+            oauthConfig,
             oauthClientSecret,
             resolvedRepoDir,
             repoContext,
@@ -1422,11 +1472,11 @@ export const serveCommand = new Command()
         if (
           req.method === "GET" && new URL(req.url).pathname === "/auth/info"
         ) {
-          const info: Record<string, string> = { mode: authConfig.mode };
+          const authInfo: Record<string, string> = { mode: authConfig.mode };
           if (authConfig.mode === "oauth") {
-            info.verificationBaseUri = authConfig.oauthProvider;
+            authInfo.verificationBaseUri = authConfig.oauthProvider;
           }
-          return new Response(JSON.stringify(info), {
+          return new Response(JSON.stringify(authInfo), {
             headers: { "content-type": "application/json" },
           });
         }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1429,13 +1429,10 @@ export const serveCommand = new Command()
           }
         }
 
-        // Device authorization endpoints (OAuth mode only, rate-limited)
+        // Device authorization endpoints (OAuth mode only)
         if (authConfig.mode === "oauth" && authConfig.oauthClientId) {
           const url = new URL(req.url);
-          if (
-            url.pathname === "/auth/device" ||
-            url.pathname === "/auth/device/token"
-          ) {
+          if (url.pathname === "/auth/device") {
             const deviceRemoteAddr = trustProxy
               ? (req.headers.get("x-forwarded-for")
                 ?.split(",")[0]?.trim() ??

--- a/src/domain/access/admission.ts
+++ b/src/domain/access/admission.ts
@@ -1,0 +1,57 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface AdmissionResult {
+  readonly admitted: boolean;
+  readonly reason: string;
+}
+
+export function checkAdmission(
+  userSub: string,
+  collectives: readonly string[],
+  allowedCollectives: readonly string[],
+  allowedUsers: readonly string[],
+): AdmissionResult {
+  if (allowedUsers.includes(userSub)) {
+    return { admitted: true, reason: "user is in the allowed-users list" };
+  }
+
+  if (allowedCollectives.length === 0 && allowedUsers.length === 0) {
+    return { admitted: true, reason: "no admission restrictions configured" };
+  }
+
+  const matchingCollective = collectives.find((c) =>
+    allowedCollectives.includes(c)
+  );
+  if (matchingCollective) {
+    return {
+      admitted: true,
+      reason: `user is a member of allowed collective '${matchingCollective}'`,
+    };
+  }
+
+  return {
+    admitted: false,
+    reason: allowedCollectives.length > 0
+      ? `user is not a member of any allowed collective (${
+        allowedCollectives.join(", ")
+      })`
+      : "user is not in the allowed-users list",
+  };
+}

--- a/src/domain/access/admission_test.ts
+++ b/src/domain/access/admission_test.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { checkAdmission } from "./admission.ts";
+
+Deno.test("checkAdmission: admits user in allowed-users list", () => {
+  const result = checkAdmission(
+    "user:alice",
+    [],
+    ["acme-corp"],
+    ["user:alice"],
+  );
+  assertEquals(result.admitted, true);
+});
+
+Deno.test("checkAdmission: admits user with matching collective", () => {
+  const result = checkAdmission(
+    "user:bob",
+    ["acme-corp", "dev-team"],
+    ["acme-corp"],
+    [],
+  );
+  assertEquals(result.admitted, true);
+  assertEquals(
+    result.reason,
+    "user is a member of allowed collective 'acme-corp'",
+  );
+});
+
+Deno.test("checkAdmission: rejects user without matching collective", () => {
+  const result = checkAdmission(
+    "user:charlie",
+    ["other-org"],
+    ["acme-corp"],
+    [],
+  );
+  assertEquals(result.admitted, false);
+});
+
+Deno.test("checkAdmission: rejects user with empty collectives", () => {
+  const result = checkAdmission(
+    "user:dave",
+    [],
+    ["acme-corp"],
+    [],
+  );
+  assertEquals(result.admitted, false);
+});
+
+Deno.test("checkAdmission: allowed-users takes precedence over collectives", () => {
+  const result = checkAdmission(
+    "user:eve",
+    [],
+    ["acme-corp"],
+    ["user:eve"],
+  );
+  assertEquals(result.admitted, true);
+  assertEquals(result.reason, "user is in the allowed-users list");
+});
+
+Deno.test("checkAdmission: admits any user when no restrictions configured", () => {
+  const result = checkAdmission(
+    "user:frank",
+    ["some-org"],
+    [],
+    [],
+  );
+  assertEquals(result.admitted, true);
+  assertEquals(result.reason, "no admission restrictions configured");
+});
+
+Deno.test("checkAdmission: rejects user not in allowed-users when no collectives configured", () => {
+  const result = checkAdmission(
+    "user:grace",
+    ["some-org"],
+    [],
+    ["user:admin"],
+  );
+  assertEquals(result.admitted, false);
+  assertEquals(result.reason, "user is not in the allowed-users list");
+});
+
+Deno.test("checkAdmission: matches first collective found", () => {
+  const result = checkAdmission(
+    "user:heidi",
+    ["dev-team", "acme-corp"],
+    ["acme-corp", "dev-team"],
+    [],
+  );
+  assertEquals(result.admitted, true);
+  assertEquals(
+    result.reason,
+    "user is a member of allowed collective 'dev-team'",
+  );
+});

--- a/src/domain/access/serve_auth_config.ts
+++ b/src/domain/access/serve_auth_config.ts
@@ -55,7 +55,15 @@ function parseCommaSeparated(value: string | undefined): string[] {
   return value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
-function validateAdmins(admins: string[]): void {
+function validateAdmins(admins: string[], mode: string): void {
+  if (mode === "oauth") {
+    for (const admin of admins) {
+      if (admin.trim().length === 0) {
+        throw new UserError("--admins contains an empty value");
+      }
+    }
+    return;
+  }
   for (const admin of admins) {
     try {
       parseSubject(admin);
@@ -85,7 +93,7 @@ export function buildServeAuthConfig(
   const groupsField = input.groupsField ?? DEFAULT_GROUPS_FIELD;
 
   if (admins.length > 0) {
-    validateAdmins(admins);
+    validateAdmins(admins, mode);
   }
 
   if (mode === "token") {
@@ -102,9 +110,20 @@ export function buildServeAuthConfig(
         '--admins is required when --auth-mode is "oauth"',
       );
     }
-    if (!oauthClientId) {
+    if (allowedCollectives.length === 0 && allowedUsers.length === 0) {
       throw new UserError(
-        '--oauth-client-id is required when --auth-mode is "oauth"',
+        '--allowed-collectives or --allowed-users is required when --auth-mode is "oauth" — ' +
+          "without admission restrictions, any swamp-club user can connect",
+      );
+    }
+    const providerUrl = new URL(oauthProvider);
+    const isLocalhost = providerUrl.hostname === "localhost" ||
+      providerUrl.hostname === "127.0.0.1" ||
+      providerUrl.hostname === "::1";
+    if (providerUrl.protocol !== "https:" && !isLocalhost) {
+      throw new UserError(
+        `--oauth-provider must use HTTPS (got ${oauthProvider}). ` +
+          "HTTP is only allowed for localhost development.",
       );
     }
   }

--- a/src/domain/access/serve_auth_config.ts
+++ b/src/domain/access/serve_auth_config.ts
@@ -116,7 +116,14 @@ export function buildServeAuthConfig(
           "without admission restrictions, any swamp-club user can connect",
       );
     }
-    const providerUrl = new URL(oauthProvider);
+    let providerUrl: URL;
+    try {
+      providerUrl = new URL(oauthProvider);
+    } catch {
+      throw new UserError(
+        `Invalid --oauth-provider URL "${oauthProvider}": expected a valid URL`,
+      );
+    }
     const isLocalhost = providerUrl.hostname === "localhost" ||
       providerUrl.hostname === "127.0.0.1" ||
       providerUrl.hostname === "::1";

--- a/src/domain/access/serve_auth_config_test.ts
+++ b/src/domain/access/serve_auth_config_test.ts
@@ -74,26 +74,57 @@ Deno.test("buildServeAuthConfig: mode oauth without admins refuses", () => {
   );
 });
 
-Deno.test("buildServeAuthConfig: mode oauth without client-id refuses", () => {
+Deno.test("buildServeAuthConfig: mode oauth without admission restrictions refuses", () => {
   assertThrows(
     () =>
       buildServeAuthConfig({
         authMode: "oauth",
-        admins: "user:oauth|user-123",
+        admins: "swampadmin",
       }),
     UserError,
-    '--oauth-client-id is required when --auth-mode is "oauth"',
+    "--allowed-collectives or --allowed-users is required",
   );
+});
+
+Deno.test("buildServeAuthConfig: mode oauth without client-id succeeds for auto-registration", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "swampadmin",
+    allowedCollectives: "acme-corp",
+  });
+  assertEquals(config.mode, "oauth");
+  assertEquals(config.oauthClientId, undefined);
+});
+
+Deno.test("buildServeAuthConfig: mode oauth with allowed-collectives succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "swampadmin",
+    allowedCollectives: "acme-corp",
+  });
+  assertEquals(config.mode, "oauth");
+  assertEquals(config.allowedCollectives, ["acme-corp"]);
+});
+
+Deno.test("buildServeAuthConfig: mode oauth with allowed-users succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "swampadmin",
+    allowedUsers: "user:alice",
+  });
+  assertEquals(config.mode, "oauth");
+  assertEquals(config.allowedUsers, ["user:alice"]);
 });
 
 Deno.test("buildServeAuthConfig: mode oauth with all required flags succeeds", () => {
   const config = buildServeAuthConfig({
     authMode: "oauth",
-    admins: "user:oauth|user-123",
+    admins: "swampadmin",
     oauthClientId: "my-client",
+    allowedCollectives: "acme-corp",
   });
   assertEquals(config.mode, "oauth");
-  assertEquals(config.admins, ["user:oauth|user-123"]);
+  assertEquals(config.admins, ["swampadmin"]);
   assertEquals(config.oauthClientId, "my-client");
   assertEquals(config.oauthProvider, "https://swamp-club.com");
   assertEquals(config.groupsField, "collectives");
@@ -176,8 +207,8 @@ Deno.test("buildServeAuthConfig: admins with empty name after colon refuses", ()
 Deno.test("buildServeAuthConfig: default oauth-provider is swamp-club.com", () => {
   const config = buildServeAuthConfig({
     authMode: "oauth",
-    admins: "user:oauth|user-123",
-    oauthClientId: "client",
+    admins: "swampadmin",
+    allowedCollectives: "acme-corp",
   });
   assertEquals(config.oauthProvider, "https://swamp-club.com");
 });
@@ -185,10 +216,44 @@ Deno.test("buildServeAuthConfig: default oauth-provider is swamp-club.com", () =
 Deno.test("buildServeAuthConfig: default groups-field is collectives", () => {
   const config = buildServeAuthConfig({
     authMode: "oauth",
-    admins: "user:oauth|user-123",
-    oauthClientId: "client",
+    admins: "swampadmin",
+    allowedCollectives: "acme-corp",
   });
   assertEquals(config.groupsField, "collectives");
+});
+
+Deno.test("buildServeAuthConfig: mode oauth rejects HTTP provider", () => {
+  assertThrows(
+    () =>
+      buildServeAuthConfig({
+        authMode: "oauth",
+        admins: "swampadmin",
+        allowedCollectives: "acme-corp",
+        oauthProvider: "http://evil.example.com",
+      }),
+    UserError,
+    "--oauth-provider must use HTTPS",
+  );
+});
+
+Deno.test("buildServeAuthConfig: mode oauth allows HTTP for localhost", () => {
+  const config = buildServeAuthConfig({
+    authMode: "oauth",
+    admins: "swampadmin",
+    allowedCollectives: "acme-corp",
+    oauthProvider: "http://localhost:8000",
+  });
+  assertEquals(config.oauthProvider, "http://localhost:8000");
+});
+
+Deno.test("buildServeAuthConfig: mode token without admission restrictions succeeds", () => {
+  const config = buildServeAuthConfig({
+    authMode: "token",
+    admins: "user:oauth|user-123",
+  });
+  assertEquals(config.mode, "token");
+  assertEquals(config.allowedCollectives, []);
+  assertEquals(config.allowedUsers, []);
 });
 
 Deno.test("buildServeAuthConfig: comma-separated admins trims whitespace", () => {

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -45,6 +45,9 @@ export const ServerTokenSchema = z.object({
   principalEmail: z.string().describe(
     "Display email (informational, not used for matching)",
   ),
+  collectives: z.array(z.string()).default([]).describe(
+    "Collective memberships snapshotted at login time (from OAuth userinfo)",
+  ),
   createdAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
   lastUsedAt: z.string().datetime().optional(),
@@ -82,6 +85,7 @@ function isExpired(token: ServerToken, nowMs: number): boolean {
 const MintArgsSchema = z.object({
   principalId: z.string().min(1),
   principalEmail: z.string().min(1),
+  collectives: z.array(z.string()).default([]),
   vaultName: z.string().min(1),
   durationMs: z.number().int().positive().optional(),
 });
@@ -112,6 +116,7 @@ async function mint(
     state: "active",
     principalId: args.principalId,
     principalEmail: args.principalEmail,
+    collectives: args.collectives,
     createdAt: new Date(now).toISOString(),
     expiresAt: new Date(now + durationMs).toISOString(),
     vaultName: args.vaultName,
@@ -200,6 +205,7 @@ async function rotate(
     state: "active",
     principalId: existing.principalId,
     principalEmail: existing.principalEmail,
+    collectives: existing.collectives,
     createdAt: new Date(now).toISOString(),
     expiresAt: new Date(now + durationMs).toISOString(),
     vaultName: existing.vaultName,

--- a/src/libswamp/auth/server_login.ts
+++ b/src/libswamp/auth/server_login.ts
@@ -1,0 +1,317 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ServerCredential } from "../../domain/auth/server_credential.ts";
+import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
+import { openBrowser } from "../../infrastructure/process/browser.ts";
+import { FileServerCredentialRepository } from "../../infrastructure/persistence/server_credential_repository.ts";
+import { UserError } from "../../domain/errors.ts";
+
+/** Data returned on successful server login via OAuth device flow. */
+export interface ServerLoginData {
+  readonly token: string;
+  readonly principalId: string;
+  readonly principalEmail: string;
+  readonly displayName: string;
+  readonly collectives: string[];
+}
+
+/** Events emitted by the server login generator. */
+export type ServerLoginEvent =
+  | { kind: "discovering" }
+  | {
+    kind: "device_verification";
+    userCode: string;
+    verificationUri: string;
+    verificationUriComplete?: string;
+  }
+  | { kind: "opening_browser" }
+  | { kind: "browser_open_failed"; message: string }
+  | { kind: "polling" }
+  | { kind: "completed"; data: ServerLoginData }
+  | { kind: "error"; error: Error };
+
+/** Input parameters for the server login generator. */
+export interface ServerLoginInput {
+  readonly serverUrl: string;
+  readonly signal?: AbortSignal;
+}
+
+/** Auth discovery response from a serve instance. */
+export interface AuthDiscovery {
+  readonly mode: string;
+  readonly verificationBaseUri?: string;
+}
+
+/** Device authorization response from a serve instance. */
+export interface DeviceAuthResponse {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresIn: number;
+  readonly interval: number;
+}
+
+/** Token response from a device code poll. */
+export interface DeviceTokenResponse {
+  readonly token: string;
+  readonly principal: {
+    readonly id: string;
+    readonly email: string;
+    readonly name: string;
+    readonly collectives: string[];
+  };
+}
+
+/** Error thrown when the device token poll receives a "pending" response. */
+export class DeviceAuthPendingError extends Error {
+  constructor() {
+    super("authorization_pending");
+    this.name = "DeviceAuthPendingError";
+  }
+}
+
+/** Dependencies for the server login operation, injected for testability. */
+export interface ServerLoginDeps {
+  readonly discoverAuthMode: (
+    serverUrl: string,
+    signal: AbortSignal,
+  ) => Promise<AuthDiscovery>;
+  readonly startDeviceAuth: (
+    serverUrl: string,
+    signal: AbortSignal,
+  ) => Promise<DeviceAuthResponse>;
+  readonly pollDeviceToken: (
+    serverUrl: string,
+    deviceCode: string,
+    signal: AbortSignal,
+  ) => Promise<DeviceTokenResponse>;
+  readonly openBrowser: (url: string) => Promise<boolean>;
+  readonly saveCredential: (credential: ServerCredential) => Promise<void>;
+  readonly normalizeServerUrl: (url: string) => string;
+}
+
+/**
+ * Convert a WebSocket URL scheme to HTTP(S) for REST calls.
+ * ws:// -> http://, wss:// -> https://. HTTP(S) URLs pass through unchanged.
+ */
+function wsToHttp(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "ws:") parsed.protocol = "http:";
+  else if (parsed.protocol === "wss:") parsed.protocol = "https:";
+  return parsed.href.replace(/\/+$/, "");
+}
+
+/**
+ * Create production dependencies for server login.
+ */
+export function createServerLoginDeps(): ServerLoginDeps {
+  const repo = new FileServerCredentialRepository();
+  return {
+    discoverAuthMode: async (
+      serverUrl: string,
+      signal: AbortSignal,
+    ): Promise<AuthDiscovery> => {
+      const httpUrl = wsToHttp(serverUrl);
+      const resp = await fetch(`${httpUrl}/auth/info`, { signal });
+      if (!resp.ok) {
+        throw new UserError(
+          `Failed to discover auth mode: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      return await resp.json() as AuthDiscovery;
+    },
+
+    startDeviceAuth: async (
+      serverUrl: string,
+      signal: AbortSignal,
+    ): Promise<DeviceAuthResponse> => {
+      const httpUrl = wsToHttp(serverUrl);
+      const resp = await fetch(`${httpUrl}/auth/device`, {
+        method: "POST",
+        signal,
+      });
+      if (!resp.ok) {
+        throw new UserError(
+          `Failed to start device authorization: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      return await resp.json() as DeviceAuthResponse;
+    },
+
+    pollDeviceToken: async (
+      serverUrl: string,
+      deviceCode: string,
+      signal: AbortSignal,
+    ): Promise<DeviceTokenResponse> => {
+      const httpUrl = wsToHttp(serverUrl);
+      const resp = await fetch(`${httpUrl}/auth/device/token`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ deviceCode }),
+        signal,
+      });
+      if (resp.status === 202) {
+        throw new DeviceAuthPendingError();
+      }
+      if (resp.status === 403 || resp.status === 410) {
+        const body = await resp.text();
+        throw new UserError(
+          `Device authorization failed: ${body || resp.statusText}`,
+        );
+      }
+      if (!resp.ok) {
+        throw new UserError(
+          `Failed to poll device token: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      return await resp.json() as DeviceTokenResponse;
+    },
+
+    openBrowser: async (url: string): Promise<boolean> => {
+      try {
+        await openBrowser(url);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    saveCredential: (credential: ServerCredential) => repo.save(credential),
+    normalizeServerUrl,
+  };
+}
+
+/** Delay helper that respects AbortSignal. */
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Authenticate with a swamp serve instance via the OAuth device code flow.
+ *
+ * Yields events as the flow progresses so the CLI can render status updates.
+ */
+export async function* serverLogin(
+  deps: ServerLoginDeps,
+  input: ServerLoginInput,
+): AsyncGenerator<ServerLoginEvent> {
+  const signal = input.signal ?? AbortSignal.timeout(300_000);
+  const serverUrl = deps.normalizeServerUrl(
+    wsToHttp(input.serverUrl),
+  );
+
+  // Step 1: Discover auth mode
+  yield { kind: "discovering" };
+  const discovery = await deps.discoverAuthMode(serverUrl, signal);
+
+  if (discovery.mode !== "oauth") {
+    throw new UserError(
+      `Server does not support OAuth login (mode: ${discovery.mode}). ` +
+        `Use 'swamp auth server-login --server <url> --token <token>' for token-based auth.`,
+    );
+  }
+
+  // Step 2: Start device authorization
+  const deviceAuth = await deps.startDeviceAuth(serverUrl, signal);
+
+  yield {
+    kind: "device_verification",
+    userCode: deviceAuth.userCode,
+    verificationUri: deviceAuth.verificationUri,
+    verificationUriComplete: deviceAuth.verificationUriComplete,
+  };
+
+  // Step 3: Try to open browser
+  const urlToOpen = deviceAuth.verificationUriComplete ??
+    deviceAuth.verificationUri;
+  yield { kind: "opening_browser" };
+  const opened = await deps.openBrowser(urlToOpen);
+  if (!opened) {
+    yield {
+      kind: "browser_open_failed",
+      message:
+        `Could not open browser automatically. Please visit: ${urlToOpen}`,
+    };
+  }
+
+  // Step 4: Poll for token
+  const intervalMs = (deviceAuth.interval > 0 ? deviceAuth.interval : 5) * 1000;
+  const deadline = Date.now() + deviceAuth.expiresIn * 1000;
+
+  while (Date.now() < deadline) {
+    yield { kind: "polling" };
+    try {
+      const tokenResult = await deps.pollDeviceToken(
+        serverUrl,
+        deviceAuth.deviceCode,
+        signal,
+      );
+
+      // Save credential
+      await deps.saveCredential({
+        serverUrl,
+        tokenName: tokenResult.principal.email,
+        token: tokenResult.token,
+        principalId: tokenResult.principal.id,
+        displayName: tokenResult.principal.name,
+        obtainedAt: new Date().toISOString(),
+      });
+
+      yield {
+        kind: "completed",
+        data: {
+          token: tokenResult.token,
+          principalId: tokenResult.principal.id,
+          principalEmail: tokenResult.principal.email,
+          displayName: tokenResult.principal.name,
+          collectives: tokenResult.principal.collectives,
+        },
+      };
+      return;
+    } catch (err) {
+      if (err instanceof DeviceAuthPendingError) {
+        await delay(intervalMs, signal);
+        continue;
+      }
+      yield {
+        kind: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+      return;
+    }
+  }
+
+  yield {
+    kind: "error",
+    error: new UserError("Device authorization timed out"),
+  };
+}

--- a/src/libswamp/auth/server_login.ts
+++ b/src/libswamp/auth/server_login.ts
@@ -206,11 +206,14 @@ function delay(ms: number, signal: AbortSignal): Promise<void> {
       reject(signal.reason);
       return;
     }
-    const timer = setTimeout(resolve, ms);
     const onAbort = () => {
       clearTimeout(timer);
       reject(signal.reason);
     };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
     signal.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/src/libswamp/auth/server_login_test.ts
+++ b/src/libswamp/auth/server_login_test.ts
@@ -1,0 +1,264 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  DeviceAuthPendingError,
+  serverLogin,
+  type ServerLoginDeps,
+  type ServerLoginEvent,
+  type ServerLoginInput,
+} from "./server_login.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function makeDeps(overrides: Partial<ServerLoginDeps> = {}): ServerLoginDeps {
+  return {
+    discoverAuthMode: () =>
+      Promise.resolve({
+        mode: "oauth",
+        verificationBaseUri: "https://swamp-club.com",
+      }),
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        verificationUriComplete: "https://swamp-club.com/device?code=ABCD-1234",
+        expiresIn: 900,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () =>
+      Promise.resolve({
+        token: "oauth-token-xyz",
+        principal: {
+          id: "user:alice",
+          email: "alice@example.com",
+          name: "Alice",
+          collectives: ["acme-corp"],
+        },
+      }),
+    openBrowser: () => Promise.resolve(true),
+    saveCredential: () => Promise.resolve(),
+    normalizeServerUrl: (url: string) => url.replace(/\/+$/, ""),
+    ...overrides,
+  };
+}
+
+function makeInput(
+  overrides: Partial<ServerLoginInput> = {},
+): ServerLoginInput {
+  return {
+    serverUrl: "https://swamp.acme.internal:9090",
+    ...overrides,
+  };
+}
+
+async function collect(
+  stream: AsyncIterable<ServerLoginEvent>,
+): Promise<ServerLoginEvent[]> {
+  const events: ServerLoginEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+Deno.test("serverLogin: happy path emits correct event sequence", async () => {
+  let savedCredential: Record<string, unknown> | null = null;
+  const deps = makeDeps({
+    saveCredential: (cred) => {
+      savedCredential = cred as unknown as Record<string, unknown>;
+      return Promise.resolve();
+    },
+  });
+  const input = makeInput();
+
+  const events = await collect(serverLogin(deps, input));
+  const kinds = events.map((e) => e.kind);
+
+  assertEquals(kinds, [
+    "discovering",
+    "device_verification",
+    "opening_browser",
+    "polling",
+    "completed",
+  ]);
+
+  const deviceEvent = events[1] as Extract<
+    ServerLoginEvent,
+    { kind: "device_verification" }
+  >;
+  assertEquals(deviceEvent.userCode, "ABCD-1234");
+  assertEquals(deviceEvent.verificationUri, "https://swamp-club.com/device");
+  assertEquals(
+    deviceEvent.verificationUriComplete,
+    "https://swamp-club.com/device?code=ABCD-1234",
+  );
+
+  const completed = events[4] as Extract<
+    ServerLoginEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.token, "oauth-token-xyz");
+  assertEquals(completed.data.principalId, "user:alice");
+  assertEquals(completed.data.principalEmail, "alice@example.com");
+  assertEquals(completed.data.displayName, "Alice");
+  assertEquals(completed.data.collectives, ["acme-corp"]);
+
+  assertEquals(savedCredential !== null, true);
+  const cred = savedCredential as unknown as Record<string, unknown>;
+  assertEquals(cred.token, "oauth-token-xyz");
+  assertEquals(cred.principalId, "user:alice");
+});
+
+Deno.test("serverLogin: non-oauth server mode throws UserError", async () => {
+  const deps = makeDeps({
+    discoverAuthMode: () => Promise.resolve({ mode: "token" }),
+  });
+  const input = makeInput();
+
+  await assertRejects(
+    async () => {
+      await collect(serverLogin(deps, input));
+    },
+    UserError,
+    "Server does not support OAuth login (mode: token)",
+  );
+});
+
+Deno.test("serverLogin: browser open failure still completes", async () => {
+  const deps = makeDeps({
+    openBrowser: () => Promise.resolve(false),
+  });
+  const input = makeInput();
+
+  const events = await collect(serverLogin(deps, input));
+  const kinds = events.map((e) => e.kind);
+
+  assertEquals(kinds, [
+    "discovering",
+    "device_verification",
+    "opening_browser",
+    "browser_open_failed",
+    "polling",
+    "completed",
+  ]);
+
+  const failedEvent = events[3] as Extract<
+    ServerLoginEvent,
+    { kind: "browser_open_failed" }
+  >;
+  assertEquals(
+    failedEvent.message.includes("Could not open browser"),
+    true,
+  );
+});
+
+Deno.test("serverLogin: retries polling on pending status", async () => {
+  let pollCount = 0;
+  const deps = makeDeps({
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        expiresIn: 900,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () => {
+      pollCount++;
+      if (pollCount < 3) {
+        return Promise.reject(new DeviceAuthPendingError());
+      }
+      return Promise.resolve({
+        token: "oauth-token-xyz",
+        principal: {
+          id: "user:alice",
+          email: "alice@example.com",
+          name: "Alice",
+          collectives: ["acme-corp"],
+        },
+      });
+    },
+  });
+  const input = makeInput();
+
+  const events = await collect(serverLogin(deps, input));
+  const kinds = events.map((e) => e.kind);
+
+  assertEquals(kinds, [
+    "discovering",
+    "device_verification",
+    "opening_browser",
+    "polling",
+    "polling",
+    "polling",
+    "completed",
+  ]);
+  assertEquals(pollCount, 3);
+});
+
+Deno.test("serverLogin: yields error on poll failure", async () => {
+  const deps = makeDeps({
+    pollDeviceToken: () =>
+      Promise.reject(
+        new UserError("Device authorization failed: access_denied"),
+      ),
+  });
+  const input = makeInput();
+
+  const events = await collect(serverLogin(deps, input));
+  const kinds = events.map((e) => e.kind);
+
+  assertEquals(kinds, [
+    "discovering",
+    "device_verification",
+    "opening_browser",
+    "polling",
+    "error",
+  ]);
+
+  const errorEvent = events[4] as Extract<
+    ServerLoginEvent,
+    { kind: "error" }
+  >;
+  assertEquals(
+    errorEvent.error.message.includes("Device authorization failed"),
+    true,
+  );
+});
+
+Deno.test("serverLogin: normalizes server URL before use", async () => {
+  let discoveredUrl = "";
+  const deps = makeDeps({
+    discoverAuthMode: (serverUrl) => {
+      discoveredUrl = serverUrl;
+      return Promise.resolve({
+        mode: "oauth",
+        verificationBaseUri: "https://swamp-club.com",
+      });
+    },
+    normalizeServerUrl: (url: string) => url.replace(/\/+$/, "").toLowerCase(),
+  });
+  const input = makeInput({ serverUrl: "wss://Swamp.Acme.Internal:9090/" });
+
+  await collect(serverLogin(deps, input));
+
+  assertEquals(discoveredUrl, "https://swamp.acme.internal:9090");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1198,6 +1198,20 @@ export {
   createAuthLogoutDeps,
 } from "./auth/logout.ts";
 
+// Server login operations (OAuth device flow for swamp serve)
+export {
+  type AuthDiscovery,
+  createServerLoginDeps,
+  DeviceAuthPendingError,
+  type DeviceAuthResponse,
+  type DeviceTokenResponse,
+  serverLogin,
+  type ServerLoginData,
+  type ServerLoginDeps,
+  type ServerLoginEvent,
+  type ServerLoginInput,
+} from "./auth/server_login.ts";
+
 // Server credential storage
 export type {
   ServerCredential,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -1,0 +1,354 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AdmissionResult } from "../domain/access/admission.ts";
+import { checkAdmission } from "../domain/access/admission.ts";
+import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
+import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import {
+  DeviceGrantPollError,
+  type DeviceGrantResponse,
+  getUserInfo as oauthGetUserInfo,
+  type OAuthTokenResponse,
+  type OAuthUserInfo,
+  pollForToken as oauthPollForToken,
+  startDeviceGrant as oauthStartDeviceGrant,
+} from "./oauth_client.ts";
+import { generateOpaqueToken } from "../domain/remote/session_credential.ts";
+import { Definition } from "../domain/definitions/definition.ts";
+import {
+  SERVER_TOKEN_MODEL_TYPE,
+  serverTokenModel,
+  serverTokenSecretKey,
+} from "../domain/models/access/server_token_model.ts";
+import { createResourceWriter } from "../domain/models/data_writer.ts";
+import { VaultService } from "../domain/vaults/vault_service.ts";
+
+const logger = getSwampLogger(["serve", "device-auth"]);
+
+/**
+ * Dependencies injected into the device auth handler for testability.
+ * Production callers should use {@link createDeviceAuthDeps} to wire up
+ * real implementations.
+ */
+export interface DeviceAuthDeps {
+  readonly authConfig: ServeAuthConfig;
+  readonly repoDir: string;
+  readonly repoContext: RepositoryContext;
+  readonly startDeviceGrant: (
+    providerUrl: string,
+    clientId: string,
+    signal: AbortSignal,
+  ) => Promise<DeviceGrantResponse>;
+  readonly pollForToken: (
+    providerUrl: string,
+    clientId: string,
+    clientSecret: string,
+    deviceCode: string,
+    signal: AbortSignal,
+  ) => Promise<OAuthTokenResponse>;
+  readonly getUserInfo: (
+    providerUrl: string,
+    accessToken: string,
+    groupsField: string,
+    signal: AbortSignal,
+  ) => Promise<OAuthUserInfo>;
+  readonly checkAdmission: (
+    userSub: string,
+    collectives: readonly string[],
+    allowedCollectives: readonly string[],
+    allowedUsers: readonly string[],
+  ) => AdmissionResult;
+  readonly mintServerToken: (
+    principalId: string,
+    principalEmail: string,
+    collectives: string[],
+    repoDir: string,
+    repoContext: RepositoryContext,
+  ) => Promise<string>;
+  readonly clientSecret: string;
+}
+
+function jsonResponse(
+  status: number,
+  body: Record<string, unknown>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Handles HTTP requests for the OAuth device authorization flow.
+ *
+ * Matches:
+ * - `POST /auth/device` — starts the device grant flow
+ * - `POST /auth/device/token` — polls for completion, checks admission,
+ *   mints a server token
+ *
+ * Returns `null` for paths that do not match, allowing the caller to
+ * fall through to other handlers.
+ */
+export async function handleDeviceAuth(
+  req: Request,
+  deps: DeviceAuthDeps,
+): Promise<Response | null> {
+  const url = new URL(req.url);
+
+  if (url.pathname === "/auth/device") {
+    if (req.method !== "POST") {
+      return jsonResponse(405, { error: "Method not allowed" });
+    }
+    return await handleStartDeviceGrant(deps);
+  }
+
+  if (url.pathname === "/auth/device/token") {
+    if (req.method !== "POST") {
+      return jsonResponse(405, { error: "Method not allowed" });
+    }
+    return await handleDeviceToken(req, deps);
+  }
+
+  return null;
+}
+
+async function handleStartDeviceGrant(
+  deps: DeviceAuthDeps,
+): Promise<Response> {
+  try {
+    const signal = AbortSignal.timeout(30_000);
+    const grant = await deps.startDeviceGrant(
+      deps.authConfig.oauthProvider,
+      deps.authConfig.oauthClientId!,
+      signal,
+    );
+    logger.info("Device grant started for provider {provider}", {
+      provider: deps.authConfig.oauthProvider,
+    });
+    return jsonResponse(200, {
+      deviceCode: grant.deviceCode,
+      userCode: grant.userCode,
+      verificationUri: grant.verificationUri,
+      verificationUriComplete: grant.verificationUriComplete,
+      expiresIn: grant.expiresIn,
+      interval: grant.interval,
+    });
+  } catch (err) {
+    logger.error`Failed to start device authorization: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    return jsonResponse(502, {
+      error: "Failed to start device authorization",
+    });
+  }
+}
+
+async function handleDeviceToken(
+  req: Request,
+  deps: DeviceAuthDeps,
+): Promise<Response> {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json() as Record<string, unknown>;
+  } catch {
+    return jsonResponse(400, { error: "Invalid JSON body" });
+  }
+
+  if (!body.deviceCode || typeof body.deviceCode !== "string") {
+    return jsonResponse(400, { error: "Missing or invalid deviceCode" });
+  }
+  const deviceCode = body.deviceCode;
+
+  try {
+    const signal = AbortSignal.timeout(30_000);
+    const tokenResponse = await deps.pollForToken(
+      deps.authConfig.oauthProvider,
+      deps.authConfig.oauthClientId!,
+      deps.clientSecret,
+      deviceCode,
+      signal,
+    );
+
+    const userInfo = await deps.getUserInfo(
+      deps.authConfig.oauthProvider,
+      tokenResponse.accessToken,
+      deps.authConfig.groupsField,
+      signal,
+    );
+
+    const admissionResult = deps.checkAdmission(
+      userInfo.sub,
+      userInfo.collectives,
+      deps.authConfig.allowedCollectives,
+      deps.authConfig.allowedUsers,
+    );
+
+    if (!admissionResult.admitted) {
+      logger.info("Admission denied for {sub}: {reason}", {
+        sub: userInfo.sub,
+        reason: admissionResult.reason,
+      });
+      return jsonResponse(403, {
+        error: "Not admitted",
+        reason: admissionResult.reason,
+      });
+    }
+
+    const principalId = `user:${userInfo.sub}`;
+    const token = await deps.mintServerToken(
+      principalId,
+      userInfo.email,
+      [...userInfo.collectives],
+      deps.repoDir,
+      deps.repoContext,
+    );
+
+    logger.info("OAuth device flow completed for {principal}", {
+      principal: principalId,
+    });
+    return jsonResponse(200, {
+      token,
+      principal: {
+        id: principalId,
+        email: userInfo.email,
+        name: userInfo.name,
+        collectives: userInfo.collectives,
+      },
+    });
+  } catch (err) {
+    if (err instanceof DeviceGrantPollError) {
+      switch (err.code) {
+        case "authorization_pending":
+          return jsonResponse(202, { status: "pending" });
+        case "slow_down":
+          return jsonResponse(202, { status: "pending", slowDown: true });
+        case "expired_token":
+          return jsonResponse(410, { error: "Device code expired" });
+        case "access_denied":
+          return jsonResponse(403, {
+            error: "Authorization denied by user",
+          });
+      }
+    }
+    logger.error`Token exchange error: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    return jsonResponse(500, {
+      error: "Internal error during token exchange",
+    });
+  }
+}
+
+/**
+ * Creates production {@link DeviceAuthDeps} wired to real implementations
+ * from `oauth_client.ts` and `admission.ts`.
+ */
+const TOKEN_DATA_NAME = "token-main";
+const DEFAULT_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+
+async function mintServerTokenImpl(
+  principalId: string,
+  principalEmail: string,
+  collectives: string[],
+  repoDir: string,
+  repoContext: RepositoryContext,
+): Promise<string> {
+  const tokenName = `oauth-${crypto.randomUUID().slice(0, 8)}`;
+  const secretKey = serverTokenSecretKey(tokenName);
+  const plaintext = generateOpaqueToken();
+
+  const vaultService = await VaultService.fromRepository(repoDir);
+  const vaultNames = vaultService.getVaultNames();
+  if (vaultNames.length === 0) {
+    throw new Error(
+      "No vaults configured — create one with: swamp vault create local default",
+    );
+  }
+  const vaultName = vaultNames[0];
+
+  await vaultService.put(vaultName, secretKey, plaintext);
+
+  const defRepo = repoContext.definitionRepo;
+  let def = await defRepo.findByName(SERVER_TOKEN_MODEL_TYPE, tokenName);
+  if (!def) {
+    def = Definition.create({
+      type: SERVER_TOKEN_MODEL_TYPE.normalized,
+      name: tokenName,
+    });
+    await defRepo.save(SERVER_TOKEN_MODEL_TYPE, def);
+  }
+
+  const now = Date.now();
+  const tokenData = {
+    name: tokenName,
+    state: "active" as const,
+    principalId,
+    principalEmail,
+    collectives,
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + DEFAULT_DURATION_MS).toISOString(),
+    vaultName,
+    secretKey,
+  };
+
+  const { writeResource } = createResourceWriter(
+    repoContext.unifiedDataRepo,
+    SERVER_TOKEN_MODEL_TYPE,
+    def.id,
+    serverTokenModel.resources!,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    tokenName,
+  );
+  await writeResource(
+    "token",
+    TOKEN_DATA_NAME,
+    tokenData as unknown as Record<string, unknown>,
+  );
+
+  logger.info("Minted OAuth server token {name} for {principal}", {
+    name: tokenName,
+    principal: principalId,
+  });
+
+  return `${tokenName}.${plaintext}`;
+}
+
+export function createDeviceAuthDeps(
+  authConfig: ServeAuthConfig,
+  clientSecret: string,
+  repoDir: string,
+  repoContext: RepositoryContext,
+): DeviceAuthDeps {
+  return {
+    authConfig,
+    repoDir,
+    repoContext,
+    clientSecret,
+    startDeviceGrant: oauthStartDeviceGrant,
+    pollForToken: oauthPollForToken,
+    getUserInfo: oauthGetUserInfo,
+    checkAdmission,
+    mintServerToken: mintServerTokenImpl,
+  };
+}

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -49,7 +49,9 @@ const logger = getSwampLogger(["serve", "device-auth"]);
  * real implementations.
  */
 export interface DeviceAuthDeps {
-  readonly authConfig: ServeAuthConfig;
+  readonly authConfig: Omit<ServeAuthConfig, "oauthClientId"> & {
+    oauthClientId: string;
+  };
   readonly repoDir: string;
   readonly repoContext: RepositoryContext;
   readonly startDeviceGrant: (
@@ -137,7 +139,7 @@ async function handleStartDeviceGrant(
     const signal = AbortSignal.timeout(30_000);
     const grant = await deps.startDeviceGrant(
       deps.authConfig.oauthProvider,
-      deps.authConfig.oauthClientId!,
+      deps.authConfig.oauthClientId,
       signal,
     );
     logger.info("Device grant started for provider {provider}", {
@@ -181,7 +183,7 @@ async function handleDeviceToken(
     const signal = AbortSignal.timeout(30_000);
     const tokenResponse = await deps.pollForToken(
       deps.authConfig.oauthProvider,
-      deps.authConfig.oauthClientId!,
+      deps.authConfig.oauthClientId,
       deps.clientSecret,
       deviceCode,
       signal,
@@ -335,7 +337,7 @@ async function mintServerTokenImpl(
 }
 
 export function createDeviceAuthDeps(
-  authConfig: ServeAuthConfig,
+  authConfig: ServeAuthConfig & { oauthClientId: string },
   clientSecret: string,
   repoDir: string,
   repoContext: RepositoryContext,

--- a/src/serve/device_auth_handler_test.ts
+++ b/src/serve/device_auth_handler_test.ts
@@ -1,0 +1,404 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  type DeviceAuthDeps,
+  handleDeviceAuth,
+} from "./device_auth_handler.ts";
+import { DeviceGrantPollError } from "./oauth_client.ts";
+import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+
+function makeMockDeps(
+  overrides: Partial<DeviceAuthDeps> = {},
+): DeviceAuthDeps {
+  return {
+    authConfig: {
+      mode: "oauth",
+      admins: ["user:admin"],
+      allowedCollectives: ["team-a"],
+      allowedUsers: ["user-1"],
+      oauthProvider: "https://auth.example.com",
+      oauthClientId: "test-client-id",
+      groupsField: "collectives",
+    },
+    repoDir: "/tmp/test-repo",
+    repoContext: {} as RepositoryContext,
+    clientSecret: "test-client-secret",
+    startDeviceGrant: (_providerUrl, _clientId, _signal) =>
+      Promise.resolve({
+        deviceCode: "dev-code-123",
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://auth.example.com/device",
+        verificationUriComplete:
+          "https://auth.example.com/device?code=ABCD-EFGH",
+        expiresIn: 900,
+        interval: 5,
+      }),
+    pollForToken: (
+      _providerUrl,
+      _clientId,
+      _clientSecret,
+      _deviceCode,
+      _signal,
+    ) =>
+      Promise.resolve({
+        accessToken: "access-token-xyz",
+        tokenType: "Bearer",
+      }),
+    getUserInfo: (_providerUrl, _accessToken, _groupsField, _signal) =>
+      Promise.resolve({
+        sub: "user-1",
+        email: "user@example.com",
+        name: "Test User",
+        collectives: ["team-a"],
+      }),
+    checkAdmission: (
+      _userSub,
+      _collectives,
+      _allowedCollectives,
+      _allowedUsers,
+    ) => ({
+      admitted: true,
+      reason: "user is in the allowed-users list",
+    }),
+    mintServerToken: (
+      _principalId,
+      _principalEmail,
+      _collectives,
+      _repoDir,
+      _repoContext,
+    ) => Promise.resolve("oauth-user-1-1234567890.secret-token"),
+    ...overrides,
+  };
+}
+
+function postRequest(path: string, body?: Record<string, unknown>): Request {
+  return new Request(`http://localhost:8080${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function getRequest(path: string): Request {
+  return new Request(`http://localhost:8080${path}`, { method: "GET" });
+}
+
+// ── Route matching ────────────────────────────────────────────────────
+
+Deno.test("handleDeviceAuth: returns null for non-matching path", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(
+    postRequest("/some/other/path"),
+    deps,
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("handleDeviceAuth: returns null for /auth but not /auth/device", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(postRequest("/auth"), deps);
+  assertEquals(result, null);
+});
+
+// ── Method enforcement ────────────────────────────────────────────────
+
+Deno.test("handleDeviceAuth: returns 405 for GET /auth/device", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(getRequest("/auth/device"), deps);
+  assertEquals(result?.status, 405);
+  const body = await result!.json();
+  assertEquals(body.error, "Method not allowed");
+});
+
+Deno.test("handleDeviceAuth: returns 405 for GET /auth/device/token", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(
+    getRequest("/auth/device/token"),
+    deps,
+  );
+  assertEquals(result?.status, 405);
+  const body = await result!.json();
+  assertEquals(body.error, "Method not allowed");
+});
+
+// ── POST /auth/device ─────────────────────────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device returns device grant response", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(postRequest("/auth/device"), deps);
+  assertEquals(result?.status, 200);
+  const body = await result!.json();
+  assertEquals(body.deviceCode, "dev-code-123");
+  assertEquals(body.userCode, "ABCD-EFGH");
+  assertEquals(body.verificationUri, "https://auth.example.com/device");
+  assertEquals(body.expiresIn, 900);
+  assertEquals(body.interval, 5);
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device returns 502 on provider error", async () => {
+  const deps = makeMockDeps({
+    startDeviceGrant: () => Promise.reject(new Error("connection refused")),
+  });
+  const result = await handleDeviceAuth(postRequest("/auth/device"), deps);
+  assertEquals(result?.status, 502);
+  const body = await result!.json();
+  assertEquals(body.error, "Failed to start device authorization");
+});
+
+// ── POST /auth/device/token — validation ──────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 400 for missing deviceCode", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", {}),
+    deps,
+  );
+  assertEquals(result?.status, 400);
+  const body = await result!.json();
+  assertEquals(body.error, "Missing or invalid deviceCode");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 400 for non-string deviceCode", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: 123 }),
+    deps,
+  );
+  assertEquals(result?.status, 400);
+  const body = await result!.json();
+  assertEquals(body.error, "Missing or invalid deviceCode");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 400 for invalid JSON", async () => {
+  const deps = makeMockDeps();
+  const req = new Request("http://localhost:8080/auth/device/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json",
+  });
+  const result = await handleDeviceAuth(req, deps);
+  assertEquals(result?.status, 400);
+  const body = await result!.json();
+  assertEquals(body.error, "Invalid JSON body");
+});
+
+// ── POST /auth/device/token — poll errors ─────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 202 for authorization_pending", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("authorization_pending")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 202);
+  const body = await result!.json();
+  assertEquals(body.status, "pending");
+  assertEquals(body.slowDown, undefined);
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 202 with slowDown for slow_down", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () => Promise.reject(new DeviceGrantPollError("slow_down")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 202);
+  const body = await result!.json();
+  assertEquals(body.status, "pending");
+  assertEquals(body.slowDown, true);
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 410 for expired_token", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("expired_token")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 410);
+  const body = await result!.json();
+  assertEquals(body.error, "Device code expired");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 403 for access_denied", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("access_denied")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 403);
+  const body = await result!.json();
+  assertEquals(body.error, "Authorization denied by user");
+});
+
+// ── POST /auth/device/token — admission ───────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 403 when admission denied", async () => {
+  const deps = makeMockDeps({
+    checkAdmission: () => ({
+      admitted: false,
+      reason: "user is not a member of any allowed collective (team-a)",
+    }),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 403);
+  const body = await result!.json();
+  assertEquals(body.error, "Not admitted");
+  assertEquals(
+    body.reason,
+    "user is not a member of any allowed collective (team-a)",
+  );
+});
+
+// ── POST /auth/device/token — success ─────────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns token and principal on success", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 200);
+  const body = await result!.json();
+  assertEquals(body.token, "oauth-user-1-1234567890.secret-token");
+  assertEquals(body.principal.id, "user:user-1");
+  assertEquals(body.principal.email, "user@example.com");
+  assertEquals(body.principal.name, "Test User");
+  assertEquals(body.principal.collectives, ["team-a"]);
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token passes correct args to deps", async () => {
+  let capturedProviderUrl = "";
+  let capturedClientId = "";
+  let capturedClientSecret = "";
+  let capturedDeviceCode = "";
+  let capturedGroupsField = "";
+  let capturedPrincipalId = "";
+  let capturedPrincipalEmail = "";
+  let capturedCollectives: string[] = [];
+
+  const deps = makeMockDeps({
+    pollForToken: (
+      providerUrl,
+      clientId,
+      clientSecret,
+      deviceCode,
+      _signal,
+    ) => {
+      capturedProviderUrl = providerUrl;
+      capturedClientId = clientId;
+      capturedClientSecret = clientSecret;
+      capturedDeviceCode = deviceCode;
+      return Promise.resolve({
+        accessToken: "tok-123",
+        tokenType: "Bearer",
+      });
+    },
+    getUserInfo: (_providerUrl, _accessToken, groupsField, _signal) => {
+      capturedGroupsField = groupsField;
+      return Promise.resolve({
+        sub: "sub-42",
+        email: "sub42@example.com",
+        collectives: ["team-x"],
+      });
+    },
+    mintServerToken: (
+      principalId,
+      principalEmail,
+      collectives,
+      _repoDir,
+      _repoContext,
+    ) => {
+      capturedPrincipalId = principalId;
+      capturedPrincipalEmail = principalEmail;
+      capturedCollectives = collectives;
+      return Promise.resolve("minted-token.secret");
+    },
+  });
+
+  await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "my-device-code" }),
+    deps,
+  );
+
+  assertEquals(capturedProviderUrl, "https://auth.example.com");
+  assertEquals(capturedClientId, "test-client-id");
+  assertEquals(capturedClientSecret, "test-client-secret");
+  assertEquals(capturedDeviceCode, "my-device-code");
+  assertEquals(capturedGroupsField, "collectives");
+  assertEquals(capturedPrincipalId, "user:sub-42");
+  assertEquals(capturedPrincipalEmail, "sub42@example.com");
+  assertEquals(capturedCollectives, ["team-x"]);
+});
+
+// ── POST /auth/device/token — unexpected error ────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 500 on unexpected error", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () => Promise.reject(new Error("unexpected failure")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 500);
+  const body = await result!.json();
+  assertEquals(body.error, "Internal error during token exchange");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 500 on getUserInfo error", async () => {
+  const deps = makeMockDeps({
+    getUserInfo: () => Promise.reject(new Error("userinfo endpoint down")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 500);
+  const body = await result!.json();
+  assertEquals(body.error, "Internal error during token exchange");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 500 on mintServerToken error", async () => {
+  const deps = makeMockDeps({
+    mintServerToken: () => Promise.reject(new Error("vault unavailable")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 500);
+  const body = await result!.json();
+  assertEquals(body.error, "Internal error during token exchange");
+});

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -125,6 +125,15 @@ export function isAccessModelType(
   return false;
 }
 
+const connectionCollectives = new WeakMap<WebSocket, readonly string[]>();
+
+export function setConnectionCollectives(
+  socket: WebSocket,
+  collectives: readonly string[],
+): void {
+  connectionCollectives.set(socket, collectives);
+}
+
 export function authorizeOrReject(
   socket: WebSocket,
   requestId: string,
@@ -155,9 +164,10 @@ export function authorizeOrReject(
     return false;
   }
 
+  const collectives = connectionCollectives.get(socket) ?? [];
   const service = ctx.policySnapshotLoader.decisionService;
   const decision = service.decide(
-    { principal, collectives: [] },
+    { principal, collectives },
     action,
     resource,
   );
@@ -166,7 +176,7 @@ export function authorizeOrReject(
 
   if (!decision) {
     const adminDecision = service.decide(
-      { principal, collectives: [] },
+      { principal, collectives },
       "admin",
       { kind: "access", name: "*", fields: {} },
     );

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -161,6 +161,12 @@ export async function getUserInfo(
     );
   }
   const data = await resp.json();
+  if (typeof data.sub !== "string" || !data.sub) {
+    throw new Error("Userinfo response missing required 'sub' field");
+  }
+  if (typeof data.email !== "string" || !data.email) {
+    throw new Error("Userinfo response missing required 'email' field");
+  }
   const rawCollectives = data[groupsField];
   const collectives = Array.isArray(rawCollectives)
     ? rawCollectives.filter((c): c is string => typeof c === "string")

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -1,0 +1,201 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/** Response from the OAuth device authorization endpoint. */
+export interface DeviceGrantResponse {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresIn: number;
+  readonly interval: number;
+}
+
+/** Successful token response from the OAuth token endpoint. */
+export interface OAuthTokenResponse {
+  readonly accessToken: string;
+  readonly tokenType: string;
+  readonly expiresIn?: number;
+  readonly refreshToken?: string;
+  readonly scope?: string;
+}
+
+/** User information retrieved from the OAuth provider's userinfo endpoint. */
+export interface OAuthUserInfo {
+  readonly sub: string;
+  readonly email: string;
+  readonly name?: string;
+  readonly collectives: string[];
+}
+
+/** Error codes returned by the OAuth token endpoint during device grant polling. */
+export type DeviceGrantPollErrorCode =
+  | "authorization_pending"
+  | "slow_down"
+  | "expired_token"
+  | "access_denied";
+
+/**
+ * Error thrown when polling the OAuth token endpoint during the device
+ * authorization flow returns an expected error code rather than a token.
+ */
+export class DeviceGrantPollError extends Error {
+  readonly code: DeviceGrantPollErrorCode;
+
+  constructor(code: DeviceGrantPollErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+    this.name = "DeviceGrantPollError";
+  }
+}
+
+const KNOWN_POLL_ERRORS = new Set<string>([
+  "authorization_pending",
+  "slow_down",
+  "expired_token",
+  "access_denied",
+]);
+
+export async function startDeviceGrant(
+  providerUrl: string,
+  clientId: string,
+  signal: AbortSignal,
+): Promise<DeviceGrantResponse> {
+  const resp = await fetch(`${providerUrl}/api/auth/device/code`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_id: clientId }),
+    signal,
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `Device authorization request failed: ${resp.status} ${resp.statusText}`,
+    );
+  }
+  const data = await resp.json();
+  const result: DeviceGrantResponse = {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    expiresIn: data.expires_in,
+    interval: data.interval ?? 5,
+  };
+  if (data.verification_uri_complete) {
+    return {
+      ...result,
+      verificationUriComplete: data.verification_uri_complete,
+    };
+  }
+  return result;
+}
+
+export async function pollForToken(
+  providerUrl: string,
+  clientId: string,
+  clientSecret: string,
+  deviceCode: string,
+  signal: AbortSignal,
+): Promise<OAuthTokenResponse> {
+  const resp = await fetch(`${providerUrl}/api/auth/device/token`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      device_code: deviceCode,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    }),
+    signal,
+  });
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    const errorCode = data.error as string | undefined;
+    if (errorCode && KNOWN_POLL_ERRORS.has(errorCode)) {
+      throw new DeviceGrantPollError(
+        errorCode as DeviceGrantPollErrorCode,
+      );
+    }
+    throw new Error(
+      `Token request failed: ${resp.status} ${data.error ?? resp.statusText}`,
+    );
+  }
+  const data = await resp.json();
+  return {
+    accessToken: data.access_token,
+    tokenType: data.token_type ?? "bearer",
+    expiresIn: data.expires_in,
+    refreshToken: data.refresh_token,
+    scope: data.scope,
+  };
+}
+
+export async function getUserInfo(
+  providerUrl: string,
+  accessToken: string,
+  groupsField: string,
+  signal: AbortSignal,
+): Promise<OAuthUserInfo> {
+  const resp = await fetch(`${providerUrl}/api/auth/oauth2/userinfo`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+    signal,
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `Userinfo request failed: ${resp.status} ${resp.statusText}`,
+    );
+  }
+  const data = await resp.json();
+  const rawCollectives = data[groupsField];
+  const collectives = Array.isArray(rawCollectives)
+    ? rawCollectives as string[]
+    : [];
+  return {
+    sub: data.sub,
+    email: data.email,
+    name: data.name,
+    collectives,
+  };
+}
+
+export async function resolveUsername(
+  providerUrl: string,
+  username: string,
+  accessToken: string,
+  signal: AbortSignal,
+): Promise<string> {
+  const resp = await fetch(
+    `${providerUrl}/api/auth/resolve-user?username=${
+      encodeURIComponent(username)
+    }`,
+    {
+      headers: { "authorization": `Bearer ${accessToken}` },
+      signal,
+    },
+  );
+  if (resp.status === 404) {
+    throw new Error(`Username '${username}' not found on ${providerUrl}`);
+  }
+  if (!resp.ok) {
+    throw new Error(
+      `Failed to resolve username '${username}': ${resp.status} ${resp.statusText}`,
+    );
+  }
+  const data = await resp.json();
+  return data.sub as string;
+}

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -163,7 +163,7 @@ export async function getUserInfo(
   const data = await resp.json();
   const rawCollectives = data[groupsField];
   const collectives = Array.isArray(rawCollectives)
-    ? rawCollectives as string[]
+    ? rawCollectives.filter((c): c is string => typeof c === "string")
     : [];
   return {
     sub: data.sub,

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -203,5 +203,10 @@ export async function resolveUsername(
     );
   }
   const data = await resp.json();
-  return data.sub as string;
+  if (typeof data.sub !== "string" || !data.sub) {
+    throw new Error(
+      `resolve-user response missing required 'sub' field for '${username}'`,
+    );
+  }
+  return data.sub;
 }

--- a/src/serve/oauth_client_test.ts
+++ b/src/serve/oauth_client_test.ts
@@ -22,6 +22,7 @@ import {
   DeviceGrantPollError,
   getUserInfo,
   pollForToken,
+  resolveUsername,
   startDeviceGrant,
 } from "./oauth_client.ts";
 
@@ -417,6 +418,86 @@ Deno.test("getUserInfo: throws on HTTP error", async () => {
       Error,
       "Userinfo request failed: 403",
     );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── resolveUsername ────────────────────────────────────────────────────
+
+Deno.test("resolveUsername: returns sub on success", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ sub: "6a4d58696938eea73751f36b" })
+  );
+  try {
+    const sub = await resolveUsername(
+      `http://localhost:${mock.port}`,
+      "swampadmin",
+      "my-token",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(sub, "6a4d58696938eea73751f36b");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("resolveUsername: throws on 404", async () => {
+  const mock = startMockServer(() =>
+    new Response("Not Found", { status: 404 })
+  );
+  try {
+    await assertRejects(
+      () =>
+        resolveUsername(
+          `http://localhost:${mock.port}`,
+          "nonexistent",
+          "my-token",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Username 'nonexistent' not found",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("resolveUsername: throws on other HTTP error", async () => {
+  const mock = startMockServer(() =>
+    new Response("Forbidden", { status: 403 })
+  );
+  try {
+    await assertRejects(
+      () =>
+        resolveUsername(
+          `http://localhost:${mock.port}`,
+          "someuser",
+          "bad-token",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Failed to resolve username 'someuser': 403",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("resolveUsername: sends Bearer auth header", async () => {
+  let receivedAuth = "";
+  const mock = startMockServer((req) => {
+    receivedAuth = req.headers.get("authorization") ?? "";
+    return Response.json({ sub: "abc" });
+  });
+  try {
+    await resolveUsername(
+      `http://localhost:${mock.port}`,
+      "testuser",
+      "my-secret-token",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(receivedAuth, "Bearer my-secret-token");
   } finally {
     await mock.shutdown();
   }

--- a/src/serve/oauth_client_test.ts
+++ b/src/serve/oauth_client_test.ts
@@ -1,0 +1,423 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  DeviceGrantPollError,
+  getUserInfo,
+  pollForToken,
+  startDeviceGrant,
+} from "./oauth_client.ts";
+
+/** Start a simple mock HTTP server that returns canned responses. */
+function startMockServer(
+  handler: (req: Request) => Response | Promise<Response>,
+): { port: number; shutdown: () => Promise<void> } {
+  const ac = new AbortController();
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal, onListen() {} },
+    handler,
+  );
+  return {
+    port: (server.addr as Deno.NetAddr).port,
+    async shutdown() {
+      ac.abort();
+      await server.finished;
+    },
+  };
+}
+
+// ── startDeviceGrant ────────────────────────────────────────────────────
+
+Deno.test("startDeviceGrant: returns device grant response with camelCase fields", async () => {
+  const mock = startMockServer((req) => {
+    assertEquals(new URL(req.url).pathname, "/api/auth/device/code");
+    assertEquals(req.method, "POST");
+    return Response.json({
+      device_code: "dev-123",
+      user_code: "ABCD-1234",
+      verification_uri: "https://example.com/activate",
+      verification_uri_complete: "https://example.com/activate?code=ABCD-1234",
+      expires_in: 900,
+      interval: 5,
+    });
+  });
+  try {
+    const result = await startDeviceGrant(
+      `http://localhost:${mock.port}`,
+      "test-client",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.deviceCode, "dev-123");
+    assertEquals(result.userCode, "ABCD-1234");
+    assertEquals(result.verificationUri, "https://example.com/activate");
+    assertEquals(
+      result.verificationUriComplete,
+      "https://example.com/activate?code=ABCD-1234",
+    );
+    assertEquals(result.expiresIn, 900);
+    assertEquals(result.interval, 5);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("startDeviceGrant: omits verificationUriComplete when absent", async () => {
+  const mock = startMockServer(() =>
+    Response.json({
+      device_code: "dev-456",
+      user_code: "WXYZ-9999",
+      verification_uri: "https://example.com/activate",
+      expires_in: 600,
+      interval: 10,
+    })
+  );
+  try {
+    const result = await startDeviceGrant(
+      `http://localhost:${mock.port}`,
+      "test-client",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.verificationUriComplete, undefined);
+    assertEquals(result.deviceCode, "dev-456");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("startDeviceGrant: sends client_id in JSON body", async () => {
+  let receivedBody: Record<string, unknown> = {};
+  const mock = startMockServer(async (req) => {
+    receivedBody = await req.json();
+    return Response.json({
+      device_code: "d",
+      user_code: "U",
+      verification_uri: "https://example.com",
+      expires_in: 60,
+      interval: 5,
+    });
+  });
+  try {
+    await startDeviceGrant(
+      `http://localhost:${mock.port}`,
+      "my-client-id",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(receivedBody.client_id, "my-client-id");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("startDeviceGrant: throws on HTTP error", async () => {
+  const mock = startMockServer(() =>
+    new Response("Bad Request", { status: 400 })
+  );
+  try {
+    await assertRejects(
+      () =>
+        startDeviceGrant(
+          `http://localhost:${mock.port}`,
+          "test-client",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Device authorization request failed: 400",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── pollForToken ────────────────────────────────────────────────────────
+
+Deno.test("pollForToken: returns access token on success", async () => {
+  const mock = startMockServer((req) => {
+    assertEquals(new URL(req.url).pathname, "/api/auth/device/token");
+    assertEquals(req.method, "POST");
+    return Response.json({ access_token: "tok-abc" });
+  });
+  try {
+    const result = await pollForToken(
+      `http://localhost:${mock.port}`,
+      "client-id",
+      "client-secret",
+      "device-code",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.accessToken, "tok-abc");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: sends correct JSON body", async () => {
+  let receivedBody: Record<string, unknown> = {};
+  const mock = startMockServer(async (req) => {
+    receivedBody = await req.json();
+    return Response.json({ access_token: "tok" });
+  });
+  try {
+    await pollForToken(
+      `http://localhost:${mock.port}`,
+      "cid",
+      "csecret",
+      "dcode",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(receivedBody.client_id, "cid");
+    assertEquals(receivedBody.client_secret, "csecret");
+    assertEquals(receivedBody.device_code, "dcode");
+    assertEquals(
+      receivedBody.grant_type,
+      "urn:ietf:params:oauth:grant-type:device_code",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws DeviceGrantPollError for authorization_pending", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "authorization_pending" }, { status: 400 })
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      DeviceGrantPollError,
+      "authorization_pending",
+    );
+    assertEquals(error.code, "authorization_pending");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws DeviceGrantPollError for slow_down", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "slow_down" }, { status: 400 })
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      DeviceGrantPollError,
+      "slow_down",
+    );
+    assertEquals(error.code, "slow_down");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws DeviceGrantPollError for expired_token", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "expired_token" }, { status: 400 })
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      DeviceGrantPollError,
+      "expired_token",
+    );
+    assertEquals(error.code, "expired_token");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws DeviceGrantPollError for access_denied", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "access_denied" }, { status: 400 })
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      DeviceGrantPollError,
+      "access_denied",
+    );
+    assertEquals(error.code, "access_denied");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws generic Error for unknown error code", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "server_error" }, { status: 500 })
+  );
+  try {
+    await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Token request failed: 500",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+// ── getUserInfo ─────────────────────────────────────────────────────────
+
+Deno.test("getUserInfo: returns user info with collectives", async () => {
+  const mock = startMockServer((req) => {
+    assertEquals(new URL(req.url).pathname, "/api/auth/oauth2/userinfo");
+    assertEquals(req.headers.get("Authorization"), "Bearer my-token");
+    return Response.json({
+      sub: "user-1",
+      email: "user@example.com",
+      name: "Test User",
+      groups: ["org-a", "org-b"],
+    });
+  });
+  try {
+    const result = await getUserInfo(
+      `http://localhost:${mock.port}`,
+      "my-token",
+      "groups",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.sub, "user-1");
+    assertEquals(result.email, "user@example.com");
+    assertEquals(result.name, "Test User");
+    assertEquals(result.collectives, ["org-a", "org-b"]);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("getUserInfo: uses custom groupsField", async () => {
+  const mock = startMockServer(() =>
+    Response.json({
+      sub: "user-2",
+      email: "user2@example.com",
+      name: "User Two",
+      teams: ["team-x"],
+    })
+  );
+  try {
+    const result = await getUserInfo(
+      `http://localhost:${mock.port}`,
+      "tok",
+      "teams",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.collectives, ["team-x"]);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("getUserInfo: defaults collectives to empty array when field is missing", async () => {
+  const mock = startMockServer(() =>
+    Response.json({
+      sub: "user-3",
+      email: "user3@example.com",
+      name: "User Three",
+    })
+  );
+  try {
+    const result = await getUserInfo(
+      `http://localhost:${mock.port}`,
+      "tok",
+      "groups",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.collectives, []);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("getUserInfo: defaults collectives to empty array when field is not an array", async () => {
+  const mock = startMockServer(() =>
+    Response.json({
+      sub: "user-4",
+      email: "user4@example.com",
+      name: "User Four",
+      groups: "not-an-array",
+    })
+  );
+  try {
+    const result = await getUserInfo(
+      `http://localhost:${mock.port}`,
+      "tok",
+      "groups",
+      AbortSignal.timeout(5000),
+    );
+    assertEquals(result.collectives, []);
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("getUserInfo: throws on HTTP error", async () => {
+  const mock = startMockServer(() =>
+    new Response("Forbidden", { status: 403 })
+  );
+  try {
+    await assertRejects(
+      () =>
+        getUserInfo(
+          `http://localhost:${mock.port}`,
+          "bad-token",
+          "groups",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Userinfo request failed: 403",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});

--- a/src/serve/oauth_registration.ts
+++ b/src/serve/oauth_registration.ts
@@ -1,0 +1,147 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "oauth-registration"]);
+
+export const OAUTH_CLIENT_ID_KEY = "oauth-client-id";
+export const OAUTH_CLIENT_SECRET_KEY = "oauth-client-secret";
+export const OAUTH_RESOLVED_ADMINS_KEY = "oauth-resolved-admins";
+
+// Well-known bootstrap client ID for first-time OAuth registration.
+// This is a public client ID baked into the binary — the same pattern
+// used by GitHub CLI (client ID 178c6fc778ccc68e1d6a), Claude Code,
+// and other CLI tools that authenticate via OAuth device grant.
+// Security is in the device grant approval (user must approve in browser),
+// not in the client ID secrecy.
+export const BOOTSTRAP_CLIENT_ID = "swamp-serve-bootstrap";
+
+export interface OAuthClientCredentials {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly accessToken: string | null;
+  readonly resolvedAdmins: Record<string, string> | null;
+}
+
+export interface OAuthRegistrationDeps {
+  readonly getVaultSecret: (
+    vaultName: string,
+    key: string,
+  ) => Promise<string | null>;
+  readonly putVaultSecret: (
+    vaultName: string,
+    key: string,
+    value: string,
+  ) => Promise<void>;
+  readonly registerClient: (
+    providerUrl: string,
+    signal: AbortSignal,
+  ) => Promise<{
+    clientId: string;
+    clientSecret: string;
+    accessToken: string;
+  }>;
+}
+
+export async function resolveOAuthClientCredentials(
+  deps: OAuthRegistrationDeps,
+  providerUrl: string,
+  vaultName: string,
+  explicitClientId: string | undefined,
+  signal: AbortSignal,
+): Promise<OAuthClientCredentials> {
+  const storedClientId = await deps.getVaultSecret(
+    vaultName,
+    OAUTH_CLIENT_ID_KEY,
+  );
+  const storedClientSecret = await deps.getVaultSecret(
+    vaultName,
+    OAUTH_CLIENT_SECRET_KEY,
+  );
+
+  const storedAdminsRaw = await deps.getVaultSecret(
+    vaultName,
+    OAUTH_RESOLVED_ADMINS_KEY,
+  );
+  const resolvedAdmins = storedAdminsRaw
+    ? JSON.parse(storedAdminsRaw) as Record<string, string>
+    : null;
+
+  if (explicitClientId && storedClientSecret) {
+    logger.info("Using explicit --oauth-client-id with stored client secret");
+    return {
+      clientId: explicitClientId,
+      clientSecret: storedClientSecret,
+      accessToken: null,
+      resolvedAdmins,
+    };
+  }
+
+  if (storedClientId && storedClientSecret) {
+    logger.info("Using stored OAuth client credentials from vault");
+    return {
+      clientId: storedClientId,
+      clientSecret: storedClientSecret,
+      accessToken: null,
+      resolvedAdmins,
+    };
+  }
+
+  logger.info(
+    "No stored OAuth client credentials found — first-time setup required",
+  );
+
+  const result = await deps.registerClient(providerUrl, signal);
+
+  await deps.putVaultSecret(vaultName, OAUTH_CLIENT_ID_KEY, result.clientId);
+  await deps.putVaultSecret(
+    vaultName,
+    OAUTH_CLIENT_SECRET_KEY,
+    result.clientSecret,
+  );
+
+  logger.info(
+    "Registered OAuth client {clientId} and stored credentials in vault",
+    { clientId: result.clientId },
+  );
+
+  return {
+    clientId: result.clientId,
+    clientSecret: result.clientSecret,
+    accessToken: result.accessToken,
+    resolvedAdmins: null,
+  };
+}
+
+export async function storeResolvedAdmins(
+  deps: Pick<OAuthRegistrationDeps, "putVaultSecret">,
+  vaultName: string,
+  admins: Record<string, string>,
+): Promise<void> {
+  await deps.putVaultSecret(
+    vaultName,
+    OAUTH_RESOLVED_ADMINS_KEY,
+    JSON.stringify(admins),
+  );
+  logger.info(
+    "Stored {count} resolved admin mapping(s) in vault",
+    { count: Object.keys(admins).length },
+  );
+}

--- a/src/serve/oauth_registration_test.ts
+++ b/src/serve/oauth_registration_test.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  OAUTH_CLIENT_ID_KEY,
+  OAUTH_CLIENT_SECRET_KEY,
+  OAUTH_RESOLVED_ADMINS_KEY,
+  type OAuthRegistrationDeps,
+  resolveOAuthClientCredentials,
+  storeResolvedAdmins,
+} from "./oauth_registration.ts";
+
+function createMockDeps(
+  overrides: Partial<OAuthRegistrationDeps> = {},
+): OAuthRegistrationDeps {
+  return {
+    getVaultSecret: () => Promise.resolve(null),
+    putVaultSecret: () => Promise.resolve(),
+    registerClient: () =>
+      Promise.resolve({
+        clientId: "new-client-id",
+        clientSecret: "new-client-secret",
+        accessToken: "new-access-token",
+      }),
+    ...overrides,
+  };
+}
+
+Deno.test("resolveOAuthClientCredentials: uses stored credentials when both exist", async () => {
+  const deps = createMockDeps({
+    getVaultSecret: (_, key) => {
+      if (key === OAUTH_CLIENT_ID_KEY) return Promise.resolve("stored-id");
+      if (key === OAUTH_CLIENT_SECRET_KEY) {
+        return Promise.resolve("stored-secret");
+      }
+      return Promise.resolve(null);
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.clientId, "stored-id");
+  assertEquals(result.clientSecret, "stored-secret");
+  assertEquals(result.accessToken, null);
+});
+
+Deno.test("resolveOAuthClientCredentials: returns cached resolved admins on subsequent boot", async () => {
+  const adminsJson = JSON.stringify({ swampadmin: "6a4d-sub-id" });
+  const deps = createMockDeps({
+    getVaultSecret: (_, key) => {
+      if (key === OAUTH_CLIENT_ID_KEY) return Promise.resolve("stored-id");
+      if (key === OAUTH_CLIENT_SECRET_KEY) {
+        return Promise.resolve("stored-secret");
+      }
+      if (key === OAUTH_RESOLVED_ADMINS_KEY) return Promise.resolve(adminsJson);
+      return Promise.resolve(null);
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.resolvedAdmins, { swampadmin: "6a4d-sub-id" });
+});
+
+Deno.test("resolveOAuthClientCredentials: bootstrap registers and returns access token", async () => {
+  const storedSecrets = new Map<string, string>();
+  const deps = createMockDeps({
+    putVaultSecret: (_, key, value) => {
+      storedSecrets.set(key, value);
+      return Promise.resolve();
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.clientId, "new-client-id");
+  assertEquals(result.clientSecret, "new-client-secret");
+  assertEquals(result.accessToken, "new-access-token");
+  assertEquals(storedSecrets.get(OAUTH_CLIENT_ID_KEY), "new-client-id");
+  assertEquals(
+    storedSecrets.get(OAUTH_CLIENT_SECRET_KEY),
+    "new-client-secret",
+  );
+  assertEquals(storedSecrets.has("oauth-access-token"), false);
+});
+
+Deno.test("storeResolvedAdmins: stores admin mapping in vault", async () => {
+  const stored = new Map<string, string>();
+  await storeResolvedAdmins(
+    { putVaultSecret: (_, k, v) => (stored.set(k, v), Promise.resolve()) },
+    "default",
+    { swampadmin: "6a4d-sub-id", alice: "abc-123" },
+  );
+  const parsed = JSON.parse(stored.get(OAUTH_RESOLVED_ADMINS_KEY)!);
+  assertEquals(parsed, { swampadmin: "6a4d-sub-id", alice: "abc-123" });
+});

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -43,7 +43,7 @@ export function splitServerToken(
 }
 
 export type ServerTokenAuthResult =
-  | { ok: true; principalId: string }
+  | { ok: true; principalId: string; collectives: readonly string[] }
   | { ok: false; error: string };
 
 /**
@@ -76,6 +76,7 @@ export async function authenticateServerToken(
   const libCtx = createLibSwampContext({});
 
   let principalId: string | undefined;
+  let collectives: readonly string[] = [];
   for await (
     const event of modelMethodRun(libCtx, deps, {
       modelIdOrName: split.name,
@@ -101,6 +102,9 @@ export async function authenticateServerToken(
       if (tokenRecord && typeof tokenRecord.principalId === "string") {
         principalId = tokenRecord.principalId;
       }
+      if (tokenRecord && Array.isArray(tokenRecord.collectives)) {
+        collectives = tokenRecord.collectives as string[];
+      }
     }
   }
 
@@ -115,5 +119,5 @@ export async function authenticateServerToken(
     name: split.name,
     principal: principalId,
   });
-  return { ok: true, principalId };
+  return { ok: true, principalId, collectives };
 }


### PR DESCRIPTION
## Summary

- Implement `--auth-mode oauth` on swamp serve using the OAuth device grant flow (RFC 8628) against swamp-club
- Users authenticate via browser, collective membership controls admission (`--allowed-collectives` / `--allowed-users`)
- After admission, the flow mints a standard server token — WebSocket auth converges to the same `?token=<name>.<secret>` path as `mode: token`
- Collectives snapshotted on the token record, threaded through `authorizeOrReject` via a per-connection WeakMap, enabling `idp-group:` grants
- Bootstrap device grant for first-time client registration (public `BOOTSTRAP_CLIENT_ID` pattern, same as GitHub CLI / Claude Code)
- Admin usernames resolved to `user:<sub>` via swamp-club's resolve-user endpoint, cached in vault for subsequent boots
- `swamp auth login --server` auto-detects OAuth mode via `GET /auth/info` and runs the device flow; falls back to static token prompt with `--token`
- OAuth provider must use HTTPS (localhost exempt); admission restrictions required at startup

## New files
- `src/domain/access/admission.ts` — admission policy domain service
- `src/serve/oauth_client.ts` — RFC 8628 client (startDeviceGrant, pollForToken, getUserInfo, resolveUsername)
- `src/serve/device_auth_handler.ts` — HTTP handler for `/auth/device` and `/auth/device/token`
- `src/serve/oauth_registration.ts` — client credential resolution + vault storage + bootstrap
- `src/libswamp/auth/server_login.ts` — async generator for CLI OAuth device flow

## Modified files
- `src/cli/commands/serve.ts` — OAuth startup (credential resolution, admin resolution, device auth endpoints, auth info endpoint, WebSocket guard)
- `src/serve/handlers/shared.ts` — WeakMap-based per-connection collectives for `authorizeOrReject`
- `src/serve/token_auth.ts` — `authenticateServerToken` returns collectives from token record
- `src/domain/models/access/server_token_model.ts` — `collectives` field on ServerToken schema
- `src/domain/access/serve_auth_config.ts` — relaxed admin validation for OAuth, admission + HTTPS requirements
- `src/cli/commands/auth_server_login.ts` — OAuth device flow when `--token` omitted

## Test plan

- 65 new unit tests across all new modules (admission, OAuth client, device auth handler, server login, OAuth registration)
- All 8543 existing tests pass unchanged (mode:none, mode:token, worker flows untouched)
- Tested end-to-end with swamp-club dev server: bootstrap registration, admin resolution, device auth login, WebSocket auth with OAuth-minted token
- Pre-existing flaky test: `shutdown_handlers_test.ts` SIGINT delivery (unrelated)

Closes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)