### PR TITLE
fix(serve): add --server support for workflow approvals/cancel, fix reject tracker staleness (swamp-club#1087)

### DIFF
--- a/design/run-tracker.md
+++ b/design/run-tracker.md
@@ -59,8 +59,8 @@ are purged on startup.
   `DefaultStepExecutor.executeModelMethod()` register with the tracker.
 - **Workflow runs** themselves register at the `WorkflowExecutionService.run()`
   level, tracking the overall workflow lifecycle.
-- Workflow suspend/approve/resume transitions are tracked (suspended → running →
-  completed).
+- Workflow suspend/approve/resume/reject transitions are tracked (suspended →
+  running → completed, or suspended → failed on reject).
 
 ### CLI Commands
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -145,7 +145,9 @@ steps:
 `swamp workflow reject <workflow> <step>` marks the step as failed and the run as
 failed. No resume needed.
 
-`swamp workflow approvals` lists all suspended runs awaiting approval.
+`swamp workflow approvals` lists all suspended runs awaiting approval. Supports
+`--server` / `SWAMP_SERVE_URL` via the `workflow.approvals` wire-protocol
+endpoint (read-only, `read` authorization verb).
 
 **Resume inputs (`--input`):** `swamp workflow resume` accepts `--input`,
 `--input-file`, and `--stdin` (same parsing as `swamp workflow run`). These let

--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -19,120 +19,128 @@
 
 import { Command } from "@cliffy/command";
 import {
+  consumeStream,
+  createLibSwampContext,
+  createWorkflowApprovalsDeps,
+  type PendingApproval,
+  workflowApprovals,
+  type WorkflowApprovalsEvent,
+} from "../../libswamp/mod.ts";
+import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
+import type { CommandContext } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
-import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { WorkflowApprovalsResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const workflowApprovalsCommand = new Command()
-  .name("approvals")
-  .description("List all workflow runs awaiting manual approval")
-  .example("List pending approvals", "swamp workflow approvals")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "workflow",
-      "approvals",
-    ]);
-
-    const { repoContext } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
-
-    // Use the datastore-aware repositories from the RepositoryContext so the
-    // pending-approval scan reads the same workflow-runs path suspended runs
-    // are written to. Constructing YamlWorkflowRunRepository(repoDir) directly
-    // would bind to repo-local .swamp/workflow-runs/ and miss runs stored in a
-    // configured datastore, yielding an empty approvals list.
-    const workflowRepo = repoContext.workflowRepo;
-    const runRepo = repoContext.workflowRunRepo;
-
-    const workflows = await workflowRepo.findAll();
-
-    interface PendingApproval {
-      workflowName: string;
-      runId: string;
-      stepName: string;
-      suspendedAt: string | undefined;
-      prompt: string | undefined;
-    }
-
-    const pending: PendingApproval[] = [];
-
-    for (const workflow of workflows) {
-      const runs = await runRepo.findAllByWorkflowId(workflow.id);
-      for (const run of runs) {
-        if (run.status !== "suspended") continue;
-        const waiting = run.findWaitingApprovalStep();
-        if (!waiting) continue;
-
-        const job = run.getJob(waiting.jobName);
-        const step = job?.getStep(waiting.stepName);
-        const taskData = workflow.jobs
-          .find((j) => j.name === waiting.jobName)?.steps
-          .find((s) => s.name === waiting.stepName)?.task.data;
-
-        // A run whose approval deadline has lapsed is no longer actionable —
-        // `swamp workflow approve` would reject it — so apply the same
-        // deadline check here and drop expired entries from the listing.
-        const timeout = evaluateApprovalTimeout(
-          step?.startedAt,
-          taskData,
-          new Date(),
-        );
-        if (timeout?.expired) continue;
-
-        const prompt = taskData && taskData.type === "manual_approval"
-          ? taskData.prompt
-          : undefined;
-
-        pending.push({
-          workflowName: workflow.name,
-          runId: run.id,
-          stepName: waiting.stepName,
-          suspendedAt: step?.startedAt?.toISOString(),
-          prompt,
-        });
-      }
-    }
-
-    if (cliCtx.outputMode === "json") {
-      console.log(JSON.stringify({ approvals: pending }, null, 2));
+function renderApprovals(
+  cliCtx: CommandContext,
+  pending: PendingApproval[],
+): void {
+  if (cliCtx.outputMode === "json") {
+    console.log(JSON.stringify({ approvals: pending }, null, 2));
+  } else {
+    if (pending.length === 0) {
+      cliCtx.logger.info("No workflows awaiting approval");
     } else {
-      if (pending.length === 0) {
-        cliCtx.logger.info("No workflows awaiting approval");
-      } else {
-        for (const item of pending) {
-          cliCtx.logger.info(
-            "{workflowName} / {stepName} — {prompt}",
-            {
-              workflowName: item.workflowName,
-              stepName: item.stepName,
-              prompt: item.prompt ?? "(no prompt)",
-            },
-          );
-          cliCtx.logger.info(
-            "  swamp workflow approve {workflowName} {stepName}",
-            { workflowName: item.workflowName, stepName: item.stepName },
-          );
-          cliCtx.logger.info(
-            "  swamp workflow reject  {workflowName} {stepName}",
-            { workflowName: item.workflowName, stepName: item.stepName },
-          );
-          cliCtx.logger.info(
-            "  After approval: swamp workflow resume {workflowName}",
-            { workflowName: item.workflowName },
-          );
-        }
+      for (const item of pending) {
+        cliCtx.logger.info(
+          "{workflowName} / {stepName} — {prompt}",
+          {
+            workflowName: item.workflowName,
+            stepName: item.stepName,
+            prompt: item.prompt ?? "(no prompt)",
+          },
+        );
+        cliCtx.logger.info(
+          "  swamp workflow approve {workflowName} {stepName}",
+          { workflowName: item.workflowName, stepName: item.stepName },
+        );
+        cliCtx.logger.info(
+          "  swamp workflow reject  {workflowName} {stepName}",
+          { workflowName: item.workflowName, stepName: item.stepName },
+        );
+        cliCtx.logger.info(
+          "  After approval: swamp workflow resume {workflowName}",
+          { workflowName: item.workflowName },
+        );
       }
     }
+  }
+}
+
+export const workflowApprovalsCommand = withRemoteOptions(
+  new Command()
+    .name("approvals")
+    .description("List all workflow runs awaiting manual approval")
+    .example("List pending approvals", "swamp workflow approvals")
+    .example(
+      "List via server",
+      "swamp workflow approvals --server ws://localhost:9090",
+    )
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    ),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "workflow",
+    "approvals",
+  ]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<WorkflowApprovalsResponse>(
+      { server, token },
+      {
+        type: "workflow.approvals",
+        payload: {},
+      },
+    );
+    const data = response.data as { approvals?: PendingApproval[] };
+    renderApprovals(cliCtx, data.approvals ?? []);
+    return;
+  }
+
+  const { repoContext } = await requireInitializedRepoUnlocked({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createWorkflowApprovalsDeps(
+    repoContext.workflowRepo,
+    repoContext.workflowRunRepo,
+  );
+
+  let pending: PendingApproval[] = [];
+  await consumeStream<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+    {
+      resolving: () => {},
+      completed: (e) => {
+        pending = e.data.approvals;
+      },
+      error: (e) => {
+        throw new Error(e.error.message);
+      },
+    },
+  );
+
+  renderApprovals(cliCtx, pending);
+});

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -111,7 +111,10 @@ export const workflowCancelCommand = withRemoteOptions(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
-    .option("--run <run_id:string>", "Target a specific run ID")
+    .option(
+      "--run <run_id:string>",
+      "Target a specific run ID (required with --server)",
+    )
     .option("--all", "Cancel all running workflow runs")
     .option("--reason <reason:string>", "Reason for cancellation"),
 ).action(
@@ -150,35 +153,42 @@ export const workflowCancelCommand = withRemoteOptions(
       }`;
       const headers: Record<string, string> = {};
       if (token) headers["Authorization"] = `Bearer ${token}`;
-      let response: Response;
+      let body: Record<string, unknown>;
       try {
-        response = await fetch(cancelUrl, {
+        const response = await fetch(cancelUrl, {
           method: "POST",
           headers,
           signal: AbortSignal.timeout(15_000),
         });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new UserError(
+            `Server returned ${response.status}: ${
+              text || response.statusText
+            }`,
+          );
+        }
+        body = await response.json();
       } catch (error) {
+        if (error instanceof UserError) throw error;
         throw new UserError(
           `Could not connect to ${server}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
       }
