### PR TITLE
fix(agent): check tool existence before prompting in agent rm

### DIFF
--- a/src/cli/commands/agent_setup.ts
+++ b/src/cli/commands/agent_setup.ts
@@ -281,6 +281,11 @@ export const agentRemoveCommand = new Command()
     const repoDir = resolveRepoDir(undefined);
 
     if (cliCtx.outputMode !== "json") {
+      const tools = await readCustomTools(repoDir);
+      if (!tools.some((t) => t.name === name)) {
+        throw new UserError(`Custom tool "${name}" not found.`);
+      }
+
       const confirmed = await promptConfirmation(
         `Remove custom tool "${name}" from .swamp-custom-tools.yaml?`,
       );


### PR DESCRIPTION
## Summary

- `swamp agent rm <name>` in log mode now checks whether the tool exists in
  `.swamp-custom-tools.yaml` before showing the confirmation prompt
- If the tool is not found, exits with `Custom tool "<name>" not found.` and
  exit code 1, matching other swamp commands that error on missing resources
- JSON mode behavior is unchanged (already returns `{ removed: false }`)

## Test Plan

- Ran full test suite (8909 passed)
- `deno fmt`, `deno lint`, `deno check` all clean
- Manual verification: `swamp agent rm nonexistent` now prints the error
  immediately instead of showing a misleading confirmation prompt