### PR TITLE
fix(workflows): apply child workflow input defaults on nested invocation (swamp-club#1062)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -26,6 +26,7 @@ import {
 } from "./for_each_expansion_service.ts";
 import { coerceToSuffix } from "./data_suffix.ts";
 import { deepMerge } from "../inputs/input_merge.ts";
+import { InputValidationService } from "../inputs/input_validation_service.ts";
 // deno-lint-ignore verbatim-module-syntax
 import { JobRun, WorkflowRun } from "./workflow_run.ts";
 import {
@@ -2850,6 +2851,18 @@ export class WorkflowExecutionService {
         task.inputs,
         expressionContext,
       ) as Record<string, unknown>;
+    }
+
+    // Apply the child workflow's input defaults — the top-level
+    // workflowRun() libswamp layer does this, but nested invocations
+    // bypass it entirely and call run() directly.
+    const childWorkflow = await this.lookupWorkflow(task.workflowIdOrName);
+    if (childWorkflow?.inputs) {
+      const validationService = new InputValidationService();
+      evaluatedInputs = validationService.applyDefaults(
+        evaluatedInputs ?? {},
+        childWorkflow.inputs,
+      );
     }
 
     // Create a child WorkflowExecutionService with nesting context.

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -1449,6 +1449,164 @@ Deno.test("DefaultStepExecutor rejects workflow task type", async () => {
   );
 });
 
+Deno.test("workflow step applies child workflow's input defaults", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    // Child workflow declares "verbose" with a default of false
+    const childWorkflow = Workflow.create({
+      name: "child-workflow",
+      inputs: {
+        properties: {
+          name: { type: "string" },
+          verbose: { type: "boolean", default: false },
+        },
+        required: ["name"],
+      },
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "child-step",
+              task: StepTask.modelMethod("some-model", "run", {
+                name: "${{ inputs.name }}",
+                verbose: "${{ inputs.verbose }}",
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(childWorkflow);
+
+    // Parent invokes the child WITHOUT passing "verbose"
+    const parentWorkflow = Workflow.create({
+      name: "parent-workflow",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "call-child",
+              task: StepTask.workflow("child-workflow", {
+                name: "test-value",
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(parentWorkflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const events: { kind: string; error?: string }[] = [];
+    for await (const event of service.run(parentWorkflow.name)) {
+      if (event.kind === "step_failed") {
+        events.push({ kind: event.kind, error: event.error });
+      }
+    }
+
+    const failures = events.filter((e) => e.kind === "step_failed");
+    assertEquals(
+      failures.length,
+      0,
+      `Child step should not fail — input defaults should be applied. Failures: ${
+        JSON.stringify(failures)
+      }`,
+    );
+    assertEquals(executor.executedSteps.includes("job1/child-step"), true);
+  });
+});
+
+Deno.test("workflow step applies child defaults when parent passes no inputs", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    // Child workflow where ALL inputs have defaults (none required)
+    const childWorkflow = Workflow.create({
+      name: "child-workflow",
+      inputs: {
+        properties: {
+          verbose: { type: "boolean", default: false },
+        },
+        required: [],
+      },
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "child-step",
+              task: StepTask.modelMethod("some-model", "run", {
+                verbose: "${{ inputs.verbose }}",
+              }),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(childWorkflow);
+
+    // Parent invokes the child with NO inputs field at all
+    const parentWorkflow = Workflow.create({
+      name: "parent-workflow",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "call-child",
+              task: StepTask.workflow("child-workflow"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(parentWorkflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const events: { kind: string; error?: string }[] = [];
+    for await (const event of service.run(parentWorkflow.name)) {
+      if (event.kind === "step_failed") {
+        events.push({ kind: event.kind, error: event.error });
+      }
+    }
+
+    const failures = events.filter((e) => e.kind === "step_failed");
+    assertEquals(
+      failures.length,
+      0,
+      `Child step should not fail when parent passes no inputs — defaults should apply. Failures: ${
+        JSON.stringify(failures)
+      }`,
+    );
+    assertEquals(executor.executedSteps.includes("job1/child-step"), true);
+  });
+});
+
 Deno.test("evaluateWorkflow skips task.inputs with step-output dependencies", async () => {
   await withTempDir(async (tempDir) => {
     const workflowRepo = new InMemoryWorkflowRepository();


### PR DESCRIPTION
## Summary

- When a workflow is invoked as a child step (`type: workflow`), the child's declared input defaults were not applied — any `${{ inputs.<name> }}` reference to an unpassed-but-defaulted input failed with `Invalid expression: No such key`
- Root cause: `runWorkflowStep()` bypasses the `workflowRun()` libswamp layer where `InputValidationService.applyDefaults()` is called
- Fix: look up the child workflow in `runWorkflowStep()` and apply its input schema defaults before passing inputs to the child service, mirroring how `workflowRun()` handles top-level runs

Fixes swamp-club#1062

## Test Plan

- Added unit test: nested workflow step applies child's input defaults when parent omits a defaulted input
- Added unit test: defaults apply even when parent passes no inputs at all (all-optional child)
- Verified against scratch reproduction in `/tmp/swamp-repro-issue-1062` — parent workflow now succeeds with `headed=false`
- All 36 workflow integration tests pass (including existing nested workflow and cycle detection tests)
- Full test suite: 8754 passed, 0 workflow-related failures