-      if (!response.ok) {
-        const text = await response.text();
-        throw new UserError(
-          `Server returned ${response.status}: ${text || response.statusText}`,
-        );
-      }
-      const body = await response.json();
       if (body.status !== "cancelled") {
         throw new UserError(
-          body.message ??
+          (body.message as string | undefined) ??
             `Failed to cancel run ${options.run as string}: ${body.status}`,
         );
       }
       if (cliCtx.outputMode === "json") {
-        console.log(JSON.stringify(body));
+        console.log(JSON.stringify({
+          runId: body.executionId ?? options.run,
+          status: "cancelled",
+          reason: options.reason ?? "Cancelled by user",
+        }));
       } else {
         cliCtx.logger
           .info`Cancelled run ${options.run as string} on server`;

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -136,6 +136,10 @@ export const workflowCancelCommand = withRemoteOptions(
           "--all is not supported with --server",
         );
       }
+      if (options.reason) {
+        cliCtx.logger
+          .warn`--reason is ignored with --server (the cancel endpoint does not accept a reason)`;
+      }
       const token = await resolveServerToken(
         server,
         options.token as string | undefined,
@@ -146,22 +150,38 @@ export const workflowCancelCommand = withRemoteOptions(
       }`;
       const headers: Record<string, string> = {};
       if (token) headers["Authorization"] = `Bearer ${token}`;
-      const response = await fetch(cancelUrl, {
-        method: "POST",
-        headers,
-        signal: AbortSignal.timeout(15_000),
-      });
+      let response: Response;
+      try {
+        response = await fetch(cancelUrl, {
+          method: "POST",
+          headers,
+          signal: AbortSignal.timeout(15_000),
+        });
+      } catch (error) {
+        throw new UserError(
+          `Could not connect to ${server}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      if (!response.ok) {
+        const text = await response.text();
+        throw new UserError(
+          `Server returned ${response.status}: ${text || response.statusText}`,
+        );
+      }
       const body = await response.json();
-      if (cliCtx.outputMode === "json") {
-        console.log(JSON.stringify(body));
-      } else if (body.status === "cancelled") {
-        cliCtx.logger
-          .info`Cancelled run ${options.run as string} on server`;
-      } else {
+      if (body.status !== "cancelled") {
         throw new UserError(
           body.message ??
             `Failed to cancel run ${options.run as string}: ${body.status}`,
         );
+      }
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify(body));
+      } else {
+        cliCtx.logger
+          .info`Cancelled run ${options.run as string} on server`;
       }
       return;
     }

