### PR TITLE
fix(data): close ephemeral CatalogStore on dispose to prevent OOM (swamp-club#1030)

### DIFF
--- a/src/infrastructure/persistence/ephemeral_store.ts
+++ b/src/infrastructure/persistence/ephemeral_store.ts
@@ -98,6 +98,7 @@ export function createEphemeralStore(
     catalog,
     dispose() {
       repo.dispose();
+      catalog.close();
     },
   };
 }

--- a/src/infrastructure/persistence/ephemeral_store_test.ts
+++ b/src/infrastructure/persistence/ephemeral_store_test.ts
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { parseByteSize } from "./ephemeral_store.ts";
+import { assertEquals, assertThrows } from "@std/assert";
+import { createEphemeralStore, parseByteSize } from "./ephemeral_store.ts";
 
 Deno.test("parseByteSize: parses plain bytes", () => {
   assertEquals(parseByteSize("1024"), 1024);
@@ -60,4 +60,14 @@ Deno.test("parseByteSize: returns undefined for invalid input", () => {
   assertEquals(parseByteSize("abc"), undefined);
   assertEquals(parseByteSize("-1m"), undefined);
   assertEquals(parseByteSize("1t"), undefined);
+});
+
+Deno.test("createEphemeralStore: dispose closes the catalog SQLite database", () => {
+  const store = createEphemeralStore();
+  store.dispose();
+
+  assertThrows(
+    () => store.catalog.markPopulated(),
+    Error,
+  );
 });


### PR DESCRIPTION
## Summary

- Close the `:memory:` SQLite `CatalogStore` in `EphemeralStore.dispose()` — it was only clearing the `InMemoryUnifiedDataRepository` maps, leaking ~158 KB of native memory per workflow/model run
- Affects all 4 call sites (`workflowRun`, `modelRun`, `workflow_resume`, `workflow_handlers`) since they all go through `dispose()`
- Only observable in long-lived processes (`swamp serve`) where leaked instances accumulate to OOM; CLI commands exit after one run so the OS reclaims everything

## Test Plan

- Added unit test proving `dispose()` closes the underlying SQLite database (operations on a closed catalog throw)
- Reproduction script: 200 ephemeral store create/dispose cycles — **+31,712 KB without fix** vs **+192 KB with fix**
- `deno fmt`, `deno lint`, `deno run test` all pass

Closes swamp-club#1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)