### PR TITLE
fix(skills): add missing reference files to bundled swamp skill (swamp-club#1100)

### DIFF
--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -63,6 +63,8 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp/references/data/references/troubleshooting.md",
     name: "swamp",
   },
+  // architecture
+  { relativePath: "swamp/references/architecture/guide.md", name: "swamp" },
   // model
   { relativePath: "swamp/references/model/guide.md", name: "swamp" },
   { relativePath: "swamp/references/model/reference.md", name: "swamp" },
@@ -88,6 +90,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   },
   {
     relativePath: "swamp/references/model/references/outputs.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/model/references/disposable-instances.md",
     name: "swamp",
   },
   {
@@ -131,6 +137,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp/references/repo/reference.md", name: "swamp" },
   {
     relativePath: "swamp/references/repo/references/ci-integration.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/repo/references/namespaces.md",
     name: "swamp",
   },
   {
@@ -352,6 +362,8 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp/references/troubleshooting/references/tracing.md",
     name: "swamp",
   },
+  // serve
+  { relativePath: "swamp/references/serve/guide.md", name: "swamp" },
   // swamp share guide area
   {
     relativePath: "swamp/references/share/guide.md",

--- a/src/infrastructure/assets/skill_assets_test.ts
+++ b/src/infrastructure/assets/skill_assets_test.ts
@@ -19,7 +19,8 @@
 
 import { assertEquals } from "@std/assert";
 import { assertPathStringIncludes } from "../persistence/path_test_helpers.ts";
-import { join } from "@std/path";
+import { join, relative, SEPARATOR } from "@std/path";
+import { walk } from "@std/fs/walk";
 import { SkillAssets } from "./skill_assets.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -481,6 +482,30 @@ Deno.test("SkillAssets.copySkillsTo copies share guide and references", async ()
     const troubleshootingStat = await Deno.stat(troubleshootingPath);
     assertEquals(troubleshootingStat.isFile, true);
   });
+});
+
+Deno.test("SkillAssets.listSkills includes every skill markdown file", async () => {
+  const assets = new SkillAssets();
+  const skillsDir = assets.getSkillsDir();
+  const bundledNames = assets.getSkillNames();
+  const sourcePaths: string[] = [];
+
+  for (const name of bundledNames) {
+    const skillDir = join(skillsDir, name);
+    for await (
+      const entry of walk(skillDir, {
+        includeDirs: false,
+        exts: [".md"],
+      })
+    ) {
+      const rel = relative(skillsDir, entry.path).split(SEPARATOR).join("/");
+      sourcePaths.push(rel);
+    }
+  }
+
+  const bundledPaths = assets.listSkills().map((skill) => skill.relativePath);
+
+  assertEquals(bundledPaths.toSorted(), sourcePaths.toSorted());
 });
 
 Deno.test("SkillAssets.listSkills includes share guide entries", () => {


### PR DESCRIPTION
## Summary

- Add 4 missing reference files to `BUNDLED_SKILLS` in `skill_assets.ts` that were added to `.claude/skills/swamp/` in prior PRs but never registered for bundling
- Add a completeness test that walks all bundled skill directories and asserts every `.md` file has a matching `BUNDLED_SKILLS` entry, preventing future omissions

Missing files:
- `references/architecture/guide.md` (added in #1733)
- `references/serve/guide.md` (added in #1809)
- `references/model/references/disposable-instances.md` (added in #1688)
- `references/repo/references/namespaces.md` (added in #1693)

Closes swamp-club#1100

## Test Plan

- `deno run test src/infrastructure/assets/skill_assets_test.ts` — 23 tests pass including the new completeness test
- Verified the new completeness test catches missing files by temporarily removing an entry and confirming the test fails
- `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)