### PR TITLE
fix(ci): scope review fail-checks to each reviewer's own reviews (swamp-club#1027)

### DIFF
--- a/.github/actions/adversarial-review/action.yml
+++ b/.github/actions/adversarial-review/action.yml
@@ -222,7 +222,7 @@ runs:
       run: |
         latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
           --json reviews \
-          --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
+          --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Adversarial Review")))] | last | .state')
         if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
           echo "::error::Adversarial review requested changes — blocking merge"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
         run: |
           latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
             --json reviews \
-            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Code Review")))] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::Code review requested changes — blocking merge"
             exit 1
@@ -435,7 +435,7 @@ jobs:
         run: |
           latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
             --json reviews \
-            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CLI UX Review")))] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::UX review requested changes — blocking merge"
             exit 1
@@ -607,7 +607,7 @@ jobs:
         run: |
           latest_state=$(gh pr view ${{ github.event.pull_request.number }} \
             --json reviews \
-            --jq '[.reviews[] | select(.author.login == "github-actions")] | last | .state')
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CI Security Review")))] | last | .state')
           if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
             echo "::error::CI security review requested changes — blocking merge"
             exit 1


### PR DESCRIPTION
## Summary

- Scoped each CI review job's "Fail if changes requested" jq filter to only match reviews whose body starts with that job's own heading prefix, preventing cross-reviewer blocking where a `CHANGES_REQUESTED` from one reviewer (e.g. adversarial) would incorrectly fail a different reviewer's job (e.g. code review)
- Used `test("^(## )?<Heading>")` regex instead of `startswith("## <Heading>")` — PR #1788 data proves Claude sometimes omits the `##` prefix (2 of 20 reviews), and `startswith` would introduce a new class of false blocks
- Added `(.body // "")` null-coalescing to prevent a jq crash on null-body reviews — the previous filter never accessed `.body` so was immune; without this the fix would be a regression

## Test Plan

- Validated the exact jq filter against real PR #1788 review data: 20/20 reviews matched their expected reviewer with zero cross-matches
- Tested locally: `test()` regex matches both `## Code Review` and `Code Review` variants
- Tested locally: `// ""` prevents crash on null bodies
- Tested locally: empty result set (no matching reviews) returns `null` → check passes correctly
- Tested locally: bash single-quote wrapping of the jq expression works correctly

Fixes swamp-club#1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)