### PR TITLE
feat(serve): accept Bearer header and Sec-WebSocket-Protocol for WS auth

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -35,7 +35,10 @@ import {
 } from "../../serve/device_auth_handler.ts";
 import { resolveOAuthClientCredentials } from "../../serve/oauth_registration.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
-import { authenticateServerToken } from "../../serve/token_auth.ts";
+import {
+  authenticateServerToken,
+  extractWebSocketToken,
+} from "../../serve/token_auth.ts";
 import { parsePrincipal } from "../../domain/access/principal.ts";
 import { executeWorkflowWithLocks } from "../../serve/deps.ts";
 import { CapabilityService } from "../../serve/capability_service.ts";
@@ -1487,10 +1490,8 @@ export const serveCommand = new Command()
               return new Response("Too Many Requests", { status: 429 });
             }
 
-            const url = new URL(req.url);
-            const tokenParam = url.searchParams.get("token");
-            url.searchParams.delete("token");
-            if (!tokenParam) {
+            const extracted = extractWebSocketToken(req);
+            if (!extracted) {
               logger.warn(
                 "WebSocket auth rejected: no token provided from {ip}",
                 { ip: remoteAddr },
@@ -1499,8 +1500,16 @@ export const serveCommand = new Command()
                 status: 401,
               });
             }
+            logger.debug(
+              "WebSocket token received via {transport} from {ip}",
+              { transport: extracted.transport, ip: remoteAddr },
+            );
+            if (extracted.transport === "query") {
+              const url = new URL(req.url);
+              url.searchParams.delete("token");
+            }
             const result = await authenticateServerToken(
-              tokenParam,
+              extracted.token,
               resolvedRepoDir,
               repoContext,
             );
@@ -1513,9 +1522,15 @@ export const serveCommand = new Command()
             }
             clearRateLimit(remoteAddr);
             const principal = parsePrincipal(result.principalId);
+            const upgradeOpts = extracted.transport === "subprotocol"
+              ? {
+                ...wsUpgradeOpts,
+                protocol: `bearer.${extracted.token}`,
+              }
+              : wsUpgradeOpts;
             const { socket, response } = Deno.upgradeWebSocket(
               req,
-              wsUpgradeOpts,
+              upgradeOpts,
             );
             setConnectionCollectives(socket, result.collectives);
             handleConnection(socket, connectionCtx, principal);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1504,10 +1504,6 @@ export const serveCommand = new Command()
               "WebSocket token received via {transport} from {ip}",
               { transport: extracted.transport, ip: remoteAddr },
             );
-            if (extracted.transport === "query") {
-              const url = new URL(req.url);
-              url.searchParams.delete("token");
-            }
             const result = await authenticateServerToken(
               extracted.token,
               resolvedRepoDir,

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -49,15 +49,18 @@ export interface ExtractedWebSocketToken {
   transport: WebSocketTokenTransport;
 }
 
-const BEARER_PREFIX = "Bearer ";
+const BEARER_PREFIX_LEN = "Bearer ".length;
 const SUBPROTOCOL_PREFIX = "bearer.";
 
 export function extractWebSocketToken(
   req: Request,
 ): ExtractedWebSocketToken | null {
   const authHeader = req.headers.get("authorization");
-  if (authHeader !== null && authHeader.startsWith(BEARER_PREFIX)) {
-    const token = authHeader.slice(BEARER_PREFIX.length);
+  if (
+    authHeader !== null &&
+    authHeader.slice(0, BEARER_PREFIX_LEN).toLowerCase() === "bearer "
+  ) {
+    const token = authHeader.slice(BEARER_PREFIX_LEN);
     if (token.length > 0) {
       return { token, transport: "bearer" };
     }

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -42,6 +42,49 @@ export function splitServerToken(
   return { name: presented.slice(0, dot), secret: presented.slice(dot + 1) };
 }
 
+export type WebSocketTokenTransport = "bearer" | "subprotocol" | "query";
+
+export interface ExtractedWebSocketToken {
+  token: string;
+  transport: WebSocketTokenTransport;
+}
+
+const BEARER_PREFIX = "Bearer ";
+const SUBPROTOCOL_PREFIX = "bearer.";
+
+export function extractWebSocketToken(
+  req: Request,
+): ExtractedWebSocketToken | null {
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== null && authHeader.startsWith(BEARER_PREFIX)) {
+    const token = authHeader.slice(BEARER_PREFIX.length);
+    if (token.length > 0) {
+      return { token, transport: "bearer" };
+    }
+  }
+
+  const protocols = req.headers.get("sec-websocket-protocol");
+  if (protocols !== null) {
+    for (const entry of protocols.split(",")) {
+      const trimmed = entry.trim();
+      if (trimmed.startsWith(SUBPROTOCOL_PREFIX)) {
+        const token = trimmed.slice(SUBPROTOCOL_PREFIX.length);
+        if (token.length > 0) {
+          return { token, transport: "subprotocol" };
+        }
+      }
+    }
+  }
+
+  const url = new URL(req.url);
+  const tokenParam = url.searchParams.get("token");
+  if (tokenParam !== null && tokenParam.length > 0) {
+    return { token: tokenParam, transport: "query" };
+  }
+
+  return null;
+}
+
 export type ServerTokenAuthResult =
   | { ok: true; principalId: string; collectives: readonly string[] }
   | { ok: false; error: string };

--- a/src/serve/token_auth_test.ts
+++ b/src/serve/token_auth_test.ts
@@ -82,6 +82,24 @@ Deno.test("extractWebSocketToken: extracts from Sec-WebSocket-Protocol bearer.*"
   });
 });
 
