### PR TITLE
fix(auth): guard setRaw() against non-TTY stdin in auth login

### DIFF
--- a/src/infrastructure/io/stdin_reader.ts
+++ b/src/infrastructure/io/stdin_reader.ts
@@ -70,6 +70,10 @@ export async function readStdin(): Promise<string | null> {
  * @throws {Error} If the user cancels with Ctrl-C (throws with message "Cancelled.")
  */
 export async function readSecretFromTty(prompt: string): Promise<string> {
+  if (!Deno.stdin.isTerminal()) {
+    throw new Error("Cannot read secret: stdin is not a TTY");
+  }
+
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
 

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -131,6 +131,9 @@ async function readLine(prompt: string): Promise<string> {
 
 /** Read a password from stdin without echoing. */
 async function readPassword(prompt: string): Promise<string> {
+  if (!Deno.stdin.isTerminal()) {
+    return "";
+  }
   try {
     return await readSecretFromTty(prompt);
   } catch (err) {


### PR DESCRIPTION
## Summary

- `readSecretFromTty` crashed with `ENODEV` when stdin was piped (e.g. `echo "" | swamp auth login`) because it called `Deno.stdin.setRaw()` without first checking `isTerminal()`
- Added a TTY guard in `readSecretFromTty` (defensive) and in `readPassword` (returns empty string on non-TTY so existing validation produces a clean `"Username and password are required."` exit)

## Test Plan

- `echo "" | ./swamp auth login` → clean error, exit 1 (was: ENODEV crash)
- `./swamp auth login < /dev/null` → clean error, exit 1 (was: ENODEV crash)
- All 8909 existing tests pass