### PR TITLE
fix(extensions): materialize skills for all enrolled tools, not just tools[0] (swamp-club#1056)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -1160,7 +1160,25 @@ mirror the archive structure:
 | `driver-bundles/`    | `.swamp/driver-bundles/<bundleNamespace(…drivers dir)>/`     |
 | `datastore-bundles/` | `.swamp/datastore-bundles/<bundleNamespace(…datastores dir)>/` |
 | `report-bundles/`    | `.swamp/report-bundles/<bundleNamespace(…reports dir)>/`     |
-| `skills/`            | Tool-specific skills dir (e.g. `.claude/skills/<skill-name>/`) |
+| `skills/`            | Every enrolled tool's skills dir (deduplicated)                |
+
+### Multi-tool skill materialization
+
+In repos enrolled for multiple AI tools (`marker.tools` has 2+ entries),
+`extension pull`, `extension update`, `extension install`, and
+`extension source add` extract skills to **every** enrolled tool's
+project-local skills directory. The directories are deduplicated so
+shared-path tools (codex/cursor/opencode/copilot, all mapping to
+`.agents/skills/`) are written only once.
+
+All skill directory roots are tracked in the lockfile's `files[]` array,
+so `extension rm` and orphan pruning correctly handle multi-tool repos:
+removal deletes all copies, and re-pulling after a tool change prunes the
+old tool's stale skill paths.
+
+The `resolveUniqueLocalSkillsDirs(repoDir, tools)` helper mirrors the
+existing `resolveUniqueGlobalSkillsDirs(tools)` pattern used for
+user-level skill directories.
 
 ### Why extension-first?
 

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -218,7 +218,7 @@ export function createAutoResolveInstallerAdapter(
           getChecksum,
           logger,
           lockfileRepository,
-          skillsDir: swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills),
+          skillsDirs: [swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills)],
           repoDir,
           force: false,
           alreadyPulled: new Set<string>(),

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -83,10 +83,9 @@ import {
 } from "../remote_run.ts";
 import type { DoctorExtensionsResponse } from "../../serve/protocol.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { readLocalManifestIdentity } from "../../infrastructure/persistence/local_manifest_reader.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
 
