### PR TITLE
feat(share): guided solo-to-team promotion with interactive CLI wizards

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -45,6 +45,7 @@ Route to the right guide based on what the user needs.
 | Issues — file bugs, features, security reports               | [references/issue/guide.md](references/issue/guide.md)                         |
 | Run tracking — active runs, stale detection, diagnostics     | [references/model/guide.md](references/model/guide.md)                         |
 | Architecture — which primitive to use, design trade-offs     | [references/architecture/guide.md](references/architecture/guide.md)           |
+| Sharing — promote solo repo to team, datastore + vault setup | [references/share/guide.md](references/share/guide.md)                         |
 | Troubleshooting — errors, health checks, diagnostics         | [references/troubleshooting/guide.md](references/troubleshooting/guide.md)     |
 
 ## Common Commands

--- a/.claude/skills/swamp/references/share/guide.md
+++ b/.claude/skills/swamp/references/share/guide.md
@@ -1,0 +1,177 @@
+# Swamp Share Skill
+
+Guide a solo swamp user through promoting their repo so a teammate can clone and
+collaborate. State machine with gates — do not advance until the current state's
+**Verify** passes.
+
+```
+assess → datastore (gate) → vaults (gate) → commit → joiner instructions
+```
+
+## CRITICAL Rules
+
+- **Never skip the assess step.** Always show the checklist first — it is the
+  anchor for every invocation.
+- **Never run commands silently.** Show the user what you are about to run and
+  explain why before executing.
+- **Resume from partial state.** If the user returns mid-flow, re-run the assess
+  step to detect current state and pick up where they left off.
+- **Prefer interactive commands over flag assembly.** Use
+  `swamp datastore setup` and `swamp vault migrate <vault>` without flags — they
+  launch interactive wizards. Only fall back to explicit flags when the user
+  provides all config upfront or when re-running a failed command with the same
+  arguments.
+- **On failure, re-run the exact same command.** When a command fails (e.g.
+  credential error), save the full command string. After the user fixes the
+  issue, re-run that saved command verbatim — do not re-assemble it from
+  conversation context, as that risks typos and drift.
+- **Check provider auth before migration.** Before running
+  `swamp vault migrate`, verify the target provider's CLI/credentials are
+  working (e.g. `op whoami` for 1Password, `aws sts get-caller-identity` for
+  AWS). Surface the auth requirement and let the user fix it before attempting
+  the migration.
+- **Verify CLI syntax**: If unsure about exact flags, run `swamp help <command>`
+  for the up-to-date schema.
+- **VCS detection**: Check for `.jj` directory to determine if the repo uses
+  jujutsu or git. Hand off to the `jujutsu` skill or `github-pr` skill
+  accordingly for the commit step.
+
+## Quick Reference
+
+| Task                   | Command                                     |
+| ---------------------- | ------------------------------------------- |
+| Check datastore status | `swamp datastore status --json`             |
+| List vault types       | `swamp vault type search --json`            |
+| List vaults            | `swamp vault search --json`                 |
+| Set up datastore       | `swamp datastore setup` (interactive)       |
+| Migrate a vault        | `swamp vault migrate <vault>` (interactive) |
+| Check git remote       | `git remote -v`                             |
+| Run diagnostics        | `swamp doctor datastores --json`            |
+
+## State 1: assess
+
+**Gate:** None (first state).
+
+**Action:** Gather current repo state and show a checklist:
+
+```bash
+swamp datastore status --json        # current datastore type + health
+swamp vault search --json            # all vaults and their types
+git remote -v                        # git remote configured?
+```
+
+Present as a checklist:
+
+- ✓/✗ Git remote configured
+- ✓/✗ Datastore is external (not filesystem at `.swamp/`)
+- ✓/✗ Each vault's provider type (green if not `local_encryption`)
+
+**Already shareable:** If datastore is external AND no vaults are
+`local_encryption`, say: "This repo is already shareable." Offer to generate
+joiner instructions (skip to State 5).
+
+**Verify:** Checklist is displayed and the user sees what needs to change.
+
+## State 2: datastore (gate)
+
+**Gate:** State 1 passed, datastore is `filesystem` at the default `.swamp/`
+path.
+
+**Skip:** If the datastore is already external, skip to State 3.
+
+**Action:** Ask the user where they want to store data. Once you have the choice
+and config details, build a single `swamp datastore setup` command and run it.
+Save the exact command string — if it fails, you will re-run it verbatim after
+the user fixes the issue.
+
+| Choice                      | Command                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| AWS S3                      | `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"…","region":"…"}'`                        |
+| Google Cloud Storage        | `swamp datastore setup extension @swamp/gcs-datastore --config '{"bucket":"…"}'`                                    |
+| S3-compatible (MinIO, etc.) | Same as S3 but add `"endpoint":"http://…","forcePathStyle":true` to config                                          |
+| Shared filesystem           | `swamp datastore setup filesystem --path <path>`                                                                    |
+| Other                       | `swamp extension search <keyword> --label datastore` → then `swamp datastore setup extension <type> --config '{…}'` |
+
+**Verify:** `swamp datastore status --json` shows the new type and
+`healthy: true`.
+
+**On Failure:** The most common failure is a credential or access error (403,
+connection refused). When this happens:
+
+1. Explain what the error means and what the user needs to fix
+2. **Save the exact command** you ran
+3. Wait for the user to say they've fixed it
+4. **Re-run the saved command verbatim** — do not rebuild it from conversation
+5. If it fails again, consult
+   [references/troubleshooting.md](references/troubleshooting.md)
+
+## State 3: vaults (gate, per vault)
+
+**Gate:** State 2 passed (or skipped).
+
+**Skip:** If no vaults exist, or no vaults use `local_encryption`, skip to
+State 4.
+
+**Action:** For each vault on `local_encryption`:
+
+1. Ask which provider to migrate to (AWS Secrets Manager, Azure Key Vault,
+   1Password, or search for another)
+2. **Pre-flight auth check** — verify the provider's credentials are working
+   before attempting the migration:
+   - 1Password: `op whoami`
+   - AWS Secrets Manager: `aws sts get-caller-identity`
+   - Azure Key Vault: `az account show`
+   - If the check fails, tell the user what to set up and wait
+3. Build the migration command:
+   `swamp vault migrate <vault> --to-type <type> --config '{...}' --force` Use
+   `--force` to skip the interactive confirmation (you already confirmed with
+   the user conversationally).
+4. If the user says "same for all", batch the remaining vaults with the same
+   type and config.
+
+The user can skip individual vaults ("I'll do that later") — show them as ✗ in
+the checklist on the next assess.
+
+**Verify:** `swamp vault search --json` shows migrated vaults with the new type.
+
+**On Failure:** Save the exact command. Most failures are auth-related — the
+pre-flight check should catch these, but if not, explain the error, wait for the
+fix, and re-run the saved command. See
+[references/troubleshooting.md](references/troubleshooting.md).
+
+## State 4: commit
+
+**Gate:** State 3 passed (or skipped).
+
+**Action:** Show which files changed and why:
+
+- `.swamp.yaml` — datastore configuration updated
+- `vaults/` — vault configs updated with new provider types
+
+Detect VCS type:
+
+- If `.jj/` directory exists → use the `jujutsu` skill
+- Otherwise → use the `github-pr` skill (or direct `git` commands)
+
+Offer to create the commit. Do not commit without asking.
+
+**Verify:** Changes are committed (or the user chose to skip).
+
+## State 5: joiner instructions
+
+**Gate:** State 4 passed (or skipped).
+
+**Action:** Generate copy-pasteable onboarding instructions tailored to the
+actual configuration. See
+[references/joiner-instructions.md](references/joiner-instructions.md) for the
+template.
+
+**Verify:** Instructions are shown to the user.
+
+## References
+
+- [reference.md](reference.md) — detailed walkthroughs with CLI output shapes
+- [references/joiner-instructions.md](references/joiner-instructions.md) —
+  joiner instruction template
+- [references/troubleshooting.md](references/troubleshooting.md) — common
+  failure modes and recovery

--- a/.claude/skills/swamp/references/share/reference.md
+++ b/.claude/skills/swamp/references/share/reference.md
@@ -1,0 +1,218 @@
+# Share — Detailed Reference
+
+Walkthroughs for each state machine step with exact commands and output shapes.
+For the state machine overview, see [guide.md](guide.md).
+
+## Assess: Reading Repo State
+
+### Datastore status
+
+```bash
+swamp datastore status --json
+```
+
+Output shape:
+
+```json
+{
+  "type": "filesystem",
+  "path": "/path/to/.swamp",
+  "healthy": true,
+  "message": "OK",
+  "latencyMs": 1,
+  "directories": ["data", "outputs", "workflow-runs", ...]
+}
+```
+
+Key fields:
+
+- `type` — `"filesystem"` means local (not shareable). Any other value (e.g.
+  `"@swamp/s3-datastore"`) means external (shareable).
+- `healthy` — `true` if the datastore is reachable.
+- `path` — only present for filesystem datastores.
+
+### Vault listing
+
+```bash
+swamp vault search --json
+```
+
+Returns an array of vault configs. Each has `name`, `type`, and `config`. Look
+for `type: "local_encryption"` — these vaults need migration for team sharing
+because their encryption keys are stored locally in `.swamp/secrets/` and won't
+be available on other machines.
+
+### Git remote
+
+```bash
+git remote -v
+```
+
+If no remote is configured, warn the user — teammates need a way to clone the
+repo. This is informational only; the share flow does not configure git.
+
+### Doctor diagnostics
+
+```bash
+swamp doctor datastores --json
+```
+
+Output shape:
+
+```json
+{
+  "overallStatus": "pass",
+  "datastoreType": "@swamp/s3-datastore",
+  "isCustom": true,
+  "healthFindings": [
+    { "check": "health", "passed": true, "message": "OK" }
+  ],
+  "vaultMismatchFindings": [
+    { "vaultName": "secrets", "vaultType": "local_encryption" }
+  ]
+}
+```
+
+The `vaultMismatchFindings` array lists vaults that need migration. If empty,
+vaults are compatible with the shared datastore.
+
+## Datastore Setup
+
+For datastore operations in depth, cross-link to the repo guide:
+[../repo/reference.md](../repo/reference.md) (Datastores section).
+
+### Interactive setup
+
+```bash
+swamp datastore setup
+```
+
+When run without a subcommand, launches an interactive wizard that:
+
+1. Shows current datastore config
+2. Asks where to store data (S3, filesystem path, other extension)
+3. Prompts for provider-specific config (bucket, region, path, etc.)
+4. Runs the migration and verifies health
+
+### S3 setup (explicit)
+
+```bash
+swamp datastore setup extension @swamp/s3-datastore \
+  --config '{"bucket":"my-bucket","prefix":"project","region":"us-east-1"}' \
+  --json
+```
+
+The migration copies local `.swamp/` data to the S3 cache, pushes to remote,
+then hydrates the cache back from remote to verify round-trip.
+
+### Filesystem setup (explicit)
+
+```bash
+swamp datastore setup filesystem --path /shared/storage/project --json
+```
+
+Moves data to a shared filesystem path. Simpler than S3 but requires all
+teammates to have access to the same path.
+
+### Verify after setup
+
+```bash
+swamp datastore status --json
+```
+
+Confirm `type` changed and `healthy: true`.
+
+## Vault Migration
+
+For vault operations in depth, cross-link to the vault guide:
+[../vault/reference.md](../vault/reference.md).
+
+### Interactive migration
+
+```bash
+swamp vault migrate <vault-name>
+```
+
+When run without `--to-type`, launches an interactive flow that:
+
+1. Shows current vault info
+2. Lists available vault providers
+3. Prompts for provider selection and config
+4. Previews the migration (secret count, source → target)
+5. Asks for confirmation
+6. Copies secrets and updates config
+
+### Explicit migration
+
+```bash
+swamp vault migrate <vault-name> \
+  --to-type @swamp/aws-sm \
+  --config '{"region":"us-east-1"}' \
+  --json
+```
+
+### Available vault providers
+
+| Provider            | Type               | Notes                                 |
+| ------------------- | ------------------ | ------------------------------------- |
+| AWS Secrets Manager | `@swamp/aws-sm`    | Needs AWS credentials                 |
+| Azure Key Vault     | `@swamp/azure-kv`  | Needs Azure credentials               |
+| 1Password           | `@swamp/1password` | Needs 1Password CLI + service account |
+
+### Batch migration
+
+If the user wants the same provider for all vaults, run each sequentially:
+
+```bash
+swamp vault migrate vault-1 --to-type @swamp/aws-sm --config '...' --force
+swamp vault migrate vault-2 --to-type @swamp/aws-sm --config '...' --force
+```
+
+Use `--force` to skip the confirmation prompt when batching.
+
+### Verify after migration
+
+```bash
+swamp vault search --json
+```
+
+Confirm each migrated vault shows the new type.
+
+## Namespaces (Optional)
+
+For multi-repo shared datastores, a namespace prevents data collisions. This is
+optional for simple two-person sharing but required when multiple repos share
+one S3 bucket.
+
+```bash
+swamp datastore namespace set <slug> --json
+swamp datastore namespace migrate --confirm --json
+```
+
+See [../repo/references/namespaces.md](../repo/references/namespaces.md) for
+full namespace documentation.
+
+## Commit Step — VCS Detection
+
+Detect which VCS the repo uses:
+
+```bash
+test -d .jj && echo "jujutsu" || echo "git"
+```
+
+- **jujutsu**: Use the `jujutsu` skill to create a change and describe it.
+- **git**: Use the `github-pr` skill or standard `git add` / `git commit`.
+
+Files that changed:
+
+- `.swamp.yaml` — datastore config updated
+- `vaults/<type>/<id>.yaml` — vault configs with new provider types
+- `.swamp/secrets/` — may have been cleaned up after vault migration
+
+Suggested commit message:
+`feat(repo): promote to shared datastore with remote vault storage`
+
+## Joiner Instructions
+
+See [references/joiner-instructions.md](references/joiner-instructions.md) for
+the template used to generate copy-pasteable onboarding instructions.

