### PR TITLE
fix(telemetry): use UTC in findByDateRange to match UTC-named files

### DIFF
--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -117,10 +117,10 @@ export class JsonTelemetryRepository implements TelemetryRepository {
 
     // Iterate through each day in the range
     const current = new Date(startDate);
-    current.setHours(0, 0, 0, 0);
+    current.setUTCHours(0, 0, 0, 0);
 
     const end = new Date(endDate);
-    end.setHours(23, 59, 59, 999);
+    end.setUTCHours(23, 59, 59, 999);
 
     while (current <= end) {
       const dayEntries = await this.findByDate(current);

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -532,6 +532,30 @@ Deno.test("JsonTelemetryRepository.deleteAllOlderThan removes both flushed and u
   });
 });
 
+Deno.test("JsonTelemetryRepository.findByDateRange uses UTC dates to match filenames", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new JsonTelemetryRepository(dir);
+
+    // Entry saved at 00:30 UTC on May 1st — file is named telemetry-2024-05-01-*.json
+    // In UTC+1 (e.g. Ireland), local time is 01:30 on May 1st. Before the fix,
+    // setHours(0,0,0,0) would produce midnight local = April 30 23:00 UTC,
+    // so toISOString() would yield "2024-04-30" and miss this file.
+    const entry = createTestEntry({
+      id: "utc-edge-uuid",
+      date: new Date("2024-05-01T00:30:00Z"),
+    });
+    await repo.save(entry);
+
+    // Query range that should include May 1st
+    const entries = await repo.findByDateRange(
+      new Date("2024-05-01T00:30:00Z"),
+      new Date("2024-05-01T23:30:00Z"),
+    );
+    assertEquals(entries.length, 1);
+    assertEquals(entries[0].id, "utc-edge-uuid");
+  });
+});
+
 Deno.test("JsonTelemetryRepository round-trips invocationContext (with detected harness)", async () => {
   await withTempDir(async (dir) => {
     const repo = new JsonTelemetryRepository(dir);


### PR DESCRIPTION
## Summary

- `findByDateRange()` used `setHours(0,0,0,0)` (local time) to set loop boundaries, but telemetry files are named with UTC dates via `toISOString()`. In positive UTC offsets (Ireland, Europe, Asia), local midnight maps to the previous UTC day, causing `getStats()` to silently miss entries from the first and last days of the requested range.
- Switched to `setUTCHours` so the date-prefix generation matches the UTC-based file naming convention used by `save()` and `markFlushed()`.

## Test Plan

- Added `findByDateRange uses UTC dates to match filenames` test that saves an entry at `00:30 UTC` and verifies it's found by a same-day range query
- All 8822 existing tests pass
- Manually verified end-to-end: seeded telemetry files in a fresh swamp repo and confirmed `telemetry stats` returns all entries including near-midnight-UTC ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)