### PR TITLE
docs(vault): document auto-refresh in skill docs

### DIFF
--- a/.claude/skills/swamp/references/vault/guide.md
+++ b/.claude/skills/swamp/references/vault/guide.md
@@ -19,22 +19,24 @@ Correct flow: `swamp vault create <type> <name> --json` → edit config if neede
 
 ## Quick Reference
 
-| Task              | Command                                                 |
-| ----------------- | ------------------------------------------------------- |
-| List vault types  | `swamp vault type search --json`                        |
-| Create a vault    | `swamp vault create <type> <name> --json`               |
-| Search vaults     | `swamp vault search [query] --json`                     |
-| Get vault details | `swamp vault get <name_or_id> --json`                   |
-| Edit vault config | `swamp vault edit <name_or_id>`                         |
-| Store a secret    | `swamp vault put <vault> KEY` (prompts for value)       |
-| Store from stdin  | `echo "$VAL" \| swamp vault put <vault> KEY --json`     |
-| Store inline      | `swamp vault put <vault> KEY=VALUE --json` (insecure)   |
-| Read a secret     | `swamp vault read-secret <vault> <key> --force --json`  |
-| List secret keys  | `swamp vault list-keys <vault> --json`                  |
-| Annotate a secret | `swamp vault annotate <vault> <key> --url <u>`          |
-| Remove a label    | `swamp vault annotate <vault> <key> --remove-label <k>` |
-| Inspect metadata  | `swamp vault inspect <vault> <key> --json`              |
-| Clear annotation  | `swamp vault annotate <vault> <key> --clear`            |
-| Migrate backend   | `swamp vault migrate <vault> --to-type <type>`          |
+| Task              | Command                                                                  |
+| ----------------- | ------------------------------------------------------------------------ |
+| List vault types  | `swamp vault type search --json`                                         |
+| Create a vault    | `swamp vault create <type> <name> --json`                                |
+| Search vaults     | `swamp vault search [query] --json`                                      |
+| Get vault details | `swamp vault get <name_or_id> --json`                                    |
+| Edit vault config | `swamp vault edit <name_or_id>`                                          |
+| Store a secret    | `swamp vault put <vault> KEY` (prompts for value)                        |
+| Store from stdin  | `echo "$VAL" \| swamp vault put <vault> KEY --json`                      |
+| Store inline      | `swamp vault put <vault> KEY=VALUE --json` (insecure)                    |
+| Auto-refresh      | `swamp vault put <vault> KEY --refresh-from "<cmd>" --refresh-ttl <dur>` |
+| Clear refresh     | `swamp vault put <vault> KEY --clear-refresh`                            |
+| Read a secret     | `swamp vault read-secret <vault> <key> --force --json`                   |
+| List secret keys  | `swamp vault list-keys <vault> --json`                                   |
+| Annotate a secret | `swamp vault annotate <vault> <key> --url <u>`                           |
+| Remove a label    | `swamp vault annotate <vault> <key> --remove-label <k>`                  |
+| Inspect metadata  | `swamp vault inspect <vault> <key> --json`                               |
+| Clear annotation  | `swamp vault annotate <vault> <key> --clear`                             |
+| Migrate backend   | `swamp vault migrate <vault> --to-type <type>`                           |
 
 For detailed walkthroughs of each operation, see [reference.md](reference.md).

--- a/.claude/skills/swamp/references/vault/reference.md
+++ b/.claude/skills/swamp/references/vault/reference.md
@@ -119,6 +119,40 @@ agent context or chat history.
 }
 ```
 
+## Automatic Refresh
+
+Attach a refresh hook to a secret so swamp automatically re-runs a command when
+the TTL elapses, replacing the stored value with the command's stdout. If the
+refresh command fails, swamp logs a WARN with the command's stderr and falls
+back to the last-known-good value — no corruption.
+
+```bash
+# Auto-refresh a GCP access token every 50 minutes
+swamp vault put my-vault GCP_TOKEN \
+  --refresh-from "gcloud auth print-access-token" \
+  --refresh-ttl 50m
+
+# Auto-refresh an AWS session token every 55 minutes
+echo "$INITIAL_TOKEN" | swamp vault put my-vault AWS_SESSION \
+  --refresh-from "aws sts get-session-token --query Credentials.SessionToken --output text" \
+  --refresh-ttl 55m --json
+```
+
+**Flag rules:**
+
+- `--refresh-from` and `--refresh-ttl` are required together — neither works
+  alone
+- `--clear-refresh` removes an existing refresh hook; it cannot be combined with
+  `--refresh-from` or `--refresh-ttl`
+
+```bash
+# Remove the refresh hook (secret becomes static again)
+swamp vault put my-vault GCP_TOKEN --clear-refresh
+```
+
+Use `vault inspect` to check whether a secret has a refresh hook and when it was
+last refreshed (see [Inspect Secret Metadata](#inspect-secret-metadata)).
+
 ## Read a Secret
 
 Retrieve a specific secret value from a vault.
@@ -217,6 +251,27 @@ swamp vault inspect my-vault API_KEY --json
   "refreshHook": null
 }
 ```
