### PR TITLE
fix(expressions): resolve vault references before CEL validation (swamp-club#1141)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -24,6 +24,7 @@
     "jsr:@std/streams@^1.1.0": "1.1.0",
     "jsr:@std/tar@~0.1.10": "0.1.10",
     "jsr:@std/text@^1.0.17": "1.0.18",
+    "jsr:@std/yaml@*": "1.1.0",
     "jsr:@std/yaml@^1.1.0": "1.1.0",
     "npm:@aws-sdk/client-cloudcontrol@^3.1042.0": "3.1042.0",
     "npm:@marcbachmann/cel-js@7.6.1": "7.6.1",

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -27,6 +27,7 @@ import {
   extractExpressions,
   replaceExpressions,
 } from "./expression_parser.ts";
+import { getLogger } from "@logtape/logtape";
 import type { ExpressionLocation } from "./expression.ts";
 import {
   extractDependencies,
@@ -434,6 +435,7 @@ export class ExpressionEvaluationService {
     definition: Definition,
     redactor?: SecretRedactor,
   ): Promise<RuntimeResolutionResult> {
+    const logger = getLogger(["swamp", "expressions"]);
     const secretBag = new VaultSecretBag();
     const definitionData = definition.toData();
     const expressions = extractExpressions(definitionData);
@@ -442,6 +444,13 @@ export class ExpressionEvaluationService {
     const runtimeExpressions = expressions.filter((expr) =>
       containsRuntimeExpression(expr.celExpression)
     );
+
+    logger.debug(
+      `Runtime expression resolution: ${expressions.length} total expressions, ${runtimeExpressions.length} runtime (vault/env)`,
+    );
+    for (const expr of runtimeExpressions) {
+      logger.debug`Runtime expression at ${expr.path}: ${expr.raw}`;
+    }
 
     if (runtimeExpressions.length === 0) {
       return { definition, secretBag };
@@ -484,15 +493,8 @@ export class ExpressionEvaluationService {
     const secretBag = new VaultSecretBag();
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
-      // Skip syntactically-invalid CEL: the ${{ ... }} sequence appears
-      // inside a prose string (e.g. a plan body that documents env.* /
-      // vault.get() syntax). Leaving the raw text in place preserves
-      // prose round-trip; real misconfigurations still throw at evaluate.
-      if (!this.celEvaluator.validate(expr.celExpression).valid) {
-        continue;
-      }
-
-      // Resolve vault references first (if any), then evaluate the full CEL
+      // Resolve vault references first — see resolveRuntimeInExpressions
+      // for rationale (vault names may contain CEL-invalid characters).
       let resolvedCelExpr = expr.celExpression;
       if (containsVaultExpression(expr.celExpression)) {
         resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
@@ -501,6 +503,18 @@ export class ExpressionEvaluationService {
           secretBag,
         );
       }
+
+      // Skip syntactically-invalid CEL after vault resolution.
+      const validation = this.celEvaluator.validate(resolvedCelExpr);
+      if (!validation.valid) {
+        if (containsVaultExpression(expr.celExpression)) {
+          getLogger(["swamp", "expressions"]).warn(
+            `Skipped vault expression at ${expr.path} because its CEL is syntactically invalid after vault resolution: ${validation.error}. Raw: ${expr.raw}`,
+          );
+        }
+        continue;
+      }
+
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {
         model: {},
         env: buildEnvContext(),
@@ -576,25 +590,45 @@ export class ExpressionEvaluationService {
     redactor?: SecretRedactor,
     secretBag?: VaultSecretBag,
   ): Promise<Definition> {
+    const logger = getLogger(["swamp", "expressions"]);
     const evaluatedValues = new Map<string, unknown>();
     for (const expr of runtimeExpressions) {
-      // Skip syntactically-invalid CEL: the ${{ ... }} sequence appears
-      // inside a prose field (e.g. a method input documenting env.* /
-      // vault.get() syntax). Leaving the raw text in place preserves
-      // prose round-trip; real misconfigurations still throw at evaluate.
-      if (!this.celEvaluator.validate(expr.celExpression).valid) {
-        continue;
-      }
-
-      // Resolve vault references first (if any), then evaluate the CEL expression
+      // Resolve vault references first (if any) — vault.get() arguments
+      // may contain characters that are not valid CEL identifiers (e.g.
+      // hyphens in vault names like "dwh-infra-1password"), so vault
+      // resolution must happen BEFORE CEL validation. resolveVaultExpressions
+      // replaces vault.get(...) calls with sentinel string literals that
+      // are always valid CEL.
       let resolvedCelExpr = expr.celExpression;
       if (containsVaultExpression(expr.celExpression)) {
+        logger.debug`Resolving vault expression at ${expr.path}`;
         resolvedCelExpr = await this.modelResolver.resolveVaultExpressions(
           expr.celExpression,
           redactor,
           secretBag,
         );
+        logger.debug`Resolved vault expression at ${expr.path}`;
       }
+
+      // Skip syntactically-invalid CEL (after vault resolution): the
+      // ${{ ... }} sequence appears inside a prose field (e.g. a method
+      // input documenting env.* / vault.get() syntax). Leaving the raw
+      // text in place preserves prose round-trip; real misconfigurations
+      // still throw at evaluate. Vault resolution runs first because
+      // vault.get() arguments may contain CEL-invalid characters (e.g.
+      // hyphens in "dwh-infra-1password"); resolveVaultExpressions uses
+      // its own regex and replaces matched calls with sentinel string
+      // literals that are always valid CEL.
+      const validation = this.celEvaluator.validate(resolvedCelExpr);
+      if (!validation.valid) {
+        if (containsVaultExpression(expr.celExpression)) {
+          logger.warn(
+            `Skipped vault expression at ${expr.path} because its CEL is syntactically invalid after vault resolution: ${validation.error}. Raw: ${expr.raw}`,
+          );
+        }
+        continue;
+      }
+
       const value = this.celEvaluator.evaluate(resolvedCelExpr, {
         model: {},
         env: buildEnvContext(),

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -36,7 +36,11 @@ import { DataOutputValidationService } from "./data_output_validation_service.ts
 import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
 import { modelRequiresVault } from "./data_writer.ts";
 import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
-import { valueContainsExpression } from "../expressions/expression_parser.ts";
+import {
+  extractExpressions,
+  valueContainsExpression,
+} from "../expressions/expression_parser.ts";
+import { containsVaultExpression } from "../expressions/expression_evaluation_service.ts";
 import type { Data } from "../data/data.ts";
 import type { ExecutionOutput } from "./execution_envelope.ts";
 import { InProcessExecutor } from "./in_process_executor.ts";
@@ -228,8 +232,15 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
         if (typeof prop === "string" && valueContainsExpression(value)) {
+          const exprs = extractExpressions(value);
+          const hasVault = exprs.some((e) =>
+            containsVaultExpression(e.celExpression)
+          );
+          const hint = hasVault
+            ? " (contains vault.get() — check vault configuration and run with --log-level debug for details)"
+            : "";
           throw new Error(
-            `Unresolved expression in globalArguments.${prop}: ${
+            `Unresolved expression in globalArguments.${prop}${hint}: ${
               JSON.stringify(value)
             }`,
           );


### PR DESCRIPTION
## Summary

- Fix `vault.get()` expressions being silently skipped when the vault name contains characters invalid in CEL (e.g. `dwh-infra-1password`, where `1password` starts with a digit). The CEL validator parsed `vault.get(dwh-infra-1password, "key")` as subtraction (`dwh - infra - 1password`) and rejected it as syntactically invalid, silently dropping the expression.
- Reorder vault resolution to run **before** CEL validation — `resolveVaultExpressions` uses its own regex (not CEL) and replaces `vault.get(…)` calls with sentinel string literals that are always valid CEL.
- Add debug-level tracing of the runtime expression resolution pipeline (`--log-level debug` now shows each expression found and resolved).
- Improve the "Unresolved expression" Proxy error to identify vault.get() expressions with an actionable hint.

Closes swamp-club#1141

## Root cause

`resolveRuntimeInExpressions` validated CEL syntax *before* resolving vault references. Vault names are not CEL identifiers — they're parsed by a dedicated regex in `resolveVaultExpressions`. When a vault name like `dwh-infra-1password` contained a segment starting with a digit, CEL parsed it as arithmetic (`dwh - infra - 1password`) and rejected it. The expression was silently skipped, leaving raw `${{ vault.get(…) }}` in the definition.

## Test plan

- [x] `deno check` — 0 errors
- [x] `deno lint` — 0 issues
- [x] `deno fmt` — all formatted
- [x] `deno run test` — 8904 tests pass, 0 failures
- [x] Reproduced bug with `@hivemq/github/environments/secrets` extension + vault name `dwh-infra-1password` → confirmed "Unresolved expression" error
- [x] Verified fix resolves the expression with the same vault name
- [x] Verified prose guard still works — all 4 prose-skip tests pass (`vault.get(...)` ellipsis doesn't match vault regex)
- [x] Verified all vault name patterns behave identically to old code except the one that was broken (now fixed)
- [x] Compiled binary and tested end-to-end with `@hivemq/github/environments/secrets` + `@swamp/1password` vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)