### PR TITLE
fix(workflows): honor allowFailure on workflow-task steps (swamp-club#1061)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2569,6 +2569,7 @@ export class WorkflowExecutionService {
           task,
           stepExprContext,
           options,
+          !!step.allowFailure,
         );
         return;
       }
@@ -2771,6 +2772,7 @@ export class WorkflowExecutionService {
     },
     expressionContext: ExpressionContext | undefined,
     options: StepOptions,
+    allowFailure: boolean,
   ): AsyncGenerator<WorkflowExecutionEvent> {
     // Resolve every available expression (self.* from the forEach variable,
     // run.*, etc.) in the task BEFORE the recursion-depth guard, cycle
@@ -2807,11 +2809,15 @@ export class WorkflowExecutionService {
           depth + 1
         }.`;
       stepRun.fail(errorMessage);
+      if (allowFailure) {
+        stepRun.markAllowedFailure();
+      }
       yield {
         kind: "step_failed",
         jobId: job.name,
         stepId: stepName,
         error: errorMessage,
+        allowedFailure: allowFailure || undefined,
       };
       return;
     }
@@ -2823,11 +2829,15 @@ export class WorkflowExecutionService {
       const errorMessage = `Workflow cycle detected: ${chain}. ` +
         `A workflow cannot invoke itself directly or indirectly.`;
       stepRun.fail(errorMessage);
+      if (allowFailure) {
+        stepRun.markAllowedFailure();
+      }
       yield {
         kind: "step_failed",
         jobId: job.name,
         stepId: stepName,
         error: errorMessage,
+        allowedFailure: allowFailure || undefined,
       };
       return;
     }
@@ -2876,8 +2886,14 @@ export class WorkflowExecutionService {
       ) {
         if (event.kind === "completed") {
           childRun = event.run;
+        } else if (event.kind === "step_failed" && allowFailure) {
+          // When the parent step allows failure, mark child step_failed
+          // events as allowed so they don't set jobFailed in the parent
+          // job runner. The parent emits its own step_failed with the
+          // correct allowedFailure flag after the child finishes.
+          yield { ...event, allowedFailure: true };
         } else {
-          yield event; // Forward child events to parent stream
+          yield event;
         }
       }
     } catch (error) {
@@ -2885,11 +2901,15 @@ export class WorkflowExecutionService {
         ? error.message
         : String(error);
       stepRun.fail(errorMessage);
+      if (allowFailure) {
+        stepRun.markAllowedFailure();
+      }
       yield {
         kind: "step_failed",
         jobId: job.name,
         stepId: stepName,
         error: errorMessage,
+        allowedFailure: allowFailure || undefined,
       };
       return;
     }
@@ -2897,11 +2917,15 @@ export class WorkflowExecutionService {
     if (!childRun || childRun.status === "failed") {
       const errorMessage = `Nested workflow "${task.workflowIdOrName}" failed.`;
       stepRun.fail(errorMessage);
+      if (allowFailure) {
+        stepRun.markAllowedFailure();
+      }
       yield {
         kind: "step_failed",
         jobId: job.name,
         stepId: stepName,
         error: errorMessage,
+        allowedFailure: allowFailure || undefined,
       };
       return;
     }

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -2084,6 +2084,205 @@ Deno.test("mix of allowFailure and regular failing steps causes job failure", as
   });
 });
 
+// allowFailure tests for workflow-type task steps (issue #1061)
+
+Deno.test("workflow-task step with allowFailure true: child fails, step marked allowedFailure, job succeeds", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("child-step");
+
+    const childWorkflow = Workflow.create({
+      name: "child-that-fails",
+      jobs: [
+        Job.create({
+          name: "child-job",
+          steps: [
+            Step.create({
+              name: "child-step",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(childWorkflow);
+
+    const parentWorkflow = Workflow.create({
+      name: "parent-allow-failure",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "optional-workflow-step",
+              task: StepTask.workflow("child-that-fails"),
+              allowFailure: true,
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(parentWorkflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(parentWorkflow.name);
+
+    assertEquals(run.status, "succeeded");
+    assertEquals(run.getJob("job1")?.status, "succeeded");
+    const stepRun = run.getJob("job1")?.getStep("optional-workflow-step");
+    assertEquals(stepRun?.status, "failed");
+    assertEquals(stepRun?.allowedFailure, true);
+  });
+});
+
+Deno.test("workflow-task step with allowFailure true: downstream completed dep runs after child fails", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("child-step");
+
+    const childWorkflow = Workflow.create({
+      name: "child-that-fails",
+      jobs: [
+        Job.create({
+          name: "child-job",
+          steps: [
+            Step.create({
+              name: "child-step",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(childWorkflow);
+
+    const parentWorkflow = Workflow.create({
+      name: "parent-completed-dep",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "first",
+              task: StepTask.workflow("child-that-fails"),
+              allowFailure: true,
+            }),
+            Step.create({
+              name: "second",
+              task: StepTask.model("test-model", "run"),
+              dependsOn: [{
+                step: "first",
+                condition: TriggerCondition.completed(),
+              }],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(parentWorkflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(parentWorkflow.name);
+
+    assertEquals(run.status, "succeeded");
+    const firstStep = run.getJob("job1")?.getStep("first");
+    assertEquals(firstStep?.status, "failed");
+    assertEquals(firstStep?.allowedFailure, true);
+    const secondStep = run.getJob("job1")?.getStep("second");
+    assertEquals(secondStep?.status, "succeeded");
+  });
+});
+
+Deno.test("workflow-task step without allowFailure: child fails, job fails", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+    executor.shouldFail.add("child-step");
+
+    const childWorkflow = Workflow.create({
+      name: "child-that-fails",
+      jobs: [
+        Job.create({
+          name: "child-job",
+          steps: [
+            Step.create({
+              name: "child-step",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(childWorkflow);
+
+    const parentWorkflow = Workflow.create({
+      name: "parent-no-allow-failure",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "workflow-step",
+              task: StepTask.workflow("child-that-fails"),
+            }),
+            Step.create({
+              name: "second",
+              task: StepTask.model("test-model", "run"),
+              dependsOn: [{
+                step: "workflow-step",
+                condition: TriggerCondition.completed(),
+              }],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(parentWorkflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(parentWorkflow.name);
+
+    assertEquals(run.status, "failed");
+    assertEquals(run.getJob("job1")?.status, "failed");
+    const stepRun = run.getJob("job1")?.getStep("workflow-step");
+    assertEquals(stepRun?.status, "failed");
+    assertEquals(stepRun?.allowedFailure, false);
+    assertEquals(run.getJob("job1")?.getStep("second")?.status, "pending");
+  });
+});
+
 // Issue #947: Check skip options and swampSha propagation through StepExecutionContext
 Deno.test("check skip options and swampSha are threaded to step context", async () => {
   await withTempDir(async (tempDir) => {


### PR DESCRIPTION
## Summary

- `allowFailure: true` on workflow-type task steps was silently ignored because `runWorkflowStep` handled failures internally and returned before the `runStep` catch block where `allowFailure` is checked
- Pass the `allowFailure` flag to `runWorkflowStep` and honor it in all four failure paths (recursion guard, cycle detection, child execution error, child run failed)
- Decorate forwarded child `step_failed` events with `allowedFailure` when the parent step allows failure, preserving telemetry visibility while preventing the parent job runner from treating child failures as hard failures

Closes swamp-club#1061

## Test Plan

- Added 3 unit tests for workflow-task steps with `allowFailure`:
  - Child fails → step marked `allowedFailure`, job succeeds
  - Child fails + downstream `completed` dep → second step runs
  - Without `allowFailure` → job fails (regression guard)
- Reproduced the original issue in a scratch repo and verified the fix: step "first" now shows `allowedFailure: true` and step "second" runs instead of staying `pending`
- All 8748 existing tests pass
- Verified telemetry bridge is unaffected (doesn't reference `allowedFailure`)