### PR TITLE
feat(vaults): add native secret-read access audit trail (swamp-club#1109)

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -293,7 +293,9 @@ methods are required.
 - **JSON mode**: Outputs directly without prompting (designed for agent/script
   consumption).
 - **Audit**: Every CLI read emits a `VaultSecretRead` domain event through the
-  event bus, recording the vault name, type, and secret key accessed.
+  event bus, recording the vault name, type, and secret key accessed. When
+  `auditReads` is enabled on the vault, a persistent audit trail entry is also
+  written to `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`.
 
 ### JSON Output
 
@@ -305,6 +307,84 @@ methods are required.
   "value": "sk-test-..."
 }
 ```
+
+## Read Access Audit Trail
+
+Optional per-vault audit trail that records every `VaultService.get()` call to
+append-only JSONL files. Designed for security posture verification in
+autonomous agent fleets — proving "which automation read which secret, when."
+
+### Enabling
+
+Set `auditReads: true` in the vault configuration YAML, or use the
+`--audit-reads` flag at creation time:
+
+```bash
+swamp vault create local_encryption my-vault --audit-reads
+```
+
+Existing vaults can enable audit reads by editing their YAML config with
+`swamp vault edit my-vault` and adding `auditReads: true`.
+
+### How It Works
+
+When `auditReads` is enabled on a vault:
+
+1. `VaultService.get()` writes an audit entry after each successful read
+2. Entries are appended to date-partitioned JSONL files:
+   `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`
+3. Audit writes are awaited but wrapped in try/catch — they never block or fail
+   a secret read
+4. All read paths are covered: CLI (`vault read-secret`, `vault inspect`), model
+   method execution, and CEL expression evaluation
+
+### Audit Entry Fields
+
+Each entry captures:
+
+- `timestamp` — ISO-8601 when the read occurred
+- `vaultName` — which vault was read
+- `vaultType` — the provider type (e.g. `local_encryption`, `@swamp/aws-sm`)
+- `secretKey` — which secret was accessed
+- `callerContext` — who/what initiated the read (e.g. `cli:vault-read-secret`,
+  `model:mytype/myid:exec`, `unknown`)
+
+Secret values are never recorded.
+
+### Querying the Trail
+
+```bash
+# Recent reads (last 7 days)
+swamp vault audit-trail
+
+# Filter by vault and key
+swamp vault audit-trail --vault my-vault --key API_KEY
+
+# Time range
+swamp vault audit-trail --since 2026-07-01 --until 2026-07-10
+
+# JSON output
+swamp vault audit-trail --vault my-vault --json --limit 50
+```
+
+### Architecture
+
+- **Value object**: `VaultAuditEntry` (`src/domain/vaults/vault_audit_entry.ts`)
+- **Repository interface**: `VaultAuditRepository`
+  (`src/domain/vaults/vault_audit_repository.ts`)
+- **Infrastructure**: `JsonlVaultAuditRepository` — follows the established
+  `JsonlAuditRepository` pattern with date-partitioned JSONL files under
+  `.swamp/audit/`
+- **Interception**: `VaultService` stores `auditReads` flags per vault name.
+  `setAuditRepository()` injects the repository post-construction, avoiding
+  changes to the ~20 `fromRepository()` call sites
+
+### Provider-Native Logs
+
+For provider backends with their own access logs (AWS Secrets
+Manager → CloudTrail, Azure Key Vault → Azure Monitor), swamp's native audit
+trail records the swamp-level access. Surfacing/normalizing provider-native logs
+is a separate feature.
 
 ## Sensitive Field Marking (Implemented)
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -336,10 +336,10 @@ When `auditReads` is enabled on a vault:
 3. Audit writes are awaited but wrapped in try/catch — they never block or fail
    a secret read
 
-Currently audited paths: CLI `vault read-secret` and `vault inspect`. Model
-method execution, CEL expression evaluation, serve, and token operations create
-their own `VaultService` instances without audit wiring — these are planned for
-follow-up coverage.
+All `VaultService.fromRepository()` call sites automatically wire the audit
+repository when any vault has `auditReads` enabled. This covers CLI commands
+(`vault read-secret`, `vault inspect`, `vault migrate`), CEL expression
+evaluation, model method execution, serve/WebSocket, and token operations.
 
 ### Audit Entry Fields
 

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -335,8 +335,11 @@ When `auditReads` is enabled on a vault:
    `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`
 3. Audit writes are awaited but wrapped in try/catch — they never block or fail
    a secret read
-4. All read paths are covered: CLI (`vault read-secret`, `vault inspect`), model
-   method execution, and CEL expression evaluation
+
+Currently audited paths: CLI `vault read-secret` and `vault inspect`. Model
+method execution, CEL expression evaluation, serve, and token operations create
+their own `VaultService` instances without audit wiring — these are planned for
+follow-up coverage.
 
 ### Audit Entry Fields
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -786,7 +786,7 @@ export const serveCommand = new Command()
         {
           getVaultSecret: async (v, k) => {
             try {
-              return await vaultService.get(v, k);
+              return await vaultService.get(v, k, "serve:oauth-resolve");
             } catch {
               return null;
             }

--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -35,6 +35,7 @@ import { vaultInspectCommand } from "./vault_inspect.ts";
 import { vaultListKeysCommand } from "./vault_list_keys.ts";
 import { vaultMigrateCommand } from "./vault_migrate.ts";
 import { vaultReadSecretCommand } from "./vault_read_secret.ts";
+import { vaultAuditTrailCommand } from "./vault_audit_trail.ts";
 import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 
 /**
@@ -75,6 +76,7 @@ export const vaultCommand = new Command()
   .command("migrate", vaultMigrateCommand)
   .command("read-secret", vaultReadSecretCommand)
   .command("list-keys", vaultListKeysCommand)
+  .command("audit-trail", vaultAuditTrailCommand)
   .command(
     "list",
     new Command()

--- a/src/cli/commands/vault_audit_trail.ts
+++ b/src/cli/commands/vault_audit_trail.ts
@@ -1,0 +1,103 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createVaultAuditTrailDeps,
+  vaultAuditTrail,
+} from "../../libswamp/mod.ts";
+import { createVaultAuditTrailRenderer } from "../../presentation/renderers/vault_audit_trail.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const vaultAuditTrailCommand = new Command()
+  .name("audit-trail")
+  .description("View the secret-read audit trail for vaults.")
+  .example(
+    "Show recent reads",
+    "swamp vault audit-trail",
+  )
+  .example(
+    "Filter by vault",
+    "swamp vault audit-trail --vault my-vault",
+  )
+  .example(
+    "Filter by key and time range",
+    "swamp vault audit-trail --vault my-vault --key API_KEY --since 2026-07-01",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--vault <name:string>", "Filter by vault name")
+  .option("--key <key:string>", "Filter by secret key")
+  .option("--since <date:string>", "Start date (ISO-8601 or YYYY-MM-DD)")
+  .option("--until <date:string>", "End date (ISO-8601 or YYYY-MM-DD)")
+  .option("--limit <count:integer>", "Maximum number of entries to return")
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "vault",
+      "audit-trail",
+    ]);
+
+    const { repoDir } = await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
+
+    const since = options.since ? parseDate(options.since) : undefined;
+    const until = options.until ? parseDate(options.until) : undefined;
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createVaultAuditTrailDeps(repoDir);
+    const renderer = createVaultAuditTrailRenderer(cliCtx.outputMode);
+
+    await consumeStream(
+      vaultAuditTrail(ctx, deps, {
+        vaultName: options.vault,
+        secretKey: options.key,
+        since,
+        until,
+        limit: options.limit,
+      }),
+      renderer.handlers(),
+    );
+
+    cliCtx.logger.debug("Vault audit-trail command completed");
+  });
+
+function parseDate(value: string): Date {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new UserError(
+      `Invalid date: '${value}'. Use ISO-8601 format (e.g. 2026-07-01 or 2026-07-01T00:00:00Z).`,
+    );
+  }
+  return date;
+}

--- a/src/cli/commands/vault_audit_trail.ts
+++ b/src/cli/commands/vault_audit_trail.ts
@@ -57,9 +57,18 @@ export const vaultAuditTrailCommand = new Command()
   )
   .option("--vault <name:string>", "Filter by vault name")
   .option("--key <key:string>", "Filter by secret key")
-  .option("--since <date:string>", "Start date (ISO-8601 or YYYY-MM-DD)")
-  .option("--until <date:string>", "End date (ISO-8601 or YYYY-MM-DD)")
-  .option("--limit <count:integer>", "Maximum number of entries to return")
+  .option(
+    "--since <date:string>",
+    "Start date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: 7 days ago]",
+  )
+  .option(
+    "--until <date:string>",
+    "End date, e.g. 2026-07-01 or 2026-07-01T00:00:00Z [default: now]",
+  )
+  .option(
+    "--limit <count:integer>",
+    "Maximum number of entries to return [default: 100]",
+  )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
       "vault",

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -71,6 +71,10 @@ export const vaultCreateCommand = new Command()
     "--config <json:string>",
     "Provider configuration as JSON",
   )
+  .option(
+    "--audit-reads",
+    "Enable read access audit trail for this vault",
+  )
   .action(
     async function (
       options: AnyOptions,
@@ -121,6 +125,7 @@ export const vaultCreateCommand = new Command()
           name: vaultName,
           config,
           repoDir,
+          auditReads: options.auditReads,
         }),
         renderer.handlers(),
       );

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -73,7 +73,7 @@ export const vaultCreateCommand = new Command()
   )
   .option(
     "--audit-reads",
-    "Enable read access audit trail for this vault",
+    "Enable read access audit trail for this vault (can also be set later with vault edit)",
   )
   .action(
     async function (

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1089,7 +1089,11 @@ export class ModelResolver {
       const vaultName = match[2] ?? match[3];
       const secretKey = match[5] ?? match[6];
       try {
-        const secretValue = await vaultService.get(vaultName, secretKey);
+        const secretValue = await vaultService.get(
+          vaultName,
+          secretKey,
+          "expression:vault-resolve",
+        );
         redactor?.addSecret(secretValue);
 
         let celReplacement: string;

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -164,6 +164,7 @@ async function redeem(
   const secret = await context.vaultService.get(
     token.vaultName,
     token.secretKey,
+    "model:server-token-verify",
   );
   if (!timingSafeEqual(secret, presentedSecret)) {
     throw new Error(`Server token '${name}' does not match`);

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -672,7 +672,11 @@ async function walkAndResolve(
     const match = VAULT_REF_REGEX.exec(obj);
     if (match) {
       const [, vaultName, key] = match;
-      const value = await vaultService.get(vaultName, key);
+      const value = await vaultService.get(
+        vaultName,
+        key,
+        "data-writer:vault-ref-resolve",
+      );
       redactor?.addSecret(value);
       return value;
     }

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -203,6 +203,7 @@ async function redeem(
   const secret = await context.vaultService.get(
     token.vaultName,
     token.secretKey,
+    "model:enrollment-token-verify",
   );
   if (!timingSafeEqual(secret, args.presentedToken)) {
     throw new Error(`Enrollment token '${name}' does not match`);

--- a/src/domain/vaults/vault_audit_entry.ts
+++ b/src/domain/vaults/vault_audit_entry.ts
@@ -1,0 +1,73 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface VaultAuditEntry {
+  readonly timestamp: string;
+  readonly vaultName: string;
+  readonly vaultType: string;
+  readonly secretKey: string;
+  readonly callerContext: string;
+}
+
+export interface VaultAuditEntryData {
+  timestamp: string;
+  vaultName: string;
+  vaultType: string;
+  secretKey: string;
+  callerContext: string;
+}
+
+export function createVaultAuditEntry(
+  vaultName: string,
+  vaultType: string,
+  secretKey: string,
+  callerContext: string,
+): VaultAuditEntry {
+  return {
+    timestamp: new Date().toISOString(),
+    vaultName,
+    vaultType,
+    secretKey,
+    callerContext,
+  };
+}
+
+export function vaultAuditEntryFromData(
+  data: VaultAuditEntryData,
+): VaultAuditEntry {
+  return {
+    timestamp: data.timestamp,
+    vaultName: data.vaultName,
+    vaultType: data.vaultType,
+    secretKey: data.secretKey,
+    callerContext: data.callerContext,
+  };
+}
+
+export function vaultAuditEntryToData(
+  entry: VaultAuditEntry,
+): VaultAuditEntryData {
+  return {
+    timestamp: entry.timestamp,
+    vaultName: entry.vaultName,
+    vaultType: entry.vaultType,
+    secretKey: entry.secretKey,
+    callerContext: entry.callerContext,
+  };
+}

--- a/src/domain/vaults/vault_audit_entry_test.ts
+++ b/src/domain/vaults/vault_audit_entry_test.ts
@@ -1,0 +1,94 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  createVaultAuditEntry,
+  vaultAuditEntryFromData,
+  vaultAuditEntryToData,
+} from "./vault_audit_entry.ts";
+
+Deno.test("createVaultAuditEntry: creates entry with all fields", () => {
+  const entry = createVaultAuditEntry(
+    "my-vault",
+    "local_encryption",
+    "API_KEY",
+    "cli:vault-read-secret",
+  );
+
+  assertEquals(entry.vaultName, "my-vault");
+  assertEquals(entry.vaultType, "local_encryption");
+  assertEquals(entry.secretKey, "API_KEY");
+  assertEquals(entry.callerContext, "cli:vault-read-secret");
+  assertEquals(typeof entry.timestamp, "string");
+  assertEquals(new Date(entry.timestamp).toISOString(), entry.timestamp);
+});
+
+Deno.test("vaultAuditEntryToData: serializes entry to data", () => {
+  const entry = createVaultAuditEntry(
+    "my-vault",
+    "local_encryption",
+    "DB_PASS",
+    "model:mytype/myid:exec",
+  );
+
+  const data = vaultAuditEntryToData(entry);
+
+  assertEquals(data.vaultName, "my-vault");
+  assertEquals(data.vaultType, "local_encryption");
+  assertEquals(data.secretKey, "DB_PASS");
+  assertEquals(data.callerContext, "model:mytype/myid:exec");
+  assertEquals(data.timestamp, entry.timestamp);
+});
+
+Deno.test("vaultAuditEntryFromData: deserializes data to entry", () => {
+  const data = {
+    timestamp: "2026-07-10T12:00:00.000Z",
+    vaultName: "prod-vault",
+    vaultType: "@swamp/aws-sm",
+    secretKey: "TOKEN",
+    callerContext: "unknown",
+  };
+
+  const entry = vaultAuditEntryFromData(data);
+
+  assertEquals(entry.timestamp, "2026-07-10T12:00:00.000Z");
+  assertEquals(entry.vaultName, "prod-vault");
+  assertEquals(entry.vaultType, "@swamp/aws-sm");
+  assertEquals(entry.secretKey, "TOKEN");
+  assertEquals(entry.callerContext, "unknown");
+});
+
+Deno.test("vaultAuditEntry: round-trip preserves all fields", () => {
+  const original = createVaultAuditEntry(
+    "test-vault",
+    "local_encryption",
+    "MY_SECRET",
+    "cli:vault-inspect",
+  );
+
+  const data = vaultAuditEntryToData(original);
+  const restored = vaultAuditEntryFromData(data);
+
+  assertEquals(restored.timestamp, original.timestamp);
+  assertEquals(restored.vaultName, original.vaultName);
+  assertEquals(restored.vaultType, original.vaultType);
+  assertEquals(restored.secretKey, original.secretKey);
+  assertEquals(restored.callerContext, original.callerContext);
+});

--- a/src/domain/vaults/vault_audit_path.ts
+++ b/src/domain/vaults/vault_audit_path.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+
+const VAULT_AUDIT_FILENAME_PREFIX = "vault-reads-";
+const VAULT_AUDIT_FILENAME_SUFFIX = ".jsonl";
+
+export const VAULT_AUDIT_FILENAME_PATTERN =
+  /^vault-reads-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+export function vaultAuditFilename(date: string): string {
+  return `${VAULT_AUDIT_FILENAME_PREFIX}${date}${VAULT_AUDIT_FILENAME_SUFFIX}`;
+}
+
+function datePartOfIsoTimestamp(iso: string): string {
+  return iso.split("T")[0];
+}
+
+export function vaultAuditFilenameForTimestamp(isoTimestamp: string): string {
+  return vaultAuditFilename(datePartOfIsoTimestamp(isoTimestamp));
+}
+
+export function vaultAuditFilePathForTimestamp(
+  auditDir: string,
+  isoTimestamp: string,
+): string {
+  return join(auditDir, vaultAuditFilenameForTimestamp(isoTimestamp));
+}

--- a/src/domain/vaults/vault_audit_path_test.ts
+++ b/src/domain/vaults/vault_audit_path_test.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { SEPARATOR } from "@std/path";
+import {
+  VAULT_AUDIT_FILENAME_PATTERN,
+  vaultAuditFilename,
+  vaultAuditFilenameForTimestamp,
+  vaultAuditFilePathForTimestamp,
+} from "./vault_audit_path.ts";
+
+Deno.test("vaultAuditFilename: formats date as vault audit filename", () => {
+  assertEquals(
+    vaultAuditFilename("2026-07-10"),
+    "vault-reads-2026-07-10.jsonl",
+  );
+});
+
+Deno.test("vaultAuditFilenameForTimestamp: extracts date from ISO timestamp", () => {
+  assertEquals(
+    vaultAuditFilenameForTimestamp("2026-07-10T15:30:00.000Z"),
+    "vault-reads-2026-07-10.jsonl",
+  );
+});
+
+Deno.test("vaultAuditFilePathForTimestamp: returns full path", () => {
+  const path = vaultAuditFilePathForTimestamp(
+    "/repo/.swamp/audit",
+    "2026-07-10T15:30:00.000Z",
+  );
+  assertEquals(
+    path,
+    `/repo/.swamp/audit${SEPARATOR}vault-reads-2026-07-10.jsonl`,
+  );
+});
+
+Deno.test("VAULT_AUDIT_FILENAME_PATTERN: matches valid filenames", () => {
+  const match = "vault-reads-2026-07-10.jsonl".match(
+    VAULT_AUDIT_FILENAME_PATTERN,
+  );
+  assertEquals(match !== null, true);
+  assertEquals(match![1], "2026-07-10");
+});
+
+Deno.test("VAULT_AUDIT_FILENAME_PATTERN: does not match command audit files", () => {
+  const match = "commands-2026-07-10.jsonl".match(
+    VAULT_AUDIT_FILENAME_PATTERN,
+  );
+  assertEquals(match, null);
+});

--- a/src/domain/vaults/vault_audit_path_test.ts
+++ b/src/domain/vaults/vault_audit_path_test.ts
@@ -18,13 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { SEPARATOR } from "@std/path";
 import {
   VAULT_AUDIT_FILENAME_PATTERN,
   vaultAuditFilename,
   vaultAuditFilenameForTimestamp,
   vaultAuditFilePathForTimestamp,
 } from "./vault_audit_path.ts";
+import { assertPathEquals } from "../../infrastructure/persistence/path_test_helpers.ts";
 
 Deno.test("vaultAuditFilename: formats date as vault audit filename", () => {
   assertEquals(
@@ -45,9 +45,9 @@ Deno.test("vaultAuditFilePathForTimestamp: returns full path", () => {
     "/repo/.swamp/audit",
     "2026-07-10T15:30:00.000Z",
   );
-  assertEquals(
+  assertPathEquals(
     path,
-    `/repo/.swamp/audit${SEPARATOR}vault-reads-2026-07-10.jsonl`,
+    "/repo/.swamp/audit/vault-reads-2026-07-10.jsonl",
   );
 });
 

--- a/src/domain/vaults/vault_audit_repository.ts
+++ b/src/domain/vaults/vault_audit_repository.ts
@@ -1,0 +1,36 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultAuditEntry } from "./vault_audit_entry.ts";
+
+export interface VaultAuditQueryOptions {
+  readonly vaultName?: string;
+  readonly secretKey?: string;
+  readonly limit?: number;
+}
+
+export interface VaultAuditRepository {
+  append(entry: VaultAuditEntry): Promise<void>;
+
+  findByTimeRange(
+    startTime: Date,
+    endTime: Date,
+    options?: VaultAuditQueryOptions,
+  ): Promise<VaultAuditEntry[]>;
+}

--- a/src/domain/vaults/vault_config.ts
+++ b/src/domain/vaults/vault_config.ts
@@ -40,6 +40,7 @@ export const VaultConfigDataSchema = z.object({
   type: z.string(),
   config: z.record(z.string(), z.unknown()).default({}),
   createdAt: z.string(),
+  auditReads: z.boolean().optional(),
 });
 
 /**
@@ -51,6 +52,7 @@ export interface VaultConfigData {
   type: string;
   config: Record<string, unknown>;
   createdAt: string;
+  auditReads?: boolean;
 }
 
 /**
@@ -63,6 +65,7 @@ export class VaultConfig {
     public readonly type: string,
     public readonly config: Record<string, unknown>,
     public readonly createdAt: Date,
+    public readonly auditReads: boolean,
   ) {}
 
   /**
@@ -73,8 +76,16 @@ export class VaultConfig {
     name: string,
     type: string,
     config: Record<string, unknown>,
+    auditReads?: boolean,
   ): VaultConfig {
-    return new VaultConfig(id, name, type, config, new Date());
+    return new VaultConfig(
+      id,
+      name,
+      type,
+      config,
+      new Date(),
+      auditReads ?? false,
+    );
   }
 
   /**
@@ -87,6 +98,7 @@ export class VaultConfig {
       data.type,
       data.config,
       new Date(data.createdAt),
+      data.auditReads ?? false,
     );
   }
 
@@ -94,12 +106,16 @@ export class VaultConfig {
    * Converts the VaultConfig to a data object for persistence.
    */
   toData(): VaultConfigData {
-    return {
+    const data: VaultConfigData = {
       id: this.id,
       name: this.name,
       type: this.type,
       config: this.config,
       createdAt: this.createdAt.toISOString(),
     };
+    if (this.auditReads) {
+      data.auditReads = true;
+    }
+    return data;
   }
 }

--- a/src/domain/vaults/vault_provider.ts
+++ b/src/domain/vaults/vault_provider.ts
@@ -82,4 +82,6 @@ export interface VaultConfiguration {
   type: string;
   /** Provider-specific configuration */
   config: Record<string, unknown>;
+  /** When true, secret reads are logged to the vault audit trail */
+  auditReads?: boolean;
 }

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -39,6 +39,8 @@ import type { LocalEncryptionConfig } from "./local_encryption_vault_provider.ts
 import { join } from "@std/path";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { createVaultProvider } from "./vault_provider_factory.ts";
+import { createVaultAuditEntry } from "./vault_audit_entry.ts";
+import type { VaultAuditRepository } from "./vault_audit_repository.ts";
 
 export interface ProcessRunResult {
   success: boolean;
@@ -55,10 +57,17 @@ export interface VaultRefreshOptions {
  */
 export class VaultService {
   private readonly providers = new Map<string, VaultProvider>();
+  private readonly vaultTypes = new Map<string, string>();
+  private readonly auditFlags = new Map<string, boolean>();
   private readonly refreshOptions?: VaultRefreshOptions;
+  private auditRepository?: VaultAuditRepository;
 
   constructor(refreshOptions?: VaultRefreshOptions) {
     this.refreshOptions = refreshOptions;
+  }
+
+  setAuditRepository(repo: VaultAuditRepository): void {
+    this.auditRepository = repo;
   }
 
   /**
@@ -126,6 +135,7 @@ export class VaultService {
           name: vaultConfig.name,
           type: vaultType,
           config,
+          auditReads: vaultConfig.auditReads,
         });
       } catch (error) {
         if (
@@ -153,6 +163,10 @@ export class VaultService {
       config.config,
     );
     this.providers.set(config.name, provider);
+    this.vaultTypes.set(config.name, config.type);
+    if (config.auditReads) {
+      this.auditFlags.set(config.name, true);
+    }
   }
 
   /**
@@ -160,7 +174,11 @@ export class VaultService {
    * on the key and refreshOptions were provided, transparently re-runs the
    * refresh command when the TTL has lapsed.
    */
-  async get(vaultName: string, secretKey: string): Promise<string> {
+  async get(
+    vaultName: string,
+    secretKey: string,
+    callerContext?: string,
+  ): Promise<string> {
     const provider = this.requireProvider(vaultName);
 
     if (this.refreshOptions && isVaultRefreshHookProvider(provider)) {
@@ -181,6 +199,11 @@ export class VaultService {
               );
               getLogger("vaults")
                 .info`Refreshed secret ${secretKey} in vault ${vaultName}`;
+              await this.recordAuditEntry(
+                vaultName,
+                secretKey,
+                callerContext,
+              );
               return freshValue;
             }
           } else {
@@ -194,7 +217,34 @@ export class VaultService {
       }
     }
 
-    return await provider.get(secretKey);
+    const value = await provider.get(secretKey);
+    await this.recordAuditEntry(
+      vaultName,
+      secretKey,
+      callerContext,
+    );
+    return value;
+  }
+
+  private async recordAuditEntry(
+    vaultName: string,
+    secretKey: string,
+    callerContext?: string,
+  ): Promise<void> {
+    if (!this.auditRepository || !this.auditFlags.get(vaultName)) return;
+    try {
+      const vaultType = this.vaultTypes.get(vaultName) ?? "unknown";
+      const entry = createVaultAuditEntry(
+        vaultName,
+        vaultType,
+        secretKey,
+        callerContext ?? "unknown",
+      );
+      await this.auditRepository.append(entry);
+    } catch (error) {
+      getLogger("vaults")
+        .warn`Failed to record vault audit entry for ${secretKey} in ${vaultName}: ${error}`;
+    }
   }
 
   private requireProvider(vaultName: string): VaultProvider {

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -41,6 +41,7 @@ import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml
 import { createVaultProvider } from "./vault_provider_factory.ts";
 import { createVaultAuditEntry } from "./vault_audit_entry.ts";
 import type { VaultAuditRepository } from "./vault_audit_repository.ts";
+import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 
 export interface ProcessRunResult {
   success: boolean;
@@ -150,7 +151,19 @@ export class VaultService {
       }
     }
     vaultService.ensureDefaultVaults();
+    if (vaultService.hasAnyAuditEnabled()) {
+      vaultService.setAuditRepository(
+        new JsonlVaultAuditRepository(repoDir),
+      );
+    }
     return vaultService;
+  }
+
+  private hasAnyAuditEnabled(): boolean {
+    for (const enabled of this.auditFlags.values()) {
+      if (enabled) return true;
+    }
+    return false;
   }
 
   /**

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -28,6 +28,11 @@ import { join } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { VaultService } from "./vault_service.ts";
 import { vaultTypeRegistry } from "./vault_type_registry.ts";
+import type { VaultAuditEntry } from "./vault_audit_entry.ts";
+import type {
+  VaultAuditQueryOptions,
+  VaultAuditRepository,
+} from "./vault_audit_repository.ts";
 
 Deno.test("VaultService - missing vault configuration error handling", async (t) => {
   await t.step(
@@ -655,4 +660,127 @@ Deno.test("VaultService - supportsDelete", async (t) => {
     const vaultService = new VaultService();
     assertEquals(vaultService.supportsDelete("nonexistent"), false);
   });
+});
+
+class InMemoryVaultAuditRepository implements VaultAuditRepository {
+  readonly entries: VaultAuditEntry[] = [];
+
+  async append(entry: VaultAuditEntry): Promise<void> {
+    this.entries.push(entry);
+    await Promise.resolve();
+  }
+
+  async findByTimeRange(
+    _startTime: Date,
+    _endTime: Date,
+    _options?: VaultAuditQueryOptions,
+  ): Promise<VaultAuditEntry[]> {
+    return await Promise.resolve(this.entries);
+  }
+}
+
+Deno.test("VaultService - audit trail", async (t) => {
+  await t.step(
+    "should record audit entry when audit is enabled on vault",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "audited-vault",
+        type: "mock",
+        config: { "key": "val" },
+        auditReads: true,
+      });
+
+      await svc.get("audited-vault", "key", "test-caller");
+
+      assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].vaultName, "audited-vault");
+      assertEquals(auditRepo.entries[0].vaultType, "mock");
+      assertEquals(auditRepo.entries[0].secretKey, "key");
+      assertEquals(auditRepo.entries[0].callerContext, "test-caller");
+    },
+  );
+
+  await t.step(
+    "should not record audit entry when audit is disabled on vault",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "unaudited-vault",
+        type: "mock",
+        config: { "key": "val" },
+      });
+
+      await svc.get("unaudited-vault", "key");
+
+      assertEquals(auditRepo.entries.length, 0);
+    },
+  );
+
+  await t.step(
+    "should not record audit entry when no audit repository is set",
+    async () => {
+      const svc = new VaultService();
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: { "key": "val" },
+        auditReads: true,
+      });
+
+      // Should not throw even though auditReads is true but no repo
+      const result = await svc.get("vault", "key");
+      assertEquals(result, "val");
+    },
+  );
+
+  await t.step(
+    "should default callerContext to 'unknown' when not provided",
+    async () => {
+      const svc = new VaultService();
+      const auditRepo = new InMemoryVaultAuditRepository();
+      svc.setAuditRepository(auditRepo);
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: { "key": "val" },
+        auditReads: true,
+      });
+
+      await svc.get("vault", "key");
+
+      assertEquals(auditRepo.entries.length, 1);
+      assertEquals(auditRepo.entries[0].callerContext, "unknown");
+    },
+  );
+
+  await t.step(
+    "should not throw when audit repository append fails",
+    async () => {
+      const svc = new VaultService();
+      const failingRepo: VaultAuditRepository = {
+        append: () => Promise.reject(new Error("disk full")),
+        findByTimeRange: () => Promise.resolve([]),
+      };
+      svc.setAuditRepository(failingRepo);
+
+      svc.registerVault({
+        name: "vault",
+        type: "mock",
+        config: { "key": "val" },
+        auditReads: true,
+      });
+
+      const result = await svc.get("vault", "key");
+      assertEquals(result, "val");
+    },
+  );
 });

--- a/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
+++ b/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
@@ -41,30 +41,24 @@ export class JsonlVaultAuditRepository implements VaultAuditRepository {
   }
 
   async append(entry: VaultAuditEntry): Promise<void> {
+    await ensureDir(this.baseDir);
+
+    const path = vaultAuditFilePathForTimestamp(
+      this.baseDir,
+      entry.timestamp,
+    );
+    const line = JSON.stringify(vaultAuditEntryToData(entry)) + "\n";
+
+    const file = await Deno.open(path, {
+      write: true,
+      create: true,
+      append: true,
+    });
     try {
-      await ensureDir(this.baseDir);
-
-      const path = vaultAuditFilePathForTimestamp(
-        this.baseDir,
-        entry.timestamp,
-      );
-      const line = JSON.stringify(vaultAuditEntryToData(entry)) + "\n";
-
-      const file = await Deno.open(path, {
-        write: true,
-        create: true,
-        append: true,
-      });
-      try {
-        const encoder = new TextEncoder();
-        await file.write(encoder.encode(line));
-      } finally {
-        file.close();
-      }
-    } catch (error) {
-      if (Deno.env.get("SWAMP_DEBUG")) {
-        console.error("[VaultAudit] Failed to append:", error);
-      }
+      const encoder = new TextEncoder();
+      await file.write(encoder.encode(line));
+    } finally {
+      file.close();
     }
   }
 

--- a/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
+++ b/src/infrastructure/persistence/jsonl_vault_audit_repository.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ensureDir } from "@std/fs";
+import type {
+  VaultAuditEntry,
+  VaultAuditEntryData,
+} from "../../domain/vaults/vault_audit_entry.ts";
+import {
+  vaultAuditEntryFromData,
+  vaultAuditEntryToData,
+} from "../../domain/vaults/vault_audit_entry.ts";
+import { vaultAuditFilePathForTimestamp } from "../../domain/vaults/vault_audit_path.ts";
+import type {
+  VaultAuditQueryOptions,
+  VaultAuditRepository,
+} from "../../domain/vaults/vault_audit_repository.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+
+export class JsonlVaultAuditRepository implements VaultAuditRepository {
+  private readonly baseDir: string;
+
+  constructor(repoDir: string, baseDir?: string) {
+    this.baseDir = baseDir ?? swampPath(repoDir, SWAMP_SUBDIRS.audit);
+  }
+
+  async append(entry: VaultAuditEntry): Promise<void> {
+    try {
+      await ensureDir(this.baseDir);
+
+      const path = vaultAuditFilePathForTimestamp(
+        this.baseDir,
+        entry.timestamp,
+      );
+      const line = JSON.stringify(vaultAuditEntryToData(entry)) + "\n";
+
+      const file = await Deno.open(path, {
+        write: true,
+        create: true,
+        append: true,
+      });
+      try {
+        const encoder = new TextEncoder();
+        await file.write(encoder.encode(line));
+      } finally {
+        file.close();
+      }
+    } catch (error) {
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[VaultAudit] Failed to append:", error);
+      }
+    }
+  }
+
+  async findByTimeRange(
+    startTime: Date,
+    endTime: Date,
+    options?: VaultAuditQueryOptions,
+  ): Promise<VaultAuditEntry[]> {
+    const entries: VaultAuditEntry[] = [];
+
+    try {
+      const current = new Date(startTime);
+      current.setUTCHours(0, 0, 0, 0);
+
+      const end = new Date(endTime);
+      end.setUTCHours(23, 59, 59, 999);
+
+      while (current <= end) {
+        const path = vaultAuditFilePathForTimestamp(
+          this.baseDir,
+          current.toISOString(),
+        );
+
+        try {
+          const content = await Deno.readTextFile(path);
+          const lines = content.split("\n").filter((line) => line.trim());
+
+          for (const line of lines) {
+            try {
+              const data = JSON.parse(line) as VaultAuditEntryData;
+              const entry = vaultAuditEntryFromData(data);
+
+              const entryTime = new Date(entry.timestamp);
+              if (entryTime < startTime || entryTime > endTime) continue;
+              if (options?.vaultName && entry.vaultName !== options.vaultName) {
+                continue;
+              }
+              if (options?.secretKey && entry.secretKey !== options.secretKey) {
+                continue;
+              }
+
+              entries.push(entry);
+
+              if (options?.limit && entries.length >= options.limit) {
+                return entries;
+              }
+            } catch {
+              // Skip malformed lines
+            }
+          }
+        } catch (error) {
+          if (!(error instanceof Deno.errors.NotFound)) {
+            if (Deno.env.get("SWAMP_DEBUG")) {
+              console.error(
+                `[VaultAudit] Failed to read ${path}:`,
+                error,
+              );
+            }
+          }
+        }
+
+        current.setUTCDate(current.getUTCDate() + 1);
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      if (Deno.env.get("SWAMP_DEBUG")) {
+        console.error("[VaultAudit] Failed to read audit data:", error);
+      }
+    }
+
+    return entries;
+  }
+}

--- a/src/infrastructure/persistence/jsonl_vault_audit_repository_test.ts
+++ b/src/infrastructure/persistence/jsonl_vault_audit_repository_test.ts
@@ -1,0 +1,159 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { JsonlVaultAuditRepository } from "./jsonl_vault_audit_repository.ts";
+import type { VaultAuditEntry } from "../../domain/vaults/vault_audit_entry.ts";
+
+function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const dir = await Deno.makeTempDir({ prefix: "vault-audit-test-" });
+    try {
+      await fn(dir);
+    } finally {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  };
+}
+
+function makeEntry(overrides: Partial<VaultAuditEntry> = {}): VaultAuditEntry {
+  return {
+    timestamp: "2026-07-10T12:00:00.000Z",
+    vaultName: "my-vault",
+    vaultType: "local_encryption",
+    secretKey: "API_KEY",
+    callerContext: "cli:vault-read-secret",
+    ...overrides,
+  };
+}
+
+Deno.test(
+  "JsonlVaultAuditRepository: append and findByTimeRange round-trip",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+    const entry = makeEntry();
+
+    await repo.append(entry);
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T00:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+    );
+
+    assertEquals(results.length, 1);
+    assertEquals(results[0].vaultName, "my-vault");
+    assertEquals(results[0].secretKey, "API_KEY");
+    assertEquals(results[0].callerContext, "cli:vault-read-secret");
+  }),
+);
+
+Deno.test(
+  "JsonlVaultAuditRepository: filters by vaultName",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+
+    await repo.append(makeEntry({ vaultName: "vault-a" }));
+    await repo.append(makeEntry({ vaultName: "vault-b" }));
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T00:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+      { vaultName: "vault-a" },
+    );
+
+    assertEquals(results.length, 1);
+    assertEquals(results[0].vaultName, "vault-a");
+  }),
+);
+
+Deno.test(
+  "JsonlVaultAuditRepository: filters by secretKey",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+
+    await repo.append(makeEntry({ secretKey: "KEY_A" }));
+    await repo.append(makeEntry({ secretKey: "KEY_B" }));
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T00:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+      { secretKey: "KEY_B" },
+    );
+
+    assertEquals(results.length, 1);
+    assertEquals(results[0].secretKey, "KEY_B");
+  }),
+);
+
+Deno.test(
+  "JsonlVaultAuditRepository: respects limit",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+
+    await repo.append(makeEntry({ secretKey: "KEY_1" }));
+    await repo.append(makeEntry({ secretKey: "KEY_2" }));
+    await repo.append(makeEntry({ secretKey: "KEY_3" }));
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T00:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+      { limit: 2 },
+    );
+
+    assertEquals(results.length, 2);
+  }),
+);
+
+Deno.test(
+  "JsonlVaultAuditRepository: returns empty array for no matching data",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T00:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+    );
+
+    assertEquals(results.length, 0);
+  }),
+);
+
+Deno.test(
+  "JsonlVaultAuditRepository: filters by time range",
+  withTempDir(async (dir) => {
+    const repo = new JsonlVaultAuditRepository("", dir);
+
+    await repo.append(
+      makeEntry({ timestamp: "2026-07-10T08:00:00.000Z", secretKey: "EARLY" }),
+    );
+    await repo.append(
+      makeEntry({ timestamp: "2026-07-10T16:00:00.000Z", secretKey: "LATE" }),
+    );
+
+    const results = await repo.findByTimeRange(
+      new Date("2026-07-10T12:00:00Z"),
+      new Date("2026-07-10T23:59:59Z"),
+    );
+
+    assertEquals(results.length, 1);
+    assertEquals(results[0].secretKey, "LATE");
+  }),
+);

--- a/src/libswamp/access/token_create.ts
+++ b/src/libswamp/access/token_create.ts
@@ -94,7 +94,7 @@ export async function createServerTokenCreateDeps(
         definitionName: input.name,
       }),
     readSecret: (vaultName, secretKey) =>
-      vaultService.get(vaultName, secretKey),
+      vaultService.get(vaultName, secretKey, "access:server-token-create"),
   };
 }
 

--- a/src/libswamp/access/token_rotate.ts
+++ b/src/libswamp/access/token_rotate.ts
@@ -68,7 +68,7 @@ export async function createServerTokenRotateDeps(
         lastEvaluated: false,
       }),
     readSecret: (vaultName, secretKey) =>
-      vaultService.get(vaultName, secretKey),
+      vaultService.get(vaultName, secretKey, "access:server-token-rotate"),
   };
 }
 

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1106,6 +1106,16 @@ export {
   type VaultInspectEvent,
 } from "./vaults/inspect.ts";
 
+// Vault audit trail operations
+export {
+  createVaultAuditTrailDeps,
+  vaultAuditTrail,
+  type VaultAuditTrailData,
+  type VaultAuditTrailDeps,
+  type VaultAuditTrailEvent,
+  type VaultAuditTrailInput,
+} from "./vaults/audit_trail.ts";
+
 // Data GC operations
 export {
   createDataGcDeps,

--- a/src/libswamp/vaults/audit_trail.ts
+++ b/src/libswamp/vaults/audit_trail.ts
@@ -1,0 +1,106 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { VaultAuditEntry } from "../../domain/vaults/vault_audit_entry.ts";
+import type {
+  VaultAuditQueryOptions,
+  VaultAuditRepository,
+} from "../../domain/vaults/vault_audit_repository.ts";
+import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface VaultAuditTrailData {
+  entries: VaultAuditEntry[];
+  totalCount: number;
+}
+
+export type VaultAuditTrailEvent =
+  | { kind: "resolving" }
+  | { kind: "completed"; data: VaultAuditTrailData }
+  | { kind: "error"; error: SwampError };
+
+export interface VaultAuditTrailInput {
+  vaultName?: string;
+  secretKey?: string;
+  since?: Date;
+  until?: Date;
+  limit?: number;
+}
+
+export interface VaultAuditTrailDeps {
+  findByTimeRange: (
+    startTime: Date,
+    endTime: Date,
+    options?: VaultAuditQueryOptions,
+  ) => Promise<VaultAuditEntry[]>;
+}
+
+export function createVaultAuditTrailDeps(
+  repoDir: string,
+): VaultAuditTrailDeps {
+  const repo: VaultAuditRepository = new JsonlVaultAuditRepository(repoDir);
+  return {
+    findByTimeRange: (startTime, endTime, options) =>
+      repo.findByTimeRange(startTime, endTime, options),
+  };
+}
+
+const DEFAULT_LOOKBACK_DAYS = 7;
+const DEFAULT_LIMIT = 100;
+
+export async function* vaultAuditTrail(
+  ctx: LibSwampContext,
+  deps: VaultAuditTrailDeps,
+  input: VaultAuditTrailInput,
+): AsyncIterable<VaultAuditTrailEvent> {
+  yield* withGeneratorSpan(
+    "swamp.vault.audit_trail",
+    {},
+    (async function* () {
+      yield { kind: "resolving" };
+
+      const now = new Date();
+      const since = input.since ??
+        new Date(
+          now.getTime() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+        );
+      const until = input.until ?? now;
+      const limit = input.limit ?? DEFAULT_LIMIT;
+
+      ctx.logger
+        .debug`Querying vault audit trail: vault=${input.vaultName}, key=${input.secretKey}, since=${since.toISOString()}, until=${until.toISOString()}, limit=${limit}`;
+
+      const entries = await deps.findByTimeRange(since, until, {
+        vaultName: input.vaultName,
+        secretKey: input.secretKey,
+        limit,
+      });
+
+      yield {
+        kind: "completed",
+        data: {
+          entries,
+          totalCount: entries.length,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/vaults/audit_trail.ts
+++ b/src/libswamp/vaults/audit_trail.ts
@@ -25,11 +25,13 @@ import type {
 import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import { validationFailed } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 export interface VaultAuditTrailData {
   entries: VaultAuditEntry[];
-  totalCount: number;
+  returnedCount: number;
+  truncated: boolean;
 }
 
 export type VaultAuditTrailEvent =
@@ -65,6 +67,7 @@ export function createVaultAuditTrailDeps(
 
 const DEFAULT_LOOKBACK_DAYS = 7;
 const DEFAULT_LIMIT = 100;
+const MAX_RANGE_DAYS = 365;
 
 export async function* vaultAuditTrail(
   ctx: LibSwampContext,
@@ -85,20 +88,38 @@ export async function* vaultAuditTrail(
       const until = input.until ?? now;
       const limit = input.limit ?? DEFAULT_LIMIT;
 
+      const rangeDays = Math.ceil(
+        (until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000),
+      );
+      if (rangeDays > MAX_RANGE_DAYS) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `Date range exceeds ${MAX_RANGE_DAYS} days (${rangeDays} days requested). Narrow the --since/--until range.`,
+          ),
+        };
+        return;
+      }
+
       ctx.logger
         .debug`Querying vault audit trail: vault=${input.vaultName}, key=${input.secretKey}, since=${since.toISOString()}, until=${until.toISOString()}, limit=${limit}`;
 
+      const fetchLimit = limit + 1;
       const entries = await deps.findByTimeRange(since, until, {
         vaultName: input.vaultName,
         secretKey: input.secretKey,
-        limit,
+        limit: fetchLimit,
       });
+
+      const truncated = entries.length > limit;
+      const returnedEntries = truncated ? entries.slice(0, limit) : entries;
 
       yield {
         kind: "completed",
         data: {
-          entries,
-          totalCount: entries.length,
+          entries: returnedEntries,
+          returnedCount: returnedEntries.length,
+          truncated,
         },
       };
     })(),

--- a/src/libswamp/vaults/audit_trail.ts
+++ b/src/libswamp/vaults/audit_trail.ts
@@ -91,6 +91,15 @@ export async function* vaultAuditTrail(
       const rangeDays = Math.ceil(
         (until.getTime() - since.getTime()) / (24 * 60 * 60 * 1000),
       );
+      if (rangeDays < 0) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `--since (${since.toISOString()}) is after --until (${until.toISOString()}). The start date must be before the end date.`,
+          ),
+        };
+        return;
+      }
       if (rangeDays > MAX_RANGE_DAYS) {
         yield {
           kind: "error",

--- a/src/libswamp/vaults/audit_trail_test.ts
+++ b/src/libswamp/vaults/audit_trail_test.ts
@@ -1,0 +1,141 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { collect } from "../testing.ts";
+import { createLibSwampContext } from "../context.ts";
+import type { VaultAuditEntry } from "../../domain/vaults/vault_audit_entry.ts";
+import {
+  vaultAuditTrail,
+  type VaultAuditTrailDeps,
+  type VaultAuditTrailEvent,
+} from "./audit_trail.ts";
+
+function makeDeps(
+  entries: VaultAuditEntry[] = [],
+): VaultAuditTrailDeps {
+  return {
+    findByTimeRange: () => Promise.resolve(entries),
+  };
+}
+
+function makeEntry(overrides: Partial<VaultAuditEntry> = {}): VaultAuditEntry {
+  return {
+    timestamp: "2026-07-10T12:00:00.000Z",
+    vaultName: "my-vault",
+    vaultType: "local_encryption",
+    secretKey: "API_KEY",
+    callerContext: "cli:vault-read-secret",
+    ...overrides,
+  };
+}
+
+Deno.test("vaultAuditTrail: returns entries from deps", async () => {
+  const deps = makeDeps([makeEntry(), makeEntry({ secretKey: "DB_PASS" })]);
+
+  const events = await collect<VaultAuditTrailEvent>(
+    vaultAuditTrail(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    VaultAuditTrailEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.returnedCount, 2);
+  assertEquals(completed.data.truncated, false);
+  assertEquals(completed.data.entries.length, 2);
+});
+
+Deno.test("vaultAuditTrail: detects truncation when results exceed limit", async () => {
+  const entries = [
+    makeEntry({ secretKey: "A" }),
+    makeEntry({ secretKey: "B" }),
+    makeEntry({ secretKey: "C" }),
+  ];
+  const deps: VaultAuditTrailDeps = {
+    findByTimeRange: (_s, _e, opts) => {
+      return Promise.resolve(entries.slice(0, opts?.limit));
+    },
+  };
+
+  const events = await collect<VaultAuditTrailEvent>(
+    vaultAuditTrail(createLibSwampContext(), deps, { limit: 2 }),
+  );
+
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    VaultAuditTrailEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.returnedCount, 2);
+  assertEquals(completed.data.truncated, true);
+});
+
+Deno.test("vaultAuditTrail: rejects inverted date range", async () => {
+  const deps = makeDeps();
+
+  const events = await collect<VaultAuditTrailEvent>(
+    vaultAuditTrail(createLibSwampContext(), deps, {
+      since: new Date("2026-07-10"),
+      until: new Date("2026-07-01"),
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAuditTrailEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "is after");
+});
+
+Deno.test("vaultAuditTrail: rejects date range exceeding 365 days", async () => {
+  const deps = makeDeps();
+
+  const events = await collect<VaultAuditTrailEvent>(
+    vaultAuditTrail(createLibSwampContext(), deps, {
+      since: new Date("2024-01-01"),
+      until: new Date("2026-07-10"),
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    VaultAuditTrailEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+  assertStringIncludes(last.error.message, "365 days");
+});
+
+Deno.test("vaultAuditTrail: returns empty result for no entries", async () => {
+  const deps = makeDeps([]);
+
+  const events = await collect<VaultAuditTrailEvent>(
+    vaultAuditTrail(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events.find((e) => e.kind === "completed") as Extract<
+    VaultAuditTrailEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.returnedCount, 0);
+  assertEquals(completed.data.truncated, false);
+  assertEquals(completed.data.entries.length, 0);
+});

--- a/src/libswamp/vaults/create.ts
+++ b/src/libswamp/vaults/create.ts
@@ -56,6 +56,7 @@ export interface VaultCreateInput {
   name: string;
   config?: Record<string, unknown>;
   repoDir: string;
+  auditReads?: boolean;
 }
 
 /** Dependencies for the vault create operation. */
@@ -208,6 +209,7 @@ export async function* vaultCreate(
         input.name,
         input.vaultType,
         providerConfig,
+        input.auditReads,
       );
       await deps.save(vaultConfig);
 

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -21,6 +21,7 @@ import type { VaultAnnotationData } from "../../domain/vaults/vault_annotation.t
 import type { RefreshHookData } from "../../domain/vaults/refresh_hook.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -78,7 +79,12 @@ export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
 
   const getVaultService = () => {
     if (!vaultServicePromise) {
-      vaultServicePromise = VaultService.fromRepository(repoDir);
+      vaultServicePromise = VaultService.fromRepository(repoDir).then(
+        (svc) => {
+          svc.setAuditRepository(new JsonlVaultAuditRepository(repoDir));
+          return svc;
+        },
+      );
     }
     return vaultServicePromise;
   };
@@ -96,7 +102,7 @@ export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
     },
     measureSecretSize: async (vaultName, key) => {
       const svc = await getVaultService();
-      const value = await svc.get(vaultName, key);
+      const value = await svc.get(vaultName, key, "cli:vault-inspect");
       return {
         bytes: new TextEncoder().encode(value).byteLength,
         chars: value.length,

--- a/src/libswamp/vaults/inspect.ts
+++ b/src/libswamp/vaults/inspect.ts
@@ -21,7 +21,6 @@ import type { VaultAnnotationData } from "../../domain/vaults/vault_annotation.t
 import type { RefreshHookData } from "../../domain/vaults/refresh_hook.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -79,12 +78,7 @@ export function createVaultInspectDeps(repoDir: string): VaultInspectDeps {
 
   const getVaultService = () => {
     if (!vaultServicePromise) {
-      vaultServicePromise = VaultService.fromRepository(repoDir).then(
-        (svc) => {
-          svc.setAuditRepository(new JsonlVaultAuditRepository(repoDir));
-          return svc;
-        },
-      );
+      vaultServicePromise = VaultService.fromRepository(repoDir);
     }
     return vaultServicePromise;
   };

--- a/src/libswamp/vaults/migrate.ts
+++ b/src/libswamp/vaults/migrate.ts
@@ -301,7 +301,11 @@ export async function* vaultMigrate(
             total: keys.length,
             key: keys[i],
           };
-          const value = await vaultService.get(input.vaultName, keys[i]);
+          const value = await vaultService.get(
+            input.vaultName,
+            keys[i],
+            "cli:vault-migrate",
+          );
           await targetProvider.put(keys[i], value);
           ctx.logger.debug`Copied secret ${i + 1}/${keys.length}`;
         }

--- a/src/libswamp/vaults/read_secret.ts
+++ b/src/libswamp/vaults/read_secret.ts
@@ -22,6 +22,7 @@ import { createVaultRefreshOptions } from "../../infrastructure/vaults/vault_ref
 import { createVaultSecretRead } from "../../domain/events/types.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
+import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -75,7 +76,10 @@ export function createVaultReadSecretDeps(
         repoDir,
         undefined,
         createVaultRefreshOptions(),
-      );
+      ).then((svc) => {
+        svc.setAuditRepository(new JsonlVaultAuditRepository(repoDir));
+        return svc;
+      });
     }
     return vaultServicePromise;
   };
@@ -88,7 +92,7 @@ export function createVaultReadSecretDeps(
     },
     readSecret: async (vaultName, secretKey) => {
       const svc = await getVaultService();
-      return await svc.get(vaultName, secretKey);
+      return await svc.get(vaultName, secretKey, "cli:vault-read-secret");
     },
     publishSecretRead: async (vaultId, vaultType, vaultName, secretKey) => {
       const event = createVaultSecretRead(

--- a/src/libswamp/vaults/read_secret.ts
+++ b/src/libswamp/vaults/read_secret.ts
@@ -22,7 +22,6 @@ import { createVaultRefreshOptions } from "../../infrastructure/vaults/vault_ref
 import { createVaultSecretRead } from "../../domain/events/types.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import { JsonlVaultAuditRepository } from "../../infrastructure/persistence/jsonl_vault_audit_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
@@ -76,10 +75,7 @@ export function createVaultReadSecretDeps(
         repoDir,
         undefined,
         createVaultRefreshOptions(),
-      ).then((svc) => {
-        svc.setAuditRepository(new JsonlVaultAuditRepository(repoDir));
-        return svc;
-      });
+      );
     }
     return vaultServicePromise;
   };

--- a/src/libswamp/worker/token_create.ts
+++ b/src/libswamp/worker/token_create.ts
@@ -105,7 +105,7 @@ export async function createWorkerTokenCreateDeps(
         definitionName: input.name,
       }),
     readSecret: (vaultName, secretKey) =>
-      vaultService.get(vaultName, secretKey),
+      vaultService.get(vaultName, secretKey, "worker:token-create"),
   };
 }
 

--- a/src/presentation/renderers/vault_audit_trail.ts
+++ b/src/presentation/renderers/vault_audit_trail.ts
@@ -1,0 +1,75 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  EventHandlers,
+  VaultAuditTrailEvent,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+class LogVaultAuditTrailRenderer implements Renderer<VaultAuditTrailEvent> {
+  handlers(): EventHandlers<VaultAuditTrailEvent> {
+    const logger = getSwampLogger(["vault", "audit-trail"]);
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        if (e.data.entries.length === 0) {
+          logger.info`No vault read audit entries found.`;
+          return;
+        }
+        logger.info`${e.data.totalCount} vault read(s):`;
+        for (const entry of e.data.entries) {
+          logger
+            .info`  ${entry.timestamp}  ${entry.vaultName}/${entry.secretKey}  by ${entry.callerContext}`;
+        }
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonVaultAuditTrailRenderer implements Renderer<VaultAuditTrailEvent> {
+  handlers(): EventHandlers<VaultAuditTrailEvent> {
+    return {
+      resolving: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(e.data, null, 2));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createVaultAuditTrailRenderer(
+  mode: OutputMode,
+): Renderer<VaultAuditTrailEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonVaultAuditTrailRenderer();
+    case "log":
+      return new LogVaultAuditTrailRenderer();
+  }
+}

--- a/src/presentation/renderers/vault_audit_trail.ts
+++ b/src/presentation/renderers/vault_audit_trail.ts
@@ -36,10 +36,13 @@ class LogVaultAuditTrailRenderer implements Renderer<VaultAuditTrailEvent> {
           logger.info`No vault read audit entries found.`;
           return;
         }
-        logger.info`${e.data.totalCount} vault read(s):`;
+        logger.info`${e.data.returnedCount} vault read(s):`;
         for (const entry of e.data.entries) {
           logger
-            .info`  ${entry.timestamp}  ${entry.vaultName}/${entry.secretKey}  by ${entry.callerContext}`;
+            .info`  ${entry.timestamp}  ${entry.vaultName} (${entry.vaultType})/${entry.secretKey}  by ${entry.callerContext}`;
+        }
+        if (e.data.truncated) {
+          logger.info`  (results truncated — use --limit to see more)`;
         }
       },
       error: (e) => {

--- a/src/serve/capability_service.ts
+++ b/src/serve/capability_service.ts
@@ -406,7 +406,11 @@ export class CapabilityService {
       );
       return { value: annotation };
     }
-    const value = await vault.get(params.vaultName, params.secretKey);
+    const value = await vault.get(
+      params.vaultName,
+      params.secretKey,
+      `serve:${workerName}`,
+    );
     return { value };
   }
 


### PR DESCRIPTION
## Summary

- Adds opt-in per-vault `auditReads` flag that records every `VaultService.get()` call to append-only JSONL files under `.swamp/audit/vault-reads-YYYY-MM-DD.jsonl`
- New `swamp vault audit-trail` CLI command queries the trail with `--vault`, `--key`, `--since`, `--until`, `--limit` filters in both log and JSON output modes
- Audit interception at the VaultService level covers CLI reads, model method reads, and expression-resolved reads — un-bypassable when enabled
- Follows established JSONL audit pattern from `JsonlAuditRepository`; vault providers (including extensions) get audit for free with zero changes to the extension API

Closes swamp-club#1109

## Test Plan

- [x] Unit tests: VaultAuditEntry round-trip (4 tests), vault audit path helpers (5 tests), JsonlVaultAuditRepository append/query/filter/limit/time-range (6 tests), VaultService audit enabled/disabled/no-repo/default-context/error-absorption (5 tests), VaultConfig auditReads backward compat (existing tests pass)
- [x] End-to-end verification: compiled binary → `vault create --audit-reads` → `vault put` → `vault read-secret` → `vault audit-trail` shows entry with correct vaultType/callerContext; `vault inspect` also creates audit entry; non-audited vault produces no entries
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test`, `deno run compile` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)