### PR TITLE
fix(serve): reuse shared catalog store in create*Deps to stop per-request FD leak (swamp-club#1120)

### DIFF
--- a/integration/serve_catalog_store_reuse_test.ts
+++ b/integration/serve_catalog_store_reuse_test.ts
@@ -1,0 +1,259 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Cross-component integration tests for the serve catalog-store FD-leak fix
+ * (swamp-club#1120). These exercise the real serve composition root — the
+ * `repoContext` / `datastoreResolver` pair that `handleConnection` injects into
+ * every request handler — and lock two invariants that the per-factory unit
+ * tests cannot show:
+ *
+ *  1. Namespace consistency (ADV-1): the shared `repoContext.unifiedDataRepo`
+ *     that serve handlers now inject carries the exact namespace the old
+ *     per-request factory would have derived from `ctx.datastoreResolver`, so
+ *     switching to the injected store shifts no write/read target.
+ *  2. Concurrency safety (ADV-2): several affected mutating/evaluating requests
+ *     built the handler-way against the single shared catalog connection run
+ *     concurrently without error or corruption.
+ *
+ * The FD-leak itself (a per-request factory opening a *new* file-based catalog
+ * store when it should reuse the injected one) is regression-guarded at the
+ * unit level: a leaked store and a reused one resolve to the *same* on-disk
+ * `_catalog.db` path (the leak is duplicate file descriptors to one file, not
+ * new files), so it is only observable as a created-vs-not-created file in an
+ * isolated empty repo with an injected store — see the `create*Deps` factory
+ * `*_test.ts` files. Here we assert instead that no affected factory opens a
+ * store at a *different* (e.g. mis-namespaced) path.
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  consumeStream,
+  createDataDeleteDeps,
+  createDataRenameDeps,
+  createLibSwampContext,
+  createModelDeleteDeps,
+  createModelEvaluateDeps,
+  createModelOutputDataDeps,
+  createModelOutputLogsDeps,
+  createModelValidateDeps,
+  createNamespace,
+  createRepoInitDeps,
+  repoInit,
+  SOLO_NAMESPACE,
+  withDefaults,
+} from "../src/libswamp/mod.ts";
+import {
+  createRepositoryContext,
+  namespaceFromResolver,
+} from "../src/infrastructure/persistence/repository_factory.ts";
+import { DefaultDatastorePathResolver } from "../src/infrastructure/persistence/default_datastore_path_resolver.ts";
+import type { DatastoreConfig } from "../src/domain/datastore/datastore_config.ts";
+import { requireInitializedRepoUnlocked } from "../src/cli/repo_context.ts";
+
+// Import models barrel to trigger built-in registration.
+import "../src/domain/models/models.ts";
+import { initializeLogging } from "../src/infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+async function withInitializedRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp-catalog-reuse-" });
+  try {
+    await consumeStream(
+      repoInit(
+        createLibSwampContext({}),
+        createRepoInitDeps("20260101.120000.0"),
+        { path: repoDir, force: false, version: "20260101.120000.0" },
+      ),
+      withDefaults({
+        error: (event) => {
+          throw new Error(String(event.error?.message ?? "repo init failed"));
+        },
+      }),
+    );
+    await fn(repoDir);
+  } finally {
+    // Best-effort: on Windows EBUSY can fire before V8 GCs native sqlite
+    // handles. Temp dir is ephemeral, the OS reclaims it either way.
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function countCatalogDbs(root: string): Promise<number> {
+  let count = 0;
+  for await (const entry of Deno.readDir(root)) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory) {
+      count += await countCatalogDbs(path);
+    } else if (entry.name === "_catalog.db") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+Deno.test({
+  name:
+    "serve seam: injected shared repo carries the connection's namespace (solo)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withInitializedRepo(async (repoDir) => {
+      const { repoContext, datastoreConfig, repoDir: resolvedRepoDir } =
+        await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+      const resolver = new DefaultDatastorePathResolver(
+        resolvedRepoDir,
+        datastoreConfig,
+      );
+
+      // The namespace the old per-request factory would derive from
+      // ctx.datastoreResolver must equal the namespace of the shared repo that
+      // serve handlers now inject.
+      assertEquals(
+        repoContext.unifiedDataRepo.namespace,
+        namespaceFromResolver(resolver),
+      );
+      assertEquals(repoContext.unifiedDataRepo.namespace, SOLO_NAMESPACE);
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "serve seam: injected shared repo carries the connection's namespace (namespaced)",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const repoDir = await Deno.makeTempDir({ prefix: "swamp-catalog-ns-" });
+    try {
+      const config: DatastoreConfig = {
+        type: "filesystem",
+        path: repoDir,
+        namespace: "security",
+      };
+      const resolver = new DefaultDatastorePathResolver(repoDir, config);
+      const repoContext = createRepositoryContext({
+        repoDir,
+        namespace: config.namespace,
+        datastoreResolver: resolver,
+      });
+
+      assertEquals(
+        repoContext.unifiedDataRepo.namespace,
+        namespaceFromResolver(resolver),
+      );
+      assertEquals(
+        repoContext.unifiedDataRepo.namespace,
+        createNamespace("security"),
+      );
+      repoContext.catalogStore.close();
+    } finally {
+      await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "serve seam: affected handlers reuse the shared store across concurrent requests",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withInitializedRepo(async (repoDir) => {
+      const { repoContext, datastoreConfig, repoDir: resolvedRepoDir } =
+        await requireInitializedRepoUnlocked({ repoDir, outputMode: "log" });
+      const resolver = new DefaultDatastorePathResolver(
+        resolvedRepoDir,
+        datastoreConfig,
+      );
+
+      // Build the seven affected deps exactly as their serve handlers now do —
+      // injecting the process-scoped shared repo (and catalog store for the two
+      // that feed a DataQueryService directly). None of these should open a new
+      // store, and none should open one at a different path.
+      const buildAllAffectedDeps = () => {
+        createModelEvaluateDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+          repoContext.catalogStore,
+        );
+        createModelValidateDeps(
+          resolvedRepoDir,
+          undefined,
+          resolver,
+          repoContext.unifiedDataRepo,
+          repoContext.catalogStore,
+        );
+        createModelDeleteDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+        );
+        createModelOutputDataDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+        );
+        createModelOutputLogsDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+        );
+        createDataDeleteDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+        );
+        createDataRenameDeps(
+          resolvedRepoDir,
+          resolver,
+          repoContext.unifiedDataRepo,
+        );
+      };
+
+      // Concurrently construct deps and drive a real read through the shared
+      // catalog connection (evaluate deps -> DataQueryService -> shared store)
+      // to confirm the single shared store tolerates concurrent use.
+      const REQUESTS = 24;
+      const results = await Promise.all(
+        Array.from({ length: REQUESTS }, async () => {
+          buildAllAffectedDeps();
+          const evalDeps = createModelEvaluateDeps(
+            resolvedRepoDir,
+            resolver,
+            repoContext.unifiedDataRepo,
+            repoContext.catalogStore,
+          );
+          return await evalDeps.evaluateAllDefinitions();
+        }),
+      );
+
+      assertEquals(results.length, REQUESTS);
+      // Exactly one file-based catalog store exists — the one the shared
+      // repoContext opened. No affected factory opened another (which, if it
+      // resolved a different namespaced path, would surface as a second file).
+      assertEquals(await countCatalogDbs(resolvedRepoDir), 1);
+    });
+  },
+});