--- a/.claude/skills/swamp/references/share/references/joiner-instructions.md
+++ b/.claude/skills/swamp/references/share/references/joiner-instructions.md
@@ -1,0 +1,109 @@
+# Joiner Instructions Template
+
+Generate copy-pasteable onboarding instructions tailored to the actual repo
+configuration. Read `.swamp.yaml` and vault configs to determine what
+credentials the teammate needs.
+
+## Template
+
+Adapt the sections below based on what the repo actually uses. Omit sections
+that don't apply.
+
+---
+
+### Prerequisites
+
+**Clone the repository:**
+
+```bash
+git clone <REPO_URL>
+cd <REPO_NAME>
+```
+
+**Install swamp:**
+
+```bash
+curl -fsSL https://get.swamp.club | bash
+```
+
+**Authenticate with swamp-club (optional, for extensions):**
+
+```bash
+swamp auth login
+```
+
+### Datastore Access
+
+_Include this section when the datastore is not `filesystem`._
+
+**For `@swamp/s3-datastore`:**
+
+You need AWS credentials with read/write access to the S3 bucket. Configure your
+AWS credentials via any standard method (`~/.aws/credentials`, environment
+variables, IAM role, SSO):
+
+```
+Bucket: <BUCKET>
+Prefix: <PREFIX>
+Region: <REGION>
+```
+
+The first `swamp` command that touches data will auto-hydrate the local cache
+from S3. This may take a moment on the first run.
+
+**For other datastore extensions:**
+
+You need credentials for the datastore provider. Check with the repo owner for
+the specific requirements.
+
+### Vault Access
+
+_Include this section for each vault that is NOT `local_encryption`._
+
+**For `@swamp/aws-sm` vaults:**
+
+You need AWS credentials with access to AWS Secrets Manager in the configured
+region. The vault secrets are stored remotely — no local setup needed beyond AWS
+credentials.
+
+**For `@swamp/azure-kv` vaults:**
+
+You need Azure credentials with access to the configured Azure Key Vault
+instance.
+
+**For `@swamp/1password` vaults:**
+
+You need the 1Password CLI installed and a service account token for the
+configured vault.
+
+### Extensions
+
+Extensions auto-install on first use. The `@swamp/*` official extensions are
+trusted by default. The repo's `upstream_extensions.json` lockfile pins exact
+versions so everyone uses the same extension builds.
+
+No manual extension setup is needed.
+
+### Verify Setup
+
+After cloning and configuring credentials, verify everything works:
+
+```bash
+swamp doctor datastores    # check datastore connectivity
+swamp doctor vaults        # check vault access
+swamp model search         # list available models
+```
+
+---
+
+## Customization Notes
+
+- **Always fill in actual values** from the repo config — don't use generic
+  placeholders unless the value is truly unknown.
+- **Omit vault access section** if the repo has no vaults or all vaults are
+  `local_encryption` (which should not happen after sharing setup).
+- **Omit datastore access section** if the datastore is `filesystem` (which
+  should not happen after sharing setup — but may apply if only vaults were
+  migrated and data is shared via git).
+- **Add namespace info** if the repo uses a namespace: mention it so the
+  teammate understands the multi-repo setup.

--- a/.claude/skills/swamp/references/share/references/troubleshooting.md
+++ b/.claude/skills/swamp/references/share/references/troubleshooting.md
@@ -1,0 +1,171 @@
+# Share — Troubleshooting
+
+Common failures during the solo-to-team sharing setup and how to recover.
+
+## Datastore Setup Failures
+
+### S3: Access Denied / No Such Bucket
+
+```
+error: S3 health check failed: Access Denied
+```
+
+**Cause:** AWS credentials don't have permission to access the bucket, or the
+bucket doesn't exist.
+
+**Fix:**
+
+1. Verify the bucket exists: `aws s3 ls s3://<bucket>/`
+2. Check IAM permissions — swamp needs `s3:GetObject`, `s3:PutObject`,
+   `s3:ListBucket`, `s3:DeleteObject`
+3. Verify the region matches the bucket's actual region
+4. Re-run `swamp datastore setup`
+
+### S3-Compatible (MinIO, etc.): Connection Refused
+
+```
+error: AggregateError / ECONNREFUSED
+```
+
+**Cause:** The S3-compatible endpoint (MinIO, Ceph, etc.) is not reachable.
+
+**Fix:**
+
+1. Verify the service is running: `docker ps | grep minio` or
+   `curl http://localhost:9000/minio/health/live`
+2. Check the endpoint URL and port in your config
+3. Make sure `forcePathStyle: true` is set in the config — required for MinIO
+4. Set the correct credentials:
+   `export AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin` (or
+   whatever your MinIO credentials are)
+
+Example config for MinIO:
+
+```json
+{
+  "bucket": "my-bucket",
+  "region": "us-east-1",
+  "endpoint": "http://localhost:9000",
+  "forcePathStyle": true
+}
+```
+
+### S3: Invalid Region
+
+```
+error: S3 health check failed: ... PermanentRedirect ...
+```
+
+**Cause:** The configured region doesn't match the bucket's region.
+
+**Fix:** Find the correct region with
+`aws s3api get-bucket-location --bucket <bucket>` and re-run setup with the
+right region.
+
+### Extension Not Found
+
+```
+error: Datastore type "@swamp/s3-datastore" not found
+```
+
+**Cause:** The S3 datastore extension is not installed.
+
+**Fix:**
+
+```bash
+swamp extension pull @swamp/s3-datastore
+swamp datastore setup
+```
+
+### Datastore Already Configured
+
+If the repo already has a non-filesystem datastore and you want to change it,
+you need to reinitialize:
+
+```bash
+swamp repo init --force
+```
+
+This resets the datastore to filesystem. Then run `swamp datastore setup` again.
+
+## Vault Migration Failures
+
+### Pre-Flight Auth Checks
+
+**Always verify provider auth before attempting migration.** Run the appropriate
+check and resolve any issues before calling `swamp vault migrate`:
+
+| Provider            | Auth check command            | What to fix                                   |
+| ------------------- | ----------------------------- | --------------------------------------------- |
+| 1Password           | `op whoami`                   | `op signin` or set `OP_SERVICE_ACCOUNT_TOKEN` |
+| AWS Secrets Manager | `aws sts get-caller-identity` | Configure AWS credentials                     |
+| Azure Key Vault     | `az account show`             | `az login`                                    |
+
+### Provider Credentials Missing
+
+```
+error: Failed to connect to AWS Secrets Manager
+```
+
+**Cause:** The target vault provider's credentials are not configured on this
+machine. The pre-flight auth check (see above) should catch this before the
+migration runs.
+
+**Fix:** Configure credentials for the target provider, verify with the auth
+check command above, then re-run the saved migration command.
+
+### Same Type Migration
+
+```
+error: Source and target vault types are the same
+```
+
+**Cause:** The vault is already on the target provider.
+
+**Fix:** This vault doesn't need migration. Skip it.
+
+### Secret Copy Failure
+
+If the migration fails partway through copying secrets, the source vault is
+unchanged — secrets are copied, not moved. Re-run the migration to retry.
+
+### Vault Extension Not Found
+
+```
+error: Vault type "@swamp/aws-sm" not found
+```
+
+**Fix:**
+
+```bash
+swamp extension pull @swamp/aws-sm
+swamp vault migrate <vault> --to-type @swamp/aws-sm
+```
+
+## General Issues
+
+### Not in a Swamp Repo
+
+```
+error: Not a swamp repository
+```
+
+**Fix:** Run `swamp repo init` first, or navigate to the repo root.
+
+### Worktree Issues
+
+If running from a Claude Code worktree (`.claude/worktrees/`), add `--repo-dir`
+pointing to the main repo:
+
+```bash
+swamp datastore status --repo-dir /path/to/main/repo --json
+```
+
+### Partial Completion
+
+If you completed some steps but not all, just re-run the share flow. The assess
+step detects current state:
+
+- Datastore already external? Skip datastore step.
+- Some vaults migrated, some not? Only show the remaining ones.
+- Everything done? Offer joiner instructions.

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -133,10 +133,13 @@ the scanner at it and swamp will detect what it can.
     }
 
     const choices = buildInstructionsChoices(detection, name);