+Deno.test("extractWebSocketToken: Bearer scheme is case-insensitive", () => {
+  const lower = makeReq("http://localhost:4000/", {
+    "authorization": "bearer mytoken.secret123",
+  });
+  assertEquals(extractWebSocketToken(lower), {
+    token: "mytoken.secret123",
+    transport: "bearer",
+  });
+
+  const upper = makeReq("http://localhost:4000/", {
+    "authorization": "BEARER mytoken.secret123",
+  });
+  assertEquals(extractWebSocketToken(upper), {
+    token: "mytoken.secret123",
+    transport: "bearer",
+  });
+});
+
 Deno.test("extractWebSocketToken: extracts from query parameter", () => {
   const req = makeReq("http://localhost:4000/?token=mytoken.secret123");
   const result = extractWebSocketToken(req);

--- a/src/serve/token_auth_test.ts
+++ b/src/serve/token_auth_test.ts
@@ -18,7 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { authenticateServerToken, splitServerToken } from "./token_auth.ts";
+import {
+  authenticateServerToken,
+  extractWebSocketToken,
+  splitServerToken,
+} from "./token_auth.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 
 // ── splitServerToken ────────────────────────────────────────────────────
@@ -48,6 +52,111 @@ Deno.test("splitServerToken: handles dots in secret", () => {
 Deno.test("splitServerToken: single-char name and secret", () => {
   const result = splitServerToken("a.b");
   assertEquals(result, { name: "a", secret: "b" });
+});
+
+// ── extractWebSocketToken ──────────────────────────────────────────────
+
+function makeReq(
+  url: string,
+  headers?: Record<string, string>,
+): Request {
+  return new Request(url, { headers });
+}
+
+Deno.test("extractWebSocketToken: extracts from Authorization Bearer header", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "authorization": "Bearer mytoken.secret123",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "mytoken.secret123", transport: "bearer" });
+});
+
+Deno.test("extractWebSocketToken: extracts from Sec-WebSocket-Protocol bearer.*", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "sec-websocket-protocol": "bearer.mytoken.secret123",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, {
+    token: "mytoken.secret123",
+    transport: "subprotocol",
+  });
+});
+
+Deno.test("extractWebSocketToken: extracts from query parameter", () => {
+  const req = makeReq("http://localhost:4000/?token=mytoken.secret123");
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "mytoken.secret123", transport: "query" });
+});
+
+Deno.test("extractWebSocketToken: returns null when no token present", () => {
+  const req = makeReq("http://localhost:4000/");
+  assertEquals(extractWebSocketToken(req), null);
+});
+
+Deno.test("extractWebSocketToken: Bearer takes priority over query param", () => {
+  const req = makeReq("http://localhost:4000/?token=query.token", {
+    "authorization": "Bearer header.token",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "header.token", transport: "bearer" });
+});
+
+Deno.test("extractWebSocketToken: Bearer takes priority over subprotocol", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "authorization": "Bearer header.token",
+    "sec-websocket-protocol": "bearer.sub.token",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "header.token", transport: "bearer" });
+});
+
+Deno.test("extractWebSocketToken: subprotocol takes priority over query param", () => {
+  const req = makeReq("http://localhost:4000/?token=query.token", {
+    "sec-websocket-protocol": "bearer.sub.token",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "sub.token", transport: "subprotocol" });
+});
+
+Deno.test("extractWebSocketToken: ignores malformed Bearer (no token after prefix)", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "authorization": "Bearer ",
+  });
+  assertEquals(extractWebSocketToken(req), null);
+});
+
+Deno.test("extractWebSocketToken: ignores non-Bearer authorization header", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "authorization": "Basic dXNlcjpwYXNz",
+  });
+  assertEquals(extractWebSocketToken(req), null);
+});
+
+Deno.test("extractWebSocketToken: ignores subprotocol without bearer. prefix", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "sec-websocket-protocol": "graphql-ws, other-protocol",
+  });
+  assertEquals(extractWebSocketToken(req), null);
+});
+
+Deno.test("extractWebSocketToken: finds bearer.* among multiple subprotocols", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "sec-websocket-protocol": "graphql-ws, bearer.mytoken.secret, other",
+  });
+  const result = extractWebSocketToken(req);
+  assertEquals(result, { token: "mytoken.secret", transport: "subprotocol" });
+});
+
+Deno.test("extractWebSocketToken: ignores empty bearer. subprotocol", () => {
+  const req = makeReq("http://localhost:4000/", {
+    "sec-websocket-protocol": "bearer.",
+  });
+  assertEquals(extractWebSocketToken(req), null);
+});
+
+Deno.test("extractWebSocketToken: ignores empty query param", () => {
+  const req = makeReq("http://localhost:4000/?token=");
+  assertEquals(extractWebSocketToken(req), null);
 });
 
 // ── authenticateServerToken ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes swamp-club#1119

- Adds `Authorization: Bearer <name>.<secret>` header support on WebSocket upgrade requests
- Adds `Sec-WebSocket-Protocol: bearer.<name>.<secret>` subprotocol support for browser clients that cannot set custom headers
- Existing `?token=<name>.<secret>` query parameter continues to work unchanged
- Priority when multiple transports are present: Bearer header > Sec-WebSocket-Protocol > query param
- Server-side only — no client changes, fully additive and backwards-compatible

## Test Plan

- [x] 13 new unit tests for `extractWebSocketToken()` covering all three transports, priority ordering, and edge cases
- [x] All 8858 existing tests pass
- [x] Verified against a live `swamp serve --auth-mode token` instance: all three transports return 101, no-token and bad-token return 401, debug logs confirm correct transport selection
- [ ] UAT coverage for live server auth: swamp-club/swamp-uat#306
- [ ] Documentation update: #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Evan Hazlett <ehazlett@users.noreply.github.com>