### PR TITLE
feat(workflows): add --traceparent/--tracestate to workflow resume (swamp-club#1108)

### DIFF
--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -22,6 +22,8 @@ import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
+  resolveTraceparent,
+  resolveTracestate,
 } from "../context.ts";
 import {
   acquireModelLocks,
@@ -54,6 +56,7 @@ import {
 } from "../../libswamp/mod.ts";
 import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
+import { withGeneratorTraceContext } from "../../infrastructure/tracing/mod.ts";
 import { GIT_SHA } from "./version.ts";
 import {
   deepMerge,
@@ -108,7 +111,15 @@ export const workflowResumeCommand = withRemoteOptions(
     )
     .option("--stdin", "Read override inputs from stdin (piped data)", {
       default: false,
-    }),
+    })
+    .option(
+      "--traceparent <value:string>",
+      "W3C traceparent for per-invocation trace context (env: TRACEPARENT)",
+    )
+    .option(
+      "--tracestate <value:string>",
+      "W3C tracestate for per-invocation trace context (env: TRACESTATE)",
+    ),
 ).action(
   async function (
     options: AnyOptions,
@@ -167,6 +178,12 @@ export const workflowResumeCommand = withRemoteOptions(
             inputs: Object.keys(resumeInputs).length > 0
               ? resumeInputs
               : undefined,
+            traceparent: resolveTraceparent(
+              options.traceparent as string | undefined,
+            ),
+            tracestate: resolveTracestate(
+              options.tracestate as string | undefined,
+            ),
           },
         }) as AsyncIterable<WorkflowRunEvent>,
         renderer.handlers(),
@@ -355,18 +372,31 @@ export const workflowResumeCommand = withRemoteOptions(
       isAuthenticated: isAuthenticated(),
     });
 
+    const traceparent = resolveTraceparent(
+      options.traceparent as string | undefined,
+    );
+    const tracestate = resolveTracestate(
+      options.tracestate as string | undefined,
+    );
+
     const resumeGenerator = async function* (): AsyncGenerator<
       WorkflowRunEvent
     > {
-      for await (
-        const event of service.resume(workflowName, run.id, {
-          signal: AbortSignal.timeout(600_000),
-          swampSha: GIT_SHA,
-          inputs: resumeInputs,
-        })
-      ) {
-        yield mapWorkflowExecutionEvent(event, runRepo);
-      }
+      yield* withGeneratorTraceContext(
+        traceparent,
+        tracestate,
+        (async function* () {
+          for await (
+            const event of service.resume(workflowName, run.id, {
+              signal: AbortSignal.timeout(600_000),
+              swampSha: GIT_SHA,
+              inputs: resumeInputs,
+            })
+          ) {
+            yield mapWorkflowExecutionEvent(event, runRepo);
+          }
+        })(),
+      );
     };
 
     try {

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -624,6 +624,8 @@ const WorkflowResumeRequestSchema = z.object({
     workflowIdOrName: z.string(),
     runId: z.string().optional(),
     inputs: z.record(z.string(), z.unknown()).optional(),
+    traceparent: z.string().optional(),
+    tracestate: z.string().optional(),
   }),
 });
 

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -2157,3 +2157,27 @@ Deno.test("validateServerRequest: workflow.schema accepts payload with workflowI
   const result = validateServerRequest(input);
   assertEquals(typeof result, "object");
 });
+
+Deno.test("validateServerRequest: workflow.resume accepts traceparent and tracestate", () => {
+  const input = {
+    type: "workflow.resume",
+    id: "req-resume-trace",
+    payload: {
+      workflowIdOrName: "deploy",
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      tracestate: "congo=t61rcWkgMzE",
+    },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});
+
+Deno.test("validateServerRequest: workflow.resume accepts request without trace fields", () => {
+  const input = {
+    type: "workflow.resume",
+    id: "req-resume-no-trace",
+    payload: { workflowIdOrName: "deploy" },
+  };
+  const result = validateServerRequest(input);
+  assertEquals(typeof result, "object");
+});

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -77,6 +77,10 @@ import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import {
+  extractTraceContext,
+  runWithParentTrace,
+} from "../../infrastructure/tracing/mod.ts";
+import {
   authorizeOrReject,
   type ConnectionContext,
   sanitizeErrorForClient,
@@ -849,18 +853,31 @@ export async function handleWorkflowResume(
       }
     };
 
-    try {
-      for await (const event of resumeGenerator()) {
-        if (socket.readyState !== WebSocket.OPEN) break;
-        const serialized = serializeEvent(
-          event as { kind: string; [key: string]: unknown },
-        );
-        send(socket, { type: "event", id: requestId, event: serialized });
+    const run_ = async () => {
+      try {
+        for await (const event of resumeGenerator()) {
+          if (socket.readyState !== WebSocket.OPEN) break;
+          const serialized = serializeEvent(
+            event as { kind: string; [key: string]: unknown },
+          );
+          send(socket, { type: "event", id: requestId, event: serialized });
+        }
+      } finally {
+        ephemeral.dispose();
       }
-    } finally {
-      ephemeral.dispose();
+      send(socket, { type: "done", id: requestId });
+    };
+
+    if (payload.traceparent) {
+      const headers: Record<string, string> = {
+        traceparent: payload.traceparent,
+      };
+      if (payload.tracestate) headers.tracestate = payload.tracestate;
+      const traceCtx = extractTraceContext(headers);
+      await runWithParentTrace(traceCtx, run_);
+    } else {
+      await run_();
     }
-    send(socket, { type: "done", id: requestId });
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -325,6 +325,8 @@ export interface WorkflowResumePayload {
   workflowIdOrName: string;
   runId?: string;
   inputs?: Record<string, unknown>;
+  traceparent?: string;
+  tracestate?: string;
 }
 
 // ── Vault operations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `--traceparent` and `--tracestate` flags to `swamp workflow resume` (with `TRACEPARENT`/`TRACESTATE` env fallback), matching the existing flags on `workflow run`
- Thread trace context through both the local CLI path (via `withGeneratorTraceContext`) and the `--server` remote path (via `extractTraceContext` + `runWithParentTrace`)
- Add `traceparent`/`tracestate` to the `WorkflowResumePayload` protocol type, Zod validation schema, and server resume handler

A workflow that suspends at a `manual_approval` gate and is resumed in a separate process now produces one connected trace instead of two disconnected ones.

Closes swamp-club#1108

## Test Plan

- Verified `workflow resume --traceparent` succeeds (previously failed with `Unknown option "--traceparent"`)
- Verified `TRACEPARENT` env var is picked up by resume
- Added 2 Zod schema validation tests for `workflow.resume` with and without trace fields
- All 8802 existing tests pass
- Compiled binary and ran end-to-end reproduction: `workflow run --traceparent` → suspend at gate → approve → `workflow resume --traceparent` → succeeds

## Follow-ups

- UAT: swamp-club/swamp-uat#304
- Docs: `opentelemetry.md` and `workflows.md` reference docs need updating (swamp-club/swamp-club has issues disabled; flagging here)
- The issue's optional request #2 (synthetic root span for injected traceparent) is scoped out for a separate issue