-    const instructionsPath = await promptChoice(
+    let instructionsPath = await promptChoice(
       `\nWhere does ${name} read rules/instructions from?`,
-      choices,
+      [...choices, "Other path"],
     );
+    if (instructionsPath === "Other path") {
+      instructionsPath = await promptLine("Path: ");
+    }
 
     let frontmatter: string | undefined;
     await Deno.stdout.write(encoder.encode(`
@@ -165,10 +168,13 @@ Some tools need a header like this to auto-load rules:
     const skillsDirChoices = buildSkillsDirChoices(detection, def.skillsDir);
     let chosenSkillsDir: string | undefined;
     if (skillsDirChoices.length > 1) {
-      const chosen = await promptChoice(
+      let chosen = await promptChoice(
         `\nWhere should swamp write skills for ${name}?`,
-        skillsDirChoices,
+        [...skillsDirChoices, "Other path"],
       );
+      if (chosen === "Other path") {
+        chosen = await promptLine("Path: ");
+      }
       if (chosen !== def.skillsDir) {
         chosenSkillsDir = chosen;
       }

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -39,49 +39,16 @@ import { UserError } from "../../domain/errors.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoService } from "../../domain/repo/repo_service.ts";
 import { VERSION } from "./version.ts";
+import {
+  promptChoice,
+  promptConfirmation,
+  promptLine,
+} from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
-
-async function promptLine(message: string): Promise<string> {
-  await Deno.stdout.write(encoder.encode(message));
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return "";
-  return decoder.decode(buf.subarray(0, n)).trim();
-}
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const response = await promptLine(`${message} [y/N] `);
-  return response === "y" || response === "yes";
-}
-
-async function promptChoice(
-  message: string,
-  choices: string[],
-): Promise<string> {
-  await Deno.stdout.write(encoder.encode(`${message}\n`));
-  for (let i = 0; i < choices.length; i++) {
-    await Deno.stdout.write(
-      encoder.encode(`  ${i + 1}. ${choices[i]}\n`),
-    );
-  }
-  await Deno.stdout.write(
-    encoder.encode(`  ${choices.length + 1}. Other path\n`),
-  );
-  const response = await promptLine("> ");
-  const index = parseInt(response, 10) - 1;
-  if (index >= 0 && index < choices.length) {
-    return choices[index];
-  }
-  if (index === choices.length) {
-    return await promptLine("Path: ");
-  }
-  return response || choices[0];
-}
 
 async function promptMultilineFrontmatter(): Promise<string> {
   await Deno.stdout.write(

--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -51,20 +51,7 @@ import {
 } from "../remote_run.ts";
 import type { DataDeleteResponse } from "../../serve/protocol.ts";
 import { UserError } from "../../domain/errors.ts";
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -39,20 +39,7 @@ import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/data_prune.ts
+++ b/src/cli/commands/data_prune.ts
@@ -39,20 +39,7 @@ import {
   requireInitializedRepo,
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -36,16 +36,53 @@ import {
   datastoreSetupFilesystem,
 } from "../../libswamp/mod.ts";
 import { createDatastoreSetupRenderer } from "../../presentation/renderers/datastore_setup.ts";
-import { DEFAULT_DATASTORE_SUBDIRS } from "../../domain/datastore/datastore_config.ts";
+import {
+  type DatastoreConfig,
+  DEFAULT_DATASTORE_SUBDIRS,
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
 import { expandEnvVars } from "../../infrastructure/persistence/env_path.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { resolveDatastoreType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { RENAMED_DATASTORE_TYPES } from "../resolve_datastore.ts";
 import { UserError } from "../../domain/errors.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { dim, yellow } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import {
+  promptChoice,
+  promptLine,
+  promptLineWithDefault,
+} from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+const encoder = new TextEncoder();
+
+async function nudgeVaultMigration(repoDir: string): Promise<void> {
+  try {
+    const vaultRepo = new YamlVaultConfigRepository(repoDir);
+    const configs = await vaultRepo.findAll();
+    const localVaults = configs.filter((vc) => vc.type === "local_encryption");
+    if (localVaults.length > 0) {
+      const names = localVaults.map((v) => v.name).join(", ");
+      writeOutput(
+        `\n${
+          yellow("⚠")
+        } ${localVaults.length} vault(s) still use local encryption: ${names}` +
+          `\n${
+            dim(
+              "  Local encryption keys won't work on other machines. Migrate with: swamp vault migrate <vault>",
+            )
+          }`,
+      );
+    }
+  } catch {
+    // Best-effort — vault discovery failure should never block datastore setup
+  }
+}
 
 const datastoreSetupFilesystemCommand = new Command()
   .description("Set up a filesystem datastore")
@@ -212,6 +249,8 @@ const datastoreSetupExtensionCommand = new Command()
       }),
       renderer.handlers(),
     );
+
+    await nudgeVaultMigration(repoDir);
   });
 
 const datastoreSetupS3DeprecatedCommand = new Command()
@@ -229,9 +268,256 @@ const datastoreSetupS3DeprecatedCommand = new Command()
     );
   });
 
+/**
+ * Describes the current datastore configuration for display during
+ * interactive setup.
+ */
+function describeCurrentDatastore(
+  datastoreConfig: DatastoreConfig,
+): string {
+  if (isCustomDatastoreConfig(datastoreConfig)) {
+    return `${datastoreConfig.type} (${datastoreConfig.datastorePath})`;
+  }
+  return `filesystem (${datastoreConfig.path})`;
+}
+
 /** Configure a datastore for this repository. */
 export const datastoreSetupCommand = new Command()
   .description("Configure a datastore for this repository")
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "datastore",
+      "setup",
+    ]);
+
+    if (cliCtx.outputMode === "json") {
+      throw new UserError(
+        "Interactive datastore setup is not available in JSON mode. " +
+          "Use 'swamp datastore setup filesystem' or " +
+          "'swamp datastore setup extension' with explicit flags.",
+      );
+    }
+
+    const repoDir = resolveRepoDir(options.repoDir);
+
+    // Show the current datastore configuration
+    try {
+      const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+      await Deno.stdout.write(
+        encoder.encode(
+          `\nCurrent datastore: ${
+            describeCurrentDatastore(datastoreConfig)
+          }\n\n`,
+        ),
+      );
+    } catch {
+      await Deno.stdout.write(
+        encoder.encode("\nNo datastore currently configured.\n\n"),
+      );
+    }
+
+    // Ask where to store data
+    const CHOICES = [
+      "AWS S3 / S3-compatible",
+      "Google Cloud Storage",
+      "Shared filesystem",
+      "Other",
+    ];
+    const choice = await promptChoice(
+      "Where do you want to store data?",
+      CHOICES,
+    );
+
+    let extensionType: string | undefined;
+    let datastoreConfig: Record<string, unknown> | undefined;
+    let filesystemPath: string | undefined;
+
+    if (choice === "AWS S3 / S3-compatible") {
+      extensionType = "@swamp/s3-datastore";
+      const defaultRegion = Deno.env.get("AWS_DEFAULT_REGION") ??
+        Deno.env.get("AWS_REGION") ?? "us-east-1";
+
+      const bucket = await promptLine("S3 bucket name: ");
+      if (!bucket) {
+        throw new UserError("No bucket name provided.");
+      }
+      const prefix = await promptLineWithDefault("Key prefix:", "");
+      const region = await promptLineWithDefault("AWS region:", defaultRegion);
+
+      const endpoint = await promptLine(
+        "Custom endpoint (for MinIO/S3-compatible, or Enter to skip): ",
+      );
+
+      datastoreConfig = { bucket, region };
+      if (prefix) {
+        datastoreConfig.prefix = prefix;
+      }
+      if (endpoint) {
+        datastoreConfig.endpoint = endpoint;
+        datastoreConfig.forcePathStyle = true;
+      }
+    } else if (choice === "Google Cloud Storage") {
+      extensionType = "@swamp/gcs-datastore";
+
+      const bucket = await promptLine("GCS bucket name: ");
+      if (!bucket) {
+        throw new UserError("No bucket name provided.");
+      }
+      const prefix = await promptLineWithDefault("Key prefix:", "");
+
+      datastoreConfig = { bucket };
+      if (prefix) {
+        datastoreConfig.prefix = prefix;
+      }
+    } else if (choice === "Shared filesystem") {
+      const path = await promptLine("Datastore path: ");
+      if (!path) {
+        throw new UserError("No path provided.");
+      }
+      filesystemPath = path;
+    } else {
+      // Other: search for a datastore extension by name
+      const query = await promptLine(
+        "Search for a datastore extension (e.g. azure, minio): ",
+      );
+      if (!query) {
+        throw new UserError("No search query provided.");
+      }
+
+      await Deno.stdout.write(
+        encoder.encode(`\nSearching for "${query}" datastore extensions…\n`),
+      );
+
+      const searchCmd = new Deno.Command(Deno.execPath(), {
+        args: [
+          "extension",
+          "search",
+          query,
+          "--label",
+          "datastore",
+          "--json",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const searchOutput = await searchCmd.output();
+      let searchResults: Array<{ type: string; description: string }> = [];
+      if (searchOutput.success) {
+        try {
+          const parsed = JSON.parse(
+            new TextDecoder().decode(searchOutput.stdout),
+          ) as {
+            extensions?: Array<{
+              name: string;
+              description: string;
+              contentTypes: string[];
+            }>;
+          };
+          searchResults = (parsed.extensions ?? [])
+            .filter((r) => r.contentTypes.includes("datastores"))
+            .map((r) => ({
+              type: r.name,
+              description: r.description,
+            }));
+        } catch {
+          // If JSON parsing fails, treat as no results
+        }
+      }
+
+      if (searchResults.length === 0) {
+        throw new UserError(
+          `No datastore extensions found for "${query}". ` +
+            `Browse available extensions at https://swamp-club.com/extensions`,
+        );
+      }
+
+      const typeChoices = searchResults.map((r) =>
+        `${r.type} — ${r.description}`
+      );
+      const chosen = await promptChoice(
+        "Which datastore extension?",
+        typeChoices,
+      );
+      extensionType = chosen.split(" — ")[0];
+
+      const configJson = await promptLine(
+        `Config JSON for ${extensionType} (e.g. {}): `,
+      );
+      try {
+        datastoreConfig = JSON.parse(configJson || "{}") as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        throw new UserError(`Invalid JSON: ${configJson}`);
+      }
+    }
+
+    // Execute the chosen setup path
+    if (filesystemPath) {
+      const { repoDir: resolvedRepoDir } = await requireInitializedRepo({
+        repoDir,
+        outputMode: cliCtx.outputMode,
+      });
+
+      const expandedPath = expandEnvVars(filesystemPath);
+      const datastorePath = isAbsolute(expandedPath)
+        ? expandedPath
+        : resolve(resolvedRepoDir, expandedPath);
+
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const deps = createDatastoreSetupDeps(resolvedRepoDir);
+      const renderer = createDatastoreSetupRenderer(cliCtx.outputMode);
+
+      await consumeStream(
+        datastoreSetupFilesystem(ctx, deps, {
+          datastorePath,
+          repoDir: resolvedRepoDir,
+          directories: [...DEFAULT_DATASTORE_SUBDIRS],
+          skipMigration: false,
+        }),
+        renderer.handlers(),
+      );
+    } else if (extensionType) {
+      await datastoreTypeRegistry.ensureLoaded();
+      try {
+        await resolveDatastoreType(extensionType, getAutoResolver());
+      } catch {
+        // Fall through to registry check
+      }
+      if (!datastoreTypeRegistry.has(extensionType)) {
+        throw new UserError(
+          `Datastore type "${extensionType}" is not registered. ` +
+            `Install it with: swamp extension pull ${extensionType}`,
+        );
+      }
+
+      const { repoDir: resolvedRepoDir, marker } =
+        await resolveDatastoreForRepo(repoDir);
+
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const deps = createDatastoreSetupDeps(resolvedRepoDir);
+      const renderer = createDatastoreSetupRenderer(cliCtx.outputMode);
+
+      await consumeStream(
+        datastoreSetupExtension(ctx, deps, {
+          type: extensionType,
+          config: datastoreConfig ?? {},
+          repoDir: resolvedRepoDir,
+          repoId: marker?.repoId,
+          skipMigration: false,
+          namespace: marker?.datastore?.namespace,
+        }),
+        renderer.handlers(),
+      );
+
+      await nudgeVaultMigration(resolvedRepoDir);
+    }
+  })
   .command("filesystem", datastoreSetupFilesystemCommand)
   .command("extension", datastoreSetupExtensionCommand)
   .command("s3", datastoreSetupS3DeprecatedCommand);

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -397,12 +397,13 @@ export const datastoreSetupCommand = new Command()
           "extension",
           "search",
           query,
