### PR TITLE
fix(extensions): surface explicit error on invalid review report verdict (swamp-club#1035)

### DIFF
--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -420,8 +420,16 @@ export function applicableDimensions(
   );
 }
 
+/** Accepted verdict values for the adversarial-review report. */
+export const REVIEW_VERDICT_VALUES = [
+  "pass",
+  "issue",
+  "na",
+  "pending",
+] as const;
+
 /** A per-dimension verdict recorded by the reviewer. */
-const ReviewVerdictSchema = z.enum(["pass", "issue", "na", "pending"]);
+const ReviewVerdictSchema = z.enum(REVIEW_VERDICT_VALUES);
 
 /** Schema for the on-disk adversarial-review report. */
 const ExtensionReviewReportSchema = z.object({
@@ -438,14 +446,29 @@ const ExtensionReviewReportSchema = z.object({
 /** The on-disk adversarial-review report. */
 export type ExtensionReviewReport = z.infer<typeof ExtensionReviewReportSchema>;
 
-/** Parses report JSON, returning null when missing or malformed. */
-export function parseReviewReport(raw: string): ExtensionReviewReport | null {
+/** Result of parsing a review report: success, validation errors, or null (not JSON). */
+export type ReviewReportParseResult =
+  | { ok: true; report: ExtensionReviewReport }
+  | { ok: false; errors: string[] }
+  | null;
+
+/** Parses report JSON. Returns null for non-JSON, structured errors for valid JSON that fails validation. */
+export function parseReviewReport(raw: string): ReviewReportParseResult {
+  let parsed: unknown;
   try {
-    const result = ExtensionReviewReportSchema.safeParse(JSON.parse(raw));
-    return result.success ? result.data : null;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  const result = ExtensionReviewReportSchema.safeParse(parsed);
+  if (result.success) {
+    return { ok: true, report: result.data };
+  }
+  const errors = result.error.issues.map((issue) => {
+    const path = issue.path.join(".");
+    return path ? `${path}: ${issue.message}` : issue.message;
+  });
+  return { ok: false, errors };
 }
 
 function reviewBaseDir(): string {
@@ -503,8 +526,10 @@ export function buildReviewReportSkeleton(
 
 /** Context for evaluating the adversarial-review report at push time. */
 export interface ReviewReportContext {
-  /** Parsed report, or null when missing/malformed. */
+  /** Parsed report, or null when missing or not JSON. */
   report: ExtensionReviewReport | null;
+  /** Validation errors when the report is valid JSON but fails schema validation. */
+  parseErrors?: string[];
   /** The content-hash-bound path the report was looked up at. */
   reportPath: string;
   /** Expected extension name (from the manifest). */
@@ -534,6 +559,20 @@ export function evaluateReviewReport(
 ): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   const gate: ReviewSeverity = "medium";
+
+  if (ctx.parseErrors && ctx.parseErrors.length > 0) {
+    const allowed = REVIEW_VERDICT_VALUES.join(", ");
+    findings.push({
+      ruleId: REVIEW_REPORT_RULE,
+      dimension: REVIEW_REPORT_DIMENSION,
+      severity: gate,
+      file: ctx.reportPath,
+      message:
+        `Review report has invalid content — ${ctx.parseErrors.join("; ")}. ` +
+        `Allowed verdict values: ${allowed}.`,
+    });
+    return findings;
+  }
 
   if (!ctx.report) {
     findings.push({
@@ -718,8 +757,21 @@ export async function checkReviewRules(
     } catch {
       raw = null;
     }
-    const report = raw === null ? null : parseReviewReport(raw);
-    findings.push(...evaluateReviewReport({ ...input.report, report }));
+    let report: ExtensionReviewReport | null = null;
+    let parseErrors: string[] | undefined;
+    if (raw !== null) {
+      const parsed = parseReviewReport(raw);
+      if (parsed === null) {
+        report = null;
+      } else if (parsed.ok) {
+        report = parsed.report;
+      } else {
+        parseErrors = parsed.errors;
+      }
+    }
+    findings.push(
+      ...evaluateReviewReport({ ...input.report, report, parseErrors }),
+    );
   }
 
   const errors = findings.filter((f) => isBlockingSeverity(f.severity));

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -29,6 +29,7 @@ import {
   type ExtensionReviewReport,
   isBlockingSeverity,
   parseReviewReport,
+  REVIEW_VERDICT_VALUES,
   type ReviewDimension,
   reviewReportPath,
   type ReviewRule,
@@ -501,10 +502,33 @@ Deno.test("reviewReportPath: falls back to OS temp when env var is unset", () =>
   }
 });
 
-Deno.test("parseReviewReport: returns null on malformed JSON or bad shape", () => {
+Deno.test("parseReviewReport: returns null on non-JSON input", () => {
   assertEquals(parseReviewReport("not json"), null);
-  assertEquals(parseReviewReport('{"extension":"x"}'), null);
-  const ok = parseReviewReport(
+});
+
+Deno.test("parseReviewReport: returns errors on valid JSON with invalid shape", () => {
+  const result = parseReviewReport('{"extension":"x"}');
+  assert(result !== null);
+  assert(!result.ok);
+  assert(result.errors.length > 0);
+});
+
+Deno.test("parseReviewReport: returns errors on invalid verdict values", () => {
+  const result = parseReviewReport(
+    JSON.stringify({
+      extension: "@a/b",
+      version: "1",
+      reviewedAt: "now",
+      dimensions: [{ id: "credentials-secrets", verdict: "fail" }],
+    }),
+  );
+  assert(result !== null);
+  assert(!result.ok);
+  assert(result.errors.some((e) => e.includes("dimensions.0.verdict")));
+});
+
+Deno.test("parseReviewReport: returns report on valid input", () => {
+  const result = parseReviewReport(
     JSON.stringify({
       extension: "@a/b",
       version: "1",
@@ -512,12 +536,15 @@ Deno.test("parseReviewReport: returns null on malformed JSON or bad shape", () =
       dimensions: [{ id: "credentials-secrets", verdict: "pass" }],
     }),
   );
-  assert(ok !== null);
+  assert(result !== null);
+  assert(result.ok);
+  assertEquals(result.report.extension, "@a/b");
 });
 
 function reportCtx(
   report: ExtensionReviewReport | null,
   dims: ReviewDimension[],
+  parseErrors?: string[],
 ) {
   return {
     report,
@@ -526,6 +553,7 @@ function reportCtx(
     extensionVersion: "1",
     applicableDimensions: dims,
     skeleton: "{}",
+    parseErrors,
   };
 }
 
@@ -542,6 +570,25 @@ Deno.test("evaluateReviewReport: missing report is a warning (prompt), never a h
   assert(!findings[0].message.includes("{"));
   // The skeleton rides on its own field for JSON consumers.
   assertEquals(findings[0].skeleton, "{}");
+});
+
+Deno.test("evaluateReviewReport: parse errors surface explicit message with allowed values", () => {
+  const parseErrors = [
+    "dimensions.0.verdict: Invalid enum value. Expected 'pass' | 'issue' | 'na' | 'pending', received 'fail'",
+  ];
+  const findings = evaluateReviewReport(
+    reportCtx(null, applicableDimensions(["model"]), parseErrors),
+  );
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].severity, "medium");
+  assert(findings[0].message.includes("invalid content"));
+  for (const v of REVIEW_VERDICT_VALUES) {
+    assert(
+      findings[0].message.includes(v),
+      `Expected message to include "${v}"`,
+    );
+  }
+  assertEquals(findings[0].skeleton, undefined);
 });
 
 Deno.test("evaluateReviewReport: name/version mismatch warns (e.g. manual version bump)", () => {


### PR DESCRIPTION
## Summary

- When a review report contained an invalid verdict value (e.g. `"fail"` instead of `"pass"`), `parseReviewReport` silently returned `null` via Zod `safeParse`, causing the system to re-emit "No adversarial review recorded" as if no report existed
- `parseReviewReport` now returns a discriminated union distinguishing Zod validation errors from truly malformed JSON, and `evaluateReviewReport` surfaces an explicit error naming the invalid values and listing the allowed verdict enum `[pass, issue, na, pending]`

## Test Plan

- [x] Added test: `parseReviewReport` returns `null` for non-JSON input
- [x] Added test: `parseReviewReport` returns structured errors for valid JSON with invalid shape
- [x] Added test: `parseReviewReport` returns structured errors for invalid verdict values
- [x] Added test: `parseReviewReport` returns report on valid input
- [x] Added test: `evaluateReviewReport` surfaces explicit message with allowed verdict values on parse errors
- [x] Verified all 41 existing + new tests pass
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)