+
+When a refresh hook is attached, the `refreshHook` object contains:
+
+```json
+{
+  "supportsRefreshHooks": true,
+  "hasRefreshHook": true,
+  "refreshHook": {
+    "command": "gcloud auth print-access-token",
+    "ttlMs": 3000000,
+    "ttl": "50m",
+    "lastRefreshedAt": "2026-07-14T12:30:00.000Z"
+  }
+}
+```
+
+- `command` — the shell command that produces the refreshed value
+- `ttlMs` — refresh interval in milliseconds
+- `ttl` — human-readable refresh interval
+- `lastRefreshedAt` — ISO timestamp of the last successful refresh (`null` if
+  the hook has never fired)
 
 Inspect degrades gracefully — providers that don't support annotations or
 refresh hooks return `null` for those fields with `supportsAnnotations: false`

--- a/.claude/skills/swamp/references/vault/references/examples.md
+++ b/.claude/skills/swamp/references/vault/references/examples.md
@@ -339,7 +339,49 @@ Update each model to use `app-secrets`.
 
 ## Rotation Patterns
 
+### Automatic Refresh (Preferred)
+
+For secrets that can be obtained by running a local command — cloud SSO tokens,
+short-lived API tokens, temporary credentials — use `--refresh-from` to let
+swamp re-run the command automatically when the TTL elapses:
+
+```bash
+# GCP access token, refreshed every 50 minutes
+swamp vault put my-vault GCP_TOKEN \
+  --refresh-from "gcloud auth print-access-token" \
+  --refresh-ttl 50m
+
+# AWS session token, refreshed every 55 minutes
+echo "$INITIAL_TOKEN" | swamp vault put my-vault AWS_SESSION \
+  --refresh-from "aws sts get-session-token --query Credentials.SessionToken --output text" \
+  --refresh-ttl 55m --json
+
+# Short-lived API token from a custom script
+swamp vault put my-vault SERVICE_TOKEN \
+  --refresh-from "./scripts/fetch-service-token.sh" \
+  --refresh-ttl 30m
+```
+
+If the refresh command fails, swamp logs a WARN with the command's stderr and
+falls back to the last-known-good value — no data loss or corruption.
+
+Check refresh status with `vault inspect`:
+
+```bash
+swamp vault inspect my-vault GCP_TOKEN --json
+# → refreshHook.command, refreshHook.ttl, refreshHook.lastRefreshedAt
+```
+
+To remove a refresh hook and make the secret static again:
+
+```bash
+swamp vault put my-vault GCP_TOKEN --clear-refresh
+```
+
 ### Manual Secret Rotation
+
+For secrets that cannot be refreshed by a local command (e.g. API keys that
+require a web console to regenerate), rotate manually:
 
 **Step 1: Generate new secret value**
 
@@ -364,7 +406,8 @@ swamp model evaluate model-2 --json
 
 ### Rotation Workflow
 
-Create a workflow that handles rotation:
+For complex rotation that requires coordination (update secret, then redeploy
+services), create a workflow:
 
 ```yaml
 # workflows/rotate-secrets/workflow.yaml
@@ -403,8 +446,10 @@ jobs:
 
 ### Best Practices for Rotation
 
-1. **Never hardcode secrets** — always use vault expressions
-2. **Test rotation in staging** — verify workflows work with new secrets
-3. **Monitor for failures** — watch for auth errors after rotation
-4. **Keep old secrets temporarily** — allow rollback if issues arise
-5. **Document rotation schedule** — establish regular rotation cadence
+1. **Prefer `--refresh-from`** for expiring credentials — it's simpler and more
+   reliable than manual rotation or custom workflows
+2. **Never hardcode secrets** — always use vault expressions
+3. **Test rotation in staging** — verify workflows work with new secrets
+4. **Monitor for failures** — watch for auth errors after rotation
+5. **Keep old secrets temporarily** — allow rollback if issues arise
+6. **Document rotation schedule** — establish regular rotation cadence


### PR DESCRIPTION
## Summary

- Add `--refresh-from`/`--refresh-ttl`/`--clear-refresh` to vault guide's quick-reference table
- Add "Automatic Refresh" section to `reference.md` explaining the mechanism, flag rules, and linking to inspect docs
- Expand `vault inspect` docs with populated `refreshHook` example showing `command`, `ttlMs`, `ttl`, `lastRefreshedAt` fields
- Update "Rotation Patterns" in `examples.md` to present auto-refresh as the preferred approach for expiring credentials (GCP tokens, AWS sessions, custom scripts), with manual rotation and rotation-workflow as fallbacks

Closes swamp-club#1146

## Test Plan

- [x] Verified flag names and validation rules match source (`src/cli/commands/vault_put.ts`)
- [x] Verified `RefreshHookData` output shape matches interface (`src/domain/vaults/refresh_hook.ts`)
- [x] Verified `vault inspect` JSON shape matches implementation (`src/libswamp/vaults/inspect.ts`)
- [x] `deno fmt --check` passes
- [x] No new files — all edits to existing skill docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)