### PR TITLE
fix(workflow): add --timeout option to workflow resume (swamp-club#1136)

### DIFF
--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -58,6 +58,7 @@ import type { WorkflowRunEvent } from "../../libswamp/mod.ts";
 import { createEphemeralStore } from "../../infrastructure/persistence/ephemeral_store.ts";
 import { withGeneratorTraceContext } from "../../infrastructure/tracing/mod.ts";
 import { GIT_SHA } from "./version.ts";
+import { parseTimeout } from "../duration_parser.ts";
 import {
   deepMerge,
   mergeInputArgs,
@@ -74,6 +75,7 @@ import {
   resumeWorkflowOverServer,
   withRemoteOptions,
 } from "../remote_run.ts";
+import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -112,6 +114,10 @@ export const workflowResumeCommand = withRemoteOptions(
     .option("--stdin", "Read override inputs from stdin (piped data)", {
       default: false,
     })
+    .option(
+      "--timeout <duration:string>",
+      "Cancellation deadline — seconds (e.g. 30, 1800) or duration string (e.g. 30s, 5m, 1h). Cooperative — only honored by methods that check AbortSignal.",
+    )
     .option(
       "--traceparent <value:string>",
       "W3C traceparent for per-invocation trace context (env: TRACEPARENT)",
@@ -163,31 +169,44 @@ export const workflowResumeCommand = withRemoteOptions(
         ? deepMerge(stdinInputs, cliInputs)
         : cliInputs;
 
+      const abort = new AbortController();
+      if (options.timeout) {
+        const timeoutMs = parseTimeout(options.timeout as string);
+        setTimeout(() => abort.abort(), timeoutMs);
+      }
+      const shutdown = registerShutdownHandler({
+        handler: () => abort.abort(),
+      });
+
       const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
         workflowName: workflowIdOrName,
         isAuthenticated: isAuthenticated(),
       });
-      await consumeStream(
-        resumeWorkflowOverServer({
-          server,
-          token,
-          signal: AbortSignal.timeout(600_000),
-          payload: {
-            workflowIdOrName,
-            runId: options.run as string | undefined,
-            inputs: Object.keys(resumeInputs).length > 0
-              ? resumeInputs
-              : undefined,
-            traceparent: resolveTraceparent(
-              options.traceparent as string | undefined,
-            ),
-            tracestate: resolveTracestate(
-              options.tracestate as string | undefined,
-            ),
-          },
-        }) as AsyncIterable<WorkflowRunEvent>,
-        renderer.handlers(),
-      );
+      try {
+        await consumeStream(
+          resumeWorkflowOverServer({
+            server,
+            token,
+            signal: abort.signal,
+            payload: {
+              workflowIdOrName,
+              runId: options.run as string | undefined,
+              inputs: Object.keys(resumeInputs).length > 0
+                ? resumeInputs
+                : undefined,
+              traceparent: resolveTraceparent(
+                options.traceparent as string | undefined,
+              ),
+              tracestate: resolveTracestate(
+                options.tracestate as string | undefined,
+              ),
+            },
+          }) as AsyncIterable<WorkflowRunEvent>,
+          renderer.handlers(),
+        );
+      } finally {
+        shutdown.dispose();
+      }
       if (renderer.workflowFailed()) {
         Deno.exitCode = 1;
       }
@@ -367,6 +386,15 @@ export const workflowResumeCommand = withRemoteOptions(
       ephemeral.catalog,
     );
 
+    const abort = new AbortController();
+    if (options.timeout) {
+      const timeoutMs = parseTimeout(options.timeout as string);
+      setTimeout(() => abort.abort(), timeoutMs);
+    }
+    const shutdownHandle = registerShutdownHandler({
+      handler: () => abort.abort(),
+    });
+
     const renderer = createWorkflowRunRenderer(cliCtx.outputMode, {
       workflowName,
       isAuthenticated: isAuthenticated(),
@@ -388,7 +416,7 @@ export const workflowResumeCommand = withRemoteOptions(
         (async function* () {
           for await (
             const event of service.resume(workflowName, run.id, {
-              signal: AbortSignal.timeout(600_000),
+              signal: abort.signal,
               swampSha: GIT_SHA,
               inputs: resumeInputs,
             })
@@ -402,6 +430,7 @@ export const workflowResumeCommand = withRemoteOptions(
     try {
       await consumeStream(resumeGenerator(), renderer.handlers());
     } finally {
+      shutdownHandle.dispose();
       ephemeral.dispose();
     }
 

--- a/src/cli/commands/workflow_resume_test.ts
+++ b/src/cli/commands/workflow_resume_test.ts
@@ -1,0 +1,51 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+Deno.test("workflowResumeCommand has --timeout option (swamp-club#1136)", async () => {
+  const { workflowResumeCommand } = await import("./workflow_resume.ts");
+  const names = workflowResumeCommand.getOptions().map((o) => o.name);
+  if (!names.includes("timeout")) {
+    throw new Error(
+      `expected --timeout option, got: ${names.join(", ")}`,
+    );
+  }
+});
+
+Deno.test("workflowResumeCommand --timeout description matches workflow run", async () => {
+  const { workflowResumeCommand } = await import("./workflow_resume.ts");
+  const options = workflowResumeCommand.getOptions();
+  const timeoutOpt = options.find((o) => o.name === "timeout");
+  assertEquals(timeoutOpt !== undefined, true);
+  assertEquals(
+    timeoutOpt!.description,
+    "Cancellation deadline — seconds (e.g. 30, 1800) or duration string (e.g. 30s, 5m, 1h). Cooperative — only honored by methods that check AbortSignal.",
+  );
+});
+
+Deno.test("workflowResumeCommand has --server option", async () => {
+  const { workflowResumeCommand } = await import("./workflow_resume.ts");
+  const options = workflowResumeCommand.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+});


### PR DESCRIPTION
## Summary

- Add `--timeout` option to `swamp workflow resume`, matching the existing option on `workflow run`
- Replace hardcoded `AbortSignal.timeout(600_000)` (10 minutes) at both local and server code paths with an `AbortController` pattern that applies a timeout only when `--timeout` is provided
- Default to unbounded when `--timeout` is omitted, matching `workflow run` behavior
- Add `registerShutdownHandler` so Ctrl+C gracefully cancels resumed runs (previously unhandled)

Closes swamp-club#1136

### Follow-up issues

- swamp-club/swamp-uat#310 — UAT: workflow resume --timeout flag
- Manual docs need `--timeout` added to the workflow resume reference (swamp-club repo has issues disabled)

## Test Plan

- [x] New unit tests verify `--timeout` option exists on the command and description matches `workflow run`
- [x] Reproduced the bug in a scratch repo: `swamp workflow resume gate-test --timeout 30s` rejected with `Unknown option "--timeout"` before the fix
- [x] Verified the fix: `swamp workflow resume gate-test --timeout 30s` now works — workflow resumes and completes successfully
- [x] `swamp workflow resume --help` shows `--timeout` with the same description as `workflow run --help`
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)