### PR TITLE
fix(workflows): don't mark job span as ERROR on manual_approval suspension (swamp-club#1067)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2426,6 +2426,10 @@ export class WorkflowExecutionService {
       jobSpan.setAttribute("job.status", jobRun.status);
       yield { kind: "job_completed", jobId: jobName, status: jobRun.status };
     } catch (error) {
+      if (error instanceof WorkflowSuspendedError) {
+        jobSpan.setStatus({ code: SpanStatusCode.OK });
+        throw error;
+      }
       jobSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3366,3 +3366,74 @@ Deno.test("resume merges override inputs over the suspended run's inputs", async
     );
   });
 });
+
+Deno.test("manual_approval suspension does not mark job span as ERROR", async () => {
+  const {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+  } = await import("@opentelemetry/sdk-trace-base");
+  const otelApi = await import("@opentelemetry/api");
+
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.register();
+
+  try {
+    await withTempDir(async (tempDir) => {
+      const workflowRepo = new InMemoryWorkflowRepository();
+      const runRepo = new InMemoryWorkflowRunRepository();
+      const executor = new MockStepExecutor();
+
+      const workflow = Workflow.create({
+        name: "approval-span-test",
+        jobs: [
+          Job.create({
+            name: "gated-job",
+            steps: [
+              Step.create({
+                name: "gate",
+                task: StepTask.manualApproval("Approve deployment"),
+              }),
+              Step.create({
+                name: "deploy",
+                task: StepTask.model("deploy-model", "run"),
+                dependsOn: [
+                  { step: "gate", condition: TriggerCondition.succeeded() },
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+      await workflowRepo.save(workflow);
+
+      const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+      const service = new WorkflowExecutionService(
+        workflowRepo,
+        runRepo,
+        tempDir,
+        executor,
+        undefined,
+        catalogStore,
+      );
+
+      const run = await service.execute(workflow.name);
+      assertEquals(run.status, "suspended");
+
+      const jobSpans = exporter.getFinishedSpans().filter((s) =>
+        s.name === "swamp.workflow.job"
+      );
+      assertEquals(jobSpans.length, 1);
+      assertNotEquals(
+        jobSpans[0].status.code,
+        otelApi.SpanStatusCode.ERROR,
+        "Job span should not be ERROR when workflow suspends at manual_approval",
+      );
+    });
+  } finally {
+    provider.shutdown();
+    otelApi.trace.disable();
+  }
+});


### PR DESCRIPTION
## Summary

- Special-case `WorkflowSuspendedError` in the `runJob` catch block so the `workflow.job` OTel span is set to OK instead of ERROR when a `manual_approval` gate suspends execution
- Add unit test using `InMemorySpanExporter` to verify the job span status is not ERROR on suspension

Fixes swamp-club#1067.

## Test Plan

- [x] Unit test: new test `manual_approval suspension does not mark job span as ERROR` passes — sets up OTel `InMemorySpanExporter`, runs a workflow with a `manual_approval` step, asserts the job span status is not ERROR
- [x] Console OTel verification: ran `OTEL_TRACES_EXPORTER=console swamp workflow run` with a `manual_approval` workflow and confirmed the `swamp.workflow.job` span shows `status: { code: 1 }` (OK) instead of `{ code: 2 }` (ERROR)
- [x] Full test suite: 8745 tests pass, 0 failures
- [x] `deno check`, `deno lint`, `deno fmt` all pass