### PR TITLE
fix(data): take prune modelName from first tagged item in orphan group (swamp-club#1091)

### DIFF
--- a/src/domain/data/data_lifecycle_service.ts
+++ b/src/domain/data/data_lifecycle_service.ts
@@ -523,7 +523,11 @@ export class DefaultDataLifecycleService implements DataLifecycleService {
       orphans.push({
         type: group.type,
         modelId: group.modelId,
-        modelName: group.items[0]?.tags.modelName,
+        // Report entries carry no modelName tag — take it from whichever
+        // item has a non-empty one.
+        modelName: group.items
+          .map((d) => d.tags["modelName"])
+          .find((n) => n !== undefined && n !== ""),
         dataNames,
         versionCount,
         bytesReclaimed,

--- a/src/domain/data/data_lifecycle_service_test.ts
+++ b/src/domain/data/data_lifecycle_service_test.ts
@@ -772,6 +772,82 @@ Deno.test("findOrphanedData - surfaces modelName from data tags", async () => {
   assertEquals(orphans[0].modelName, "my-model");
 });
 
+Deno.test("findOrphanedData - surfaces modelName when an untagged report entry is first", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const report = Data.create({
+    name: "report-swamp-method-summary",
+    contentType: "text/markdown",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "report" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+  });
+  const result = Data.create({
+    name: "result",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test", modelName: "shell-echo" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+  });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: report, modelType, modelId: "orphan" },
+      { data: result, modelType, modelId: "orphan" },
+    ]);
+  mockRepo.listVersions = () => Promise.resolve([1]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor([]));
+
+  assertEquals(orphans.length, 1);
+  assertEquals(orphans[0].modelName, "shell-echo");
+});
+
+Deno.test("findOrphanedData - skips empty-string modelName tags in favor of a later non-empty tag", async () => {
+  const mockRepo = new MockDataRepository();
+  const modelType = ModelType.create("test/model");
+  const untagged = Data.create({
+    name: "report-swamp-method-summary",
+    contentType: "text/markdown",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "report", modelName: "" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+  });
+  const named = Data.create({
+    name: "result",
+    contentType: "application/json",
+    lifetime: "infinite",
+    garbageCollection: 5,
+    tags: { type: "test", modelName: "shell-echo" },
+    ownerDefinition: { ownerType: "model-method", ownerRef: "test-ref" },
+  });
+
+  mockRepo.findAllGlobal = () =>
+    Promise.resolve([
+      { data: untagged, modelType, modelId: "orphan" },
+      { data: named, modelType, modelId: "orphan" },
+    ]);
+  mockRepo.listVersions = () => Promise.resolve([1]);
+
+  const service = new DefaultDataLifecycleService(
+    mockRepo as never,
+    new MockWorkflowRunRepository() as never,
+  );
+
+  const orphans = await service.findOrphanedData(isModelLiveFor([]));
+
+  assertEquals(orphans.length, 1);
+  assertEquals(orphans[0].modelName, "shell-echo");
+});
+
 Deno.test("deleteOrphanedData - hard-deletes orphaned data, leaves live untouched", async () => {
   const mockRepo = new MockDataRepository();
   const modelType = ModelType.create("test/model");


### PR DESCRIPTION
## Summary

`swamp data prune --json` omitted `reclaimedModels[].modelName` whenever a report data entry happened to enumerate first in an orphan group. `DefaultDataLifecycleService.findOrphanedData` read `group.items[0]?.tags.modelName`, but report entries (`report-swamp-method-summary`, `report-swamp-method-summary-json`) are written without a `modelName` tag — so `modelName` came back `undefined` and `JSON.stringify` dropped the key, failing `DataPruneSchema` validation in the swamp-uat prune test.

Fixes swamp-club#1091.

- Derive `modelName` from the first grouped item carrying a **non-empty** `modelName` tag (report entries can also surface an empty-string value, so `""` is rejected alongside `undefined`).
- Add two unit tests pinning the adversarial ordering: an untagged report-style entry first in the group, and an empty-string tag skipped in favor of a later non-empty tag.

Groups where *no* item carries a non-empty tag still omit `modelName`, matching the documented optional contract on `OrphanedDataInfo` ("may be absent on old data").

## Test Plan

- New unit tests in `data_lifecycle_service_test.ts`; data-domain suite passes 37/37.
- `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass.
- End-to-end: reproduced the bug per the issue steps (command/shell model → run → delete definition → `swamp data prune --force --json`) with the pre-fix binary (`modelName` absent), then replayed with the recompiled binary — `reclaimedModels[0].modelName: "shell-echo"` present with report entries still enumerating first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)