### PR TITLE
fix(ci): skip re-running review jobs that already approved the current diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Check if review needed
+        id: check-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          review_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Code Review")))] | last | .state')
+          if [ "$review_state" != "APPROVED" ] && [ "$review_state" != "COMMENTED" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          approved_sha=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Code Review")))] | last | .commit.oid')
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          domain_changes=$(gh api "repos/${{ github.repository }}/compare/${approved_sha}...${head_sha}" \
+            --jq '[.files[].filename | select(test("^\\.github/") | not)] | length' 2>/dev/null) || domain_changes=1
+          if [ "$domain_changes" -gt 0 ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Claude Code Review
+        if: steps.check-review.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -275,6 +300,7 @@ jobs:
             --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        if: steps.check-review.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -305,7 +331,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Check if review needed
+        id: check-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          review_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Adversarial Review")))] | last | .state')
+          if [ "$review_state" != "APPROVED" ] && [ "$review_state" != "COMMENTED" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          approved_sha=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?Adversarial Review")))] | last | .commit.oid')
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          domain_changes=$(gh api "repos/${{ github.repository }}/compare/${approved_sha}...${head_sha}" \
+            --jq '[.files[].filename | select(test("^src/(domain|infrastructure|libswamp|serve|worker)/"))] | length' 2>/dev/null) || domain_changes=1
+          if [ "$domain_changes" -gt 0 ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Adversarial Code Review
+        if: steps.check-review.outputs.skip != 'true'
         uses: ./.github/actions/adversarial-review
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -330,7 +381,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Check if review needed
+        id: check-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          review_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CLI UX Review")))] | last | .state')
+          if [ "$review_state" != "APPROVED" ] && [ "$review_state" != "COMMENTED" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          approved_sha=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CLI UX Review")))] | last | .commit.oid')
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          domain_changes=$(gh api "repos/${{ github.repository }}/compare/${approved_sha}...${head_sha}" \
+            --jq '[.files[].filename | select(test("^src/(cli/commands|presentation|libswamp)/|^src/domain/errors\\.ts$"))] | length' 2>/dev/null) || domain_changes=1
+          if [ "$domain_changes" -gt 0 ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: CLI UX Review
+        if: steps.check-review.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -430,6 +506,7 @@ jobs:
             --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        if: steps.check-review.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -460,7 +537,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Check if review needed
+        id: check-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          review_state=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CI Security Review")))] | last | .state')
+          if [ "$review_state" != "APPROVED" ] && [ "$review_state" != "COMMENTED" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          approved_sha=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions" and ((.body // "") | test("^(## )?CI Security Review")))] | last | .commit.oid')
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          domain_changes=$(gh api "repos/${{ github.repository }}/compare/${approved_sha}...${head_sha}" \
+            --jq '[.files[].filename | select(test("^\\.github/workflows/"))] | length' 2>/dev/null) || domain_changes=1
+          if [ "$domain_changes" -gt 0 ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: CI Security Review
+        if: steps.check-review.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -602,6 +704,7 @@ jobs:
             --allowedTools "Read,Glob,Grep,Bash(gh pr review:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Fail if changes requested
+        if: steps.check-review.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Closes swamp-club#1028

- Adds a domain-aware early-exit check to each of the four Claude review jobs (`claude-review`, `claude-adversarial-review`, `claude-ux-review`, `claude-ci-security-review`)
- Each check queries the PR's last review (filtered by body prefix), extracts the approved commit SHA, and uses the GitHub compare API to detect if domain-relevant files changed since that commit
- If no files in the reviewer's domain changed since its last approval, the review is skipped — the existing approval stands
- All failure paths (API errors, missing commits, force-pushes) default to running the review — fail-open by design

### Domain patterns per reviewer

| Reviewer | Retriggers on |
|---|---|
| `claude-review` | Any non-`.github/` file change |
| `claude-adversarial-review` | `src/(domain\|infrastructure\|libswamp\|serve\|worker)/` |
| `claude-ux-review` | `src/(cli/commands\|presentation\|libswamp)/` or `src/domain/errors.ts` |
| `claude-ci-security-review` | `.github/workflows/` |

## Test Plan

- [x] YAML syntax validated with `yaml.safe_load`
- [x] Step IDs, output names, and `if`-conditions verified consistent across all four jobs
- [x] Domain regex patterns verified against the `changes` job's `dorny/paths-filter` config
- [x] `.commit.oid` field availability confirmed on live PR review data (PR #1801)
- [ ] Manual verification: push a fix to a PR where some reviewers already approved and confirm only domain-affected reviewers re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)