--- a/src/cli/commands/workflow_cancel.ts
+++ b/src/cli/commands/workflow_cancel.ts
@@ -36,6 +36,11 @@ import type {
   WorkflowRunRepository,
 } from "../../domain/workflows/repositories.ts";
 import { killProcessTree } from "../../infrastructure/process/process_kill.ts";
+import {
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -77,166 +82,213 @@ async function findAllActiveRuns(
   return results;
 }
 
-export const workflowCancelCommand = new Command()
-  .name("cancel")
-  .description("Cancel a running workflow run")
-  .example(
-    "Cancel latest running run",
-    "swamp workflow cancel my-workflow",
-  )
-  .example(
-    "Cancel a specific run",
-    "swamp workflow cancel my-workflow --run <run-id>",
-  )
-  .example(
-    "Cancel all running runs",
-    "swamp workflow cancel --all",
-  )
-  .example(
-    "Cancel with reason",
-    "swamp workflow cancel my-workflow --reason 'No longer needed'",
-  )
-  .arguments("[workflow_id_or_name:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--run <run_id:string>", "Target a specific run ID")
-  .option("--all", "Cancel all running workflow runs")
-  .option("--reason <reason:string>", "Reason for cancellation")
-  .action(
-    async function (
-      options: AnyOptions,
-      workflowIdOrName?: string,
-    ) {
-      const cliCtx = createContext(options as GlobalOptions, [
-        "workflow",
-        "cancel",
-      ]);
+export const workflowCancelCommand = withRemoteOptions(
+  new Command()
+    .name("cancel")
+    .description("Cancel a running workflow run")
+    .example(
+      "Cancel latest running run",
+      "swamp workflow cancel my-workflow",
+    )
+    .example(
+      "Cancel a specific run",
+      "swamp workflow cancel my-workflow --run <run-id>",
+    )
+    .example(
+      "Cancel all running runs",
+      "swamp workflow cancel --all",
+    )
+    .example(
+      "Cancel with reason",
+      "swamp workflow cancel my-workflow --reason 'No longer needed'",
+    )
+    .example(
+      "Cancel via server",
+      "swamp workflow cancel --run <run-id> --server ws://localhost:9090",
+    )
+    .arguments("[workflow_id_or_name:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--run <run_id:string>", "Target a specific run ID")
+    .option("--all", "Cancel all running workflow runs")
+    .option("--reason <reason:string>", "Reason for cancellation"),
+).action(
+  async function (
+    options: AnyOptions,
+    workflowIdOrName?: string,
+  ) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "workflow",
+      "cancel",
+    ]);
 
-      if (!options.all && !workflowIdOrName) {
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (server) {
+      if (!options.run) {
         throw new UserError(
-          "Provide a workflow name or ID, or use --all to cancel all running runs",
+          "Remote cancel requires --run <run-id>. Use 'swamp workflow history search --server' to find run IDs.",
         );
       }
-
-      const { repoContext } = await requireInitializedRepoUnlocked({
-        repoDir: resolveRepoDir(options.repoDir),
-        outputMode: cliCtx.outputMode,
-      });
-
-      const workflowRepo = repoContext.workflowRepo;
-      const runRepo = repoContext.workflowRunRepo;
-      const reason = options.reason ?? "Cancelled by user";
-
       if (options.all) {
-        const activeRuns = await findAllActiveRuns(workflowRepo, runRepo);
-        if (activeRuns.length === 0) {
-          if (cliCtx.outputMode === "json") {
-            console.log(JSON.stringify({ cancelled: [] }));
-          } else {
-            cliCtx.logger.info("No active workflow runs found to cancel.");
-          }
-          return;
-        }
+        throw new UserError(
+          "--all is not supported with --server",
+        );
+      }
+      const token = await resolveServerToken(
+        server,
+        options.token as string | undefined,
+      );
+      const httpUrl = server.replace(/^ws(s?):/, "http$1:");
+      const cancelUrl = `${httpUrl}/api/v1/cancel/workflow-run/${
+        encodeURIComponent(options.run as string)
+      }`;
+      const headers: Record<string, string> = {};
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+      const response = await fetch(cancelUrl, {
+        method: "POST",
+        headers,
+        signal: AbortSignal.timeout(15_000),
+      });
+      const body = await response.json();
+      if (cliCtx.outputMode === "json") {
+        console.log(JSON.stringify(body));
+      } else if (body.status === "cancelled") {
+        cliCtx.logger
+          .info`Cancelled run ${options.run as string} on server`;
+      } else {
+        throw new UserError(
+          body.message ??
+            `Failed to cancel run ${options.run as string}: ${body.status}`,
+        );
+      }
+      return;
+    }
 
-        const cancelled: {
-          runId: string;
-          workflowName: string;
-          previousStatus: string;
-        }[] = [];
-        for (const { run, workflowId, workflowName } of activeRuns) {
-          const previousStatus = run.status;
-          await cancelRun(run, reason);
-          await runRepo.save(workflowId, run);
-          cancelled.push({
-            runId: run.id,
-            workflowName,
-            previousStatus,
-          });
-        }
+    if (!options.all && !workflowIdOrName) {
+      throw new UserError(
+        "Provide a workflow name or ID, or use --all to cancel all running runs",
+      );
+    }
 
+    const { repoContext } = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const workflowRepo = repoContext.workflowRepo;
+    const runRepo = repoContext.workflowRunRepo;
+    const reason = options.reason ?? "Cancelled by user";
+
+    if (options.all) {
+      const activeRuns = await findAllActiveRuns(workflowRepo, runRepo);
+      if (activeRuns.length === 0) {
         if (cliCtx.outputMode === "json") {
-          console.log(JSON.stringify({
-            cancelled,
-            count: cancelled.length,
-            reason,
-          }));
+          console.log(JSON.stringify({ cancelled: [] }));
         } else {
-          cliCtx.logger
-            .info`Cancelled ${cancelled.length} workflow run(s)`;
-          for (const entry of cancelled) {
-            cliCtx.logger
-              .info`  ${entry.workflowName} (${entry.runId}): ${entry.previousStatus} -> cancelled`;
-          }
+          cliCtx.logger.info("No active workflow runs found to cancel.");
         }
         return;
       }
 
-      // Single workflow cancel path
-      const workflow = await workflowRepo.findByName(workflowIdOrName!) ??
-        await workflowRepo.findById(
-          createWorkflowId(workflowIdOrName!),
-        );
-      if (!workflow) {
-        throw new UserError(`Workflow not found: ${workflowIdOrName}`);
-      }
-
-      let run: WorkflowRun;
-      if (options.run) {
-        const found = await runRepo.findById(
-          workflow.id,
-          createWorkflowRunId(options.run),
-        );
-        if (!found) {
-          throw new UserError(`Workflow run not found: ${options.run}`);
-        }
-        run = found;
-      } else {
-        const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
-        const activeRuns = allRuns.filter(
-          (r) => !TERMINAL_STATUSES.has(r.status),
-        );
-
-        if (activeRuns.length === 0) {
-          throw new UserError(
-            `No active runs found for workflow "${workflow.name}"`,
-          );
-        }
-
-        run = activeRuns.reduce((latest, current) => {
-          if (!latest.startedAt) return current;
-          if (!current.startedAt) return latest;
-          return current.startedAt > latest.startedAt ? current : latest;
+      const cancelled: {
+        runId: string;
+        workflowName: string;
+        previousStatus: string;
+      }[] = [];
+      for (const { run, workflowId, workflowName } of activeRuns) {
+        const previousStatus = run.status;
+        await cancelRun(run, reason);
+        await runRepo.save(workflowId, run);
+        cancelled.push({
+          runId: run.id,
+          workflowName,
+          previousStatus,
         });
       }
 
-      if (TERMINAL_STATUSES.has(run.status)) {
-        throw new UserError(
-          `Run ${run.id} is already in a terminal state (status: ${run.status})`,
-        );
-      }
-
-      const previousStatus = run.status;
-      await cancelRun(run, reason);
-      await runRepo.save(createWorkflowId(workflow.id), run);
-
       if (cliCtx.outputMode === "json") {
         console.log(JSON.stringify({
-          runId: run.id,
-          workflowName: workflow.name,
-          previousStatus,
-          status: "cancelled",
+          cancelled,
+          count: cancelled.length,
           reason,
         }));
       } else {
         cliCtx.logger
-          .info`Cancelled run ${run.id} of workflow ${workflow.name}`;
-        cliCtx.logger
-          .info`Status: ${previousStatus} -> cancelled`;
-        if (options.reason) {
-          cliCtx.logger.info`Reason: ${reason}`;
+          .info`Cancelled ${cancelled.length} workflow run(s)`;
+        for (const entry of cancelled) {
+          cliCtx.logger
+            .info`  ${entry.workflowName} (${entry.runId}): ${entry.previousStatus} -> cancelled`;
         }
       }
-    },
-  );
+      return;
+    }
+
+    // Single workflow cancel path
+    const workflow = await workflowRepo.findByName(workflowIdOrName!) ??
+      await workflowRepo.findById(
+        createWorkflowId(workflowIdOrName!),
+      );
+    if (!workflow) {
+      throw new UserError(`Workflow not found: ${workflowIdOrName}`);
+    }
+
+    let run: WorkflowRun;
+    if (options.run) {
+      const found = await runRepo.findById(
+        workflow.id,
+        createWorkflowRunId(options.run),
+      );
+      if (!found) {
+        throw new UserError(`Workflow run not found: ${options.run}`);
+      }
+      run = found;
+    } else {
+      const allRuns = await runRepo.findAllByWorkflowId(workflow.id);
+      const activeRuns = allRuns.filter(
+        (r) => !TERMINAL_STATUSES.has(r.status),
+      );
+
+      if (activeRuns.length === 0) {
+        throw new UserError(
+          `No active runs found for workflow "${workflow.name}"`,
+        );
+      }
+
+      run = activeRuns.reduce((latest, current) => {
+        if (!latest.startedAt) return current;
+        if (!current.startedAt) return latest;
+        return current.startedAt > latest.startedAt ? current : latest;
+      });
+    }
+
+    if (TERMINAL_STATUSES.has(run.status)) {
+      throw new UserError(
+        `Run ${run.id} is already in a terminal state (status: ${run.status})`,
+      );
+    }
+
+    const previousStatus = run.status;
+    await cancelRun(run, reason);
+    await runRepo.save(createWorkflowId(workflow.id), run);
+
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({
+        runId: run.id,
+        workflowName: workflow.name,
+        previousStatus,
+        status: "cancelled",
+        reason,
+      }));
+    } else {
+      cliCtx.logger
+        .info`Cancelled run ${run.id} of workflow ${workflow.name}`;
+      cliCtx.logger
+        .info`Status: ${previousStatus} -> cancelled`;
+      if (options.reason) {
+        cliCtx.logger.info`Reason: ${reason}`;
+      }
+    }
+  },
+);

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -39,6 +39,8 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { WorkflowRejectResponse } from "../../serve/protocol.ts";
+import { RunTrackerStore } from "../../infrastructure/persistence/run_tracker_store.ts";
+import { swampPath } from "../../infrastructure/persistence/paths.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -117,15 +119,17 @@ export const workflowRejectCommand = withRemoteOptions(
       return;
     }
 
