### PR TITLE
feat(telemetry): record telemetry globally (user-level), not gated on a repo

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
   "workspace": ["packages/client", "packages/testing"],
   "tasks": {
     "dev": "deno run --unstable-bundle --allow-read --allow-write --allow-env --allow-run --allow-sys main.ts",
-    "test": "deno test --parallel --unstable-bundle --allow-read --allow-write --allow-env --allow-run --allow-net --allow-sys",
+    "test": "SWAMP_NO_TELEMETRY=1 deno test --parallel --unstable-bundle --allow-read --allow-write --allow-env --allow-run --allow-net --allow-sys",
     "check": "deno check main.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",

--- a/integration/telemetry_global_spool_test.ts
+++ b/integration/telemetry_global_spool_test.ts
@@ -1,0 +1,278 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+// Verifies that CLI telemetry is user-global: every invocation spools to
+// `<XDG_CONFIG_HOME>/swamp/telemetry/` — whether or not it ran inside a swamp
+// repo — and never to a repo-local `.swamp/telemetry/` directory.
+//
+// The integration harness (CLI_ARGS) grants no `--allow-net`, so the
+// post-command telemetry flush always fails and the entry stays on disk for
+// inspection without ever reaching a real endpoint.
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { CLI_ARGS } from "./test_helpers.ts";
+
+interface CliRunResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+async function runCliWithEnv(
+  args: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<CliRunResult> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [...CLI_ARGS, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    cwd,
+    env,
+    clearEnv: true,
+  });
+  const { code, stdout, stderr } = await command.output();
+  return {
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+    code,
+  };
+}
+
+async function readEntries(
+  telemetryDir: string,
+): Promise<Record<string, unknown>[]> {
+  const entries: Record<string, unknown>[] = [];
+  try {
+    for await (const file of Deno.readDir(telemetryDir)) {
+      if (!file.isFile || !file.name.endsWith(".json")) continue;
+      const text = await Deno.readTextFile(join(telemetryDir, file.name));
+      entries.push(JSON.parse(text) as Record<string, unknown>);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return [];
+    throw error;
+  }
+  return entries;
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tel-global-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+/** Minimal child env; XDG_CONFIG_HOME is set per-test to isolate the spool. */
+function baseChildEnv(configDir: string): Record<string, string> {
+  const env: Record<string, string> = { XDG_CONFIG_HOME: configDir };
+  for (const key of ["HOME", "PATH", "USER", "TMPDIR", "TMP", "TEMP"]) {
+    const value = Deno.env.get(key);
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+Deno.test("repo-less telemetry spools to the user-global directory", async () => {
+  await withTempDir(async (configDir) => {
+    await withTempDir(async (workDir) => {
+      // `telemetry stats` flows through the full action pipeline (recordSuccess
+      // runs in teardown) and now works outside a repo. workDir has no marker.
+      const run = await runCliWithEnv(
+        ["--json", "telemetry", "stats"],
+        workDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(run.code, 0, `telemetry stats failed: ${run.stderr}`);
+
+      const spoolDir = join(configDir, "swamp", "telemetry");
+      const entries = await readEntries(spoolDir);
+      assert(
+        entries.length > 0,
+        "no telemetry entry written to the user-global spool",
+      );
+
+      const target = entries.find((entry) => {
+        const inv = entry.invocation as Record<string, unknown> | undefined;
+        return inv?.command === "telemetry" && inv?.subcommand === "stats";
+      });
+      assert(target, "no entry matched the telemetry stats invocation");
+
+      const ctx = target!.invocationContext as
+        | Record<string, unknown>
+        | undefined;
+      assert(ctx, "entry missing invocationContext");
+      // Repo-less: no marker, so there is no configured tool list to report.
+      assertEquals(ctx!.configuredAiTools, undefined);
+
+      // There is no repo, so no repo-local spool should ever be created.
+      await assertRejects(
+        () => Deno.stat(join(workDir, ".swamp", "telemetry")),
+        Deno.errors.NotFound,
+      );
+    });
+  });
+});
+
+async function seedRepoLocalEntry(repoDir: string): Promise<string> {
+  // Simulate a legacy repo-local spool holding one unflushed entry.
+  const spool = join(repoDir, ".swamp", "telemetry");
+  await Deno.mkdir(spool, { recursive: true });
+  const name = `telemetry-2026-07-13-${crypto.randomUUID()}.json`;
+  await Deno.writeTextFile(join(spool, name), '{"id":"legacy"}');
+  return name;
+}
+
+Deno.test("repo upgrade migrates unflushed repo-local telemetry to the global spool", async () => {
+  await withTempDir(async (configDir) => {
+    await withTempDir(async (repoDir) => {
+      const init = await runCliWithEnv(
+        ["--json", "repo", "init", "--tool", "claude"],
+        repoDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+
+      const legacyName = await seedRepoLocalEntry(repoDir);
+
+      const run = await runCliWithEnv(
+        ["--json", "repo", "upgrade"],
+        repoDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(run.code, 0, `repo upgrade failed: ${run.stderr}`);
+
+      // The legacy entry was moved to the user-global spool...
+      assertEquals(
+        await Deno.stat(join(configDir, "swamp", "telemetry", legacyName))
+          .then(() => true),
+        true,
+      );
+      // ...and removed from the repo-local spool.
+      await assertRejects(
+        () => Deno.stat(join(repoDir, ".swamp", "telemetry", legacyName)),
+        Deno.errors.NotFound,
+      );
+    });
+  });
+});
+
+Deno.test("repo upgrade does NOT migrate telemetry for a disabled repo", async () => {
+  await withTempDir(async (configDir) => {
+    await withTempDir(async (repoDir) => {
+      const init = await runCliWithEnv(
+        ["--json", "repo", "init", "--tool", "claude"],
+        repoDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+
+      // Opt this repo out of telemetry.
+      const markerPath = join(repoDir, ".swamp.yaml");
+      const marker = await Deno.readTextFile(markerPath);
+      await Deno.writeTextFile(
+        markerPath,
+        marker + "\ntelemetryDisabled: true\n",
+      );
+
+      const legacyName = await seedRepoLocalEntry(repoDir);
+
+      const run = await runCliWithEnv(
+        ["--json", "repo", "upgrade"],
+        repoDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(run.code, 0, `repo upgrade failed: ${run.stderr}`);
+
+      // The opted-out repo's entry stays orphaned in the repo-local spool...
+      assertEquals(
+        await Deno.stat(join(repoDir, ".swamp", "telemetry", legacyName))
+          .then(() => true),
+        true,
+      );
+      // ...and is never moved into the global spool (where it would be sent).
+      await assertRejects(
+        () => Deno.stat(join(configDir, "swamp", "telemetry", legacyName)),
+        Deno.errors.NotFound,
+      );
+    });
+  });
+});
+
+Deno.test("in-repo telemetry spools to the user-global directory, not the repo", async () => {
+  await withTempDir(async (configDir) => {
+    await withTempDir(async (repoDir) => {
+      const init = await runCliWithEnv(
+        ["--json", "repo", "init", "--tool", "claude"],
+        repoDir,
+        baseChildEnv(configDir),
+      );
+      assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
+
+      // repo init must not scaffold a repo-local telemetry directory.
+      await assertRejects(
+        () => Deno.stat(join(repoDir, ".swamp", "telemetry")),
+        Deno.errors.NotFound,
+      );
+
+      // A real command through the full pipeline (repo upgrade is a cheap
+      // no-op on an already-initialised repo). Set the claude harness signal.
+      const runEnv = baseChildEnv(configDir);
+      runEnv.CLAUDECODE = "1";
+      const run = await runCliWithEnv(
+        ["--json", "repo", "upgrade"],
+        repoDir,
+        runEnv,
+      );
+      assertEquals(run.code, 0, `repo upgrade failed: ${run.stderr}`);
+
+      // The entry landed in the user-global spool, enriched from the marker.
+      const entries = await readEntries(join(configDir, "swamp", "telemetry"));
+      const target = entries.find((entry) => {
+        const inv = entry.invocation as Record<string, unknown> | undefined;
+        return inv?.command === "repo" && inv?.subcommand === "upgrade";
+      });
+      assert(
+        target,
+        "no user-global entry matched the repo upgrade invocation",
+      );
+
+      const ctx = target!.invocationContext as
+        | Record<string, unknown>
+        | undefined;
+      assert(ctx, "entry missing invocationContext");
+      // Marker enrichment is preserved on the global event.
+      assertEquals(ctx!.configuredAiTools, ["claude"]);
+      assertEquals(ctx!.detectedAiTool, "claude");
+
+      // Nothing was written to a repo-local spool.
+      await assertRejects(
+        () => Deno.stat(join(repoDir, ".swamp", "telemetry")),
+        Deno.errors.NotFound,
+      );
+    });
+  });
+});

--- a/integration/telemetry_invocation_context_test.ts
+++ b/integration/telemetry_invocation_context_test.ts
@@ -49,9 +49,11 @@ async function runCliWithEnv(
 }
 
 async function readPersistedEntries(
-  repoDir: string,
+  configDir: string,
 ): Promise<Record<string, unknown>[]> {
-  const dir = join(repoDir, ".swamp", "telemetry");
+  // Telemetry is user-global: entries spool under <config>/swamp/telemetry,
+  // never under the repo.
+  const dir = join(configDir, "swamp", "telemetry");
   const entries: Record<string, unknown>[] = [];
   for await (const file of Deno.readDir(dir)) {
     if (!file.isFile || !file.name.endsWith(".json")) continue;
@@ -91,12 +93,21 @@ function baseChildEnv(): Record<string, string> {
 
 Deno.test("CLI bootstrap stamps invocationContext on persisted telemetry", async () => {
   await withTempDir(async (dir) => {
+    // Isolate the user-global telemetry spool (and identity/auth) to a temp
+    // config dir so the test never touches the developer's real ~/.config.
+    const configDir = join(dir, "xdg");
+    const childEnvWith = (extra: Record<string, string> = {}) => ({
+      ...baseChildEnv(),
+      XDG_CONFIG_HOME: configDir,
+      ...extra,
+    });
+
     // Initialise a repo enrolled with both claude and cursor. Use --json so
     // we can parse the result if needed.
     const init = await runCliWithEnv(
       ["--json", "repo", "init", "--tool", "claude", "--tool", "cursor"],
       dir,
-      baseChildEnv(),
+      childEnvWith(),
     );
     assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
 
@@ -116,17 +127,15 @@ Deno.test("CLI bootstrap stamps invocationContext on persisted telemetry", async
     // upgrade on an already-initialised repo is a cheap no-op and goes
     // through the full path. Set the claude harness signal in the child
     // env so detection has something to identify.
-    const childEnv = baseChildEnv();
-    childEnv.CLAUDECODE = "1";
     const run = await runCliWithEnv(
       ["--json", "repo", "upgrade"],
       dir,
-      childEnv,
+      childEnvWith({ CLAUDECODE: "1" }),
     );
     assertEquals(run.code, 0, `repo upgrade failed: ${run.stderr}`);
 
-    // Read what was persisted under .swamp/telemetry/.
-    const persisted = await readPersistedEntries(dir);
+    // Read what was persisted under the user-global telemetry spool.
+    const persisted = await readPersistedEntries(configDir);
     assert(persisted.length > 0, "no telemetry entries were written");
 
     // Find the entry corresponding to the upgrade run.

--- a/integration/telemetry_workflow_method_invocations_test.ts
+++ b/integration/telemetry_workflow_method_invocations_test.ts
@@ -61,9 +61,11 @@ async function runCli(
 }
 
 async function readPersistedEntries(
-  repoDir: string,
+  configDir: string,
 ): Promise<Record<string, unknown>[]> {
-  const dir = join(repoDir, ".swamp", "telemetry");
+  // Telemetry is user-global: parent and child entries spool under
+  // <config>/swamp/telemetry, never under the repo.
+  const dir = join(configDir, "swamp", "telemetry");
   const entries: Record<string, unknown>[] = [];
   for await (const file of Deno.readDir(dir)) {
     if (!file.isFile || !file.name.endsWith(".json")) continue;
@@ -163,11 +165,20 @@ Deno.test({
   ignore: Deno.build.os === "windows",
   fn: async () => {
     await withTempDir(async (repoDir) => {
+      // Isolate the user-global telemetry spool (and identity/auth) to a temp
+      // config dir so the test never touches the developer's real ~/.config.
+      const configDir = join(repoDir, "xdg");
+      const childEnvWith = (extra: Record<string, string> = {}) => ({
+        ...baseChildEnv(),
+        XDG_CONFIG_HOME: configDir,
+        ...extra,
+      });
+
       // 1. Initialize a single-tool repo
       const init = await runCli(
         ["--json", "repo", "init", "--tool", "claude"],
         repoDir,
-        baseChildEnv(),
+        childEnvWith(),
       );
       assertEquals(init.code, 0, `repo init failed: ${init.stderr}`);
       await pinTelemetryEndpoint(repoDir);
@@ -247,7 +258,7 @@ Deno.test({
       );
 
       // 4. Run the workflow
-      const env = baseChildEnv();
+      const env = childEnvWith();
       const run = await runCli(
         [
           "--json",
@@ -274,7 +285,7 @@ Deno.test({
 
       // 5. Read persisted telemetry
       const persisted = await readPersistedEntries(
-        repoDir,
+        configDir,
       ) as unknown as PersistedEntry[];
 
       // Find the parent entry for `workflow run`. It carries no

--- a/src/cli/commands/telemetry_stats.ts
+++ b/src/cli/commands/telemetry_stats.ts
@@ -19,12 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
-import {
-  createContext,
-  type GlobalOptions,
-  resolveRepoDir,
-} from "../context.ts";
-import { requireRepoMarker } from "../repo_context.ts";
+import { createContext, type GlobalOptions } from "../context.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -39,10 +34,6 @@ export const telemetryStatsCommand = new Command()
   .description("View telemetry usage statistics")
   .example("View usage statistics", "swamp telemetry stats")
   .example("Last 7 days", "swamp telemetry stats --days 7")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
   .option("--days <days:number>", "Number of days to analyze", { default: 2 })
   .action(async function (options) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -51,12 +42,10 @@ export const telemetryStatsCommand = new Command()
     ]);
     cliCtx.logger.debug`Fetching telemetry stats`;
 
-    const { repoDir } = await requireRepoMarker(
-      resolveRepoDir(options.repoDir),
-    );
-
+    // Telemetry is user-global — stats read the single user-level spool and do
+    // not require (or accept) a repo.
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createTelemetryStatsDeps(repoDir, VERSION);
+    const deps = createTelemetryStatsDeps(VERSION);
     const renderer = createTelemetryStatsRenderer(cliCtx.outputMode);
 
     await consumeStream(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -20,7 +20,10 @@
 import { Command } from "@cliffy/command";
 import { setColorEnabled } from "@std/fmt/colors";
 import { isAbsolute, join, resolve } from "@std/path";
-import { swampPath } from "../infrastructure/persistence/paths.ts";
+import {
+  globalTelemetryDir,
+  swampPath,
+} from "../infrastructure/persistence/paths.ts";
 import { UserError } from "../domain/errors.ts";
 import { enumeratePulledExtensionDirs } from "../libswamp/mod.ts";
 import { getLogger, parseLogLevel } from "@logtape/logtape";
@@ -121,6 +124,7 @@ import {
 } from "./telemetry_integration.ts";
 import type { CommandInvocationData } from "../domain/telemetry/command_invocation.ts";
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
+import { TelemetryPreferencesFileRepository } from "../infrastructure/persistence/telemetry_preferences_file_repository.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
@@ -1039,15 +1043,28 @@ import { resolveTrustedCollectives } from "../libswamp/mod.ts";
 interface TelemetryContext {
   service: TelemetryService;
   userId: string | null;
-  repoId: string;
+  /**
+   * Repo-specific identifier, present only when the run happened inside a
+   * swamp repo. Undefined for repo-less runs — the event is then keyed solely
+   * by the user identity (userId).
+   */
+  repoId: string | undefined;
   telemetryEndpoint: string;
   keepFlushed: boolean;
   authToken: string | null;
 }
 
 /**
- * Initialize telemetry service if in a swamp repository.
- * Lazy-migrates repoId if missing from marker file.
+ * Initialize the telemetry service for this invocation.
+ *
+ * Telemetry is global: every run spools to the single user-level directory
+ * ({@link globalTelemetryDir}) whether or not it happened inside a swamp repo.
+ * A repo marker, when present, only *enriches* the event (repoId, configured
+ * tools, datastore, endpoint, keepFlushed) and can opt the repo out; it no
+ * longer gates telemetry or selects the spool. Repo-less runs honor a
+ * persistent user-level opt-out at `<config>/telemetry.yaml`.
+ *
+ * Returns null only when telemetry is disabled for this run.
  */
 async function initTelemetryService(
   repoDir: string,
@@ -1055,22 +1072,38 @@ async function initTelemetryService(
   try {
     const markerRepo = new RepoMarkerRepository();
     const repoPath = RepoPath.create(repoDir);
-
     const marker = await markerRepo.read(repoPath);
-    if (!marker) {
-      return null; // Not in a swamp repo
-    }
 
-    if (isTelemetryDisabledByConfig(marker)) {
-      return null;
-    }
+    // Enrichment fields default to the repo-less state; a marker decorates the
+    // event with repo-specific detail when the run happened inside a repo.
+    let repoId: string | undefined;
+    let configuredAiTools: string[] | undefined;
+    let externalDatastore = false;
+    let markerEndpoint: string | undefined;
+    let keepFlushed = false;
 
-    // Lazy-migrate repoId if missing
-    let repoId = marker.repoId;
-    if (!repoId) {
-      repoId = crypto.randomUUID();
-      marker.repoId = repoId;
-      await markerRepo.write(repoPath, marker);
+    if (marker) {
+      if (isTelemetryDisabledByConfig(marker)) {
+        return null; // Per-repo opt-out via marker telemetryDisabled
+      }
+
+      // Lazy-migrate repoId if missing
+      repoId = marker.repoId;
+      if (!repoId) {
+        repoId = crypto.randomUUID();
+        marker.repoId = repoId;
+        await markerRepo.write(repoPath, marker);
+      }
+      configuredAiTools = marker.tools;
+      externalDatastore = isExternalDatastoreConfigured(marker.datastore);
+      markerEndpoint = marker.telemetryEndpoint;
+      keepFlushed = marker.telemetryKeepFlushed ?? false;
+    } else {
+      // Repo-less: honor the persistent user-level opt-out.
+      const prefs = await new TelemetryPreferencesFileRepository().read();
+      if (prefs.disabled) {
+        return null;
+      }
     }
 
     // Resolve user-level identity (lazy-creates ~/.config/swamp/identity.json)
@@ -1094,11 +1127,15 @@ async function initTelemetryService(
       // Auth file unreadable — continue without auth
     }
 
-    const repository = new JsonTelemetryRepository(repoDir);
+    // Single, user-level spool — never repo-local.
+    const repository = new JsonTelemetryRepository(
+      repoDir,
+      globalTelemetryDir(),
+    );
     const invocationContext = buildInvocationContext(
       projectEnvSnapshot(),
-      marker.tools,
-      isExternalDatastoreConfigured(marker.datastore),
+      configuredAiTools,
+      externalDatastore,
     );
     const service = new TelemetryService(
       repository,
@@ -1106,11 +1143,9 @@ async function initTelemetryService(
       invocationContext,
     );
     const telemetryEndpoint = resolveTelemetryEndpoint(
-      marker.telemetryEndpoint,
+      markerEndpoint,
       authServerUrl,
     );
-
-    const keepFlushed = marker.telemetryKeepFlushed ?? false;
 
     return {
       service,
@@ -1121,7 +1156,7 @@ async function initTelemetryService(
       authToken,
     };
   } catch {
-    // Not in a swamp repo or other error
+    // Best-effort — any failure disables telemetry for this run.
     return null;
   }
 }
@@ -1393,21 +1428,27 @@ export async function runCli(args: string[]): Promise<void> {
         try {
           await telemetryCtx.service.recordSuccess(commandInfo, startTime);
 
-          const sender = new HttpTelemetrySender(
-            telemetryCtx.telemetryEndpoint,
-            USER_AGENT,
-          );
-          const flushed = await telemetryCtx.service.flushTelemetry({
-            sender,
-            distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
-            repoId: telemetryCtx.repoId,
-            authToken: telemetryCtx.authToken ?? undefined,
-            keepFlushed: telemetryCtx.keepFlushed,
-            signal: AbortSignal.timeout(2000),
-          });
-          if (!flushed) {
-            logger
-              .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+          // distinct_id is required by the sender. For repo-less runs it is
+          // the global userId; if neither userId nor repoId resolved, skip the
+          // flush and leave the entry spooled for a future run.
+          const distinctId = telemetryCtx.userId ?? telemetryCtx.repoId;
+          if (distinctId) {
+            const sender = new HttpTelemetrySender(
+              telemetryCtx.telemetryEndpoint,
+              USER_AGENT,
+            );
+            const flushed = await telemetryCtx.service.flushTelemetry({
+              sender,
+              distinctId,
+              repoId: telemetryCtx.repoId,
+              authToken: telemetryCtx.authToken ?? undefined,
+              keepFlushed: telemetryCtx.keepFlushed,
+              signal: AbortSignal.timeout(2000),
+            });
+            if (!flushed) {
+              logger
+                .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+            }
           }
 
           // Trigger cleanup asynchronously (fire-and-forget)
@@ -1571,18 +1612,23 @@ export async function runCli(args: string[]): Promise<void> {
     if (telemetryCtx && error instanceof Error) {
       await telemetryCtx.service.recordError(commandInfo, startTime, error);
 
-      const sender = new HttpTelemetrySender(
-        telemetryCtx.telemetryEndpoint,
-        USER_AGENT,
-      );
-      await telemetryCtx.service.flushTelemetry({
-        sender,
-        distinctId: telemetryCtx.userId ?? telemetryCtx.repoId,
-        repoId: telemetryCtx.repoId,
-        authToken: telemetryCtx.authToken ?? undefined,
-        keepFlushed: telemetryCtx.keepFlushed,
-        signal: AbortSignal.timeout(2000),
-      });
+      // distinct_id is required by the sender (see success path). Skip the
+      // flush if neither userId nor repoId resolved.
+      const distinctId = telemetryCtx.userId ?? telemetryCtx.repoId;
+      if (distinctId) {
+        const sender = new HttpTelemetrySender(
+          telemetryCtx.telemetryEndpoint,
+          USER_AGENT,
+        );
+        await telemetryCtx.service.flushTelemetry({
+          sender,
+          distinctId,
+          repoId: telemetryCtx.repoId,
+          authToken: telemetryCtx.authToken ?? undefined,
+          keepFlushed: telemetryCtx.keepFlushed,
+          signal: AbortSignal.timeout(2000),
+        });
+      }
     }
     throw error;
   } finally {

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -21,6 +21,7 @@ import { join, resolve, SEPARATOR } from "@std/path";
 import { ensureDir } from "@std/fs";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
+import { migrateRepoTelemetryToGlobal } from "../../infrastructure/persistence/telemetry_spool_migration.ts";
 import { defaultCommandResolver } from "../../infrastructure/process/resolve_command.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
@@ -487,6 +488,10 @@ export class RepoService {
 
     // Migrate from symlink-based layout to datastore layout
     await this.migrateFromSymlinks(repoPath);
+
+    // Migrate any unflushed entries from a legacy repo-local telemetry spool
+    // to the user-global spool (telemetry is no longer repo-scoped).
+    await this.migrateRepoLocalTelemetry(repoPath, existingMarker);
 
     if (localSkillCopies.length === 0) {
       delete updatedMarker.lastSkillMigrationWarning;
@@ -2084,13 +2089,33 @@ export const SwampAudit: Plugin = async ({ directory }) => {
       SWAMP_SUBDIRS.workflowsEvaluated,
       SWAMP_SUBDIRS.definitionsEvaluated,
       SWAMP_SUBDIRS.secrets,
-      SWAMP_SUBDIRS.telemetry,
+      // Telemetry is user-global (~/.config/swamp/telemetry), not repo-local —
+      // do not scaffold a repo-local telemetry directory.
       SWAMP_SUBDIRS.audit,
       SWAMP_SUBDIRS.vaultBundles,
     ];
 
     for (const subdir of runtimeSubdirs) {
       await ensureDir(swampPath(repoPath.value, subdir));
+    }
+  }
+
+  /**
+   * Drains a legacy repo-local telemetry spool into the user-global spool
+   * during upgrade. Repos that opted out of telemetry are skipped so their
+   * leftover entries are never sent. The repo-local directory is left orphaned,
+   * never deleted. Best-effort — telemetry migration must never fail an
+   * upgrade.
+   */
+  private async migrateRepoLocalTelemetry(
+    repoPath: RepoPath,
+    marker: RepoMarkerData,
+  ): Promise<void> {
+    if (marker.telemetryDisabled === true) return;
+    try {
+      await migrateRepoTelemetryToGlobal(repoPath.value);
+    } catch {
+      // Best-effort — never break an upgrade over telemetry.
     }
   }
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -160,7 +160,6 @@ Deno.test("RepoService.init creates data directory structure", async () => {
       ".swamp/workflows-evaluated",
       ".swamp/definitions-evaluated",
       ".swamp/secrets",
-      ".swamp/telemetry",
     ];
 
     for (const dir of expectedDirs) {
@@ -168,6 +167,12 @@ Deno.test("RepoService.init creates data directory structure", async () => {
       const stat = await Deno.stat(dirPath);
       assertEquals(stat.isDirectory, true, `${dir} should exist`);
     }
+
+    // Telemetry is user-global — init must NOT scaffold a repo-local spool.
+    await assertRejects(
+      () => Deno.stat(join(tempDir, ".swamp/telemetry")),
+      Deno.errors.NotFound,
+    );
   });
 });
 

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -33,9 +33,9 @@ import type { DetectableAiTool } from "./agent_harness_detection.ts";
  *
  * `configuredAiTools` distinguishes two states with different downstream
  * meanings:
- *  - `undefined` — the entry was recorded outside a swamp repo (forward-
- *    compat reserve; today initTelemetryService bails before recording in
- *    this case).
+ *  - `undefined` — the entry was recorded outside a swamp repo. Telemetry is
+ *    global (user-level), so repo-less runs are recorded; with no marker there
+ *    is no configured tool list to report.
  *  - `[]` — the repo exists with `tools: []` (legacy `tool: none`
  *    normalised), an explicit opt-out of tool integration.
  */

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -280,3 +280,18 @@ export function getSwampConfigDir(): string {
   }
   return join(home, ".config", "swamp");
 }
+
+/**
+ * Returns the single, user-level telemetry spool directory.
+ *
+ * Telemetry is global (keyed to the user identity), not repo-scoped: every CLI
+ * invocation spools here regardless of whether it ran inside a swamp repo. This
+ * is the one spool — there is no repo-local telemetry directory.
+ *
+ * @returns The absolute path to `<config>/telemetry` (XDG-aware via
+ *   {@link getSwampConfigDir})
+ * @throws Error if HOME environment variable is not set
+ */
+export function globalTelemetryDir(): string {
+  return join(getSwampConfigDir(), SWAMP_SUBDIRS.telemetry);
+}

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -22,6 +22,7 @@ import {
   bundleNamespace,
   getSwampConfigDir,
   getSwampDataDir,
+  globalTelemetryDir,
   homeDirectory,
   homeDirectoryIsSet,
   SWAMP_DATA_DIR,
@@ -193,6 +194,35 @@ Deno.test("getSwampConfigDir throws when HOME is not set", () => {
       () => getSwampConfigDir(),
       Error,
       "HOME environment variable is not set",
+    );
+  } finally {
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
+    if (originalHome) Deno.env.set("HOME", originalHome);
+    else Deno.env.delete("HOME");
+  }
+});
+
+Deno.test("globalTelemetryDir is the telemetry subdir under the config dir", () => {
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
+  try {
+    Deno.env.set("XDG_CONFIG_HOME", "/custom/config");
+    assertPathEquals(globalTelemetryDir(), "/custom/config/swamp/telemetry");
+  } finally {
+    if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
+  }
+});
+
+Deno.test("globalTelemetryDir falls back to HOME/.config/swamp/telemetry", () => {
+  const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
+  const originalHome = Deno.env.get("HOME");
+  try {
+    Deno.env.delete("XDG_CONFIG_HOME");
+    Deno.env.set("HOME", "/home/testuser");
+    assertPathEquals(
+      globalTelemetryDir(),
+      "/home/testuser/.config/swamp/telemetry",
     );
   } finally {
     if (originalXdg) Deno.env.set("XDG_CONFIG_HOME", originalXdg);

--- a/src/infrastructure/persistence/telemetry_preferences_file_repository.ts
+++ b/src/infrastructure/persistence/telemetry_preferences_file_repository.ts
@@ -1,0 +1,82 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import { parse, stringify } from "@std/yaml";
+import { getSwampConfigDir } from "./paths.ts";
+import { atomicWriteTextFile } from "./atomic_write.ts";
+
+const PREFERENCES_FILE_NAME = "telemetry.yaml";
+
+/**
+ * User-level telemetry preferences, persisted at
+ * `<config>/telemetry.yaml` (XDG-aware).
+ *
+ * This is the persistent opt-out for the repo-less telemetry path: outside a
+ * swamp repo there is no marker to carry `telemetryDisabled`, so this file is
+ * the durable equivalent. `disabled` mirrors the marker's `telemetryDisabled`
+ * polarity (default `false` = telemetry enabled).
+ */
+export interface TelemetryPreferences {
+  readonly disabled: boolean;
+}
+
+/** Default preferences when no file exists: telemetry enabled. */
+export const DEFAULT_TELEMETRY_PREFERENCES: TelemetryPreferences = {
+  disabled: false,
+};
+
+/**
+ * Reads and writes the user-level telemetry preferences file. Never throws on
+ * read — a missing or malformed file yields the default (enabled), matching the
+ * best-effort discipline of the rest of the telemetry pipeline.
+ */
+export class TelemetryPreferencesFileRepository {
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ??
+      join(getSwampConfigDir(), PREFERENCES_FILE_NAME);
+  }
+
+  async read(): Promise<TelemetryPreferences> {
+    try {
+      const content = await Deno.readTextFile(this.filePath);
+      const data = parse(content) as Record<string, unknown> | null;
+
+      if (!data || typeof data !== "object") {
+        return { ...DEFAULT_TELEMETRY_PREFERENCES };
+      }
+
+      return {
+        disabled: typeof data.disabled === "boolean"
+          ? data.disabled
+          : DEFAULT_TELEMETRY_PREFERENCES.disabled,
+      };
+    } catch {
+      return { ...DEFAULT_TELEMETRY_PREFERENCES };
+    }
+  }
+
+  async write(preferences: TelemetryPreferences): Promise<void> {
+    const dir = dirname(this.filePath);
+    await Deno.mkdir(dir, { recursive: true });
+    await atomicWriteTextFile(this.filePath, stringify({ ...preferences }));
+  }
+}

--- a/src/infrastructure/persistence/telemetry_preferences_file_repository_test.ts
+++ b/src/infrastructure/persistence/telemetry_preferences_file_repository_test.ts
@@ -1,0 +1,93 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  DEFAULT_TELEMETRY_PREFERENCES,
+  TelemetryPreferencesFileRepository,
+} from "./telemetry_preferences_file_repository.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("TelemetryPreferencesFileRepository: enabled by default when file missing", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new TelemetryPreferencesFileRepository(
+      join(dir, "nonexistent", "telemetry.yaml"),
+    );
+    const prefs = await repo.read();
+    assertEquals(prefs, DEFAULT_TELEMETRY_PREFERENCES);
+    assertEquals(prefs.disabled, false);
+  });
+});
+
+Deno.test("TelemetryPreferencesFileRepository: honors disabled: true", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "telemetry.yaml");
+    const repo = new TelemetryPreferencesFileRepository(filePath);
+
+    await repo.write({ disabled: true });
+
+    const result = await repo.read();
+    assertEquals(result.disabled, true);
+  });
+});
+
+Deno.test("TelemetryPreferencesFileRepository: round-trips disabled: false", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "telemetry.yaml");
+    const repo = new TelemetryPreferencesFileRepository(filePath);
+
+    await repo.write({ disabled: false });
+
+    const result = await repo.read();
+    assertEquals(result.disabled, false);
+  });
+});
+
+Deno.test("TelemetryPreferencesFileRepository: falls back to enabled on corrupt file", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "telemetry.yaml");
+    await Deno.writeTextFile(filePath, "not: [valid: yaml: {{{");
+
+    const repo = new TelemetryPreferencesFileRepository(filePath);
+    const prefs = await repo.read();
+    assertEquals(prefs, DEFAULT_TELEMETRY_PREFERENCES);
+  });
+});
+
+Deno.test("TelemetryPreferencesFileRepository: ignores non-boolean disabled field", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "telemetry.yaml");
+    await Deno.writeTextFile(filePath, "disabled: yes-please\n");
+
+    const repo = new TelemetryPreferencesFileRepository(filePath);
+    const prefs = await repo.read();
+    assertEquals(prefs.disabled, false);
+  });
+});

--- a/src/infrastructure/persistence/telemetry_spool_migration.ts
+++ b/src/infrastructure/persistence/telemetry_spool_migration.ts
@@ -1,0 +1,84 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { globalTelemetryDir, SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+
+/**
+ * Migrates UNFLUSHED telemetry entries from a legacy repo-local spool
+ * (`<repoDir>/.swamp/telemetry/`) to the single user-global spool.
+ *
+ * Telemetry became user-global, so a repo upgraded from an older layout may
+ * still hold entries that were recorded but never sent. This moves them to the
+ * global spool so they are not lost. Each file keeps its name (which embeds a
+ * UUID, making collisions effectively impossible). Already-flushed entries
+ * (`*.flushed.json`) were already sent and are left behind. The repo-local
+ * directory itself is NOT removed — it is left orphaned.
+ *
+ * The caller is responsible for skipping repos that have opted out of
+ * telemetry: a disabled repo's leftover entries must never be moved into the
+ * global spool, or they would be sent despite the opt-out.
+ *
+ * @param repoDir - The repository root whose legacy spool should be drained.
+ * @param destDir - The destination spool; defaults to the user-global spool.
+ *   Injectable for tests.
+ * @returns The number of entries migrated.
+ */
+export async function migrateRepoTelemetryToGlobal(
+  repoDir: string,
+  destDir: string = globalTelemetryDir(),
+): Promise<number> {
+  const sourceDir = swampPath(repoDir, SWAMP_SUBDIRS.telemetry);
+
+  const sourceNames: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(sourceDir)) {
+      if (!entry.isFile) continue;
+      if (!entry.name.startsWith("telemetry-")) continue;
+      if (!entry.name.endsWith(".json")) continue;
+      // Only unflushed entries (never sent). Flushed copies are left behind.
+      if (entry.name.endsWith(".flushed.json")) continue;
+      sourceNames.push(entry.name);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return 0; // no repo-local spool
+    throw error;
+  }
+
+  if (sourceNames.length === 0) return 0;
+  await ensureDir(destDir);
+
+  let migrated = 0;
+  for (const name of sourceNames) {
+    const src = join(sourceDir, name);
+    const dest = join(destDir, name);
+    try {
+      await Deno.rename(src, dest);
+    } catch {
+      // Cross-filesystem move (repo and home on different mounts): rename
+      // throws EXDEV, so fall back to copy-then-remove.
+      await Deno.copyFile(src, dest);
+      await Deno.remove(src);
+    }
+    migrated++;
+  }
+
+  return migrated;
+}

--- a/src/infrastructure/persistence/telemetry_spool_migration_test.ts
+++ b/src/infrastructure/persistence/telemetry_spool_migration_test.ts
@@ -1,0 +1,106 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+import { migrateRepoTelemetryToGlobal } from "./telemetry_spool_migration.ts";
+import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-tel-mig-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+Deno.test("migrateRepoTelemetryToGlobal: returns 0 when no repo-local spool exists", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    const destDir = join(dir, "global");
+    const count = await migrateRepoTelemetryToGlobal(repoDir, destDir);
+    assertEquals(count, 0);
+  });
+});
+
+Deno.test("migrateRepoTelemetryToGlobal: moves unflushed entries and leaves flushed ones", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    const destDir = join(dir, "global");
+    const spool = swampPath(repoDir, SWAMP_SUBDIRS.telemetry);
+    await ensureDir(spool);
+
+    const unflushedA = "telemetry-2026-07-13-aaaaaaaa.json";
+    const unflushedB = "telemetry-2026-07-13-bbbbbbbb.json";
+    const flushed = "telemetry-2026-07-13-cccccccc.flushed.json";
+    await Deno.writeTextFile(join(spool, unflushedA), '{"id":"a"}');
+    await Deno.writeTextFile(join(spool, unflushedB), '{"id":"b"}');
+    await Deno.writeTextFile(join(spool, flushed), '{"id":"c"}');
+
+    const count = await migrateRepoTelemetryToGlobal(repoDir, destDir);
+    assertEquals(count, 2);
+
+    // Unflushed entries moved to the destination...
+    assert(await fileExists(join(destDir, unflushedA)));
+    assert(await fileExists(join(destDir, unflushedB)));
+    assertEquals(
+      await Deno.readTextFile(join(destDir, unflushedA)),
+      '{"id":"a"}',
+    );
+    // ...and removed from the source.
+    assertEquals(await fileExists(join(spool, unflushedA)), false);
+    assertEquals(await fileExists(join(spool, unflushedB)), false);
+
+    // The already-flushed entry is left behind and not copied.
+    assert(await fileExists(join(spool, flushed)));
+    assertEquals(await fileExists(join(destDir, flushed)), false);
+
+    // The (now-empty) repo-local spool directory is left orphaned, not deleted.
+    assert(await fileExists(spool));
+  });
+});
+
+Deno.test("migrateRepoTelemetryToGlobal: ignores non-telemetry files", async () => {
+  await withTempDir(async (dir) => {
+    const repoDir = join(dir, "repo");
+    const destDir = join(dir, "global");
+    const spool = swampPath(repoDir, SWAMP_SUBDIRS.telemetry);
+    await ensureDir(spool);
+    await Deno.writeTextFile(join(spool, "README.txt"), "not telemetry");
+    await Deno.writeTextFile(join(spool, "telemetry-2026-07-13-dd.json"), "{}");
+
+    const count = await migrateRepoTelemetryToGlobal(repoDir, destDir);
+    assertEquals(count, 1);
+    assert(await fileExists(join(spool, "README.txt")));
+  });
+});

--- a/src/libswamp/telemetry/stats.ts
+++ b/src/libswamp/telemetry/stats.ts
@@ -22,6 +22,7 @@ import {
   type TelemetryStats,
 } from "../../domain/telemetry/telemetry_service.ts";
 import { JsonTelemetryRepository } from "../../infrastructure/persistence/json_telemetry_repository.ts";
+import { globalTelemetryDir } from "../../infrastructure/persistence/paths.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
@@ -45,10 +46,12 @@ export interface TelemetryStatsInput {
 
 /** Wires real infrastructure into TelemetryStatsDeps. */
 export function createTelemetryStatsDeps(
-  repoDir: string,
   version: string,
 ): TelemetryStatsDeps {
-  const repository = new JsonTelemetryRepository(repoDir);
+  // Telemetry is user-global; the spool location does not depend on any repo.
+  // The repository's repoDir arg only feeds the default baseDir, which we
+  // override with the global spool, so it is unused here.
+  const repository = new JsonTelemetryRepository("", globalTelemetryDir());
   const service = new TelemetryService(repository, version);
   return {
     getStats: (days: number) => service.getStats(days),


### PR DESCRIPTION
## Summary

`cli_invocation` telemetry was only recorded inside a swamp repo — `initTelemetryService` returned `null` without a `.swamp` marker and the spool was repo-local. Every repo-less command (`auth login`, `extension search`, `version`, `repo init` pre-marker) dropped its event: zero events reached the lake, and that activity never counted toward leaderboard score.

Telemetry is now **user-global**. There is exactly one spool at `~/.config/swamp/telemetry/` (XDG-aware); every invocation records there whether or not it ran inside a repo. A repo marker, when present, only **enriches** the event (`repoId`, configured tools, datastore, endpoint, `keepFlushed`) — it no longer gates telemetry or selects the spool.

- `initTelemetryService` always builds a context unless disabled; `repoId` is optional and `configuredAiTools` is `undefined` for repo-less runs.
- New persistent user-level opt-out at `~/.config/swamp/telemetry.yaml` (`disabled: true`), alongside the existing `SWAMP_NO_TELEMETRY` / `--no-telemetry`.
- `swamp telemetry stats` reads the global spool, runs outside a repo, and **no longer accepts `--repo-dir`**.
- `swamp repo init` no longer scaffolds a repo-local `.swamp/telemetry/` directory.
- `swamp repo upgrade` migrates unflushed entries from a legacy repo-local spool to the global spool, **skipping repos that opted out** (their entries are never sent); the old folder is left orphaned, never deleted.
- Integration tests run with `SWAMP_NO_TELEMETRY=1` by default so test subprocesses don't pollute the developer's real global spool (and never inflate their score).

Fixes swamp-club#1125. Docs follow-up: Lab #1129. A swamp-uat test (`tests/cli/telemetry/stats_test.ts` — "stats in non-repo directory exits 1") needs updating, being handled separately.

## Test Plan

- Unit: telemetry-preferences repo, `globalTelemetryDir()`, spool migration (moves unflushed, leaves flushed, ignores non-telemetry), repo-init no longer creates the dir.
- Integration (`integration/telemetry_global_spool_test.ts`): repo-less **and** in-repo both spool globally, never repo-local; upgrade migrates unflushed entries; disabled repos are skipped. Existing telemetry integration tests updated to read the global spool.
- Full suite: **8898 passed, 0 failed**; `deno check`, `deno lint`, `deno fmt --check`, `deno run compile` all clean.
- Live reproduction against the compiled binary across every case (repo-less, in-repo, model method, workflow parent+children with `workflowContext`, migration, disabled repo, opt-out file) — all emit with the full field set; enrichment preserved; disabled/opt-out suppress correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)