### PR TITLE
fix(cli): make vault list-keys vault_name argument required (swamp-club#1073)

### DIFF
--- a/src/cli/commands/vault_list_keys.ts
+++ b/src/cli/commands/vault_list_keys.ts
@@ -48,13 +48,12 @@ export const vaultListKeysCommand = withRemoteOptions(
     .name("list-keys")
     .description("List all secret keys in a vault (without values)")
     .example("List keys in a vault", "swamp vault list-keys my-vault")
-    .example("List all vault keys", "swamp vault list-keys")
-    .arguments("[vault_name:string]")
+    .arguments("<vault_name:string>")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     ),
-).action(async function (options: AnyOptions, vaultName?: string) {
+).action(async function (options: AnyOptions, vaultName: string) {
   const cliCtx = createContext(options as GlobalOptions, [
     "vault",
     "list-keys",
@@ -97,7 +96,7 @@ export const vaultListKeysCommand = withRemoteOptions(
 
   const renderer = createVaultListKeysRenderer(cliCtx.outputMode);
   await consumeStream(
-    vaultListKeys(ctx, deps, { vaultName: vaultName ?? "" }),
+    vaultListKeys(ctx, deps, { vaultName }),
     renderer.handlers(),
   );
 

--- a/src/libswamp/vaults/list_keys_test.ts
+++ b/src/libswamp/vaults/list_keys_test.ts
@@ -54,6 +54,19 @@ Deno.test("vaultListKeys yields resolving then completed", async () => {
   assertEquals(completed.data.count, 2);
 });
 
+Deno.test("vaultListKeys: yields validation error for empty vaultName", async () => {
+  const deps = makeDeps();
+  const events = await collect<VaultListKeysEvent>(
+    vaultListKeys(createLibSwampContext(), deps, { vaultName: "" }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  assertEquals(events[1].kind, "error");
+  const error = events[1] as Extract<VaultListKeysEvent, { kind: "error" }>;
+  assertEquals(error.error.code, "validation_failed");
+});
+
 Deno.test("vaultListKeys yields error when vault not found", async () => {
   const deps = makeDeps({
     findVaultByName: () => Promise.resolve(null),


### PR DESCRIPTION
## Summary

- Make `vault_name` a required CLI argument (`<vault_name:string>` instead of `[vault_name:string]`) so Cliffy enforces it before reaching the domain layer
- Remove the misleading "List all vault keys" example that implied a no-arg form works
- Add missing unit test for the empty-vaultName domain validation path (defense-in-depth for the server handler)

Closes swamp-club/lab#1073

## Test Plan

- `deno check` passes on both changed files
- `deno lint` and `deno fmt --check` pass
- Unit tests pass: new test asserts `validation_failed` for empty vaultName
- Verified with compiled binary: `swamp vault list-keys` now shows Cliffy's `Missing argument(s): vault_name` error
- Help text shows `<vault_name>` (required) and the misleading example is gone