### PR TITLE
fix(models): wire nested-invocation provenance through ModelOutput persistence (swamp-club#1077)

### DIFF
--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -746,82 +746,124 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
           traceHeaders: injectTraceContext(),
         };
 
+      // Pre-create ModelOutput before execution so its ID is available
+      // as parentOutputId for nested runModel() invocations.
+      let output: ModelOutput | undefined;
+      if (context.outputRepository) {
+        const provenance = context._invocationProvenance
+          ? {
+            definitionHash,
+            modelVersion: modelDef.version,
+            triggeredBy: context._invocationProvenance.triggeredBy,
+            parentOutputId: context._invocationProvenance.parentOutputId,
+            callerExtension: context._invocationProvenance.callerExtension,
+          }
+          : {
+            definitionHash,
+            modelVersion: modelDef.version,
+            triggeredBy: "manual" as const,
+          };
+        output = ModelOutput.create({
+          definitionId: currentDefinition.id,
+          methodName,
+          status: "running",
+          provenance,
+        });
+        context._currentOutputId = output.id;
+        await context.outputRepository.save(modelDef.type, methodName, output);
+      }
+
       let currentHandles: DataHandle[];
       let result: MethodResult;
       let executionContext: MethodContext = context;
 
-      if (context.placement && hasPlacement(context.placement)) {
-        // Remote placement: the method body runs on a matching worker; the
-        // surrounding pipeline (checks above, output records and follow-up
-        // actions below) stays at the orchestrator. See
-        // design/remote-execution.md.
-        const remoteResult = await this.#executeRemotely(
-          context,
-          executionRequest,
-          modelDef,
-          currentDefinition,
-          methodName,
-        );
-        // Rebuild full handles from the durable records the data plane
-        // persisted — downstream consumers (data-record mapping, workflow
-        // artifact tracking) read metadata like ownerDefinition, which the
-        // wire-thin dispatch outputs do not carry.
-        currentHandles = await Promise.all(
-          remoteResult.outputs.map((output) =>
-            this.#rebuildRemoteHandle(context, output)
-          ),
-        );
-        result = {
-          dataHandles: currentHandles,
-          followUpActions: remoteResult
-            .followUpActions as FollowUpAction[] | undefined,
-          executor: remoteResult.workerName,
-        };
-      } else {
-        // Execute in-process — the single-host path (see
-        // design/remote-execution.md "No execution drivers").
-        const inProcessExecutor = new InProcessExecutor(
-          this,
-          currentDefinition,
-          method,
-          modelDef,
-          context,
-          methodName,
-          this.modelInvocationService,
-        );
-        const executionResult = await withSpan("swamp.method.execute", {
-          "model.type": context.modelType.normalized,
-        }, () => inProcessExecutor.execute(executionRequest));
+      try {
+        if (context.placement && hasPlacement(context.placement)) {
+          // Remote placement: the method body runs on a matching worker; the
+          // surrounding pipeline (checks above, output records and follow-up
+          // actions below) stays at the orchestrator. See
+          // design/remote-execution.md.
+          const remoteResult = await this.#executeRemotely(
+            context,
+            executionRequest,
+            modelDef,
+            currentDefinition,
+            methodName,
+          );
+          // Rebuild full handles from the durable records the data plane
+          // persisted — downstream consumers (data-record mapping, workflow
+          // artifact tracking) read metadata like ownerDefinition, which the
+          // wire-thin dispatch outputs do not carry.
+          currentHandles = await Promise.all(
+            remoteResult.outputs.map((output) =>
+              this.#rebuildRemoteHandle(context, output)
+            ),
+          );
+          result = {
+            dataHandles: currentHandles,
+            followUpActions: remoteResult
+              .followUpActions as FollowUpAction[] | undefined,
+            executor: remoteResult.workerName,
+          };
+        } else {
+          // Execute in-process — the single-host path (see
+          // design/remote-execution.md "No execution drivers").
+          const inProcessExecutor = new InProcessExecutor(
+            this,
+            currentDefinition,
+            method,
+            modelDef,
+            context,
+            methodName,
+            this.modelInvocationService,
+          );
+          const executionResult = await withSpan("swamp.method.execute", {
+            "model.type": context.modelType.normalized,
+          }, () => inProcessExecutor.execute(executionRequest));
 
-        if (executionResult.outputs.some((o) => o.kind === "pending")) {
-          throw new Error(
-            "In-process execution unexpectedly produced pending outputs — " +
-              "this is a bug; in-process execution should only produce " +
-              "persisted outputs",
+          if (executionResult.outputs.some((o) => o.kind === "pending")) {
+            throw new Error(
+              "In-process execution unexpectedly produced pending outputs — " +
+                "this is a bug; in-process execution should only produce " +
+                "persisted outputs",
+            );
+          }
+          // Process outputs first — even on error, data may have been written
+          // to disk before the method threw (e.g. code-review writes log then
+          // throws on verdict=FAIL). Handles must survive the error path.
+          currentHandles = collectPersistedHandles(executionResult.outputs);
+
+          if (executionResult.status === "error") {
+            const err = new Error(
+              executionResult.error ?? "Method execution failed",
+            );
+            (err as unknown as Record<string, unknown>).dataHandles =
+              currentHandles;
+            throw err;
+          }
+
+          result = {
+            dataHandles: currentHandles,
+            followUpActions: executionResult
+              .followUpActions as FollowUpAction[] | undefined,
+            executor: "loopback",
+          };
+          // Use the executor's context with writers for follow-up actions
+          executionContext = inProcessExecutor.contextWithWriters ?? context;
+        }
+      } catch (error) {
+        if (output && context.outputRepository) {
+          output.markFailed({
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+          await context.outputRepository.save(
+            modelDef.type,
+            methodName,
+            output,
           );
         }
-        // Process outputs first — even on error, data may have been written
-        // to disk before the method threw (e.g. code-review writes log then
-        // throws on verdict=FAIL). Handles must survive the error path.
-        currentHandles = collectPersistedHandles(executionResult.outputs);
-
-        if (executionResult.status === "error") {
-          const err = new Error(
-            executionResult.error ?? "Method execution failed",
-          );
-          (err as unknown as Record<string, unknown>).dataHandles =
-            currentHandles;
-          throw err;
-        }
-
-        result = {
-          dataHandles: currentHandles,
-          followUpActions: executionResult
-            .followUpActions as FollowUpAction[] | undefined,
-          executor: "loopback",
-        };
-        // Use the executor's context with writers for follow-up actions
-        executionContext = inProcessExecutor.contextWithWriters ?? context;
+        throw error;
       }
 
       // Collect artifact refs from handles (data is already persisted)
@@ -832,19 +874,10 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         tags: h.tags,
       }));
 
-      // Create ModelOutput if output repository is available
-      if (context.outputRepository) {
-        const output = ModelOutput.create({
-          definitionId: currentDefinition.id,
-          methodName,
-          status: "running",
-          provenance: {
-            definitionHash,
-            modelVersion: modelDef.version,
-            triggeredBy: "manual",
-          },
-          artifacts: { dataArtifacts: storedArtifacts },
-        });
+      if (output && context.outputRepository) {
+        for (const artifact of storedArtifacts) {
+          output.addDataArtifact(artifact);
+        }
         output.markSucceeded();
         await context.outputRepository.save(modelDef.type, methodName, output);
       }

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -39,6 +39,7 @@ import { type DataId, generateDataId } from "../data/data_id.ts";
 import { Data } from "../data/data.ts";
 import { UserError } from "../errors.ts";
 import { getLogger } from "@logtape/logtape";
+import { createModelOutputId, type ModelOutput } from "./model_output.ts";
 import { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 
 /**
@@ -3275,3 +3276,179 @@ Deno.test("executeWorkflow - placed step with a vanished output record fails lou
     setRemoteStepDispatcher(null);
   }
 });
+
+// ---------- Invocation Provenance Tests ----------
+
+function createMockOutputRepo(): {
+  repo: MethodContext["outputRepository"];
+  saved: Array<{ type: ModelType; method: string; output: ModelOutput }>;
+} {
+  const saved: Array<{
+    type: ModelType;
+    method: string;
+    output: ModelOutput;
+  }> = [];
+  return {
+    repo: {
+      findById: () => Promise.resolve(null),
+      findByDefinition: () => Promise.resolve([]),
+      findLatestByDefinition: () => Promise.resolve(null),
+      findAll: () => Promise.resolve([]),
+      findAllGlobal: () => Promise.resolve([]),
+      findAllGlobalSince: () => Promise.resolve([]),
+      save: (type: ModelType, method: string, output: ModelOutput) => {
+        saved.push({ type, method, output });
+        return Promise.resolve();
+      },
+      delete: () => Promise.resolve(),
+      nextId: () => createModelOutputId(crypto.randomUUID()),
+      getPath: () => "",
+    },
+    saved,
+  };
+}
+
+Deno.test(
+  "executeWorkflow: output has triggeredBy 'manual' for top-level execution",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    const model = createTestModel({});
+    const definition = Definition.create({
+      name: "test-provenance-manual",
+      globalArguments: { value: "test" },
+    });
+
+    const { repo, saved } = createMockOutputRepo();
+    const { context } = createTestContext({
+      modelType: model.type,
+      outputRepository: repo,
+    });
+
+    await service.executeWorkflow(definition, model, "start", context);
+
+    const lastSave = saved[saved.length - 1];
+    assertEquals(lastSave.output.status, "succeeded");
+    assertEquals(lastSave.output.provenance.triggeredBy, "manual");
+    assertEquals(lastSave.output.provenance.parentOutputId, undefined);
+    assertEquals(lastSave.output.provenance.callerExtension, undefined);
+  },
+);
+
+Deno.test(
+  "executeWorkflow: output uses _invocationProvenance when set",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    const model = createTestModel({});
+    const definition = Definition.create({
+      name: "test-provenance-model",
+      globalArguments: { value: "test" },
+    });
+
+    const { repo, saved } = createMockOutputRepo();
+    const { context } = createTestContext({
+      modelType: model.type,
+      outputRepository: repo,
+      _invocationProvenance: {
+        triggeredBy: "model",
+        parentOutputId: "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+        callerExtension: "@test/caller-ext",
+      },
+    });
+
+    await service.executeWorkflow(definition, model, "start", context);
+
+    const lastSave = saved[saved.length - 1];
+    assertEquals(lastSave.output.status, "succeeded");
+    assertEquals(lastSave.output.provenance.triggeredBy, "model");
+    assertEquals(
+      lastSave.output.provenance.parentOutputId,
+      "aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+    );
+    assertEquals(
+      lastSave.output.provenance.callerExtension,
+      "@test/caller-ext",
+    );
+  },
+);
+
+Deno.test(
+  "executeWorkflow: sets _currentOutputId on context before execution",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+
+    let capturedOutputId: string | undefined;
+    const model: ModelDefinition = {
+      type: ModelType.create("test/capture-output-id"),
+      version: "2026.07.11.1",
+      globalArguments: z.object({}),
+      methods: {
+        run: {
+          description: "capture output id",
+          arguments: z.object({}),
+          execute: (_args: Record<string, unknown>, ctx: MethodContext) => {
+            capturedOutputId = ctx._currentOutputId;
+            return Promise.resolve({ dataHandles: [] });
+          },
+        },
+      },
+    };
+
+    const definition = Definition.create({
+      name: "test-capture-output-id",
+      globalArguments: {},
+    });
+
+    const { repo } = createMockOutputRepo();
+    const { context } = createTestContext({
+      modelType: model.type,
+      outputRepository: repo,
+    });
+
+    await service.executeWorkflow(definition, model, "run", context);
+
+    assertEquals(typeof capturedOutputId, "string");
+    assertEquals(capturedOutputId!.length > 0, true);
+  },
+);
+
+Deno.test(
+  "executeWorkflow: failed execution persists output with failed status",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+    const model: ModelDefinition = {
+      type: ModelType.create("test/fail-output"),
+      version: "2026.07.11.1",
+      globalArguments: z.object({}),
+      methods: {
+        boom: {
+          description: "always fails",
+          arguments: z.object({}),
+          execute: () => {
+            throw new Error("intentional failure");
+          },
+        },
+      },
+    };
+
+    const definition = Definition.create({
+      name: "test-fail-output",
+      globalArguments: {},
+    });
+
+    const { repo, saved } = createMockOutputRepo();
+    const { context } = createTestContext({
+      modelType: model.type,
+      outputRepository: repo,
+    });
+
+    await assertRejects(
+      () => service.executeWorkflow(definition, model, "boom", context),
+      Error,
+      "intentional failure",
+    );
+
+    const lastSave = saved[saved.length - 1];
+    assertEquals(lastSave.output.status, "failed");
+    assertEquals(lastSave.output.error?.message, "intentional failure");
+  },
+);

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -393,6 +393,16 @@ export interface MethodContext {
 
   /** @internal Invocation tracking — not part of the extension author API. */
   _invocationTracking?: InvocationTracking;
+
+  /** @internal Output ID of the ModelOutput pre-created for this execution. */
+  _currentOutputId?: string;
+
+  /** @internal Provenance override when this execution was triggered by a model invocation. */
+  _invocationProvenance?: {
+    triggeredBy: "model";
+    parentOutputId?: string;
+    callerExtension?: string;
+  };
 }
 
 /**

--- a/src/domain/models/model_invocation_service.ts
+++ b/src/domain/models/model_invocation_service.ts
@@ -199,6 +199,13 @@ export class ModelInvocationService {
     );
     childContext._invocationTracking = childTracking;
 
+    const callerModelDef = modelRegistry.get(callerContext.modelType);
+    childContext._invocationProvenance = {
+      triggeredBy: "model",
+      parentOutputId: callerContext._currentOutputId,
+      callerExtension: callerModelDef?.extensionName,
+    };
+
     try {
       const result = await this.#deps.executionService.executeWorkflow(
         definition,

--- a/src/domain/models/model_invocation_service_test.ts
+++ b/src/domain/models/model_invocation_service_test.ts
@@ -23,11 +23,16 @@ import "../../domain/models/models.ts";
 import type {
   InvocationTracking,
   MethodContext,
+  ModelDefinition,
   RunModelResult,
 } from "./model.ts";
+import { defineModel, modelRegistry } from "./model.ts";
 import type { MethodExecutionService } from "./method_execution_service.ts";
 import type { CommonMethodContextDeps } from "./method_context.ts";
 import { ModelInvocationService } from "./model_invocation_service.ts";
+import { ModelType } from "./model_type.ts";
+import { Definition } from "../definitions/definition.ts";
+import { z } from "zod";
 
 await initializeLogging({});
 
@@ -225,5 +230,126 @@ Deno.test("ModelInvocationService: depth 9 allows call (under limit of 10)", asy
   assertStringIncludes(
     (result as RunModelResult & { ok: false }).error.message,
     "not found",
+  );
+});
+
+// ── Invocation provenance tests ──
+
+const PROVENANCE_TARGET_TYPE = ModelType.create("test/provenance-target");
+if (!modelRegistry.get(PROVENANCE_TARGET_TYPE)) {
+  const targetModel: ModelDefinition = {
+    type: PROVENANCE_TARGET_TYPE,
+    version: "2026.07.11.1",
+    methods: {
+      greet: {
+        description: "test method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+  defineModel(targetModel);
+}
+
+function makeProvenanceSvc(options: {
+  captureContext: (ctx: MethodContext) => void;
+  targetDefName: string;
+  targetDef: Definition;
+}) {
+  const mockExecutionService: MethodExecutionService = {
+    execute: () => Promise.resolve({ dataHandles: [] }),
+    executeWorkflow: (_def, _modelDef, _method, ctx) => {
+      options.captureContext(ctx);
+      return Promise.resolve({ dataHandles: [] });
+    },
+  };
+
+  const stubDataRepo = {
+    findAllForModel: () => Promise.resolve([]),
+    getContent: () => Promise.resolve(null),
+  };
+
+  return new ModelInvocationService({
+    executionService: mockExecutionService,
+    commonDeps: {
+      dataRepository: stubDataRepo,
+      definitionRepository: {
+        findByNameGlobal: (name: string) => {
+          if (name === options.targetDefName) {
+            return Promise.resolve({
+              definition: options.targetDef,
+              type: PROVENANCE_TARGET_TYPE,
+            });
+          }
+          return Promise.resolve(null);
+        },
+        findById: () => Promise.resolve(null),
+      },
+      createCelEnvironment: () =>
+        ({}) as ReturnType<MethodContext["createCelEnvironment"]>,
+    } as unknown as CommonMethodContextDeps,
+    repoDir: "/tmp/test-repo",
+  });
+}
+
+Deno.test("ModelInvocationService: sets _invocationProvenance on child context", async () => {
+  let capturedContext: MethodContext | undefined;
+
+  const targetDef = Definition.create({
+    name: "target-def",
+    type: "test/provenance-target",
+    globalArguments: {},
+  });
+
+  const svc = makeProvenanceSvc({
+    captureContext: (ctx) => {
+      capturedContext = ctx;
+    },
+    targetDefName: "target-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext({ _currentOutputId: "parent-output-123" });
+  const result = await svc.invoke(
+    { definition: "target-def", method: "greet" },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedContext?._invocationProvenance?.triggeredBy, "model");
+  assertEquals(
+    capturedContext?._invocationProvenance?.parentOutputId,
+    "parent-output-123",
+  );
+});
+
+Deno.test("ModelInvocationService: parentOutputId is undefined when caller has no output", async () => {
+  let capturedContext: MethodContext | undefined;
+
+  const targetDef = Definition.create({
+    name: "target-def-2",
+    type: "test/provenance-target",
+    globalArguments: {},
+  });
+
+  const svc = makeProvenanceSvc({
+    captureContext: (ctx) => {
+      capturedContext = ctx;
+    },
+    targetDefName: "target-def-2",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    { definition: "target-def-2", method: "greet" },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedContext?._invocationProvenance?.triggeredBy, "model");
+  assertEquals(
+    capturedContext?._invocationProvenance?.parentOutputId,
+    undefined,
   );
 });


### PR DESCRIPTION
## Summary

- `runModel()` nested outputs recorded `triggeredBy: "manual"` with no `parentOutputId` — the design doc (`design/models.md:293-295`) promises `triggeredBy: "model"` with full lineage. The schema already supported the fields but the code never set them.
- Pre-create `ModelOutput` before execution (matching the workflow path) so its ID is available as `parentOutputId` for child invocations. Thread an `_invocationProvenance` struct through `MethodContext` so `executeWorkflow` distinguishes nested calls from manual ones.
- Failed executions now persist output records with `status: "failed"`, consistent with the workflow path.

Closes swamp-club/lab#1077

## Test Plan

- Reproduced the bug with a two-model invocation chain: parent calls child via `context.runModel()`, verified child output had `triggeredBy: "manual"` and no `parentOutputId`
- After fix, verified child output has `triggeredBy: "model"` and `parentOutputId` correctly linked to parent's output ID
- Added unit tests for `ModelInvocationService` provenance threading (2 tests)
- Added unit tests for `DefaultMethodExecutionService` output lifecycle: manual provenance, model provenance, `_currentOutputId` set before execution, failed output persistence (4 tests)
- Verified workflow path is unaffected (`outputRepository` is not passed to `buildMethodContext` from workflow execution service)
- All 8773+ existing tests pass; `deno check`, `deno lint`, `deno fmt`, `deno run compile` clean

Co-authored-by: mgreten <mgreten@users.noreply.github.com>