### PR TITLE
feat(models): add approveWorkflowGate/rejectWorkflowGate to MethodContext (swamp-club#1086)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -301,6 +301,48 @@ workflow for orchestration.
 `triggeredBy: "model"`, `parentOutputId` pointing to the caller's output, and
 `callerExtension` for provenance tracking.
 
+### Workflow Gate Control (`context.approveWorkflowGate`, `context.rejectWorkflowGate`)
+
+`context.approveWorkflowGate(options)` and `context.rejectWorkflowGate(options)`
+let a model method programmatically approve or reject a suspended workflow's
+`manual_approval` gate without shelling out to a child `swamp` process. This
+enables webhook-driven approvals, scheduler-driven gates, and other in-process
+automation.
+
+```typescript
+// Approve a suspended gate
+const result = await context.approveWorkflowGate({
+  workflowIdOrName: "deploy-pipeline",
+  stepName: "prod-approval",
+  reason: "Approved via Linear webhook",
+});
+
+// Reject a gate
+const result = await context.rejectWorkflowGate({
+  workflowIdOrName: "deploy-pipeline",
+  stepName: "prod-approval",
+  reason: "Reviewer rejected",
+});
+```
+
+Returns a discriminated result:
+
+- `{ ok: true, runId, workflowName, stepName, approved, decidedBy }` on success
+- `{ ok: false, error: { message } }` on failure
+
+**Approve** marks the step as succeeded and saves the run. The workflow remains
+suspended until explicitly resumed via `swamp workflow resume`.
+
+**Reject** marks the step as failed, fails the job, and completes the run as
+failed. No resume is needed.
+
+**`decidedBy` is auto-populated** from the calling model's definition name and
+method name (e.g. `model:webhook-handler/on_comment`). Extensions cannot
+override this value — it is enforced for audit integrity.
+
+**Remote execution:** Not available in remote worker contexts. Returns
+`{ ok: false }` with an actionable error message.
+
 ## Pre-flight Checks
 
 Pre-flight checks are optional guards that run automatically before any

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -147,6 +147,12 @@ failed. No resume needed.
 
 `swamp workflow approvals` lists all suspended runs awaiting approval.
 
+**Programmatic gate control:** Gates can also be approved or rejected from within
+a model method via `context.approveWorkflowGate()` and
+`context.rejectWorkflowGate()`. This enables webhook-driven and
+scheduler-driven approvals without shelling out to a child `swamp` process. See
+[models.md](./models.md) for the API reference.
+
 **Resume inputs (`--input`):** `swamp workflow resume` accepts `--input`,
 `--input-file`, and `--stdin` (same parsing as `swamp workflow run`). These let
 an operator supply values that were not available at the original run time —

--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -210,5 +210,7 @@ export function buildModelMethodRunDeps(
         );
       }
       : undefined,
+    workflowRepo: repoContext.workflowRepo,
+    workflowRunRepo: repoContext.workflowRunRepo,
   };
 }

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -376,6 +376,8 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
             }
             : undefined,
           runTracker,
+          workflowRepo: repoContext.workflowRepo,
+          workflowRunRepo: repoContext.workflowRunRepo,
         };
 
         const timeoutMs = options.timeout

--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -27,7 +27,10 @@ import type {
   MethodDefinition,
   MethodResult,
   ModelDefinition,
+  WorkflowGateApproveOptions,
+  WorkflowGateRejectOptions,
 } from "./model.ts";
+import type { WorkflowGateService } from "./workflow_gate_service.ts";
 import {
   createFileWriterFactory,
   createResourceDeleter,
@@ -89,6 +92,7 @@ export class InProcessExecutor {
         callerContext: MethodContext,
       ) => ReturnType<NonNullable<MethodContext["runModel"]>>;
     },
