### PR TITLE
feat(serve-auth): declarative grants directory with validate-and-reconcile on reload (swamp-club#1037)

### DIFF
--- a/design/repo.md
+++ b/design/repo.md
@@ -76,6 +76,11 @@ Source-of-truth files live in top-level directories tracked in git:
 - **`models/`** — Model definitions: `models/{normalized-type}/{id}.yaml`
 - **`workflows/`** — Workflow definitions: `workflows/workflow-{id}.yaml`
 - **`vaults/`** — Vault configurations: `vaults/{vault-type}/{id}.yaml`
+- **`grants/`** — Declarative access grant files: `grants/{name}.yaml` or
+  `grants/{name}.yml`. Each file contains a `grants:` array of grant entries
+  (subject, effect, actions, resource, optional condition). Reconciled against
+  stored `source: file:<filename>` grants on `swamp serve` startup and
+  `swamp access reload`.
 
 Runtime data (versioned model data, workflow runs, method outputs, secrets) is
 stored through a datastore abstraction. The default datastore uses the `.swamp/`

--- a/src/cli/commands/access_reload.ts
+++ b/src/cli/commands/access_reload.ts
@@ -89,6 +89,12 @@ export const accessReloadCommand = new Command()
       );
 
       if (!response.success) {
+        renderer.render({
+          success: false,
+          grantCount: 0,
+          groupCount: 0,
+          errors: response.errors,
+        });
         throw new UserError("Policy reload failed on the server");
       }
 
@@ -96,6 +102,8 @@ export const accessReloadCommand = new Command()
         success: true,
         grantCount: response.grantCount,
         groupCount: response.groupCount,
+        filesProcessed: response.filesProcessed,
+        fileResults: response.fileResults,
       });
       return;
     }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -76,6 +76,15 @@ import {
   materializeAdmins,
   migrateGrantDefinitions,
 } from "../../domain/access/admin_materializer.ts";
+import {
+  collectErrors,
+  readGrantFiles,
+} from "../../domain/access/grant_file.ts";
+import { validateGrantCondition } from "../../infrastructure/cel/grant_condition_environment.ts";
+import {
+  createFileGrantStore,
+  reconcileAllFileGrants,
+} from "../../domain/access/grant_file_reconciler.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { GRANT_MODEL_TYPE } from "../../domain/models/access/grant_model.ts";
 import { cleanupEmptyParentDirs } from "../../infrastructure/persistence/directory_cleanup.ts";
@@ -1016,6 +1025,57 @@ export const serveCommand = new Command()
     ) {
       logger
         .info`Admin grants materialized: ${materializeResult.created} created, ${materializeResult.revoked} revoked, ${materializeResult.reactivated} reactivated, ${materializeResult.unchanged} unchanged`;
+    }
+
+    const grantsDir = join(resolvedRepoDir, "grants");
+    const grantFileResults = await readGrantFiles(
+      grantsDir,
+      validateGrantCondition,
+    );
+    const grantFileErrors = collectErrors(grantFileResults);
+
+    if (grantFileErrors.length > 0) {
+      const errorMessages = grantFileErrors.map((e) => {
+        const loc = e.entryIndex !== undefined
+          ? `${e.filename} entry ${e.entryIndex + 1}`
+          : e.filename;
+        return `  ${loc}: ${e.message}`;
+      });
+      throw new UserError(
+        `Grant file validation failed — refusing to start:\n${
+          errorMessages.join("\n")
+        }`,
+      );
+    }
+
+    if (grantFileResults.size > 0) {
+      const validEntries = new Map<
+        string,
+        import("../../domain/access/grant_file.ts").GrantFileEntry[]
+      >();
+      for (const [filename, result] of grantFileResults) {
+        validEntries.set(filename, result.entries);
+      }
+
+      const fileGrantStore = createFileGrantStore(
+        repoContext.definitionRepo,
+        autoDefRepo,
+        repoContext.unifiedDataRepo,
+      );
+
+      const fileReconcileResult = await reconcileAllFileGrants(
+        validEntries,
+        fileGrantStore,
+      );
+
+      if (
+        fileReconcileResult.totalCreated > 0 ||
+        fileReconcileResult.totalRevoked > 0 ||
+        fileReconcileResult.totalReactivated > 0
+      ) {
+        logger
+          .info`File grants reconciled (${fileReconcileResult.filesProcessed} file(s)): ${fileReconcileResult.totalCreated} created, ${fileReconcileResult.totalRevoked} revoked, ${fileReconcileResult.totalReactivated} reactivated, ${fileReconcileResult.totalUnchanged} unchanged`;
+      }
     }
 
     const policySnapshotLoader = new PolicySnapshotLoader(

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1048,34 +1048,32 @@ export const serveCommand = new Command()
       );
     }
 
-    if (grantFileResults.size > 0) {
-      const validEntries = new Map<
-        string,
-        import("../../domain/access/grant_file.ts").GrantFileEntry[]
-      >();
-      for (const [filename, result] of grantFileResults) {
-        validEntries.set(filename, result.entries);
-      }
+    const validEntries = new Map<
+      string,
+      import("../../domain/access/grant_file.ts").GrantFileEntry[]
+    >();
+    for (const [filename, result] of grantFileResults) {
+      validEntries.set(filename, result.entries);
+    }
 
-      const fileGrantStore = createFileGrantStore(
-        repoContext.definitionRepo,
-        autoDefRepo,
-        repoContext.unifiedDataRepo,
-      );
+    const fileGrantStore = createFileGrantStore(
+      repoContext.definitionRepo,
+      autoDefRepo,
+      repoContext.unifiedDataRepo,
+    );
 
-      const fileReconcileResult = await reconcileAllFileGrants(
-        validEntries,
-        fileGrantStore,
-      );
+    const fileReconcileResult = await reconcileAllFileGrants(
+      validEntries,
+      fileGrantStore,
+    );
 
-      if (
-        fileReconcileResult.totalCreated > 0 ||
-        fileReconcileResult.totalRevoked > 0 ||
-        fileReconcileResult.totalReactivated > 0
-      ) {
-        logger
-          .info`File grants reconciled (${fileReconcileResult.filesProcessed} file(s)): ${fileReconcileResult.totalCreated} created, ${fileReconcileResult.totalRevoked} revoked, ${fileReconcileResult.totalReactivated} reactivated, ${fileReconcileResult.totalUnchanged} unchanged`;
-      }
+    if (
+      fileReconcileResult.totalCreated > 0 ||
+      fileReconcileResult.totalRevoked > 0 ||
+      fileReconcileResult.totalReactivated > 0
+    ) {
+      logger
+        .info`File grants reconciled (${fileReconcileResult.filesProcessed} file(s)): ${fileReconcileResult.totalCreated} created, ${fileReconcileResult.totalRevoked} revoked, ${fileReconcileResult.totalReactivated} reactivated, ${fileReconcileResult.totalUnchanged} unchanged`;
     }
 
     const policySnapshotLoader = new PolicySnapshotLoader(

--- a/src/domain/access/grant_file.ts
+++ b/src/domain/access/grant_file.ts
@@ -1,0 +1,221 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { parse as parseYaml } from "@std/yaml";
+import { z } from "zod";
+import { type Action, ActionSchema } from "./action.ts";
+import { type Effect, EffectSchema } from "./effect.ts";
+import type { Subject } from "./subject.ts";
+import { parseSubject } from "./subject.ts";
+import {
+  parseResourceSelector,
+  type ResourceKind,
+  type ResourceSelector,
+} from "./resource_selector.ts";
+
+const GrantFileEntryRawSchema = z.object({
+  subject: z.string().min(1),
+  effect: EffectSchema,
+  actions: z.array(ActionSchema).min(1),
+  resource: z.string().min(1),
+  condition: z.string().optional(),
+});
+
+const GrantFileRawSchema = z.object({
+  grants: z.array(GrantFileEntryRawSchema).min(1),
+});
+
+export interface GrantFileEntry {
+  subject: Subject;
+  effect: Effect;
+  actions: Action[];
+  resource: ResourceSelector;
+  condition?: string;
+}
+
+export interface GrantFileError {
+  filename: string;
+  entryIndex?: number;
+  message: string;
+}
+
+export interface GrantFileParseResult {
+  entries: GrantFileEntry[];
+  errors: GrantFileError[];
+}
+
+export interface ConditionValidator {
+  (condition: string, resourceKind: ResourceKind): {
+    valid: boolean;
+    error?: string;
+  };
+}
+
+function entryIdentityKey(entry: GrantFileEntry): string {
+  const subject = `${entry.subject.kind}:${entry.subject.name}`;
+  const actions = [...entry.actions].sort().join(",");
+  const resource = `${entry.resource.kind}:${entry.resource.pattern}`;
+  const condition = entry.condition?.trim() ?? "";
+  return `${subject}|${entry.effect}|${actions}|${resource}|${condition}`;
+}
+
+export function parseGrantFile(
+  filename: string,
+  content: string,
+  validateCondition?: ConditionValidator,
+): GrantFileParseResult {
+  const entries: GrantFileEntry[] = [];
+  const errors: GrantFileError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch {
+    errors.push({ filename, message: "Invalid YAML syntax" });
+    return { entries, errors };
+  }
+
+  const result = GrantFileRawSchema.safeParse(parsed);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const path = issue.path.join(".");
+      errors.push({
+        filename,
+        message: `Schema error at ${path}: ${issue.message}`,
+      });
+    }
+    return { entries, errors };
+  }
+
+  const seenKeys = new Map<string, number>();
+
+  for (let i = 0; i < result.data.grants.length; i++) {
+    const raw = result.data.grants[i];
+
+    let subject: Subject;
+    try {
+      subject = parseSubject(raw.subject);
+    } catch (e) {
+      errors.push({
+        filename,
+        entryIndex: i,
+        message: (e as Error).message,
+      });
+      continue;
+    }
+
+    let resource: ResourceSelector;
+    try {
+      resource = parseResourceSelector(raw.resource);
+    } catch (e) {
+      errors.push({
+        filename,
+        entryIndex: i,
+        message: (e as Error).message,
+      });
+      continue;
+    }
+
+    if (raw.condition && validateCondition) {
+      const validation = validateCondition(raw.condition, resource.kind);
+      if (!validation.valid) {
+        errors.push({
+          filename,
+          entryIndex: i,
+          message: `CEL condition invalid: ${validation.error}`,
+        });
+        continue;
+      }
+    }
+
+    const entry: GrantFileEntry = {
+      subject,
+      effect: raw.effect,
+      actions: raw.actions,
+      resource,
+      condition: raw.condition,
+    };
+
+    const key = entryIdentityKey(entry);
+    const existingIndex = seenKeys.get(key);
+    if (existingIndex !== undefined) {
+      errors.push({
+        filename,
+        entryIndex: i,
+        message: `Duplicate grant entry (same as entry ${existingIndex + 1})`,
+      });
+      continue;
+    }
+
+    seenKeys.set(key, i);
+    entries.push(entry);
+  }
+
+  return { entries, errors };
+}
+
+function isGrantFileExtension(name: string): boolean {
+  return name.endsWith(".yaml") || name.endsWith(".yml");
+}
+
+export async function readGrantFiles(
+  grantsDir: string,
+  validateCondition?: ConditionValidator,
+): Promise<Map<string, GrantFileParseResult>> {
+  const results = new Map<string, GrantFileParseResult>();
+
+  let dirEntries: Deno.DirEntry[];
+  try {
+    dirEntries = [];
+    for await (const entry of Deno.readDir(grantsDir)) {
+      dirEntries.push(entry);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return results;
+    }
+    throw error;
+  }
+
+  const files = dirEntries
+    .filter((e) => e.isFile && isGrantFileExtension(e.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const file of files) {
+    const path = join(grantsDir, file.name);
+    const content = await Deno.readTextFile(path);
+    results.set(
+      file.name,
+      parseGrantFile(file.name, content, validateCondition),
+    );
+  }
+
+  return results;
+}
+
+export function collectErrors(
+  results: Map<string, GrantFileParseResult>,
+): GrantFileError[] {
+  const allErrors: GrantFileError[] = [];
+  for (const result of results.values()) {
+    allErrors.push(...result.errors);
+  }
+  return allErrors;
+}

--- a/src/domain/access/grant_file.ts
+++ b/src/domain/access/grant_file.ts
@@ -68,7 +68,7 @@ export interface ConditionValidator {
   };
 }
 
