### PR TITLE
fix(serve-auth): fix vacuous cost-budget and explain-truncation tests

### DIFF
--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -435,7 +435,14 @@ Deno.test("decide: grants without conditions do not count toward aggregate budge
 });
 
 Deno.test("explain: truncates when aggregate condition budget exceeded", () => {
-  const grants = Array.from(
+  const matchingGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+    condition: 'name == "@acme/deploy"',
+  });
+  const nonMatchingGrants = Array.from(
     { length: MAX_AGGREGATE_CONDITIONS + 10 },
     (_, i) =>
       makeGrant({
@@ -443,12 +450,18 @@ Deno.test("explain: truncates when aggregate condition budget exceeded", () => {
         effect: "allow",
         actions: ["read"],
         resource: { kind: "workflow", pattern: "*" },
-        condition: `name == "workflow-${i}"`,
+        condition: `name == "no-match-${i}"`,
       }),
   );
+  const grants = [matchingGrant, ...nonMatchingGrants];
   const snapshot = new PolicySnapshot(grants, [], celEvaluator);
   const service = new GrantBasedAccessDecisionService(snapshot);
 
   const result = service.explain(makePrincipal("adam"), "read", makeResource());
-  assertEquals(result.length < grants.length, true);
+  assertEquals(
+    result.length,
+    1,
+    "matching grant before budget should be included",
+  );
+  assertEquals(result[0].grantId, matchingGrant.id);
 });

--- a/src/infrastructure/cel/grant_condition_environment_test.ts
+++ b/src/infrastructure/cel/grant_condition_environment_test.ts
@@ -21,7 +21,6 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   evaluateGrantCondition,
   MAX_AST_DEPTH,
-  MAX_CONDITION_COST,
   type PrincipalContext,
   validateGrantCondition,
 } from "./grant_condition_environment.ts";
@@ -346,14 +345,15 @@ Deno.test("validateGrantCondition: accepts condition within cost budget", () => 
 });
 
 Deno.test("validateGrantCondition: rejects condition exceeding cost budget", () => {
-  const terms = Array.from(
-    { length: Math.ceil(MAX_CONDITION_COST / 3) + 1 },
-    (_, i) => `name == "${i}"`,
+  const listElements = Array.from({ length: 50 }, () => "1").join(",");
+  const clause = `[${listElements}].all(x, true)`;
+  const clauses = Array.from({ length: 8 }, () => clause);
+  const condition = clauses.join(" && ");
+  assertEquals(
+    condition.length <= 1024,
+    true,
+    "test condition must fit in 1KB",
   );
-  const condition = terms.join(" || ");
-  if (condition.length > 1024) {
-    return;
-  }
   const result = validateGrantCondition(condition, "workflow");
   assertEquals(result.valid, false);
   assertStringIncludes(result.error!, "cost budget");


### PR DESCRIPTION
## Summary

- Fix cost-budget test that passed vacuously — condition exceeded 1KB length limit so it returned early without assertions. Now uses comprehension macros over 50-element lists to exceed the cost budget while staying under 1KB.
- Fix explain truncation test that asserted a tautology — no conditions matched, so `result.length` was always 0. Now includes a matching grant before the budget cutoff and asserts it appears in results.

Both issues flagged by Claude adversarial review on #1797.

## Test Plan

- Both tests now exercise their intended code paths and fail if the underlying logic is broken
- 65 tests pass across both test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)