### PR TITLE
fix(vaults): remove unnecessary datastore sync from vault commands

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1481,116 +1481,19 @@ export interface VaultSyncResult {
 }
 
 /**
- * Acquires a lockless pull/push lifecycle for vault commands.
+ * Lifecycle hook for vault commands.
  *
- * Vault writes (put, annotate, read-secret refresh) only touch individual
- * secret files — they don't need a distributed lock during execution. But
- * push must still hold the global lock to protect the `.datastore-index.json`
- * from concurrent read-modify-write corruption (same reason
- * `acquireModelLocks` flush acquires the global lock at push time).
- *
- * Flow: lockless pull → caller executes → push under global lock.
+ * Vault data lives entirely in `.swamp/secrets/` which is always-local
+ * (ALWAYS_LOCAL_SUBDIRS) — it never enters the datastore. There is nothing
+ * to pull or push, so the returned flush is a no-op. The function and its
+ * interface are preserved to keep callers stable.
  */
-export async function acquireVaultSync(
-  config: DatastoreConfig,
-  syncService?: DatastoreSyncService,
-  repoDir?: string,
+export function acquireVaultSync(
+  _config: DatastoreConfig,
+  _syncService?: DatastoreSyncService,
+  _repoDir?: string,
 ): Promise<VaultSyncResult> {
-  const logger = getSwampLogger(["datastore", "sync"]);
-
-  let customProvider: DatastoreProvider | undefined;
-  let customSyncService = syncService;
-  if (isCustomDatastoreConfig(config)) {
-    customProvider = await resolveCustomProvider(config);
-    if (!customSyncService && config.cachePath) {
-      customSyncService = customProvider.createSyncService?.(
-        repoDir ?? ".",
-        config.cachePath,
-      );
-    }
-  }
-
-  // Pull (no lock — vault reads don't conflict with structural writes)
-  if (customSyncService) {
-    const ns = isCustomDatastoreConfig(config) ? config.namespace : undefined;
-    try {
-      logger.info("Syncing vault data from datastore...");
-      if (ns) {
-        await customSyncService.pullChanged({ namespace: ns });
-      } else {
-        await customSyncService.pullChanged();
-      }
-    } catch (error) {
-      const { summary, fields } = summarizeSyncError(
-        "pull",
-        isCustomDatastoreConfig(config) ? config.type : "filesystem",
-        error,
-      );
-      logger.error("{summary}", { summary, ...fields });
-      throw new Error(summary, { cause: error });
-    }
-  }
-
-  const flush = async () => {
-    // Push under global lock (protects .datastore-index.json)
-    if (
-      customSyncService && customProvider && isCustomDatastoreConfig(config)
-    ) {
-      const pushLock = customProvider.createLock(
-        config.datastorePath,
-        {
-          ...datastoreGlobalLockOptions(config),
-          maxWaitMs: resolveLockTimeoutMs(),
-        },
-      );
-      try {
-        const lockStart = Date.now();
-        await pushLock.acquire();
-        const lockMs = Date.now() - lockStart;
-        if (lockMs > 5_000 && !config.namespace) {
-          logger.warn(
-            "Lock acquisition took {ms}ms — multiple repos sharing this " +
-              "datastore without namespaces serialize all writes behind a " +
-              "single global lock. Run 'swamp datastore namespace set " +
-              "<name>' to scope each repo to its own lock and index",
-            { ms: lockMs },
-          );
-        }
-        logger.info`Pushing vault changes to datastore...`;
-
-        const pushNs = config.namespace;
-        let pushed: number | void;
-        if (pushNs) {
-          pushed = await customSyncService.pushChanged({ namespace: pushNs });
-        } else {
-          pushed = await customSyncService.pushChanged();
-        }
-        if (pushed && pushed > 0) {
-          logger.info("Pushed {count} vault file(s) to datastore", {
-            count: pushed,
-          });
-        } else {
-          logger.info`Vault push complete, no changes`;
-        }
-      } catch (error) {
-        const { summary, fields } = summarizeSyncError(
-          "push",
-          config.type,
-          error,
-        );
-        logger.error("{summary}", { summary, ...fields });
-        throw new Error(summary, { cause: error });
-      } finally {
-        try {
-          await pushLock.release();
-        } catch {
-          // Best-effort release — lock expires via TTL if release fails.
-        }
-      }
-    }
-  };
-
-  return { flush };
+  return Promise.resolve({ flush: () => Promise.resolve() });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove the `pullChanged()` and `pushChanged()` calls from `acquireVaultSync` in `src/cli/repo_context.ts`
- Vault data lives entirely in `.swamp/secrets/` (`ALWAYS_LOCAL_SUBDIRS`) — it never enters the datastore, so the sync was a no-op for vault data while misleadingly flushing unrelated dirty files and logging "Pushed N vault file(s) to datastore"
- Replace the function body with a no-op flush, preserving the `VaultSyncResult` interface so all 7 callers remain unchanged

## Test Plan

- [x] `deno check` — pass
- [x] `deno lint` — pass
- [x] `deno fmt` — pass
- [x] `deno run test` — 8556 passed, 0 failed
- [x] `deno run compile` — pass
- [x] Verified no tests assert on `acquireVaultSync` behavior directly
- [x] Confirmed vault provider writes exclusively to `.swamp/secrets/` (always-local)
- [x] Confirmed no vault code calls `markDirty` on the datastore sync service

Closes swamp-club/lab#1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)