+    private readonly workflowGateService?: WorkflowGateService,
   ) {}
 
   async execute(
@@ -184,6 +188,21 @@ export class InProcessExecutor {
       const callerCtx = this.contextWithWriters;
       this.contextWithWriters.runModel = (options) =>
         svc.invoke(options, callerCtx);
+    }
+
+    if (this.workflowGateService) {
+      const gateSvc = this.workflowGateService;
+      const callerInfo = {
+        definitionName: this.definition.name,
+        methodName: this.methodName,
+      };
+      const { signal, logger } = this.context;
+      this.contextWithWriters.approveWorkflowGate = (
+        options: WorkflowGateApproveOptions,
+      ) => gateSvc.approve(options, callerInfo, signal, logger);
+      this.contextWithWriters.rejectWorkflowGate = (
+        options: WorkflowGateRejectOptions,
+      ) => gateSvc.reject(options, callerInfo, signal, logger);
     }
 
     const savedTraceparent = Deno.env.get("TRACEPARENT");

--- a/src/domain/models/in_process_executor_test.ts
+++ b/src/domain/models/in_process_executor_test.ts
@@ -29,7 +29,11 @@ import type {
   MethodContext,
   MethodDefinition,
   ModelDefinition,
+  WorkflowGateApproveOptions,
+  WorkflowGateRejectOptions,
+  WorkflowGateResult,
 } from "./model.ts";
+import type { WorkflowGateService } from "./workflow_gate_service.ts";
 import { z } from "zod";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
@@ -550,4 +554,167 @@ Deno.test("InProcessExecutor: wires deleteResource onto context", async () => {
 
   assertEquals(result.status, "success");
   assertEquals(deletedName, "stale-resource");
+});
+
+Deno.test("InProcessExecutor: wires approveWorkflowGate when workflowGateService is provided", async () => {
+  let capturedOptions: WorkflowGateApproveOptions | undefined;
+  let capturedCallerInfo:
+    | { definitionName: string; methodName: string }
+    | undefined;
+
+  const mockGateService: WorkflowGateService = {
+    approve: (options, callerContext, _signal, _logger) => {
+      capturedOptions = options;
+      capturedCallerInfo = callerContext;
+      return Promise.resolve({
+        ok: true as const,
+        runId: "run-123",
+        workflowName: "test-workflow",
+        stepName: "gate-step",
+        approved: true,
+        decidedBy:
+          `model:${callerContext.definitionName}/${callerContext.methodName}`,
+      });
+    },
+    reject: () =>
+      Promise.resolve({
+        ok: true as const,
+        runId: "",
+        workflowName: "",
+        stepName: "",
+        approved: false,
+        decidedBy: "",
+      }),
+  };
+
+  let gateResult: WorkflowGateResult | undefined;
+  const executor: MethodExecutor = {
+    execute: async (_def, _method, context) => {
+      gateResult = await context.approveWorkflowGate!({
+        workflowIdOrName: "my-workflow",
+        stepName: "approval-gate",
+        reason: "webhook approved",
+      });
+      return {};
+    },
+  };
+
+  const context = createMockContext();
+  const inProcessExecutor = new InProcessExecutor(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+    undefined,
+    mockGateService,
+  );
+
+  const result = await inProcessExecutor.execute(createMockRequest());
+
+  assertEquals(result.status, "success");
+  assertEquals(capturedOptions?.workflowIdOrName, "my-workflow");
+  assertEquals(capturedOptions?.stepName, "approval-gate");
+  assertEquals(capturedOptions?.reason, "webhook approved");
+  assertEquals(capturedCallerInfo?.definitionName, "test-model");
+  assertEquals(capturedCallerInfo?.methodName, "test");
+  assertEquals(gateResult?.ok, true);
+  if (gateResult?.ok) {
+    assertEquals(gateResult.runId, "run-123");
+    assertEquals(gateResult.workflowName, "test-workflow");
+    assertEquals(gateResult.approved, true);
+    assertEquals(gateResult.decidedBy, "model:test-model/test");
+  }
+});
+
+Deno.test("InProcessExecutor: wires rejectWorkflowGate when workflowGateService is provided", async () => {
+  let capturedOptions: WorkflowGateRejectOptions | undefined;
+
+  const mockGateService: WorkflowGateService = {
+    approve: () =>
+      Promise.resolve({
+        ok: true as const,
+        runId: "",
+        workflowName: "",
+        stepName: "",
+        approved: true,
+        decidedBy: "",
+      }),
+    reject: (options, callerContext, _signal, _logger) => {
+      capturedOptions = options;
+      return Promise.resolve({
+        ok: true as const,
+        runId: "run-456",
+        workflowName: "deploy-wf",
+        stepName: "prod-gate",
+        approved: false,
+        decidedBy:
+          `model:${callerContext.definitionName}/${callerContext.methodName}`,
+      });
+    },
+  };
+
+  let gateResult: WorkflowGateResult | undefined;
+  const executor: MethodExecutor = {
+    execute: async (_def, _method, context) => {
+      gateResult = await context.rejectWorkflowGate!({
+        workflowIdOrName: "deploy-wf",
+        stepName: "prod-gate",
+        reason: "reviewer rejected",
+      });
+      return {};
+    },
+  };
+
+  const context = createMockContext();
+  const inProcessExecutor = new InProcessExecutor(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+    undefined,
+    mockGateService,
+  );
+
+  const result = await inProcessExecutor.execute(createMockRequest());
+
+  assertEquals(result.status, "success");
+  assertEquals(capturedOptions?.workflowIdOrName, "deploy-wf");
+  assertEquals(capturedOptions?.stepName, "prod-gate");
+  assertEquals(gateResult?.ok, true);
+  if (gateResult?.ok) {
+    assertEquals(gateResult.approved, false);
+    assertEquals(gateResult.decidedBy, "model:test-model/test");
+  }
+});
+
+Deno.test("InProcessExecutor: does not wire gate methods when no workflowGateService", async () => {
+  let hasApprove = false;
+  let hasReject = false;
+
+  const executor: MethodExecutor = {
+    execute: (_def, _method, context) => {
+      hasApprove = context.approveWorkflowGate !== undefined;
+      hasReject = context.rejectWorkflowGate !== undefined;
+      return Promise.resolve({});
+    },
+  };
+
+  const context = createMockContext();
+  const inProcessExecutor = new InProcessExecutor(
+    executor,
+    testDefinition,
+    testMethod,
+    testModelDef,
+    context,
+    "test",
+  );
+
+  await inProcessExecutor.execute(createMockRequest());
+
+  assertEquals(hasApprove, false);
+  assertEquals(hasReject, false);
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -160,6 +160,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
     ) => ReturnType<NonNullable<MethodContext["runModel"]>>;
   };
 
+  workflowGateService?:
+    import("./workflow_gate_service.ts").WorkflowGateService;
+
   async execute(
     definition: Definition,
     method: MethodDefinition,
@@ -816,6 +819,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             context,
             methodName,
             this.modelInvocationService,
+            this.workflowGateService,
           );
           const executionResult = await withSpan("swamp.method.execute", {
             "model.type": context.modelType.normalized,

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -391,6 +391,34 @@ export interface MethodContext {
    */
   runModel?: (options: RunModelOptions) => Promise<RunModelResult>;
 
+  /**
+   * Approve a suspended workflow's manual_approval gate by workflow
+   * name/ID and step name. Records the decision and marks the step as
+   * succeeded. The workflow remains suspended until explicitly resumed.
+   *
+   * `decidedBy` is auto-populated from the calling model and method
+   * for audit integrity — extensions cannot override it.
+   *
+   * Not available in remote execution contexts.
+   */
+  approveWorkflowGate?: (
+    options: WorkflowGateApproveOptions,
+  ) => Promise<WorkflowGateResult>;
+
+  /**
+   * Reject a suspended workflow's manual_approval gate by workflow
+   * name/ID and step name. Records the decision, marks the step as
+   * failed, fails the job, and completes the run as failed.
+   *
+   * `decidedBy` is auto-populated from the calling model and method
+   * for audit integrity — extensions cannot override it.
+   *
+   * Not available in remote execution contexts.
+   */
+  rejectWorkflowGate?: (
+    options: WorkflowGateRejectOptions,
+  ) => Promise<WorkflowGateResult>;
+
   /** @internal Invocation tracking — not part of the extension author API. */
   _invocationTracking?: InvocationTracking;
 
@@ -443,6 +471,48 @@ export interface RunModelSuccess {
 export interface RunModelFailure {
   ok: false;
   error: { message: string; stack?: string };
+}
+
+/**
+ * Options for `context.approveWorkflowGate()`.
+ */
+export interface WorkflowGateApproveOptions {
+  workflowIdOrName: string;
+  stepName: string;
+  runId?: string;
+  reason?: string;
+}
+
+/**
+ * Options for `context.rejectWorkflowGate()`.
+ */
+export interface WorkflowGateRejectOptions {
+  workflowIdOrName: string;
+  stepName: string;
+  runId?: string;
+  reason?: string;
+}
+
+/**
+ * Result of `context.approveWorkflowGate()` or `context.rejectWorkflowGate()`.
+ * Carries correlation data for logging and audit.
+ */
+export type WorkflowGateResult =
+  | WorkflowGateSuccess
+  | WorkflowGateFailure;
+
+export interface WorkflowGateSuccess {
+  ok: true;
+  runId: string;
+  workflowName: string;
+  stepName: string;
+  approved: boolean;
+  decidedBy: string;
+}
+
+export interface WorkflowGateFailure {
+  ok: false;
+  error: { message: string };
 }
 
 /**

--- a/src/domain/models/workflow_gate_service.ts
+++ b/src/domain/models/workflow_gate_service.ts
@@ -1,0 +1,41 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  WorkflowGateApproveOptions,
+  WorkflowGateRejectOptions,
+  WorkflowGateResult,
+} from "./model.ts";
+import type { Logger } from "@logtape/logtape";
+
+export interface WorkflowGateService {
+  approve(
+    options: WorkflowGateApproveOptions,
+    callerContext: { definitionName: string; methodName: string },
+    signal: AbortSignal,
+    logger: Logger,
+  ): Promise<WorkflowGateResult>;
+
+  reject(
+    options: WorkflowGateRejectOptions,
+    callerContext: { definitionName: string; methodName: string },
+    signal: AbortSignal,
+    logger: Logger,
+  ): Promise<WorkflowGateResult>;
+}

--- a/src/domain/models/workflow_gate_service_test.ts
+++ b/src/domain/models/workflow_gate_service_test.ts
@@ -1,0 +1,195 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createWorkflowGateService } from "../../libswamp/models/workflow_gate.ts";
+import { Workflow } from "../workflows/workflow.ts";
+import { Job } from "../workflows/job.ts";
+import { Step } from "../workflows/step.ts";
+import { StepTask } from "../workflows/step_task.ts";
+import { WorkflowRun } from "../workflows/workflow_run.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "../workflows/repositories.ts";
+import { getLogger } from "@logtape/logtape";
+
+function createSuspendedWorkflowAndRun(): {
+  workflow: Workflow;
+  run: WorkflowRun;
+} {
+  const workflow = Workflow.create({
+    name: "test-gate-workflow",
+    jobs: [
+      Job.create({
+        name: "gate-job",
+        steps: [
+          Step.create({
+            name: "approval-step",
+            task: StepTask.manualApproval("Do you approve?"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const run = WorkflowRun.create(workflow);
+  run.start();
+  const job = run.jobs[0];
+  job.start();
+  const step = job.getStep("approval-step")!;
+  step.start();
+  step.waitForApproval();
+  run.suspend();
+
+  return { workflow, run };
+}
+
+function createMockRepos(
+  workflow: Workflow,
+  run: WorkflowRun,
+): { workflowRepo: WorkflowRepository; runRepo: WorkflowRunRepository } {
+  return {
+    workflowRepo: {
+      findByIdOrName: () => Promise.resolve(workflow),
+      findById: () => Promise.resolve(workflow),
+      findByName: () => Promise.resolve(workflow),
+      findAll: () => Promise.resolve([workflow]),
+      save: () => Promise.resolve(),
+      delete: () => Promise.resolve(),
+    } as unknown as WorkflowRepository,
+    runRepo: {
+      findById: () => Promise.resolve(run),
+      findAllByWorkflowId: () => Promise.resolve([run]),
+      findLatestByWorkflowId: () => Promise.resolve(run),
+      save: () => Promise.resolve(),
+      delete: () => Promise.resolve(),
+    } as unknown as WorkflowRunRepository,
+  };
+}
+
+Deno.test("createWorkflowGateService: approve returns richer result with correct fields", async () => {
+  const { workflow, run } = createSuspendedWorkflowAndRun();
+  const { workflowRepo, runRepo } = createMockRepos(workflow, run);
+
+  const service = createWorkflowGateService(workflowRepo, runRepo);
+  const result = await service.approve(
+    { workflowIdOrName: "test-gate-workflow", stepName: "approval-step" },
+    { definitionName: "webhook-handler", methodName: "handle" },
+    new AbortController().signal,
+    getLogger(["test"]),
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.runId, run.id);
+    assertEquals(result.workflowName, "test-gate-workflow");
+    assertEquals(result.stepName, "approval-step");
+    assertEquals(result.approved, true);
+    assertEquals(result.decidedBy, "model:webhook-handler/handle");
+  }
+});
+
+Deno.test("createWorkflowGateService: reject returns richer result with approved=false", async () => {
+  const { workflow, run } = createSuspendedWorkflowAndRun();
+  const { workflowRepo, runRepo } = createMockRepos(workflow, run);
+
+  const service = createWorkflowGateService(workflowRepo, runRepo);
+  const result = await service.reject(
+    {
+      workflowIdOrName: "test-gate-workflow",
+      stepName: "approval-step",
+      reason: "not ready",
+    },
+    { definitionName: "reviewer-model", methodName: "review" },
+    new AbortController().signal,
+    getLogger(["test"]),
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.runId, run.id);
+    assertEquals(result.workflowName, "test-gate-workflow");
+    assertEquals(result.stepName, "approval-step");
+    assertEquals(result.approved, false);
+    assertEquals(result.decidedBy, "model:reviewer-model/review");
+  }
+});
+
+Deno.test("createWorkflowGateService: approve auto-populates decidedBy from caller context", async () => {
+  const { workflow, run } = createSuspendedWorkflowAndRun();
+  const { workflowRepo, runRepo } = createMockRepos(workflow, run);
+
+  const service = createWorkflowGateService(workflowRepo, runRepo);
+  const result = await service.approve(
+    { workflowIdOrName: "test-gate-workflow", stepName: "approval-step" },
+    { definitionName: "linear-bridge", methodName: "on_comment" },
+    new AbortController().signal,
+    getLogger(["test"]),
+  );
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.decidedBy, "model:linear-bridge/on_comment");
+  }
+});
+
+Deno.test("createWorkflowGateService: approve returns error for non-existent workflow", async () => {
+  const workflowRepo = {
+    findByIdOrName: () => Promise.resolve(null),
+    findByName: () => Promise.resolve(null),
+    findById: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+  } as unknown as WorkflowRepository;
+  const runRepo = {
+    findAllByWorkflowId: () => Promise.resolve([]),
+  } as unknown as WorkflowRunRepository;
+
+  const service = createWorkflowGateService(workflowRepo, runRepo);
+  const result = await service.approve(
+    { workflowIdOrName: "nonexistent", stepName: "any-step" },
+    { definitionName: "test", methodName: "test" },
+    new AbortController().signal,
+    getLogger(["test"]),
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(typeof result.error.message, "string");
+    assertEquals(result.error.message.length > 0, true);
+  }
+});
+
+Deno.test("createWorkflowGateService: approve returns error for wrong step name", async () => {
+  const { workflow, run } = createSuspendedWorkflowAndRun();
+  const { workflowRepo, runRepo } = createMockRepos(workflow, run);
+
+  const service = createWorkflowGateService(workflowRepo, runRepo);
+  const result = await service.approve(
+    { workflowIdOrName: "test-gate-workflow", stepName: "wrong-step" },
+    { definitionName: "test", methodName: "test" },
+    new AbortController().signal,
+    getLogger(["test"]),
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.message.includes("wrong-step"), true);
+  }
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -289,6 +289,8 @@ export interface StepExecutionContext {
   ephemeralCatalog?: CatalogStore;
   workflowRepo?: WorkflowRepository;
   workflowRunRepo?: WorkflowRunRepository;
+  workflowGateService?:
+    import("../models/workflow_gate_service.ts").WorkflowGateService;
 }
 
 /**
@@ -547,16 +549,9 @@ export class DefaultStepExecutor implements StepExecutor {
     if (
       executionService instanceof DefaultMethodExecutionService &&
       !executionService.workflowGateService &&
-      ctx.workflowRepo &&
-      ctx.workflowRunRepo
+      ctx.workflowGateService
     ) {
-      const { createWorkflowGateService } = await import(
-        "../../libswamp/models/workflow_gate.ts"
-      );
-      executionService.workflowGateService = createWorkflowGateService(
-        ctx.workflowRepo,
-        ctx.workflowRunRepo,
-      );
+      executionService.workflowGateService = ctx.workflowGateService;
     }
 
     // Resolve every available expression (self.* from the forEach variable,
@@ -1454,6 +1449,9 @@ export class WorkflowExecutionService {
   private readonly workflowReportRunner = new WorkflowReportRunner();
   /** Evaluator for sub-workflow input expressions. Per-instance, not per-call. */
   private readonly expressionEvaluator: ExpressionEvaluationService;
+
+  workflowGateService?:
+    import("../models/workflow_gate_service.ts").WorkflowGateService;
 
   constructor(
     private readonly workflowRepo: WorkflowRepository,
@@ -2629,6 +2627,7 @@ export class WorkflowExecutionService {
           ephemeralCatalog: this.ephemeralCatalog,
           workflowRepo: this.workflowRepo,
           workflowRunRepo: this.runRepo,
+          workflowGateService: this.workflowGateService,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -287,6 +287,8 @@ export interface StepExecutionContext {
   runTracker?: RunTrackerRepository;
   ephemeralRepo?: UnifiedDataRepository;
   ephemeralCatalog?: CatalogStore;
+  workflowRepo?: WorkflowRepository;
+  workflowRunRepo?: WorkflowRunRepository;
 }
 
 /**
@@ -540,6 +542,21 @@ export class DefaultStepExecutor implements StepExecutor {
         },
         repoDir: ctx.repoDir,
       });
+    }
+
+    if (
+      executionService instanceof DefaultMethodExecutionService &&
+      !executionService.workflowGateService &&
+      ctx.workflowRepo &&
+      ctx.workflowRunRepo
+    ) {
+      const { createWorkflowGateService } = await import(
+        "../../libswamp/models/workflow_gate.ts"
+      );
+      executionService.workflowGateService = createWorkflowGateService(
+        ctx.workflowRepo,
+        ctx.workflowRunRepo,
+      );
     }
 
     // Resolve every available expression (self.* from the forEach variable,
@@ -2610,6 +2627,8 @@ export class WorkflowExecutionService {
           runTracker: this.runTracker,
           ephemeralRepo: this.ephemeralRepo,
           ephemeralCatalog: this.ephemeralCatalog,
+          workflowRepo: this.workflowRepo,
+          workflowRunRepo: this.runRepo,
         };
         return this.executor.execute(step, ctx);
       });

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -121,5 +121,7 @@ export async function createServerTokenRunDeps(
         `${id}.yaml`,
       );
     },
+    workflowRepo: repoContext.workflowRepo,
+    workflowRunRepo: repoContext.workflowRunRepo,
   };
 }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -207,6 +207,10 @@ export interface ModelMethodRunDeps {
   ) => Promise<void>;
   getDefinitionPath?: (type: ModelType, id: string) => string;
   runTracker?: RunTrackerRepository;
+  workflowRepo?:
+    import("../../domain/workflows/repositories.ts").WorkflowRepository;
+  workflowRunRepo?:
+    import("../../domain/workflows/repositories.ts").WorkflowRunRepository;
 }
 
 /**
@@ -665,6 +669,24 @@ export async function* modelMethodRun(
                 commonDeps,
                 repoDir: deps.repoDir,
               });
+          }
+
+          if (
+            "workflowGateService" in executionService &&
+            !executionService.workflowGateService &&
+            deps.workflowRepo &&
+            deps.workflowRunRepo
+          ) {
+            const { createWorkflowGateService } = await import(
+              "./workflow_gate.ts"
+            );
+            (executionService as {
+              workflowGateService?:
+                import("../../domain/models/workflow_gate_service.ts").WorkflowGateService;
+            }).workflowGateService = createWorkflowGateService(
+              deps.workflowRepo,
+              deps.workflowRunRepo,
+            );
           }
 
           // Start heartbeat inside the try so it's always cleaned up on error.

--- a/src/libswamp/models/workflow_gate.ts
+++ b/src/libswamp/models/workflow_gate.ts
@@ -1,0 +1,131 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  WorkflowGateApproveOptions,
+  WorkflowGateRejectOptions,
+  WorkflowGateResult,
+} from "../../domain/models/model.ts";
+import type { WorkflowGateService } from "../../domain/models/workflow_gate_service.ts";
+import type {
+  WorkflowRepository,
+  WorkflowRunRepository,
+} from "../../domain/workflows/repositories.ts";
+import { createLibSwampContext } from "../context.ts";
+import { workflowApprove } from "../workflows/approve.ts";
+import { workflowReject } from "../workflows/reject.ts";
+import { result } from "../stream.ts";
+import type { SwampError } from "../errors.ts";
+import type { Logger } from "@logtape/logtape";
+
+export function createWorkflowGateService(
+  workflowRepo: WorkflowRepository,
+  runRepo: WorkflowRunRepository,
+): WorkflowGateService {
+  return {
+    async approve(
+      options: WorkflowGateApproveOptions,
+      callerContext: { definitionName: string; methodName: string },
+      signal: AbortSignal,
+      logger: Logger,
+    ): Promise<WorkflowGateResult> {
+      const ctx = createLibSwampContext({ signal, logger });
+      const decidedBy =
+        `model:${callerContext.definitionName}/${callerContext.methodName}`;
+
+      try {
+        const completed = await result(
+          workflowApprove(ctx, { workflowRepo, runRepo }, {
+            workflowIdOrName: options.workflowIdOrName,
+            stepName: options.stepName,
+            runId: options.runId,
+            reason: options.reason,
+            decidedBy,
+          }),
+        );
+        return {
+          ok: true,
+          runId: completed.data.runId,
+          workflowName: completed.data.workflowName,
+          stepName: completed.data.stepName,
+          approved: true,
+          decidedBy,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: {
+            message: isSwampError(error)
+              ? error.message
+              : error instanceof Error
+              ? error.message
+              : String(error),
+          },
+        };
+      }
+    },
+
+    async reject(
+      options: WorkflowGateRejectOptions,
+      callerContext: { definitionName: string; methodName: string },
+      signal: AbortSignal,
+      logger: Logger,
+    ): Promise<WorkflowGateResult> {
+      const ctx = createLibSwampContext({ signal, logger });
+      const decidedBy =
+        `model:${callerContext.definitionName}/${callerContext.methodName}`;
+
+      try {
+        const completed = await result(
+          workflowReject(ctx, { workflowRepo, runRepo }, {
+            workflowIdOrName: options.workflowIdOrName,
+            stepName: options.stepName,
+            runId: options.runId,
+            reason: options.reason,
+            decidedBy,
+          }),
+        );
+        return {
+          ok: true,
+          runId: completed.data.runId,
+          workflowName: completed.data.workflowName,
+          stepName: completed.data.stepName,
+          approved: false,
+          decidedBy,
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: {
+            message: isSwampError(error)
+              ? error.message
+              : error instanceof Error
+              ? error.message
+              : String(error),
+          },
+        };
+      }
+    },
+  };
+}
+
+function isSwampError(error: unknown): error is SwampError {
+  return typeof error === "object" && error !== null && "code" in error &&
+    "message" in error;
+}

--- a/src/libswamp/models/workflow_gate_test.ts
+++ b/src/libswamp/models/workflow_gate_test.ts
@@ -18,16 +18,16 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { createWorkflowGateService } from "../../libswamp/models/workflow_gate.ts";
-import { Workflow } from "../workflows/workflow.ts";
-import { Job } from "../workflows/job.ts";
-import { Step } from "../workflows/step.ts";
-import { StepTask } from "../workflows/step_task.ts";
-import { WorkflowRun } from "../workflows/workflow_run.ts";
+import { createWorkflowGateService } from "./workflow_gate.ts";
+import { Workflow } from "../../domain/workflows/workflow.ts";
+import { Job } from "../../domain/workflows/job.ts";
+import { Step } from "../../domain/workflows/step.ts";
+import { StepTask } from "../../domain/workflows/step_task.ts";
+import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type {
   WorkflowRepository,
   WorkflowRunRepository,
-} from "../workflows/repositories.ts";
+} from "../../domain/workflows/repositories.ts";
 import { getLogger } from "@logtape/logtape";
 
 function createSuspendedWorkflowAndRun(): {

--- a/src/libswamp/worker/run_deps.ts
+++ b/src/libswamp/worker/run_deps.ts
@@ -130,5 +130,7 @@ export async function createWorkerModelRunDeps(
         `${id}.yaml`,
       );
     },
+    workflowRepo: repoContext.workflowRepo,
+    workflowRunRepo: repoContext.workflowRunRepo,
   };
 }

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -548,6 +548,16 @@ export async function* workflowRun(
           ephemeral.catalog,
         );
 
+        if (!service.workflowGateService) {
+          const { createWorkflowGateService } = await import(
+            "../models/workflow_gate.ts"
+          );
+          service.workflowGateService = createWorkflowGateService(
+            deps.workflowRepo,
+            deps.runRepo,
+          );
+        }
+
         // Per-method-invocation telemetry bridge. Constructed once per
         // stream consumption and finalized in the outer try/finally so
         // any in-flight invocations on cancellation / throw are still

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -270,6 +270,8 @@ export async function createModelMethodRunDeps(
       }
       : undefined,
     runTracker: options?.runTracker,
+    workflowRepo: repoContext.workflowRepo,
+    workflowRunRepo: repoContext.workflowRunRepo,
   };
 }
 

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -589,6 +589,24 @@ export function createRemoteMethodContext(
             "move the runModel call to a local orchestrator model or workflow.",
         },
       }),
+    approveWorkflowGate: () =>
+      Promise.resolve({
+        ok: false as const,
+        error: {
+          message:
+            "context.approveWorkflowGate() is not available in remote execution — " +
+            "move the call to a local orchestrator model or workflow.",
+        },
+      }),
+    rejectWorkflowGate: () =>
+      Promise.resolve({
+        ok: false as const,
+        error: {
+          message:
+            "context.rejectWorkflowGate() is not available in remote execution — " +
+            "move the call to a local orchestrator model or workflow.",
+        },
+      }),
   };
 
   return { context, getHandles: writers.getHandles };


### PR DESCRIPTION
## Summary

- Add `context.approveWorkflowGate()` and `context.rejectWorkflowGate()` to `MethodContext`, allowing extension model methods to programmatically approve or reject `manual_approval` workflow gates without shelling out to a child `swamp` process
- Returns a richer `WorkflowGateResult` with `runId`, `workflowName`, `stepName`, `approved`, and `decidedBy` fields for logging and audit
- Auto-populates `decidedBy` from calling model/method context (e.g. `model:webhook-handler/on_comment`) — extensions cannot override this

Closes swamp-club#1086

## Design

Follows the `runModel()` injection pattern exactly:

1. **Domain interface** — `WorkflowGateService` in `src/domain/models/workflow_gate_service.ts` (pure interface, no libswamp deps)
2. **Implementation** — `createWorkflowGateService()` in `src/libswamp/models/workflow_gate.ts` wraps existing `workflowApprove`/`workflowReject` async generators using the `result()` helper
3. **Wiring** — `InProcessExecutor` accepts optional `WorkflowGateService` constructor param, conditionally attaches methods to context (like `modelInvocationService`)
4. **Threading** — `DefaultMethodExecutionService` holds and passes the service; workflow repos threaded through `ModelMethodRunDeps` and `StepExecutionContext`
5. **Remote stubs** — `remote_method_context.ts` returns `{ ok: false }` with actionable error message

Resume is intentionally excluded from v1 — it's a long-running operation that would block the calling model method.

## Test plan

### Unit tests (8 new tests, all passing)
- `in_process_executor_test.ts`: approve wiring, reject wiring, no-service behavior
- `workflow_gate_service_test.ts`: approve success with richer result, reject success, decidedBy auto-population, workflow-not-found error, wrong-step-name error

### End-to-end verification (compiled binary, scratch repo)

**Approve path:**
1. Created scratch repo with workflow containing `manual_approval` step and extension model with `approveWorkflowGate` call
2. `swamp workflow run gated-deploy` → workflow suspended at gate
3. `swamp model @test/gate-controller method run approve_gate gate-approver --input workflowName=gated-deploy --input stepName=approval-gate`
4. Verified result:
   ```
   ok: True
   runId: d4aaa7bd-c1ff-467d-8ed1-7ccd2a208a92
   workflowName: gated-deploy
   stepName: approval-gate
   approved: True
   decidedBy: model:gate-approver/approve_gate
   ```

**Reject path:**
1. Fresh workflow run → suspended
2. Model method called `rejectWorkflowGate` with `reason: "failed security review"`
3. Verified result:
   ```
   ok: True
   approved: False
   decidedBy: model:gate-rejector/reject_gate
   runId: f43dc32e-71c3-47a9-9496-7d2efe7f064e
   stepName: approval-gate
   ```

**Error handling:**
- Multiple suspended runs correctly returned `{ ok: false, error: { message: "Multiple suspended runs found..." } }`
- Non-existent workflow returned `{ ok: false }` with descriptive error
- Wrong step name returned `{ ok: false }` with step name in error message

### Full verification suite
- `deno check` — clean
- `deno lint` — clean (1736 files)
- `deno fmt` — clean (1867 files)
- `deno run test` — 8794 passed, 0 failed
- `deno run compile` — binary built successfully