### PR TITLE
fix(workflows): release per-run log sink in a finally to stop serve FD leak (swamp-club#1118)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1826,7 +1826,6 @@ export class WorkflowExecutionService {
         );
         await this.saveRun(workflow.id, run);
         yield { kind: "cancelled" as const, run };
-        runFileSink.unregister(workflowLogHandle);
         runSpan.setStatus({ code: SpanStatusCode.OK });
         return;
       }
@@ -1864,9 +1863,6 @@ export class WorkflowExecutionService {
         } finally {
           wfSaveSpan.end();
         }
-
-        // Unregister workflow log file sink
-        runFileSink.unregister(workflowLogHandle);
       } finally {
         wfTeardownSpan.end();
       }
@@ -1877,7 +1873,6 @@ export class WorkflowExecutionService {
         if (this.runTracker) {
           this.runTracker.complete(workflowRun.id, "suspended");
         }
-        runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
           run: workflowRun,
@@ -1903,7 +1898,6 @@ export class WorkflowExecutionService {
           workflowRun,
         );
         yield { kind: "cancelled" as const, run: workflowRun };
-        runFileSink.unregister(workflowLogHandle);
         runSpan.setStatus({ code: SpanStatusCode.OK });
         return;
       }
@@ -1918,13 +1912,17 @@ export class WorkflowExecutionService {
         );
         yield { kind: "completed" as const, run: workflowRun };
       }
-      runFileSink.unregister(workflowLogHandle);
       runSpan.setStatus({
         code: SpanStatusCode.ERROR,
         message: error instanceof Error ? error.message : String(error),
       });
       throw error;
     } finally {
+      // Always release the per-run log file sink when the generator is
+      // disposed — including early abandonment via generator.return() (e.g. a
+      // streaming consumer that breaks on socket close). Cleanup placed after a
+      // yield would be skipped on .return(); only finally blocks unwind.
+      runFileSink.unregister(workflowLogHandle);
       runSpan.end();
     }
   }
@@ -2040,69 +2038,77 @@ export class WorkflowExecutionService {
       swampPath(this.repoDir),
     );
 
-    yield {
-      kind: "started",
-      runId: existingRun.id,
-      workflowName: resolvedWorkflow.name,
-      logPath: workflowLogPath,
-      jobs: resolvedWorkflow.jobs.map((job) => ({
-        id: job.name,
-        stepCount: job.steps.length,
-        dependsOn: job.getDependencyNames(),
-      })),
-    };
-
-    const stepOpts: StepOptions = {
-      workflowTags: resolvedWorkflow.tags,
-      runtimeTags: options?.runtimeTags,
-      secretRedactor,
-      signal: options?.signal,
-      // workflow resume never receives CLI report flags — default so
-      // resumed runs still execute reports instead of silently skipping.
-      reportFilterOptions: options?.reportFilterOptions ?? {},
-      swampSha: options?.swampSha,
-    };
-
-    // Re-activate the tracker row (suspended → running) and start heartbeat
+    // Declared before the try so the finally at the end of this method can
+    // clear it. The try opens immediately after register() — before the
+    // "started" yield — so early consumer abandonment (a client that receives
+    // "started" then disconnects) still unwinds the finally and releases the
+    // log sink.
     let resumeHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
