### PR TITLE
feat(tracing): per-invocation TRACEPARENT for serve-hosted runs (swamp-club#1017)

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -23,6 +23,8 @@ import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
+  resolveTraceparent,
+  resolveTracestate,
 } from "../context.ts";
 import {
   acquireModelLocks,
@@ -206,6 +208,14 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
   .option(
     "--token <token:string>",
     "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
+  )
+  .option(
+    "--traceparent <value:string>",
+    "W3C traceparent for per-invocation trace context (env: TRACEPARENT)",
+  )
+  .option(
+    "--tracestate <value:string>",
+    "W3C tracestate for per-invocation trace context (env: TRACESTATE)",
   )
   .action(
     // @ts-expect-error - Cliffy custom type returns unknown instead of string
@@ -449,6 +459,12 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
                 reportLabels: options.reportLabel as string[] | undefined,
                 swampSha: GIT_SHA || undefined,
                 autoGc,
+                traceparent: resolveTraceparent(
+                  options.traceparent as string | undefined,
+                ),
+                tracestate: resolveTracestate(
+                  options.tracestate as string | undefined,
+                ),
               }),
               renderer.handlers(),
             );
@@ -608,6 +624,12 @@ async function runMethodViaServer(
             inputs: inputSets[i],
             lastEvaluated: options.lastEvaluated as boolean,
             runtimeTags,
+            traceparent: resolveTraceparent(
+              options.traceparent as string | undefined,
+            ),
+            tracestate: resolveTracestate(
+              options.tracestate as string | undefined,
+            ),
           },
         }) as AsyncIterable<ModelMethodRunEvent>,
         renderer.handlers(),

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -22,6 +22,8 @@ import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
+  resolveTraceparent,
+  resolveTracestate,
 } from "../context.ts";
 import {
   acquireModelLocks,
@@ -183,6 +185,14 @@ export const workflowRunCommand = new Command()
   .option(
     "--token <token:string>",
     "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
+  )
+  .option(
+    "--traceparent <value:string>",
+    "W3C traceparent for per-invocation trace context (env: TRACEPARENT)",
+  )
+  .option(
+    "--tracestate <value:string>",
+    "W3C tracestate for per-invocation trace context (env: TRACESTATE)",
   )
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
@@ -419,6 +429,12 @@ export const workflowRunCommand = new Command()
           skipAllChecks: options.skipChecks as boolean | undefined,
           skipCheckNames: options.skipCheck as string[] | undefined,
           skipCheckLabels: options.skipCheckLabel as string[] | undefined,
+          traceparent: resolveTraceparent(
+            options.traceparent as string | undefined,
+          ),
+          tracestate: resolveTracestate(
+            options.tracestate as string | undefined,
+          ),
         });
 
         const baseHandlers = renderer.handlers();
@@ -583,6 +599,12 @@ async function runWorkflowViaServer(
             lastEvaluated: options.lastEvaluated as boolean,
             verbose: ctx.verbosity === "verbose",
             runtimeTags,
+            traceparent: resolveTraceparent(
+              options.traceparent as string | undefined,
+            ),
+            tracestate: resolveTracestate(
+              options.tracestate as string | undefined,
+            ),
           },
         }) as AsyncIterable<WorkflowRunEvent>,
         renderer.handlers(),

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -153,6 +153,36 @@ export function resolveRepoDir(cliValue: string | undefined): string {
 }
 
 /**
+ * Resolves the traceparent for a command, given the Cliffy parsed
+ * `--traceparent` option value.
+ *
+ * Priority: --traceparent flag > TRACEPARENT env var > undefined.
+ */
+export function resolveTraceparent(
+  cliValue: string | undefined,
+): string | undefined {
+  if (cliValue !== undefined) {
+    return cliValue;
+  }
+  return Deno.env.get("TRACEPARENT") || undefined;
+}
+
+/**
+ * Resolves the tracestate for a command, given the Cliffy parsed
+ * `--tracestate` option value.
+ *
+ * Priority: --tracestate flag > TRACESTATE env var > undefined.
+ */
+export function resolveTracestate(
+  cliValue: string | undefined,
+): string | undefined {
+  if (cliValue !== undefined) {
+    return cliValue;
+  }
+  return Deno.env.get("TRACESTATE") || undefined;
+}
+
+/**
  * Pre-parses --extensions-dir from raw CLI arguments before Cliffy option
  * parsing.
  *

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -27,6 +27,8 @@ import {
   type GlobalOptions,
   resolveExtensionsDir,
   resolveRepoDir,
+  resolveTraceparent,
+  resolveTracestate,
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { assertPathEquals } from "../infrastructure/persistence/path_test_helpers.ts";
@@ -392,4 +394,93 @@ Deno.test("createContext: log and json can both be set", () => {
   const ctx = createContext({ json: true, log: true });
   assertEquals(ctx.outputMode, "json");
   assertEquals(ctx.forceLog, true);
+});
+
+// ============================================================================
+// resolveTraceparent Tests
+// ============================================================================
+
+Deno.test("resolveTraceparent: returns cli value when provided", () => {
+  const original = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.set("TRACEPARENT", "00-env-trace-id-env-span-01");
+    assertEquals(
+      resolveTraceparent("00-cli-trace-id-cli-span-01"),
+      "00-cli-trace-id-cli-span-01",
+    );
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACEPARENT", original);
+    else Deno.env.delete("TRACEPARENT");
+  }
+});
+
+Deno.test("resolveTraceparent: returns TRACEPARENT env var when cli value undefined", () => {
+  const original = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.set("TRACEPARENT", "00-env-trace-id-env-span-01");
+    assertEquals(
+      resolveTraceparent(undefined),
+      "00-env-trace-id-env-span-01",
+    );
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACEPARENT", original);
+    else Deno.env.delete("TRACEPARENT");
+  }
+});
+
+Deno.test("resolveTraceparent: returns undefined when neither cli nor env set", () => {
+  const original = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.delete("TRACEPARENT");
+    assertEquals(resolveTraceparent(undefined), undefined);
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACEPARENT", original);
+  }
+});
+
+Deno.test("resolveTraceparent: returns undefined for empty TRACEPARENT env var", () => {
+  const original = Deno.env.get("TRACEPARENT");
+  try {
+    Deno.env.set("TRACEPARENT", "");
+    assertEquals(resolveTraceparent(undefined), undefined);
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACEPARENT", original);
+    else Deno.env.delete("TRACEPARENT");
+  }
+});
+
+// ============================================================================
+// resolveTracestate Tests
+// ============================================================================
+
+Deno.test("resolveTracestate: returns cli value when provided", () => {
+  const original = Deno.env.get("TRACESTATE");
+  try {
+    Deno.env.set("TRACESTATE", "vendor=env-value");
+    assertEquals(resolveTracestate("vendor=cli-value"), "vendor=cli-value");
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACESTATE", original);
+    else Deno.env.delete("TRACESTATE");
+  }
+});
+
+Deno.test("resolveTracestate: returns TRACESTATE env var when cli value undefined", () => {
+  const original = Deno.env.get("TRACESTATE");
+  try {
+    Deno.env.set("TRACESTATE", "vendor=env-value");
+    assertEquals(resolveTracestate(undefined), "vendor=env-value");
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACESTATE", original);
+    else Deno.env.delete("TRACESTATE");
+  }
+});
+
+Deno.test("resolveTracestate: returns undefined when neither cli nor env set", () => {
+  const original = Deno.env.get("TRACESTATE");
+  try {
+    Deno.env.delete("TRACESTATE");
+    assertEquals(resolveTracestate(undefined), undefined);
+  } finally {
+    if (original !== undefined) Deno.env.set("TRACESTATE", original);
+  }
 });

--- a/src/infrastructure/tracing/mod.ts
+++ b/src/infrastructure/tracing/mod.ts
@@ -26,4 +26,7 @@ export {
 } from "./tracer.ts";
 export { extractTraceContext, injectTraceContext } from "./propagation.ts";
 
-export { runWithParentTrace } from "./parent_trace.ts";
+export {
+  runWithParentTrace,
+  withGeneratorTraceContext,
+} from "./parent_trace.ts";

--- a/src/infrastructure/tracing/parent_trace.ts
+++ b/src/infrastructure/tracing/parent_trace.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { type Context, context } from "@opentelemetry/api";
+import { type Context, context, propagation } from "@opentelemetry/api";
 
 /**
  * Runs `fn` within the given parent trace context, or directly if no
@@ -32,4 +32,29 @@ export function runWithParentTrace<T>(
     return context.with(parentCtx, fn);
   }
   return fn();
+}
+
+/**
+ * Wraps an async generator to run each iteration within the trace context
+ * extracted from the given W3C headers. When no traceparent is provided,
+ * yields from the generator unchanged.
+ */
+export async function* withGeneratorTraceContext<T>(
+  traceparent: string | undefined,
+  tracestate: string | undefined,
+  generator: AsyncIterable<T>,
+): AsyncGenerator<T> {
+  if (!traceparent) {
+    yield* generator;
+    return;
+  }
+  const headers: Record<string, string> = { traceparent };
+  if (tracestate) headers.tracestate = tracestate;
+  const parentCtx = propagation.extract(context.active(), headers);
+  const iterator = generator[Symbol.asyncIterator]();
+  while (true) {
+    const result = await context.with(parentCtx, () => iterator.next());
+    if (result.done) break;
+    yield result.value;
+  }
 }

--- a/src/infrastructure/tracing/parent_trace_test.ts
+++ b/src/infrastructure/tracing/parent_trace_test.ts
@@ -19,7 +19,10 @@
 
 import { assertEquals } from "@std/assert";
 import { ROOT_CONTEXT } from "@opentelemetry/api";
