### PR TITLE
fix(extensions): skip non-secret Zod types in credentials-sensitive-field rule (swamp-club#1044)

### DIFF
--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -143,6 +143,14 @@ function stripLineComment(line: string): string {
 const SENSITIVE_FIELD_PATTERN =
   /password|passwd|secret|token|api[_-]?key|access[_-]?key|credential|private[_-]?key/i;
 
+/**
+ * Zod types that cannot hold a secret value. When a line's Zod call matches
+ * one of these, the credentials-sensitive-field rule skips it even if the
+ * field name looks sensitive.
+ */
+const NON_SECRET_ZOD_TYPE =
+  /z\s*\.\s*(number|boolean|literal|object|array|enum)\s*\(/;
+
 /** Matches `z.object({}).passthrough()` — an empty-object passthrough. */
 const EMPTY_OBJECT_PASSTHROUGH =
   /z\s*\.\s*object\s*\(\s*\{\s*\}\s*\)\s*\.\s*passthrough\s*\(/;
@@ -207,6 +215,8 @@ export const DEFAULT_REVIEW_RULES: ReviewRule[] = [
           !SENSITIVE_FIELD_PATTERN.test(line) ||
           !/z\s*\./.test(line)
         ) continue;
+
+        if (NON_SECRET_ZOD_TYPE.test(line)) continue;
 
         if (/sensitive/i.test(line)) continue;
 

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -220,6 +220,104 @@ const other = z.object({}).meta({ sensitive: true });`,
   );
 });
 
+Deno.test("credentials-sensitive-field: no warning for z.number() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: "  tokens: z.number().nullable(),",
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: no warning for z.boolean() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: "  hasApiToken: z.boolean(),",
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: no warning for z.literal() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: '  credentialsScope: z.literal("deferred-to-capture"),',
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: no warning for z.enum() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: '  tokenStatus: z.enum(["active", "revoked"]),',
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: no warning for z.array() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: "  tokenTypes: z.array(z.string()),",
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: no warning for schema/type-alias declaration", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: "export const CredentialsSchema = z.object({",
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    0,
+  );
+});
+
+Deno.test("credentials-sensitive-field: still warns on z.string() with sensitive name", () => {
+  const result = evaluateReviewRules([
+    source({
+      kind: "model",
+      content: "  apiToken: z.string(),",
+    }),
+  ]);
+  assertEquals(
+    result.warnings.filter((w) => w.ruleId === "credentials-sensitive-field")
+      .length,
+    1,
+  );
+});
+
 Deno.test("testing-completeness: warns when entry point lacks a sibling test", () => {
   const result = evaluateReviewRules([
     source({ isEntryPoint: true, hasSiblingTest: false, content: "" }),


### PR DESCRIPTION
## Summary

- The `credentials-sensitive-field` review rule fired on field **names** matching a sensitive pattern (token, secret, credential, etc.) but ignored the Zod **type** — producing false positives on `z.number()`, `z.boolean()`, `z.literal()`, `z.object()`, `z.array()`, and `z.enum()` fields that cannot hold secrets
- Added a `NON_SECRET_ZOD_TYPE` regex to skip these non-secret types; only `z.string()`-typed fields are now flagged
- Added 7 unit tests covering each false-positive case plus a regression guard for `z.string()`

Fixes swamp-club#1044

## Test Plan

- [x] Unit tests: 37/37 pass (7 new + 30 existing)
- [x] Reproduction: created scratch repo at `/tmp/swamp-repro-issue-1044` with all false-positive field types from the issue
  - Before: 8 `credentials-sensitive-field` warnings (7 false positives)
  - After: 1 warning — only the legitimate `apiToken: z.string()` field
- [x] `deno check` — type check passes
- [x] `deno lint` — lint passes
- [x] `deno fmt --check` — formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)