### PR TITLE
fix(tracing): honor OTEL_RESOURCE_ATTRIBUTES in span Resource (swamp-club#1084)

### DIFF
--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -47,7 +47,7 @@ export async function initTracing(): Promise<Context | undefined> {
       ConsoleSpanExporter,
     },
     { AsyncLocalStorageContextManager },
-    { Resource },
+    { Resource, envDetectorSync },
     { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION },
     contextApi,
   ] = await Promise.all([
@@ -70,10 +70,14 @@ export async function initTracing(): Promise<Context | undefined> {
 
   const serviceName = Deno.env.get("OTEL_SERVICE_NAME") ?? "swamp";
 
-  const resource = new Resource({
-    [ATTR_SERVICE_NAME]: serviceName,
-    [ATTR_SERVICE_VERSION]: Deno.env.get("SWAMP_VERSION") ?? "dev",
-  });
+  const resource = Resource.default()
+    .merge(envDetectorSync.detect())
+    .merge(
+      new Resource({
+        [ATTR_SERVICE_NAME]: serviceName,
+        [ATTR_SERVICE_VERSION]: Deno.env.get("SWAMP_VERSION") ?? "dev",
+      }),
+    );
 
   const provider = new BasicTracerProvider({ resource });
 

--- a/src/infrastructure/tracing/otel_init_test.ts
+++ b/src/infrastructure/tracing/otel_init_test.ts
@@ -174,6 +174,76 @@ Deno.test("initTracing: returns undefined when no TRACEPARENT is set", async () 
   }
 });
 
+Deno.test("initTracing: includes OTEL_RESOURCE_ATTRIBUTES in resource", async () => {
+  const originalResAttrs = Deno.env.get("OTEL_RESOURCE_ATTRIBUTES");
+  try {
+    Deno.env.set(
+      "OTEL_RESOURCE_ATTRIBUTES",
+      "site=bed,deployment.environment=prod",
+    );
+
+    const { Resource, envDetectorSync } = await import(
+      "@opentelemetry/resources"
+    );
+    const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = await import(
+      "@opentelemetry/semantic-conventions"
+    );
+
+    const resource = Resource.default()
+      .merge(envDetectorSync.detect())
+      .merge(
+        new Resource({
+          [ATTR_SERVICE_NAME]: "swamp-test",
+          [ATTR_SERVICE_VERSION]: "1.0.0",
+        }),
+      );
+
+    const attrs = resource.attributes;
+    assertEquals(attrs["site"], "bed");
+    assertEquals(attrs["deployment.environment"], "prod");
+    assertEquals(attrs["service.name"], "swamp-test");
+    assertEquals(attrs["service.version"], "1.0.0");
+    assertEquals(attrs["telemetry.sdk.language"], "nodejs");
+  } finally {
+    if (originalResAttrs) {
+      Deno.env.set("OTEL_RESOURCE_ATTRIBUTES", originalResAttrs);
+    } else {
+      Deno.env.delete("OTEL_RESOURCE_ATTRIBUTES");
+    }
+  }
+});
+
+Deno.test("initTracing: explicit service.name wins over OTEL_RESOURCE_ATTRIBUTES", async () => {
+  const originalResAttrs = Deno.env.get("OTEL_RESOURCE_ATTRIBUTES");
+  try {
+    Deno.env.set("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-env");
+
+    const { Resource, envDetectorSync } = await import(
+      "@opentelemetry/resources"
+    );
+    const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = await import(
+      "@opentelemetry/semantic-conventions"
+    );
+
+    const resource = Resource.default()
+      .merge(envDetectorSync.detect())
+      .merge(
+        new Resource({
+          [ATTR_SERVICE_NAME]: "swamp",
+          [ATTR_SERVICE_VERSION]: "dev",
+        }),
+      );
+
+    assertEquals(resource.attributes["service.name"], "swamp");
+  } finally {
+    if (originalResAttrs) {
+      Deno.env.set("OTEL_RESOURCE_ATTRIBUTES", originalResAttrs);
+    } else {
+      Deno.env.delete("OTEL_RESOURCE_ATTRIBUTES");
+    }
+  }
+});
+
 Deno.test("shutdownTracing: no-op when tracing was not initialized", async () => {
   // Should not throw
   await shutdownTracing();


### PR DESCRIPTION
## Summary

- Merge `Resource.default()` and `envDetectorSync.detect()` into the span
  Resource so custom attributes set via `OTEL_RESOURCE_ATTRIBUTES` (e.g.
  `site`, `deployment.environment`) reach exported spans
- Explicit `service.name` and `service.version` still win on conflict via
  last-merge-wins ordering
- Add two unit tests: one verifying env-detected attributes appear in the
  resource, one verifying explicit attributes take precedence

Fixes swamp-club#1084

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes
- [x] `deno fmt` — passes
- [x] `deno run test` — 8786 passed, 0 failed
- [x] Reproduced bug with console exporter: `OTEL_RESOURCE_ATTRIBUTES="site=bed,deployment.environment=prod"` — attributes absent before fix, present after
- [x] Verified explicit `service.name` wins over env-provided value