### PR TITLE
fix(extensions): warn instead of fatal abort on yanked extension during repo upgrade (swamp-club#1045)

### DIFF
--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -324,22 +324,11 @@ export async function* repoUpgrade(
       // idempotent: on repos with no legacy layout and no missing
       // files, it's a no-op.
       if (input.extensionInstallDeps) {
-        const failures: Array<{ name: string; error: string }> = [];
         try {
           for await (
             const event of extensionInstall(ctx, input.extensionInstallDeps)
           ) {
             yield { kind: "extensions", event };
-            if (event.kind === "completed") {
-              for (const entry of event.data.entries) {
-                if (entry.status === "failed") {
-                  failures.push({
-                    name: entry.name,
-                    error: entry.error ?? "unknown error",
-                  });
-                }
-              }
-            }
           }
         } catch (error) {
           // extensionInstall catches per-entry failures internally;
@@ -352,21 +341,6 @@ export async function* repoUpgrade(
             kind: "error",
             error: validationFailed(
               error instanceof Error ? error.message : String(error),
-            ),
-          };
-          return;
-        }
-        if (failures.length > 0) {
-          const list = failures
-            .map((f) => `  - ${f.name}: ${f.error}`)
-            .join("\n");
-          yield {
-            kind: "error",
-            error: validationFailed(
-              `Extension migration failed for ${failures.length} ` +
-                `extension(s). Legacy files have been preserved. ` +
-                `Re-run 'swamp repo upgrade' once the issue is ` +
-                `resolved (usually registry access):\n${list}`,
             ),
           };
           return;

--- a/src/libswamp/repo/init_test.ts
+++ b/src/libswamp/repo/init_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -28,6 +29,7 @@ import {
   type RepoUpgradeDeps,
   type RepoUpgradeEvent,
 } from "./init.ts";
+import { LockfileRepository } from "../../infrastructure/persistence/lockfile_repository.ts";
 
 function makeInitDeps(
   overrides: Partial<RepoInitDeps> = {},
@@ -261,4 +263,57 @@ Deno.test("repoUpgrade: yields completed on successful upgrade", async () => {
   assertEquals(completed.data.gitignoreAction, "updated");
   assertEquals(completed.data.tools, ["claude"]);
   assertEquals(completed.data.tool, "claude");
+});
+
+Deno.test("repoUpgrade: completes with warning when extension install fails", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_test_" });
+  try {
+    const lockfilePath = join(tmpDir, "upstream_extensions.json");
+    await Deno.writeTextFile(
+      lockfilePath,
+      JSON.stringify({
+        "@test/yanked-ext": {
+          version: "1.0.0",
+          pulledAt: "2026-01-01T00:00:00Z",
+          files: [".swamp/pulled-extensions/@test/yanked-ext/models/m.ts"],
+        },
+      }),
+    );
+
+    const deps = makeUpgradeDeps();
+    const events = await collect<RepoUpgradeEvent>(
+      repoUpgrade(createLibSwampContext(), deps, {
+        path: tmpDir,
+        version: "1.0.0",
+        extensionInstallDeps: {
+          lockfilePath,
+          repoDir: tmpDir,
+          createInstallContext: async () => ({
+            getExtension: () => Promise.resolve(null),
+            downloadArchive: () =>
+              Promise.reject(
+                new Error(
+                  "Extension API error (HTTP 410): Version has been yanked",
+                ),
+              ),
+            getChecksum: () => Promise.resolve(null),
+            lockfileRepository: await LockfileRepository.create(lockfilePath),
+            skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+            repoDir: tmpDir,
+            force: true,
+            alreadyPulled: new Set<string>(),
+            depth: 0,
+          }),
+        },
+      }),
+    );
+
+    const errorEvents = events.filter((e) => e.kind === "error");
+    assertEquals(errorEvents.length, 0, "upgrade must not emit error events");
+
+    const completed = events.find((e) => e.kind === "completed");
+    assertEquals(completed?.kind, "completed");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
 });

--- a/src/presentation/renderers/extension_install.ts
+++ b/src/presentation/renderers/extension_install.ts
@@ -98,6 +98,9 @@ class LogExtensionInstallRenderer implements Renderer<ExtensionInstallEvent> {
               });
             }
           }
+          logger.warn(
+            "Run 'swamp extension update <name>' to resolve failed extensions.",
+          );
         }
       },
       error: (e) => {


### PR DESCRIPTION
## Summary

- `swamp repo upgrade` no longer fatally aborts when a pinned extension version has been yanked (HTTP 410) from the registry
- Extension install failures are now warned about but don't block the upgrade — the extension install renderer already logged per-entry warnings; the fatal error block in `repoUpgrade()` was redundant
- Adds guidance message suggesting `swamp extension update <name>` to resolve failed extensions

Fixes swamp-club#1045

## Test Plan

- [x] Added unit test verifying `repoUpgrade()` emits `completed` (not `error`) when extension install has failures
- [x] Reproduced the bug in a scratch repo with a yanked extension (`@atalanta/external-reviewer@2026.06.27.1`), confirmed the fatal abort
- [x] Verified the fix: upgrade now completes with warnings and the `Upgraded swamp repository` success message
- [x] Full test suite passes (8589 tests)
- [x] Type check, lint, and format all pass