-          "--label",
-          "datastore",
+          "--content-type",
+          "datastores",
           "--json",
         ],
         stdout: "piped",
         stderr: "piped",
+        signal: AbortSignal.timeout(30_000),
       });
       const searchOutput = await searchCmd.output();
       let searchResults: Array<{ type: string; description: string }> = [];
@@ -414,15 +415,12 @@ export const datastoreSetupCommand = new Command()
             extensions?: Array<{
               name: string;
               description: string;
-              contentTypes: string[];
             }>;
           };
-          searchResults = (parsed.extensions ?? [])
-            .filter((r) => r.contentTypes.includes("datastores"))
-            .map((r) => ({
-              type: r.name,
-              description: r.description,
-            }));
+          searchResults = (parsed.extensions ?? []).map((r) => ({
+            type: r.name,
+            description: r.description,
+          }));
         } catch {
           // If JSON parsing fails, treat as no results
         }

--- a/src/cli/commands/datastore_setup_test.ts
+++ b/src/cli/commands/datastore_setup_test.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("datastoreSetupCommand module loads", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  // The name is set by the parent command when registering; verify it exists
+  assertEquals(typeof datastoreSetupCommand.getName(), "string");
+});
+
+Deno.test("datastoreSetupCommand has filesystem subcommand", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  const fsCmd = datastoreSetupCommand.getCommand("filesystem");
+  assertEquals(fsCmd !== undefined, true, "filesystem subcommand should exist");
+  assertEquals(fsCmd?.getDescription(), "Set up a filesystem datastore");
+});
+
+Deno.test("datastoreSetupCommand has extension subcommand", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  const extCmd = datastoreSetupCommand.getCommand("extension");
+  assertEquals(extCmd !== undefined, true, "extension subcommand should exist");
+  assertEquals(
+    extCmd?.getDescription(),
+    "Set up an extension-provided datastore (e.g., @swamp/s3-datastore)",
+  );
+});
+
+Deno.test("datastoreSetupCommand has s3 deprecated subcommand", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  const s3Cmd = datastoreSetupCommand.getCommand("s3");
+  assertEquals(s3Cmd !== undefined, true, "s3 subcommand should exist");
+});
+
+Deno.test("datastoreSetupCommand has parent action for interactive mode", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  // Verify the command has an action set (parent interactive wizard)
+  // by checking the command description matches
+  assertEquals(
+    datastoreSetupCommand.getDescription(),
+    "Configure a datastore for this repository",
+  );
+  // The parent command should have 3 subcommands
+  const commands = datastoreSetupCommand.getCommands();
+  const names = commands.map((c) => c.getName()).sort();
+  assertEquals(names, ["extension", "filesystem", "s3"]);
+});

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
 import { doctorAuditCommand } from "./doctor_audit.ts";
+import { doctorDatastoresCommand } from "./doctor_datastores.ts";
 import { doctorExtensionsCommand } from "./doctor_extensions.ts";
 import { doctorInstallCommand } from "./doctor_install.ts";
 import { doctorSecretsCommand } from "./doctor_secrets.ts";
@@ -58,6 +59,10 @@ export const doctorCommand = new Command()
     "Check models with sensitive outputs have a vault configured",
     "swamp doctor vaults",
   )
+  .example(
+    "Check datastore health and vault compatibility",
+    "swamp doctor datastores",
+  )
   // `--repo-dir` is accepted on the top-level command for consistency
   // with subcommands and other repo-scoped commands. The top-level
   // action only shows help; subcommands consume the option.
@@ -67,6 +72,7 @@ export const doctorCommand = new Command()
   )
   .action(groupCommandAction)
   .command("audit", doctorAuditCommand)
+  .command("datastores", doctorDatastoresCommand)
   .command("extensions", doctorExtensionsCommand)
   .command("install", doctorInstallCommand)
   .command("secrets", doctorSecretsCommand)

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -20,10 +20,10 @@
 import { Command } from "@cliffy/command";
 import {
   consumeStream,
-  createDoctorDatastoresDeps,
   createLibSwampContext,
   doctorDatastores,
   type DoctorDatastoresData,
+  type DoctorDatastoresDeps,
 } from "../../libswamp/mod.ts";
 import { createDoctorDatastoresRenderer } from "../../presentation/renderers/doctor_datastores.ts";
 import {
@@ -39,9 +39,59 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { DoctorDatastoresResponse } from "../../serve/protocol.ts";
+import {
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolveDatastoreConfig } from "../resolve_datastore.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
+
+async function createDoctorDatastoresDeps(
+  repoDir: string,
+): Promise<DoctorDatastoresDeps> {
+  await datastoreTypeRegistry.ensureLoaded();
+  return {
+    getDatastoreConfig: async () => {
+      const markerRepo = new RepoMarkerRepository();
+      const marker = await markerRepo.read(RepoPath.create(repoDir));
+      return await resolveDatastoreConfig(marker, undefined, repoDir);
+    },
+    checkHealth: async (config) => {
+      if (isCustomDatastoreConfig(config)) {
+        await datastoreTypeRegistry.ensureTypeLoaded(config.type);
+        const typeInfo = datastoreTypeRegistry.get(config.type);
+        if (typeInfo?.createProvider) {
+          const provider = typeInfo.createProvider(config.config);
+          const verifier = provider.createVerifier();
+          return await verifier.verify();
+        }
+        return {
+          healthy: false,
+          message: "No provider available for datastore type",
+          latencyMs: 0,
+        };
+      } else {
+        const verifier = new FilesystemDatastoreVerifier(config.path);
+        return await verifier.verify();
+      }
+    },
+    getVaultConfigs: async () => {
+      const vaultRepo = new YamlVaultConfigRepository(repoDir);
+      try {
+        const vaultConfigs = await vaultRepo.findAll();
+        return vaultConfigs.map((vc) => ({ name: vc.name, type: vc.type }));
+      } catch {
+        return [];
+      }
+    },
+  };
+}
 
 export const doctorDatastoresCommand = withRemoteOptions(
   new Command()

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createDoctorDatastoresDeps,
+  createLibSwampContext,
+  doctorDatastores,
+  type DoctorDatastoresData,
+} from "../../libswamp/mod.ts";
+import { createDoctorDatastoresRenderer } from "../../presentation/renderers/doctor_datastores.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { DoctorDatastoresResponse } from "../../serve/protocol.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const doctorDatastoresCommand = withRemoteOptions(
+  new Command()
+    .description(
+      "Check that the configured datastore is healthy and flag any " +
+        "vault compatibility issues.",
+    )
+    .example("Check this repo's datastore", "swamp doctor datastores")
+    .example("Machine-readable output for CI", "swamp doctor datastores --json")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "doctor",
+    "datastores",
+  ]);
+  cliCtx.logger.debug("Executing doctor datastores command");
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<DoctorDatastoresResponse>(
+      { server, token },
+      {
+        type: "doctor.datastores",
+        payload: {},
+      },
+    );
+    const renderer = createDoctorDatastoresRenderer(cliCtx.outputMode);
+    await consumeStream(
+      (async function* () {
+        yield {
+          kind: "completed" as const,
+          data: response.data as unknown as DoctorDatastoresData,
+        };
+      })(),
+      renderer.handlers(),
+    );
+    if (renderer.overallStatus === "fail") {
+      Deno.exit(1);
+    }
+    return;
+  }
+
+  const repoDir = resolveRepoDir(options.repoDir);
+  await resolveDatastoreForRepo(repoDir);
+
+  const libCtx = createLibSwampContext();
+  const deps = await createDoctorDatastoresDeps(repoDir);
+  const renderer = createDoctorDatastoresRenderer(cliCtx.outputMode);
+
+  await consumeStream(
+    doctorDatastores(libCtx, deps),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("doctor datastores command completed");
+
+  if (renderer.overallStatus === "fail") {
+    Deno.exit(1);
+  }
+});

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -88,17 +88,7 @@ import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { readLocalManifestIdentity } from "../../infrastructure/persistence/local_manifest_reader.ts";
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/extension_deprecate.ts
+++ b/src/cli/commands/extension_deprecate.ts
@@ -32,23 +32,10 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const extensionDeprecateCommand = new Command()
   .name("deprecate")

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -72,22 +72,10 @@ export {
   validateExtensionName,
 } from "../../libswamp/mod.ts";
 