-function entryIdentityKey(entry: GrantFileEntry): string {
+export function entryIdentityKey(entry: GrantFileEntry): string {
   const subject = `${entry.subject.kind}:${entry.subject.name}`;
   const actions = [...entry.actions].sort().join(",");
   const resource = `${entry.resource.kind}:${entry.resource.pattern}`;

--- a/src/domain/access/grant_file_reconciler.ts
+++ b/src/domain/access/grant_file_reconciler.ts
@@ -24,7 +24,7 @@ import {
   grantModel,
   GrantSchema,
 } from "../models/access/grant_model.ts";
-import type { GrantFileEntry } from "./grant_file.ts";
+import { entryIdentityKey, type GrantFileEntry } from "./grant_file.ts";
 import { isFileSource, parseFileSourceFilename } from "./grant_source.ts";
 import { subjectToString } from "./subject.ts";
 import { resourceSelectorToString } from "./resource_selector.ts";
@@ -46,14 +46,6 @@ export interface FileGrantStore {
     instanceName: string,
     grant: Grant,
   ): Promise<void>;
-}
-
-function entryIdentityKey(entry: GrantFileEntry): string {
-  const subject = `${entry.subject.kind}:${entry.subject.name}`;
-  const actions = [...entry.actions].sort().join(",");
-  const resource = `${entry.resource.kind}:${entry.resource.pattern}`;
-  const condition = entry.condition?.trim() ?? "";
-  return `${subject}|${entry.effect}|${actions}|${resource}|${condition}`;
 }
 
 function grantIdentityKey(grant: Grant): string {
@@ -79,34 +71,43 @@ function buildFileGrant(entry: GrantFileEntry, filename: string): Grant {
   };
 }
 
-export async function reconcileFileGrants(
+interface StoredFileGrant {
+  grant: Grant;
+  modelId: string;
+  instanceName: string;
+}
+
+function groupByFilename(
+  allFileGrants: Map<string, StoredFileGrant>,
+): Map<string, Map<string, StoredFileGrant>> {
+  const byFile = new Map<string, Map<string, StoredFileGrant>>();
+  for (const [_id, entry] of allFileGrants) {
+    if (!isFileSource(entry.grant.source)) continue;
+    const filename = parseFileSourceFilename(entry.grant.source);
+    let fileMap = byFile.get(filename);
+    if (!fileMap) {
+      fileMap = new Map();
+      byFile.set(filename, fileMap);
+    }
+    const key = grantIdentityKey(entry.grant);
+    fileMap.set(key, entry);
+  }
+  return byFile;
+}
+
+function reconcileOneFile(
   filename: string,
   entries: GrantFileEntry[],
+  grantsForFile: Map<string, StoredFileGrant>,
   store: FileGrantStore,
-): Promise<MaterializeResult> {
+): { result: MaterializeResult; writes: Promise<void>[] } {
   const result: MaterializeResult = {
     created: 0,
     revoked: 0,
     reactivated: 0,
     unchanged: 0,
   };
-
-  const allFileGrants = await store.queryFileGrants();
-
-  const grantsForFile = new Map<
-    string,
-    { grant: Grant; modelId: string; instanceName: string; key: string }
-  >();
-  for (const [_id, entry] of allFileGrants) {
-    if (
-      isFileSource(entry.grant.source) &&
-      parseFileSourceFilename(entry.grant.source) === filename
-    ) {
-      const key = grantIdentityKey(entry.grant);
-      grantsForFile.set(key, { ...entry, key });
-    }
-  }
-
+  const writes: Promise<void>[] = [];
   const desiredKeys = new Set<string>();
 
   for (const entry of entries) {
@@ -122,10 +123,12 @@ export async function reconcileFileGrants(
 
     if (existing && existing.grant.state === "revoked") {
       const reactivated: Grant = { ...existing.grant, state: "active" };
-      await store.writeGrant(
-        existing.modelId,
-        existing.instanceName,
-        reactivated,
+      writes.push(
+        store.writeGrant(
+          existing.modelId,
+          existing.instanceName,
+          reactivated,
+        ),
       );
       result.reactivated++;
       const subjectStr = subjectToString(entry.subject);
@@ -136,9 +139,12 @@ export async function reconcileFileGrants(
     }
 
     const instanceName = `grant-file-${crypto.randomUUID().slice(0, 16)}`;
-    const modelId = await store.ensureDefinition(instanceName);
-    const grant = buildFileGrant(entry, filename);
-    await store.writeGrant(modelId, instanceName, grant);
+    writes.push(
+      store.ensureDefinition(instanceName).then((modelId) => {
+        const grant = buildFileGrant(entry, filename);
+        return store.writeGrant(modelId, instanceName, grant);
+      }),
+    );
     result.created++;
     const subjectStr = subjectToString(entry.subject);
     const resourceStr = resourceSelectorToString(entry.resource);
@@ -154,7 +160,7 @@ export async function reconcileFileGrants(
     }
 
     const revoked: Grant = { ...grant, state: "revoked" };
-    await store.writeGrant(modelId, instanceName, revoked);
+    writes.push(store.writeGrant(modelId, instanceName, revoked));
     const subjectStr = subjectToString(grant.subject);
     const resourceStr = resourceSelectorToString(grant.resource);
     result.revoked++;
@@ -162,7 +168,7 @@ export async function reconcileFileGrants(
       .info`Revoked file grant for ${subjectStr} on ${resourceStr} from ${filename}`;
   }
 
-  return result;
+  return { result, writes };
 }
 
 export interface ReconcileAllResult {
@@ -178,20 +184,49 @@ export async function reconcileAllFileGrants(
   fileEntries: Map<string, GrantFileEntry[]>,
   store: FileGrantStore,
 ): Promise<ReconcileAllResult> {
+  const allFileGrants = await store.queryFileGrants();
+  const grantsByFile = groupByFilename(allFileGrants);
+
   const perFile = new Map<string, MaterializeResult>();
+  const allWrites: Promise<void>[] = [];
   let totalCreated = 0;
   let totalRevoked = 0;
   let totalReactivated = 0;
   let totalUnchanged = 0;
 
   for (const [filename, entries] of fileEntries) {
-    const result = await reconcileFileGrants(filename, entries, store);
+    const grantsForFile = grantsByFile.get(filename) ?? new Map();
+    const { result, writes } = reconcileOneFile(
+      filename,
+      entries,
+      grantsForFile,
+      store,
+    );
     perFile.set(filename, result);
+    allWrites.push(...writes);
     totalCreated += result.created;
     totalRevoked += result.revoked;
     totalReactivated += result.reactivated;
     totalUnchanged += result.unchanged;
   }
+
+  for (const [filename, grantsForFile] of grantsByFile) {
+    if (fileEntries.has(filename)) continue;
+    const { result, writes } = reconcileOneFile(
+      filename,
+      [],
+      grantsForFile,
+      store,
+    );
+    perFile.set(filename, result);
+    allWrites.push(...writes);
+    totalCreated += result.created;
+    totalRevoked += result.revoked;
+    totalReactivated += result.reactivated;
+    totalUnchanged += result.unchanged;
+  }
+
+  await Promise.all(allWrites);
 
   return {
     totalCreated,
@@ -237,7 +272,7 @@ export function createFileGrantStore(
         const parsed = GrantSchema.safeParse(attrs);
         if (parsed.success && isFileSource(parsed.data.source)) {
           const modelName = data.tags["modelName"] ?? "";
-          fileGrants.set(modelName, {
+          fileGrants.set(modelId, {
             grant: parsed.data,
             modelId,
             instanceName: modelName,

--- a/src/domain/access/grant_file_reconciler.ts
+++ b/src/domain/access/grant_file_reconciler.ts
@@ -1,0 +1,284 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import {
+  type Grant,
+  GRANT_MODEL_TYPE,
+  grantModel,
+  GrantSchema,
+} from "../models/access/grant_model.ts";
+import type { GrantFileEntry } from "./grant_file.ts";
+import { isFileSource, parseFileSourceFilename } from "./grant_source.ts";
+import { subjectToString } from "./subject.ts";
+import { resourceSelectorToString } from "./resource_selector.ts";
+import type { MaterializeResult } from "./admin_materializer.ts";
+import type { DefinitionRepository } from "../definitions/repositories.ts";
+import { Definition } from "../definitions/definition.ts";
+import type { UnifiedDataRepository } from "../data/repositories.ts";
+import { createResourceWriter } from "../models/data_writer.ts";
+
+const logger = getLogger(["swamp", "grant-file-reconciler"]);
+
+export interface FileGrantStore {
+  queryFileGrants(): Promise<
+    Map<string, { grant: Grant; modelId: string; instanceName: string }>
+  >;
+  ensureDefinition(instanceName: string): Promise<string>;
+  writeGrant(
+    modelId: string,
+    instanceName: string,
+    grant: Grant,
+  ): Promise<void>;
+}
+
+function entryIdentityKey(entry: GrantFileEntry): string {
+  const subject = `${entry.subject.kind}:${entry.subject.name}`;
+  const actions = [...entry.actions].sort().join(",");
+  const resource = `${entry.resource.kind}:${entry.resource.pattern}`;
+  const condition = entry.condition?.trim() ?? "";
+  return `${subject}|${entry.effect}|${actions}|${resource}|${condition}`;
+}
+
+function grantIdentityKey(grant: Grant): string {
+  const subject = `${grant.subject.kind}:${grant.subject.name}`;
+  const actions = [...grant.actions].sort().join(",");
+  const resource = `${grant.resource.kind}:${grant.resource.pattern}`;
+  const condition = grant.condition?.trim() ?? "";
+  return `${subject}|${grant.effect}|${actions}|${resource}|${condition}`;
+}
+
+function buildFileGrant(entry: GrantFileEntry, filename: string): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: entry.subject,
+    effect: entry.effect,
+    actions: entry.actions,
+    resource: entry.resource,
+    condition: entry.condition,
+    state: "active",
+    source: `file:${filename}`,
+    createdBy: { kind: "user", id: "system" },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export async function reconcileFileGrants(
+  filename: string,
+  entries: GrantFileEntry[],
+  store: FileGrantStore,
+): Promise<MaterializeResult> {
+  const result: MaterializeResult = {
+    created: 0,
+    revoked: 0,
+    reactivated: 0,
+    unchanged: 0,
+  };
+
+  const allFileGrants = await store.queryFileGrants();
+
+  const grantsForFile = new Map<
+    string,
+    { grant: Grant; modelId: string; instanceName: string; key: string }
+  >();
+  for (const [_id, entry] of allFileGrants) {
+    if (
+      isFileSource(entry.grant.source) &&
+      parseFileSourceFilename(entry.grant.source) === filename
+    ) {
+      const key = grantIdentityKey(entry.grant);
+      grantsForFile.set(key, { ...entry, key });
+    }
+  }
+
+  const desiredKeys = new Set<string>();
+
+  for (const entry of entries) {
+    const key = entryIdentityKey(entry);
+    desiredKeys.add(key);
+
+    const existing = grantsForFile.get(key);
+
+    if (existing && existing.grant.state === "active") {
+      result.unchanged++;
+      continue;
+    }
+
+    if (existing && existing.grant.state === "revoked") {
+      const reactivated: Grant = { ...existing.grant, state: "active" };
+      await store.writeGrant(
+        existing.modelId,
+        existing.instanceName,
+        reactivated,
+      );
+      result.reactivated++;
+      const subjectStr = subjectToString(entry.subject);
+      const resourceStr = resourceSelectorToString(entry.resource);
+      logger
+        .info`Re-activated file grant for ${subjectStr} on ${resourceStr} from ${filename}`;
+      continue;
+    }
+
+    const instanceName = `grant-file-${crypto.randomUUID().slice(0, 16)}`;
+    const modelId = await store.ensureDefinition(instanceName);
+    const grant = buildFileGrant(entry, filename);
+    await store.writeGrant(modelId, instanceName, grant);
+    result.created++;
+    const subjectStr = subjectToString(entry.subject);
+    const resourceStr = resourceSelectorToString(entry.resource);
+    logger
+      .info`Created file grant for ${subjectStr} on ${resourceStr} from ${filename}`;
+  }
+
+  for (const [key, { grant, modelId, instanceName }] of grantsForFile) {
+    if (desiredKeys.has(key)) continue;
+    if (grant.state === "revoked") {
+      result.unchanged++;
+      continue;
+    }
+
+    const revoked: Grant = { ...grant, state: "revoked" };
+    await store.writeGrant(modelId, instanceName, revoked);
+    const subjectStr = subjectToString(grant.subject);
+    const resourceStr = resourceSelectorToString(grant.resource);
+    result.revoked++;
+    logger
+      .info`Revoked file grant for ${subjectStr} on ${resourceStr} from ${filename}`;
+  }
+
+  return result;
+}
+
+export interface ReconcileAllResult {
+  totalCreated: number;
+  totalRevoked: number;
+  totalReactivated: number;
+  totalUnchanged: number;
+  filesProcessed: number;
+  perFile: Map<string, MaterializeResult>;
+}
+
+export async function reconcileAllFileGrants(
+  fileEntries: Map<string, GrantFileEntry[]>,
+  store: FileGrantStore,
+): Promise<ReconcileAllResult> {
+  const perFile = new Map<string, MaterializeResult>();
+  let totalCreated = 0;
+  let totalRevoked = 0;
+  let totalReactivated = 0;
+  let totalUnchanged = 0;
+
+  for (const [filename, entries] of fileEntries) {
+    const result = await reconcileFileGrants(filename, entries, store);
+    perFile.set(filename, result);
+    totalCreated += result.created;
+    totalRevoked += result.revoked;
+    totalReactivated += result.reactivated;
+    totalUnchanged += result.unchanged;
+  }
+
+  return {
+    totalCreated,
+    totalRevoked,
+    totalReactivated,
+    totalUnchanged,
+    filesProcessed: fileEntries.size,
+    perFile,
+  };
+}
+
+const GRANT_DATA_NAME = "grant-main";
+
+export function createFileGrantStore(
+  readRepo: DefinitionRepository,
+  writeRepo: DefinitionRepository,
+  dataRepo: UnifiedDataRepository,
+): FileGrantStore {
+  return {
+    async queryFileGrants() {
+      const grantDataItems = await dataRepo.findAllForType(GRANT_MODEL_TYPE);
+
+      const fileGrants = new Map<
+        string,
+        { grant: Grant; modelId: string; instanceName: string }
+      >();
+      for (const { data, modelType, modelId } of grantDataItems) {
+        const content = await dataRepo.getContent(
+          modelType,
+          modelId,
+          data.name,
+        );
+        if (!content) continue;
+        let attrs: Record<string, unknown>;
+        try {
+          attrs = JSON.parse(new TextDecoder().decode(content)) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          continue;
+        }
+        const parsed = GrantSchema.safeParse(attrs);
+        if (parsed.success && isFileSource(parsed.data.source)) {
+          const modelName = data.tags["modelName"] ?? "";
+          fileGrants.set(modelName, {
+            grant: parsed.data,
+            modelId,
+            instanceName: modelName,
+          });
+        }
+      }
+      return fileGrants;
+    },
+
+    async ensureDefinition(instanceName: string) {
+      let def = await readRepo.findByName(
+        GRANT_MODEL_TYPE,
+        instanceName,
+      );
+      if (!def) {
+        def = Definition.create({
+          type: GRANT_MODEL_TYPE.normalized,
+          name: instanceName,
+        });
+        await writeRepo.save(GRANT_MODEL_TYPE, def);
+      }
+      return def.id;
+    },
+
+    async writeGrant(modelId: string, instanceName: string, grant: Grant) {
+      const { writeResource } = createResourceWriter(
+        dataRepo,
+        GRANT_MODEL_TYPE,
+        modelId,
+        grantModel.resources!,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        instanceName,
+      );
+      await writeResource(
+        "grant",
+        GRANT_DATA_NAME,
+        grant as unknown as Record<string, unknown>,
+      );
+    },
+  };
+}

--- a/src/domain/access/grant_file_reconciler_test.ts
+++ b/src/domain/access/grant_file_reconciler_test.ts
@@ -1,0 +1,369 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { Grant } from "../models/access/grant_model.ts";
+import type { GrantFileEntry } from "./grant_file.ts";
+import {
+  type FileGrantStore,
+  reconcileAllFileGrants,
+  reconcileFileGrants,
+} from "./grant_file_reconciler.ts";
+
+await initializeLogging({});
+
+function makeFileGrant(
+  overrides: Partial<Grant> & { source: string },
+): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+    state: "active",
+    createdBy: { kind: "user", id: "system" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMockStore(
+  existingGrants: Map<
+    string,
+    { grant: Grant; modelId: string; instanceName: string }
+  > = new Map(),
+): FileGrantStore & {
+  written: Map<string, Grant>;
+  definitions: Set<string>;
+} {
+  const written = new Map<string, Grant>();
+  const definitions = new Set<string>();
+  const grants = new Map(existingGrants);
+
+  return {
+    written,
+    definitions,
+    queryFileGrants() {
+      return Promise.resolve(new Map(grants));
+    },
+    ensureDefinition(instanceName: string) {
+      definitions.add(instanceName);
+      return Promise.resolve(`model-id-for-${instanceName}`);
+    },
+    writeGrant(
+      _modelId: string,
+      instanceName: string,
+      grant: Grant,
+    ) {
+      written.set(instanceName, grant);
+      grants.set(instanceName, { grant, modelId: _modelId, instanceName });
+      return Promise.resolve();
+    },
+  };
+}
+
+const entry1: GrantFileEntry = {
+  subject: { kind: "idp-group", name: "platform-eng" },
+  effect: "allow",
+  actions: ["run"],
+  resource: { kind: "workflow", pattern: "@acme/*" },
+};
+
+const entry2: GrantFileEntry = {
+  subject: { kind: "idp-group", name: "developers" },
+  effect: "allow",
+  actions: ["read"],
+  resource: { kind: "data", pattern: "*" },
+};
+
+Deno.test("reconcileFileGrants: creates grants for new entries", async () => {
+  const store = createMockStore();
+  const result = await reconcileFileGrants(
+    "platform-team.yaml",
+    [entry1],
+    store,
+  );
+
+  assertEquals(result.created, 1);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 0);
+  assertEquals(store.written.size, 1);
+
+  const grant = [...store.written.values()][0];
+  assertEquals(grant.subject, { kind: "idp-group", name: "platform-eng" });
+  assertEquals(grant.source, "file:platform-team.yaml");
+  assertEquals(grant.state, "active");
+});
+
+Deno.test("reconcileFileGrants: leaves unchanged grants untouched", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "idp-group", name: "platform-eng" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 0);
+  assertEquals(result.unchanged, 1);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("reconcileFileGrants: revokes grants removed from file", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "idp-group", name: "platform-eng" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+    [
+      "inst-2",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "idp-group", name: "developers" },
+          actions: ["read"],
+          resource: { kind: "data", pattern: "*" },
+        }),
+        modelId: "model-2",
+        instanceName: "inst-2",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 1);
+  assertEquals(result.unchanged, 1);
+
+  const revokedGrant = store.written.get("inst-2")!;
+  assertEquals(revokedGrant.state, "revoked");
+});
+
+Deno.test("reconcileFileGrants: reactivates revoked grant when re-added", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "idp-group", name: "platform-eng" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+          state: "revoked",
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.reactivated, 1);
+  assertEquals(result.unchanged, 0);
+
+  const reactivated = store.written.get("inst-1")!;
+  assertEquals(reactivated.state, "active");
+});
+
+Deno.test("reconcileFileGrants: does not touch grants from other files", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:other-team.yaml",
+          subject: { kind: "idp-group", name: "platform-eng" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileFileGrants("team.yaml", [], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(result.unchanged, 0);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("reconcileFileGrants: does not touch method or config grants", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "method",
+          subject: { kind: "user", name: "sarah" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+    [
+      "inst-2",
+      {
+        grant: makeFileGrant({
+          source: "config",
+          subject: { kind: "user", name: "admin" },
+          actions: ["admin"],
+          resource: { kind: "access", pattern: "*" },
+        }),
+        modelId: "model-2",
+        instanceName: "inst-2",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileFileGrants("team.yaml", [], store);
+
+  assertEquals(result.created, 0);
+  assertEquals(result.revoked, 0);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("reconcileFileGrants: matches with different action order", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "user", name: "adam" },
+          actions: ["read", "run"],
+          resource: { kind: "workflow", pattern: "*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const entry: GrantFileEntry = {
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run", "read"],
+    resource: { kind: "workflow", pattern: "*" },
+  };
+
+  const result = await reconcileFileGrants("team.yaml", [entry], store);
+
+  assertEquals(result.unchanged, 1);
+  assertEquals(result.created, 0);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("reconcileFileGrants: matches with trimmed condition whitespace", async () => {
+  const existing = new Map([
+    [
+      "inst-1",
+      {
+        grant: makeFileGrant({
+          source: "file:team.yaml",
+          subject: { kind: "user", name: "adam" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "*" },
+          condition: '  tags.env == "prod"  ',
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const entry: GrantFileEntry = {
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+    condition: 'tags.env == "prod"',
+  };
+
+  const result = await reconcileFileGrants("team.yaml", [entry], store);
+
+  assertEquals(result.unchanged, 1);
+  assertEquals(result.created, 0);
+  assertEquals(store.written.size, 0);
+});
+
+Deno.test("reconcileAllFileGrants: reconciles multiple files", async () => {
+  const store = createMockStore();
+  const fileEntries = new Map<string, GrantFileEntry[]>([
+    ["platform-team.yaml", [entry1]],
+    ["compliance.yaml", [entry2]],
+  ]);
+
+  const result = await reconcileAllFileGrants(fileEntries, store);
+
+  assertEquals(result.filesProcessed, 2);
+  assertEquals(result.totalCreated, 2);
+  assertEquals(result.totalRevoked, 0);
+  assertEquals(result.perFile.size, 2);
+  assertEquals(result.perFile.get("platform-team.yaml")!.created, 1);
+  assertEquals(result.perFile.get("compliance.yaml")!.created, 1);
+});
+
+Deno.test("reconcileAllFileGrants: empty file map is no-op", async () => {
+  const store = createMockStore();
+  const result = await reconcileAllFileGrants(new Map(), store);
+
+  assertEquals(result.filesProcessed, 0);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 0);
+});

--- a/src/domain/access/grant_file_reconciler_test.ts
+++ b/src/domain/access/grant_file_reconciler_test.ts
@@ -24,7 +24,6 @@ import type { GrantFileEntry } from "./grant_file.ts";
 import {
   type FileGrantStore,
   reconcileAllFileGrants,
-  reconcileFileGrants,
 } from "./grant_file_reconciler.ts";
 
 await initializeLogging({});
@@ -94,18 +93,17 @@ const entry2: GrantFileEntry = {
   resource: { kind: "data", pattern: "*" },
 };
 
-Deno.test("reconcileFileGrants: creates grants for new entries", async () => {
+Deno.test("reconcileAllFileGrants: creates grants for new entries", async () => {
   const store = createMockStore();
-  const result = await reconcileFileGrants(
-    "platform-team.yaml",
-    [entry1],
+  const result = await reconcileAllFileGrants(
+    new Map([["platform-team.yaml", [entry1]]]),
     store,
   );
 
-  assertEquals(result.created, 1);
-  assertEquals(result.revoked, 0);
-  assertEquals(result.reactivated, 0);
-  assertEquals(result.unchanged, 0);
+  assertEquals(result.totalCreated, 1);
+  assertEquals(result.totalRevoked, 0);
+  assertEquals(result.totalReactivated, 0);
+  assertEquals(result.totalUnchanged, 0);
   assertEquals(store.written.size, 1);
 
   const grant = [...store.written.values()][0];
@@ -114,10 +112,10 @@ Deno.test("reconcileFileGrants: creates grants for new entries", async () => {
   assertEquals(grant.state, "active");
 });
 
-Deno.test("reconcileFileGrants: leaves unchanged grants untouched", async () => {
+Deno.test("reconcileAllFileGrants: leaves unchanged grants untouched", async () => {
   const existing = new Map([
     [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -132,19 +130,22 @@ Deno.test("reconcileFileGrants: leaves unchanged grants untouched", async () => 
   ]);
   const store = createMockStore(existing);
 
-  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", [entry1]]]),
+    store,
+  );
 
-  assertEquals(result.created, 0);
-  assertEquals(result.revoked, 0);
-  assertEquals(result.reactivated, 0);
-  assertEquals(result.unchanged, 1);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 0);
+  assertEquals(result.totalReactivated, 0);
+  assertEquals(result.totalUnchanged, 1);
   assertEquals(store.written.size, 0);
 });
 
-Deno.test("reconcileFileGrants: revokes grants removed from file", async () => {
+Deno.test("reconcileAllFileGrants: revokes grants removed from file", async () => {
   const existing = new Map([
     [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -157,7 +158,7 @@ Deno.test("reconcileFileGrants: revokes grants removed from file", async () => {
       },
     ],
     [
-      "inst-2",
+      "model-2",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -172,20 +173,23 @@ Deno.test("reconcileFileGrants: revokes grants removed from file", async () => {
   ]);
   const store = createMockStore(existing);
 
-  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", [entry1]]]),
+    store,
+  );
 
-  assertEquals(result.created, 0);
-  assertEquals(result.revoked, 1);
-  assertEquals(result.unchanged, 1);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 1);
+  assertEquals(result.totalUnchanged, 1);
 
   const revokedGrant = store.written.get("inst-2")!;
   assertEquals(revokedGrant.state, "revoked");
 });
 
-Deno.test("reconcileFileGrants: reactivates revoked grant when re-added", async () => {
+Deno.test("reconcileAllFileGrants: reactivates revoked grant when re-added", async () => {
   const existing = new Map([
     [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -201,47 +205,24 @@ Deno.test("reconcileFileGrants: reactivates revoked grant when re-added", async 
   ]);
   const store = createMockStore(existing);
 
-  const result = await reconcileFileGrants("team.yaml", [entry1], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", [entry1]]]),
+    store,
+  );
 
-  assertEquals(result.created, 0);
-  assertEquals(result.revoked, 0);
-  assertEquals(result.reactivated, 1);
-  assertEquals(result.unchanged, 0);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 0);
+  assertEquals(result.totalReactivated, 1);
+  assertEquals(result.totalUnchanged, 0);
 
   const reactivated = store.written.get("inst-1")!;
   assertEquals(reactivated.state, "active");
 });
 
-Deno.test("reconcileFileGrants: does not touch grants from other files", async () => {
+Deno.test("reconcileAllFileGrants: does not touch method or config grants", async () => {
   const existing = new Map([
     [
-      "inst-1",
-      {
-        grant: makeFileGrant({
-          source: "file:other-team.yaml",
-          subject: { kind: "idp-group", name: "platform-eng" },
-          actions: ["run"],
-          resource: { kind: "workflow", pattern: "@acme/*" },
-        }),
-        modelId: "model-1",
-        instanceName: "inst-1",
-      },
-    ],
-  ]);
-  const store = createMockStore(existing);
-
-  const result = await reconcileFileGrants("team.yaml", [], store);
-
-  assertEquals(result.created, 0);
-  assertEquals(result.revoked, 0);
-  assertEquals(result.unchanged, 0);
-  assertEquals(store.written.size, 0);
-});
-
-Deno.test("reconcileFileGrants: does not touch method or config grants", async () => {
-  const existing = new Map([
-    [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "method",
@@ -254,7 +235,7 @@ Deno.test("reconcileFileGrants: does not touch method or config grants", async (
       },
     ],
     [
-      "inst-2",
+      "model-2",
       {
         grant: makeFileGrant({
           source: "config",
@@ -269,17 +250,20 @@ Deno.test("reconcileFileGrants: does not touch method or config grants", async (
   ]);
   const store = createMockStore(existing);
 
-  const result = await reconcileFileGrants("team.yaml", [], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", []]]),
+    store,
+  );
 
-  assertEquals(result.created, 0);
-  assertEquals(result.revoked, 0);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 0);
   assertEquals(store.written.size, 0);
 });
 
-Deno.test("reconcileFileGrants: matches with different action order", async () => {
+Deno.test("reconcileAllFileGrants: matches with different action order", async () => {
   const existing = new Map([
     [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -301,17 +285,20 @@ Deno.test("reconcileFileGrants: matches with different action order", async () =
     resource: { kind: "workflow", pattern: "*" },
   };
 
-  const result = await reconcileFileGrants("team.yaml", [entry], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", [entry]]]),
+    store,
+  );
 
-  assertEquals(result.unchanged, 1);
-  assertEquals(result.created, 0);
+  assertEquals(result.totalUnchanged, 1);
+  assertEquals(result.totalCreated, 0);
   assertEquals(store.written.size, 0);
 });
 
-Deno.test("reconcileFileGrants: matches with trimmed condition whitespace", async () => {
+Deno.test("reconcileAllFileGrants: matches with trimmed condition whitespace", async () => {
   const existing = new Map([
     [
-      "inst-1",
+      "model-1",
       {
         grant: makeFileGrant({
           source: "file:team.yaml",
@@ -335,10 +322,13 @@ Deno.test("reconcileFileGrants: matches with trimmed condition whitespace", asyn
     condition: 'tags.env == "prod"',
   };
 
-  const result = await reconcileFileGrants("team.yaml", [entry], store);
+  const result = await reconcileAllFileGrants(
+    new Map([["team.yaml", [entry]]]),
+    store,
+  );
 
-  assertEquals(result.unchanged, 1);
-  assertEquals(result.created, 0);
+  assertEquals(result.totalUnchanged, 1);
+  assertEquals(result.totalCreated, 0);
   assertEquals(store.written.size, 0);
 });
 
@@ -366,4 +356,83 @@ Deno.test("reconcileAllFileGrants: empty file map is no-op", async () => {
   assertEquals(result.filesProcessed, 0);
   assertEquals(result.totalCreated, 0);
   assertEquals(result.totalRevoked, 0);
+});
+
+Deno.test("reconcileAllFileGrants: revokes grants from deleted files", async () => {
+  const existing = new Map([
+    [
+      "model-1",
+      {
+        grant: makeFileGrant({
+          source: "file:deleted.yaml",
+          subject: { kind: "idp-group", name: "interns" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const result = await reconcileAllFileGrants(new Map(), store);
+
+  assertEquals(result.totalRevoked, 1);
+  assertEquals(result.totalCreated, 0);
+
+  const revokedGrant = store.written.get("inst-1")!;
+  assertEquals(revokedGrant.state, "revoked");
+});
+
+Deno.test("reconcileAllFileGrants: does not touch other files' grants when one is deleted", async () => {
+  const existing = new Map([
+    [
+      "model-1",
+      {
+        grant: makeFileGrant({
+          source: "file:keep.yaml",
+          subject: { kind: "user", name: "adam" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "*" },
+        }),
+        modelId: "model-1",
+        instanceName: "inst-1",
+      },
+    ],
+    [
+      "model-2",
+      {
+        grant: makeFileGrant({
+          source: "file:deleted.yaml",
+          subject: { kind: "idp-group", name: "interns" },
+          actions: ["run"],
+          resource: { kind: "workflow", pattern: "@acme/*" },
+        }),
+        modelId: "model-2",
+        instanceName: "inst-2",
+      },
+    ],
+  ]);
+  const store = createMockStore(existing);
+
+  const keepEntry: GrantFileEntry = {
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "*" },
+  };
+
+  const result = await reconcileAllFileGrants(
+    new Map([["keep.yaml", [keepEntry]]]),
+    store,
+  );
+
+  assertEquals(result.totalUnchanged, 1);
+  assertEquals(result.totalRevoked, 1);
+  assertEquals(result.totalCreated, 0);
+
+  const revokedGrant = store.written.get("inst-2")!;
+  assertEquals(revokedGrant.state, "revoked");
+  assertEquals(store.written.has("inst-1"), false);
 });

--- a/src/domain/access/grant_file_test.ts
+++ b/src/domain/access/grant_file_test.ts
@@ -1,0 +1,371 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { collectErrors, parseGrantFile, readGrantFiles } from "./grant_file.ts";
+
+Deno.test("parseGrantFile: parses valid grant file", () => {
+  const content = `
+grants:
+  - subject: "idp-group:platform-eng"
+    effect: allow
+    actions: [run]
+    resource: "workflow:@acme/*"
+`;
+  const result = parseGrantFile("platform-team.yaml", content);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].subject, {
+    kind: "idp-group",
+    name: "platform-eng",
+  });
+  assertEquals(result.entries[0].effect, "allow");
+  assertEquals(result.entries[0].actions, ["run"]);
+  assertEquals(result.entries[0].resource, {
+    kind: "workflow",
+    pattern: "@acme/*",
+  });
+});
+
+Deno.test("parseGrantFile: parses multiple entries", () => {
+  const content = `
+grants:
+  - subject: "idp-group:developers"
+    effect: allow
+    actions: [read]
+    resource: "data:*"
+  - subject: "idp-group:developers"
+    effect: deny
+    actions: [read]
+    resource: "data:@acme/secrets-*"
+`;
+  const result = parseGrantFile("compliance.yaml", content);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries.length, 2);
+  assertEquals(result.entries[0].effect, "allow");
+  assertEquals(result.entries[1].effect, "deny");
+});
+
+Deno.test("parseGrantFile: parses entry with condition", () => {
+  const content = `
+grants:
+  - subject: "idp-group:platform-eng"
+    effect: allow
+    actions: [run]
+    resource: "workflow:@acme/*"
+    condition: 'tags.env == "staging"'
+`;
+  const result = parseGrantFile("staging.yaml", content);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].condition, 'tags.env == "staging"');
+});
+
+Deno.test("parseGrantFile: rejects invalid YAML syntax", () => {
+  const content = `grants:\n  - subject: [invalid yaml`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length, 1);
+  assertStringIncludes(result.errors[0].message, "Invalid YAML syntax");
+});
+
+Deno.test("parseGrantFile: rejects missing grants key", () => {
+  const content = `rules:\n  - subject: "user:adam"`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length >= 1, true);
+});
+
+Deno.test("parseGrantFile: rejects empty grants array", () => {
+  const content = `grants: []`;
+  const result = parseGrantFile("empty.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length >= 1, true);
+});
+
+Deno.test("parseGrantFile: rejects invalid subject format", () => {
+  const content = `
+grants:
+  - subject: "badformat"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length, 1);
+  assertStringIncludes(result.errors[0].message, "subject");
+  assertEquals(result.errors[0].entryIndex, 0);
+});
+
+Deno.test("parseGrantFile: rejects invalid resource selector", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "badkind:*"
+`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length, 1);
+  assertStringIncludes(result.errors[0].message, "resource kind");
+  assertEquals(result.errors[0].entryIndex, 0);
+});
+
+Deno.test("parseGrantFile: rejects invalid effect", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: maybe
+    actions: [run]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length >= 1, true);
+});
+
+Deno.test("parseGrantFile: rejects invalid action", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [destroy]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("bad.yaml", content);
+  assertEquals(result.entries.length, 0);
+  assertEquals(result.errors.length >= 1, true);
+});
+
+Deno.test("parseGrantFile: detects duplicate identity tuples", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("dups.yaml", content);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.errors.length, 1);
+  assertStringIncludes(result.errors[0].message, "Duplicate");
+  assertEquals(result.errors[0].entryIndex, 1);
+});
+
+Deno.test("parseGrantFile: duplicate detection normalizes action order", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [read, run]
+    resource: "workflow:*"
+  - subject: "user:adam"
+    effect: allow
+    actions: [run, read]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("dups.yaml", content);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.errors.length, 1);
+  assertStringIncludes(result.errors[0].message, "Duplicate");
+});
+
+Deno.test("parseGrantFile: duplicate detection trims condition whitespace", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+    condition: 'tags.env == "prod"'
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+    condition: '  tags.env == "prod"  '
+`;
+  const result = parseGrantFile("dups.yaml", content);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.errors.length, 1);
+});
+
+Deno.test("parseGrantFile: different effects are not duplicates", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+  - subject: "user:adam"
+    effect: deny
+    actions: [run]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("not-dups.yaml", content);
+  assertEquals(result.entries.length, 2);
+  assertEquals(result.errors.length, 0);
+});
+
+Deno.test("parseGrantFile: valid and invalid entries in same file", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+  - subject: "badformat"
+    effect: allow
+    actions: [run]
+    resource: "workflow:*"
+`;
+  const result = parseGrantFile("mixed.yaml", content);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.errors.length, 1);
+  assertEquals(result.errors[0].entryIndex, 1);
+});
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+Deno.test("readGrantFiles: reads .yaml and .yml files", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(grantsDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.writeTextFile(
+      join(grantsDir, "other.yml"),
+      `grants:\n  - subject: "user:sarah"\n    effect: allow\n    actions: [read]\n    resource: "data:*"`,
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 2);
+    assertEquals(results.has("team.yaml"), true);
+    assertEquals(results.has("other.yml"), true);
+  });
+});
+
+Deno.test("readGrantFiles: ignores non-YAML files", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+    await Deno.writeTextFile(
+      join(grantsDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.writeTextFile(join(grantsDir, "README.md"), "# Grants");
+    await Deno.writeTextFile(join(grantsDir, ".gitkeep"), "");
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 1);
+    assertEquals(results.has("team.yaml"), true);
+  });
+});
+
+Deno.test("readGrantFiles: ignores subdirectories", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(join(grantsDir, "subdir"));
+    await Deno.writeTextFile(
+      join(grantsDir, "team.yaml"),
+      `grants:\n  - subject: "user:adam"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+    await Deno.writeTextFile(
+      join(grantsDir, "subdir", "nested.yaml"),
+      `grants:\n  - subject: "user:sarah"\n    effect: allow\n    actions: [run]\n    resource: "workflow:*"`,
+    );
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 1);
+    assertEquals(results.has("team.yaml"), true);
+  });
+});
+
+Deno.test("readGrantFiles: returns empty map when directory does not exist", async () => {
+  const results = await readGrantFiles("/nonexistent/grants");
+  assertEquals(results.size, 0);
+});
+
+Deno.test("readGrantFiles: returns empty map for empty directory", async () => {
+  await withTempDir(async (dir) => {
+    const grantsDir = join(dir, "grants");
+    await ensureDir(grantsDir);
+
+    const results = await readGrantFiles(grantsDir);
+    assertEquals(results.size, 0);
+  });
+});
+
+Deno.test("collectErrors: aggregates errors from all files", () => {
+  const results = new Map([
+    [
+      "a.yaml",
+      {
+        entries: [],
+        errors: [{ filename: "a.yaml", message: "err1" }],
+      },
+    ],
+    [
+      "b.yaml",
+      {
+        entries: [
+          {
+            subject: { kind: "user" as const, name: "x" },
+            effect: "allow" as const,
+            actions: ["run" as const],
+            resource: { kind: "workflow" as const, pattern: "*" },
+          },
+        ],
+        errors: [],
+      },
+    ],
+    [
+      "c.yaml",
+      {
+        entries: [],
+        errors: [
+          { filename: "c.yaml", entryIndex: 0, message: "err2" },
+          { filename: "c.yaml", entryIndex: 1, message: "err3" },
+        ],
+      },
+    ],
+  ]);
+  const errors = collectErrors(results);
+  assertEquals(errors.length, 3);
+});

--- a/src/domain/access/grant_source.ts
+++ b/src/domain/access/grant_source.ts
@@ -19,18 +19,21 @@
 
 import { z } from "zod";
 
-const FIXED_SOURCES = ["method", "file", "config"] as const;
+const FIXED_SOURCES = ["method", "config"] as const;
+
+const PREFIXED_SOURCES = ["file:", "extension:"] as const;
 
 export const GrantSourceSchema = z.string().min(1).refine(
   (value) => {
     if ((FIXED_SOURCES as readonly string[]).includes(value)) {
       return true;
     }
-    return value.startsWith("extension:");
+    return PREFIXED_SOURCES.some((prefix) => value.startsWith(prefix)) &&
+      !PREFIXED_SOURCES.some((prefix) => value === prefix);
   },
   {
     message:
-      'Grant source must be "method", "file", "config", or "extension:<name>"',
+      'Grant source must be "method", "config", "file:<filename>", or "extension:<name>"',
   },
 );
 
@@ -40,8 +43,21 @@ export function parseGrantSource(value: string): GrantSource {
   const result = GrantSourceSchema.safeParse(value);
   if (!result.success) {
     throw new Error(
-      `Invalid grant source "${value}": must be "method", "file", "config", or "extension:<name>"`,
+      `Invalid grant source "${value}": must be "method", "config", "file:<filename>", or "extension:<name>"`,
     );
   }
   return result.data;
+}
+
+export function isFileSource(source: string): boolean {
+  return source.startsWith("file:");
+}
+
+export function parseFileSourceFilename(source: string): string {
+  if (!isFileSource(source)) {
+    throw new Error(
+      `Cannot parse filename from non-file source "${source}"`,
+    );
+  }
+  return source.slice("file:".length);
 }

--- a/src/domain/access/grant_source_test.ts
+++ b/src/domain/access/grant_source_test.ts
@@ -1,0 +1,109 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  GrantSourceSchema,
+  isFileSource,
+  parseFileSourceFilename,
+  parseGrantSource,
+} from "./grant_source.ts";
+
+Deno.test("GrantSourceSchema: accepts method", () => {
+  assertEquals(GrantSourceSchema.safeParse("method").success, true);
+});
+
+Deno.test("GrantSourceSchema: accepts config", () => {
+  assertEquals(GrantSourceSchema.safeParse("config").success, true);
+});
+
+Deno.test("GrantSourceSchema: accepts file:<filename>", () => {
+  assertEquals(
+    GrantSourceSchema.safeParse("file:platform-team.yaml").success,
+    true,
+  );
+});
+
+Deno.test("GrantSourceSchema: rejects bare file", () => {
+  assertEquals(GrantSourceSchema.safeParse("file").success, false);
+});
+
+Deno.test("GrantSourceSchema: rejects bare file:", () => {
+  assertEquals(GrantSourceSchema.safeParse("file:").success, false);
+});
+
+Deno.test("GrantSourceSchema: accepts extension:<name>", () => {
+  assertEquals(
+    GrantSourceSchema.safeParse("extension:my-ext").success,
+    true,
+  );
+});
+
+Deno.test("GrantSourceSchema: rejects bare extension:", () => {
+  assertEquals(GrantSourceSchema.safeParse("extension:").success, false);
+});
+
+Deno.test("GrantSourceSchema: rejects unknown source", () => {
+  assertEquals(GrantSourceSchema.safeParse("other").success, false);
+});
+
+Deno.test("GrantSourceSchema: rejects empty string", () => {
+  assertEquals(GrantSourceSchema.safeParse("").success, false);
+});
+
+Deno.test("parseGrantSource: returns valid source", () => {
+  assertEquals(parseGrantSource("method"), "method");
+  assertEquals(
+    parseGrantSource("file:compliance.yaml"),
+    "file:compliance.yaml",
+  );
+});
+
+Deno.test("parseGrantSource: throws on invalid source", () => {
+  assertThrows(
+    () => parseGrantSource("file"),
+    Error,
+    "file:<filename>",
+  );
+});
+
+Deno.test("isFileSource: returns true for file: prefix", () => {
+  assertEquals(isFileSource("file:team.yaml"), true);
+});
+
+Deno.test("isFileSource: returns false for other sources", () => {
+  assertEquals(isFileSource("method"), false);
+  assertEquals(isFileSource("config"), false);
+  assertEquals(isFileSource("extension:foo"), false);
+});
+
+Deno.test("parseFileSourceFilename: extracts filename", () => {
+  assertEquals(
+    parseFileSourceFilename("file:platform-team.yaml"),
+    "platform-team.yaml",
+  );
+});
+
+Deno.test("parseFileSourceFilename: throws for non-file source", () => {
+  assertThrows(
+    () => parseFileSourceFilename("method"),
+    Error,
+    "non-file source",
+  );
+});

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -37,8 +37,28 @@ export { type PrincipalContext } from "./principal_context.ts";
 export { type Effect, EffectSchema } from "./effect.ts";
 
 export {
+  collectErrors,
+  type ConditionValidator,
+  type GrantFileEntry,
+  type GrantFileError,
+  type GrantFileParseResult,
+  parseGrantFile,
+  readGrantFiles,
+} from "./grant_file.ts";
+
+export {
+  createFileGrantStore,
+  type FileGrantStore,
+  reconcileAllFileGrants,
+  type ReconcileAllResult,
+  reconcileFileGrants,
+} from "./grant_file_reconciler.ts";
+
+export {
   type GrantSource,
   GrantSourceSchema,
+  isFileSource,
+  parseFileSourceFilename,
   parseGrantSource,
 } from "./grant_source.ts";
 

--- a/src/domain/access/mod.ts
+++ b/src/domain/access/mod.ts
@@ -39,6 +39,7 @@ export { type Effect, EffectSchema } from "./effect.ts";
 export {
   collectErrors,
   type ConditionValidator,
+  entryIdentityKey,
   type GrantFileEntry,
   type GrantFileError,
   type GrantFileParseResult,
@@ -51,7 +52,6 @@ export {
   type FileGrantStore,
   reconcileAllFileGrants,
   type ReconcileAllResult,
-  reconcileFileGrants,
 } from "./grant_file_reconciler.ts";
 
 export {

--- a/src/domain/models/access/grant_model_test.ts
+++ b/src/domain/models/access/grant_model_test.ts
@@ -183,7 +183,14 @@ Deno.test("create: schema rejects invalid source value", () => {
 });
 
 Deno.test("create: schema accepts valid source values", () => {
-  for (const source of ["method", "file", "config", "extension:my-ext"]) {
+  for (
+    const source of [
+      "method",
+      "config",
+      "file:test.yaml",
+      "extension:my-ext",
+    ]
+  ) {
     const result = GrantSourceSchema.safeParse(source);
     assertEquals(result.success, true, `Expected "${source}" to be valid`);
   }
@@ -192,13 +199,13 @@ Deno.test("create: schema accepts valid source values", () => {
 Deno.test("create: source field is set at creation and persisted", async () => {
   const { context, store } = createTestContext();
   await grantModel.methods.create.execute(
-    { ...VALID_CREATE_ARGS, source: "file" },
+    { ...VALID_CREATE_ARGS, source: "file:test.yaml" },
     context,
   );
   const grant = store.get("grant-main") as unknown as Grant;
-  assertEquals(grant.source, "file");
+  assertEquals(grant.source, "file:test.yaml");
 
   await grantModel.methods.revoke.execute({}, context);
   const revoked = store.get("grant-main") as unknown as Grant;
-  assertEquals(revoked.source, "file");
+  assertEquals(revoked.source, "file:test.yaml");
 });

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -2046,7 +2046,7 @@ export const SwampAudit: Plugin = async ({ directory }) => {
     repoPath: RepoPath,
   ): Promise<void> {
     // Top-level directories for source-of-truth files
-    const topLevelDirs = ["models", "workflows", "vaults"];
+    const topLevelDirs = ["models", "workflows", "vaults", "grants"];
     for (const dir of topLevelDirs) {
       await ensureDir(join(repoPath.value, dir));
     }

--- a/src/presentation/renderers/access_reload.ts
+++ b/src/presentation/renderers/access_reload.ts
@@ -20,17 +20,9 @@
 import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type { AccessReloadFileResult } from "../../serve/protocol.ts";
 
 const logger = getSwampLogger(["access", "reload"]);
-
-export interface AccessReloadFileResult {
-  filename: string;
-  entryCount: number;
-  created: number;
-  revoked: number;
-  reactivated: number;
-  unchanged: number;
-}
 
 export interface AccessReloadResult {
   success: boolean;
@@ -48,8 +40,7 @@ export interface AccessReloadRenderer {
 class LogAccessReloadRenderer implements AccessReloadRenderer {
   render(result: AccessReloadResult): void {
     if (!result.success && result.errors) {
-      logger
-        .error`Reconciliation aborted. Current policy unchanged.`;
+      logger.error`Reconciliation aborted. Current policy unchanged.`;
       for (const error of result.errors) {
         logger.error`${error}`;
       }
@@ -71,12 +62,16 @@ class LogAccessReloadRenderer implements AccessReloadRenderer {
         (s, f) => s + f.revoked,
         0,
       );
+      const totalReactivated = result.fileResults.reduce(
+        (s, f) => s + f.reactivated,
+        0,
+      );
       const totalUnchanged = result.fileResults.reduce(
         (s, f) => s + f.unchanged,
         0,
       );
       logger
-        .info`Reconciling files: ${totalCreated} created, ${totalRevoked} revoked, ${totalUnchanged} unchanged`;
+        .info`Reconciling files: ${totalCreated} created, ${totalRevoked} revoked, ${totalReactivated} reactivated, ${totalUnchanged} unchanged`;
     }
 
     logger

--- a/src/presentation/renderers/access_reload.ts
+++ b/src/presentation/renderers/access_reload.ts
@@ -23,10 +23,22 @@ import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 
 const logger = getSwampLogger(["access", "reload"]);
 
+export interface AccessReloadFileResult {
+  filename: string;
+  entryCount: number;
+  created: number;
+  revoked: number;
+  reactivated: number;
+  unchanged: number;
+}
+
 export interface AccessReloadResult {
   success: boolean;
   grantCount: number;
   groupCount: number;
+  filesProcessed?: number;
+  fileResults?: AccessReloadFileResult[];
+  errors?: string[];
 }
 
 export interface AccessReloadRenderer {
@@ -35,6 +47,38 @@ export interface AccessReloadRenderer {
 
 class LogAccessReloadRenderer implements AccessReloadRenderer {
   render(result: AccessReloadResult): void {
+    if (!result.success && result.errors) {
+      logger
+        .error`Reconciliation aborted. Current policy unchanged.`;
+      for (const error of result.errors) {
+        logger.error`${error}`;
+      }
+      return;
+    }
+
+    if (result.fileResults && result.fileResults.length > 0) {
+      for (const fr of result.fileResults) {
+        logger
+          .info`Reading grants/${fr.filename}... ${fr.entryCount} grant(s)`;
+      }
+      logger.info`Validating... ok`;
+
+      const totalCreated = result.fileResults.reduce(
+        (s, f) => s + f.created,
+        0,
+      );
+      const totalRevoked = result.fileResults.reduce(
+        (s, f) => s + f.revoked,
+        0,
+      );
+      const totalUnchanged = result.fileResults.reduce(
+        (s, f) => s + f.unchanged,
+        0,
+      );
+      logger
+        .info`Reconciling files: ${totalCreated} created, ${totalRevoked} revoked, ${totalUnchanged} unchanged`;
+    }
+
     logger
       .info`Policy snapshot reloaded: ${result.grantCount} grant(s), ${result.groupCount} group(s)`;
   }
@@ -42,17 +86,21 @@ class LogAccessReloadRenderer implements AccessReloadRenderer {
 
 class JsonAccessReloadRenderer implements AccessReloadRenderer {
   render(result: AccessReloadResult): void {
-    writeOutput(
-      JSON.stringify(
-        {
-          success: result.success,
-          grantCount: result.grantCount,
-          groupCount: result.groupCount,
-        },
-        null,
-        2,
-      ),
-    );
+    const output: Record<string, unknown> = {
+      success: result.success,
+      grantCount: result.grantCount,
+      groupCount: result.groupCount,
+    };
+    if (result.filesProcessed !== undefined) {
+      output.filesProcessed = result.filesProcessed;
+    }
+    if (result.fileResults) {
+      output.fileResults = result.fileResults;
+    }
+    if (result.errors) {
+      output.errors = result.errors;
+    }
+    writeOutput(JSON.stringify(output, null, 2));
   }
 }
 

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -21,12 +21,25 @@
  * Access-control request handlers (access.* verbs).
  */
 
+import { join } from "@std/path";
 import type {
   AccessCanIPayload,
   AccessCheckPayload,
   AccessGrantListPayload,
   AccessGroupListPayload,
+  AccessReloadFileResult,
 } from "../protocol.ts";
+import {
+  collectErrors,
+  type GrantFileError,
+  readGrantFiles,
+} from "../../domain/access/grant_file.ts";
+import {
+  createFileGrantStore,
+  reconcileAllFileGrants,
+} from "../../domain/access/grant_file_reconciler.ts";
+import { validateGrantCondition } from "../../infrastructure/cel/grant_condition_environment.ts";
+import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -364,6 +377,15 @@ export function handleAccessCanI(
   }
 }
 
+function formatGrantFileErrors(errors: GrantFileError[]): string[] {
+  return errors.map((e) => {
+    const loc = e.entryIndex !== undefined
+      ? `${e.filename} entry ${e.entryIndex + 1}`
+      : e.filename;
+    return `${loc}: ${e.message}`;
+  });
+}
+
 export async function handleAccessReload(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -389,17 +411,90 @@ export async function handleAccessReload(
       return;
     }
 
-    const result = await ctx.policySnapshotLoader.loadWithCounts();
+    const grantsDir = join(ctx.repoDir, "grants");
+    const fileResults = await readGrantFiles(grantsDir, validateGrantCondition);
+    const allErrors = collectErrors(fileResults);
 
-    send(socket, {
-      type: "access.reload",
-      id: requestId,
-      payload: {
-        success: true,
-        grantCount: result.grantCount,
-        groupCount: result.groupCount,
-      },
-    });
+    if (allErrors.length > 0) {
+      send(socket, {
+        type: "access.reload",
+        id: requestId,
+        payload: {
+          success: false,
+          grantCount: 0,
+          groupCount: 0,
+          errors: formatGrantFileErrors(allErrors),
+        },
+      });
+      return;
+    }
+
+    if (fileResults.size > 0) {
+      const validEntries = new Map<
+        string,
+        import("../../domain/access/grant_file.ts").GrantFileEntry[]
+      >();
+      for (const [filename, result] of fileResults) {
+        validEntries.set(filename, result.entries);
+      }
+
+      const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
+      const autoDefRepo = new YamlDefinitionRepository(
+        ctx.repoDir,
+        undefined,
+        autoDefDir,
+        false,
+      );
+      const fileGrantStore = createFileGrantStore(
+        ctx.repoContext.definitionRepo,
+        autoDefRepo,
+        ctx.repoContext.unifiedDataRepo,
+      );
+
+      const reconcileResult = await reconcileAllFileGrants(
+        validEntries,
+        fileGrantStore,
+      );
+
+      const fileResultList: AccessReloadFileResult[] = [];
+      for (const [filename, result] of fileResults) {
+        const perFile = reconcileResult.perFile.get(filename);
+        fileResultList.push({
+          filename,
+          entryCount: result.entries.length,
+          created: perFile?.created ?? 0,
+          revoked: perFile?.revoked ?? 0,
+          reactivated: perFile?.reactivated ?? 0,
+          unchanged: perFile?.unchanged ?? 0,
+        });
+      }
+
+      const snapshotResult = await ctx.policySnapshotLoader.loadWithCounts();
+
+      send(socket, {
+        type: "access.reload",
+        id: requestId,
+        payload: {
+          success: true,
+          grantCount: snapshotResult.grantCount,
+          groupCount: snapshotResult.groupCount,
+          filesProcessed: reconcileResult.filesProcessed,
+          fileResults: fileResultList,
+        },
+      });
+    } else {
+      const result = await ctx.policySnapshotLoader.loadWithCounts();
+
+      send(socket, {
+        type: "access.reload",
+        id: requestId,
+        payload: {
+          success: true,
+          grantCount: result.grantCount,
+          groupCount: result.groupCount,
+        },
+      });
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "access_reload_failed", message);

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -429,72 +429,58 @@ export async function handleAccessReload(
       return;
     }
 
-    if (fileResults.size > 0) {
-      const validEntries = new Map<
-        string,
-        import("../../domain/access/grant_file.ts").GrantFileEntry[]
-      >();
-      for (const [filename, result] of fileResults) {
-        validEntries.set(filename, result.entries);
-      }
+    const validEntries = new Map<
+      string,
+      import("../../domain/access/grant_file.ts").GrantFileEntry[]
+    >();
+    for (const [filename, result] of fileResults) {
+      validEntries.set(filename, result.entries);
+    }
 
-      const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
-      const autoDefRepo = new YamlDefinitionRepository(
-        ctx.repoDir,
-        undefined,
-        autoDefDir,
-        false,
-      );
-      const fileGrantStore = createFileGrantStore(
-        ctx.repoContext.definitionRepo,
-        autoDefRepo,
-        ctx.repoContext.unifiedDataRepo,
-      );
+    const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
+    const autoDefRepo = new YamlDefinitionRepository(
+      ctx.repoDir,
+      undefined,
+      autoDefDir,
+      false,
+    );
+    const fileGrantStore = createFileGrantStore(
+      ctx.repoContext.definitionRepo,
+      autoDefRepo,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
-      const reconcileResult = await reconcileAllFileGrants(
-        validEntries,
-        fileGrantStore,
-      );
+    const reconcileResult = await reconcileAllFileGrants(
+      validEntries,
+      fileGrantStore,
+    );
 
-      const fileResultList: AccessReloadFileResult[] = [];
-      for (const [filename, result] of fileResults) {
-        const perFile = reconcileResult.perFile.get(filename);
-        fileResultList.push({
-          filename,
-          entryCount: result.entries.length,
-          created: perFile?.created ?? 0,
-          revoked: perFile?.revoked ?? 0,
-          reactivated: perFile?.reactivated ?? 0,
-          unchanged: perFile?.unchanged ?? 0,
-        });
-      }
-
-      const snapshotResult = await ctx.policySnapshotLoader.loadWithCounts();
-
-      send(socket, {
-        type: "access.reload",
-        id: requestId,
-        payload: {
-          success: true,
-          grantCount: snapshotResult.grantCount,
-          groupCount: snapshotResult.groupCount,
-          filesProcessed: reconcileResult.filesProcessed,
-          fileResults: fileResultList,
-        },
-      });
-    } else {
-      const result = await ctx.policySnapshotLoader.loadWithCounts();
-
-      send(socket, {
-        type: "access.reload",
-        id: requestId,
-        payload: {
-          success: true,
-          grantCount: result.grantCount,
-          groupCount: result.groupCount,
-        },
+    const fileResultList: AccessReloadFileResult[] = [];
+    for (const [filename, perFile] of reconcileResult.perFile) {
+      const parsed = fileResults.get(filename);
+      fileResultList.push({
+        filename,
+        entryCount: parsed?.entries.length ?? 0,
+        created: perFile.created,
+        revoked: perFile.revoked,
+        reactivated: perFile.reactivated,
+        unchanged: perFile.unchanged,
       });
     }
+
+    const snapshotResult = await ctx.policySnapshotLoader.loadWithCounts();
+
+    send(socket, {
+      type: "access.reload",
+      id: requestId,
+      payload: {
+        success: true,
+        grantCount: snapshotResult.grantCount,
+        groupCount: snapshotResult.groupCount,
+        filesProcessed: reconcileResult.filesProcessed,
+        fileResults: fileResultList.length > 0 ? fileResultList : undefined,
+      },
+    });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "access_reload_failed", message);

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -594,10 +594,22 @@ export interface AccessCanIResponse {
   decisions: AccessCanIDecision[];
 }
 
+export interface AccessReloadFileResult {
+  filename: string;
+  entryCount: number;
+  created: number;
+  revoked: number;
+  reactivated: number;
+  unchanged: number;
+}
+
 export interface AccessReloadResponse {
   success: boolean;
   grantCount: number;
   groupCount: number;
+  filesProcessed?: number;
+  fileResults?: AccessReloadFileResult[];
+  errors?: string[];
 }
 
 export interface DataGetResponse {


### PR DESCRIPTION
## Summary

- Add a `grants/` directory convention where admins author YAML grant definitions, check them into git, and apply them to a running `swamp serve` instance
- On serve startup, validate all files and refuse to start on errors; on `swamp access reload`, validate-then-reconcile file-sourced grants against stored grants, rebuild the policy snapshot, and return a full reconciliation summary
- File grants coexist with CLI (`source: method`) and config (`source: config`) grants — the reconciler only touches `source: file:*` grants
- `GrantSourceSchema` updated: bare `"file"` rejected, only `"file:<filename>"` accepted (mirrors `"extension:<name>"`)
- `repo init` now creates `grants/` alongside `models/`, `workflows/`, `vaults/`

### New domain modules

| Module | Purpose |
|--------|---------|
| `grant_file.ts` | YAML parser with entry validation (subject, resource selector, CEL condition via injected `ConditionValidator`), intra-file duplicate detection |
| `grant_file_reconciler.ts` | Desired-vs-actual diff per file following the `materializeAdmins` pattern — create, revoke, skip unchanged, reactivate |
| `grant_source.ts` | `isFileSource()`, `parseFileSourceFilename()` helpers |

### Key design decisions

- **Atomic reload**: all files validate before any reconciliation begins — if file A is valid and file B is invalid, neither is reconciled
- **Identity matching**: tuple `(subject, effect, sorted-actions, resource, trimmed-condition)` for stable comparison across action order and whitespace
- **DDD layer compliance**: CEL condition validation injected via `ConditionValidator` interface rather than importing from infrastructure
- **File extensions**: both `.yaml` and `.yml` accepted, all other files ignored, flat-only (no subdirectory recursion)

Closes swamp-club#1037

## Test Plan

- 46 new unit tests across 3 test files (grant_source, grant_file, grant_file_reconciler)
- All 182 access domain tests pass (including existing materializer, policy snapshot, grant model tests)
- DDD layer rules ratchet passes (no new domain→infrastructure violations)
- Full test suite: 8623 passed, 1 failed (pre-existing SIGINT handler flake)
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)