### PR TITLE
feat(auth): add first-run nudge and installer account prompt

### DIFF
--- a/integration/auth_nudge_test.ts
+++ b/integration/auth_nudge_test.ts
@@ -23,7 +23,10 @@ import { CLI_ARGS } from "./test_helpers.ts";
 import { YamlDefinitionRepository } from "../src/infrastructure/persistence/yaml_definition_repository.ts";
 import { Definition } from "../src/domain/definitions/definition.ts";
 import { SHELL_MODEL_TYPE } from "../src/domain/models/command/shell/shell_model.ts";
-import { AUTH_NUDGE_MESSAGE } from "../src/domain/auth/auth_nudge.ts";
+import {
+  AUTH_FIRST_RUN_MESSAGE_LINES,
+  AUTH_NUDGE_MESSAGE,
+} from "../src/domain/auth/auth_nudge.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-auth-nudge-" });
@@ -178,7 +181,7 @@ Deno.test({
       await withTempDir(async (configDir) => {
         await initializeTestRepo(repoDir);
 
-        // First run: nudge should appear in stderr
+        // First run: first-run nudge should appear in stderr
         const first = await runCliCommand(
           ["version", "--no-telemetry"],
           repoDir,
@@ -188,7 +191,7 @@ Deno.test({
         assertEquals(first.code, 0, `version failed: ${first.stderr}`);
         assertStringIncludes(
           first.stderr,
-          "Join & participate in the community",
+          AUTH_FIRST_RUN_MESSAGE_LINES[0],
         );
         assertStringIncludes(first.stderr, "swamp auth login");
 
@@ -201,9 +204,14 @@ Deno.test({
 
         assertEquals(second.code, 0, `version failed: ${second.stderr}`);
         assertEquals(
+          second.stderr.includes(AUTH_FIRST_RUN_MESSAGE_LINES[0]),
+          false,
+          "first-run nudge should not repeat",
+        );
+        assertEquals(
           second.stderr.includes("Join & participate in the community"),
           false,
-          "nudge should be throttled on second run within 24h",
+          "regular nudge should be throttled on second run within 24h",
         );
       });
     });

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -329,10 +329,11 @@ function Main {
     # Prompt to connect to SWAMP CLUB when running interactively
     if ([Environment]::UserInteractive -and [Console]::KeyAvailable -ne $null) {
         Write-Host ""
-        Write-Header "swamp is powered by SWAMP CLUB (swamp-club.com)"
+        Write-Header "Swamp is powered by SWAMP CLUB (swamp-club.com)"
         Write-Info ""
-        Write-Info "Connect your account to unlock extensions, sharing,"
-        Write-Info "and higher rate limits."
+        Write-Info "Connect your account to unlock:"
+        Write-Info "  - Higher rate limits"
+        Write-Info "  - Community features"
         Write-Info ""
         $answer = Read-Host "  Set up your SWAMP CLUB account now? [Y/n]"
         if ($answer -match '^[nN]') {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -332,6 +332,7 @@ function Main {
         Write-Header "Swamp is powered by SWAMP CLUB (swamp-club.com)"
         Write-Info ""
         Write-Info "Connect your account to unlock:"
+        Write-Info "  - Share extensions with the community"
         Write-Info "  - Higher rate limits"
         Write-Info "  - Community features"
         Write-Info ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -329,12 +329,12 @@ function Main {
     # Prompt to connect to SWAMP CLUB when running interactively
     if ([Environment]::UserInteractive -and [Console]::KeyAvailable -ne $null) {
         Write-Host ""
-        Write-Header "Swamp is powered by SWAMP CLUB (swamp-club.com)"
+        Write-Header "Swamp is better with SWAMP CLUB (swamp-club.com)"
         Write-Info ""
         Write-Info "Connect your account to unlock:"
-        Write-Info "  - Share extensions with the community"
-        Write-Info "  - Higher rate limits"
-        Write-Info "  - Community features"
+        Write-Info "  - Submit bug reports and feature requests"
+        Write-Info "  - Publish extensions to share with the community"
+        Write-Info "  - Higher rate limits on CLI usage"
         Write-Info ""
         $answer = Read-Host "  Set up your SWAMP CLUB account now? [Y/n]"
         if ($answer -match '^[nN]') {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -325,6 +325,27 @@ function Main {
 
     Write-Header "Installation of '$BinName' release '$Version' complete"
     Write-Info ""
+
+    # Prompt to connect to SWAMP CLUB when running interactively
+    if ([Environment]::UserInteractive -and [Console]::KeyAvailable -ne $null) {
+        Write-Host ""
+        Write-Header "swamp is powered by SWAMP CLUB (swamp-club.com)"
+        Write-Info ""
+        Write-Info "Connect your account to unlock extensions, sharing,"
+        Write-Info "and higher rate limits."
+        Write-Info ""
+        $answer = Read-Host "  Set up your SWAMP CLUB account now? [Y/n]"
+        if ($answer -match '^[nN]') {
+            Write-Info ""
+            Write-Info "No problem! You can connect later: swamp auth login"
+        } else {
+            Write-Host ""
+            $installedBinary = Join-Path $Destination $BinExe
+            & $installedBinary auth login
+        }
+        Write-Host ""
+    }
+
     Write-Success "Run 'swamp --help' to get started"
     if (-not $AddToPath) {
         $binaryLocation = Join-Path $Destination $BinExe

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,7 +88,7 @@ main() {
   echo
 
   # Prompt to connect to SWAMP CLUB when running interactively
-  if [ -t 0 ] && [ -t 1 ]; then
+  if [ -e /dev/tty ] && [ -t 1 ]; then
     echo
     section "Swamp is better with SWAMP CLUB (swamp-club.com)"
     info ""
@@ -106,7 +106,7 @@ main() {
         ;;
       *)
         echo
-        "$dest/$bin" auth login
+        "$dest/$bin" auth login </dev/tty
         ;;
     esac
     echo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,6 +93,7 @@ main() {
     section "Swamp is powered by SWAMP CLUB (swamp-club.com)"
     info ""
     info "Connect your account to unlock:"
+    info "  - Share extensions with the community"
     info "  - Higher rate limits"
     info "  - Community features"
     info ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,10 +90,11 @@ main() {
   # Prompt to connect to SWAMP CLUB when running interactively
   if [ -t 0 ] && [ -t 1 ]; then
     echo
-    section "swamp is powered by SWAMP CLUB (swamp-club.com)"
+    section "Swamp is powered by SWAMP CLUB (swamp-club.com)"
     info ""
-    info "Connect your account to unlock extensions, sharing,"
-    info "and higher rate limits."
+    info "Connect your account to unlock:"
+    info "  - Higher rate limits"
+    info "  - Community features"
     info ""
     printf "  Set up your SWAMP CLUB account now? [Y/n] "
     read -r _answer </dev/tty || _answer=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,12 +90,12 @@ main() {
   # Prompt to connect to SWAMP CLUB when running interactively
   if [ -t 0 ] && [ -t 1 ]; then
     echo
-    section "Swamp is powered by SWAMP CLUB (swamp-club.com)"
+    section "Swamp is better with SWAMP CLUB (swamp-club.com)"
     info ""
     info "Connect your account to unlock:"
-    info "  - Share extensions with the community"
-    info "  - Higher rate limits"
-    info "  - Community features"
+    info "  - Submit bug reports and feature requests"
+    info "  - Publish extensions to share with the community"
+    info "  - Higher rate limits on CLI usage"
     info ""
     printf "  Set up your SWAMP CLUB account now? [Y/n] "
     read -r _answer </dev/tty || _answer=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -86,6 +86,30 @@ main() {
   section "Installation of '$bin' release '$version' complete"
   indent "$dest/$bin" --version
   echo
+
+  # Prompt to connect to SWAMP CLUB when running interactively
+  if [ -t 0 ] && [ -t 1 ]; then
+    echo
+    section "swamp is powered by SWAMP CLUB (swamp-club.com)"
+    info ""
+    info "Connect your account to unlock extensions, sharing,"
+    info "and higher rate limits."
+    info ""
+    printf "  Set up your SWAMP CLUB account now? [Y/n] "
+    read -r _answer </dev/tty || _answer=""
+    case "$_answer" in
+      [nN]*)
+        info ""
+        info "No problem! You can connect later: swamp auth login"
+        ;;
+      *)
+        echo
+        "$dest/$bin" auth login
+        ;;
+    esac
+    echo
+  fi
+
   info "Next steps:"
   info ""
   info "  1. Initialize a swamp repository:"

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -131,8 +131,14 @@ import { UpdateCheckCacheFileRepository } from "../infrastructure/update/update_
 import { HttpUpdateChecker } from "../infrastructure/update/http_update_checker.ts";
 import { Platform } from "../domain/update/platform.ts";
 import { renderUpdateNotification } from "../presentation/renderers/update_notification.ts";
-import { renderAuthNudge } from "../presentation/renderers/auth_nudge.ts";
-import { shouldShowAuthNudge } from "../domain/auth/auth_nudge.ts";
+import {
+  renderAuthNudge,
+  renderFirstRunNudge,
+} from "../presentation/renderers/auth_nudge.ts";
+import {
+  isFirstRunNudge,
+  shouldShowAuthNudge,
+} from "../domain/auth/auth_nudge.ts";
 import { AuthNudgeRepository } from "../infrastructure/persistence/auth_nudge_repository.ts";
 import { UpdatePreferencesFileRepository } from "../infrastructure/update/update_preferences_file_repository.ts";
 import { AutoupdateLogFileRepository } from "../infrastructure/update/autoupdate_log_file_repository.ts";
@@ -1533,7 +1539,11 @@ export async function runCli(args: string[]): Promise<void> {
             const nudgeRepo = new AuthNudgeRepository();
             const nudgeState = await nudgeRepo.read();
             if (shouldShowAuthNudge(nudgeState)) {
-              renderAuthNudge();
+              if (isFirstRunNudge(nudgeState)) {
+                renderFirstRunNudge();
+              } else {
+                renderAuthNudge();
+              }
               await nudgeRepo.markShown();
             }
           } catch {

--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -24,6 +24,7 @@ export const AUTH_FIRST_RUN_MESSAGE_LINES = [
   "Swamp is powered by SWAMP CLUB (swamp-club.com)",
   "",
   "Connect your account to unlock:",
+  "  - Share extensions with the community",
   "  - Higher rate limits",
   "  - Community features",
   "",

--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -21,10 +21,9 @@ export const AUTH_NUDGE_MESSAGE =
   "Tip: Join & participate in the community by logging in to swamp-club.com: swamp auth login";
 
 export const AUTH_FIRST_RUN_MESSAGE_LINES = [
-  "swamp is powered by SWAMP CLUB (swamp-club.com)",
+  "Swamp is powered by SWAMP CLUB (swamp-club.com)",
   "",
   "Connect your account to unlock:",
-  "  - Publishing & installing extensions",
   "  - Higher rate limits",
   "  - Community features",
   "",

--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -21,12 +21,12 @@ export const AUTH_NUDGE_MESSAGE =
   "Tip: Join & participate in the community by logging in to swamp-club.com: swamp auth login";
 
 export const AUTH_FIRST_RUN_MESSAGE_LINES = [
-  "Swamp is powered by SWAMP CLUB (swamp-club.com)",
+  "Swamp is better with SWAMP CLUB (swamp-club.com)",
   "",
   "Connect your account to unlock:",
-  "  - Share extensions with the community",
-  "  - Higher rate limits",
-  "  - Community features",
+  "  - Submit bug reports and feature requests",
+  "  - Publish extensions to share with the community",
+  "  - Higher rate limits on CLI usage",
   "",
   "Get started: swamp auth login",
 ] as const;

--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -20,13 +20,30 @@
 export const AUTH_NUDGE_MESSAGE =
   "Tip: Join & participate in the community by logging in to swamp-club.com: swamp auth login";
 
+export const AUTH_FIRST_RUN_MESSAGE_LINES = [
+  "swamp is powered by SWAMP CLUB (swamp-club.com)",
+  "",
+  "Connect your account to unlock:",
+  "  - Publishing & installing extensions",
+  "  - Higher rate limits",
+  "  - Community features",
+  "",
+  "Get started: swamp auth login",
+] as const;
+
 export interface AuthNudgeState {
   lastShown?: string;
+  firstRunShown?: boolean;
 }
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+export function isFirstRunNudge(state: AuthNudgeState): boolean {
+  return !state.firstRunShown;
+}
+
 export function shouldShowAuthNudge(state: AuthNudgeState): boolean {
+  if (!state.firstRunShown) return true;
   if (!state.lastShown) return true;
   const lastShown = new Date(state.lastShown).getTime();
   return Date.now() - lastShown >= ONE_DAY_MS;

--- a/src/domain/auth/auth_nudge_test.ts
+++ b/src/domain/auth/auth_nudge_test.ts
@@ -18,23 +18,48 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { shouldShowAuthNudge } from "./auth_nudge.ts";
+import { isFirstRunNudge, shouldShowAuthNudge } from "./auth_nudge.ts";
 
 Deno.test("shouldShowAuthNudge: returns true when no lastShown", () => {
   assertEquals(shouldShowAuthNudge({}), true);
 });
 
+Deno.test("shouldShowAuthNudge: returns true when firstRunShown is false and no lastShown", () => {
+  assertEquals(shouldShowAuthNudge({ firstRunShown: false }), true);
+});
+
 Deno.test("shouldShowAuthNudge: returns true when lastShown is over 24 hours ago", () => {
   const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
-  assertEquals(shouldShowAuthNudge({ lastShown: twoDaysAgo }), true);
+  assertEquals(
+    shouldShowAuthNudge({ lastShown: twoDaysAgo, firstRunShown: true }),
+    true,
+  );
 });
 
 Deno.test("shouldShowAuthNudge: returns false when lastShown is within 24 hours", () => {
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
-  assertEquals(shouldShowAuthNudge({ lastShown: oneHourAgo }), false);
+  assertEquals(
+    shouldShowAuthNudge({ lastShown: oneHourAgo, firstRunShown: true }),
+    false,
+  );
 });
 
 Deno.test("shouldShowAuthNudge: returns true when lastShown is exactly 24 hours ago", () => {
   const exactly24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  assertEquals(shouldShowAuthNudge({ lastShown: exactly24h }), true);
+  assertEquals(
+    shouldShowAuthNudge({ lastShown: exactly24h, firstRunShown: true }),
+    true,
+  );
+});
+
+Deno.test("isFirstRunNudge: returns true when firstRunShown is undefined", () => {
+  assertEquals(isFirstRunNudge({}), true);
+});
+
+Deno.test("isFirstRunNudge: returns true when firstRunShown is false", () => {
+  assertEquals(isFirstRunNudge({ firstRunShown: false }), true);
+});
+
+Deno.test("isFirstRunNudge: returns false when firstRunShown is true", () => {
+  assertEquals(isFirstRunNudge({ firstRunShown: true }), false);
 });

--- a/src/infrastructure/persistence/auth_nudge_repository.ts
+++ b/src/infrastructure/persistence/auth_nudge_repository.ts
@@ -41,7 +41,12 @@ export class AuthNudgeRepository {
   }
 
   async markShown(): Promise<void> {
-    const state: AuthNudgeState = { lastShown: new Date().toISOString() };
+    const existing = await this.read();
+    const state: AuthNudgeState = {
+      ...existing,
+      firstRunShown: true,
+      lastShown: new Date().toISOString(),
+    };
     try {
       await Deno.mkdir(dirname(this.filePath), { recursive: true });
       await atomicWriteTextFile(

--- a/src/infrastructure/persistence/auth_nudge_repository_test.ts
+++ b/src/infrastructure/persistence/auth_nudge_repository_test.ts
@@ -34,7 +34,7 @@ Deno.test("AuthNudgeRepository: read returns empty state when file does not exis
   }
 });
 
-Deno.test("AuthNudgeRepository: markShown writes timestamp and read returns it", async () => {
+Deno.test("AuthNudgeRepository: markShown writes timestamp and firstRunShown", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
     const filePath = join(tmpDir, "auth_nudge.json");
@@ -44,6 +44,7 @@ Deno.test("AuthNudgeRepository: markShown writes timestamp and read returns it",
     const state = await repo.read();
 
     assertEquals(typeof state.lastShown, "string");
+    assertEquals(state.firstRunShown, true);
     const parsed = new Date(state.lastShown!).getTime();
     const now = Date.now();
     assertEquals(now - parsed < 5000, true);

--- a/src/presentation/renderers/auth_nudge.ts
+++ b/src/presentation/renderers/auth_nudge.ts
@@ -17,8 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { bold, cyan } from "@std/fmt/colors";
-import { AUTH_NUDGE_MESSAGE } from "../../domain/auth/auth_nudge.ts";
+import { bold, cyan, dim } from "@std/fmt/colors";
+import {
+  AUTH_FIRST_RUN_MESSAGE_LINES,
+  AUTH_NUDGE_MESSAGE,
+} from "../../domain/auth/auth_nudge.ts";
 
 export function renderAuthNudge(): void {
   console.error("");
@@ -30,4 +33,24 @@ export function renderAuthNudge(): void {
       ),
     ),
   );
+}
+
+export function renderFirstRunNudge(): void {
+  const maxLen = AUTH_FIRST_RUN_MESSAGE_LINES.reduce(
+    (max, line) => Math.max(max, line.length),
+    0,
+  );
+  const top = dim(`  ┌${"─".repeat(maxLen + 2)}┐`);
+  const bottom = dim(`  └${"─".repeat(maxLen + 2)}┘`);
+
+  console.error("");
+  console.error(top);
+  for (const line of AUTH_FIRST_RUN_MESSAGE_LINES) {
+    const padded = line.padEnd(maxLen);
+    const content = line.includes("swamp auth login")
+      ? padded.replace("swamp auth login", bold("swamp auth login"))
+      : padded;
+    console.error(`  ${dim("│")} ${cyan(content)} ${dim("│")}`);
+  }
+  console.error(bottom);
 }

--- a/src/presentation/renderers/auth_nudge_test.ts
+++ b/src/presentation/renderers/auth_nudge_test.ts
@@ -62,7 +62,7 @@ Deno.test("renderFirstRunNudge: outputs boxed first-run message to stderr", () =
 
   assertStringIncludes(stripped.join("\n"), "SWAMP CLUB");
   assertStringIncludes(stripped.join("\n"), "swamp auth login");
-  assertStringIncludes(stripped.join("\n"), "Community features");
+  assertStringIncludes(stripped.join("\n"), "bug reports and feature requests");
 
   const topBorder = stripped.find((l) => l.includes("┌"));
   const bottomBorder = stripped.find((l) => l.includes("└"));

--- a/src/presentation/renderers/auth_nudge_test.ts
+++ b/src/presentation/renderers/auth_nudge_test.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { renderAuthNudge } from "./auth_nudge.ts";
+import { renderAuthNudge, renderFirstRunNudge } from "./auth_nudge.ts";
 
 Deno.test("renderAuthNudge: outputs nudge message to stderr", () => {
   const lines: string[] = [];
@@ -40,4 +40,32 @@ Deno.test("renderAuthNudge: outputs nudge message to stderr", () => {
   const stripped = lines[1].replace(/\x1b\[[0-9;]*m/g, "");
   assertStringIncludes(stripped, "Join & participate in the community");
   assertStringIncludes(stripped, "swamp auth login");
+});
+
+Deno.test("renderFirstRunNudge: outputs boxed first-run message to stderr", () => {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  try {
+    renderFirstRunNudge();
+  } finally {
+    console.error = original;
+  }
+
+  // deno-lint-ignore no-control-regex
+  const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+  const stripped = lines.map(strip);
+
+  assertStringIncludes(stripped.join("\n"), "SWAMP CLUB");
+  assertStringIncludes(stripped.join("\n"), "swamp auth login");
+  assertStringIncludes(stripped.join("\n"), "extensions");
+
+  const topBorder = stripped.find((l) => l.includes("┌"));
+  const bottomBorder = stripped.find((l) => l.includes("└"));
+  assertEquals(topBorder !== undefined, true);
+  assertEquals(bottomBorder !== undefined, true);
 });

--- a/src/presentation/renderers/auth_nudge_test.ts
+++ b/src/presentation/renderers/auth_nudge_test.ts
@@ -62,7 +62,7 @@ Deno.test("renderFirstRunNudge: outputs boxed first-run message to stderr", () =
 
   assertStringIncludes(stripped.join("\n"), "SWAMP CLUB");
   assertStringIncludes(stripped.join("\n"), "swamp auth login");
-  assertStringIncludes(stripped.join("\n"), "extensions");
+  assertStringIncludes(stripped.join("\n"), "Community features");
 
   const topBorder = stripped.find((l) => l.includes("┌"));
   const bottomBorder = stripped.find((l) => l.includes("└"));


### PR DESCRIPTION
## Summary

- Adds an interactive prompt to `install.sh` and `install.ps1` that asks users to connect their SWAMP CLUB account immediately after binary installation (TTY-gated, skipped for non-interactive installs)
- Enhances the existing auth nudge system with a first-run variant: a prominent boxed message explaining what SWAMP CLUB is and what connecting unlocks (extensions, higher rate limits, community features)
- After the first-run nudge fires once, falls back to the existing daily tip-line cadence

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 8847 tests pass
- [x] First-run nudge can be tested locally via `XDG_CONFIG_HOME=$(mktemp -d) swamp version`
- [ ] Installer prompt tested manually via `install.sh` in an interactive terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)