-import { runWithParentTrace } from "./parent_trace.ts";
+import {
+  runWithParentTrace,
+  withGeneratorTraceContext,
+} from "./parent_trace.ts";
 
 Deno.test("runWithParentTrace: passes through when parentCtx is undefined", () => {
   const result = runWithParentTrace(undefined, () => 42);
@@ -37,4 +40,58 @@ Deno.test("runWithParentTrace: propagates async return values", async () => {
     () => Promise.resolve("async-value"),
   );
   assertEquals(result, "async-value");
+});
+
+// ============================================================================
+// withGeneratorTraceContext Tests
+// ============================================================================
+
+Deno.test("withGeneratorTraceContext: passes through when traceparent is undefined", async () => {
+  async function* source() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+  const results: number[] = [];
+  for await (
+    const value of withGeneratorTraceContext(undefined, undefined, source())
+  ) {
+    results.push(value);
+  }
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("withGeneratorTraceContext: yields all values with traceparent set", async () => {
+  async function* source() {
+    yield "a";
+    yield "b";
+  }
+  const results: string[] = [];
+  for await (
+    const value of withGeneratorTraceContext(
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+      undefined,
+      source(),
+    )
+  ) {
+    results.push(value);
+  }
+  assertEquals(results, ["a", "b"]);
+});
+
+Deno.test("withGeneratorTraceContext: handles empty generator", async () => {
+  async function* source(): AsyncGenerator<never> {
+    // empty
+  }
+  const results: never[] = [];
+  for await (
+    const value of withGeneratorTraceContext(
+      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+      "vendor=value",
+      source(),
+    )
+  ) {
+    results.push(value);
+  }
+  assertEquals(results, []);
 });

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -71,6 +71,7 @@ import { getRunLogger } from "../../infrastructure/logging/logger.ts";
 import {
   getTracer,
   withGeneratorSpan,
+  withGeneratorTraceContext,
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
 import { autoGc } from "../data/gc.ts";
@@ -228,6 +229,10 @@ export interface ModelMethodRunInput {
   reportLabels?: string[];
   swampSha?: string;
   autoGc?: boolean;
+  /** W3C traceparent header for per-invocation trace context. */
+  traceparent?: string;
+  /** W3C tracestate header for per-invocation trace context. */
+  tracestate?: string;
 }
 
 /**
@@ -238,510 +243,684 @@ export async function* modelMethodRun(
   deps: ModelMethodRunDeps,
   input: ModelMethodRunInput,
 ): AsyncGenerator<ModelMethodRunEvent> {
-  yield* withGeneratorSpan(
-    "swamp.model.method.run",
-    {
-      "model.id_or_name": input.modelIdOrName,
-      "method.name": input.methodName,
-    },
-    (async function* () {
-      const ephemeral = createEphemeralStore(deps.dataRepo.namespace);
-      if (deps.catalogStore) {
-        const wrapped = wrapWithEphemeral(
-          deps.dataRepo,
-          deps.catalogStore,
-          ephemeral,
-        );
-        deps = { ...deps, ...wrapped };
-      }
-
-      // --- Validate inputs phase ---
-      yield { kind: "validating_inputs" };
-
-      // --- Resolve model ---
-      yield { kind: "resolving_model", modelIdOrName: input.modelIdOrName };
-
-      let definition: Definition;
-      let modelType: ModelType;
-      let modelDef: ModelDefinition;
-
-      if (input.typeArg && input.definitionName) {
-        // Direct type execution path: auto-create-then-run
-        const typeArg = input.typeArg;
-        let resolvedType = ModelType.create(typeArg);
-
-        let resolvedModelDef = await Promise.resolve(
-          deps.getModelDef(resolvedType),
-        );
-
-        // Fallback: the @ prefix is the CLI syntax marker for direct execution
-        // but repo-local extensions register types without @. Try stripping it.
-        if (!resolvedModelDef && typeArg.startsWith("@")) {
-          const strippedType = ModelType.create(typeArg.slice(1));
-          const strippedDef = await Promise.resolve(
-            deps.getModelDef(strippedType),
+  yield* withGeneratorTraceContext(
+    input.traceparent,
+    input.tracestate,
+    withGeneratorSpan(
+      "swamp.model.method.run",
+      {
+        "model.id_or_name": input.modelIdOrName,
+        "method.name": input.methodName,
+      },
+      (async function* () {
+        const ephemeral = createEphemeralStore(deps.dataRepo.namespace);
+        if (deps.catalogStore) {
+          const wrapped = wrapWithEphemeral(
+            deps.dataRepo,
+            deps.catalogStore,
+            ephemeral,
           );
-          if (strippedDef) {
-            resolvedType = strippedType;
-            resolvedModelDef = strippedDef;
+          deps = { ...deps, ...wrapped };
+        }
+
+        // --- Validate inputs phase ---
+        yield { kind: "validating_inputs" };
+
+        // --- Resolve model ---
+        yield { kind: "resolving_model", modelIdOrName: input.modelIdOrName };
+
+        let definition: Definition;
+        let modelType: ModelType;
+        let modelDef: ModelDefinition;
+
+        if (input.typeArg && input.definitionName) {
+          // Direct type execution path: auto-create-then-run
+          const typeArg = input.typeArg;
+          let resolvedType = ModelType.create(typeArg);
+
+          let resolvedModelDef = await Promise.resolve(
+            deps.getModelDef(resolvedType),
+          );
+
+          // Fallback: the @ prefix is the CLI syntax marker for direct execution
+          // but repo-local extensions register types without @. Try stripping it.
+          if (!resolvedModelDef && typeArg.startsWith("@")) {
+            const strippedType = ModelType.create(typeArg.slice(1));
+            const strippedDef = await Promise.resolve(
+              deps.getModelDef(strippedType),
+            );
+            if (strippedDef) {
+              resolvedType = strippedType;
+              resolvedModelDef = strippedDef;
+            }
           }
-        }
 
-        if (!resolvedModelDef) {
-          yield {
-            kind: "error",
-            error: unknownModelType(resolvedType.normalized),
-          };
-          return;
-        }
-
-        if (!deps.createAndSaveDefinition || !deps.getDefinitionPath) {
-          yield {
-            kind: "error",
-            error: {
-              code: "missing_deps",
-              message: "Direct type execution is not supported in this context",
-            },
-          };
-          return;
-        }
-
-        const result = await resolveOrCreateDefinition(
-          {
-            lookupDefinition: deps.lookupDefinition,
-            getModelDef: deps.getModelDef,
-            saveDefinition: deps.createAndSaveDefinition,
-            getDefinitionPath: deps.getDefinitionPath,
-          },
-          typeArg,
-          input.definitionName,
-          input.methodName,
-          input.inputs,
-          resolvedType,
-          resolvedModelDef,
-        );
-
-        if (!result.ok) {
-          yield { kind: "error", error: result.error };
-          return;
-        }
-
-        if (result.created) {
-          yield {
-            kind: "auto_created",
-            modelType: resolvedType.normalized,
-            definitionName: result.definition.name,
-            definitionPath: result.definitionPath,
-          };
-        }
-
-        if (result.globalArgsUpdated) {
-          yield {
-            kind: "global_args_updated",
-            definitionName: result.definition.name,
-          };
-        }
-
-        definition = result.definition;
-        modelType = result.modelType;
-        modelDef = result.modelDef;
-
-        // Use routed method arguments as the inputs for downstream processing.
-        // Global args are already stored in the auto-created definition.
-        input = {
-          ...input,
-          inputs: { ...result.routedInputs.methodArguments },
-        };
-      } else {
-        // Standard path: look up existing definition
-        const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
-        if (!lookupResult) {
-          yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
-          return;
-        }
-        definition = lookupResult.definition;
-        modelType = lookupResult.type;
-
-        const resolvedModelDef = await Promise.resolve(
-          deps.getModelDef(modelType),
-        );
-        if (!resolvedModelDef) {
-          yield {
-            kind: "error",
-            error: unknownModelType(modelType.normalized),
-          };
-          return;
-        }
-        modelDef = resolvedModelDef;
-      }
-
-      // Validate method exists
-      const method = modelDef.methods[input.methodName];
-      if (!method) {
-        const availableMethods = Object.keys(modelDef.methods).join(", ");
-        yield {
-          kind: "error",
-          error: unknownMethod(
-            input.methodName,
-            modelType.normalized,
-            availableMethods,
-          ),
-        };
-        return;
-      }
-
-      // Coerce and validate inputs against model's input schema
-      const inputs = { ...input.inputs };
-      if (definition.inputs) {
-        const coercedInputs = coerceInputTypes(inputs, definition.inputs);
-        Object.assign(inputs, coercedInputs);
-
-        const validationService = new InputValidationService();
-        const inputsWithDefaults = validationService.applyDefaults(
-          inputs,
-          definition.inputs,
-        );
-
-        // Build effective schema: only require inputs referenced by the method's arguments
-        const referencedInputs = extractInputReferences(
-          definition.getMethodArguments(input.methodName),
-        );
-        const originalRequired = definition.inputs.required ?? [];
-        const effectiveRequired = originalRequired.filter((name) =>
-          referencedInputs.has(name)
-        );
-        const effectiveSchema: InputsSchema = {
-          ...definition.inputs,
-          required: effectiveRequired,
-        };
-
-        const validationResult = validationService.validate(
-          inputsWithDefaults,
-          effectiveSchema,
-        );
-        if (!validationResult.valid) {
-          yield {
-            kind: "error",
-            error: inputValidationFailed(validationResult.errors),
-          };
-          return;
-        }
-        Object.assign(inputs, inputsWithDefaults);
-      }
-
-      yield {
-        kind: "model_resolved",
-        modelName: definition.name,
-        modelType: modelType.normalized,
-        modelId: definition.id,
-        methodName: input.methodName,
-      };
-
-      // --- Check for env var usage and warn ---
-      const envVarUsages = detectEnvVarUsageInDefinition(definition);
-      if (envVarUsages.length > 0) {
-        yield {
-          kind: "env_var_warning",
-          modelName: definition.name,
-          envVars: envVarUsages,
-          message:
-            "Data stored under this model will vary depending on these environment variables at runtime. Consider using separate models per environment, or vault.get() for sensitive values.",
-        };
-      }
-
-      // --- Set up logging ---
-      const setupSpan = getTracer().startSpan("swamp.model.method.setup");
-      const runLog = await deps.createRunLog(
-        modelType,
-        input.methodName,
-        definition.id,
-      );
-      const { logFilePath, redactor } = runLog;
-
-      try {
-        // --- Evaluate expressions ---
-        const exprSpan = getTracer().startSpan(
-          "swamp.model.method.evaluate_expressions",
-        );
-        yield {
-          kind: "evaluating_expressions",
-          lastEvaluated: input.lastEvaluated,
-        };
-
-        const evaluationService = deps.createEvaluationService();
-        let evaluatedDefinition = definition;
-
-        if (input.lastEvaluated) {
-          const lastEval = await deps.loadEvaluatedDefinition(
-            modelType,
-            definition.name,
-          );
-          if (!lastEval) {
-            exprSpan.end();
-            setupSpan.end();
+          if (!resolvedModelDef) {
             yield {
               kind: "error",
-              error: noEvaluatedDefinition(definition.name),
+              error: unknownModelType(resolvedType.normalized),
             };
             return;
           }
-          evaluatedDefinition = lastEval;
-        } else {
-          if (evaluationService.hasDefinitionExpressions(definition)) {
-            const evalResult = await evaluationService.evaluateDefinition(
-              definition,
-              modelType,
-              inputs,
-            );
-            evaluatedDefinition = evalResult.definition;
+
+          if (!deps.createAndSaveDefinition || !deps.getDefinitionPath) {
+            yield {
+              kind: "error",
+              error: {
+                code: "missing_deps",
+                message:
+                  "Direct type execution is not supported in this context",
+              },
+            };
+            return;
           }
-          await deps.saveEvaluatedDefinition(modelType, evaluatedDefinition);
+
+          const result = await resolveOrCreateDefinition(
+            {
+              lookupDefinition: deps.lookupDefinition,
+              getModelDef: deps.getModelDef,
+              saveDefinition: deps.createAndSaveDefinition,
+              getDefinitionPath: deps.getDefinitionPath,
+            },
+            typeArg,
+            input.definitionName,
+            input.methodName,
+            input.inputs,
+            resolvedType,
+            resolvedModelDef,
+          );
+
+          if (!result.ok) {
+            yield { kind: "error", error: result.error };
+            return;
+          }
+
+          if (result.created) {
+            yield {
+              kind: "auto_created",
+              modelType: resolvedType.normalized,
+              definitionName: result.definition.name,
+              definitionPath: result.definitionPath,
+            };
+          }
+
+          if (result.globalArgsUpdated) {
+            yield {
+              kind: "global_args_updated",
+              definitionName: result.definition.name,
+            };
+          }
+
+          definition = result.definition;
+          modelType = result.modelType;
+          modelDef = result.modelDef;
+
+          // Use routed method arguments as the inputs for downstream processing.
+          // Global args are already stored in the auto-created definition.
+          input = {
+            ...input,
+            inputs: { ...result.routedInputs.methodArguments },
+          };
+        } else {
+          // Standard path: look up existing definition
+          const lookupResult = await deps.lookupDefinition(input.modelIdOrName);
+          if (!lookupResult) {
+            yield { kind: "error", error: modelNotFound(input.modelIdOrName) };
+            return;
+          }
+          definition = lookupResult.definition;
+          modelType = lookupResult.type;
+
+          const resolvedModelDef = await Promise.resolve(
+            deps.getModelDef(modelType),
+          );
+          if (!resolvedModelDef) {
+            yield {
+              kind: "error",
+              error: unknownModelType(modelType.normalized),
+            };
+            return;
+          }
+          modelDef = resolvedModelDef;
         }
 
-        // Merge override inputs into method arguments.
-        // Override inputs are --input flags whose keys are not model inputs
-        // schema keys (i.e. not used for CEL expression evaluation). They map
-        // directly to method argument schema keys, so reject unknown ones here
-        // before Zod's default strip mode silently discards them.
-        const definitionInputKeys = definition.inputs
-          ? Object.keys(
-            (definition.inputs as { properties?: Record<string, unknown> })
-              .properties || {},
-          )
-          : [];
-        const overrideInputs = Object.fromEntries(
-          Object.entries(inputs).filter(([key]) =>
-            !definitionInputKeys.includes(key)
-          ),
+        // Validate method exists
+        const method = modelDef.methods[input.methodName];
+        if (!method) {
+          const availableMethods = Object.keys(modelDef.methods).join(", ");
+          yield {
+            kind: "error",
+            error: unknownMethod(
+              input.methodName,
+              modelType.normalized,
+              availableMethods,
+            ),
+          };
+          return;
+        }
+
+        // Coerce and validate inputs against model's input schema
+        const inputs = { ...input.inputs };
+        if (definition.inputs) {
+          const coercedInputs = coerceInputTypes(inputs, definition.inputs);
+          Object.assign(inputs, coercedInputs);
+
+          const validationService = new InputValidationService();
+          const inputsWithDefaults = validationService.applyDefaults(
+            inputs,
+            definition.inputs,
+          );
+
+          // Build effective schema: only require inputs referenced by the method's arguments
+          const referencedInputs = extractInputReferences(
+            definition.getMethodArguments(input.methodName),
+          );
+          const originalRequired = definition.inputs.required ?? [];
+          const effectiveRequired = originalRequired.filter((name) =>
+            referencedInputs.has(name)
+          );
+          const effectiveSchema: InputsSchema = {
+            ...definition.inputs,
+            required: effectiveRequired,
+          };
+
+          const validationResult = validationService.validate(
+            inputsWithDefaults,
+            effectiveSchema,
+          );
+          if (!validationResult.valid) {
+            yield {
+              kind: "error",
+              error: inputValidationFailed(validationResult.errors),
+            };
+            return;
+          }
+          Object.assign(inputs, inputsWithDefaults);
+        }
+
+        yield {
+          kind: "model_resolved",
+          modelName: definition.name,
+          modelType: modelType.normalized,
+          modelId: definition.id,
+          methodName: input.methodName,
+        };
+
+        // --- Check for env var usage and warn ---
+        const envVarUsages = detectEnvVarUsageInDefinition(definition);
+        if (envVarUsages.length > 0) {
+          yield {
+            kind: "env_var_warning",
+            modelName: definition.name,
+            envVars: envVarUsages,
+            message:
+              "Data stored under this model will vary depending on these environment variables at runtime. Consider using separate models per environment, or vault.get() for sensitive values.",
+          };
+        }
+
+        // --- Set up logging ---
+        const setupSpan = getTracer().startSpan("swamp.model.method.setup");
+        const runLog = await deps.createRunLog(
+          modelType,
+          input.methodName,
+          definition.id,
         );
-        if (Object.keys(overrideInputs).length > 0) {
-          const shape = getObjectShape(method.arguments);
-          if (shape) {
-            const unknownKeys = Object.keys(overrideInputs).filter(
-              (k) => !Object.hasOwn(shape, k),
+        const { logFilePath, redactor } = runLog;
+
+        try {
+          // --- Evaluate expressions ---
+          const exprSpan = getTracer().startSpan(
+            "swamp.model.method.evaluate_expressions",
+          );
+          yield {
+            kind: "evaluating_expressions",
+            lastEvaluated: input.lastEvaluated,
+          };
+
+          const evaluationService = deps.createEvaluationService();
+          let evaluatedDefinition = definition;
+
+          if (input.lastEvaluated) {
+            const lastEval = await deps.loadEvaluatedDefinition(
+              modelType,
+              definition.name,
             );
-            if (unknownKeys.length > 0) {
-              const validInputs = Object.keys(shape).join(", ");
+            if (!lastEval) {
               exprSpan.end();
               setupSpan.end();
               yield {
                 kind: "error",
-                error: validationFailed(
-                  `Unknown method input(s): ${unknownKeys.join(", ")}. ` +
-                    `Valid inputs are: ${validInputs || "none"}`,
-                ),
+                error: noEvaluatedDefinition(definition.name),
               };
               return;
             }
-          }
-          for (const [key, value] of Object.entries(overrideInputs)) {
-            evaluatedDefinition.setMethodArgument(input.methodName, key, value);
-          }
-        }
-
-        exprSpan.end();
-
-        // Capture pre-vault args for report context (so vault secrets stay as expressions)
-        const reportGlobalArgs = evaluatedDefinition.globalArguments;
-        const reportMethodArgs = evaluatedDefinition.getMethodArguments(
-          input.methodName,
-        );
-
-        // Resolve runtime expressions (vault and env).
-        // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
-        const runtimeSpan = getTracer().startSpan(
-          "swamp.model.method.resolve_runtime",
-        );
-        const runtimeResult = await evaluationService
-          .resolveRuntimeExpressionsInDefinition(evaluatedDefinition, redactor);
-        evaluatedDefinition = runtimeResult.definition;
-        const secretBag = runtimeResult.secretBag;
-
-        // Register sensitive argument values with the redactor so they are
-        // scrubbed from per-run log files. Must use post-vault-resolution values.
-        const globalArgSchema = modelDef.globalArguments;
-        if (globalArgSchema) {
-          for (
-            const secret of extractSensitiveFieldValues(
-              globalArgSchema,
-              evaluatedDefinition.globalArguments,
-            )
-          ) {
-            redactor.addSecret(secret);
-          }
-        }
-        const methodArgSchema = modelDef.methods[input.methodName]?.arguments;
-        if (methodArgSchema) {
-          for (
-            const secret of extractSensitiveFieldValues(
-              methodArgSchema,
-              evaluatedDefinition.getMethodArguments(input.methodName),
-            )
-          ) {
-            redactor.addSecret(secret);
-          }
-        }
-
-        runtimeSpan.end();
-
-        // --- Execute ---
-        yield {
-          kind: "executing",
-          modelName: definition.name,
-          methodName: input.methodName,
-        };
-
-        // Create ModelOutput for tracking
-        const preExecSpan = getTracer().startSpan(
-          "swamp.model.method.pre_execute",
-        );
-        const definitionHash = await definition.computeHash();
-        const output = ModelOutput.create({
-          definitionId: definition.id,
-          methodName: input.methodName,
-          provenance: {
-            definitionHash,
-            modelVersion: modelDef.version,
-            triggeredBy: "manual",
-          },
-        });
-        output.markRunning(Deno.pid);
-        output.setLogFile(logFilePath);
-
-        // Register with the run tracker (if available).
-        // Output YAML is only written in terminal state (write-once).
-        let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-        if (deps.runTracker) {
-          const activeRun = ActiveRun.createModelMethodRun({
-            id: output.id,
-            modelType: modelType.normalized,
-            methodName: input.methodName,
-            pid: Deno.pid,
-            hostname: hostname(),
-          });
-          deps.runTracker.register(activeRun);
-        }
-
-        const vaultService = await deps.createVaultService();
-        const executionService = deps.createExecutionService();
-
-        // Start heartbeat inside the try so it's always cleaned up on error.
-        if (deps.runTracker) {
-          heartbeatInterval = setInterval(() => {
-            try {
-              deps.runTracker!.heartbeat(output.id);
-            } catch {
-              // Heartbeat failure is non-fatal
-            }
-          }, 30_000);
-        }
-
-        preExecSpan.end();
-        setupSpan.end();
-
-        let execResult: MethodResult;
-        try {
-          execResult = yield* withEventBridge<
-            ModelMethodRunEvent,
-            MethodResult
-          >(
-            (push) =>
-              executionService.executeWorkflow(
-                evaluatedDefinition,
-                modelDef,
-                input.methodName,
-                buildMethodContext(
-                  {
-                    dataRepository: deps.dataRepo,
-                    definitionRepository: deps.definitionRepo,
-                    vaultService,
-                    redactor,
-                    dataQueryService: deps.dataQueryService,
-                    createCelEnvironment: createExtensionCelEnvironment,
-                  },
-                  {
-                    signal: ctx.signal,
-                    repoDir: deps.repoDir,
-                    modelType,
-                    modelId: evaluatedDefinition.id,
-                    globalArgs: evaluatedDefinition.globalArguments,
-                    definition: {
-                      id: evaluatedDefinition.id,
-                      name: evaluatedDefinition.name,
-                      version: evaluatedDefinition.version,
-                      tags: evaluatedDefinition.tags,
-                    },
-                    methodName: input.methodName,
-                    logger: getRunLogger(definition.name, input.methodName),
-                    runtimeTags: input.runtimeTags,
-                    dataOutputOverrides: evaluatedDefinition.resources
-                      ? Object.entries(
-                        evaluatedDefinition.resources,
-                      ).map(([specName, override]) => ({
-                        specName,
-                        lifetime: override.lifetime,
-                        garbageCollection: override.garbageCollection,
-                      }))
-                      : undefined,
-                    vaultSecrets: secretBag,
-                    skipCheckNames: input.skipCheckNames,
-                    skipCheckLabels: input.skipCheckLabels,
-                    skipAllChecks: input.skipAllChecks,
-                    extensionFilesRoot: modelDef.extensionFilesRoot,
-                    onEvent: (event: MethodExecutionEvent) => {
-                      if (event.type === "output") {
-                        push({
-                          kind: "method_output",
-                          modelName: definition.name,
-                          methodName: input.methodName,
-                          stream: event.stream,
-                          line: event.line,
-                        });
-                      } else {
-                        push({
-                          kind: "method_event",
-                          modelName: definition.name,
-                          methodName: input.methodName,
-                          event,
-                        });
-                      }
-                    },
-                  },
-                ),
-              ),
-          );
-        } catch (error) {
-          const errorMessage = error instanceof Error
-            ? error.message
-            : String(error);
-          const errorStack = error instanceof Error ? error.stack : undefined;
-
-          if (heartbeatInterval) clearInterval(heartbeatInterval);
-
-          if (
-            ctx.signal.aborted ||
-            (error instanceof DOMException && error.name === "AbortError")
-          ) {
-            output.markCancelled("aborted");
-            await deps.outputRepo.save(modelType, input.methodName, output);
-            if (deps.runTracker) {
-              deps.runTracker.complete(output.id, "cancelled");
-            }
+            evaluatedDefinition = lastEval;
           } else {
-            output.markFailed({ message: errorMessage, stack: errorStack });
-            await deps.outputRepo.save(modelType, input.methodName, output);
-            if (deps.runTracker) {
-              deps.runTracker.complete(output.id, "failed");
+            if (evaluationService.hasDefinitionExpressions(definition)) {
+              const evalResult = await evaluationService.evaluateDefinition(
+                definition,
+                modelType,
+                inputs,
+              );
+              evaluatedDefinition = evalResult.definition;
+            }
+            await deps.saveEvaluatedDefinition(modelType, evaluatedDefinition);
+          }
+
+          // Merge override inputs into method arguments.
+          // Override inputs are --input flags whose keys are not model inputs
+          // schema keys (i.e. not used for CEL expression evaluation). They map
+          // directly to method argument schema keys, so reject unknown ones here
+          // before Zod's default strip mode silently discards them.
+          const definitionInputKeys = definition.inputs
+            ? Object.keys(
+              (definition.inputs as { properties?: Record<string, unknown> })
+                .properties || {},
+            )
+            : [];
+          const overrideInputs = Object.fromEntries(
+            Object.entries(inputs).filter(([key]) =>
+              !definitionInputKeys.includes(key)
+            ),
+          );
+          if (Object.keys(overrideInputs).length > 0) {
+            const shape = getObjectShape(method.arguments);
+            if (shape) {
+              const unknownKeys = Object.keys(overrideInputs).filter(
+                (k) => !Object.hasOwn(shape, k),
+              );
+              if (unknownKeys.length > 0) {
+                const validInputs = Object.keys(shape).join(", ");
+                exprSpan.end();
+                setupSpan.end();
+                yield {
+                  kind: "error",
+                  error: validationFailed(
+                    `Unknown method input(s): ${unknownKeys.join(", ")}. ` +
+                      `Valid inputs are: ${validInputs || "none"}`,
+                  ),
+                };
+                return;
+              }
+            }
+            for (const [key, value] of Object.entries(overrideInputs)) {
+              evaluatedDefinition.setMethodArgument(
+                input.methodName,
+                key,
+                value,
+              );
             }
           }
 
-          // Run method-summary report for failed executions so JSON consumers
-          // see structured error output (not just the raw error event).
-          if (
-            output.status === "failed" && !input.skipAllReports &&
-            reportRegistry.getAll().length > 0
-          ) {
-            const failedMethodContext = buildMethodReportContext(
+          exprSpan.end();
+
+          // Capture pre-vault args for report context (so vault secrets stay as expressions)
+          const reportGlobalArgs = evaluatedDefinition.globalArguments;
+          const reportMethodArgs = evaluatedDefinition.getMethodArguments(
+            input.methodName,
+          );
+
+          // Resolve runtime expressions (vault and env).
+          // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
+          const runtimeSpan = getTracer().startSpan(
+            "swamp.model.method.resolve_runtime",
+          );
+          const runtimeResult = await evaluationService
+            .resolveRuntimeExpressionsInDefinition(
+              evaluatedDefinition,
+              redactor,
+            );
+          evaluatedDefinition = runtimeResult.definition;
+          const secretBag = runtimeResult.secretBag;
+
+          // Register sensitive argument values with the redactor so they are
+          // scrubbed from per-run log files. Must use post-vault-resolution values.
+          const globalArgSchema = modelDef.globalArguments;
+          if (globalArgSchema) {
+            for (
+              const secret of extractSensitiveFieldValues(
+                globalArgSchema,
+                evaluatedDefinition.globalArguments,
+              )
+            ) {
+              redactor.addSecret(secret);
+            }
+          }
+          const methodArgSchema = modelDef.methods[input.methodName]?.arguments;
+          if (methodArgSchema) {
+            for (
+              const secret of extractSensitiveFieldValues(
+                methodArgSchema,
+                evaluatedDefinition.getMethodArguments(input.methodName),
+              )
+            ) {
+              redactor.addSecret(secret);
+            }
+          }
+
+          runtimeSpan.end();
+
+          // --- Execute ---
+          yield {
+            kind: "executing",
+            modelName: definition.name,
+            methodName: input.methodName,
+          };
+
+          // Create ModelOutput for tracking
+          const preExecSpan = getTracer().startSpan(
+            "swamp.model.method.pre_execute",
+          );
+          const definitionHash = await definition.computeHash();
+          const output = ModelOutput.create({
+            definitionId: definition.id,
+            methodName: input.methodName,
+            provenance: {
+              definitionHash,
+              modelVersion: modelDef.version,
+              triggeredBy: "manual",
+            },
+          });
+          output.markRunning(Deno.pid);
+          output.setLogFile(logFilePath);
+
+          // Register with the run tracker (if available).
+          // Output YAML is only written in terminal state (write-once).
+          let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+          if (deps.runTracker) {
+            const activeRun = ActiveRun.createModelMethodRun({
+              id: output.id,
+              modelType: modelType.normalized,
+              methodName: input.methodName,
+              pid: Deno.pid,
+              hostname: hostname(),
+            });
+            deps.runTracker.register(activeRun);
+          }
+
+          const vaultService = await deps.createVaultService();
+          const executionService = deps.createExecutionService();
+
+          // Start heartbeat inside the try so it's always cleaned up on error.
+          if (deps.runTracker) {
+            heartbeatInterval = setInterval(() => {
+              try {
+                deps.runTracker!.heartbeat(output.id);
+              } catch {
+                // Heartbeat failure is non-fatal
+              }
+            }, 30_000);
+          }
+
+          preExecSpan.end();
+          setupSpan.end();
+
+          let execResult: MethodResult;
+          try {
+            execResult = yield* withEventBridge<
+              ModelMethodRunEvent,
+              MethodResult
+            >(
+              (push) =>
+                executionService.executeWorkflow(
+                  evaluatedDefinition,
+                  modelDef,
+                  input.methodName,
+                  buildMethodContext(
+                    {
+                      dataRepository: deps.dataRepo,
+                      definitionRepository: deps.definitionRepo,
+                      vaultService,
+                      redactor,
+                      dataQueryService: deps.dataQueryService,
+                      createCelEnvironment: createExtensionCelEnvironment,
+                    },
+                    {
+                      signal: ctx.signal,
+                      repoDir: deps.repoDir,
+                      modelType,
+                      modelId: evaluatedDefinition.id,
+                      globalArgs: evaluatedDefinition.globalArguments,
+                      definition: {
+                        id: evaluatedDefinition.id,
+                        name: evaluatedDefinition.name,
+                        version: evaluatedDefinition.version,
+                        tags: evaluatedDefinition.tags,
+                      },
+                      methodName: input.methodName,
+                      logger: getRunLogger(definition.name, input.methodName),
+                      runtimeTags: input.runtimeTags,
+                      dataOutputOverrides: evaluatedDefinition.resources
+                        ? Object.entries(
+                          evaluatedDefinition.resources,
+                        ).map(([specName, override]) => ({
+                          specName,
+                          lifetime: override.lifetime,
+                          garbageCollection: override.garbageCollection,
+                        }))
+                        : undefined,
+                      vaultSecrets: secretBag,
+                      skipCheckNames: input.skipCheckNames,
+                      skipCheckLabels: input.skipCheckLabels,
+                      skipAllChecks: input.skipAllChecks,
+                      extensionFilesRoot: modelDef.extensionFilesRoot,
+                      onEvent: (event: MethodExecutionEvent) => {
+                        if (event.type === "output") {
+                          push({
+                            kind: "method_output",
+                            modelName: definition.name,
+                            methodName: input.methodName,
+                            stream: event.stream,
+                            line: event.line,
+                          });
+                        } else {
+                          push({
+                            kind: "method_event",
+                            modelName: definition.name,
+                            methodName: input.methodName,
+                            event,
+                          });
+                        }
+                      },
+                    },
+                  ),
+                ),
+            );
+          } catch (error) {
+            const errorMessage = error instanceof Error
+              ? error.message
+              : String(error);
+            const errorStack = error instanceof Error ? error.stack : undefined;
+
+            if (heartbeatInterval) clearInterval(heartbeatInterval);
+
+            if (
+              ctx.signal.aborted ||
+              (error instanceof DOMException && error.name === "AbortError")
+            ) {
+              output.markCancelled("aborted");
+              await deps.outputRepo.save(modelType, input.methodName, output);
+              if (deps.runTracker) {
+                deps.runTracker.complete(output.id, "cancelled");
+              }
+            } else {
+              output.markFailed({ message: errorMessage, stack: errorStack });
+              await deps.outputRepo.save(modelType, input.methodName, output);
+              if (deps.runTracker) {
+                deps.runTracker.complete(output.id, "failed");
+              }
+            }
+
+            // Run method-summary report for failed executions so JSON consumers
+            // see structured error output (not just the raw error event).
+            if (
+              output.status === "failed" && !input.skipAllReports &&
+              reportRegistry.getAll().length > 0
+            ) {
+              const failedMethodContext = buildMethodReportContext(
+                {
+                  repoDir: deps.repoDir,
+                  logger: getRunLogger(definition.name, input.methodName),
+                  dataRepository: deps.dataRepo,
+                  definitionRepository: deps.definitionRepo,
+                  swampSha: input.swampSha,
+                },
+                {
+                  modelType,
+                  modelId: evaluatedDefinition.id,
+                  definition: {
+                    id: evaluatedDefinition.id,
+                    name: evaluatedDefinition.name,
+                    version: evaluatedDefinition.version,
+                    tags: evaluatedDefinition.tags,
+                  },
+                  globalArgs: reportGlobalArgs,
+                  methodArgs: reportMethodArgs,
+                  methodName: input.methodName,
+                  executionStatus: "failed",
+                  errorMessage,
+                  dataHandles: [],
+                  outputSpecs: buildOutputSpecs(modelDef),
+                  extensionFilesRoot: modelDef.extensionFilesRoot,
+                },
+              );
+
+              const failedSummary = await executeReports(
+                reportRegistry,
+                failedMethodContext,
+                modelType,
+                evaluatedDefinition.id,
+                definition.reportSelection,
+                {
+                  skipAllReports: input.skipAllReports,
+                  skipReportNames: input.skipReportNames,
+                  skipReportLabels: input.skipReportLabels,
+                  reportNames: input.reportNames,
+                  reportLabels: input.reportLabels,
+                },
+                {
+                  onReportStarted: () => {},
+                  onReportCompleted: () => {},
+                  onReportFailed: () => {},
+                },
+                input.methodName,
+                [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
+              );
+
+              for (const result of failedSummary.results) {
+                yield {
+                  kind: "report_started" as const,
+                  reportName: result.name,
+                  scope: result.scope,
+                };
+                if (result.success) {
+                  yield {
+                    kind: "report_completed" as const,
+                    reportName: result.name,
+                    scope: result.scope,
+                    markdown: result.markdown!,
+                    json: result.json!,
+                  };
+                } else {
+                  yield {
+                    kind: "report_failed" as const,
+                    reportName: result.name,
+                    scope: result.scope,
+                    error: result.error!,
+                  };
+                }
+              }
+            }
+
+            if (output.status === "cancelled") {
+              return;
+            }
+
+            if (
+              error instanceof DOMException && error.name === "AbortError"
+            ) {
+              yield { kind: "error", error: cancelled(error) };
+              return;
+            }
+
+            yield { kind: "error", error: methodExecutionFailed(error) };
+            return;
+          }
+
+          // --- Process data artifacts ---
+          const postExecSpan = getTracer().startSpan(
+            "swamp.model.method.post_execute",
+          );
+          const dataArtifacts: DataArtifactView[] = [];
+          if (execResult.dataHandles && execResult.dataHandles.length > 0) {
+            for (const handle of execResult.dataHandles) {
+              const dataPath = deps.dataRepo.getPath(
+                modelType,
+                definition.id,
+                handle.name,
+                handle.version,
+              );
+
+              output.addDataArtifact({
+                dataId: handle.dataId,
+                name: handle.name,
+                version: handle.version,
+                tags: handle.tags,
+              });
+
+              // Parse content if JSON for display
+              let attributes: Record<string, unknown> | undefined;
+              if (handle.metadata.contentType === "application/json") {
+                try {
+                  const content = await deps.dataRepo.getContent(
+                    modelType,
+                    evaluatedDefinition.id,
+                    handle.name,
+                    handle.version,
+                  );
+                  if (content) {
+                    const text = new TextDecoder().decode(content);
+                    attributes = JSON.parse(text) as Record<string, unknown>;
+                  }
+                } catch {
+                  // Not valid JSON, skip attributes
+                }
+              }
+
+              dataArtifacts.push({
+                id: handle.dataId,
+                name: handle.name,
+                path: dataPath,
+                attributes,
+              });
+              yield {
+                kind: "data_artifact_saved",
+                name: handle.name,
+                path: dataPath,
+              };
+            }
+          }
+
+          // Mark output as succeeded and save (write-once)
+          if (heartbeatInterval) clearInterval(heartbeatInterval);
+          output.markSucceeded();
+          await deps.outputRepo.save(modelType, input.methodName, output);
+          if (deps.runTracker) {
+            deps.runTracker.complete(output.id, "completed");
+          }
+
+          // --- Post-run reports ---
+          const reportsSpan = getTracer().startSpan(
+            "swamp.model.method.reports",
+          );
+          let reportResults: Record<string, ReportResultView> | undefined;
+          let reportFailures = 0;
+
+          if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
+            const dataHandles = execResult.dataHandles ?? [];
+
+            // Run method-scope reports
+            const methodContext = buildMethodReportContext(
               {
                 repoDir: deps.repoDir,
                 logger: getRunLogger(definition.name, input.methodName),
@@ -761,17 +940,16 @@ export async function* modelMethodRun(
                 globalArgs: reportGlobalArgs,
                 methodArgs: reportMethodArgs,
                 methodName: input.methodName,
-                executionStatus: "failed",
-                errorMessage,
-                dataHandles: [],
+                executionStatus: "succeeded",
+                dataHandles,
                 outputSpecs: buildOutputSpecs(modelDef),
                 extensionFilesRoot: modelDef.extensionFilesRoot,
               },
             );
 
-            const failedSummary = await executeReports(
+            const methodSummary = await executeReports(
               reportRegistry,
-              failedMethodContext,
+              methodContext,
               modelType,
               evaluatedDefinition.id,
               definition.reportSelection,
@@ -791,7 +969,9 @@ export async function* modelMethodRun(
               [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
             );
 
-            for (const result of failedSummary.results) {
+            // Yield report events and collect results
+            reportResults = {};
+            for (const result of methodSummary.results) {
               yield {
                 kind: "report_started" as const,
                 reportName: result.name,
@@ -813,270 +993,107 @@ export async function* modelMethodRun(
                   error: result.error!,
                 };
               }
+              reportResults[result.name] = toReportResultView(result);
             }
-          }
+            reportFailures += methodSummary.failures;
 
-          if (output.status === "cancelled") {
-            return;
-          }
+            // Run model-scope reports
+            const modelContext: ModelReportContext = {
+              ...methodContext,
+              scope: "model",
+            };
 
-          if (
-            error instanceof DOMException && error.name === "AbortError"
-          ) {
-            yield { kind: "error", error: cancelled(error) };
-            return;
-          }
-
-          yield { kind: "error", error: methodExecutionFailed(error) };
-          return;
-        }
-
-        // --- Process data artifacts ---
-        const postExecSpan = getTracer().startSpan(
-          "swamp.model.method.post_execute",
-        );
-        const dataArtifacts: DataArtifactView[] = [];
-        if (execResult.dataHandles && execResult.dataHandles.length > 0) {
-          for (const handle of execResult.dataHandles) {
-            const dataPath = deps.dataRepo.getPath(
+            const modelSummary = await executeReports(
+              reportRegistry,
+              modelContext,
               modelType,
-              definition.id,
-              handle.name,
-              handle.version,
+              evaluatedDefinition.id,
+              definition.reportSelection,
+              {
+                skipAllReports: input.skipAllReports,
+                skipReportNames: input.skipReportNames,
+                skipReportLabels: input.skipReportLabels,
+                reportNames: input.reportNames,
+                reportLabels: input.reportLabels,
+              },
+              {
+                onReportStarted: () => {},
+                onReportCompleted: () => {},
+                onReportFailed: () => {},
+              },
+              input.methodName,
+              [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
+              undefined,
+              // The method-scope call above already emitted failures for
+              // unresolvable required reports — suppress duplicates.
+              false,
             );
 
-            output.addDataArtifact({
-              dataId: handle.dataId,
-              name: handle.name,
-              version: handle.version,
-              tags: handle.tags,
-            });
-
-            // Parse content if JSON for display
-            let attributes: Record<string, unknown> | undefined;
-            if (handle.metadata.contentType === "application/json") {
-              try {
-                const content = await deps.dataRepo.getContent(
-                  modelType,
-                  evaluatedDefinition.id,
-                  handle.name,
-                  handle.version,
-                );
-                if (content) {
-                  const text = new TextDecoder().decode(content);
-                  attributes = JSON.parse(text) as Record<string, unknown>;
-                }
-              } catch {
-                // Not valid JSON, skip attributes
+            for (const result of modelSummary.results) {
+              yield {
+                kind: "report_started" as const,
+                reportName: result.name,
+                scope: result.scope,
+              };
+              if (result.success) {
+                yield {
+                  kind: "report_completed" as const,
+                  reportName: result.name,
+                  scope: result.scope,
+                  markdown: result.markdown!,
+                  json: result.json!,
+                };
+              } else {
+                yield {
+                  kind: "report_failed" as const,
+                  reportName: result.name,
+                  scope: result.scope,
+                  error: result.error!,
+                };
               }
+              reportResults[result.name] = toReportResultView(result);
             }
-
-            dataArtifacts.push({
-              id: handle.dataId,
-              name: handle.name,
-              path: dataPath,
-              attributes,
-            });
-            yield {
-              kind: "data_artifact_saved",
-              name: handle.name,
-              path: dataPath,
-            };
+            reportFailures += modelSummary.failures;
           }
-        }
 
-        // Mark output as succeeded and save (write-once)
-        if (heartbeatInterval) clearInterval(heartbeatInterval);
-        output.markSucceeded();
-        await deps.outputRepo.save(modelType, input.methodName, output);
-        if (deps.runTracker) {
-          deps.runTracker.complete(output.id, "completed");
-        }
+          reportsSpan.end();
+          postExecSpan.end();
 
-        // --- Post-run reports ---
-        const reportsSpan = getTracer().startSpan(
-          "swamp.model.method.reports",
-        );
-        let reportResults: Record<string, ReportResultView> | undefined;
-        let reportFailures = 0;
-
-        if (!input.skipAllReports && reportRegistry.getAll().length > 0) {
-          const dataHandles = execResult.dataHandles ?? [];
-
-          // Run method-scope reports
-          const methodContext = buildMethodReportContext(
-            {
-              repoDir: deps.repoDir,
-              logger: getRunLogger(definition.name, input.methodName),
-              dataRepository: deps.dataRepo,
-              definitionRepository: deps.definitionRepo,
-              swampSha: input.swampSha,
-            },
-            {
-              modelType,
-              modelId: evaluatedDefinition.id,
-              definition: {
-                id: evaluatedDefinition.id,
-                name: evaluatedDefinition.name,
-                version: evaluatedDefinition.version,
-                tags: evaluatedDefinition.tags,
-              },
-              globalArgs: reportGlobalArgs,
-              methodArgs: reportMethodArgs,
-              methodName: input.methodName,
-              executionStatus: "succeeded",
-              dataHandles,
-              outputSpecs: buildOutputSpecs(modelDef),
-              extensionFilesRoot: modelDef.extensionFilesRoot,
-            },
-          );
-
-          const methodSummary = await executeReports(
-            reportRegistry,
-            methodContext,
-            modelType,
-            evaluatedDefinition.id,
-            definition.reportSelection,
-            {
-              skipAllReports: input.skipAllReports,
-              skipReportNames: input.skipReportNames,
-              skipReportLabels: input.skipReportLabels,
-              reportNames: input.reportNames,
-              reportLabels: input.reportLabels,
-            },
-            {
-              onReportStarted: () => {},
-              onReportCompleted: () => {},
-              onReportFailed: () => {},
-            },
-            input.methodName,
-            [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
-          );
-
-          // Yield report events and collect results
-          reportResults = {};
-          for (const result of methodSummary.results) {
-            yield {
-              kind: "report_started" as const,
-              reportName: result.name,
-              scope: result.scope,
-            };
-            if (result.success) {
-              yield {
-                kind: "report_completed" as const,
-                reportName: result.name,
-                scope: result.scope,
-                markdown: result.markdown!,
-                json: result.json!,
-              };
-            } else {
-              yield {
-                kind: "report_failed" as const,
-                reportName: result.name,
-                scope: result.scope,
-                error: result.error!,
-              };
-            }
-            reportResults[result.name] = toReportResultView(result);
-          }
-          reportFailures += methodSummary.failures;
-
-          // Run model-scope reports
-          const modelContext: ModelReportContext = {
-            ...methodContext,
-            scope: "model",
+          // --- Complete ---
+          const view: ModelMethodRunView = {
+            modelId: definition.id,
+            modelName: definition.name,
+            modelType: modelType.normalized,
+            methodName: input.methodName,
+            status: reportFailures > 0 ? "failed" : "succeeded",
+            duration: output.durationMs,
+            outputId: output.id,
+            logFile: logFilePath,
+            dataArtifacts,
+            reports: reportResults,
           };
+          yield { kind: "completed", run: view };
 
-          const modelSummary = await executeReports(
-            reportRegistry,
-            modelContext,
-            modelType,
-            evaluatedDefinition.id,
-            definition.reportSelection,
-            {
-              skipAllReports: input.skipAllReports,
-              skipReportNames: input.skipReportNames,
-              skipReportLabels: input.skipReportLabels,
-              reportNames: input.reportNames,
-              reportLabels: input.reportLabels,
-            },
-            {
-              onReportStarted: () => {},
-              onReportCompleted: () => {},
-              onReportFailed: () => {},
-            },
-            input.methodName,
-            [...BUILTIN_METHOD_REPORTS, ...(modelDef.reports ?? [])],
-            undefined,
-            // The method-scope call above already emitted failures for
-            // unresolvable required reports — suppress duplicates.
-            false,
-          );
-
-          for (const result of modelSummary.results) {
-            yield {
-              kind: "report_started" as const,
-              reportName: result.name,
-              scope: result.scope,
-            };
-            if (result.success) {
+          if (input.autoGc) {
+            const gcResult = await autoGc(
+              deps.dataRepo,
+              modelType,
+              definition.id,
+            );
+            if (gcResult && gcResult.versionsRemoved > 0) {
               yield {
-                kind: "report_completed" as const,
-                reportName: result.name,
-                scope: result.scope,
-                markdown: result.markdown!,
-                json: result.json!,
-              };
-            } else {
-              yield {
-                kind: "report_failed" as const,
-                reportName: result.name,
-                scope: result.scope,
-                error: result.error!,
+                kind: "auto_gc_completed" as const,
+                versionsDeleted: gcResult.versionsRemoved,
+                bytesReclaimed: gcResult.bytesReclaimed,
               };
             }
-            reportResults[result.name] = toReportResultView(result);
           }
-          reportFailures += modelSummary.failures;
+        } finally {
+          runLog.cleanup();
+          ephemeral.dispose();
         }
-
-        reportsSpan.end();
-        postExecSpan.end();
-
-        // --- Complete ---
-        const view: ModelMethodRunView = {
-          modelId: definition.id,
-          modelName: definition.name,
-          modelType: modelType.normalized,
-          methodName: input.methodName,
-          status: reportFailures > 0 ? "failed" : "succeeded",
-          duration: output.durationMs,
-          outputId: output.id,
-          logFile: logFilePath,
-          dataArtifacts,
-          reports: reportResults,
-        };
-        yield { kind: "completed", run: view };
-
-        if (input.autoGc) {
-          const gcResult = await autoGc(
-            deps.dataRepo,
-            modelType,
-            definition.id,
-          );
-          if (gcResult && gcResult.versionsRemoved > 0) {
-            yield {
-              kind: "auto_gc_completed" as const,
-              versionsDeleted: gcResult.versionsRemoved,
-              bytesReclaimed: gcResult.bytesReclaimed,
-            };
-          }
-        }
-      } finally {
-        runLog.cleanup();
-        ephemeral.dispose();
-      }
-    })(),
+      })(),
+    ),
   );
 }
 

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -52,7 +52,10 @@ import type { CatalogStore } from "../../infrastructure/persistence/catalog_stor
 import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
 import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
-import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import {
+  withGeneratorSpan,
+  withGeneratorTraceContext,
+} from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
 
 /**
@@ -271,6 +274,10 @@ export interface WorkflowRunInput {
   skipCheckNames?: string[];
   skipCheckLabels?: string[];
   skipAllChecks?: boolean;
+  /** W3C traceparent header for per-invocation trace context. */
+  traceparent?: string;
+  /** W3C tracestate header for per-invocation trace context. */
+  tracestate?: string;
 }
 
 /**
@@ -474,167 +481,174 @@ export async function* workflowRun(
   deps: WorkflowRunDeps,
   input: WorkflowRunInput,
 ): AsyncGenerator<WorkflowRunEvent> {
-  yield* withGeneratorSpan(
-    "swamp.workflow.run.command",
-    { "workflow.id_or_name": input.workflowIdOrName },
-    (async function* () {
-      const ephemeral = createEphemeralStore();
-      let resolvedInput = input;
+  yield* withGeneratorTraceContext(
+    input.traceparent,
+    input.tracestate,
+    withGeneratorSpan(
+      "swamp.workflow.run.command",
+      { "workflow.id_or_name": input.workflowIdOrName },
+      (async function* () {
+        const ephemeral = createEphemeralStore();
+        let resolvedInput = input;
 
-      yield { kind: "validating_inputs" };
+        yield { kind: "validating_inputs" };
 
-      // Look up workflow
-      const workflow = await deps.lookupWorkflow(
-        deps.workflowRepo,
-        input.workflowIdOrName,
-      );
-      if (!workflow) {
-        yield {
-          kind: "error",
-          error: workflowNotFound(input.workflowIdOrName),
-        };
-        return;
-      }
-
-      // Coerce and validate inputs
-      if (workflow.inputs && !input.lastEvaluated) {
-        const coercedInputs = coerceInputTypes(
-          input.inputs ?? {},
-          workflow.inputs,
+        // Look up workflow
+        const workflow = await deps.lookupWorkflow(
+          deps.workflowRepo,
+          input.workflowIdOrName,
         );
-        const validationService = new InputValidationService();
-        const inputsWithDefaults = validationService.applyDefaults(
-          coercedInputs,
-          workflow.inputs,
-        );
-        const result = validationService.validate(
-          inputsWithDefaults,
-          workflow.inputs,
-        );
-        if (!result.valid) {
-          yield { kind: "error", error: inputValidationFailed(result.errors) };
+        if (!workflow) {
+          yield {
+            kind: "error",
+            error: workflowNotFound(input.workflowIdOrName),
+          };
           return;
         }
-        resolvedInput = { ...input, inputs: inputsWithDefaults };
-      } else if (workflow.inputs) {
-        // lastEvaluated: still coerce types but skip validation
-        resolvedInput = {
-          ...input,
-          inputs: coerceInputTypes(input.inputs ?? {}, workflow.inputs),
-        };
-      }
 
-      yield { kind: "evaluating_workflow" };
-
-      const service = deps.createExecutionService(
-        deps.workflowRepo,
-        deps.runRepo,
-        deps.repoDir,
-        deps.catalogStore,
-        ephemeral.repo,
-        ephemeral.catalog,
-      );
-
-      // Per-method-invocation telemetry bridge. Constructed once per
-      // stream consumption and finalized in the outer try/finally so
-      // any in-flight invocations on cancellation / throw are still
-      // recorded as error child entries.
-      const telemetryBridge = deps.telemetrySink
-        ? new WorkflowTelemetryBridge(deps.telemetrySink)
-        : undefined;
-
-      try {
-        // Aggregate report results from both method-scope (yielded during
-        // step execution) and workflow-scope (yielded by the execution
-        // service after run.complete()). All report_completed and
-        // report_failed events arrive before the completed event, so the
-        // accumulated list is attached to the run view at that point.
-        const reportResults: ReportResultView[] = [];
-
-        for await (
-          const event of service.run(resolvedInput.workflowIdOrName, {
-            lastEvaluated: resolvedInput.lastEvaluated,
-            inputs: resolvedInput.inputs,
-            runtimeTags: resolvedInput.runtimeTags,
-            signal: ctx.signal,
-            reportFilterOptions: {
-              skipAllReports: resolvedInput.skipAllReports,
-              skipReportNames: resolvedInput.skipReportNames,
-              skipReportLabels: resolvedInput.skipReportLabels,
-              reportNames: resolvedInput.reportNames,
-              reportLabels: resolvedInput.reportLabels,
-            },
-            swampSha: resolvedInput.swampSha,
-            skipCheckNames: resolvedInput.skipCheckNames,
-            skipCheckLabels: resolvedInput.skipCheckLabels,
-            skipAllChecks: resolvedInput.skipAllChecks,
-          })
-        ) {
-          if (event.kind === "report_completed") {
-            reportResults.push({
-              name: event.reportName,
-              scope: event.scope,
-              success: true,
-              markdown: event.markdown,
-              json: event.json,
-            });
-          } else if (event.kind === "report_failed") {
-            reportResults.push({
-              name: event.reportName,
-              scope: event.scope,
-              success: false,
-              error: event.error,
-            });
-          }
-
-          let mapped = mapWorkflowExecutionEvent(
-            event,
-            deps.runRepo,
-            resolvedInput.verbose,
+        // Coerce and validate inputs
+        if (workflow.inputs && !input.lastEvaluated) {
+          const coercedInputs = coerceInputTypes(
+            input.inputs ?? {},
+            workflow.inputs,
           );
-
-          // Per-method telemetry observer — runs alongside existing
-          // event handling. Skipped when telemetry is disabled.
-          if (telemetryBridge) {
-            await telemetryBridge.observe(mapped);
-          }
-
-          if (
-            (mapped.kind === "completed" || mapped.kind === "cancelled" ||
-              mapped.kind === "suspended") &&
-            reportResults.length > 0
-          ) {
-            mapped = {
-              ...mapped,
-              run: { ...mapped.run, reports: reportResults },
+          const validationService = new InputValidationService();
+          const inputsWithDefaults = validationService.applyDefaults(
+            coercedInputs,
+            workflow.inputs,
+          );
+          const result = validationService.validate(
+            inputsWithDefaults,
+            workflow.inputs,
+          );
+          if (!result.valid) {
+            yield {
+              kind: "error",
+              error: inputValidationFailed(result.errors),
             };
+            return;
           }
+          resolvedInput = { ...input, inputs: inputsWithDefaults };
+        } else if (workflow.inputs) {
+          // lastEvaluated: still coerce types but skip validation
+          resolvedInput = {
+            ...input,
+            inputs: coerceInputTypes(input.inputs ?? {}, workflow.inputs),
+          };
+        }
 
-          yield mapped;
+        yield { kind: "evaluating_workflow" };
+
+        const service = deps.createExecutionService(
+          deps.workflowRepo,
+          deps.runRepo,
+          deps.repoDir,
+          deps.catalogStore,
+          ephemeral.repo,
+          ephemeral.catalog,
+        );
+
+        // Per-method-invocation telemetry bridge. Constructed once per
+        // stream consumption and finalized in the outer try/finally so
+        // any in-flight invocations on cancellation / throw are still
+        // recorded as error child entries.
+        const telemetryBridge = deps.telemetrySink
+          ? new WorkflowTelemetryBridge(deps.telemetrySink)
+          : undefined;
+
+        try {
+          // Aggregate report results from both method-scope (yielded during
+          // step execution) and workflow-scope (yielded by the execution
+          // service after run.complete()). All report_completed and
+          // report_failed events arrive before the completed event, so the
+          // accumulated list is attached to the run view at that point.
+          const reportResults: ReportResultView[] = [];
+
+          for await (
+            const event of service.run(resolvedInput.workflowIdOrName, {
+              lastEvaluated: resolvedInput.lastEvaluated,
+              inputs: resolvedInput.inputs,
+              runtimeTags: resolvedInput.runtimeTags,
+              signal: ctx.signal,
+              reportFilterOptions: {
+                skipAllReports: resolvedInput.skipAllReports,
+                skipReportNames: resolvedInput.skipReportNames,
+                skipReportLabels: resolvedInput.skipReportLabels,
+                reportNames: resolvedInput.reportNames,
+                reportLabels: resolvedInput.reportLabels,
+              },
+              swampSha: resolvedInput.swampSha,
+              skipCheckNames: resolvedInput.skipCheckNames,
+              skipCheckLabels: resolvedInput.skipCheckLabels,
+              skipAllChecks: resolvedInput.skipAllChecks,
+            })
+          ) {
+            if (event.kind === "report_completed") {
+              reportResults.push({
+                name: event.reportName,
+                scope: event.scope,
+                success: true,
+                markdown: event.markdown,
+                json: event.json,
+              });
+            } else if (event.kind === "report_failed") {
+              reportResults.push({
+                name: event.reportName,
+                scope: event.scope,
+                success: false,
+                error: event.error,
+              });
+            }
+
+            let mapped = mapWorkflowExecutionEvent(
+              event,
+              deps.runRepo,
+              resolvedInput.verbose,
+            );
+
+            // Per-method telemetry observer — runs alongside existing
+            // event handling. Skipped when telemetry is disabled.
+            if (telemetryBridge) {
+              await telemetryBridge.observe(mapped);
+            }
+
+            if (
+              (mapped.kind === "completed" || mapped.kind === "cancelled" ||
+                mapped.kind === "suspended") &&
+              reportResults.length > 0
+            ) {
+              mapped = {
+                ...mapped,
+                run: { ...mapped.run, reports: reportResults },
+              };
+            }
+
+            yield mapped;
+          }
+        } catch (error) {
+          if (
+            error instanceof DOMException && error.name === "AbortError"
+          ) {
+            yield { kind: "error", error: cancelled(error) };
+            return;
+          }
+          yield {
+            kind: "error",
+            error: workflowExecutionFailed(error),
+          };
+        } finally {
+          // Drain any in-flight method invocations as error entries. Runs
+          // on every stream termination — normal completion, thrown
+          // errors, and AbortSignal cancellation — so methods that
+          // started but never received a terminal event don't disappear
+          // from telemetry.
+          if (telemetryBridge) {
+            await telemetryBridge.finalize();
+          }
+          ephemeral.dispose();
         }
-      } catch (error) {
-        if (
-          error instanceof DOMException && error.name === "AbortError"
-        ) {
-          yield { kind: "error", error: cancelled(error) };
-          return;
-        }
-        yield {
-          kind: "error",
-          error: workflowExecutionFailed(error),
-        };
-      } finally {
-        // Drain any in-flight method invocations as error entries. Runs
-        // on every stream termination — normal completion, thrown
-        // errors, and AbortSignal cancellation — so methods that
-        // started but never received a terminal event don't disappear
-        // from telemetry.
-        if (telemetryBridge) {
-          await telemetryBridge.finalize();
-        }
-        ephemeral.dispose();
-      }
-    })(),
+      })(),
+    ),
   );
 }
 

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -40,6 +40,7 @@ import {
   extractFirstStepError,
   type WorkflowRunView,
 } from "./workflow_run_view.ts";
+import { withSpan } from "../../infrastructure/tracing/mod.ts";
 
 const logger = getSwampLogger(["scheduled-execution"]);
 
@@ -343,24 +344,29 @@ export class ScheduledExecutionService {
       let completedRun: WorkflowRunView | undefined;
       let streamError: string | undefined;
 
-      await this.deps.executeWorkflow(
-        { workflowIdOrName: workflowName },
-        controller.signal,
-        (event) => {
-          if (event.kind === "started") {
-            runId = event.runId;
-            // Update the running entry with the actual run ID
-            this.running.set(workflowId, { controller, runId });
-          }
-          if (event.kind === "completed") {
-            completedRun = event.run;
-          }
-          if (event.kind === "cancelled") {
-            completedRun = event.run;
-          }
-          if (event.kind === "error") {
-            streamError = event.error.message;
-          }
+      await withSpan(
+        "swamp.scheduled.fire",
+        { "workflow.id": String(workflowId), "workflow.name": workflowName },
+        async (_span) => {
+          await this.deps.executeWorkflow(
+            { workflowIdOrName: workflowName },
+            controller.signal,
+            (event) => {
+              if (event.kind === "started") {
+                runId = event.runId;
+                this.running.set(workflowId, { controller, runId });
+              }
+              if (event.kind === "completed") {
+                completedRun = event.run;
+              }
+              if (event.kind === "cancelled") {
+                completedRun = event.run;
+              }
+              if (event.kind === "error") {
+                streamError = event.error.message;
+              }
+            },
+          );
         },
       );
 

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -132,6 +132,8 @@ const WorkflowRunRequestSchema = z.object({
     lastEvaluated: z.boolean().optional(),
     verbose: z.boolean().optional(),
     runtimeTags: z.record(z.string(), z.string()).optional(),
+    traceparent: z.string().optional(),
+    tracestate: z.string().optional(),
   }),
 });
 
@@ -146,6 +148,8 @@ const ModelMethodRunRequestSchema = z.object({
     runtimeTags: z.record(z.string(), z.string()).optional(),
     typeArg: z.string().optional(),
     definitionName: z.string().optional(),
+    traceparent: z.string().optional(),
+    tracestate: z.string().optional(),
   }),
 });
 

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -66,6 +66,10 @@ import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
+import {
+  extractTraceContext,
+  runWithParentTrace,
+} from "../infrastructure/tracing/mod.ts";
 
 export async function createWorkflowRunDeps(
   repoDir: string,
@@ -347,7 +351,20 @@ export async function executeWorkflowWithLocks(
     }
     : input;
 
-  for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
-    onEvent(event);
+  const run = async () => {
+    for await (const event of workflowRun(libCtx, deps, effectiveInput)) {
+      onEvent(event);
+    }
+  };
+
+  if (input.traceparent) {
+    const headers: Record<string, string> = {
+      traceparent: input.traceparent,
+    };
+    if (input.tracestate) headers.tracestate = input.tracestate;
+    const traceCtx = extractTraceContext(headers);
+    await runWithParentTrace(traceCtx, run);
+  } else {
+    await run();
   }
 }

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -73,6 +73,10 @@ import type {
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { createDefinitionId } from "../../domain/definitions/definition.ts";
 import { acquireModelLocks } from "../../cli/repo_context.ts";
+import {
+  extractTraceContext,
+  runWithParentTrace,
+} from "../../infrastructure/tracing/mod.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { Principal } from "../../domain/access/principal.ts";
@@ -177,25 +181,40 @@ export async function handleModelMethodRun(
       ctx.cancelRegistry.register("method-run", requestId, controller);
     }
 
-    for await (
-      const event of modelMethodRun(libCtx, deps, {
-        modelIdOrName: payload.modelIdOrName,
-        methodName: payload.methodName,
-        inputs: payload.inputs ?? {},
-        lastEvaluated: payload.lastEvaluated ?? false,
-        runtimeTags: payload.runtimeTags,
-        typeArg: payload.typeArg,
-        definitionName: payload.definitionName,
-        skipAllReports: isDirectExecution,
-      })
-    ) {
-      if (socket.readyState !== WebSocket.OPEN) break;
-      const serialized = serializeEvent(
-        event as { kind: string; [key: string]: unknown },
-      );
-      send(socket, { type: "event", id: requestId, event: serialized });
+    const runMethod = async () => {
+      for await (
+        const event of modelMethodRun(libCtx, deps, {
+          modelIdOrName: payload.modelIdOrName,
+          methodName: payload.methodName,
+          inputs: payload.inputs ?? {},
+          lastEvaluated: payload.lastEvaluated ?? false,
+          runtimeTags: payload.runtimeTags,
+          typeArg: payload.typeArg,
+          definitionName: payload.definitionName,
+          skipAllReports: isDirectExecution,
+          traceparent: payload.traceparent,
+          tracestate: payload.tracestate,
+        })
+      ) {
+        if (socket.readyState !== WebSocket.OPEN) break;
+        const serialized = serializeEvent(
+          event as { kind: string; [key: string]: unknown },
+        );
+        send(socket, { type: "event", id: requestId, event: serialized });
+      }
+      send(socket, { type: "done", id: requestId });
+    };
+
+    if (payload.traceparent) {
+      const headers: Record<string, string> = {
+        traceparent: payload.traceparent,
+      };
+      if (payload.tracestate) headers.tracestate = payload.tracestate;
+      const traceCtx = extractTraceContext(headers);
+      await runWithParentTrace(traceCtx, runMethod);
+    } else {
+      await runMethod();
     }
-    send(socket, { type: "done", id: requestId });
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -109,6 +109,8 @@ export async function handleWorkflowRun(
         lastEvaluated: payload.lastEvaluated,
         verbose: payload.verbose,
         runtimeTags: payload.runtimeTags,
+        traceparent: payload.traceparent,
+        tracestate: payload.tracestate,
       },
       controller.signal,
       (event) => {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -33,6 +33,8 @@ export interface WorkflowRunPayload {
   lastEvaluated?: boolean;
   verbose?: boolean;
   runtimeTags?: Record<string, string>;
+  traceparent?: string;
+  tracestate?: string;
 }
 
 export interface ModelMethodRunPayload {
@@ -43,6 +45,8 @@ export interface ModelMethodRunPayload {
   runtimeTags?: Record<string, string>;
   typeArg?: string;
   definitionName?: string;
+  traceparent?: string;
+  tracestate?: string;
 }
 
 export interface AccessGrantListPayload {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -311,6 +311,8 @@ export class WebhookService {
     workflowIdOrName: string;
     route: string;
     payload: WebhookPayload;
+    traceparent?: string;
+    tracestate?: string;
   }> = [];
   private processing = false;
   private processingPromise: Promise<void> = Promise.resolve();
@@ -422,6 +424,8 @@ export class WebhookService {
         endpoint.route,
         verifier.signatureHeader,
       ),
+      traceparent: req.headers.get("traceparent") ?? undefined,
+      tracestate: req.headers.get("tracestate") ?? undefined,
     });
 
     this.emit({
@@ -469,8 +473,15 @@ export class WebhookService {
 
     try {
       while (this.runQueue.length > 0) {
-        const { workflowIdOrName, route, payload } = this.runQueue.shift()!;
-        await this.executeWorkflow(workflowIdOrName, route, payload);
+        const { workflowIdOrName, route, payload, traceparent, tracestate } =
+          this.runQueue.shift()!;
+        await this.executeWorkflow(
+          workflowIdOrName,
+          route,
+          payload,
+          traceparent,
+          tracestate,
+        );
       }
     } finally {
       this.processing = false;
@@ -481,6 +492,8 @@ export class WebhookService {
     workflowIdOrName: string,
     route: string,
     payload: WebhookPayload,
+    traceparent?: string,
+    tracestate?: string,
   ): Promise<void> {
     const controller = new AbortController();
     const execId = crypto.randomUUID();
@@ -494,7 +507,7 @@ export class WebhookService {
         this.deps.repoDir,
         this.deps.repoContext,
         this.deps.datastoreConfig,
-        { workflowIdOrName, webhook: payload },
+        { workflowIdOrName, webhook: payload, traceparent, tracestate },
         controller.signal,
         (event) => {
           if (event.kind === "started") {


### PR DESCRIPTION
## Summary

- Add `--traceparent` / `--tracestate` CLI flags to `workflow run` and `model method run` with `TRACEPARENT` / `TRACESTATE` env var fallbacks, following the established `resolve*` pattern
- Add `traceparent` / `tracestate` fields to the WebSocket protocol (`WorkflowRunPayload`, `ModelMethodRunPayload`) and Zod schemas
- Extract `traceparent` / `tracestate` from HTTP request headers on webhook-triggered workflow runs
- Wrap `executeWorkflowWithLocks` (the shared serve execution path) with `extractTraceContext` + `runWithParentTrace` when traceparent is present — single injection point covers WebSocket, webhook, and scheduled paths
- Add `withGeneratorTraceContext` helper to wrap async generators in a caller-supplied trace context, used by `workflowRun` and `modelMethodRun` for the local CLI path
- Mint a fresh root span (`swamp.scheduled.fire`) per scheduled/cron invocation via `withSpan`

Closes swamp-club#1017

## Test Plan

- Unit tests for `resolveTraceparent` / `resolveTracestate` helpers — flag precedence over env var, empty env treated as unset
- Unit tests for `withGeneratorTraceContext` — passthrough when no traceparent, correct yield with traceparent, empty generator
- Full test suite passes (8566 tests)
- Verified end-to-end: ran `swamp model method run` with `--traceparent "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"` and `OTEL_TRACES_EXPORTER=console`, confirmed the supplied trace ID (`0af7651916cd43dd8448eb211c80319c`) appears on all method execution spans with the supplied span ID (`b7ad6b7169203331`) as the parent
- Verified invalid traceparent values are silently ignored (OTel SDK handles validation)