### PR TITLE
fix(update): sync global skills only to enrolled tool directories (swamp-club#1051)

### DIFF
--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -114,11 +114,13 @@ Today these commands copy skills into the repo. Under the new model:
 Global skills are synced automatically in three places:
 
 1. **`swamp update`** — after the binary is updated (interactive and background),
-   skills are written to existing global tool directories. For built-in tools,
-   only directories that already exist on disk are synced — `swamp update` does
-   not create new directories. For custom tools, directories registered in
+   skills are written to enrolled global tool directories. For built-in tools,
+   directories registered in `~/.config/swamp/builtin-tool-skill-dirs.json` are
+   synced (see below). For custom tools, directories registered in
    `custom-tool-skill-dirs.json` are synced (see below). Stale registry entries
-   for deleted directories are pruned automatically.
+   for deleted directories are pruned automatically. If no built-in registry
+   file exists (pre-registry CLI version), a heuristic fallback syncs to all
+   built-in directories that already exist on disk.
 2. **`swamp repo init`** — writes global skills as part of first-time setup.
    Creates built-in tool directories and custom tool global directories.
 3. **`swamp repo upgrade`** — writes global skills as part of the upgrade flow.
@@ -154,6 +156,27 @@ registered — those are project-local directories, not global skill targets.
 > the `~/` prefix on the existing `skillsDir` field instead. This is simpler and
 > covers the common case. The `globalSkillsDir` field can be added later if
 > finer-grained control is needed.
+
+### Built-in Tool Global Skills Registry
+
+Built-in tools (claude, cursor, opencode, codex, copilot, kiro) use a parallel
+registry at `~/.config/swamp/builtin-tool-skill-dirs.json`. During `repo init`
+and `repo upgrade`, swamp registers the resolved global skill directories for
+each enrolled built-in tool. The registry is additive — initializing multiple
+repos with different tools unions their directories.
+
+The registry is a simple JSON array of absolute directory paths:
+
+```json
+["/home/user/.claude/skills", "/home/user/.agents/skills"]
+```
+
+When `swamp update` runs, it reads this registry to determine which built-in
+directories to sync. If the registry file does not exist (pre-registry CLI
+version or no repo has been initialized), `swamp update` falls back to a
+directory-existence heuristic for backwards compatibility. If the registry
+exists but is empty (user has no built-in tools enrolled), no built-in
+directories are synced.
 
 ## Migration: Local to Global
 

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -57,6 +57,7 @@ import {
   resolveUniqueGlobalSkillsDirs,
 } from "../../domain/repo/skill_dirs.ts";
 import { removeSupersededSkills } from "../../domain/repo/superseded_skills.ts";
+import { BuiltInToolSkillDirsRepository } from "../../infrastructure/persistence/builtin_tool_skill_dirs_repository.ts";
 import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
 import { resolve, SEPARATOR } from "@std/path";
 import { homeDirectory } from "../../infrastructure/persistence/paths.ts";
@@ -78,14 +79,15 @@ async function dirExists(path: string): Promise<boolean> {
 async function syncGlobalSkills(
   logger: ReturnType<typeof getSwampLogger>,
 ): Promise<void> {
-  const allTools = Object.keys(GLOBAL_SKILL_DIRS);
-  let globalDirs: string[];
+  let home: string | null = null;
   try {
-    globalDirs = resolveUniqueGlobalSkillsDirs(allTools);
+    home = homeDirectory();
   } catch {
     logger.warn`Skipping global skill sync: home directory not available`;
     return;
   }
+
+  const builtInDirs = await resolveBuiltInDirs(logger);
 
   let customToolRepo: CustomToolSkillDirsRepository | null = null;
   let customDirs: string[] = [];
@@ -98,26 +100,23 @@ async function syncGlobalSkills(
 
   const skillAssets = new SkillAssets();
 
-  for (const dir of globalDirs) {
-    if (!await dirExists(dir)) {
-      logger
-        .debug`Skipping global skill sync for ${dir}: directory does not exist`;
+  for (const dir of builtInDirs) {
+    const resolved = resolve(dir);
+    if (!resolved.startsWith(home + SEPARATOR) && resolved !== home) {
+      logger.debug`Skipping built-in tool skill dir outside home: ${dir}`;
       continue;
     }
-    await skillAssets.copySkillsTo(dir);
-    await removeSupersededSkills(dir);
-    logger.info`Synced global skills to ${dir}`;
+    if (!await dirExists(resolved)) {
+      logger
+        .debug`Skipping global skill sync for ${resolved}: directory does not exist`;
+      continue;
+    }
+    await skillAssets.copySkillsTo(resolved);
+    await removeSupersededSkills(resolved);
+    logger.info`Synced global skills to ${resolved}`;
   }
 
   if (customDirs.length === 0) return;
-
-  let home: string | null = null;
-  try {
-    home = homeDirectory();
-  } catch {
-    // Can't validate containment — skip custom dirs entirely
-  }
-  if (!home) return;
 
   const survivingCustomDirs: string[] = [];
   for (const dir of customDirs) {
@@ -144,6 +143,33 @@ async function syncGlobalSkills(
     } catch {
       logger.warn`Failed to update custom tool skill dirs registry`;
     }
+  }
+}
+
+async function resolveBuiltInDirs(
+  logger: ReturnType<typeof getSwampLogger>,
+): Promise<string[]> {
+  let builtInRepo: BuiltInToolSkillDirsRepository | null = null;
+  try {
+    builtInRepo = new BuiltInToolSkillDirsRepository();
+  } catch {
+    // Config dir not available — fall through to heuristic
+  }
+
+  if (builtInRepo && await builtInRepo.exists()) {
+    return await builtInRepo.read();
+  }
+
+  // No registry file yet — no repo has been initialized with this version.
+  // Fall back to the pre-registry heuristic (all built-in dirs that exist)
+  // so existing users aren't broken before they run repo upgrade.
+  logger
+    .debug`Built-in tool skill dirs registry not found, using directory-existence heuristic`;
+  const allTools = Object.keys(GLOBAL_SKILL_DIRS);
+  try {
+    return resolveUniqueGlobalSkillsDirs(allTools);
+  } catch {
+    return [];
   }
 }
 

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -45,6 +45,7 @@ import { removeSupersededSkills } from "./superseded_skills.ts";
 import { assertPathContained, type ToolConfig } from "./custom_tool.ts";
 import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
+import { BuiltInToolSkillDirsRepository } from "../../infrastructure/persistence/builtin_tool_skill_dirs_repository.ts";
 import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
 
 const logger = getLogger(["swamp", "repo", "service"]);
@@ -539,6 +540,18 @@ export class RepoService {
       logger.warn`Skipping global skill install: home directory not available`;
       return [];
     }
+
+    try {
+      const builtInRepo = new BuiltInToolSkillDirsRepository();
+      if (globalDirs.length > 0) {
+        await builtInRepo.addDirs(globalDirs);
+      } else if (!await builtInRepo.exists()) {
+        await builtInRepo.write([]);
+      }
+    } catch {
+      logger.warn`Failed to register built-in tool skill dirs`;
+    }
+
     if (globalDirs.length === 0) return [];
 
     for (const dir of globalDirs) {

--- a/src/infrastructure/persistence/builtin_tool_skill_dirs_repository.ts
+++ b/src/infrastructure/persistence/builtin_tool_skill_dirs_repository.ts
@@ -1,0 +1,71 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+import { getSwampConfigDir } from "./paths.ts";
+
+const BUILTIN_TOOL_SKILL_DIRS_FILE = "builtin-tool-skill-dirs.json";
+
+export class BuiltInToolSkillDirsRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ??
+      join(getSwampConfigDir(), BUILTIN_TOOL_SKILL_DIRS_FILE);
+  }
+
+  async exists(): Promise<boolean> {
+    try {
+      await Deno.stat(this.filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async read(): Promise<string[]> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      const parsed = JSON.parse(content);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((entry): entry is string =>
+        typeof entry === "string"
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  async write(dirs: string[]): Promise<void> {
+    const unique = [...new Set(dirs)];
+    await Deno.mkdir(dirname(this.filePath), { recursive: true });
+    await atomicWriteTextFile(
+      this.filePath,
+      JSON.stringify(unique, null, 2) + "\n",
+    );
+  }
+
+  async addDirs(dirs: string[]): Promise<void> {
+    const existing = await this.read();
+    const toAdd = dirs.filter((d) => !existing.includes(d));
+    if (toAdd.length === 0) return;
+    await this.write([...existing, ...toAdd]);
+  }
+}

--- a/src/infrastructure/persistence/builtin_tool_skill_dirs_repository_test.ts
+++ b/src/infrastructure/persistence/builtin_tool_skill_dirs_repository_test.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { BuiltInToolSkillDirsRepository } from "./builtin_tool_skill_dirs_repository.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("BuiltInToolSkillDirsRepository: exists returns false when file does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(
+      join(dir, "nonexistent.json"),
+    );
+    assertEquals(await repo.exists(), false);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: exists returns true after write", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write([]);
+    assertEquals(await repo.exists(), true);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: read returns empty array when file does not exist", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(
+      join(dir, "nonexistent.json"),
+    );
+    assertEquals(await repo.read(), []);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: write and read round-trips", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write([
+      "/home/user/.claude/skills",
+      "/home/user/.agents/skills",
+    ]);
+    assertEquals(await repo.read(), [
+      "/home/user/.claude/skills",
+      "/home/user/.agents/skills",
+    ]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: write deduplicates entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write([
+      "/home/user/.claude/skills",
+      "/home/user/.claude/skills",
+    ]);
+    assertEquals(await repo.read(), ["/home/user/.claude/skills"]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: write with empty array creates file", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write([]);
+    assertEquals(await repo.exists(), true);
+    assertEquals(await repo.read(), []);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: addDirs appends new entries", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.claude/skills"]);
+    await repo.addDirs(["/home/user/.agents/skills"]);
+    assertEquals(await repo.read(), [
+      "/home/user/.claude/skills",
+      "/home/user/.agents/skills",
+    ]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: addDirs is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.claude/skills"]);
+    await repo.addDirs(["/home/user/.claude/skills"]);
+    assertEquals(await repo.read(), ["/home/user/.claude/skills"]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: addDirs creates file when none exists", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.addDirs(["/home/user/.claude/skills"]);
+    assertEquals(await repo.read(), ["/home/user/.claude/skills"]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: addDirs with empty array is no-op", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new BuiltInToolSkillDirsRepository(join(dir, "dirs.json"));
+    await repo.write(["/home/user/.claude/skills"]);
+    await repo.addDirs([]);
+    assertEquals(await repo.read(), ["/home/user/.claude/skills"]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: read filters out non-string entries", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "dirs.json");
+    await Deno.writeTextFile(
+      filePath,
+      JSON.stringify(["/valid", 42, null, "/also-valid"]),
+    );
+    const repo = new BuiltInToolSkillDirsRepository(filePath);
+    assertEquals(await repo.read(), ["/valid", "/also-valid"]);
+  });
+});
+
+Deno.test("BuiltInToolSkillDirsRepository: read returns empty for malformed JSON", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "dirs.json");
+    await Deno.writeTextFile(filePath, "not json");
+    const repo = new BuiltInToolSkillDirsRepository(filePath);
+    assertEquals(await repo.read(), []);
+  });
+});


### PR DESCRIPTION
## Summary

- `swamp update` was syncing global skills to **all** built-in tool directories
  that existed on disk (`~/.claude/skills`, `~/.agents/skills`, `~/.kiro/skills`),
  regardless of whether those tools were enrolled — causing skill pollution for
  users who only configured custom tools like `pi`.
- Added `BuiltInToolSkillDirsRepository` (mirrors `CustomToolSkillDirsRepository`)
  to persist enrolled built-in tool directories in
  `~/.config/swamp/builtin-tool-skill-dirs.json`.
- `repo init` and `repo upgrade` now register enrolled built-in tool dirs in the
  registry (including writing an empty registry when no built-in tools are
  enrolled).
- `syncGlobalSkills` reads from the registry instead of iterating all built-in
  tools. Falls back to the previous directory-existence heuristic when no
  registry file exists (backwards compatibility for users who haven't re-run
  `repo init`/`upgrade` yet).

Closes swamp-club/lab#1051

## Test Plan

- 12 unit tests for `BuiltInToolSkillDirsRepository` (exists, read, write,
  addDirs, dedup, idempotency, malformed JSON, non-string filtering)
- Existing update tests pass (9 tests)
- Full test suite passes (8695 tests)
- Type check, lint, and format all pass
- Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)