--- a/src/libswamp/data/delete.ts
+++ b/src/libswamp/data/delete.ts
@@ -94,10 +94,14 @@ export interface DataDeleteDeps {
 export function createDataDeleteDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // Reuse an injected shared data repo (e.g. serve's process-scoped
+  // RepositoryContext) so we don't open a new file-based catalog store — and
+  // leak its 3 FDs — on every request.
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/data/delete_test.ts
+++ b/src/libswamp/data/delete_test.ts
@@ -21,6 +21,7 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createDataDeleteDeps,
   dataBatchDelete,
   type DataBatchDeleteEvent,
   dataBatchDeletePreview,
@@ -29,6 +30,58 @@ import {
   type DataDeleteEvent,
   dataDeletePreview,
 } from "./delete.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createDataDeleteDeps: reuses an injected data repo and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createDataDeleteDeps(dir, undefined, injected);
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createDataDeleteDeps: opens a file-based catalog db when no repo is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createDataDeleteDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeDeps(overrides: Partial<DataDeleteDeps> = {}): DataDeleteDeps {
   return {

--- a/src/libswamp/data/rename.ts
+++ b/src/libswamp/data/rename.ts
@@ -73,10 +73,14 @@ export interface DataRenameDeps {
 export function createDataRenameDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataRenameDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // Reuse an injected shared data repo (e.g. serve's process-scoped
+  // RepositoryContext) so we don't open a new file-based catalog store — and
+  // leak its 3 FDs — on every request.
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/data/rename_test.ts
+++ b/src/libswamp/data/rename_test.ts
@@ -21,10 +21,63 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createDataRenameDeps,
   dataRename,
   type DataRenameDeps,
   type DataRenameEvent,
 } from "./rename.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createDataRenameDeps: reuses an injected data repo and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createDataRenameDeps(dir, undefined, injected);
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createDataRenameDeps: opens a file-based catalog db when no repo is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createDataRenameDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeDeps(overrides: Partial<DataRenameDeps> = {}): DataRenameDeps {
   return {

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -104,19 +104,24 @@ export interface ModelDeleteDeps {
 export function createModelDeleteDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): ModelDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   const workflowRepo = new YamlWorkflowRepository(repoDir);
-  const unifiedDataRepo = new FileSystemUnifiedDataRepository(
-    repoDir,
-    dsPath(SWAMP_SUBDIRS.data),
-    createCatalogStore(repoDir, datastoreResolver),
-    undefined,
-    undefined,
-    namespaceFromResolver(datastoreResolver),
-  );
+  // Reuse an injected shared data repo (e.g. serve's process-scoped
+  // RepositoryContext) so we don't open a new file-based catalog store — and
+  // leak its 3 FDs — on every request.
+  const unifiedDataRepo = injectedDataRepo ??
+    new FileSystemUnifiedDataRepository(
+      repoDir,
+      dsPath(SWAMP_SUBDIRS.data),
+      createCatalogStore(repoDir, datastoreResolver),
+      undefined,
+      undefined,
+      namespaceFromResolver(datastoreResolver),
+    );
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),

--- a/src/libswamp/models/delete_test.ts
+++ b/src/libswamp/models/delete_test.ts
@@ -21,11 +21,64 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createModelDeleteDeps,
   modelDelete,
   type ModelDeleteDeps,
   type ModelDeleteEvent,
   modelDeletePreview,
 } from "./delete.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createModelDeleteDeps: reuses an injected data repo and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createModelDeleteDeps(dir, undefined, injected);
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createModelDeleteDeps: opens a file-based catalog db when no repo is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createModelDeleteDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 const testDefinition = {
   id: "550e8400-e29b-41d4-a716-446655440000",

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -34,6 +34,7 @@ import {
   createCatalogStore,
   namespaceFromResolver,
 } from "../../infrastructure/persistence/repository_factory.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
@@ -92,12 +93,19 @@ export interface ModelEvaluateDeps {
 export function createModelEvaluateDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
+  injectedCatalogStore?: CatalogStore,
 ): ModelEvaluateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // When a shared catalog store / data repo is injected (e.g. by serve
+  // handlers passing the process-scoped RepositoryContext), reuse it and skip
+  // createCatalogStore so we don't open a new file-based SQLite store — and
+  // leak its 3 FDs — on every request.
+  const catalogStore = injectedCatalogStore ??
+    createCatalogStore(repoDir, datastoreResolver);
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,

--- a/src/libswamp/models/evaluate_test.ts
+++ b/src/libswamp/models/evaluate_test.ts
@@ -23,6 +23,7 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createModelEvaluateDeps,
   isModelEvaluateAllData,
   modelEvaluate,
   type ModelEvaluateAllData,
@@ -30,6 +31,63 @@ import {
   type ModelEvaluateEvent,
   type ModelEvaluateItemData,
 } from "./evaluate.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createModelEvaluateDeps: reuses an injected store and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createModelEvaluateDeps(
+        dir,
+        undefined,
+        injected,
+        new CatalogStore(":memory:"),
+      );
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createModelEvaluateDeps: opens a file-based catalog db when no store is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createModelEvaluateDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeDeps(
   overrides?: Partial<ModelEvaluateDeps>,

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -107,6 +107,7 @@ export interface ModelOutputDataDeps {
 export function createModelOutputDataDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): ModelOutputDataDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -115,7 +116,10 @@ export function createModelOutputDataDeps(
     dsPath(SWAMP_SUBDIRS.outputs),
   );
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // Reuse an injected shared data repo (e.g. serve's process-scoped
+  // RepositoryContext) so we don't open a new file-based catalog store — and
+  // leak its 3 FDs — on every request.
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/models/output_data_test.ts
+++ b/src/libswamp/models/output_data_test.ts
@@ -24,10 +24,63 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createModelOutputDataDeps,
   modelOutputData,
   type ModelOutputDataDeps,
   type ModelOutputDataEvent,
 } from "./output_data.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createModelOutputDataDeps: reuses an injected data repo and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createModelOutputDataDeps(dir, undefined, injected);
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createModelOutputDataDeps: opens a file-based catalog db when no repo is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createModelOutputDataDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeOutput(
   opts?: { withDataArtifact?: boolean },

--- a/src/libswamp/models/output_logs.ts
+++ b/src/libswamp/models/output_logs.ts
@@ -84,6 +84,7 @@ export interface ModelOutputLogsDeps {
 export function createModelOutputLogsDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): ModelOutputLogsDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -91,7 +92,10 @@ export function createModelOutputLogsDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
   );
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // Reuse an injected shared data repo (e.g. serve's process-scoped
+  // RepositoryContext) so we don't open a new file-based catalog store — and
+  // leak its 3 FDs — on every request.
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     createCatalogStore(repoDir, datastoreResolver),

--- a/src/libswamp/models/output_logs_test.ts
+++ b/src/libswamp/models/output_logs_test.ts
@@ -24,10 +24,63 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createModelOutputLogsDeps,
   modelOutputLogs,
   type ModelOutputLogsDeps,
   type ModelOutputLogsEvent,
 } from "./output_logs.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createModelOutputLogsDeps: reuses an injected data repo and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createModelOutputLogsDeps(dir, undefined, injected);
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createModelOutputLogsDeps: opens a file-based catalog db when no repo is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createModelOutputLogsDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeOutput(
   opts?: { withLogArtifact?: boolean },

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -33,6 +33,7 @@ import {
   createCatalogStore,
   namespaceFromResolver,
 } from "../../infrastructure/persistence/repository_factory.ts";
+import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import { createExtensionCelEnvironment } from "../../infrastructure/cel/cel_evaluator.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
@@ -123,12 +124,19 @@ export function createModelValidateDeps(
   repoDir: string,
   options?: { labels?: string[]; method?: string },
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
+  injectedCatalogStore?: CatalogStore,
 ): ModelValidateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const definitionRepo = new YamlDefinitionRepository(repoDir);
-  const catalogStore = createCatalogStore(repoDir, datastoreResolver);
-  const dataRepo = new FileSystemUnifiedDataRepository(
+  // When a shared catalog store / data repo is injected (e.g. by serve
+  // handlers passing the process-scoped RepositoryContext), reuse it and skip
+  // createCatalogStore so we don't open a new file-based SQLite store — and
+  // leak its 3 FDs — on every request.
+  const catalogStore = injectedCatalogStore ??
+    createCatalogStore(repoDir, datastoreResolver);
+  const dataRepo = injectedDataRepo ?? new FileSystemUnifiedDataRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.data),
     catalogStore,

--- a/src/libswamp/models/validate_test.ts
+++ b/src/libswamp/models/validate_test.ts
@@ -23,12 +23,71 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createModelValidateDeps,
   isModelValidateAllData,
   modelValidate,
   type ModelValidateData,
   type ModelValidateDeps,
   type ModelValidateEvent,
 } from "./validate.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
+import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native sqlite handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+async function catalogDbExists(repoDir: string): Promise<boolean> {
+  try {
+    await Deno.lstat(catalogDbPath(repoDir));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test(
+  "createModelValidateDeps: reuses an injected store and opens no new catalog db",
+  async () => {
+    await withTempDir(async (dir) => {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      createModelValidateDeps(
+        dir,
+        undefined,
+        undefined,
+        injected,
+        new CatalogStore(":memory:"),
+      );
+      assertEquals(await catalogDbExists(dir), false);
+    });
+  },
+);
+
+Deno.test(
+  "createModelValidateDeps: opens a file-based catalog db when no store is injected",
+  async () => {
+    await withTempDir(async (dir) => {
+      createModelValidateDeps(dir);
+      assertEquals(await catalogDbExists(dir), true);
+    });
+  },
+);
 
 function makeDeps(
   overrides?: Partial<ModelValidateDeps>,

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -427,7 +427,11 @@ export async function handleDataDelete(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createDataDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createDataDeleteDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -486,7 +490,11 @@ export async function handleDataRename(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createDataRenameDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createDataRenameDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -512,7 +512,11 @@ export async function handleModelDelete(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createModelDeleteDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
     const preview = await modelDeletePreview(
       libCtx,
@@ -648,7 +652,11 @@ export async function handleModelOutputData(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelOutputDataDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createModelOutputDataDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -708,7 +716,11 @@ export async function handleModelOutputLogs(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelOutputLogsDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createModelOutputLogsDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1020,10 +1032,16 @@ export async function handleModelValidate(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelValidateDeps(ctx.repoDir, {
-      labels: payload?.labels,
-      method: payload?.method,
-    });
+    const deps = createModelValidateDeps(
+      ctx.repoDir,
+      {
+        labels: payload?.labels,
+        method: payload?.method,
+      },
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+      ctx.repoContext.catalogStore,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1075,7 +1093,12 @@ export async function handleModelEvaluate(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelEvaluateDeps(ctx.repoDir);
+    const deps = createModelEvaluateDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.unifiedDataRepo,
+      ctx.repoContext.catalogStore,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(


### PR DESCRIPTION
## Summary

Several `create*Deps()` factories open a **file-based** SQLite `CatalogStore` (via `createCatalogStore`) with no way to close it. In one-shot CLI commands this is harmless, but under `swamp serve` these factories are invoked **per API request**, so every request against an affected endpoint permanently leaks **3 file descriptors** (`.db` + `-wal` + `-shm`). A polled `serve` instance climbs toward `RLIMIT_NOFILE` and eventually fails every `Deno.open`/`Deno.readDir` with `Too many open files` — the same end state as swamp-club#1118, via a different mechanism.

**Fix:** give each of the seven serve-reachable factories a shared-store escape hatch (mirroring the already-safe `createDataGetDeps`/`List`/`Versions`) and have the serve handlers inject the process-scoped `RepositoryContext` store instead of minting a new one per request.

- `createModelEvaluateDeps`, `createModelValidateDeps` — add `injectedDataRepo?` **and** `injectedCatalogStore?` (they feed the store into a `DataQueryService` directly).
- `createModelDeleteDeps`, `createModelOutputDataDeps`, `createModelOutputLogsDeps`, `createDataDeleteDeps`, `createDataRenameDeps` — add `injectedDataRepo?`.
- `createCatalogStore` is guarded behind `??`, so it is never called when a shared store is injected. **All new params are optional**, so CLI call sites are unchanged; only the seven serve handlers change behavior (reuse the one long-lived catalog connection).
- The seven handlers now pass `ctx.repoContext.unifiedDataRepo` (and `.catalogStore` for evaluate/validate).

The four `create*Deps` factories that open a store unconditionally but are **not** reachable from any serve handler (`createWorkflowEvaluateDeps`, `createDataPruneDeps`, `createDataGcDeps`, `createReportSearchDeps`) are intentionally left unchanged — they don't leak (the process exits), and the change keeps the blast radius small.

## Test Plan

- **Unit (14 tests, one pair per factory):** the injected path opens **no** new on-disk `_catalog.db` under an empty temp repo, with a positive control asserting the un-injected path **does** create it (`CatalogStore` opens eagerly in its constructor).
- **Integration (`serve_catalog_store_reuse_test.ts`):** at the real serve composition-root seam — (1) the injected shared repo carries the connection's namespace (`repoContext.unifiedDataRepo.namespace === namespaceFromResolver(datastoreResolver)`) for both solo and namespaced connections, so switching to the injected store shifts no read/write target; (2) 24 concurrent affected requests built the handler-way through the single shared store complete without error; (3) no affected factory opens a store at a different (mis-namespaced) path.
- `deno check`, `deno lint`, `deno fmt --check`, `deno run compile` all pass.

Fixes swamp-club#1120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)