### PR TITLE
feat(skill): add serve, grants, and access control guidance to swamp skill

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -27,6 +27,10 @@ description: >
 - **Extensions** — TypeScript packages adding model types, vault backends,
   datastores, and report generators; published to a registry.
 - **Reports** — summaries of data across models for observability.
+- **Grants** — authorization rules controlling who can do what on a swamp serve
+  instance. Authored via CLI commands or YAML files in the `grants/` directory.
+- **Serve** — exposes the repo over the network with TLS, authentication (token
+  or OAuth via swamp-club), and grant-based authorization.
 
 ## Routing Table
 
@@ -46,6 +50,7 @@ Route to the right guide based on what the user needs.
 | Run tracking — active runs, stale detection, diagnostics     | [references/model/guide.md](references/model/guide.md)                         |
 | Architecture — which primitive to use, design trade-offs     | [references/architecture/guide.md](references/architecture/guide.md)           |
 | Sharing — promote solo repo to team, datastore + vault setup | [references/share/guide.md](references/share/guide.md)                         |
+| Serve — auth, grants, access control, tokens, OAuth          | [references/serve/guide.md](references/serve/guide.md)                         |
 | Troubleshooting — errors, health checks, diagnostics         | [references/troubleshooting/guide.md](references/troubleshooting/guide.md)     |
 
 ## Common Commands

--- a/.claude/skills/swamp/references/serve/guide.md
+++ b/.claude/skills/swamp/references/serve/guide.md
@@ -1,0 +1,126 @@
+# Swamp Serve & Access Control
+
+Expose a swamp repo over the network with authentication, authorization, and
+grant-based access control.
+
+## Auth Modes
+
+| Mode    | Flag                | Use case                                       |
+| ------- | ------------------- | ---------------------------------------------- |
+| `none`  | `--auth-mode none`  | Loopback only, no auth (deprecated)            |
+| `token` | `--auth-mode token` | Manual token minting, no swamp-club dependency |
+| `oauth` | `--auth-mode oauth` | Users authenticate via swamp-club              |
+
+OAuth mode requires `--allowed-collectives` or `--allowed-users` to control
+admission. Use `--admins` to grant admin access to specific principals.
+
+```bash
+# Token auth
+swamp serve --auth-mode token --admins 'user:oauth|user-123'
+
+# OAuth with collective-based admission
+swamp serve --auth-mode oauth \
+  --allowed-collectives platform-eng \
+  --admins 'user:oauth|admin-456'
+```
+
+## Grant Model
+
+Grants control what authenticated users can do. Default deny — no matching grant
+means denied.
+
+| Concept    | Format                                                  |
+| ---------- | ------------------------------------------------------- |
+| Subjects   | `user:<id>`, `group:<name>`, `idp-group:<collective>`   |
+| Effects    | `allow`, `deny` (deny wins)                             |
+| Actions    | `run`, `read`, `write`, `admin`                         |
+| Resources  | `workflow:@acme/*`, `model:hello`, `data:*`, `access:*` |
+| Conditions | CEL expressions via `--when 'tags.env == "staging"'`    |
+
+Admin on `access:*` implies all actions (superuser).
+
+## CLI Grant Management
+
+```bash
+# Create grants
+swamp access grant create --subject user:alice --allow run --on workflow:@acme/*
+swamp access grant create --subject group:ops --deny read --on data:@acme/secrets-*
+swamp access grant create --subject idp-group:platform-eng \
+  --allow run,read --on workflow:@acme/* --when 'tags.env == "staging"' \
+  --server wss://swamp.example.com
+
+# List and revoke
+swamp access grant list [--server wss://...]
+swamp access grant revoke <grant-id> [--server wss://...]
+
+# Rebuild policy snapshot from grants and groups
+swamp access reload [--server wss://...]
+```
+
+`swamp access policy` is an alias for `swamp access grant`.
+
+## Declarative Grants
+
+For production deployments, manage grants as YAML files in the `grants/`
+directory at the repo root (alongside `models/`, `workflows/`, `vaults/`).
+
+```yaml
+# grants/platform-eng.yaml
+grants:
+  - subject: idp-group:platform-eng
+    effect: allow
+    actions: [run]
+    resource: workflow:@acme/*
+  - subject: idp-group:developers
+    effect: deny
+    actions: [read]
+    resource: data:@acme/secrets-*
+```
+
+Apply with `swamp access reload --server wss://...`. Reload validates all files
+first — rejects the entire reload if any file is invalid. The reconciler only
+touches `source: file:*` grants; CLI-created grants are independent. Both
+`.yaml` and `.yml` are accepted; flat directory only.
+
+## Groups
+
+```bash
+swamp access group create <name>
+swamp access group add-member <group> <principal>
+swamp access group remove-member <group> <principal>
+```
+
+## Access Checking
+
+```bash
+# Admin explain mode — see why a subject is allowed or denied
+swamp access check --subject user:alice --action run --on workflow:@acme/deploy
+
+# User self-service — check your own permissions
+swamp access can-i --action run --on workflow:@acme/deploy --server wss://...
+```
+
+## Token Management
+
+```bash
+swamp access token mint <name> --principal user:<id>   # plaintext shown once
+swamp access token list
+swamp access token revoke <name>
+swamp access token rotate <name>                       # revoke + mint replacement
+```
+
+## OAuth Login
+
+```bash
+# Device grant flow via swamp-club
+swamp auth server-login --server wss://swamp.example.com
+```
+
+## When to Use What
+
+| Scenario                           | Approach                  |
+| ---------------------------------- | ------------------------- |
+| A few grants for a small team      | CLI commands              |
+| Policy for a production deployment | `grants/` directory files |
+| Team on swamp-club                 | `--auth-mode oauth`       |
+| Air-gapped or no swamp-club        | `--auth-mode token`       |


### PR DESCRIPTION
## Summary

- Add **Grants** and **Serve** to Core Concepts in the swamp skill's `SKILL.md`
- Add routing table row for serve/auth/grants/access control
- Create `references/serve/guide.md` covering auth modes, grant model, declarative grants, CLI grant/group/token commands, access checking, and OAuth login

Skill-only change — no source code modifications.

Fixes swamp-club#1048

## Test Plan

- `deno fmt --check` — passed
- `deno lint` — passed (1729 files checked)
- `npx tessl skill review .claude/skills/swamp` — **98%** (threshold: 90%)
- `deno run eval-skill-triggers` — skipped (no `ANTHROPIC_API_KEY` in environment), will run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)