-    const { repoContext } = await requireInitializedRepoUnlocked({
+    const { repoDir, repoContext } = await requireInitializedRepoUnlocked({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
 
+    const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
     const deps = createWorkflowRejectDeps(
       repoContext.workflowRepo,
       repoContext.workflowRunRepo,
+      runTracker,
     );
 
     await consumeStream(

--- a/src/cli/commands/workflow_reject.ts
+++ b/src/cli/commands/workflow_reject.ts
@@ -125,35 +125,39 @@ export const workflowRejectCommand = withRemoteOptions(
     });
 
     const runTracker = RunTrackerStore.fromSwampDir(swampPath(repoDir));
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowRejectDeps(
-      repoContext.workflowRepo,
-      repoContext.workflowRunRepo,
-      runTracker,
-    );
+    try {
+      const ctx = createLibSwampContext({ logger: cliCtx.logger });
+      const deps = createWorkflowRejectDeps(
+        repoContext.workflowRepo,
+        repoContext.workflowRunRepo,
+        runTracker,
+      );
 
-    await consumeStream(
-      workflowReject(ctx, deps, {
-        workflowIdOrName,
-        stepName,
-        reason: options.reason as string | undefined,
-        runId: options.run as string | undefined,
-      }),
-      {
-        resolving: () => {},
-        completed: (e) => {
-          if (cliCtx.outputMode === "json") {
-            console.log(JSON.stringify(e.data));
-          } else {
-            cliCtx.logger
-              .info`Rejected step ${e.data.stepName} in workflow ${e.data.workflowName}`;
-            cliCtx.logger.info("Workflow run marked as failed.");
-          }
+      await consumeStream(
+        workflowReject(ctx, deps, {
+          workflowIdOrName,
+          stepName,
+          reason: options.reason as string | undefined,
+          runId: options.run as string | undefined,
+        }),
+        {
+          resolving: () => {},
+          completed: (e) => {
+            if (cliCtx.outputMode === "json") {
+              console.log(JSON.stringify(e.data));
+            } else {
+              cliCtx.logger
+                .info`Rejected step ${e.data.stepName} in workflow ${e.data.workflowName}`;
+              cliCtx.logger.info("Workflow run marked as failed.");
+            }
+          },
+          error: (e) => {
+            throw new Error(e.error.message);
+          },
         },
-        error: (e) => {
-          throw new Error(e.error.message);
-        },
-      },
-    );
+      );
+    } finally {
+      runTracker.close();
+    }
   },
 );

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -286,6 +286,14 @@ export {
   type WorkflowRejectEvent,
   type WorkflowRejectInput,
 } from "./workflows/reject.ts";
+export {
+  createWorkflowApprovalsDeps,
+  type PendingApproval,
+  workflowApprovals,
+  type WorkflowApprovalsData,
+  type WorkflowApprovalsDeps,
+  type WorkflowApprovalsEvent,
+} from "./workflows/approvals.ts";
 
 // Vault operations
 export {

--- a/src/libswamp/workflows/approvals.ts
+++ b/src/libswamp/workflows/approvals.ts
@@ -1,0 +1,108 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "../../domain/workflows/repositories.ts";
+import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface PendingApproval {
+  workflowName: string;
+  runId: string;
+  stepName: string;
+  suspendedAt: string | undefined;
+  prompt: string | undefined;
+}
+
+export interface WorkflowApprovalsData {
+  approvals: PendingApproval[];
+}
+
+export type WorkflowApprovalsEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: WorkflowApprovalsData }
+  | { kind: "error"; error: SwampError };
+
+export interface WorkflowApprovalsDeps {
+  workflowRepo: WorkflowRepository;
+  runRepo: WorkflowRunRepository;
+}
+
+export function createWorkflowApprovalsDeps(
+  workflowRepo: WorkflowRepository,
+  runRepo: WorkflowRunRepository,
+): WorkflowApprovalsDeps {
+  return { workflowRepo, runRepo };
+}
+
+export async function* workflowApprovals(
+  _ctx: LibSwampContext,
+  deps: WorkflowApprovalsDeps,
+): AsyncIterable<WorkflowApprovalsEvent> {
+  yield* withGeneratorSpan(
+    "swamp.workflow.approvals",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const workflows = await deps.workflowRepo.findAll();
+      const pending: PendingApproval[] = [];
+
+      for (const workflow of workflows) {
+        const runs = await deps.runRepo.findAllByWorkflowId(workflow.id);
+        for (const run of runs) {
+          if (run.status !== "suspended") continue;
+          const waiting = run.findWaitingApprovalStep();
+          if (!waiting) continue;
+
+          const job = run.getJob(waiting.jobName);
+          const step = job?.getStep(waiting.stepName);
+          const taskData = workflow.jobs
+            .find((j) => j.name === waiting.jobName)?.steps
+            .find((s) => s.name === waiting.stepName)?.task.data;
+
+          const timeout = evaluateApprovalTimeout(
+            step?.startedAt,
+            taskData,
+            new Date(),
+          );
+          if (timeout?.expired) continue;
+
+          const prompt = taskData && taskData.type === "manual_approval"
+            ? taskData.prompt
+            : undefined;
+
+          pending.push({
+            workflowName: workflow.name,
+            runId: run.id,
+            stepName: waiting.stepName,
+            suspendedAt: step?.startedAt?.toISOString(),
+            prompt,
+          });
+        }
+      }
+
+      yield { kind: "completed", data: { approvals: pending } };
+    })(),
+  );
+}

--- a/src/libswamp/workflows/approvals_test.ts
+++ b/src/libswamp/workflows/approvals_test.ts
@@ -1,0 +1,179 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import {
+  workflowApprovals,
+  type WorkflowApprovalsDeps,
+  type WorkflowApprovalsEvent,
+} from "./approvals.ts";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { Workflow } from "../../domain/workflows/workflow.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+
+const WF_ID = "550e8400-e29b-41d4-a716-446655440000" as unknown as WorkflowId;
+
+function makeWorkflow(overrides?: {
+  id?: WorkflowId;
+  name?: string;
+  stepType?: string;
+  timeout?: number;
+}): Workflow {
+  const stepTask = overrides?.stepType === "manual_approval"
+    ? {
+      type: "manual_approval" as const,
+      prompt: "Approve deployment",
+      timeout: overrides?.timeout,
+    }
+    : { type: "model_method" as const, modelIdOrName: "m", methodName: "run" };
+  return {
+    id: overrides?.id ?? WF_ID,
+    name: overrides?.name ?? "test-workflow",
+    version: 1,
+    tags: {},
+    jobs: [{
+      name: "main",
+      description: "",
+      steps: [{
+        name: "gate",
+        description: "",
+        task: { data: stepTask, toData: () => stepTask },
+        dependsOn: [],
+        weight: 0,
+        allowFailure: false,
+      }],
+      dependsOn: [],
+      weight: 0,
+      getDependencyNames: () => [],
+    }],
+  } as unknown as Workflow;
+}
+
+function makeRun(overrides?: {
+  id?: string;
+  status?: string;
+  stepStatus?: string;
+  startedAt?: Date;
+}): WorkflowRun {
+  const stepStatus = overrides?.stepStatus ?? "waiting_approval";
+  const startedAt = overrides?.startedAt ?? new Date();
+  return {
+    id: overrides?.id ?? "run-1",
+    status: overrides?.status ?? "suspended",
+    findWaitingApprovalStep: () =>
+      stepStatus === "waiting_approval"
+        ? { jobName: "main", stepName: "gate" }
+        : undefined,
+    getJob: (name: string) =>
+      name === "main"
+        ? {
+          getStep: (sn: string) =>
+            sn === "gate" ? { startedAt, status: stepStatus } : undefined,
+        }
+        : undefined,
+  } as unknown as WorkflowRun;
+}
+
+function makeDeps(
+  workflows: Workflow[],
+  runsByWorkflow: Map<string, WorkflowRun[]>,
+): WorkflowApprovalsDeps {
+  return {
+    workflowRepo: {
+      findAll: () => Promise.resolve(workflows),
+    } as WorkflowApprovalsDeps["workflowRepo"],
+    runRepo: {
+      findAllByWorkflowId: (id: WorkflowId) =>
+        Promise.resolve(runsByWorkflow.get(id as string) ?? []),
+    } as WorkflowApprovalsDeps["runRepo"],
+  };
+}
+
+const ctx = createLibSwampContext();
+
+Deno.test("workflowApprovals: returns empty list when no workflows exist", async () => {
+  const deps = makeDeps([], new Map());
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals, []);
+  }
+});
+
+Deno.test("workflowApprovals: skips runs that are not suspended", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ status: "running" });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 0);
+  }
+});
+
+Deno.test("workflowApprovals: skips suspended runs without waiting_approval step", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ stepStatus: "succeeded" });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 0);
+  }
+});
+
+Deno.test("workflowApprovals: returns pending approval for suspended run with waiting_approval step", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ id: "run-abc" });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].workflowName, "test-workflow");
+    assertEquals(completed.data.approvals[0].runId, "run-abc");
+    assertEquals(completed.data.approvals[0].stepName, "gate");
+    assertEquals(completed.data.approvals[0].prompt, "Approve deployment");
+  }
+});
+
+Deno.test("workflowApprovals: filters out expired approval timeouts", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval", timeout: 60 });
+  const twoMinutesAgo = new Date(Date.now() - 120_000);
+  const run = makeRun({ startedAt: twoMinutesAgo });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 0);
+  }
+});