-    if (this.runTracker) {
-      this.runTracker.reactivate(existingRun.id);
-      const tracker = this.runTracker;
-      const runId = existingRun.id;
-      resumeHeartbeatInterval = setInterval(() => {
-        try {
-          tracker.heartbeat(runId);
-        } catch {
-          // Heartbeat failure is non-fatal
-        }
-      }, 30_000);
-    }
-
-    const jobNodes: GraphNode[] = resolvedWorkflow.jobs.map((job) => ({
-      name: job.name,
-      weight: job.weight,
-      dependencies: job.getDependencyNames(),
-    }));
-    const sortedJobs = this.sortService.sort(jobNodes);
-    const jobConcurrency = resolvedWorkflow.concurrency;
-
-    const modelInfoByStep = new Map<
-      string,
-      {
-        modelName: string;
-        modelType: string;
-        modelId: string;
-        methodName: string;
-      }
-    >();
-    const stepStatuses = new Map<string, "succeeded" | "failed" | "skipped">();
-    const stepJobNames = new Map<string, string>();
-    const dataHandlesByStep = new Map<
-      string,
-      import("../models/model.ts").DataHandle[]
-    >();
-
     try {
+      yield {
+        kind: "started",
+        runId: existingRun.id,
+        workflowName: resolvedWorkflow.name,
+        logPath: workflowLogPath,
+        jobs: resolvedWorkflow.jobs.map((job) => ({
+          id: job.name,
+          stepCount: job.steps.length,
+          dependsOn: job.getDependencyNames(),
+        })),
+      };
+
+      const stepOpts: StepOptions = {
+        workflowTags: resolvedWorkflow.tags,
+        runtimeTags: options?.runtimeTags,
+        secretRedactor,
+        signal: options?.signal,
+        // workflow resume never receives CLI report flags — default so
+        // resumed runs still execute reports instead of silently skipping.
+        reportFilterOptions: options?.reportFilterOptions ?? {},
+        swampSha: options?.swampSha,
+      };
+
+      // Re-activate the tracker row (suspended → running) and start heartbeat
+      if (this.runTracker) {
+        this.runTracker.reactivate(existingRun.id);
+        const tracker = this.runTracker;
+        const runId = existingRun.id;
+        resumeHeartbeatInterval = setInterval(() => {
+          try {
+            tracker.heartbeat(runId);
+          } catch {
+            // Heartbeat failure is non-fatal
+          }
+        }, 30_000);
+      }
+
+      const jobNodes: GraphNode[] = resolvedWorkflow.jobs.map((job) => ({
+        name: job.name,
+        weight: job.weight,
+        dependencies: job.getDependencyNames(),
+      }));
+      const sortedJobs = this.sortService.sort(jobNodes);
+      const jobConcurrency = resolvedWorkflow.concurrency;
+
+      const modelInfoByStep = new Map<
+        string,
+        {
+          modelName: string;
+          modelType: string;
+          modelId: string;
+          methodName: string;
+        }
+      >();
+      const stepStatuses = new Map<
+        string,
+        "succeeded" | "failed" | "skipped"
+      >();
+      const stepJobNames = new Map<string, string>();
+      const dataHandlesByStep = new Map<
+        string,
+        import("../models/model.ts").DataHandle[]
+      >();
+
       for (const level of sortedJobs.levels) {
         const jobStreams = level.map((jobName: string) => {
           const jobRun = existingRun.getJob(jobName);
@@ -2172,7 +2178,6 @@ export class WorkflowExecutionService {
       }
 
       if (options?.signal?.aborted) {
-        if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
         if (this.runTracker) {
           this.runTracker.complete(existingRun.id, "cancelled");
         }
@@ -2181,11 +2186,9 @@ export class WorkflowExecutionService {
         );
         await this.saveRun(workflow.id, existingRun);
         yield { kind: "cancelled" as const, run: existingRun };
-        runFileSink.unregister(workflowLogHandle);
         return;
       }
 
-      if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
       if (this.runTracker) {
         this.runTracker.complete(existingRun.id, "completed");
       }
@@ -2203,14 +2206,11 @@ export class WorkflowExecutionService {
 
       yield { kind: "completed", run: existingRun };
       await this.saveRun(workflow.id, existingRun);
-      runFileSink.unregister(workflowLogHandle);
     } catch (error) {
-      if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
       if (error instanceof WorkflowSuspendedError) {
         if (this.runTracker) {
           this.runTracker.complete(existingRun.id, "suspended");
         }
-        runFileSink.unregister(workflowLogHandle);
         yield {
           kind: "suspended" as const,
           run: existingRun,
@@ -2230,7 +2230,6 @@ export class WorkflowExecutionService {
         );
         await this.saveRun(workflow.id, existingRun);
         yield { kind: "cancelled" as const, run: existingRun };
-        runFileSink.unregister(workflowLogHandle);
         return;
       }
       if (this.runTracker) {
@@ -2239,8 +2238,15 @@ export class WorkflowExecutionService {
       existingRun.complete();
       await this.saveRun(workflow.id, existingRun);
       yield { kind: "completed" as const, run: existingRun };
-      runFileSink.unregister(workflowLogHandle);
       throw error;
+    } finally {
+      // Always stop the heartbeat and release the per-run log sink when the
+      // generator is disposed — including early abandonment via
+      // generator.return() (e.g. a streaming consumer that breaks on socket
+      // close). Cleanup placed after a yield would be skipped on .return();
+      // only finally blocks unwind.
+      if (resumeHeartbeatInterval) clearInterval(resumeHeartbeatInterval);
+      runFileSink.unregister(workflowLogHandle);
     }
   }
 

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -27,6 +27,7 @@ import {
   WorkflowExecutionService,
 } from "./execution_service.ts";
 import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { runFileSink } from "../../infrastructure/logging/logger.ts";
 import { reportRegistry } from "../reports/report_registry.ts";
 import { Workflow } from "./workflow.ts";
 import { Job } from "./job.ts";
@@ -3721,6 +3722,120 @@ Deno.test("resume merges override inputs over the suspended run's inputs", async
       JSON.stringify(persisted!.resumeInputs).includes("tskey-abc123"),
       false,
     );
+  });
+});
+
+// Regression for #1118: the per-run workflow log file is opened by
+// runFileSink.register() and must be released even when a streaming consumer
+// abandons the event generator early (e.g. a WebSocket client that disconnects
+// mid-run, breaking the `for await` loop). The cleanup lives in a `finally`, so
+// generator.return() unwinds it. Asserting on runFileSink.activeCount rather
+// than raw OS file descriptors keeps the test portable across platforms; a
+// before/after delta (not an absolute count) tolerates handles registered by
+// other tests sharing the process-wide singleton.
+Deno.test("run() releases the log file sink when the consumer abandons the stream early", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = createSimpleWorkflow();
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const baseline = runFileSink.activeCount;
+    let sinkOpenAtStarted = false;
+    for await (const event of service.run(workflow.name)) {
+      if (event.kind === "started") {
+        // register() runs before the "started" event, so the log sink is open.
+        sinkOpenAtStarted = runFileSink.activeCount === baseline + 1;
+        break; // abandon the generator mid-run (mirrors a client disconnect)
+      }
+    }
+
+    assertEquals(sinkOpenAtStarted, true);
+    // The finally must have unregistered the handle despite the early break.
+    assertEquals(runFileSink.activeCount, baseline);
+  });
+});
+
+// Regression for #1118: resume() has the same log-sink lifecycle as run(). Its
+// try/finally must open before the "started" yield so that a consumer which
+// disconnects right after "started" still releases the sink.
+Deno.test("resume() releases the log file sink when the consumer abandons the stream early", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    class NoopExecutor implements StepExecutor {
+      execute(_step: Step, _ctx: StepExecutionContext): Promise<unknown> {
+        return Promise.resolve({ executed: true });
+      }
+    }
+
+    // A manual-approval gate suspends the run so it can be resumed.
+    const workflow = Workflow.create({
+      name: "gated-workflow",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "gate",
+              task: StepTask.manualApproval("Approve before continuing"),
+            }),
+            Step.create({
+              name: "after",
+              task: StepTask.model("test-model", "run"),
+              dependsOn: [
+                { step: "gate", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      new NoopExecutor(),
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+    assertEquals(suspended.status, "suspended");
+
+    // Approve the gate so resume() proceeds past it.
+    const toApprove = await runRepo.findById(workflow.id, suspended.id);
+    const waiting = toApprove!.findWaitingApprovalStep()!;
+    toApprove!.getJob(waiting.jobName)!.getStep(waiting.stepName)!.succeed();
+    await runRepo.save(workflow.id, toApprove!);
+
+    const baseline = runFileSink.activeCount;
+    let sinkOpenAtStarted = false;
+    for await (const event of service.resume(workflow.name, suspended.id)) {
+      if (event.kind === "started") {
+        sinkOpenAtStarted = runFileSink.activeCount === baseline + 1;
+        break; // abandon the generator right after "started"
+      }
+    }
+
+    assertEquals(sinkOpenAtStarted, true);
+    assertEquals(runFileSink.activeCount, baseline);
   });
 });
 

--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -65,6 +65,16 @@ export class RunFileSink {
   private writers = new Map<string, FileWriter>();
 
   /**
+   * Number of currently registered writers (each holds one open file
+   * descriptor). Test-only observability: lets tests assert that a run's log
+   * handle was released without counting raw OS file descriptors (which is not
+   * portable across Linux, macOS, and Windows). Not used by production code.
+   */
+  get activeCount(): number {
+    return this.writers.size;
+  }
+
+  /**
    * Register a log file for a category prefix and return an opaque handle that
    * identifies this registration. All log records matching the prefix while the
    * registration is active are written to the file. Pass the returned handle to

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -488,7 +488,6 @@ export async function* workflowRun(
       "swamp.workflow.run.command",
       { "workflow.id_or_name": input.workflowIdOrName },
       (async function* () {
-        const ephemeral = createEphemeralStore();
         let resolvedInput = input;
 
         yield { kind: "validating_inputs" };
@@ -539,6 +538,11 @@ export async function* workflowRun(
 
         yield { kind: "evaluating_workflow" };
 
+        // Created here — after the input-validation early returns above — so the
+        // scratch store is only allocated once the run will actually execute,
+        // and those early-return paths never leak it. Disposed in the finally
+        // below on every exit, including early consumer abandonment.
+        const ephemeral = createEphemeralStore();
         const service = deps.createExecutionService(
           deps.workflowRepo,
           deps.runRepo,


### PR DESCRIPTION
## Summary

Fixes the `serve` file-descriptor leak reported in swamp-club#1118 (`Too many
open files (os error 24)`).

`WorkflowExecutionService.run()` and `.resume()` open the per-run workflow log
file via `runFileSink.register()` but called `unregister()` **after `yield`
statements** rather than in a `finally`. These are async generators: when a
streaming consumer abandons iteration early — e.g. a WebSocket client that
disconnects mid-run, breaking the `for await` loop at
`workflow_handlers.ts:859` / `model_handlers.ts:206` — Deno invokes
`generator.return()`, which unwinds **only `finally` blocks**. The post-`yield`
`unregister` was skipped, leaking the log file descriptor. Over hours a `serve`
process crosses its `RLIMIT_NOFILE` soft limit (default 1024) and every
`Deno.open`/`Deno.readDir` fails — the scheduled-workflow `readdir` in the report
is just the first syscall to hit the wall, not the cause.

The model-method run path already does this correctly (`runLog.cleanup()` in a
`finally`, `libswamp/models/run.ts`); this change brings the workflow-run path in
line.

## Changes

- **`run()`** — remove the 5 inline `runFileSink.unregister()` calls; unregister
  once in the outer `finally`.
- **`resume()`** — open the `try` immediately after `register()` (before the
  `started` yield, so a disconnect-right-after-`started` still cleans up), hoist
  the heartbeat-interval declaration, and clear the heartbeat + unregister in a
  new `finally`.
- **`run_file_sink.ts`** — add a test-only `activeCount` getter.
- **`libswamp/workflows/run.ts`** — create the ephemeral `:memory:` store after
  the input-validation early returns, so those paths never allocate it. Same
  cleanup-on-early-exit class; `:memory:` costs 0 OS FDs, so this is memory
  hygiene, not part of the EMFILE cause.
- **Tests** — two regression tests that abandon `run()`/`resume()` early and
  assert the log handle is released (via an `activeCount` before/after delta,
  since the sink is a process-wide singleton).

## Test Plan

- `deno check`, `deno lint`, `deno fmt --check`, `deno run compile` — all pass.
- `run_file_sink_test.ts` — 12/12 pass.
- New regression tests **fail against the pre-fix code** (`activeCount` 1 vs 0
  for `run()`, 2 vs 1 for `resume()`) and **pass with the fix** — confirming they
  are genuine guards, not tautologies.
- Mechanism independently reproduced during triage: 200 early-abandoned
  generator runs leak exactly 200 FDs with post-`yield` cleanup, 0 with `finally`.

## Notes

- One unrelated test (`manual_approval suspension does not mark job span as
  ERROR`) fails identically on `main` (OTel `InMemorySpanExporter` timer leak) —
  filed as swamp-club#1121, not touched here.
- The separate serve `create*Deps` catalog-store FD leak found during
  investigation is filed as swamp-club#1120.

Fixes swamp-club#1118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
