### PR TITLE
fix(models): route runModel arguments to per-method args instead of globalArgs (swamp-club#1080)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -266,6 +266,13 @@ Returns a discriminated result:
 - `{ ok: true, resources: DataHandle[] }` on success
 - `{ ok: false, error: { message, stack? } }` on failure
 
+**Argument routing:** The `arguments` object is routed between globalArguments
+and method arguments using the target type's Zod schemas — the same mechanism as
+CLI `--input`. Method arguments take precedence on ambiguous keys. Unknown keys
+return `{ ok: false }`. For direct type execution, only global-arg values are
+persisted in the auto-created definition; method-arg values are applied
+ephemerally for that invocation.
+
 **Data ownership:** When model X calls model Y, Y's data writes scope to Y's
 definition, not X's. This is consistent regardless of whether Y was run
 standalone, from a workflow, or from inside X.

--- a/src/domain/models/model_invocation_service.ts
+++ b/src/domain/models/model_invocation_service.ts
@@ -19,7 +19,7 @@
 
 import { join, resolve, SEPARATOR } from "@std/path";
 import { getLogger } from "@logtape/logtape";
-import type { Definition } from "../definitions/definition.ts";
+import { Definition } from "../definitions/definition.ts";
 import { parseExtensionManifest } from "../extensions/extension_manifest.ts";
 import type {
   InvocationTracking,
@@ -38,6 +38,7 @@ import { resolveModelType } from "../extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../extensions/auto_resolver_context.ts";
 import { buildMethodContext } from "./method_context.ts";
 import type { CommonMethodContextDeps } from "./method_context.ts";
+import { getObjectShape } from "./zod_type_coercion.ts";
 
 const MAX_INVOCATION_DEPTH = 10;
 const MAX_INVOCATION_BREADTH = 100;
@@ -70,6 +71,73 @@ function isResolveSuccess(r: ResolveResult): r is ResolveSuccess {
 
 function ancestorKey(modelType: string, method: string): string {
   return `${modelType}::${method}`;
+}
+
+interface RoutedArgs {
+  globalArgs: Record<string, unknown>;
+  methodArgs: Record<string, unknown>;
+}
+
+function routeArguments(
+  args: Record<string, unknown>,
+  methodName: string,
+  modelDef: ModelDefinition,
+): RoutedArgs | RunModelResult {
+  const method = modelDef.methods[methodName];
+  if (!method) {
+    return {
+      ok: false,
+      error: {
+        message:
+          `Method "${methodName}" not found on model type "${modelDef.type.normalized}".`,
+      },
+    };
+  }
+
+  const methodShape = getObjectShape(method.arguments);
+  const globalShape = modelDef.globalArguments
+    ? getObjectShape(modelDef.globalArguments)
+    : null;
+
+  const methodKeys = methodShape
+    ? new Set(Object.keys(methodShape))
+    : new Set<string>();
+  const globalKeys = globalShape
+    ? new Set(Object.keys(globalShape))
+    : new Set<string>();
+
+  const globalArgs: Record<string, unknown> = {};
+  const methodArgs: Record<string, unknown> = {};
+  const unknownKeys: string[] = [];
+
+  for (const [key, value] of Object.entries(args)) {
+    if (methodKeys.has(key)) {
+      methodArgs[key] = value;
+    } else if (globalKeys.has(key)) {
+      globalArgs[key] = value;
+    } else {
+      unknownKeys.push(key);
+    }
+  }
+
+  if (unknownKeys.length > 0) {
+    const allValid = [...methodKeys, ...globalKeys];
+    return {
+      ok: false,
+      error: {
+        message: `Unknown argument(s): ${unknownKeys.join(", ")}. ` +
+          `Valid arguments are: ${allValid.join(", ") || "none"}`,
+      },
+    };
+  }
+
+  return { globalArgs, methodArgs };
+}
+
+function isRoutedArgs(
+  r: RoutedArgs | RunModelResult,
+): r is RoutedArgs {
+  return "globalArgs" in r;
 }
 
 export class ModelInvocationService {
@@ -168,9 +236,22 @@ export class ModelInvocationService {
       breadthCounter: tracking.breadthCounter,
     };
 
-    const mergedGlobalArgs = options.arguments
-      ? { ...definition.globalArguments, ...options.arguments }
-      : (definition.globalArguments ?? {});
+    let childDefinition = definition;
+    let mergedGlobalArgs = definition.globalArguments ?? {};
+
+    if (options.arguments && Object.keys(options.arguments).length > 0) {
+      const routed = routeArguments(options.arguments, methodName, modelDef);
+      if (!isRoutedArgs(routed)) return routed;
+
+      childDefinition = Definition.fromData(definition.toData());
+      for (const [key, value] of Object.entries(routed.methodArgs)) {
+        childDefinition.setMethodArgument(methodName, key, value);
+      }
+      mergedGlobalArgs = {
+        ...definition.globalArguments,
+        ...routed.globalArgs,
+      };
+    }
 
     const childContext = buildMethodContext(
       this.#deps.commonDeps,
@@ -178,20 +259,20 @@ export class ModelInvocationService {
         signal: callerContext.signal,
         repoDir: this.#deps.repoDir,
         modelType: modelDef.type,
-        modelId: definition.id,
+        modelId: childDefinition.id,
         globalArgs: mergedGlobalArgs,
         definition: {
-          id: definition.id,
-          name: definition.name,
-          version: definition.version,
-          tags: definition.tags ?? {},
+          id: childDefinition.id,
+          name: childDefinition.name,
+          version: childDefinition.version,
+          tags: childDefinition.tags ?? {},
         },
         methodName,
         logger: getLogger([
           "swamp",
           "model",
           "run",
-          definition.name,
+          childDefinition.name,
           methodName,
         ]),
         extensionFilesRoot: modelDef.extensionFilesRoot,
@@ -208,7 +289,7 @@ export class ModelInvocationService {
 
     try {
       const result = await this.#deps.executionService.executeWorkflow(
-        definition,
+        childDefinition,
         modelDef,
         methodName,
         childContext,
@@ -312,14 +393,21 @@ export class ModelInvocationService {
       }
       definition = existing.definition;
     } else {
-      const { Definition: DefinitionClass } = await import(
-        "../definitions/definition.ts"
-      );
-      definition = DefinitionClass.create({
+      let globalArgs: Record<string, unknown> = {};
+      if (options.arguments && Object.keys(options.arguments).length > 0) {
+        const routed = routeArguments(
+          options.arguments,
+          options.method,
+          modelDef,
+        );
+        if (!isRoutedArgs(routed)) return routed;
+        globalArgs = routed.globalArgs;
+      }
+      definition = Definition.create({
         name: options.name,
         type: modelDef.type.normalized,
         typeVersion: modelDef.version,
-        globalArguments: options.arguments ?? {},
+        globalArguments: globalArgs,
       });
       await definitionRepo.save(modelDef.type, definition);
       logger

--- a/src/domain/models/model_invocation_service_test.ts
+++ b/src/domain/models/model_invocation_service_test.ts
@@ -353,3 +353,277 @@ Deno.test("ModelInvocationService: parentOutputId is undefined when caller has n
     undefined,
   );
 });
+
+// ── Argument routing tests ──
+
+const ARG_ROUTING_TYPE = ModelType.create("test/arg-routing-target");
+if (!modelRegistry.get(ARG_ROUTING_TYPE)) {
+  const targetModel: ModelDefinition = {
+    type: ARG_ROUTING_TYPE,
+    version: "2026.07.11.1",
+    globalArguments: z.object({
+      region: z.string().default("us-east-1"),
+    }),
+    methods: {
+      greet: {
+        description: "test method with per-method args",
+        arguments: z.object({
+          name: z.string(),
+        }),
+        execute: (_args) => Promise.resolve({ dataHandles: [] }),
+      },
+      noargs: {
+        description: "test method with no args",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+  defineModel(targetModel);
+}
+
+function makeArgRoutingSvc(options: {
+  captureDefinition: (def: Definition) => void;
+  captureContext: (ctx: MethodContext) => void;
+  targetDefName: string;
+  targetDef: Definition;
+  saveDefinition?: (type: unknown, def: Definition) => Promise<void>;
+}) {
+  const mockExecutionService: MethodExecutionService = {
+    execute: () => Promise.resolve({ dataHandles: [] }),
+    executeWorkflow: (def, _modelDef, _method, ctx) => {
+      options.captureDefinition(def);
+      options.captureContext(ctx);
+      return Promise.resolve({ dataHandles: [] });
+    },
+  };
+
+  const stubDataRepo = {
+    findAllForModel: () => Promise.resolve([]),
+    getContent: () => Promise.resolve(null),
+  };
+
+  return new ModelInvocationService({
+    executionService: mockExecutionService,
+    commonDeps: {
+      dataRepository: stubDataRepo,
+      definitionRepository: {
+        findByNameGlobal: (name: string) => {
+          if (name === options.targetDefName) {
+            return Promise.resolve({
+              definition: options.targetDef,
+              type: ARG_ROUTING_TYPE,
+            });
+          }
+          return Promise.resolve(null);
+        },
+        findById: () => Promise.resolve(null),
+        save: options.saveDefinition ??
+          (() => Promise.resolve()),
+      },
+      createCelEnvironment: () =>
+        ({}) as ReturnType<MethodContext["createCelEnvironment"]>,
+    } as unknown as CommonMethodContextDeps,
+    repoDir: "/tmp/test-repo",
+  });
+}
+
+Deno.test("ModelInvocationService: routes method args to child definition (by-definition)", async () => {
+  let capturedDef: Definition | undefined;
+  let capturedCtx: MethodContext | undefined;
+
+  const targetDef = Definition.create({
+    name: "routed-def",
+    type: "test/arg-routing-target",
+    globalArguments: { region: "eu-west-1" },
+  });
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: (def) => {
+      capturedDef = def;
+    },
+    captureContext: (ctx) => {
+      capturedCtx = ctx;
+    },
+    targetDefName: "routed-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    { definition: "routed-def", method: "greet", arguments: { name: "World" } },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedDef!.getMethodArguments("greet"), { name: "World" });
+  assertEquals(capturedCtx!.globalArgs, { region: "eu-west-1" });
+});
+
+Deno.test("ModelInvocationService: routes mixed global and method args (by-definition)", async () => {
+  let capturedDef: Definition | undefined;
+  let capturedCtx: MethodContext | undefined;
+
+  const targetDef = Definition.create({
+    name: "mixed-def",
+    type: "test/arg-routing-target",
+    globalArguments: { region: "us-east-1" },
+  });
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: (def) => {
+      capturedDef = def;
+    },
+    captureContext: (ctx) => {
+      capturedCtx = ctx;
+    },
+    targetDefName: "mixed-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    {
+      definition: "mixed-def",
+      method: "greet",
+      arguments: { name: "World", region: "ap-south-1" },
+    },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedDef!.getMethodArguments("greet"), { name: "World" });
+  assertEquals(capturedCtx!.globalArgs, { region: "ap-south-1" });
+});
+
+Deno.test("ModelInvocationService: unknown arguments return error", async () => {
+  const targetDef = Definition.create({
+    name: "unknown-def",
+    type: "test/arg-routing-target",
+    globalArguments: {},
+  });
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: () => {},
+    captureContext: () => {},
+    targetDefName: "unknown-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    {
+      definition: "unknown-def",
+      method: "greet",
+      arguments: { bogus: "value" },
+    },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(
+    (result as RunModelResult & { ok: false }).error.message,
+    "Unknown argument(s): bogus",
+  );
+});
+
+Deno.test("ModelInvocationService: no arguments preserves existing behavior", async () => {
+  let capturedDef: Definition | undefined;
+  let capturedCtx: MethodContext | undefined;
+
+  const targetDef = Definition.create({
+    name: "noargs-def",
+    type: "test/arg-routing-target",
+    globalArguments: { region: "us-west-2" },
+  });
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: (def) => {
+      capturedDef = def;
+    },
+    captureContext: (ctx) => {
+      capturedCtx = ctx;
+    },
+    targetDefName: "noargs-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    { definition: "noargs-def", method: "noargs" },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedCtx!.globalArgs, { region: "us-west-2" });
+  assertEquals(capturedDef!.getMethodArguments("noargs"), {});
+});
+
+Deno.test("ModelInvocationService: does not mutate original definition", async () => {
+  const targetDef = Definition.create({
+    name: "immutable-def",
+    type: "test/arg-routing-target",
+    globalArguments: { region: "eu-central-1" },
+  });
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: () => {},
+    captureContext: () => {},
+    targetDefName: "immutable-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  await svc.invoke(
+    {
+      definition: "immutable-def",
+      method: "greet",
+      arguments: { name: "Test" },
+    },
+    callerCtx,
+  );
+
+  assertEquals(targetDef.getMethodArguments("greet"), {});
+  assertEquals(targetDef.globalArguments, { region: "eu-central-1" });
+});
+
+Deno.test("ModelInvocationService: routes method args for by-type auto-creation", async () => {
+  let capturedDef: Definition | undefined;
+  let capturedCtx: MethodContext | undefined;
+  let savedDef: Definition | undefined;
+
+  const svc = makeArgRoutingSvc({
+    captureDefinition: (def) => {
+      capturedDef = def;
+    },
+    captureContext: (ctx) => {
+      capturedCtx = ctx;
+    },
+    targetDefName: "__no_match__",
+    targetDef: Definition.create({
+      name: "unused",
+      type: "test/arg-routing-target",
+      globalArguments: {},
+    }),
+    saveDefinition: (_type, def) => {
+      savedDef = def;
+      return Promise.resolve();
+    },
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    {
+      modelType: "test/arg-routing-target",
+      name: "new-instance",
+      method: "greet",
+      arguments: { name: "World", region: "us-west-2" },
+    },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(savedDef!.globalArguments, { region: "us-west-2" });
+  assertEquals(capturedDef!.getMethodArguments("greet"), { name: "World" });
+  assertEquals(capturedCtx!.globalArgs, { region: "us-west-2" });
+});


### PR DESCRIPTION
## Summary

- `context.runModel()` merged `options.arguments` into `globalArgs`, so per-method argument values were either silently dropped (by-definition form) or rejected by strict globalArgs validation (by-type form)
- Add schema-aware argument routing using `getObjectShape` to split caller-provided arguments between global and method args — matching the CLI `--input` routing behavior
- For by-type auto-creation, only persist global-arg portion in the definition; method args are applied ephemerally per invocation
- Clone the definition before applying method args to avoid mutating persisted state

Fixes swamp-club#1080

## Test Plan

- [x] 6 new unit tests covering: by-definition routing, mixed args, unknown args error, no-args backward compat, definition immutability, by-type auto-creation
- [x] All 15 tests in `model_invocation_service_test.ts` pass
- [x] Full test suite passes (8780 passed, 1 pre-existing env failure unrelated to this change)
- [x] Reproduced bug with installed binary: `Global arguments validation failed: Unknown argument(s): name`
- [x] Verified fix from source: reproduction scenario now succeeds
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)