### PR TITLE
feat(workflows): surface concurrency, locking, and run context in docs and approvals (swamp-club#1097)

### DIFF
--- a/.claude/skills/swamp/references/model/references/concurrency.md
+++ b/.claude/skills/swamp/references/model/references/concurrency.md
@@ -1,0 +1,58 @@
+# Model Method Concurrency and Locking
+
+When a model method runs, it holds a per-instance file lock for the entire
+method execution — including any awaited subprocess work inside the method.
+Concurrent method runs on the **same** model instance serialize at this lock;
+runs on **different** model instances proceed in parallel.
+
+## Per-Instance Lock
+
+- **Location:** `.swamp/data/<modelType>/<modelId>/.lock`
+- **Granularity:** one lock per model instance
+- **TTL:** ~30 seconds, with a heartbeat every TTL/3 (~10 seconds)
+- **Stale detection:** if the lock-holder PID is no longer running, the lock is
+  considered stale and force-released on the next acquisition attempt
+
+A model method acquires its per-instance lock before execution and releases it
+in a `finally` block after the method completes. If the process crashes without
+releasing, the lock expires after the TTL.
+
+## Workflow Step Locking
+
+Workflow steps acquire per-model locks individually — the workflow does not hold
+all locks upfront. Each `model_method` step acquires its target model's lock
+before execution and releases it after the step completes. This means:
+
+- Parallel steps on **different models** lock independently and run concurrently
+- Parallel steps on the **same model** serialize at the lock (correct —
+  concurrent writes to the same model are unsafe)
+- Nested processes are handled via `SWAMP_LOCK_HOLDER_PID` — a child `swamp`
+  command skips locks held by its parent to avoid deadlock
+
+## Global Datastore Lock
+
+Structural commands (`swamp repo init`, `swamp datastore sync`, etc.) acquire a
+global datastore lock with a symmetric drain protocol. Per-model commands
+inspect this lock before acquiring their own — if a structural command is in
+flight, model commands wait for it to finish.
+
+## Breakglass Commands
+
+If a lock gets stuck (e.g., after a crash where stale detection hasn't kicked
+in):
+
+```bash
+swamp datastore lock status                          # show who holds locks
+swamp datastore lock release --force                 # release the global lock
+swamp datastore lock release --force --model type/id # release a per-model lock
+```
+
+The `--force` flag is required. These commands bypass normal acquire/release and
+directly delete the lock file.
+
+## Key Takeaway
+
+**Will concurrent model method runs serialize?** Yes, if they target the same
+model instance. Different instances run in parallel. This applies equally to
+standalone `swamp model method run` and workflow steps — both use the same
+per-instance locking mechanism.

--- a/.claude/skills/swamp/references/workflow/references/execution-semantics.md
+++ b/.claude/skills/swamp/references/workflow/references/execution-semantics.md
@@ -1,0 +1,61 @@
+# Workflow Execution Semantics
+
+## Blocking Behavior
+
+`swamp workflow run` blocks the calling process until the run reaches a terminal
+or suspended state:
+
+- **completed** — all steps succeeded
+- **failed** — a step failed (and `allowFailure` was not set)
+- **cancelled** — the run was cancelled via `swamp workflow cancel` or timeout
+- **suspended** — a `manual_approval` step is waiting for approval; the CLI
+  exits and the run can be resumed later with `swamp workflow resume`
+
+There is no async, detached, or fire-and-forget mode. If you need non-blocking
+execution, run the workflow through `swamp serve` (which processes runs
+asynchronously via its WebSocket protocol) or use a shell backgrounding
+mechanism (`&`, `nohup`).
+
+## Webhook Delivery
+
+When `swamp serve` receives a webhook, it fires the matching workflow
+synchronously within the HTTP request handler. Webhook deliveries are processed
+sequentially (FIFO) per endpoint — a second delivery to the same endpoint waits
+for the first run to complete or suspend before starting.
+
+## Suspension and Resume
+
+When a `manual_approval` step is reached:
+
+1. The step is marked `waiting_approval`
+2. The run's effective inputs are persisted to the run record
+3. The run status becomes `suspended`
+4. The CLI process exits
+
+Resume is a separate invocation: `swamp workflow resume <workflow>`. It
+re-enters the executor, skips completed steps, and runs the remaining pending
+steps. Resume accepts `--input` to supply or override values that were not
+available at the original run time (e.g., elevated credentials issued during the
+gate).
+
+## Concurrency Limits
+
+The `concurrency` field caps parallel execution at three levels:
+
+| Level    | Scope                                 |
+| -------- | ------------------------------------- |
+| workflow | caps parallel jobs                    |
+| job      | caps parallel steps within the job    |
+| step     | caps forEach iterations for that step |
+
+Resolution order: step > job > workflow > `SWAMP_MAX_CONCURRENT_STEPS` env var >
+unbounded. The most-local non-zero value wins.
+
+## Timeouts and Cancellation
+
+`swamp workflow run --timeout <seconds>` sets a cancellation deadline. If the
+run has not completed when the timeout expires, it is cancelled. The `--timeout`
+applies to the total wall-clock time of the run, not individual steps.
+
+`swamp workflow cancel <workflow>` cancels an in-flight run from another
+terminal or via `--server`.

--- a/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
@@ -263,6 +263,76 @@ attributes:
   api_key: ${{ env.API_KEY }}
 ```
 
+## Workflow Run Context
+
+Inside workflow step inputs, the `run` namespace exposes metadata about the
+current workflow execution. These variables are only available at **step
+execution time** — not in workflow-level fields like `description`.
+
+| Variable           | Type                    | Description                    |
+| ------------------ | ----------------------- | ------------------------------ |
+| `run.id`           | string (UUID)           | Unique ID of this workflow run |
+| `run.workflowId`   | string (UUID)           | Workflow definition ID         |
+| `run.workflowName` | string                  | Workflow name                  |
+| `run.startedAt`    | string (ISO 8601)       | Timestamp when the run started |
+| `run.tags`         | `Record<string,string>` | Merged workflow + runtime tags |
+
+The flat `workflowRunId` variable is also available (equivalent to `run.id`) for
+backward compatibility with `data.query()` predicates.
+
+Use `run.id` to prevent data collisions when the same workflow runs
+concurrently:
+
+```yaml
+steps:
+  - name: process
+    task:
+      type: model_method
+      modelIdOrName: my-processor
+      methodName: run
+      inputs:
+        outputKey: "result-${{ run.id }}"
+```
+
+## Webhook Payload Context
+
+For webhook-triggered runs, the `webhook` namespace exposes the verified request
+payload. It is available **only inside `trigger.inputs`**, where expressions are
+evaluated against the payload at fire time (before input validation) to map
+payload fields onto named inputs.
+
+| Variable          | Type                    | Description                                         |
+| ----------------- | ----------------------- | --------------------------------------------------- |
+| `webhook.body`    | unknown                 | JSON-parsed body; raw string if not JSON            |
+| `webhook.headers` | `Record<string,string>` | Lowercased header names (signature header excluded) |
+| `webhook.route`   | string                  | Matched webhook route (e.g. `/hooks/linear`)        |
+
+```yaml
+trigger:
+  inputs:
+    identifier: "${{ webhook.body.data.issue.identifier }}"
+    eventType: '${{ webhook.headers["x-linear-event"] }}'
+```
+
+Guard optional payload fields with `has()` and a ternary — swamp's CEL has no
+`??` operator:
+
+```yaml
+trigger:
+  inputs:
+    identifier: >-
+      ${{ has(webhook.body.data.issue) ?
+        webhook.body.data.issue.identifier : webhook.body.data.identifier }}
+```
+
+A hard reference to a missing field surfaces an error and the run does not
+start. The rest of the workflow reads extracted values as normal inputs
+(`${{ inputs.identifier }}`).
+
+**Security:** `webhook.headers` values are not redacted. Avoid forwarding
+sensitive headers into model attributes — they would be stored in `.swamp/data/`
+and visible in `swamp data get` output.
+
 ## Data Artifact Tracking
 
 Workflow steps track all Data artifacts produced during execution. Each step run

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -92,7 +92,9 @@ type AnyOptions = any;
 
 export const workflowRunCommand = new Command()
   .name("run")
-  .description("Execute a workflow")
+  .description(
+    "Execute a workflow. Blocks until the run completes, suspends (manual approval), fails, or is cancelled. There is no async/detached mode.",
+  )
   .example("Run a workflow", "swamp workflow run deploy-pipeline")
   .example(
     "With inputs",

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -69,6 +69,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   { relativePath: "swamp/references/model/guide.md", name: "swamp" },
   { relativePath: "swamp/references/model/reference.md", name: "swamp" },
   {
+    relativePath: "swamp/references/model/references/concurrency.md",
+    name: "swamp",
+  },
+  {
     relativePath: "swamp/references/model/references/data-chaining.md",
     name: "swamp",
   },
@@ -113,6 +117,10 @@ const BUNDLED_SKILLS: SkillInfo[] = [
   },
   {
     relativePath: "swamp/references/workflow/references/direct-execution.md",
+    name: "swamp",
+  },
+  {
+    relativePath: "swamp/references/workflow/references/execution-semantics.md",
     name: "swamp",
   },
   {

--- a/src/libswamp/workflows/approvals.ts
+++ b/src/libswamp/workflows/approvals.ts
@@ -32,6 +32,7 @@ export interface PendingApproval {
   stepName: string;
   suspendedAt: string | undefined;
   prompt: string | undefined;
+  inputs: Readonly<Record<string, unknown>>;
 }
 
 export interface WorkflowApprovalsData {
@@ -98,6 +99,7 @@ export async function* workflowApprovals(
             stepName: waiting.stepName,
             suspendedAt: step?.startedAt?.toISOString(),
             prompt,
+            inputs: run.inputs,
           });
         }
       }

--- a/src/libswamp/workflows/approvals_test.ts
+++ b/src/libswamp/workflows/approvals_test.ts
@@ -72,12 +72,15 @@ function makeRun(overrides?: {
   status?: string;
   stepStatus?: string;
   startedAt?: Date;
+  inputs?: Record<string, unknown>;
 }): WorkflowRun {
   const stepStatus = overrides?.stepStatus ?? "waiting_approval";
   const startedAt = overrides?.startedAt ?? new Date();
+  const inputs = overrides?.inputs ?? {};
   return {
     id: overrides?.id ?? "run-1",
     status: overrides?.status ?? "suspended",
+    inputs,
     findWaitingApprovalStep: () =>
       stepStatus === "waiting_approval"
         ? { jobName: "main", stepName: "gate" }
@@ -161,6 +164,40 @@ Deno.test("workflowApprovals: returns pending approval for suspended run with wa
     assertEquals(completed.data.approvals[0].runId, "run-abc");
     assertEquals(completed.data.approvals[0].stepName, "gate");
     assertEquals(completed.data.approvals[0].prompt, "Approve deployment");
+  }
+});
+
+Deno.test("workflowApprovals: includes run inputs in pending approval", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({
+    id: "run-with-inputs",
+    inputs: { environment: "prod", region: "us-west-2" },
+  });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].inputs, {
+      environment: "prod",
+      region: "us-west-2",
+    });
+  }
+});
+
+Deno.test("workflowApprovals: returns empty inputs when run has no inputs", async () => {
+  const wf = makeWorkflow({ stepType: "manual_approval" });
+  const run = makeRun({ id: "run-no-inputs" });
+  const deps = makeDeps([wf], new Map([[WF_ID as string, [run]]]));
+  const events = await collect<WorkflowApprovalsEvent>(
+    workflowApprovals(ctx, deps),
+  );
+  const completed = events.find((e) => e.kind === "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.data.approvals.length, 1);
+    assertEquals(completed.data.approvals[0].inputs, {});
   }
 });
 


### PR DESCRIPTION
## Summary

Closes swamp-club#1097.

- Add `inputs` field to `PendingApproval` interface so `workflow approvals --json` includes per-run inputs (complements PR #1843 which added inputs to search)
- Add model concurrency/locking skill reference doc explaining per-instance file lock semantics, workflow step locking, and breakglass commands
- Add workflow execution semantics skill reference doc documenting blocking behavior, webhook FIFO delivery, suspension, and cancellation
- Add CEL `run.*` context variables (`run.id`, `run.workflowId`, `run.workflowName`, `run.startedAt`, `run.tags`) and `webhook.*` context variables (`webhook.body`, `webhook.headers`, `webhook.route`) to the workflow expression skill docs
- Update `workflow run` CLI help text to state it blocks until completion/suspension with no async mode
- Register new skill files in the `SkillAssets` inventory

### Issue coverage

Of the 6 items in the issue:

| # | Item | Resolution |
|---|------|-----------|
| 1 | Lock semantics | New skill doc: `model/references/concurrency.md` |
| 2 | Worker placement | Already documented in skill docs — no action needed |
| 3 | Workflow run blocking | CLI help text updated + new skill doc: `workflow/references/execution-semantics.md` |
| 4 | Run introspection | Fixed by PR #1843 (inputs in search); approvals inputs added here |
| 5 | Concurrency field | Already documented in skill docs — no action needed |
| 6 | CEL run.id | Added to `workflow/references/expressions-and-foreach.md` |

### Follow-up issues filed

- #1852 — manual docs: CEL `run.*` and `webhook.*` variables
- #1853 — manual docs: workflow blocking semantics and lock concurrency

## Test plan

- [x] `deno fmt` — formatting clean
- [x] `deno lint` — no lint issues
- [x] `deno check` — type checking passes
- [x] `deno run test` — all tests pass (2 new tests for approvals inputs)
- [x] `deno run compile` — binary compiles cleanly
- [x] Skill assets inventory test passes with new files registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)