+import { promptConfirmation } from "../prompt_helpers.ts";
+
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 /** PullContext for use by extension_search.ts and other callers. */
 export interface PullContext {

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -59,6 +59,7 @@ import type {
 import type { CompilationError, SwampError } from "../../libswamp/mod.ts";
 import { loadIdentity } from "../load_identity.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 interface ExtensionPushOptions extends GlobalOptions {
   repoDir?: string;
@@ -68,20 +69,6 @@ interface ExtensionPushOptions extends GlobalOptions {
   releaseNotes?: string;
   channel?: string;
   versionSuffix?: string;
-}
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
 }
 
 /**

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -50,23 +50,10 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionRmResponse } from "../../serve/protocol.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const extensionRemoveCommand = withRemoteOptions(
   new Command()

--- a/src/cli/commands/extension_undeprecate.ts
+++ b/src/cli/commands/extension_undeprecate.ts
@@ -32,23 +32,10 @@ import {
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const extensionUndeprecateCommand = new Command()
   .name("undeprecate")

--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -34,23 +34,10 @@ import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
 import { loadIdentity } from "../load_identity.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const extensionUnyankCommand = new Command()
   .name("unyank")

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -34,23 +34,10 @@ import { UserError } from "../../domain/errors.ts";
 import { parseExtensionRef } from "./extension_pull.ts";
 import { loadIdentity } from "../load_identity.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const extensionYankCommand = new Command()
   .name("yank")

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -48,23 +48,10 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ModelDeleteResponse } from "../../serve/protocol.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const modelDeleteCommand = withRemoteOptions(
   new Command()

--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -48,23 +48,10 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { VaultDeleteResponse } from "../../serve/protocol.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const vaultDeleteCommand = withRemoteOptions(
   new Command()

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -182,12 +182,13 @@ Both the source and target vaults must be different types.`,
             "extension",
             "search",
             query,
-            "--label",
-            "vault",
+            "--content-type",
+            "vaults",
             "--json",
           ],
           stdout: "piped",
           stderr: "piped",
+          signal: AbortSignal.timeout(30_000),
         });
         const searchOutput = await searchCmd.output();
         let searchResults: Array<{ type: string; description: string }> = [];
@@ -199,15 +200,12 @@ Both the source and target vaults must be different types.`,
               extensions?: Array<{
                 name: string;
                 description: string;
-                contentTypes: string[];
               }>;
             };
-            searchResults = (parsed.extensions ?? [])
-              .filter((r) => r.contentTypes.includes("vaults"))
-              .map((r) => ({
-                type: r.name,
-                description: r.description,
-              }));
+            searchResults = (parsed.extensions ?? []).map((r) => ({
+              type: r.name,
+              description: r.description,
+            }));
           } catch {
             // Treat parse failure as no results
           }

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -37,20 +37,11 @@ import {
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import {
+  promptChoice,
+  promptConfirmation,
+  promptLine,
+} from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -67,7 +58,7 @@ vault references continue to work without modification.
 Both the source and target vaults must be different types.`,
   )
   .arguments("<vault_name:string>")
-  .option("--to-type <type:string>", "Target vault type", { required: true })
+  .option("--to-type <type:string>", "Target vault type")
   .option(
     "--config <config:string>",
     'Provider-specific config as JSON (e.g. \'{"region":"us-east-1"}\')',
@@ -81,6 +72,10 @@ Both the source and target vaults must be different types.`,
   .example(
     "Migrate to AWS Secrets Manager",
     'swamp vault migrate my-vault --to-type @swamp/aws-sm --config \'{"region":"us-east-1"}\'',
+  )
+  .example(
+    "Interactive migration",
+    "swamp vault migrate my-vault",
   )
   .example(
     "Preview migration (dry run)",
@@ -113,12 +108,146 @@ Both the source and target vaults must be different types.`,
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = await createVaultMigrateDeps(repoDir);
 
+    // Resolve --to-type: use the provided value or prompt interactively
+    let toType: string = options.toType;
+    if (!toType) {
+      if (cliCtx.outputMode === "json") {
+        throw new UserError(
+          "Interactive vault migration is not available in JSON mode. Provide --to-type explicitly.",
+        );
+      }
+
+      // Look up the vault to show current type
+      const vaultConfig = await deps.findVaultConfig(vaultName);
+      if (!vaultConfig) {
+        throw new UserError(
+          `Vault '${vaultName}' not found. Use 'swamp vault search' to see available vaults.`,
+        );
+      }
+
+      const currentType = vaultConfig.type;
+      const logger = getSwampLogger(["vault", "migrate"]);
+      logger
+        .info`Vault ${vaultName} is currently using type ${currentType}.`;
+
+      const VAULT_CHOICES = [
+        "AWS Secrets Manager",
+        "Azure Key Vault",
+        "1Password",
+        "Other",
+      ];
+      const chosen = await promptChoice(
+        "Select the target vault provider:",
+        VAULT_CHOICES,
+      );
+
+      if (chosen === "AWS Secrets Manager") {
+        toType = "@swamp/aws-sm";
+        const region = await promptLine("AWS region (e.g. us-east-1): ");
+        if (region) {
+          targetConfig = { region };
+        }
+      } else if (chosen === "Azure Key Vault") {
+        toType = "@swamp/azure-kv";
+        const vaultUrl = await promptLine("Azure Key Vault URL: ");
+        if (vaultUrl) {
+          targetConfig = { vaultUrl };
+        }
+      } else if (chosen === "1Password") {
+        toType = "@swamp/1password";
+        const vault = await promptLine(
+          "1Password vault name (or Enter for default): ",
+        );
+        if (vault) {
+          targetConfig = { vault };
+        }
+      } else {
+        // Other: search for a vault extension by keyword
+        const query = await promptLine(
+          "Search for a vault extension (e.g. hashicorp, doppler): ",
+        );
+        if (!query) {
+          throw new UserError("No search query provided.");
+        }
+
+        const encoder = new TextEncoder();
+        await Deno.stdout.write(
+          encoder.encode(
+            `\nSearching for "${query}" vault extensions…\n`,
+          ),
+        );
+
+        const searchCmd = new Deno.Command(Deno.execPath(), {
+          args: [
+            "extension",
+            "search",
+            query,
+            "--label",
+            "vault",
+            "--json",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const searchOutput = await searchCmd.output();
+        let searchResults: Array<{ type: string; description: string }> = [];
+        if (searchOutput.success) {
+          try {
+            const parsed = JSON.parse(
+              new TextDecoder().decode(searchOutput.stdout),
+            ) as {
+              extensions?: Array<{
+                name: string;
+                description: string;
+                contentTypes: string[];
+              }>;
+            };
+            searchResults = (parsed.extensions ?? [])
+              .filter((r) => r.contentTypes.includes("vaults"))
+              .map((r) => ({
+                type: r.name,
+                description: r.description,
+              }));
+          } catch {
+            // Treat parse failure as no results
+          }
+        }
+
+        if (searchResults.length === 0) {
+          throw new UserError(
+            `No vault extensions found for "${query}". ` +
+              `Browse available extensions at https://swamp-club.com/extensions`,
+          );
+        }
+
+        const typeChoices = searchResults.map((r) =>
+          `${r.type} — ${r.description}`
+        );
+        const chosenExt = await promptChoice(
+          "Which vault extension?",
+          typeChoices,
+        );
+        toType = chosenExt.split(" — ")[0];
+
+        const configJson = await promptLine(
+          `Config JSON for ${toType} (e.g. {}, or Enter to skip): `,
+        );
+        if (configJson) {
+          try {
+            targetConfig = JSON.parse(configJson);
+          } catch {
+            throw new UserError(`Invalid JSON: ${configJson}`);
+          }
+        }
+      }
+    }
+
     // Phase 1: Preview
     let preview;
     try {
       preview = await vaultMigratePreview(ctx, deps, {
         vaultName,
-        targetType: options.toType,
+        targetType: toType,
         targetConfig,
         repoDir,
       });
@@ -175,7 +304,7 @@ Both the source and target vaults must be different types.`,
     await consumeStream(
       vaultMigrate(ctx, deps, {
         vaultName,
-        targetType: options.toType,
+        targetType: toType,
         targetConfig,
         repoDir,
       }),

--- a/src/cli/commands/vault_migrate_test.ts
+++ b/src/cli/commands/vault_migrate_test.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("vaultMigrateCommand: module loads", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  assertEquals(vaultMigrateCommand.getName(), "migrate");
+});
+
+Deno.test("vaultMigrateCommand: --to-type is not required", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  const options = vaultMigrateCommand.getOptions();
+  const toTypeOpt = options.find((o) => o.name === "to-type");
+  assertEquals(toTypeOpt !== undefined, true);
+  assertEquals(toTypeOpt?.required ?? false, false);
+});
+
+Deno.test("vaultMigrateCommand: has --config option", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  const options = vaultMigrateCommand.getOptions();
+  const opt = options.find((o) => o.name === "config");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("vaultMigrateCommand: has --force option", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  const options = vaultMigrateCommand.getOptions();
+  const opt = options.find((o) => o.name === "force");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("vaultMigrateCommand: has --dry-run option", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  const options = vaultMigrateCommand.getOptions();
+  const opt = options.find((o) => o.name === "dry-run");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("vaultMigrateCommand: has --repo-dir option", async () => {
+  const { vaultMigrateCommand } = await import("./vault_migrate.ts");
+  const options = vaultMigrateCommand.getOptions();
+  const opt = options.find((o) => o.name === "repo-dir");
+  assertEquals(opt !== undefined, true);
+});

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -115,19 +115,7 @@ export function resolveKeyValue(
   };
 }
 
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;

--- a/src/cli/commands/vault_read_secret.ts
+++ b/src/cli/commands/vault_read_secret.ts
@@ -34,23 +34,10 @@ import {
   acquireVaultSync,
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const vaultReadSecretCommand = new Command()
   .name("read-secret")

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -36,23 +36,10 @@ import {
 } from "../context.ts";
 import { requireInitializedRepo } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
-
-async function promptConfirmation(message: string): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-
-  await Deno.stdout.write(encoder.encode(`${message} [y/N] `));
-
-  const buf = new Uint8Array(1024);
-  const n = await Deno.stdin.read(buf);
-  if (n === null) return false;
-
-  const response = decoder.decode(buf.subarray(0, n)).trim().toLowerCase();
-  return response === "y" || response === "yes";
-}
 
 export const workflowDeleteCommand = new Command()
   .name("delete")

--- a/src/cli/prompt_helpers.ts
+++ b/src/cli/prompt_helpers.ts
@@ -1,0 +1,94 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Shared interactive prompt helpers for CLI commands.
+ *
+ * These thin wrappers over raw stdin/stdout keep the prompt UX
+ * consistent across every command that needs user confirmation or
+ * free-text input.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * Prompt for a single line of text input.
+ * Returns the trimmed response, or an empty string on EOF.
+ */
+export async function promptLine(message: string): Promise<string> {
+  await Deno.stdout.write(encoder.encode(message));
+  const buf = new Uint8Array(1024);
+  const n = await Deno.stdin.read(buf);
+  if (n === null) return "";
+  return decoder.decode(buf.subarray(0, n)).trim();
+}
+
+/**
+ * Prompt for a yes/no confirmation.
+ * Appends ` [y/N] ` to the message. Returns `true` for "y" or "yes"
+ * (case-insensitive), `false` otherwise (including EOF).
+ */
+export async function promptConfirmation(message: string): Promise<boolean> {
+  const response = await promptLine(`${message} [y/N] `);
+  if (response === "") return false;
+  return response.toLowerCase() === "y" ||
+    response.toLowerCase() === "yes";
+}
+
+/**
+ * Prompt the user to choose from a numbered list of options.
+ * An extra "Other path" option is appended; selecting it prompts for
+ * a free-text path. Returns the chosen string.
+ */
+export async function promptChoice(
+  message: string,
+  choices: string[],
+): Promise<string> {
+  await Deno.stdout.write(encoder.encode(`${message}\n`));
+  for (let i = 0; i < choices.length; i++) {
+    await Deno.stdout.write(
+      encoder.encode(`  ${i + 1}. ${choices[i]}\n`),
+    );
+  }
+  await Deno.stdout.write(
+    encoder.encode(`  ${choices.length + 1}. Other path\n`),
+  );
+  const response = await promptLine("> ");
+  const index = parseInt(response, 10) - 1;
+  if (index >= 0 && index < choices.length) {
+    return choices[index];
+  }
+  if (index === choices.length) {
+    return await promptLine("Path: ");
+  }
+  return response || choices[0];
+}
+
+/**
+ * Like {@link promptLine} but displays a default value and returns it
+ * when the user presses Enter without typing anything.
+ */
+export async function promptLineWithDefault(
+  message: string,
+  defaultValue: string,
+): Promise<string> {
+  const response = await promptLine(`${message} (default: ${defaultValue}) `);
+  return response === "" ? defaultValue : response;
+}

--- a/src/cli/prompt_helpers.ts
+++ b/src/cli/prompt_helpers.ts
@@ -61,24 +61,23 @@ export async function promptChoice(
   message: string,
   choices: string[],
 ): Promise<string> {
-  await Deno.stdout.write(encoder.encode(`${message}\n`));
-  for (let i = 0; i < choices.length; i++) {
+  while (true) {
+    await Deno.stdout.write(encoder.encode(`${message}\n`));
+    for (let i = 0; i < choices.length; i++) {
+      await Deno.stdout.write(
+        encoder.encode(`  ${i + 1}. ${choices[i]}\n`),
+      );
+    }
+    const response = await promptLine("> ");
+    const index = parseInt(response, 10) - 1;
+    if (index >= 0 && index < choices.length) {
+      return choices[index];
+    }
+    if (response === "") return choices[0];
     await Deno.stdout.write(
-      encoder.encode(`  ${i + 1}. ${choices[i]}\n`),
+      encoder.encode(`Invalid choice. Please enter 1-${choices.length}.\n`),
     );
   }
-  await Deno.stdout.write(
-    encoder.encode(`  ${choices.length + 1}. Other path\n`),
-  );
-  const response = await promptLine("> ");
-  const index = parseInt(response, 10) - 1;
-  if (index >= 0 && index < choices.length) {
-    return choices[index];
-  }
-  if (index === choices.length) {
-    return await promptLine("Path: ");
-  }
-  return response || choices[0];
 }
 
 /**

--- a/src/cli/prompt_helpers_test.ts
+++ b/src/cli/prompt_helpers_test.ts
@@ -1,0 +1,238 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  promptChoice,
+  promptConfirmation,
+  promptLine,
+  promptLineWithDefault,
+} from "./prompt_helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers — stub Deno.stdin.read and Deno.stdout.write so the prompt
+// functions can be tested without a real TTY.
+// ---------------------------------------------------------------------------
+
+function fakeStdinRead(
+  response: string | null,
+): (buf: Uint8Array) => Promise<number | null> {
+  const encoder = new TextEncoder();
+  return (buf: Uint8Array) => {
+    if (response === null) return Promise.resolve(null);
+    const encoded = encoder.encode(response);
+    buf.set(encoded);
+    return Promise.resolve(encoded.length);
+  };
+}
+
+/** Capture stdout writes into a string array and stub stdin to return `input`. */
+function stubIO(input: string | null): {
+  written: string[];
+  restore: () => void;
+} {
+  const written: string[] = [];
+  const decoder = new TextDecoder();
+  const origStdoutWrite = Deno.stdout.write.bind(Deno.stdout);
+  const origStdinRead = Deno.stdin.read.bind(Deno.stdin);
+
+  Deno.stdout.write = (data: Uint8Array) => {
+    written.push(decoder.decode(data));
+    return Promise.resolve(data.length);
+  };
+  Deno.stdin.read = fakeStdinRead(input);
+
+  return {
+    written,
+    restore() {
+      Deno.stdout.write = origStdoutWrite;
+      Deno.stdin.read = origStdinRead;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// promptLine
+// ---------------------------------------------------------------------------
+
+Deno.test("promptLine: returns trimmed user input", async () => {
+  const io = stubIO("  hello world  \n");
+  try {
+    const result = await promptLine("Enter: ");
+    assertEquals(result, "hello world");
+    assertEquals(io.written, ["Enter: "]);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptLine: returns empty string on EOF", async () => {
+  const io = stubIO(null);
+  try {
+    const result = await promptLine("Enter: ");
+    assertEquals(result, "");
+  } finally {
+    io.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// promptConfirmation
+// ---------------------------------------------------------------------------
+
+Deno.test("promptConfirmation: accepts 'y'", async () => {
+  const io = stubIO("y\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), true);
+    assertEquals(io.written, ["Delete? [y/N] "]);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: accepts 'yes'", async () => {
+  const io = stubIO("yes\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), true);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: accepts 'Y' (case-insensitive)", async () => {
+  const io = stubIO("Y\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), true);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: accepts 'YES' (case-insensitive)", async () => {
+  const io = stubIO("YES\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), true);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: rejects 'n'", async () => {
+  const io = stubIO("n\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), false);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: rejects empty input", async () => {
+  const io = stubIO("\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), false);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: returns false on EOF", async () => {
+  const io = stubIO(null);
+  try {
+    assertEquals(await promptConfirmation("Delete?"), false);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptConfirmation: rejects arbitrary text", async () => {
+  const io = stubIO("yep\n");
+  try {
+    assertEquals(await promptConfirmation("Delete?"), false);
+  } finally {
+    io.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// promptChoice
+// ---------------------------------------------------------------------------
+
+Deno.test("promptChoice: selects a numbered choice", async () => {
+  const choices = ["alpha", "beta", "gamma"];
+  // Simulate user typing "2" to pick "beta"
+  const io = stubIO("2\n");
+  try {
+    const result = await promptChoice("Pick one:", choices);
+    assertEquals(result, "beta");
+    // Verify it printed the menu
+    const output = io.written.join("");
+    assertEquals(output.includes("1. alpha"), true);
+    assertEquals(output.includes("2. beta"), true);
+    assertEquals(output.includes("3. gamma"), true);
+    assertEquals(output.includes("4. Other path"), true);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptChoice: falls back to first choice on empty input", async () => {
+  const choices = ["alpha", "beta"];
+  const io = stubIO("\n");
+  try {
+    const result = await promptChoice("Pick:", choices);
+    assertEquals(result, "alpha");
+  } finally {
+    io.restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// promptLineWithDefault
+// ---------------------------------------------------------------------------
+
+Deno.test("promptLineWithDefault: returns user input when provided", async () => {
+  const io = stubIO("custom\n");
+  try {
+    const result = await promptLineWithDefault("Value:", "fallback");
+    assertEquals(result, "custom");
+    assertEquals(io.written, ["Value: (default: fallback) "]);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptLineWithDefault: returns default on empty input", async () => {
+  const io = stubIO("\n");
+  try {
+    const result = await promptLineWithDefault("Value:", "fallback");
+    assertEquals(result, "fallback");
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptLineWithDefault: returns default on EOF", async () => {
+  const io = stubIO(null);
+  try {
+    const result = await promptLineWithDefault("Value:", "fallback");
+    assertEquals(result, "fallback");
+  } finally {
+    io.restore();
+  }
+});

--- a/src/cli/prompt_helpers_test.ts
+++ b/src/cli/prompt_helpers_test.ts
@@ -175,17 +175,15 @@ Deno.test("promptConfirmation: rejects arbitrary text", async () => {
 
 Deno.test("promptChoice: selects a numbered choice", async () => {
   const choices = ["alpha", "beta", "gamma"];
-  // Simulate user typing "2" to pick "beta"
   const io = stubIO("2\n");
   try {
     const result = await promptChoice("Pick one:", choices);
     assertEquals(result, "beta");
-    // Verify it printed the menu
     const output = io.written.join("");
     assertEquals(output.includes("1. alpha"), true);
     assertEquals(output.includes("2. beta"), true);
     assertEquals(output.includes("3. gamma"), true);
-    assertEquals(output.includes("4. Other path"), true);
+    assertEquals(output.includes("Other path"), false);
   } finally {
     io.restore();
   }

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -352,6 +352,23 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp/references/troubleshooting/references/tracing.md",
     name: "swamp",
   },
+  // swamp share guide area
+  {
+    relativePath: "swamp/references/share/guide.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/share/reference.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/share/references/joiner-instructions.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/share/references/troubleshooting.md",
+    name: "swamp",
+  },
   // swamp-getting-started (standalone skill)
   {
     relativePath: "swamp-getting-started/SKILL.md",

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -432,3 +432,70 @@ Deno.test("SkillAssets.copySkillsTo copies extension datastore references", asyn
     assertEquals(apiStat.isFile, true);
   });
 });
+
+Deno.test("SkillAssets.copySkillsTo copies share guide and references", async () => {
+  await withTempDir(async (dir) => {
+    const assets = new SkillAssets();
+    await assets.copySkillsTo(dir);
+
+    const guidePath = join(
+      dir,
+      "swamp",
+      "references",
+      "share",
+      "guide.md",
+    );
+    const referencePath = join(
+      dir,
+      "swamp",
+      "references",
+      "share",
+      "reference.md",
+    );
+    const joinerPath = join(
+      dir,
+      "swamp",
+      "references",
+      "share",
+      "references",
+      "joiner-instructions.md",
+    );
+    const troubleshootingPath = join(
+      dir,
+      "swamp",
+      "references",
+      "share",
+      "references",
+      "troubleshooting.md",
+    );
+
+    const guideStat = await Deno.stat(guidePath);
+    assertEquals(guideStat.isFile, true);
+
+    const referenceStat = await Deno.stat(referencePath);
+    assertEquals(referenceStat.isFile, true);
+
+    const joinerStat = await Deno.stat(joinerPath);
+    assertEquals(joinerStat.isFile, true);
+
+    const troubleshootingStat = await Deno.stat(troubleshootingPath);
+    assertEquals(troubleshootingStat.isFile, true);
+  });
+});
+
+Deno.test("SkillAssets.listSkills includes share guide entries", () => {
+  const assets = new SkillAssets();
+  const skills = assets.listSkills();
+
+  const shareGuide = skills.find((s) =>
+    s.relativePath === "swamp/references/share/guide.md"
+  );
+  assertEquals(shareGuide !== undefined, true);
+  assertEquals(shareGuide?.name, "swamp");
+
+  const joiner = skills.find((s) =>
+    s.relativePath ===
+      "swamp/references/share/references/joiner-instructions.md"
+  );
+  assertEquals(joiner !== undefined, true);
+});

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -1,0 +1,170 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { resolveDatastoreConfig } from "../../cli/resolve_datastore.ts";
+
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+/** Result of a single health check within the datastore doctor scan. */
+export interface DatastoreHealthFinding {
+  check: string;
+  passed: boolean;
+  message: string;
+}
+
+/** A vault whose type is incompatible with a remote datastore. */
+export interface VaultMismatchFinding {
+  vaultName: string;
+  vaultType: string;
+}
+
+/** Outcome of a `doctor datastores` scan. */
+export interface DoctorDatastoresData {
+  datastoreType: string;
+  isCustom: boolean;
+  healthFindings: DatastoreHealthFinding[];
+  vaultMismatchFindings: VaultMismatchFinding[];
+}
+
+export type DoctorDatastoresEvent =
+  | { kind: "scanning" }
+  | { kind: "completed"; data: DoctorDatastoresData }
+  | { kind: "error"; error: SwampError };
+
+/** Dependencies for the `doctor datastores` scan. */
+export interface DoctorDatastoresDeps {
+  getDatastoreConfig: () => Promise<DatastoreConfig>;
+  checkHealth: (
+    config: DatastoreConfig,
+  ) => Promise<{ healthy: boolean; message: string; latencyMs: number }>;
+  getVaultConfigs: () => Promise<Array<{ name: string; type: string }>>;
+}
+
+/**
+ * Wires real infrastructure into {@link DoctorDatastoresDeps}.
+ */
+export async function createDoctorDatastoresDeps(
+  repoDir: string,
+): Promise<DoctorDatastoresDeps> {
+  await datastoreTypeRegistry.ensureLoaded();
+  return {
+    getDatastoreConfig: async () => {
+      const markerRepo = new RepoMarkerRepository();
+      const marker = await markerRepo.read(RepoPath.create(repoDir));
+      return await resolveDatastoreConfig(marker, undefined, repoDir);
+    },
+    checkHealth: async (config: DatastoreConfig) => {
+      if (isCustomDatastoreConfig(config)) {
+        await datastoreTypeRegistry.ensureTypeLoaded(config.type);
+        const typeInfo = datastoreTypeRegistry.get(config.type);
+        if (typeInfo?.createProvider) {
+          const provider = typeInfo.createProvider(config.config);
+          const verifier = provider.createVerifier();
+          return await verifier.verify();
+        }
+        return {
+          healthy: false,
+          message: "No provider available for datastore type",
+          latencyMs: 0,
+        };
+      } else {
+        const verifier = new FilesystemDatastoreVerifier(config.path);
+        return await verifier.verify();
+      }
+    },
+    getVaultConfigs: async () => {
+      const vaultRepo = new YamlVaultConfigRepository(repoDir);
+      try {
+        const vaultConfigs = await vaultRepo.findAll();
+        return vaultConfigs.map((vc) => ({ name: vc.name, type: vc.type }));
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+/**
+ * Diagnostic scan that checks:
+ * 1. The configured datastore is reachable (health check).
+ * 2. When a custom (remote) datastore is in use, any `local_encryption`
+ *    vaults are flagged as an advisory mismatch — local encryption keys
+ *    are tied to the machine and won't work from other hosts sharing the
+ *    remote datastore.
+ */
+export async function* doctorDatastores(
+  _ctx: LibSwampContext,
+  deps: DoctorDatastoresDeps,
+): AsyncGenerator<DoctorDatastoresEvent> {
+  yield* withGeneratorSpan(
+    "swamp.doctor.datastores",
+    {},
+    (async function* () {
+      yield { kind: "scanning" };
+
+      const config = await deps.getDatastoreConfig();
+      const isCustom = isCustomDatastoreConfig(config);
+      const healthFindings: DatastoreHealthFinding[] = [];
+      const vaultMismatchFindings: VaultMismatchFinding[] = [];
+
+      // Health check
+      const { healthy, message } = await deps.checkHealth(config);
+      healthFindings.push({
+        check: "health",
+        passed: healthy,
+        message,
+      });
+
+      // Vault mismatch check — only relevant for custom (remote) datastores
+      if (isCustom) {
+        const vaults = await deps.getVaultConfigs();
+        for (const vault of vaults) {
+          if (vault.type === "local_encryption") {
+            vaultMismatchFindings.push({
+              vaultName: vault.name,
+              vaultType: vault.type,
+            });
+          }
+        }
+      }
+
+      yield {
+        kind: "completed",
+        data: {
+          datastoreType: config.type,
+          isCustom,
+          healthFindings,
+          vaultMismatchFindings,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -21,12 +21,6 @@ import {
   type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
-import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
-import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
-import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveDatastoreConfig } from "../../cli/resolve_datastore.ts";
 
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -66,50 +60,6 @@ export interface DoctorDatastoresDeps {
     config: DatastoreConfig,
   ) => Promise<{ healthy: boolean; message: string; latencyMs: number }>;
   getVaultConfigs: () => Promise<Array<{ name: string; type: string }>>;
-}
-
-/**
- * Wires real infrastructure into {@link DoctorDatastoresDeps}.
- */
-export async function createDoctorDatastoresDeps(
-  repoDir: string,
-): Promise<DoctorDatastoresDeps> {
-  await datastoreTypeRegistry.ensureLoaded();
-  return {
-    getDatastoreConfig: async () => {
-      const markerRepo = new RepoMarkerRepository();
-      const marker = await markerRepo.read(RepoPath.create(repoDir));
-      return await resolveDatastoreConfig(marker, undefined, repoDir);
-    },
-    checkHealth: async (config: DatastoreConfig) => {
-      if (isCustomDatastoreConfig(config)) {
-        await datastoreTypeRegistry.ensureTypeLoaded(config.type);
-        const typeInfo = datastoreTypeRegistry.get(config.type);
-        if (typeInfo?.createProvider) {
-          const provider = typeInfo.createProvider(config.config);
-          const verifier = provider.createVerifier();
-          return await verifier.verify();
-        }
-        return {
-          healthy: false,
-          message: "No provider available for datastore type",
-          latencyMs: 0,
-        };
-      } else {
-        const verifier = new FilesystemDatastoreVerifier(config.path);
-        return await verifier.verify();
-      }
-    },
-    getVaultConfigs: async () => {
-      const vaultRepo = new YamlVaultConfigRepository(repoDir);
-      try {
-        const vaultConfigs = await vaultRepo.findAll();
-        return vaultConfigs.map((vc) => ({ name: vc.name, type: vc.type }));
-      } catch {
-        return [];
-      }
-    },
-  };
 }
 
 /**

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -1,0 +1,176 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  doctorDatastores,
+  type DoctorDatastoresDeps,
+  type DoctorDatastoresEvent,
+} from "./doctor_datastores.ts";
+import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+
+function makeDeps(
+  config: DatastoreConfig,
+  healthResult: { healthy: boolean; message: string; latencyMs: number },
+  vaults: Array<{ name: string; type: string }>,
+): DoctorDatastoresDeps {
+  return {
+    getDatastoreConfig: () => Promise.resolve(config),
+    checkHealth: () => Promise.resolve(healthResult),
+    getVaultConfigs: () => Promise.resolve(vaults),
+  };
+}
+
+const filesystemConfig: DatastoreConfig = {
+  type: "filesystem",
+  path: "/tmp/test-repo/.swamp",
+};
+
+const customConfig: DatastoreConfig = {
+  type: "@swamp/s3-datastore",
+  config: { bucket: "test-bucket" },
+  datastorePath: "/tmp/cache",
+};
+
+Deno.test("doctorDatastores: filesystem datastore, healthy", async () => {
+  const deps = makeDeps(
+    filesystemConfig,
+    { healthy: true, message: "Datastore is accessible", latencyMs: 1 },
+    [],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.datastoreType, "filesystem");
+    assertEquals(completed.data.isCustom, false);
+    assertEquals(completed.data.healthFindings.length, 1);
+    assertEquals(completed.data.healthFindings[0].passed, true);
+    assertEquals(completed.data.vaultMismatchFindings.length, 0);
+  }
+});
+
+Deno.test("doctorDatastores: custom datastore, healthy, no local_encryption vaults", async () => {
+  const deps = makeDeps(
+    customConfig,
+    { healthy: true, message: "S3 bucket accessible", latencyMs: 42 },
+    [{ name: "prod-vault", type: "aws_secretsmanager" }],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.datastoreType, "@swamp/s3-datastore");
+    assertEquals(completed.data.isCustom, true);
+    assertEquals(completed.data.healthFindings.length, 1);
+    assertEquals(completed.data.healthFindings[0].passed, true);
+    assertEquals(completed.data.vaultMismatchFindings.length, 0);
+  }
+});
+
+Deno.test("doctorDatastores: custom datastore, unhealthy", async () => {
+  const deps = makeDeps(
+    customConfig,
+    { healthy: false, message: "S3 bucket not found", latencyMs: 100 },
+    [],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.healthFindings.length, 1);
+    assertEquals(completed.data.healthFindings[0].passed, false);
+    assertEquals(
+      completed.data.healthFindings[0].message,
+      "S3 bucket not found",
+    );
+  }
+});
+
+Deno.test("doctorDatastores: custom datastore, healthy, local_encryption vaults flagged", async () => {
+  const deps = makeDeps(
+    customConfig,
+    { healthy: true, message: "S3 bucket accessible", latencyMs: 30 },
+    [
+      { name: "local-vault", type: "local_encryption" },
+      { name: "remote-vault", type: "aws_secretsmanager" },
+    ],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.healthFindings[0].passed, true);
+    assertEquals(completed.data.vaultMismatchFindings.length, 1);
+    assertEquals(
+      completed.data.vaultMismatchFindings[0].vaultName,
+      "local-vault",
+    );
+    assertEquals(
+      completed.data.vaultMismatchFindings[0].vaultType,
+      "local_encryption",
+    );
+  }
+});
+
+Deno.test("doctorDatastores: filesystem datastore skips vault mismatch check", async () => {
+  const deps = makeDeps(
+    filesystemConfig,
+    { healthy: true, message: "Datastore is accessible", latencyMs: 1 },
+    [{ name: "local-vault", type: "local_encryption" }],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    // Vault mismatch is not checked for filesystem datastores
+    assertEquals(completed.data.vaultMismatchFindings.length, 0);
+  }
+});
+
+Deno.test("doctorDatastores: emits scanning event first", async () => {
+  const deps = makeDeps(
+    filesystemConfig,
+    { healthy: true, message: "OK", latencyMs: 1 },
+    [],
+  );
+
+  const events = await collect<DoctorDatastoresEvent>(
+    doctorDatastores(createLibSwampContext(), deps),
+  );
+  assertEquals(events[0].kind, "scanning");
+  assertEquals(events[1].kind, "completed");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -220,6 +220,15 @@ export {
   type VaultRequiredFinding,
 } from "./models/doctor_vaults.ts";
 export {
+  createDoctorDatastoresDeps,
+  type DatastoreHealthFinding,
+  doctorDatastores,
+  type DoctorDatastoresData,
+  type DoctorDatastoresDeps,
+  type DoctorDatastoresEvent,
+  type VaultMismatchFinding,
+} from "./datastores/doctor_datastores.ts";
+export {
   modelOutputSearch,
   type ModelOutputSearchData,
   type ModelOutputSearchDeps,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -220,7 +220,6 @@ export {
   type VaultRequiredFinding,
 } from "./models/doctor_vaults.ts";
 export {
-  createDoctorDatastoresDeps,
   type DatastoreHealthFinding,
   doctorDatastores,
   type DoctorDatastoresData,

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -1,0 +1,131 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import type {
+  DoctorDatastoresEvent,
+  EventHandlers,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { OutputMode } from "../output/output.ts";
+
+export type DoctorDatastoresStatus = "pass" | "fail";
+
+export interface DoctorDatastoresRenderer {
+  handlers(): EventHandlers<DoctorDatastoresEvent>;
+  readonly overallStatus: DoctorDatastoresStatus;
+}
+
+class LogDoctorDatastoresRenderer implements DoctorDatastoresRenderer {
+  overallStatus: DoctorDatastoresStatus = "pass";
+
+  handlers(): EventHandlers<DoctorDatastoresEvent> {
+    return {
+      scanning: () => {
+        writeOutput(dim("Checking datastore health…"));
+      },
+      completed: (e) => {
+        const { data } = e;
+
+        writeOutput(`\nDatastore type: ${bold(data.datastoreType)}`);
+
+        // Render health findings
+        for (const finding of data.healthFindings) {
+          if (finding.passed) {
+            writeOutput(`${green("✓")} ${finding.message}`);
+          } else {
+            this.overallStatus = "fail";
+            writeOutput(`${red("✗")} ${finding.message}`);
+          }
+        }
+
+        // Render vault mismatch advisory (yellow, does not cause failure)
+        if (data.vaultMismatchFindings.length > 0) {
+          writeOutput(
+            `\n${yellow("⚠")} ${
+              bold(
+                `${data.vaultMismatchFindings.length} vault(s) use local_encryption with a remote datastore`,
+              )
+            }`,
+          );
+          for (const finding of data.vaultMismatchFindings) {
+            writeOutput(
+              `    ${yellow("•")} ${finding.vaultName} ${
+                dim(`[${finding.vaultType}]`)
+              }`,
+            );
+          }
+          writeOutput(
+            dim(
+              "\n  Local encryption keys are tied to this machine and won't work " +
+                "from other hosts sharing the remote datastore. " +
+                "Migrate with: swamp vault migrate <name>",
+            ),
+          );
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonDoctorDatastoresRenderer implements DoctorDatastoresRenderer {
+  overallStatus: DoctorDatastoresStatus = "pass";
+
+  handlers(): EventHandlers<DoctorDatastoresEvent> {
+    return {
+      scanning: () => {},
+      completed: (e) => {
+        const { data } = e;
+        const anyFailed = data.healthFindings.some((f) => !f.passed);
+        this.overallStatus = anyFailed ? "fail" : "pass";
+        console.log(
+          JSON.stringify(
+            {
+              overallStatus: this.overallStatus,
+              datastoreType: data.datastoreType,
+              isCustom: data.isCustom,
+              healthFindings: data.healthFindings,
+              vaultMismatchFindings: data.vaultMismatchFindings,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createDoctorDatastoresRenderer(
+  mode: OutputMode,
+): DoctorDatastoresRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonDoctorDatastoresRenderer();
+    case "log":
+      return new LogDoctorDatastoresRenderer();
+  }
+}

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -92,6 +92,7 @@ import {
 import {
   handleAuditTimeline,
   handleDatastoreStatus,
+  handleDoctorDatastores,
   handleDoctorExtensions,
   handleDoctorSecrets,
   handleDoctorVaults,
@@ -1568,6 +1569,15 @@ export function handleMessage(
       break;
     case "extension.outdated":
       task = handleExtensionOutdated(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+      );
+      break;
+    case "doctor.datastores":
+      task = handleDoctorDatastores(
         socket,
         ctx,
         request.id,

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -29,7 +29,6 @@ import {
   auditTimeline,
   consumeStream,
   createAuditTimelineDeps,
-  createDoctorDatastoresDeps,
   createDoctorSecretsDeps,
   createDoctorVaultsDeps,
   createExtensionInfoDeps,
@@ -38,6 +37,7 @@ import {
   createWorkerListDeps,
   createWorkerQueueListDeps,
   doctorDatastores,
+  type DoctorDatastoresDeps,
   doctorSecrets,
   doctorVaults,
   doctorWorkflows,
@@ -47,6 +47,13 @@ import {
   workerList,
   workerQueueList,
 } from "../../libswamp/mod.ts";
+import {
+  isCustomDatastoreConfig,
+} from "../../domain/datastore/datastore_config.ts";
+import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
+import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/filesystem_datastore_verifier.ts";
+import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { resolveDatastoreConfig } from "../../cli/resolve_datastore.ts";
 import type {
   AuditTimelinePayload,
   ExtensionInfoPayload,
@@ -562,7 +569,46 @@ export async function handleDoctorDatastores(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createDoctorDatastoresDeps(ctx.repoDir);
+    await datastoreTypeRegistry.ensureLoaded();
+    const repoDir = ctx.repoDir;
+    const deps: DoctorDatastoresDeps = {
+      getDatastoreConfig: async () => {
+        const markerRepo = new RepoMarkerRepository();
+        const marker = await markerRepo.read(RepoPath.create(repoDir));
+        return await resolveDatastoreConfig(marker, undefined, repoDir);
+      },
+      checkHealth: async (config) => {
+        if (isCustomDatastoreConfig(config)) {
+          await datastoreTypeRegistry.ensureTypeLoaded(config.type);
+          const typeInfo = datastoreTypeRegistry.get(config.type);
+          if (typeInfo?.createProvider) {
+            const provider = typeInfo.createProvider(config.config);
+            const verifier = provider.createVerifier();
+            return await verifier.verify();
+          }
+          return {
+            healthy: false,
+            message: "No provider available for datastore type",
+            latencyMs: 0,
+          };
+        } else {
+          const verifier = new FilesystemDatastoreVerifier(config.path);
+          return await verifier.verify();
+        }
+      },
+      getVaultConfigs: async () => {
+        const vaultRepo = new YamlVaultConfigRepository(repoDir);
+        try {
+          const vaultConfigs = await vaultRepo.findAll();
+          return vaultConfigs.map((vc) => ({
+            name: vc.name,
+            type: vc.type,
+          }));
+        } catch {
+          return [];
+        }
+      },
+    };
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -29,6 +29,7 @@ import {
   auditTimeline,
   consumeStream,
   createAuditTimelineDeps,
+  createDoctorDatastoresDeps,
   createDoctorSecretsDeps,
   createDoctorVaultsDeps,
   createExtensionInfoDeps,
@@ -36,6 +37,7 @@ import {
   createLibSwampContext,
   createWorkerListDeps,
   createWorkerQueueListDeps,
+  doctorDatastores,
   doctorSecrets,
   doctorVaults,
   doctorWorkflows,
@@ -540,6 +542,55 @@ export async function handleDoctorVaults(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "doctor_vaults_failed", message);
+  }
+}
+
+export async function handleDoctorDatastores(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "access",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = await createDoctorDatastoresDeps(ctx.repoDir);
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      doctorDatastores(libCtx, deps),
+      {
+        scanning: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "doctor.datastores",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "doctor_datastores_failed", message);
   }
 }
 

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -388,6 +388,8 @@ export type ExtensionOutdatedPayload = Record<string, never>;
 
 export type DoctorVaultsPayload = Record<string, never>;
 
+export type DoctorDatastoresPayload = Record<string, never>;
+
 export type DoctorSecretsPayload = Record<string, never>;
 
 export type DoctorWorkflowsPayload = Record<string, never>;
@@ -530,6 +532,11 @@ export type ServerRequest =
     payload?: ExtensionOutdatedPayload;
   }
   | { type: "doctor.vaults"; id: string; payload?: DoctorVaultsPayload }
+  | {
+    type: "doctor.datastores";
+    id: string;
+    payload?: DoctorDatastoresPayload;
+  }
   | { type: "doctor.secrets"; id: string; payload?: DoctorSecretsPayload }
   | {
     type: "doctor.workflows";
@@ -855,6 +862,10 @@ export interface DoctorVaultsResponse {
   data: Record<string, unknown>;
 }
 
+export interface DoctorDatastoresResponse {
+  data: Record<string, unknown>;
+}
+
 export interface DoctorSecretsResponse {
   data: Record<string, unknown>;
 }
@@ -1023,6 +1034,11 @@ export type ServerMessage =
     payload: ExtensionOutdatedResponse;
   }
   | { type: "doctor.vaults"; id: string; payload: DoctorVaultsResponse }
+  | {
+    type: "doctor.datastores";
+    id: string;
+    payload: DoctorDatastoresResponse;
+  }
   | { type: "doctor.secrets"; id: string; payload: DoctorSecretsResponse }
   | { type: "doctor.workflows"; id: string; payload: DoctorWorkflowsResponse }
   | {


### PR DESCRIPTION
## Summary

Implements swamp-club#1047 — a combined body of work that makes the solo-to-team transition smooth:

- **Share guide area** in the swamp skill — a state-machine-driven checklist (`assess → datastore → vaults → commit → joiner instructions`) that an AI agent works through with the user
- **Interactive CLI wizards** — `swamp datastore setup` and `swamp vault migrate` gain interactive modes with curated provider choices and extension search fallback
- **`swamp doctor datastores`** — new diagnostic check for datastore health and vault/datastore mismatch detection
- **Shared prompt helpers** — extracted `promptConfirmation` from 18 duplicated copies into `src/cli/prompt_helpers.ts`
- **Post-promotion vault nudge** — yellow advisory after external datastore setup when `local_encryption` vaults remain

### Interactive datastore setup choices
1. AWS S3 / S3-compatible (MinIO, etc.)
2. Google Cloud Storage
3. Shared filesystem
4. Other → extension search filtered by `contentTypes: "datastores"`

### Interactive vault migrate choices
1. AWS Secrets Manager
2. Azure Key Vault
3. 1Password
4. Other → extension search filtered by `contentTypes: "vaults"`

### Skill content
The share guide teaches the AI agent to:
- Run an assess step on every invocation (checklist anchor)
- Save failed commands verbatim and re-run them after the user fixes credentials
- Pre-flight auth check before vault migration (`op whoami`, `aws sts get-caller-identity`, `az account show`)
- Detect VCS type (jj vs git) for the commit step
- Generate config-tailored joiner instructions for teammates

### New files
- `src/cli/prompt_helpers.ts` + tests
- `src/libswamp/datastores/doctor_datastores.ts` + tests (three-layer pattern)
- `src/cli/commands/doctor_datastores.ts`
- `src/presentation/renderers/doctor_datastores.ts`
- `src/cli/commands/datastore_setup_test.ts`
- `src/cli/commands/vault_migrate_test.ts`
- `.claude/skills/swamp/references/share/` (guide, reference, joiner-instructions, troubleshooting)

## Test plan

- [x] `deno check` — 0 type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 8670 passed, 0 failed
- [x] `deno run license-headers` — all headers present
- [x] Skill assets test verifies share guide files in BUNDLED_SKILLS and copyable
- [x] Manual testing: compiled binary, set up test repo with filesystem datastore + local_encryption vault, triggered share skill via Claude Code, walked through full flow including credential failure recovery and MinIO pivot

Closes swamp-club#1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)