### PR TITLE
fix(repo): switch Cursor/Kiro to shared instructionsMode, add wizard mode prompt (swamp-club#1106)

### DIFF
--- a/.claude/skills/swamp/references/repo/reference.md
+++ b/.claude/skills/swamp/references/repo/reference.md
@@ -62,6 +62,38 @@ primary stable.
 Duplicate `--tool` values are silently collapsed. `--tool none` cannot be
 combined with other `--tool` values.
 
+### Instructions mode
+
+Each tool's instructions file uses one of two modes that control how
+`repo upgrade` handles the file:
+
+- **`shared`** — swamp manages a marked section
+  (`<!-- BEGIN swamp managed
+  section -->` / `<!-- END ... -->`) inside the
+  file, preserving any user content outside the markers. Used by all built-in
+  tools (Claude, Cursor, Kiro, OpenCode, Codex, Copilot).
+- **`owned`** — swamp fully controls the file and overwrites it on every
+  `repo upgrade`. No user content is preserved. Used when you explicitly want
+  swamp to own the entire file.
+
+For custom tools defined via `swamp agent setup`, the wizard asks which mode to
+use. The default is derived from the filename: root-level files matching a known
+set (`AGENTS.md`, `AGENT.md`, `CLAUDE.md`, `CONVENTIONS.md`) default to
+`shared`; all other paths default to `owned`.
+
+To override the mode after setup, edit `.swamp-custom-tools.yaml` directly:
+
+```yaml
+tools:
+  - name: mytool
+    instructionsFile: .mytool/rules/swamp.md
+    instructionsMode: shared # or "owned"
+    skillsDir: .mytool/skills
+    skillReferenceStyle: path
+```
+
+Use `swamp agent list` to see the current mode for each custom tool.
+
 **Output shape:**
 
 ```json

--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -165,6 +165,23 @@ Some tools need a header like this to auto-load rules:
       def.frontmatter = frontmatter;
     }
 
+    if (def.instructionsMode === "owned") {
+      await Deno.stdout.write(encoder.encode(`
+The instructions file "${def.instructionsFile}" will use "owned" mode by default,
+which means swamp fully controls the file and overwrites it on every \`repo upgrade\`.
+
+If this file may contain content you want to preserve (hand-written rules,
+project-specific instructions), choose "shared" mode instead — swamp will only
+manage a marked section and leave the rest untouched.
+`));
+      const useShared = await promptConfirmation(
+        "Use shared mode (preserve surrounding content)?",
+      );
+      if (useShared) {
+        def.instructionsMode = "shared";
+      }
+    }
+
     const skillsDirChoices = buildSkillsDirChoices(detection, def.skillsDir);
     let chosenSkillsDir: string | undefined;
     if (skillsDirChoices.length > 1) {
@@ -206,9 +223,11 @@ Some tools need a header like this to auto-load rules:
     await Deno.stdout.write(encoder.encode(`
 Custom agent "${name}" configured:
   Skills:        ${def.skillsDir}/
-  Instructions:  ${def.instructionsFile}${
-      def.instructionsMode === "shared" ? " (shared)" : ""
-    }
+  Instructions:  ${def.instructionsFile} (${
+      def.instructionsMode === "owned"
+        ? "owned — fully overwritten on upgrade"
+        : "shared"
+    })
   Frontmatter:   ${def.frontmatter ? "yes" : "none"}
 
 Saved to .swamp-custom-tools.yaml

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -112,7 +112,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         isBuiltIn: true,
         skillsDir: ".cursor/skills",
         instructionsFile: ".cursor/rules/swamp.mdc",
-        instructionsMode: "owned",
+        instructionsMode: "shared",
         frontmatter:
           "---\ndescription: Swamp automation rules\nalwaysApply: true\n---\n",
         skillReferenceStyle: "path",
@@ -150,7 +150,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         isBuiltIn: true,
         skillsDir: ".kiro/skills",
         instructionsFile: ".kiro/steering/swamp-rules.md",
-        instructionsMode: "owned",
+        instructionsMode: "shared",
         frontmatter: "---\ninclusion: always\n---\n",
         skillReferenceStyle: "path",
       };

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -116,7 +116,7 @@ Deno.test("builtInToolConfig: cursor config", () => {
   assertEquals(config.isBuiltIn, true);
   assertEquals(config.skillsDir, ".cursor/skills");
   assertEquals(config.instructionsFile, ".cursor/rules/swamp.mdc");
-  assertEquals(config.instructionsMode, "owned");
+  assertEquals(config.instructionsMode, "shared");
   assertEquals(config.skillReferenceStyle, "path");
   assertEquals(config.frontmatter !== undefined, true);
 });
@@ -127,7 +127,7 @@ Deno.test("builtInToolConfig: kiro config", () => {
   assertEquals(config.isBuiltIn, true);
   assertEquals(config.skillsDir, ".kiro/skills");
   assertEquals(config.instructionsFile, ".kiro/steering/swamp-rules.md");
-  assertEquals(config.instructionsMode, "owned");
+  assertEquals(config.instructionsMode, "shared");
 });
 
 Deno.test("builtInToolConfig: opencode/codex/copilot share AGENTS.md", () => {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -843,7 +843,8 @@ export class RepoService {
     // Case 1: No file exists — create with managed section
     if (existingContent === null) {
       await ensureDir(join(filePath, ".."));
-      await Deno.writeTextFile(filePath, newSection + "\n");
+      const prefix = config.frontmatter ?? "";
+      await Deno.writeTextFile(filePath, prefix + newSection + "\n");
       return true;
     }
 
@@ -924,9 +925,19 @@ export class RepoService {
       return newSection + "\n" + separator + content;
     }
 
-    // Find end: "Use `swamp --help` to see available commands.\n"
-    const endMarker = "Use `swamp --help` to see available commands.\n";
-    const endIndex = content.indexOf(endMarker, startMatch.index);
+    const endMarkers = [
+      "scopes to a subtree.\n",
+      "Use `swamp --help` to see available commands.\n",
+    ];
+    let endIndex = -1;
+    let endMarker = "";
+    for (const marker of endMarkers) {
+      endIndex = content.indexOf(marker, startMatch.index);
+      if (endIndex !== -1) {
+        endMarker = marker;
+        break;
+      }
+    }
 
     if (endIndex === -1) {
       // Start matched but end didn't — the user edited the template.

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -683,12 +683,14 @@ Deno.test("RepoService.init with cursor creates .cursor/skills/ and .cursor/rule
     // Skills are now installed globally, not in repo
     assertEquals(result.skillsCopied.includes("swamp"), true);
 
-    // Check instructions file is .cursor/rules/swamp.mdc with MDC frontmatter
+    // Check instructions file is .cursor/rules/swamp.mdc with MDC frontmatter at byte 0
     const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
     const content = await Deno.readTextFile(mdcPath);
+    assertEquals(content.startsWith("---\n"), true);
     assertStringIncludes(content, "alwaysApply: true");
     assertStringIncludes(content, "swamp");
     assertStringIncludes(content, "## Skills");
+    assertStringIncludes(content, "<!-- BEGIN swamp managed section");
 
     // Check .cursor/hooks.json was created
     const hooksPath = join(tempDir, ".cursor", "hooks.json");
@@ -1082,7 +1084,7 @@ Deno.test("RepoService.upgrade returns unchanged when section is current", async
   });
 });
 
-Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () => {
+Deno.test("RepoService.init cursor instructions have MDC frontmatter at byte 0 with managed section", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
@@ -1092,10 +1094,13 @@ Deno.test("RepoService.init cursor instructions have MDC frontmatter", async () 
     const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
     const content = await Deno.readTextFile(mdcPath);
 
-    // Check MDC frontmatter
-    assertStringIncludes(content, "---\n");
+    // Frontmatter at byte 0
+    assertEquals(content.startsWith("---\n"), true);
     assertStringIncludes(content, "description: Swamp automation rules");
     assertStringIncludes(content, "alwaysApply: true");
+    // Managed section markers present
+    assertStringIncludes(content, "<!-- BEGIN swamp managed section");
+    assertStringIncludes(content, "<!-- END swamp managed section");
   });
 });
 
@@ -2100,69 +2105,78 @@ Use \`swamp --help\` to see available commands.
   });
 });
 
-Deno.test("RepoService.upgrade cursor files are still fully overwritten (no markers)", async () => {
+Deno.test("RepoService.upgrade cursor uses shared mode with managed section markers", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     await service.init(repoPath, { tools: ["cursor"] });
 
-    // Replace cursor instructions with stale content
     const mdcPath = join(tempDir, ".cursor", "rules", "swamp.mdc");
-    await Deno.writeTextFile(mdcPath, "---\nalwaysApply: true\n---\nold");
+
+    // Add user content after the managed section
+    const original = await Deno.readTextFile(mdcPath);
+    await Deno.writeTextFile(
+      mdcPath,
+      original + "\n## My Custom Rules\n\nUse TypeScript strict mode.\n",
+    );
 
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath, {
       tools: ["cursor"],
     });
 
-    assertEquals(result.instructionsUpdated, true);
+    assertEquals(result.instructionsUpdated, false);
 
     const content = await Deno.readTextFile(mdcPath);
-    // Full overwrite — should not have markers
-    assertEquals(
-      content.includes("<!-- BEGIN swamp managed section"),
-      false,
-    );
-    // Should have current template
-    assertStringIncludes(content, "## Skills");
+    // Should have managed section markers
+    assertStringIncludes(content, "<!-- BEGIN swamp managed section");
+    assertStringIncludes(content, "<!-- END swamp managed section");
+    // Frontmatter at byte 0
+    assertEquals(content.startsWith("---\n"), true);
     assertStringIncludes(content, "alwaysApply: true");
+    // User content preserved
+    assertStringIncludes(content, "## My Custom Rules");
+    assertStringIncludes(content, "Use TypeScript strict mode.");
   });
 });
 
-Deno.test("RepoService.upgrade kiro files are still fully overwritten (no markers)", async () => {
+Deno.test("RepoService.upgrade kiro uses shared mode with managed section markers", async () => {
   await withTempDir(async (tempDir) => {
     const service = new RepoService("0.1.0");
     const repoPath = RepoPath.create(tempDir);
 
     await service.init(repoPath, { tools: ["kiro"] });
 
-    // Replace kiro instructions with stale content
     const steeringPath = join(
       tempDir,
       ".kiro",
       "steering",
       "swamp-rules.md",
     );
+
+    // Add user content after the managed section
+    const original = await Deno.readTextFile(steeringPath);
     await Deno.writeTextFile(
       steeringPath,
-      "---\ninclusion: always\n---\nold content",
+      original + "\n## My Custom Rules\n\nUse TypeScript strict mode.\n",
     );
 
     const upgradeService = new RepoService("0.2.0");
     const result = await upgradeService.upgrade(repoPath, { tools: ["kiro"] });
 
-    assertEquals(result.instructionsUpdated, true);
+    assertEquals(result.instructionsUpdated, false);
 
     const content = await Deno.readTextFile(steeringPath);
-    // Full overwrite — should not have markers
-    assertEquals(
-      content.includes("<!-- BEGIN swamp managed section"),
-      false,
-    );
-    // Should have current template
-    assertStringIncludes(content, "## Skills");
+    // Should have managed section markers
+    assertStringIncludes(content, "<!-- BEGIN swamp managed section");
+    assertStringIncludes(content, "<!-- END swamp managed section");
+    // Frontmatter at byte 0
+    assertEquals(content.startsWith("---\n"), true);
     assertStringIncludes(content, "inclusion: always");
+    // User content preserved
+    assertStringIncludes(content, "## My Custom Rules");
+    assertStringIncludes(content, "Use TypeScript strict mode.");
   });
 });
 


### PR DESCRIPTION
## Summary

- Switch Cursor and Kiro built-in tool configs from `owned` to `shared` instructionsMode, so `repo upgrade` preserves user content outside the managed section markers instead of silently overwriting the entire file
- Fix `ensureInstructionsSection()` to prepend frontmatter before the managed section (at byte 0) so Cursor's `.mdc` parser and Kiro's steering parser can still read their required headers
- Fix stale `endMarker` in `migrateLegacyInstructions()` — the template text evolved but the end marker wasn't updated, causing migration from old owned-mode files to fall back to prepend (which buried frontmatter below the markers)
- Add an `instructionsMode` prompt to the `swamp agent setup` wizard when the derived default is `owned`, letting users choose `shared` mode for custom tools
- Always annotate the mode in the wizard completion summary and `agent list` output — previously only `shared` was annotated, `owned` showed nothing
- Document `instructionsMode` in the swamp skill repo reference

Closes swamp-club#1106

### Migration note

Existing Cursor/Kiro users will see a one-time diff on their next `repo upgrade`: the instructions file gets wrapped in `<!-- BEGIN/END swamp managed section -->` markers. The frontmatter stays at byte 0. Any hand-written content after the template body is preserved after the END marker.

## Test Plan

- Updated `builtInToolConfig` tests to assert `shared` mode for cursor/kiro
- Updated `RepoService.upgrade` tests from "fully overwritten (no markers)" to "shared mode with managed section markers" — verifies frontmatter at byte 0, markers present, and user content preserved after upgrade
- Updated `RepoService.init` cursor test to verify frontmatter at byte 0 with managed section markers
- Verified with compiled binary: fresh init, upgrade with custom content, and migration from old format all produce correct output
- All 8800 tests pass, `deno check`/`deno lint`/`deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)