### PR TITLE
fix(extensions): verify filesChecksum during install to detect stale on-disk files (#1021)

### DIFF
--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
+import { join, resolve } from "@std/path";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
+import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { assertContainedPath } from "../../infrastructure/persistence/safe_path.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -166,11 +167,32 @@ export async function* extensionInstall(
         // when any of its files are absent from disk, OR when any are at
         // a legacy layout (gen-1 or gen-2) and must be migrated to the
         // current per-extension subtree.
-        const needs = await needsInstallOrMigration(
+        let needs = await needsInstallOrMigration(
           originalFiles,
           deps.repoDir,
           deps.skillsDirRelative,
         );
+
+        // When all files exist at current layout, verify their content
+        // matches the lockfile's filesChecksum. This catches the case
+        // where upstream_extensions.json was updated via git but the
+        // on-disk files weren't re-fetched (swamp-club#1021).
+        if (needs === "up_to_date" && entry.filesChecksum) {
+          try {
+            const extRoot = join(
+              resolve(deps.repoDir),
+              ".swamp",
+              "pulled-extensions",
+              name,
+            );
+            const onDisk = await readInstalledExtensionDigest(extRoot);
+            if (onDisk !== entry.filesChecksum) {
+              needs = "install";
+            }
+          } catch {
+            // Degrade gracefully on I/O errors — don't block install.
+          }
+        }
 
         if (needs === "up_to_date") {
           entries.push({ name, version, status: "up_to_date" });

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -28,6 +28,7 @@ import {
   sweepLegacyPaths,
 } from "./install.ts";
 import { pruneOrphanFiles } from "../../infrastructure/persistence/directory_cleanup.ts";
+import { readInstalledExtensionDigest } from "../../infrastructure/persistence/installed_extension_digest_reader.ts";
 import { createLibSwampContext } from "../context.ts";
 import type { InstallContext } from "./pull.ts";
 import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
@@ -125,6 +126,199 @@ Deno.test("extensionInstall: skips extensions with all files present", async () 
     }
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extensionInstall: reinstalls when filesChecksum mismatches on-disk digest", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const pulledDir = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      "@test",
+      "ext",
+      "models",
+    );
+    await ensureDir(pulledDir);
+    await Deno.writeTextFile(join(pulledDir, "test.ts"), "// old version");
+
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      "@test",
+      "ext",
+    );
+    const realDigest = await readInstalledExtensionDigest(extRoot);
+
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@test/ext": {
+          version: "2.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@test/ext/models/test.ts"],
+          filesChecksum: "a".repeat(64),
+        },
+      }),
+    );
+
+    // Sanity: on-disk digest differs from the fake lockfile checksum
+    if (realDigest === "a".repeat(64)) {
+      throw new Error("test setup: digest should not match the fake checksum");
+    }
+
+    let installCalled = false;
+    const ctx = createLibSwampContext({});
+    const events = await collectEvents(
+      extensionInstall(ctx, {
+        lockfilePath,
+        repoDir: tmpDir,
+        createInstallContext: async () => {
+          installCalled = true;
+          return {
+            getExtension: () => Promise.resolve(null),
+            downloadArchive: () => Promise.reject(new Error("test stub")),
+            getChecksum: () => Promise.resolve(null),
+            lockfileRepository: await LockfileRepository.create(lockfilePath),
+            skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+            repoDir: tmpDir,
+            force: true,
+            alreadyPulled: new Set<string>(),
+            depth: 0,
+          };
+        },
+      }),
+    );
+
+    assertEquals(installCalled, true);
+
+    const installing = events.find((e) => e.kind === "installing");
+    assertEquals(installing?.kind, "installing");
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+    if (completed?.kind === "completed") {
+      assertEquals(completed.data.failed, 1);
+      assertEquals(completed.data.upToDate, 0);
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("extensionInstall: stays up_to_date when filesChecksum matches", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const pulledDir = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      "@test",
+      "ext",
+      "models",
+    );
+    await ensureDir(pulledDir);
+    await Deno.writeTextFile(join(pulledDir, "test.ts"), "// current version");
+
+    const extRoot = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      "@test",
+      "ext",
+    );
+    const realDigest = await readInstalledExtensionDigest(extRoot);
+
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@test/ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@test/ext/models/test.ts"],
+          filesChecksum: realDigest,
+        },
+      }),
+    );
+
+    const ctx = createLibSwampContext({});
+    const events = await collectEvents(
+      extensionInstall(ctx, {
+        lockfilePath,
+        repoDir: tmpDir,
+        createInstallContext: () => {
+          return Promise.reject(
+            new Error("should not be called for up-to-date"),
+          );
+        },
+      }),
+    );
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+    if (completed?.kind === "completed") {
+      assertEquals(completed.data.upToDate, 1);
+      assertEquals(completed.data.installed, 0);
+      assertEquals(completed.data.entries[0].status, "up_to_date");
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("extensionInstall: no filesChecksum in lockfile skips digest check (grandfather)", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const pulledDir = join(
+      tmpDir,
+      ".swamp",
+      "pulled-extensions",
+      "@test",
+      "ext",
+      "models",
+    );
+    await ensureDir(pulledDir);
+    await Deno.writeTextFile(join(pulledDir, "test.ts"), "// old version");
+
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@test/ext": {
+          version: "2.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@test/ext/models/test.ts"],
+          // No filesChecksum — pre-filesChecksum entry
+        },
+      }),
+    );
+
+    const ctx = createLibSwampContext({});
+    const events = await collectEvents(
+      extensionInstall(ctx, {
+        lockfilePath,
+        repoDir: tmpDir,
+        createInstallContext: () => {
+          return Promise.reject(
+            new Error("should not be called for up-to-date"),
+          );
+        },
+      }),
+    );
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+    if (completed?.kind === "completed") {
+      assertEquals(completed.data.upToDate, 1);
+      assertEquals(completed.data.installed, 0);
+      assertEquals(completed.data.entries[0].status, "up_to_date");
+    }
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 


### PR DESCRIPTION
## Summary

- `swamp extension install` now verifies the lockfile's `filesChecksum` against the actual on-disk digest when all files exist at current layout, catching the case where `upstream_extensions.json` was updated via `git pull` but on-disk files weren't re-fetched
- Pre-`filesChecksum` lockfile entries skip the check (grandfather path), and I/O errors degrade gracefully

Fixes swamp-club/swamp-club#1021

## Test Plan

- [x] Three new unit tests in `install_test.ts`: checksum mismatch triggers re-install, matching checksum stays up-to-date, no-checksum entry skips check
- [x] Full test suite passes (8492 tests, 0 failures)
- [x] Manual reproduction: set up scratch repo, pulled extension, tampered lockfile to simulate git-pull divergence — `install` now correctly detects stale files and attempts re-install instead of reporting "up to date"
- [x] Verified matching-checksum case still correctly reports "up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)