### PR TITLE
docs(skills): add anti-bypass guidance for agents (swamp-club#1078)

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -112,3 +112,10 @@ swamp extension init <name>                    # scaffold a new extension
    explaining a design trade-off to a human, load
    [references/architecture/guide.md](references/architecture/guide.md) and cite
    the design doc or manual page you relied on.
+8. **Use swamp commands, don't go around them.** Query data with
+   `swamp data query`, not by grepping `.swamp/` files. Interact with resources
+   through model methods, not raw CLI tools (`curl`, `aws`, `gcloud`, `kubectl`)
+   when a model type already wraps the API — check with
+   `swamp model type search`. Use `swamp help` for CLI discovery. Composing with
+   swamp `--json` output (e.g. piping through `jq`) is fine — the anti-pattern
+   is bypassing swamp entirely.

--- a/.claude/skills/swamp/references/data/guide.md
+++ b/.claude/skills/swamp/references/data/guide.md
@@ -59,4 +59,16 @@ for the full list of queryable fields and predicate operators.
 See [references/concepts.md](references/concepts.md) for lifetime types, tags,
 and version GC policies.
 
+## Common Mistakes
+
+| Don't do this                             | Do this instead                                       |
+| ----------------------------------------- | ----------------------------------------------------- |
+| `grep`/`find` on `.swamp/data/` files     | `swamp data query '<predicate>'`                      |
+| `cat .swamp/data/.../raw \| jq`           | `swamp data get <model> <name> --json`                |
+| `ls .swamp/data/` to list artifacts       | `swamp data list <model>`                             |
+| Re-fetching data a model already produced | Use CEL: `data.latest("<name>", "<data>").attributes` |
+
+Composing with swamp's `--json` output (e.g. piping through `jq` to reshape for
+`--stdin`) is fine — the anti-pattern is bypassing swamp's data layer entirely.
+
 For detailed walkthroughs of each operation, see [reference.md](reference.md).

--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -79,4 +79,18 @@ create per-input ephemeral instances for concurrent dispatch. See
 | Recent runs         | `swamp run history`                                                  |
 | Diagnose stale runs | `swamp run doctor`                                                   |
 
+## Discover Before Shelling Out
+
+Before reaching for raw CLI tools (`aws`, `gcloud`, `kubectl`, `curl`), check
+whether a model type already wraps that API:
+
+```bash
+swamp model type search "ec2"          # find types by keyword
+swamp extension search "kubernetes"    # find community extensions
+swamp model type describe <type> --compact --json  # see available methods
+```
+
+If a type exists, use its methods instead of shelling out — model methods
+produce versioned data, wire into workflows, and compose with CEL expressions.
+
 For detailed walkthroughs of each operation, see [reference.md](reference.md).

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -1009,6 +1009,7 @@ This repository is managed with [swamp](https://github.com/swamp-club/swamp).
 9. **"Workflow" means a swamp workflow.** In this repository the word "workflow" (and "create/run/execute/validate/debug workflow", "automate", "orchestrate", "automated/nightly job") refers to a swamp workflow — a declarative YAML DAG of model-method steps authored via \`swamp workflow create\`. ${
       skillAction("swamp", "Load and follow")
     } for these requests. Do NOT interpret these as a request to build an agent task list, spin up worktrees, or schedule a cron/remote agent. Only use those orchestration mechanisms when the user explicitly names one (e.g. "task list", "subagent", "worktree", "cron", "remote agent") or explicitly asks you to do the work yourself step by step rather than author a swamp workflow.
+10. **Use swamp, don't bypass it.** Always work through swamp commands — don't go around them with raw shell tools. Use \`swamp data query\` to find data, not \`grep\`/\`find\` on \`.swamp/\` files. Use model methods to interact with resources, not \`curl\`/\`aws\`/\`gcloud\`/\`kubectl\` when a model type already wraps that API — check with \`swamp model type search\`. Use \`swamp help\` for CLI discovery, not guesswork. Composing with swamp output is fine (e.g. piping \`--json\` through \`jq\`) — the anti-pattern is bypassing swamp entirely.
 
 ## Skills
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -556,6 +556,26 @@ Deno.test("RepoService.init generates CLAUDE.md disambiguating workflow to swamp
   });
 });
 
+Deno.test("RepoService.init generates CLAUDE.md with anti-bypass guidance", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+
+    await service.init(repoPath);
+
+    const claudeMdPath = join(tempDir, "CLAUDE.md");
+    const content = await Deno.readTextFile(claudeMdPath);
+
+    assertStringIncludes(content, "Use swamp, don't bypass it");
+    assertStringIncludes(content, "swamp data query");
+    assertStringIncludes(content, "swamp model type search");
+    assertStringIncludes(
+      content,
+      "the anti-pattern is bypassing swamp entirely",
+    );
+  });
+});
+
 Deno.test("RepoService.init always creates .gitignore with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");


### PR DESCRIPTION
## Summary

- Add rule 10 to the generated instructions template (`repo_service.ts` → `generateInstructionsBody`) so every swamp repo gets anti-bypass guidance via `repo init`/`upgrade`
- Add rule 8 to the swamp skill's Rules section with the same guidance
- Add "Common Mistakes" table to the data guide showing bypass patterns vs correct swamp commands
- Add "Discover Before Shelling Out" section to the model guide encouraging `model type search`/`extension search` before reaching for raw CLI tools
- All guidance explicitly notes that composing with swamp `--json` output (e.g. piping through `jq`) is fine — the anti-pattern is bypassing swamp entirely

Closes swamp-club/lab#1078

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test src/domain/repo/repo_service_test.ts` — 115 tests pass including new test asserting anti-bypass rule appears in generated instructions
- [x] `deno check` passes
- [x] `npx tessl skill review .claude/skills/swamp` — 98% score