### PR TITLE
fix(extensions): skip broken bundle exports instead of fatal abort (swamp-club#1018)

### DIFF
--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -526,6 +526,11 @@ export class ExtensionLoader {
 
     await this.importAndRegisterBundle(entry);
 
+    if (!this.adapter.isFullyLoaded(typeNormalized)) {
+      catalog.removeBySourcePath(entry.source_path);
+      return;
+    }
+
     if (this.adapter.findExtensionsForType) {
       const extensions = this.adapter.findExtensionsForType(
         catalog,
@@ -654,9 +659,9 @@ export class ExtensionLoader {
 
     const exportKey = this.adapter.primaryExportKey;
     if (!module[exportKey]) {
-      throw new Error(
-        `Bundle has no ${exportKey} export: ${entry.bundle_path}`,
-      );
+      this.logger
+        .warn`Skipping bundle with no ${exportKey} export: ${entry.bundle_path}`;
+      return;
     }
 
     const parsed = this.adapter.validatePrimaryExport(module[exportKey]);

--- a/src/domain/extensions/extension_loader_test.ts
+++ b/src/domain/extensions/extension_loader_test.ts
@@ -23,6 +23,11 @@ import { toFileUrl } from "@std/path";
 import { findStaleFiles, type FreshnessCatalog } from "./bundle_freshness.ts";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import type { ExtensionTypeRow } from "../../infrastructure/persistence/extension_catalog_store.ts";
+import { ExtensionLoader } from "./extension_loader.ts";
+import type { KindAdapter } from "./kind_adapter.ts";
+import { ExtensionRepository } from "../../infrastructure/persistence/extension_repository.ts";
+import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
+import type { DenoRuntime } from "../runtime/deno_runtime.ts";
 
 Deno.test("importBundleByPath: non-empty fingerprint appends ?fp= to import URL", async () => {
   const dir = await Deno.makeTempDir({ prefix: "swamp_fp_url_" });
@@ -323,6 +328,118 @@ Deno.test("findStaleFiles: ValidationFailed entries for missing sources are remo
         remaining.length,
         0,
         "ValidationFailed entry for deleted source must be removed by findStaleFiles",
+      );
+    } finally {
+      catalog.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+// -- loadSingleType skip-with-warning for broken bundles (swamp-club#1018) ----
+
+function makeStubAdapter(loaded: Set<string>): KindAdapter {
+  return {
+    kind: "model",
+    bundleSubdir: "bundles",
+    catalogKinds: ["model"],
+    primaryExportKey: "model",
+    exportRegex: /export\s+const\s+model\s*[=:]/,
+    useResolver: false,
+    validatePrimaryExport() {
+      return { success: true, data: {} };
+    },
+    formatValidationError() {
+      return "validation error";
+    },
+    normalizeType() {
+      return "";
+    },
+    extractTypeFromSource() {
+      return null;
+    },
+    register() {},
+    registerLazy() {},
+    promoteFromLazy(_type, _validated, _module, _ctx) {
+      loaded.add(_type);
+    },
+    hasType(type) {
+      return loaded.has(type);
+    },
+    isFullyLoaded(type) {
+      return loaded.has(type);
+    },
+  };
+}
+
+const stubDenoRuntime: DenoRuntime = {
+  ensureDeno: () => Promise.resolve("/usr/bin/deno"),
+};
+
+Deno.test("loadSingleType: skips bundle without primary export and removes catalog entry", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp_1018_" });
+  try {
+    const bundlePath = join(dir, "helper.js");
+    await Deno.writeTextFile(
+      bundlePath,
+      "export const helper = true;\n",
+    );
+
+    const sourcePath = join(dir, "helper.ts");
+    await Deno.writeTextFile(sourcePath, "");
+
+    const dbPath = join(dir, "catalog.db");
+    const catalog = new ExtensionCatalogStore(dbPath);
+    try {
+      catalog.upsert({
+        type_normalized: "@test/broken",
+        kind: "model",
+        bundle_path: bundlePath,
+        source_path: sourcePath,
+        version: "1.0.0",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "",
+      });
+
+      assertEquals(
+        catalog.findByType("@test/broken", "model") !== undefined,
+        true,
+        "catalog entry must exist before loadSingleType",
+      );
+
+      const loaded = new Set<string>();
+      const adapter = makeStubAdapter(loaded);
+      const lockfileRepo = new LockfileRepository(join(dir, "lockfile.json"));
+      const repository = new ExtensionRepository({
+        catalog,
+        lockfileRepository: lockfileRepo,
+        repoRoot: dir,
+      });
+      const loader = new ExtensionLoader(
+        stubDenoRuntime,
+        adapter,
+        dir,
+        undefined,
+        repository,
+      );
+
+      await loader.loadSingleType("@test/broken", {
+        bundlePath,
+        sourcePath,
+      });
+
+      assertEquals(
+        loaded.has("@test/broken"),
+        false,
+        "broken bundle must not be promoted",
+      );
+      assertEquals(
+        catalog.findByType("@test/broken", "model"),
+        undefined,
+        "stale catalog entry must be removed after skip",
       );
     } finally {
       catalog.close();

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -856,10 +856,13 @@ export class ModelRegistry {
       const loader = this.typeLoader;
       const lazyEntry = this.lazyTypes.get(key);
       promise = loader(key, lazyEntry ?? undefined).then(() => {
-        // promoteFromLazy() already deleted the lazy entry during
-        // the loader call, so no lazyTypes cleanup needed here.
-        // Prune the resolved promise — it's no longer needed since
-        // the type is now fully registered in this.models.
+        // promoteFromLazy() deletes the lazy entry on success.
+        // If the loader skipped a broken bundle (no primary export),
+        // the type was never promoted — discard the lazy entry so
+        // subsequent calls treat it as unknown instead of retrying.
+        if (!this.models.has(key)) {
+          this.lazyTypes.delete(key);
+        }
         this.typeLoadPromises.delete(key);
       }).catch((err) => {
         this.typeLoadPromises.delete(key);


### PR DESCRIPTION
## Summary

- `importAndRegisterBundle` now logs a warning and returns early when a bundle `.js` file lacks the expected primary export, instead of throwing a fatal `Error` that aborts all type resolution
- `loadSingleType` removes the stale catalog entry after a skipped bundle so the broken entry doesn't persist across commands
- `ensureTypeLoaded` discards the orphaned lazy type entry so subsequent calls treat the type as unknown instead of retrying the broken load indefinitely

Closes swamp-club#1018

## Test Plan

- Added unit test `loadSingleType: skips bundle without primary export and removes catalog entry` that creates a `.js` bundle without a `model` export, sets up a catalog entry pointing to it, calls `loadSingleType`, and verifies: no throw, type not promoted, catalog entry removed
- Reproduced the original fatal error in a scratch repo and confirmed the fix resolves it
- Full test suite passes (8490 tests, 0 failures)
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)