--- a/src/libswamp/workflows/reject.ts
+++ b/src/libswamp/workflows/reject.ts
@@ -23,6 +23,7 @@ import type {
   WorkflowRepository,
   WorkflowRunRepository,
 } from "../../domain/workflows/repositories.ts";
+import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
 import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
@@ -57,13 +58,15 @@ export interface WorkflowRejectInput {
 export interface WorkflowRejectDeps {
   workflowRepo: WorkflowRepository;
   runRepo: WorkflowRunRepository;
+  runTracker?: RunTrackerRepository;
 }
 
 export function createWorkflowRejectDeps(
   workflowRepo: WorkflowRepository,
   runRepo: WorkflowRunRepository,
+  runTracker?: RunTrackerRepository,
 ): WorkflowRejectDeps {
-  return { workflowRepo, runRepo };
+  return { workflowRepo, runRepo, runTracker };
 }
 
 export async function* workflowReject(
@@ -162,6 +165,9 @@ export async function* workflowReject(
       matchedJob.fail();
       run.complete();
       await deps.runRepo.save(createWorkflowId(workflowId), run);
+      if (deps.runTracker) {
+        deps.runTracker.complete(run.id, "failed");
+      }
 
       yield {
         kind: "completed",

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -54,6 +54,7 @@ import {
   handleModelValidate,
 } from "./handlers/model_handlers.ts";
 import {
+  handleWorkflowApprovals,
   handleWorkflowApprove,
   handleWorkflowGet,
   handleWorkflowHistoryGet,
@@ -327,6 +328,11 @@ const WorkflowSearchRequestSchema = z.object({
   payload: z.object({
     query: z.string().optional(),
   }).optional(),
+});
+
+const WorkflowApprovalsRequestSchema = z.object({
+  type: z.literal("workflow.approvals"),
+  id: z.string().min(1).max(256),
 });
 
 const VaultGetRequestSchema = z.object({
@@ -833,6 +839,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkflowHistorySearchRequestSchema,
   WorkflowRunSearchRequestSchema,
   WorkflowSchemaRequestSchema,
+  WorkflowApprovalsRequestSchema,
   WorkflowApproveRequestSchema,
   WorkflowRejectRequestSchema,
   WorkflowResumeRequestSchema,
@@ -1145,6 +1152,15 @@ export function handleMessage(
         controller,
         principal,
         request.payload,
+      );
+      break;
+    case "workflow.approvals":
+      task = handleWorkflowApprovals(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
       );
       break;
     case "vault.get":

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -24,12 +24,15 @@
 import {
   consumeStream,
   createLibSwampContext,
+  createWorkflowApprovalsDeps,
   createWorkflowApproveDeps,
   createWorkflowGetDeps,
   createWorkflowHistoryGetDeps,
   createWorkflowHistoryLogsDeps,
   createWorkflowRejectDeps,
   mapWorkflowExecutionEvent,
+  workflowApprovals,
+  type WorkflowApprovalsEvent,
   workflowApprove,
   workflowGet,
   workflowHistoryGet,
@@ -206,6 +209,58 @@ export async function handleWorkflowSearch(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "workflow_search_failed", message);
+  }
+}
+
+export async function handleWorkflowApprovals(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "read", {
+      kind: "workflow",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const deps = createWorkflowApprovalsDeps(
+      ctx.repoContext.workflowRepo,
+      ctx.repoContext.workflowRunRepo,
+    );
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream<WorkflowApprovalsEvent>(
+      workflowApprovals(libCtx, deps),
+      {
+        resolving: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "workflow.approvals",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "workflow_approvals_failed", message);
   }
 }
 
@@ -658,6 +713,7 @@ export async function handleWorkflowReject(
     const deps = createWorkflowRejectDeps(
       ctx.repoContext.workflowRepo,
       ctx.repoContext.workflowRunRepo,
+      ctx.runTracker,
     );
 
     let result: Record<string, unknown> | undefined;

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -508,6 +508,7 @@ export type ServerRequest =
     payload: WorkflowSchemaPayload;
   }
   | { type: "workflow.search"; id: string; payload?: WorkflowSearchPayload }
+  | { type: "workflow.approvals"; id: string }
   | { type: "workflow.approve"; id: string; payload: WorkflowApprovePayload }
   | { type: "workflow.reject"; id: string; payload: WorkflowRejectPayload }
   | { type: "workflow.resume"; id: string; payload: WorkflowResumePayload }
@@ -748,6 +749,10 @@ export interface WorkflowSchemaResponse {
 }
 
 export interface WorkflowSearchResponse {
+  data: Record<string, unknown>;
+}
+
+export interface WorkflowApprovalsResponse {
   data: Record<string, unknown>;
 }
 
@@ -1011,6 +1016,11 @@ export type ServerMessage =
   }
   | { type: "workflow.schema"; id: string; payload: WorkflowSchemaResponse }
   | { type: "workflow.search"; id: string; payload: WorkflowSearchResponse }
+  | {
+    type: "workflow.approvals";
+    id: string;
+    payload: WorkflowApprovalsResponse;
+  }
   | { type: "workflow.approve"; id: string; payload: WorkflowApproveResponse }
   | { type: "workflow.reject"; id: string; payload: WorkflowRejectResponse }
   | { type: "vault.get"; id: string; payload: VaultGetResponse }


### PR DESCRIPTION
## Summary

- **`workflow approvals` now supports `--server` / `SWAMP_SERVE_URL`**: adds a `workflow.approvals` wire-protocol endpoint with `read` authorization, extracts approval listing to a libswamp generator (`workflowApprovals`), and wires the CLI command with `withRemoteOptions`. Previously this was the only workflow command without `--server` support, so automations using the serve wire protocol could not discover pending approvals.
- **`workflow reject` now updates the RunTrackerStore**: passes `RunTrackerRepository` through `WorkflowRejectDeps` and calls `complete(runId, "failed")` on reject from both CLI and serve paths. Previously rejected runs stayed as `"suspended"` in `swamp run history` forever.
- **`workflow cancel` now supports `--server`**: uses the existing REST `/api/v1/cancel/workflow-run/{runId}` endpoint when `--server` is set (requires `--run` for remote cancel).

Fixes swamp-club#1087.
Fixes swamp-club#1085.

## Test Plan

- [x] `deno check` — passes
- [x] `deno lint` — passes  
- [x] `deno fmt --check` — passes
- [x] `deno run test` — 8784 tests pass
- [x] Compiled binary and verified in scratch repo:
  - `swamp workflow approvals --server ws://...` returns pending approvals (was "Unknown option --server")
  - `SWAMP_SERVE_URL=ws://... swamp workflow approvals` routes through serve (was silently ignored)
  - `swamp run history` shows `status: failed` after reject (was stuck at `suspended`)
  - `swamp workflow history get` still shows correct `status: failed` after reject