### PR TITLE
fix(auth): don't show first-run nudge to existing users on upgrade

### DIFF
--- a/src/domain/auth/auth_nudge.ts
+++ b/src/domain/auth/auth_nudge.ts
@@ -39,11 +39,10 @@ export interface AuthNudgeState {
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export function isFirstRunNudge(state: AuthNudgeState): boolean {
-  return !state.firstRunShown;
+  return !state.firstRunShown && !state.lastShown;
 }
 
 export function shouldShowAuthNudge(state: AuthNudgeState): boolean {
-  if (!state.firstRunShown) return true;
   if (!state.lastShown) return true;
   const lastShown = new Date(state.lastShown).getTime();
   return Date.now() - lastShown >= ONE_DAY_MS;

--- a/src/domain/auth/auth_nudge_test.ts
+++ b/src/domain/auth/auth_nudge_test.ts
@@ -28,6 +28,11 @@ Deno.test("shouldShowAuthNudge: returns true when firstRunShown is false and no 
   assertEquals(shouldShowAuthNudge({ firstRunShown: false }), true);
 });
 
+Deno.test("shouldShowAuthNudge: returns false for existing user within 24 hours missing firstRunShown", () => {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  assertEquals(shouldShowAuthNudge({ lastShown: oneHourAgo }), false);
+});
+
 Deno.test("shouldShowAuthNudge: returns true when lastShown is over 24 hours ago", () => {
   const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
   assertEquals(
@@ -56,10 +61,15 @@ Deno.test("isFirstRunNudge: returns true when firstRunShown is undefined", () =>
   assertEquals(isFirstRunNudge({}), true);
 });
 
-Deno.test("isFirstRunNudge: returns true when firstRunShown is false", () => {
+Deno.test("isFirstRunNudge: returns true when firstRunShown is false and no lastShown", () => {
   assertEquals(isFirstRunNudge({ firstRunShown: false }), true);
 });
 
 Deno.test("isFirstRunNudge: returns false when firstRunShown is true", () => {
   assertEquals(isFirstRunNudge({ firstRunShown: true }), false);
+});
+
+Deno.test("isFirstRunNudge: returns false for existing user missing firstRunShown field", () => {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  assertEquals(isFirstRunNudge({ lastShown: oneHourAgo }), false);
 });


### PR DESCRIPTION
## Summary

- Existing users whose `auth_nudge.json` had `lastShown` but no `firstRunShown` field would see the boxed first-run message and bypass the 24-hour throttle after upgrading
- `isFirstRunNudge` now requires `!state.lastShown` in addition to `!state.firstRunShown` — only genuine first runs (no prior state at all) trigger the first-run message
- Removed the redundant `!state.firstRunShown` early return from `shouldShowAuthNudge` that was bypassing the 24-hour throttle for upgrading users — `!state.lastShown` on the next line already handles genuine first runs

## Test Plan

- Added unit test for existing user upgrade scenario in `isFirstRunNudge` (has `lastShown`, no `firstRunShown` → `false`)
- Added unit test for existing user upgrade scenario in `shouldShowAuthNudge` (has `lastShown` within 24h, no `firstRunShown` → `false`)
- All existing unit and integration tests pass
- `deno check`, `deno lint`, `deno fmt` all pass