### PR TITLE
fix(update): use atomic rename to avoid SIGKILLing running processes on macOS

### DIFF
--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { dirname, join } from "@std/path";
 import type { Platform } from "../../domain/update/platform.ts";
 import type { UpdateChecker } from "../../domain/update/update_service.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -54,45 +55,67 @@ async function removeQuarantine(path: string): Promise<void> {
 /**
  * Replace a binary at `targetPath` with the file at `sourcePath`.
  *
- * On Linux, overwriting a running binary fails with ETXTBSY because the kernel
- * prevents writing to an inode with active text mappings. The standard fix is
- * to remove the directory entry first (the running process keeps its fd open),
- * then move the new file into place.
+ * Uses atomic rename to create a new inode at the target path. Running
+ * processes keep their vnode reference to the old inode — no SIGKILL on
+ * macOS (code-signed binaries stay valid), no ETXTBSY on Linux (rename
+ * operates on directory entries, not file data).
  *
  * Strategy:
- * 1. Try `Deno.rename()` — atomic, no ETXTBSY (operates on directory entries).
- * 2. If rename fails with EXDEV (cross-filesystem), fall back to
- *    `Deno.remove()` + `Deno.copyFile()`.
+ * 1. Try `Deno.rename()` — atomic, replaces the target in one syscall.
+ * 2. If rename fails with EXDEV (cross-filesystem), copy to a temp file
+ *    in the target directory (guaranteeing same-filesystem), then rename.
  */
 async function replaceBinary(
   sourcePath: string,
   targetPath: string,
 ): Promise<void> {
+  // Clean up stale temp files from a previous crashed update
+  const targetDir = dirname(targetPath);
   try {
-    // Unlink first to release the inode on Linux
-    try {
-      await Deno.remove(targetPath);
-    } catch (error) {
-      // NotFound is fine — target may not exist yet
-      if (error instanceof Deno.errors.NotFound) {
-        // OK
-      } else if (error instanceof Deno.errors.PermissionDenied) {
-        throw new UserError(
-          `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`,
-        );
-      } else {
-        throw error;
+    for await (const entry of Deno.readDir(targetDir)) {
+      if (entry.name.startsWith(".swamp.tmp.")) {
+        try {
+          await Deno.remove(join(targetDir, entry.name));
+        } catch {
+          // Best-effort cleanup
+        }
       }
     }
+  } catch {
+    // readDir may fail on permission errors — not fatal
+  }
+
+  try {
     await Deno.rename(sourcePath, targetPath);
   } catch (error) {
-    // EXDEV: source and target on different filesystems — rename won't work
+    if (error instanceof Deno.errors.PermissionDenied) {
+      throw new UserError(
+        `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`,
+      );
+    }
+    // EXDEV: source and target on different filesystems — rename won't work.
+    // Copy to a temp file in the target directory, then atomic rename.
     const code = error instanceof Error
       ? (error as Error & { code?: string }).code
       : undefined;
     if (code === "EXDEV") {
-      // Target already removed above, so copyFile won't hit ETXTBSY
-      await Deno.copyFile(sourcePath, targetPath);
+      const tmpPath = join(targetDir, `.swamp.tmp.${crypto.randomUUID()}`);
+      try {
+        await Deno.copyFile(sourcePath, tmpPath);
+        await Deno.rename(tmpPath, targetPath);
+      } catch (innerError) {
+        try {
+          await Deno.remove(tmpPath);
+        } catch {
+          // Best-effort cleanup
+        }
+        if (innerError instanceof Deno.errors.PermissionDenied) {
+          throw new UserError(
+            `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`,
+          );
+        }
+        throw innerError;
+      }
     } else {
       throw error;
     }
@@ -244,7 +267,7 @@ export class HttpUpdateChecker implements UpdateChecker {
         await removeQuarantine(extractedBinary);
       }
 
-      // Replace the current binary (unlink-then-rename to avoid ETXTBSY on Linux)
+      // Replace the current binary (atomic rename to preserve running processes)
       await replaceBinary(extractedBinary, binaryPath);
 
       // chmod is meaningless on Windows (file permissions live in the ACL,

--- a/src/infrastructure/update/http_update_checker_test.ts
+++ b/src/infrastructure/update/http_update_checker_test.ts
@@ -17,7 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { Platform } from "../../domain/update/platform.ts";
@@ -171,6 +176,100 @@ Deno.test({
           stat.mode! & 0o777,
           0o755,
           `expected mode 0o755; got 0o${(stat.mode! & 0o777).toString(8)}`,
+        );
+      } finally {
+        await server.shutdown();
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "HttpUpdateChecker.downloadAndInstall: replacement creates a new inode (old inode survives)",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-update-test-" });
+    try {
+      const { body, checksum } = await buildFakeSwampTarball();
+      const binaryPath = join(tempDir, "swamp");
+
+      // Place an initial binary and record its inode
+      await Deno.writeTextFile(binaryPath, "#!/bin/sh\necho original\n");
+      await Deno.chmod(binaryPath, 0o755);
+      const oldStat = await Deno.stat(binaryPath);
+      const oldIno = oldStat.ino;
+
+      const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+        return new Response(body, {
+          headers: { "content-type": "application/gzip" },
+        });
+      });
+
+      try {
+        const port = server.addr.port;
+        const url = `http://localhost:${port}/swamp.tar.gz`;
+
+        const checker = new HttpUpdateChecker();
+        await checker.downloadAndInstall(url, binaryPath, checksum);
+
+        const newStat = await Deno.stat(binaryPath);
+        assertNotEquals(
+          newStat.ino,
+          oldIno,
+          "replacement must create a new inode so running processes keep the old one",
+        );
+      } finally {
+        await server.shutdown();
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "HttpUpdateChecker.downloadAndInstall: cleans up stale .swamp.tmp files",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "swamp-update-test-" });
+    try {
+      const { body, checksum } = await buildFakeSwampTarball();
+      const binaryPath = join(tempDir, "swamp");
+
+      // Simulate a stale temp file from a previous crashed update
+      const stalePath = join(tempDir, ".swamp.tmp.stale-uuid");
+      await Deno.writeTextFile(stalePath, "stale");
+
+      const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+        return new Response(body, {
+          headers: { "content-type": "application/gzip" },
+        });
+      });
+
+      try {
+        const port = server.addr.port;
+        const url = `http://localhost:${port}/swamp.tar.gz`;
+
+        const checker = new HttpUpdateChecker();
+        await checker.downloadAndInstall(url, binaryPath, checksum);
+
+        // Stale temp file should be cleaned up
+        let staleExists = true;
+        try {
+          await Deno.stat(stalePath);
+        } catch (error) {
+          if (error instanceof Deno.errors.NotFound) {
+            staleExists = false;
+          }
+        }
+        assertEquals(
+          staleExists,
+          false,
+          "stale .swamp.tmp file should be cleaned up during update",
         );
       } finally {
         await server.shutdown();


### PR DESCRIPTION
## Summary

- Rewrite `replaceBinary()` to use atomic `rename()` instead of `remove()` + `rename()`, preventing macOS from SIGKILLing running processes (like `swamp serve`) whose code-signed binary is being updated
- Add EXDEV fallback that copies to a temp file in the target directory before renaming, guaranteeing same-filesystem atomicity
- Clean up stale `.swamp.tmp.*` files from previously crashed updates

Fixes swamp-club#1114

## Root Cause

PR #859 added `Deno.remove(targetPath)` before `Deno.rename()` to fix Linux ETXTBSY. On macOS, unlinking a code-signed Mach-O binary that's memory-mapped by running processes causes the kernel to SIGKILL those processes. The atomic `rename()` approach (used by rustup's `self-replace` crate) avoids both issues: it operates on directory entries without opening files for writing (no ETXTBSY) and creates a new inode at the target path (running processes keep the old vnode with valid code-signing).

## Test plan

- [x] New unit test: replacement creates a new inode (old inode survives)
- [x] New unit test: stale `.swamp.tmp` files are cleaned up
- [x] All 30 existing update tests pass
- [x] Manual E2E: compiled binary, started `swamp serve`, replaced binary — serve process survived (PID unchanged, 30+ seconds uptime, clean SIGTERM termination)
- [x] `deno check` / `deno lint` / `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)