### PR TITLE
feat(workflows): surface per-run inputs in search results

### DIFF
--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -22,6 +22,7 @@ import {
   consumeStream,
   createLibSwampContext,
   type JobRunView,
+  parseTags,
   type StepRunView,
   workflowHistorySearch,
   type WorkflowHistorySearchData,
@@ -139,13 +140,16 @@ export async function workflowHistorySearchAction(
       server,
       options.token as string | undefined,
     );
+    const parsedInputs = options.input
+      ? parseTags(options.input as string[])
+      : undefined;
     const response = await requestServerResponse<
       WorkflowHistorySearchResponse
     >(
       { server, token },
       {
         type: "workflow.history.search",
-        payload: { query },
+        payload: { query, inputs: parsedInputs },
       },
     );
     const renderer = createWorkflowHistorySearchRenderer(effectiveMode);
@@ -185,8 +189,12 @@ export async function workflowHistorySearchAction(
     effectiveMode,
     fetchPreview,
   );
+  const parsedInputs = options.input
+    ? parseTags(options.input as string[])
+    : undefined;
+
   await consumeStream(
-    workflowHistorySearch(libCtx, deps, { query }),
+    workflowHistorySearch(libCtx, deps, { query, inputs: parsedInputs }),
     renderer.handlers(),
   );
 
@@ -227,5 +235,10 @@ export const workflowHistorySearchCommand = withRemoteOptions(
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--input <input:string>",
+      "Filter by workflow input (KEY=VALUE), can be repeated",
+      { collect: true },
     ),
 ).action(workflowHistorySearchAction);

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -141,6 +141,9 @@ export async function workflowRunSearchAction(
     const parsedTags = options.tag
       ? parseTags(options.tag as string[])
       : undefined;
+    const parsedInputs = options.input
+      ? parseTags(options.input as string[])
+      : undefined;
     const response = await requestServerResponse<WorkflowRunSearchResponse>(
       { server, token },
       {
@@ -151,6 +154,7 @@ export async function workflowRunSearchAction(
           status: options.status as string | undefined,
           workflow: options.workflow as string | undefined,
           tags: parsedTags,
+          inputs: parsedInputs,
           limit: options.limit as number | undefined,
         },
       },
@@ -178,9 +182,12 @@ export async function workflowRunSearchAction(
   const workflowRepo = repoContext.workflowRepo;
   const runRepo = repoContext.workflowRunRepo;
 
-  // Parse --tag values into Record<string, string>
+  // Parse --tag and --input values into Record<string, string>
   const parsedTags = options.tag
     ? parseTags(options.tag as string[])
+    : undefined;
+  const parsedInputs = options.input
+    ? parseTags(options.input as string[])
     : undefined;
 
   const deps: WorkflowRunSearchDeps = {
@@ -204,6 +211,7 @@ export async function workflowRunSearchAction(
       status: options.status as string | undefined,
       workflow: options.workflow as string | undefined,
       tags: parsedTags,
+      inputs: parsedInputs,
       limit: options.limit as number | undefined,
     }),
     renderer.handlers(),
@@ -262,6 +270,11 @@ export const workflowRunSearchCommand = withRemoteOptions(
     .option(
       "--tag <tag:string>",
       "Filter by tag (KEY=VALUE), can be repeated",
+      { collect: true },
+    )
+    .option(
+      "--input <input:string>",
+      "Filter by workflow input (KEY=VALUE), can be repeated",
       { collect: true },
     )
     .option("--limit <n:number>", "Max results", { default: 50 }),

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1615,6 +1615,9 @@ export class WorkflowExecutionService {
           ...(options?.runtimeTags ?? {}),
         };
         run = WorkflowRun.create(workflow, mergedTags);
+        if (options?.inputs) {
+          run.captureInputs(options.inputs);
+        }
         workflowRun = run;
 
         // workflowRunId is set here for backward compat; the structured

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -669,12 +669,16 @@ export class WorkflowRun implements TriggerEvaluationContext {
   }
 
   /**
+   * Records the effective workflow inputs on this run. Called at run
+   * creation so every run persists its inputs, and again at suspend
+   * so resume-time steps can resolve `inputs.*`.
+   */
+  captureInputs(inputs: Record<string, unknown>): void {
+    this._inputs = inputs;
+  }
+
+  /**
    * Marks the workflow run as suspended (waiting for manual approval).
-   *
-   * The effective workflow inputs are captured here so that, on resume, steps
-   * that run after the gate can still resolve `inputs.*`. Inputs are recorded
-   * only at suspend (not at run creation) so runs that never suspend never
-   * write their input values to the persisted run record.
    */
   suspend(inputs?: Record<string, unknown>): void {
     this._status = "suspended";
@@ -684,8 +688,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
   }
 
   /**
-   * The effective workflow inputs persisted when this run last suspended.
-   * Empty for runs that have never suspended.
+   * The effective workflow inputs for this run.
    */
   get inputs(): Readonly<Record<string, unknown>> {
     return this._inputs;

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -684,6 +684,12 @@ Deno.test("WorkflowRun: a fresh run has empty inputs and resumeInputs", () => {
   assertEquals(run.resumeInputs, []);
 });
 
+Deno.test("WorkflowRun.captureInputs: records inputs on the run", () => {
+  const run = WorkflowRun.create(createTestWorkflow());
+  run.captureInputs({ workItem: "PLT-1033", region: "us-east-1" });
+  assertEquals(run.inputs, { workItem: "PLT-1033", region: "us-east-1" });
+});
+
 Deno.test("WorkflowRun.suspend captures the effective inputs", () => {
   const run = WorkflowRun.create(createTestWorkflow());
   run.start();

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -55,6 +55,7 @@ export interface WorkflowHistorySearchDeps {
       completedAt?: Date;
       duration?: number;
       tags: Record<string, string>;
+      inputs: Record<string, unknown>;
     }>
   >;
 }
@@ -64,6 +65,7 @@ export interface WorkflowHistorySearchDeps {
  */
 export interface WorkflowHistorySearchInput {
   query?: string;
+  inputs?: Record<string, string>;
 }
 
 /**
@@ -102,11 +104,14 @@ export async function* workflowHistorySearch(
       });
 
       // Convert to search items
-      const results: WorkflowHistorySearchItem[] = allRuns.map((run) => {
+      let results: WorkflowHistorySearchItem[] = allRuns.map((run) => {
         const startTime = run.startedAt?.getTime();
         const endTime = run.completedAt?.getTime();
         const tags = run.tags && Object.keys(run.tags).length > 0
           ? { ...run.tags }
+          : undefined;
+        const inputs = run.inputs && Object.keys(run.inputs).length > 0
+          ? { ...run.inputs }
           : undefined;
 
         return {
@@ -118,8 +123,16 @@ export async function* workflowHistorySearch(
           completedAt: run.completedAt?.toISOString(),
           duration: startTime && endTime ? endTime - startTime : undefined,
           tags,
+          inputs,
         };
       });
+
+      if (input.inputs) {
+        const inputEntries = Object.entries(input.inputs);
+        results = results.filter((r) =>
+          inputEntries.every(([k, v]) => String(r.inputs?.[k]) === v)
+        );
+      }
 
       yield {
         kind: "completed",

--- a/src/libswamp/workflows/history_search_test.ts
+++ b/src/libswamp/workflows/history_search_test.ts
@@ -48,6 +48,7 @@ function makeDeps(
             startedAt: new Date(now - 1000),
             completedAt: new Date(now),
             tags: {},
+            inputs: {},
           },
         ]);
       }
@@ -61,6 +62,7 @@ function makeDeps(
             startedAt: new Date(now - 3000),
             completedAt: new Date(now - 2000),
             tags: {},
+            inputs: {},
           },
         ]);
       }
@@ -88,6 +90,77 @@ Deno.test("workflowHistorySearch: returns all runs sorted by startedAt desc", as
   // Most recent first
   assertEquals(completed.data.results[0].runId, "run-1");
   assertEquals(completed.data.results[1].runId, "run-2");
+});
+
+Deno.test("workflowHistorySearch: includes inputs in results", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "deploy" }]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        {
+          id: "run-with-inputs",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          completedAt: new Date(now),
+          tags: {},
+          inputs: { workItem: "PLT-1033" },
+        },
+      ]),
+  });
+
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results[0].inputs, { workItem: "PLT-1033" });
+});
+
+Deno.test("workflowHistorySearch: filters by inputs", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "deploy" }]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        {
+          id: "run-match",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          completedAt: new Date(now),
+          tags: {},
+          inputs: { workItem: "PLT-1033" },
+        },
+        {
+          id: "run-no-match",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 2000),
+          completedAt: new Date(now - 1000),
+          tags: {},
+          inputs: { workItem: "PLT-1034" },
+        },
+      ]),
+  });
+
+  const events = await collect<WorkflowHistorySearchEvent>(
+    workflowHistorySearch(createLibSwampContext(), deps, {
+      inputs: { workItem: "PLT-1033" },
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowHistorySearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-match");
 });
 
 Deno.test("workflowHistorySearch: returns empty results when no runs exist", async () => {

--- a/src/libswamp/workflows/run_search.ts
+++ b/src/libswamp/workflows/run_search.ts
@@ -34,6 +34,7 @@ export interface WorkflowRunSearchItem {
   completedAt?: string;
   duration?: number;
   tags?: Record<string, string>;
+  inputs?: Record<string, unknown>;
 }
 
 /**
@@ -64,6 +65,7 @@ export interface WorkflowRunSearchDeps {
       completedAt?: Date;
       duration?: number;
       tags: Record<string, string>;
+      inputs: Record<string, unknown>;
     }>
   >;
 }
@@ -77,6 +79,7 @@ export interface WorkflowRunSearchInput {
   status?: string;
   workflow?: string;
   tags?: Record<string, string>;
+  inputs?: Record<string, string>;
   limit?: number;
 }
 
@@ -122,6 +125,9 @@ export async function* workflowRunSearch(
         const tags = run.tags && Object.keys(run.tags).length > 0
           ? { ...run.tags }
           : undefined;
+        const inputs = run.inputs && Object.keys(run.inputs).length > 0
+          ? { ...run.inputs }
+          : undefined;
 
         return {
           runId: run.id,
@@ -132,6 +138,7 @@ export async function* workflowRunSearch(
           completedAt: run.completedAt?.toISOString(),
           duration: startTime && endTime ? endTime - startTime : undefined,
           tags,
+          inputs,
         };
       });
 
@@ -161,6 +168,13 @@ export async function* workflowRunSearch(
         const tagEntries = Object.entries(input.tags);
         results = results.filter((r) =>
           tagEntries.every(([k, v]) => r.tags?.[k] === v)
+        );
+      }
+
+      if (input.inputs) {
+        const inputEntries = Object.entries(input.inputs);
+        results = results.filter((r) =>
+          inputEntries.every(([k, v]) => String(r.inputs?.[k]) === v)
         );
       }
 

--- a/src/libswamp/workflows/run_search_test.ts
+++ b/src/libswamp/workflows/run_search_test.ts
@@ -36,6 +36,7 @@ function makeRun(overrides: {
   startedAt?: Date;
   completedAt?: Date;
   tags?: Record<string, string>;
+  inputs?: Record<string, unknown>;
 }) {
   return {
     id: overrides.id,
@@ -45,6 +46,7 @@ function makeRun(overrides: {
     startedAt: overrides.startedAt,
     completedAt: overrides.completedAt,
     tags: overrides.tags ?? {},
+    inputs: overrides.inputs ?? {},
   };
 }
 
@@ -176,4 +178,87 @@ Deno.test("workflowRunSearch: applies limit", async () => {
     { kind: "completed" }
   >;
   assertEquals(completed.data.results.length, 2);
+});
+
+Deno.test("workflowRunSearch: includes inputs in results", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "deploy" }]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        makeRun({
+          id: "run-with-inputs",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          inputs: { workItem: "PLT-1033", region: "us-east-1" },
+        }),
+        makeRun({
+          id: "run-no-inputs",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 2000),
+        }),
+      ]),
+  });
+
+  const events = await collect<WorkflowRunSearchEvent>(
+    workflowRunSearch(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowRunSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results[0].inputs, {
+    workItem: "PLT-1033",
+    region: "us-east-1",
+  });
+  assertEquals(completed.data.results[1].inputs, undefined);
+});
+
+Deno.test("workflowRunSearch: filters by inputs", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([{ id: "wf-1", name: "deploy" }]),
+    findAllRunsByWorkflowId: () =>
+      Promise.resolve([
+        makeRun({
+          id: "run-plt-1033",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 1000),
+          inputs: { workItem: "PLT-1033" },
+        }),
+        makeRun({
+          id: "run-plt-1034",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 2000),
+          inputs: { workItem: "PLT-1034" },
+        }),
+        makeRun({
+          id: "run-no-inputs",
+          workflowId: "wf-1",
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: new Date(now - 3000),
+        }),
+      ]),
+  });
+
+  const events = await collect<WorkflowRunSearchEvent>(
+    workflowRunSearch(createLibSwampContext(), deps, {
+      inputs: { workItem: "PLT-1033" },
+    }),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowRunSearchEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.results.length, 1);
+  assertEquals(completed.data.results[0].runId, "run-plt-1033");
 });

--- a/src/presentation/renderers/workflow_history_search.tsx
+++ b/src/presentation/renderers/workflow_history_search.tsx
@@ -71,7 +71,11 @@ function filterRuns(
     (r) =>
       r.workflowName.toLowerCase().includes(lowerQuery) ||
       r.runId.toLowerCase().includes(lowerQuery) ||
-      r.status.toLowerCase().includes(lowerQuery),
+      r.status.toLowerCase().includes(lowerQuery) ||
+      (r.inputs &&
+        Object.entries(r.inputs).some(([k, v]) =>
+          `${k}=${String(v)}`.toLowerCase().includes(lowerQuery)
+        )),
   );
 }
 
@@ -135,7 +139,11 @@ class InkWorkflowHistorySearchRenderer
                 " ",
               )
               : "";
-            return `${item.workflowName} ${item.runId} ${item.status} ${tagStr}`
+            const inputStr = item.inputs
+              ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`)
+                .join(" ")
+              : "";
+            return `${item.workflowName} ${item.runId} ${item.status} ${tagStr} ${inputStr}`
               .trim();
           },
           renderHistoryResultLine,
@@ -188,6 +196,11 @@ function renderHistoryResultLine(
   const tagStr = item.tags && Object.keys(item.tags).length > 0
     ? Object.entries(item.tags).map(([k, v]) => `${k}=${v}`).join(", ")
     : "";
+  const inputStr = item.inputs && Object.keys(item.inputs).length > 0
+    ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+      ", ",
+    )
+    : "";
 
   return (
     <Text>
@@ -196,6 +209,7 @@ function renderHistoryResultLine(
       {` ${dateStr}`}
       {durationStr ? ` ${durationStr}` : ""}
       {tagStr ? <Text color="cyan">{` [${tagStr}]`}</Text> : null}
+      {inputStr ? <Text color="magenta">{` {${inputStr}}`}</Text> : null}
     </Text>
   );
 }
@@ -251,6 +265,18 @@ function renderHistoryPreview(
     if (tagStr) {
       lines.push(
         <Text key="tags" dimColor wrap="truncate-end">tags: {tagStr}</Text>,
+      );
+    }
+    const previewInputStr = item.inputs && Object.keys(item.inputs).length > 0
+      ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+        ", ",
+      )
+      : "";
+    if (previewInputStr) {
+      lines.push(
+        <Text key="inputs" dimColor wrap="truncate-end">
+          inputs: {previewInputStr}
+        </Text>,
       );
     }
     return (
@@ -354,6 +380,14 @@ function renderHistoryScrollback(
     }
     if (tagStr) {
       lines.push(`tags: ${tagStr}`);
+    }
+    const scrollInputStr = item.inputs && Object.keys(item.inputs).length > 0
+      ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+        ", ",
+      )
+      : "";
+    if (scrollInputStr) {
+      lines.push(`inputs: ${scrollInputStr}`);
     }
 
     return lines.join("\n");

--- a/src/presentation/renderers/workflow_run_search.tsx
+++ b/src/presentation/renderers/workflow_run_search.tsx
@@ -115,7 +115,11 @@ class InkWorkflowRunSearchRenderer implements WorkflowRunSearchRenderer {
                 " ",
               )
               : "";
-            return `${item.workflowName} ${item.runId} ${item.status} ${tagStr}`
+            const inputStr = item.inputs
+              ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`)
+                .join(" ")
+              : "";
+            return `${item.workflowName} ${item.runId} ${item.status} ${tagStr} ${inputStr}`
               .trim();
           },
           renderRunResultLine,
@@ -168,6 +172,11 @@ function renderRunResultLine(
   const tagStr = item.tags && Object.keys(item.tags).length > 0
     ? Object.entries(item.tags).map(([k, v]) => `${k}=${v}`).join(", ")
     : "";
+  const inputStr = item.inputs && Object.keys(item.inputs).length > 0
+    ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+      ", ",
+    )
+    : "";
 
   return (
     <Text>
@@ -176,6 +185,7 @@ function renderRunResultLine(
       {` ${dateStr}`}
       {durationStr ? ` ${durationStr}` : ""}
       {tagStr ? <Text color="cyan">{` [${tagStr}]`}</Text> : null}
+      {inputStr ? <Text color="magenta">{` {${inputStr}}`}</Text> : null}
     </Text>
   );
 }
@@ -231,6 +241,18 @@ function renderRunPreview(
     if (tagStr) {
       lines.push(
         <Text key="tags" dimColor wrap="truncate-end">tags: {tagStr}</Text>,
+      );
+    }
+    const previewInputStr = item.inputs && Object.keys(item.inputs).length > 0
+      ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+        ", ",
+      )
+      : "";
+    if (previewInputStr) {
+      lines.push(
+        <Text key="inputs" dimColor wrap="truncate-end">
+          inputs: {previewInputStr}
+        </Text>,
       );
     }
     return (
@@ -334,6 +356,14 @@ function renderRunScrollback(
     }
     if (tagStr) {
       lines.push(`tags: ${tagStr}`);
+    }
+    const scrollInputStr = item.inputs && Object.keys(item.inputs).length > 0
+      ? Object.entries(item.inputs).map(([k, v]) => `${k}=${String(v)}`).join(
+        ", ",
+      )
+      : "";
+    if (scrollInputStr) {
+      lines.push(`inputs: ${scrollInputStr}`);
     }
 
     return lines.join("\n");

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -569,6 +569,7 @@ const WorkflowHistorySearchRequestSchema = z.object({
   id: z.string().min(1).max(256),
   payload: z.object({
     query: z.string().optional(),
+    inputs: z.record(z.string(), z.string()).optional(),
   }).optional(),
 });
 
@@ -581,6 +582,7 @@ const WorkflowRunSearchRequestSchema = z.object({
     status: z.string().optional(),
     workflow: z.string().optional(),
     tags: z.record(z.string(), z.string()).optional(),
+    inputs: z.record(z.string(), z.string()).optional(),
     limit: z.number().int().positive().max(10_000).optional(),
   }).optional(),
 });

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -483,7 +483,10 @@ export async function handleWorkflowHistorySearch(
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
-      workflowHistorySearch(libCtx, deps, { query: payload?.query }),
+      workflowHistorySearch(libCtx, deps, {
+        query: payload?.query,
+        inputs: payload?.inputs,
+      }),
       {
         resolving: () => {},
         completed: (e) => {
@@ -550,6 +553,7 @@ export async function handleWorkflowRunSearch(
         status: payload?.status,
         workflow: payload?.workflow,
         tags: payload?.tags,
+        inputs: payload?.inputs,
         limit: payload?.limit,
       }),
       {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -290,6 +290,7 @@ export interface WorkflowHistoryLogsPayload {
 
 export interface WorkflowHistorySearchPayload {
   query?: string;
+  inputs?: Record<string, string>;
 }
 
 export interface WorkflowRunSearchPayload {
@@ -298,6 +299,7 @@ export interface WorkflowRunSearchPayload {
   status?: string;
   workflow?: string;
   tags?: Record<string, string>;
+  inputs?: Record<string, string>;
   limit?: number;
 }
 


### PR DESCRIPTION
## Summary

Closes swamp-club#799.

- Add `inputs` field to `WorkflowRunSearchItem` so `workflow history search --json` and `workflow run search --json` include per-run inputs in results
- Add `--input KEY=VALUE` flag (repeatable, AND logic) to both commands for filtering runs by input values
- Capture inputs at run creation via `WorkflowRun.captureInputs()` — previously inputs were only persisted when a run suspended, so workflows without manual approval gates never recorded their inputs
- Wire `inputs` through the full serve/WebSocket path (Zod validation schemas, protocol types, handlers)
- Render inputs in interactive picker (result lines, preview panes, scrollback) and include in fuzzy search

### Changes across layers

| Layer | Files | What changed |
|-------|-------|-------------|
| Domain | `workflow_run.ts`, `execution_service.ts` | New `captureInputs()` method; call it at run creation |
| Libswamp | `run_search.ts`, `history_search.ts` | `inputs` on search item type, deps interfaces, generators; `--input` filter logic |
| CLI | `workflow_history_search.ts`, `workflow_run_search.ts` | `--input` flag, wired for both local and remote modes |
| Serve | `protocol.ts`, `connection.ts`, `workflow_handlers.ts` | Zod schemas, payload types, handler pass-through |
| Presentation | `workflow_history_search.tsx`, `workflow_run_search.tsx` | Render inputs in result lines, previews, scrollback; extend `filterRuns` and fuzzy search |

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint issues
- [x] `deno fmt` — formatting clean
- [x] `deno run test` — 8890 tests pass (0 failures)
- [x] New unit tests for `captureInputs()`, inputs in search results, `--input` filtering (both generators)
- [x] Manual E2E: compiled binary, created workflow with inputs, ran 3 times with different `workItem`/`region` values, verified `--json` output shows `inputs` and `--input` flag filters correctly
- [x] Manual E2E via `--server ws://...`: same tests pass through WebSocket path

🤖 Generated with [Claude Code](https://claude.com/claude-code)