@@ -277,11 +276,13 @@ export const doctorExtensionsCommand = withRemoteOptions(
     // per-extension roots referenced by the lockfile. (lockfilePath /
     // marker / repoPath / modelsDir / absoluteModelsDir are hoisted
     // above the rescan call earlier in this function.)
-    const tool = resolvePrimaryTool(marker);
-    const absoluteSkillsDir = resolveSkillsDir(repoDir, tool);
-    // detectOrphanFiles wants a repo-relative skills dir so it can
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const absoluteSkillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+    // detectOrphanFiles wants repo-relative skills dirs so it can
     // compare against entry.files[] paths (which are repo-relative).
-    const repoRelativeSkillsDir = relative(repoDir, absoluteSkillsDir);
+    const repoRelativeSkillsDirs = absoluteSkillsDirs.map((d) =>
+      relative(repoDir, d)
+    );
 
     const controller = new AbortController();
     const renderer = createDoctorExtensionsRenderer(cliCtx.outputMode, {
@@ -294,7 +295,7 @@ export const doctorExtensionsCommand = withRemoteOptions(
         registries,
         lockfileRepository: doctorLockfileRepo,
         repoDir,
-        skillsDir: repoRelativeSkillsDir,
+        skillsDirs: repoRelativeSkillsDirs,
         abortSignal: controller.signal,
         buildAggregateState: async () => {
           const aggLockfileRepo = await LockfileRepository.create(
@@ -361,8 +362,6 @@ export const doctorExtensionsCommand = withRemoteOptions(
                 const pullLockfileRepo = await LockfileRepository.create(
                   lockfilePath,
                 );
-                const pullTool = resolvePrimaryTool(marker);
-                const skillsDir = resolveSkillsDir(repoDir, pullTool);
                 const denoRuntime = new EmbeddedDenoRuntime();
                 const pullRepo = new ExtensionRepository({
                   catalog: sharedCatalog,
@@ -373,7 +372,7 @@ export const doctorExtensionsCommand = withRemoteOptions(
                 const deps = await createExtensionPullDeps(
                   serverUrl,
                   lockfilePath,
-                  skillsDir,
+                  absoluteSkillsDirs,
                   repoDir,
                   { identity },
                 );
@@ -385,7 +384,7 @@ export const doctorExtensionsCommand = withRemoteOptions(
                     getChecksum: deps.getChecksum,
                     logger: cliCtx.logger,
                     lockfileRepository: deps.lockfileRepository,
-                    skillsDir,
+                    skillsDirs: absoluteSkillsDirs,
                     repoDir,
                     force: true,
                     outputMode: cliCtx.outputMode,

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -34,8 +34,7 @@ import {
 import { requireRepoMarker } from "../repo_context.ts";
 import { resolveModelsDir } from "../resolve_models_dir.ts";
 import { UserError } from "../../domain/errors.ts";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { loadIdentity } from "../load_identity.ts";
 import {
   ConflictError,
@@ -100,8 +99,11 @@ export interface PullContext {
    * Captures a snapshot at construction; construct fresh per pull.
    */
   lockfileRepository: LockfileRepository;
-  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
-  skillsDir: string;
+  /**
+   * Tool-aware skills destinations — one per unique enrolled tool.
+   * See {@link InstallContext.skillsDirs}.
+   */
+  skillsDirs: string[];
   repoDir: string;
   force: boolean;
   outputMode: "log" | "json";
@@ -135,7 +137,7 @@ export async function pullExtension(
     downloadArchive: ctx.downloadArchive,
     getChecksum: ctx.getChecksum,
     lockfileRepository: ctx.lockfileRepository,
-    skillsDir: ctx.skillsDir,
+    skillsDirs: ctx.skillsDirs,
     repoDir: ctx.repoDir,
     alreadyPulled: ctx.alreadyPulled,
     depth: ctx.depth,
@@ -230,13 +232,13 @@ export const extensionPullCommand = new Command()
     const absoluteModelsDir = resolve(repoDir, modelsDir);
     const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
 
-    const tool = resolvePrimaryTool(marker);
-    const skillsDir = resolveSkillsDir(repoDir, tool);
-    const skillsDirRelative = relative(repoDir, skillsDir);
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+    const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => ctx.logger.warn(msg),
-      skillsDirRelative,
+      primarySkillsDirRelative,
     );
 
     // 7. Construct W2 service deps (denoRuntime + ExtensionRepository)
@@ -253,7 +255,7 @@ export const extensionPullCommand = new Command()
       const deps = await createExtensionPullDeps(
         serverUrl,
         lockfilePath,
-        skillsDir,
+        skillsDirs,
         repoDir,
         { identity },
       );
@@ -271,7 +273,7 @@ export const extensionPullCommand = new Command()
         getChecksum: deps.getChecksum,
         logger: ctx.logger,
         lockfileRepository: deps.lockfileRepository,
-        skillsDir,
+        skillsDirs,
         repoDir,
         force: options.force ?? false,
         outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -45,8 +45,7 @@ import {
   warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
 import { createExtensionSearchRenderer } from "../../presentation/renderers/extension_search.tsx";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 import { loadIdentity } from "../load_identity.ts";
 import {
@@ -263,14 +262,13 @@ export const extensionSearchCommand = withRemoteOptions(
       "upstream_extensions.json",
     );
 
-    const skillsDirRelative = relative(
-      repoDir,
-      resolveSkillsDir(repoDir, resolvePrimaryTool(marker)),
-    );
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+    const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => ctx.logger.warn(msg),
-      skillsDirRelative,
+      primarySkillsDirRelative,
     );
 
     const lockfileRepository = await LockfileRepository.create(lockfilePath);
@@ -282,7 +280,7 @@ export const extensionSearchCommand = withRemoteOptions(
         client.getChecksum(name, version, channel),
       logger: ctx.logger,
       lockfileRepository,
-      skillsDir: resolveSkillsDir(repoDir, resolvePrimaryTool(marker)),
+      skillsDirs,
       repoDir,
       force: false,
       outputMode: ctx.outputMode,

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -35,8 +35,7 @@ import type { ExtensionKind } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -84,9 +83,8 @@ export const extensionSourceAddCommand = new Command()
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
-    const primaryTool = resolvePrimaryTool(marker);
-    const skillsDir = resolveSkillsDir(repoDir, primaryTool);
-    const deps = createSourceAddDeps(repoDir, tools, skillsDir);
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+    const deps = createSourceAddDeps(repoDir, tools, skillsDirs);
 
     let only: ExtensionKind[] | undefined;
     if (options.only) {

--- a/src/cli/commands/extension_source_rm.ts
+++ b/src/cli/commands/extension_source_rm.ts
@@ -32,8 +32,7 @@ import {
 import { createSourceModifyRenderer } from "../../presentation/renderers/extension_source_modify.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -62,9 +61,9 @@ export const extensionSourceRmCommand = new Command()
     const repoDir = resolveRepoDir(options.repoDir);
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const primaryTool = resolvePrimaryTool(marker);
-    const skillsDir = resolveSkillsDir(repoDir, primaryTool);
-    const deps = createSourceRemoveDeps(repoDir, skillsDir);
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+    const deps = createSourceRemoveDeps(repoDir, skillsDirs);
 
     const renderer = createSourceModifyRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -40,8 +40,7 @@ import { ExtensionCatalogStore } from "../../infrastructure/persistence/extensio
 import { EmbeddedDenoRuntime } from "../../infrastructure/runtime/embedded_deno_runtime.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { createExtensionUpdateRenderer } from "../../presentation/renderers/extension_update.ts";
-import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 import { loadIdentity } from "../load_identity.ts";
 
@@ -83,14 +82,14 @@ export const extensionUpdateCommand = new Command()
     // Per-extension models/workflows/vaults/drivers/datastores/reports
     // destinations are derived inside installExtension from the
     // extension's scoped name. Only skillsDir is tool-dependent.
-    const tool = resolvePrimaryTool(marker);
-    const skillsDir = resolveSkillsDir(repoDir, tool);
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
 
-    const skillsDirRelative = relative(repoDir, skillsDir);
+    const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
     await warnLegacyExtensionLayout(
       lockfilePath,
       (msg) => cliCtx.logger.warn(msg),
-      skillsDirRelative,
+      primarySkillsDirRelative,
     );
 
     // 4. Parse extension name if given
@@ -131,7 +130,7 @@ export const extensionUpdateCommand = new Command()
           const installCtx = await createInstallContext(serverUrl, {
             logger: cliCtx.logger,
             lockfilePath,
-            skillsDir,
+            skillsDirs,
             repoDir,
             force: true,
             identity,

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -20,8 +20,7 @@
 import { join, relative, resolve } from "@std/path";
 import type { Logger } from "@logtape/logtape";
 import { RepoPath } from "../domain/repo/repo_path.ts";
-import { resolveSkillsDir } from "../domain/repo/skill_dirs.ts";
-import { resolvePrimaryTool } from "../domain/repo/primary_tool.ts";
+import { resolveUniqueLocalSkillsDirs } from "../domain/repo/skill_dirs.ts";
 import { RepoMarkerRepository } from "../infrastructure/persistence/repo_marker_repository.ts";
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import { loadIdentity } from "./load_identity.ts";
@@ -56,16 +55,20 @@ export async function createExtensionInstallDeps(
   const modelsDir = resolveModelsDir(marker);
   const absoluteModelsDir = resolve(absoluteRepoDir, modelsDir);
   const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
-  const tool = resolvePrimaryTool(marker);
-  const absoluteSkillsDir = resolveSkillsDir(absoluteRepoDir, tool);
+  const tools = marker?.tools?.length ? marker.tools : ["claude"];
+  const absoluteSkillsDirs = resolveUniqueLocalSkillsDirs(
+    absoluteRepoDir,
+    tools,
+  );
   // `entry.files[]` paths in the lockfile are relative to the repo
   // root, so the skill-dir filter in needsInstallOrMigration /
   // sweepLegacyPaths must compare against a repo-relative skillsDir.
-  // The InstallContext's `skillsDir` stays absolute — pull.ts joins it
-  // with the destination dir and that path is independent of the
-  // lockfile's relative-path convention. Two fields with the same
-  // logical role but different conventions; keep them named distinctly.
-  const skillsDirRelative = relative(absoluteRepoDir, absoluteSkillsDir);
+  // The InstallContext's `skillsDirs` stays absolute — pull.ts joins
+  // them with the destination dir and that path is independent of the
+  // lockfile's relative-path convention.
+  const skillsDirsRelative = absoluteSkillsDirs.map((d) =>
+    relative(absoluteRepoDir, d)
+  );
 
   const serverUrl = resolveServerUrl();
   const identity = await loadIdentity();
@@ -74,7 +77,7 @@ export async function createExtensionInstallDeps(
   return {
     lockfilePath,
     repoDir: absoluteRepoDir,
-    skillsDirRelative,
+    skillsDirsRelative,
     createInstallContext: async (_name, _version) => ({
       getExtension: (n) => client.getExtension(n),
       downloadArchive: (n, v, ch) =>
@@ -82,7 +85,7 @@ export async function createExtensionInstallDeps(
       getChecksum: (n, v, ch) => client.getChecksum(n, v, ch),
       logger,
       lockfileRepository: await LockfileRepository.create(lockfilePath),
-      skillsDir: absoluteSkillsDir,
+      skillsDirs: absoluteSkillsDirs,
       repoDir: absoluteRepoDir,
       force: true,
       alreadyPulled: new Set(),

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -74,6 +74,35 @@ export function resolveGlobalSkillsDir(tool: string): string | null {
 }
 
 /**
+ * Returns deduplicated absolute project-local skill directory paths for
+ * a set of enrolled tools. Since multiple tools may share the same path
+ * (e.g., codex/cursor/opencode/copilot all use `.agents/skills/`), this
+ * deduplicates so each directory is only written to once.
+ *
+ * When tools is empty, returns a single-element array with the fallback
+ * `.swamp/pulled-extensions/skills/` directory — there is always at
+ * least one target dir so callers don't need to special-case.
+ */
+export function resolveUniqueLocalSkillsDirs(
+  repoDir: string,
+  tools: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tool of tools) {
+    const dir = resolveSkillsDir(repoDir, tool);
+    if (!seen.has(dir)) {
+      seen.add(dir);
+      result.push(dir);
+    }
+  }
+  if (result.length === 0) {
+    result.push(swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills));
+  }
+  return result;
+}
+
+/**
  * Returns deduplicated absolute global skill directory paths for a set of
  * enrolled tools. Since multiple tools may share the same global path
  * (e.g., codex/cursor/opencode/copilot all use ~/.agents/skills/), this

--- a/src/domain/repo/skill_dirs_test.ts
+++ b/src/domain/repo/skill_dirs_test.ts
@@ -24,6 +24,7 @@ import {
   GLOBAL_SKILL_DIRS,
   resolveGlobalSkillsDir,
   resolveUniqueGlobalSkillsDirs,
+  resolveUniqueLocalSkillsDirs,
 } from "./skill_dirs.ts";
 
 Deno.test("GLOBAL_SKILL_DIRS: claude uses vendor-specific path", () => {
@@ -78,4 +79,38 @@ Deno.test("resolveUniqueGlobalSkillsDirs: skips none tool", () => {
 Deno.test("resolveUniqueGlobalSkillsDirs: empty tools returns empty", () => {
   const dirs = resolveUniqueGlobalSkillsDirs([]);
   assertEquals(dirs.length, 0);
+});
+
+Deno.test("resolveUniqueLocalSkillsDirs: deduplicates shared paths", () => {
+  const dirs = resolveUniqueLocalSkillsDirs("/repo", [
+    "claude",
+    "codex",
+    "cursor",
+    "opencode",
+    "copilot",
+    "kiro",
+  ]);
+  assertEquals(dirs.length, 4);
+  assertPathStringIncludes(dirs[0], `.claude${SEPARATOR}skills`);
+  assertPathStringIncludes(dirs[1], `.agents${SEPARATOR}skills`);
+  assertPathStringIncludes(dirs[2], `.cursor${SEPARATOR}skills`);
+  assertPathStringIncludes(dirs[3], `.kiro${SEPARATOR}skills`);
+});
+
+Deno.test("resolveUniqueLocalSkillsDirs: empty tools returns fallback", () => {
+  const dirs = resolveUniqueLocalSkillsDirs("/repo", []);
+  assertEquals(dirs.length, 1);
+  assertPathStringIncludes(dirs[0], "pulled-extensions");
+});
+
+Deno.test("resolveUniqueLocalSkillsDirs: single tool returns one dir", () => {
+  const dirs = resolveUniqueLocalSkillsDirs("/repo", ["claude"]);
+  assertEquals(dirs.length, 1);
+  assertPathStringIncludes(dirs[0], `.claude${SEPARATOR}skills`);
+});
+
+Deno.test("resolveUniqueLocalSkillsDirs: unknown tool uses fallback path", () => {
+  const dirs = resolveUniqueLocalSkillsDirs("/repo", ["unknown-tool"]);
+  assertEquals(dirs.length, 1);
+  assertPathStringIncludes(dirs[0], "pulled-extensions");
 });

--- a/src/libswamp/extensions/doctor.ts
+++ b/src/libswamp/extensions/doctor.ts
@@ -25,7 +25,7 @@ import type { SwampError } from "../errors.ts";
 import type { DoctorAggregateReport } from "./doctor_aggregate.ts";
 import type { RepairReport } from "./doctor_repair.ts";
 import type { ReconcileTransition } from "./reconcile_from_disk_service.ts";
-import { extractTopLevelRoot } from "./layout.ts";
+import { extractTopLevelRootMulti } from "./layout.ts";
 
 /**
  * Public registry name for the doctor report. The infrastructure-layer
@@ -160,11 +160,12 @@ export interface DoctorExtensionsDeps {
   /** Repo root used to resolve repo-relative paths for filesystem walks. */
   repoDir: string;
   /**
-   * Tool-aware skills directory (e.g. `.claude/skills`). Repo-relative.
-   * Skill paths are tracked as directory paths only, so the orphan walk
-   * skips them — extractTopLevelRoot needs this to recognise skill paths.
+   * Tool-aware skills directories (e.g. `[".claude/skills", ".kiro/skills"]`).
+   * Repo-relative. Skill paths are tracked as directory paths only, so the
+   * orphan walk skips them — extractTopLevelRoot needs these to recognise
+   * skill paths.
    */
-  skillsDir: string;
+  skillsDirs: string[];
   abortSignal: AbortSignal;
   /**
    * W6: Callback that builds aggregate state from the catalog after
@@ -237,10 +238,10 @@ function toForwardSlashes(p: string): string {
 async function detectOrphanFiles(
   upstreamMap: UpstreamExtensionsMap,
   repoDir: string,
-  skillsDir: string,
+  skillsDirs: string[],
 ): Promise<DoctorOrphanFile[]> {
   const orphans: DoctorOrphanFile[] = [];
-  const normalizedSkillsDir = toForwardSlashes(skillsDir);
+  const normalizedSkillsDirs = skillsDirs.map(toForwardSlashes);
 
   for (const [extensionName, entry] of Object.entries(upstreamMap)) {
     const trackedFiles = (entry.files ?? []).map(toForwardSlashes);
@@ -249,9 +250,9 @@ async function detectOrphanFiles(
     const tracked = new Set(trackedFiles);
     const roots = new Set<string>();
     for (const file of trackedFiles) {
-      const root = extractTopLevelRoot(
+      const root = extractTopLevelRootMulti(
         file,
-        normalizedSkillsDir,
+        normalizedSkillsDirs,
         extensionName,
       );
       if (root !== null) {
@@ -371,7 +372,7 @@ export async function* doctorExtensions(
     orphanFiles = await detectOrphanFiles(
       upstreamMap,
       deps.repoDir,
-      deps.skillsDir,
+      deps.skillsDirs,
     );
   }
 

--- a/src/libswamp/extensions/doctor_test.ts
+++ b/src/libswamp/extensions/doctor_test.ts
@@ -74,7 +74,7 @@ function buildDeps(
       {},
     ),
     repoDir: options.repoDir ?? "/tmp/swamp-test-repo",
-    skillsDir: options.skillsDir ?? ".claude/skills",
+    skillsDirs: [options.skillsDir ?? ".claude/skills"],
     abortSignal: new AbortController().signal,
     buildAggregateState: options.aggregateState
       ? () => Promise.resolve(options.aggregateState!)

--- a/src/libswamp/extensions/install.ts
+++ b/src/libswamp/extensions/install.ts
@@ -32,7 +32,7 @@ import {
   type InstallResult,
   parseExtensionRef,
 } from "./pull.ts";
-import { classifyExtensionFile, isSkillDirEntry } from "./layout.ts";
+import { classifyExtensionFile, isSkillDirEntryMulti } from "./layout.ts";
 
 /**
  * Test seam for `extensionInstall`. Production always uses
@@ -86,13 +86,13 @@ export interface ExtensionInstallDeps {
   lockfilePath: string;
   repoDir: string;
   /**
-   * Tool-aware skills destination as a **repo-relative** path (e.g.
-   * `.claude/skills`, `.cursor/skills`, or
-   * `.swamp/pulled-extensions/skills` for `tool=none`). Repo-relative
+   * Tool-aware skills destinations as **repo-relative** paths (e.g.
+   * `[".claude/skills", ".kiro/skills"]`, or
+   * `[".swamp/pulled-extensions/skills"]` for `tool=none`). Repo-relative
    * is load-bearing: `entry.files[]` paths in the lockfile are
    * repo-relative, and `isSkillDirEntry` compares them directly. Note
-   * the deliberate asymmetry with `InstallContext.skillsDir`, which is
-   * **absolute** because `pull.ts` joins it with destination dirs to
+   * the deliberate asymmetry with `InstallContext.skillsDirs`, which is
+   * **absolute** because `pull.ts` joins them with destination dirs to
    * write skill files. Don't conflate the two.
    *
    * Optional for source-compat with direct libswamp consumers that
@@ -104,7 +104,7 @@ export interface ExtensionInstallDeps {
    * indistinguishable from a gen-2 path and would be destructively
    * removed.
    */
-  skillsDirRelative?: string;
+  skillsDirsRelative?: string[];
   /**
    * Async factory that constructs a fresh {@link InstallContext} for
    * each install entry. The async return type matters: each context
@@ -170,7 +170,7 @@ export async function* extensionInstall(
         let needs = await needsInstallOrMigration(
           originalFiles,
           deps.repoDir,
-          deps.skillsDirRelative,
+          deps.skillsDirsRelative,
         );
 
         // When all files exist at current layout, verify their content
@@ -227,7 +227,7 @@ export async function* extensionInstall(
             await sweepLegacyPaths(
               originalFiles,
               deps.repoDir,
-              deps.skillsDirRelative,
+              deps.skillsDirsRelative,
             );
             entries.push({ name, version, status: "migrated" });
             migrated++;
@@ -282,7 +282,7 @@ export async function* extensionInstall(
  * Missing beats legacy: a missing file cannot be migrated without a
  * re-pull, so the flow is the same either way.
  *
- * `skillsDirRelative` (when provided, repo-relative) filters skill
+ * `skillsDirsRelative` (when provided, repo-relative) filters skill
  * directory entries out of legacy classification — they are always
  * considered current-layout regardless of physical location. Their
  * on-disk presence is still checked so a skill dir deleted by a prior
@@ -292,7 +292,7 @@ export async function* extensionInstall(
 export async function needsInstallOrMigration(
   files: string[],
   repoDir: string,
-  skillsDirRelative?: string,
+  skillsDirsRelative?: string[],
 ): Promise<"install" | "migrate" | "up_to_date"> {
   let hasLegacy = false;
   for (const file of files) {
@@ -306,7 +306,7 @@ export async function needsInstallOrMigration(
       }
       throw error;
     }
-    if (isSkillDirEntry(file, skillsDirRelative)) {
+    if (isSkillDirEntryMulti(file, skillsDirsRelative)) {
       continue;
     }
     const generation = classifyExtensionFile(file);
@@ -328,7 +328,7 @@ export async function needsInstallOrMigration(
  * tracked by their root, with nested files inside) are handled — a plain
  * Deno.remove fails on non-empty directories.
  *
- * `skillsDirRelative` (when provided, repo-relative) excludes skill
+ * `skillsDirsRelative` (when provided, repo-relative) excludes skill
  * directory entries from the sweep — skill paths are current-layout
  * regardless of physical location and the freshly-restored skill dir
  * must survive the post-install cleanup. Without this filter, the
@@ -342,11 +342,11 @@ export async function needsInstallOrMigration(
 export async function sweepLegacyPaths(
   originalFiles: string[],
   repoDir: string,
-  skillsDirRelative?: string,
+  skillsDirsRelative?: string[],
 ): Promise<void> {
   for (const file of originalFiles) {
     assertContainedPath(file, repoDir);
-    if (isSkillDirEntry(file, skillsDirRelative)) {
+    if (isSkillDirEntryMulti(file, skillsDirsRelative)) {
       continue;
     }
     if (classifyExtensionFile(file) === "current") {

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -138,7 +138,7 @@ function makeInstallContext(
     downloadArchive: () => Promise.reject(new Error("stub")),
     getChecksum: () => Promise.resolve(null),
     lockfileRepository,
-    skillsDir: join(repoDir, ".claude", "skills"),
+    skillsDirs: [join(repoDir, ".claude", "skills")],
     repoDir,
     force: false,
     alreadyPulled: new Set(),

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -183,7 +183,7 @@ Deno.test("extensionInstall: reinstalls when filesChecksum mismatches on-disk di
             downloadArchive: () => Promise.reject(new Error("test stub")),
             getChecksum: () => Promise.resolve(null),
             lockfileRepository: await LockfileRepository.create(lockfilePath),
-            skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+            skillsDirs: [join(tmpDir, ".swamp/pulled-extensions/skills")],
             repoDir: tmpDir,
             force: true,
             alreadyPulled: new Set<string>(),
@@ -352,7 +352,7 @@ Deno.test("extensionInstall: detects missing files and calls install", async () 
             downloadArchive: () => Promise.reject(new Error("test stub")),
             getChecksum: () => Promise.resolve(null),
             lockfileRepository: await LockfileRepository.create(lockfilePath),
-            skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+            skillsDirs: [join(tmpDir, ".swamp/pulled-extensions/skills")],
             repoDir: tmpDir,
             force: true,
             alreadyPulled: new Set<string>(),
@@ -449,7 +449,7 @@ Deno.test("extensionInstall: lockfile-anchored checksum mismatch fails with drif
             Promise.resolve(new TextEncoder().encode("drifted content")),
           getChecksum: () => Promise.resolve(null),
           lockfileRepository: await LockfileRepository.create(lockfilePath),
-          skillsDir: "unused",
+          skillsDirs: ["unused"],
           repoDir: tmpDir,
           force: true,
           alreadyPulled: new Set<string>(),
@@ -493,7 +493,7 @@ async function makeStubInstallContext(
     downloadArchive: () => Promise.reject(new Error("unused")),
     getChecksum: () => Promise.resolve(null),
     lockfileRepository: await LockfileRepository.create(lockfilePath),
-    skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+    skillsDirs: [join(tmpDir, ".swamp/pulled-extensions/skills")],
     repoDir: tmpDir,
     force: true,
     alreadyPulled: new Set<string>(),
@@ -695,7 +695,7 @@ Deno.test(
           ".claude/skills/foo",
         ],
         tmpDir,
-        ".claude/skills",
+        [".claude/skills"],
       );
       assertEquals(result, "up_to_date");
     } finally {
@@ -732,7 +732,7 @@ Deno.test(
           ".swamp/pulled-extensions/skills/foo",
         ],
         tmpDir,
-        ".swamp/pulled-extensions/skills",
+        [".swamp/pulled-extensions/skills"],
       );
       assertEquals(result, "up_to_date");
     } finally {
@@ -766,7 +766,7 @@ Deno.test(
           ".claude/skills/foo",
         ],
         tmpDir,
-        ".claude/skills",
+        [".claude/skills"],
       );
       assertEquals(result, "install");
     } finally {
@@ -1098,7 +1098,7 @@ Deno.test(
         extensionInstall(ctx, {
           lockfilePath,
           repoDir: tmpDir,
-          skillsDirRelative: ".claude/skills",
+          skillsDirsRelative: [".claude/skills"],
           createInstallContext: () =>
             makeStubInstallContext(tmpDir, lockfilePath),
           installExtensionFn: makeSuccessfulInstallWithSkill(
@@ -1185,7 +1185,7 @@ Deno.test(
         extensionInstall(ctx, {
           lockfilePath,
           repoDir: tmpDir,
-          skillsDirRelative: ".swamp/pulled-extensions/skills",
+          skillsDirsRelative: [".swamp/pulled-extensions/skills"],
           createInstallContext: () =>
             makeStubInstallContext(tmpDir, lockfilePath),
           installExtensionFn: makeSuccessfulInstallWithSkill(
@@ -1372,7 +1372,7 @@ Deno.test(
       await sweepLegacyPaths(
         ["extensions/models/legacy.ts", ".claude/skills/good-planning"],
         tmpDir,
-        ".claude/skills",
+        [".claude/skills"],
       );
 
       // gen-1 path swept.
@@ -1413,7 +1413,7 @@ Deno.test(
       await sweepLegacyPaths(
         [".swamp/pulled-extensions/skills/good-planning"],
         tmpDir,
-        ".swamp/pulled-extensions/skills",
+        [".swamp/pulled-extensions/skills"],
       );
 
       const stat = await Deno.stat(skillDir);

--- a/src/libswamp/extensions/layout.ts
+++ b/src/libswamp/extensions/layout.ts
@@ -160,6 +160,21 @@ export function isSkillDirEntry(
 }
 
 /**
+ * Multi-dir variant of {@link isSkillDirEntry}. Returns true when the
+ * file matches ANY of the provided skill dirs.
+ */
+export function isSkillDirEntryMulti(
+  file: string,
+  skillsDirs: string[] | undefined,
+): boolean {
+  if (!skillsDirs) return false;
+  for (const dir of skillsDirs) {
+    if (isSkillDirEntry(file, dir)) return true;
+  }
+  return false;
+}
+
+/**
  * Returns the per-extension root subtree that owns a tracked file path,
  * or `null` when the path does not anchor to a root that
  * `doctor extensions` should walk for orphan detection.
@@ -238,6 +253,50 @@ export function extractTopLevelRoot(
 
   // Anything else current-layout but not under a known root — no
   // orphan walk possible.
+  return null;
+}
+
+/**
+ * Multi-dir variant of {@link extractTopLevelRoot}. Returns null when
+ * the file is a skill entry under ANY of the provided skill dirs.
+ */
+export function extractTopLevelRootMulti(
+  filePath: string,
+  skillsDirs: string[],
+  extensionName: string,
+): string | null {
+  if (classifyExtensionFile(filePath) !== "current") {
+    return null;
+  }
+  for (const dir of skillsDirs) {
+    if (isSkillDirEntry(filePath, dir)) {
+      return null;
+    }
+  }
+  if (filePath.startsWith(PULLED_PREFIX)) {
+    const nameSegments = extensionName.split("/");
+    const rest = filePath.slice(PULLED_PREFIX.length);
+    const segments = rest.split("/");
+    if (segments.length < nameSegments.length) return null;
+    return `${PULLED_PREFIX}${
+      segments.slice(0, nameSegments.length).join("/")
+    }`;
+  }
+  const BUNDLE_KINDS = [
+    "bundles",
+    "vault-bundles",
+    "driver-bundles",
+    "datastore-bundles",
+    "report-bundles",
+  ];
+  for (const kind of BUNDLE_KINDS) {
+    const prefix = `${SWAMP_DATA_DIR}/${kind}/`;
+    if (filePath.startsWith(prefix)) {
+      const segments = filePath.slice(prefix.length).split("/");
+      if (segments.length < 1) continue;
+      return `${prefix}${segments[0]}`;
+    }
+  }
   return null;
 }
 

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -119,9 +119,9 @@ export interface InstallResult {
  * datastores/reports) are deliberately NOT fields on this context —
  * `installExtension` derives them itself as
  * `.swamp/pulled-extensions/<ref.name>/<type>/` so filesystem state is
- * strictly per-extension (issue 120). Only `skillsDir` remains because
- * skills land in a tool-specific dir (`.claude/skills/`, etc.) that
- * the caller owns.
+ * strictly per-extension (issue 120). Only `skillsDirs` remains because
+ * skills land in tool-specific dirs (`.claude/skills/`, `.kiro/skills/`,
+ * etc.) that the caller owns — one per enrolled tool.
  */
 export interface InstallContext {
   getExtension: (name: string) => Promise<ExtensionRegistryInfo | null>;
@@ -153,8 +153,14 @@ export interface InstallContext {
    * preserves that timing.
    */
   lockfileRepository: LockfileRepository;
-  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
-  skillsDir: string;
+  /**
+   * Tool-aware skills destinations — one per unique enrolled tool
+   * (e.g. `["/repo/.claude/skills", "/repo/.kiro/skills"]`). Skills are
+   * extracted to every directory in this array; all paths are tracked in
+   * the lockfile so orphan pruning and extension rm handle multi-tool
+   * repos correctly.
+   */
+  skillsDirs: string[];
   repoDir: string;
   force: boolean;
   alreadyPulled: Set<string>;
@@ -232,8 +238,11 @@ export interface ExtensionPullDeps {
    * and the single-use rule.
    */
   lockfileRepository: LockfileRepository;
-  /** Tool-aware skills destination (e.g. `.claude/skills/`). */
-  skillsDir: string;
+  /**
+   * Tool-aware skills destinations — one per unique enrolled tool.
+   * See {@link InstallContext.skillsDirs}.
+   */
+  skillsDirs: string[];
   repoDir: string;
   alreadyPulled: Set<string>;
   depth: number;
@@ -847,7 +856,7 @@ export async function installExtension(
     // dedicated subtree under .swamp/pulled-extensions/<ext-name>/. Prevents
     // cross-extension filename collisions (e.g. _lib/aws.ts shared between
     // @swamp/aws/ec2 and @swamp/aws/eks, or README.md across unrelated
-    // extensions). Skills remain at ctx.skillsDir — already per-skill.
+    // extensions). Skills fan out to ctx.skillsDirs — one per enrolled tool.
     const absoluteExtRoot = join(
       swampPath(repoDir, "pulled-extensions"),
       ref.name,
@@ -1017,7 +1026,7 @@ export async function installExtension(
       }
     }
 
-    // Extract skills to tool-specific skill directory.
+    // Extract skills to every enrolled tool's skill directory.
     // Track only the skill directory root (not individual files) so that
     // extension rm can delete the entire directory in one shot.
     let hasSkills = false;
@@ -1031,28 +1040,35 @@ export async function installExtension(
       }
       if (skillEntries.length > 0) {
         hasSkills = true;
-        const absoluteSkillsDir = resolve(repoDir, ctx.skillsDir);
-        await Deno.mkdir(absoluteSkillsDir, { recursive: true });
-        for (const entry of skillEntries) {
-          if (!entry.isDirectory) continue;
-          const srcSkillDir = join(skillsSrc, entry.name);
-          const destSkillDir = join(absoluteSkillsDir, entry.name);
-          await Deno.mkdir(destSkillDir, { recursive: true });
-          const extracted = await copyDir(srcSkillDir, destSkillDir, repoDir);
-          // Track the skill directory root, not individual files
-          const skillDirRelative = relative(repoDir, destSkillDir);
-          extractedFiles.push(skillDirRelative);
-          skillFiles.push(...extracted);
+        for (const skillsDir of ctx.skillsDirs) {
+          const absoluteSkillsDir = resolve(repoDir, skillsDir);
+          await Deno.mkdir(absoluteSkillsDir, { recursive: true });
+          for (const entry of skillEntries) {
+            if (!entry.isDirectory) continue;
+            const srcSkillDir = join(skillsSrc, entry.name);
+            const destSkillDir = join(absoluteSkillsDir, entry.name);
+            await Deno.mkdir(destSkillDir, { recursive: true });
+            const extracted = await copyDir(
+              srcSkillDir,
+              destSkillDir,
+              repoDir,
+            );
+            const skillDirRelative = relative(repoDir, destSkillDir);
+            extractedFiles.push(skillDirRelative);
+            skillFiles.push(...extracted);
 
-          // Check for scripts/ directory
-          try {
-            const scriptsDir = join(srcSkillDir, "scripts");
-            const stat = await Deno.stat(scriptsDir);
-            if (stat.isDirectory) {
-              hasSkillScripts = true;
+            // Check for scripts/ directory (once per skill, not per tool)
+            if (!hasSkillScripts) {
+              try {
+                const scriptsDir = join(srcSkillDir, "scripts");
+                const stat = await Deno.stat(scriptsDir);
+                if (stat.isDirectory) {
+                  hasSkillScripts = true;
+                }
+              } catch {
+                // No scripts/ directory
+              }
             }
-          } catch {
-            // No scripts/ directory
           }
         }
       }
@@ -1275,7 +1291,7 @@ export async function* extensionPull(
         getChecksum: deps.getChecksum,
         logger: ctx.logger,
         lockfileRepository: deps.lockfileRepository,
-        skillsDir: deps.skillsDir,
+        skillsDirs: deps.skillsDirs,
         repoDir: deps.repoDir,
         force: input.force,
         alreadyPulled: deps.alreadyPulled,
@@ -1335,7 +1351,7 @@ export async function* extensionPull(
 export async function createExtensionPullDeps(
   serverUrl: string,
   lockfilePath: string,
-  skillsDir: string,
+  skillsDirs: string[],
   repoDir: string,
   args?: {
     denoRuntime?: DenoRuntime;
@@ -1356,7 +1372,7 @@ export async function createExtensionPullDeps(
     getChecksum: (name, version, channel) =>
       client.getChecksum(name, version, channel),
     lockfileRepository,
-    skillsDir,
+    skillsDirs,
     repoDir,
     alreadyPulled: new Set(),
     depth: 0,
@@ -1376,7 +1392,7 @@ export async function createInstallContext(
   serverUrl: string,
   opts: {
     lockfilePath: string;
-    skillsDir: string;
+    skillsDirs: string[];
     repoDir: string;
     force: boolean;
     logger?: Logger;
@@ -1394,7 +1410,7 @@ export async function createInstallContext(
       client.getChecksum(name, version, channel),
     logger: opts.logger,
     lockfileRepository,
-    skillsDir: opts.skillsDir,
+    skillsDirs: opts.skillsDirs,
     repoDir: opts.repoDir,
     force: opts.force,
     alreadyPulled: new Set(),

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -234,7 +234,7 @@ async function makeStubDeps(
     lockfileRepository: await LockfileRepository.create(
       join(tmpDir, "upstream_extensions.json"),
     ),
-    skillsDir: join(tmpDir, "skills"),
+    skillsDirs: [join(tmpDir, "skills")],
     repoDir: tmpDir,
     alreadyPulled: new Set(),
     depth: 0,

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -132,7 +132,7 @@ function makeInstallContext(
     downloadArchive: () => Promise.reject(new Error("stub")),
     getChecksum: () => Promise.resolve(null),
     lockfileRepository,
-    skillsDir: join(repoDir, ".claude", "skills"),
+    skillsDirs: [join(repoDir, ".claude", "skills")],
     repoDir,
     force: false,
     alreadyPulled: new Set(),

--- a/src/libswamp/extensions/upgrade_extension_service_test.ts
+++ b/src/libswamp/extensions/upgrade_extension_service_test.ts
@@ -123,7 +123,7 @@ function makeInstallContext(
     downloadArchive: () => Promise.reject(new Error("stub")),
     getChecksum: () => Promise.resolve(null),
     lockfileRepository,
-    skillsDir: join(repoDir, ".claude", "skills"),
+    skillsDirs: [join(repoDir, ".claude", "skills")],
     repoDir,
     force: false,
     alreadyPulled: new Set(),

--- a/src/libswamp/repo/init_test.ts
+++ b/src/libswamp/repo/init_test.ts
@@ -298,7 +298,7 @@ Deno.test("repoUpgrade: completes with warning when extension install fails", as
               ),
             getChecksum: () => Promise.resolve(null),
             lockfileRepository: await LockfileRepository.create(lockfilePath),
-            skillsDir: join(tmpDir, ".swamp/pulled-extensions/skills"),
+            skillsDirs: [join(tmpDir, ".swamp/pulled-extensions/skills")],
             repoDir: tmpDir,
             force: true,
             alreadyPulled: new Set<string>(),

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -62,9 +62,10 @@ export interface SourceAddDeps {
 export function createSourceAddDeps(
   repoDir: string,
   tools?: string[],
-  skillsDir?: string,
+  skillsDirs?: string[],
 ): SourceAddDeps {
   const resolvedTools = tools?.length ? tools : ["claude"];
+  const dirs = skillsDirs?.length ? skillsDirs : [];
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
@@ -72,10 +73,19 @@ export function createSourceAddDeps(
     expandSource: (source) => expandSourcePaths({ sources: [source] }, repoDir),
     resolveSkills: (sourcePath) =>
       resolveSourceSkills(sourcePath, resolvedTools),
-    copySkills: (skills) =>
-      skillsDir ? copySourceSkills(skills, skillsDir) : Promise.resolve([]),
-    cleanupSkills: (skillNames) =>
-      skillsDir ? removeSourceSkills(skillNames, skillsDir) : Promise.resolve(),
+    copySkills: async (skills) => {
+      const allCopied: string[] = [];
+      for (const dir of dirs) {
+        const copied = await copySourceSkills(skills, dir);
+        allCopied.push(...copied);
+      }
+      return allCopied;
+    },
+    cleanupSkills: async (skillNames) => {
+      for (const dir of dirs) {
+        await removeSourceSkills(skillNames, dir);
+      }
+    },
   };
 }
 

--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -46,8 +46,9 @@ export interface SourceRemoveDeps {
 /** Wires real infrastructure into SourceRemoveDeps. */
 export function createSourceRemoveDeps(
   repoDir: string,
-  skillsDir?: string,
+  skillsDirs?: string[],
 ): SourceRemoveDeps {
+  const dirs = skillsDirs?.length ? skillsDirs : [];
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
@@ -69,8 +70,11 @@ export function createSourceRemoveDeps(
       );
       return expanded.map((s) => s.path);
     },
-    removeSkills: (skillNames) =>
-      skillsDir ? removeSourceSkills(skillNames, skillsDir) : Promise.resolve(),
+    removeSkills: async (skillNames) => {
+      for (const dir of dirs) {
+        await removeSourceSkills(skillNames, dir);
+      }
+    },
   };
 }
 

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -252,8 +252,8 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
             logger.info(
               `  ${entry.names.length} extension(s) installed for the ` +
                 `previous tool were NOT copied to ${entry.tool}. ` +
-                `Re-run \`swamp extension pull <name>\` to install ` +
-                `for ${entry.tool}: ${list}`,
+                `Run \`swamp extension pull <name> --force\` to install ` +
+                `for all enrolled tools: ${list}`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- Fan out extension skill materialization to every enrolled tool's project-local skills directory (deduplicated) instead of only `tools[0]`
- Add `resolveUniqueLocalSkillsDirs(repoDir, tools)` helper mirroring the existing global pattern
- Change `InstallContext.skillsDir` to `skillsDirs: string[]` and update all extension commands (pull, update, install, source add/rm, doctor, search)
- Reword the `repo upgrade` advisory to reflect that a single `--force` pull now installs for all tools
- Document multi-tool skill materialization in `design/extension.md`

Closes swamp-club/swamp-club#1056

## Test Plan

- Added unit tests for `resolveUniqueLocalSkillsDirs` (dedup, empty tools, unknown tools, single tool)
- Updated all existing test mocks for the `skillsDir` → `skillsDirs` interface change (8 test files)
- Verified fix against reproduction scenario: `repo init --tool kiro` → `extension pull` → `repo upgrade --tool claude --tool kiro` → `extension pull --force` → both `.claude/skills/` and `.kiro/skills/` have the extension's skills, neither is deleted
- Full test suite: 8756 passed, 0 failed (1 pre-existing env-specific failure unrelated to this change)