### PR TITLE
fix(serve): query hot-reload catalog rows by source path prefix (swamp-club#1149)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -115,6 +115,7 @@ import {
   RunTrackerStore,
 } from "../../infrastructure/persistence/run_tracker_store.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
+import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { sweepStaleRecords } from "../../serve/boot_reconciliation.ts";
 import { installUnhandledRejectionGuard } from "../../serve/unhandled_rejection_guard.ts";
@@ -477,11 +478,17 @@ async function reloadPulledExtensions(
     // Re-bundle only sources whose fingerprint changed since the catalog
     // was last written. Unchanged sources keep their existing bundle and
     // skip the expensive deno-bundle subprocess.
+    // Query by source_path prefix instead of extension_name — the
+    // source_path PK always reflects the pulled-extensions directory
+    // layout, even when extension_name is empty (swamp-club#1149).
     const pulledRoot = join(repoDir, ".swamp", "pulled-extensions");
     const rebundled = new Set<string>();
     let denoPath: string | undefined;
-    for (const [extName, entry] of Object.entries(entries)) {
-      const allRows = catalog.findByExtension(extName, entry.version);
+    for (const [extName] of Object.entries(entries)) {
+      const sourcePrefix = canonicalizePath(
+        join(pulledRoot, extName) + "/",
+      );
+      const allRows = catalog.findBySourcePathPrefix(sourcePrefix);
       for (const row of allRows) {
         if (
           !row.source_path || !row.bundle_path ||
@@ -518,8 +525,11 @@ async function reloadPulledExtensions(
     }
 
     let reloadedCount = 0;
-    for (const [name, entry] of Object.entries(entries)) {
-      const rows = catalog.findByExtension(name, entry.version);
+    for (const [name] of Object.entries(entries)) {
+      const sourcePrefix = canonicalizePath(
+        join(pulledRoot, name) + "/",
+      );
+      const rows = catalog.findBySourcePathPrefix(sourcePrefix);
       if (rows.length === 0) continue;
 
       for (const row of rows) {

--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -821,6 +821,20 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Returns rows whose source_path starts with the given prefix.
+   * Used by the hot-reload path to find catalog rows belonging to a
+   * pulled extension regardless of whether extension_name is populated.
+   */
+  findBySourcePathPrefix(sourcePrefix: string): ExtensionTypeRow[] {
+    const stmt = this.db.prepare(
+      "SELECT * FROM bundle_types WHERE source_path LIKE ? ORDER BY source_path",
+    );
+    return (stmt.all(`${sourcePrefix}%`) as Record<string, unknown>[]).map(
+      (r) => this.mapRow(r),
+    );
+  }
+
+  /**
    * Removes all entries for a given source path prefix.
    * Used when an extension is removed — deletes all types that came from
    * source files under that directory.

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -291,6 +291,75 @@ Deno.test("ExtensionCatalogStore: removeBySourcePrefix removes matching entries"
   store.close();
 });
 
+Deno.test("findBySourcePathPrefix: returns matching rows ordered by source_path", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(makeRow({
+    type_normalized: "@swamp/aws/ec2/vpc",
+    source_path: "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/models/vpc.ts",
+  }));
+  store.upsert(makeRow({
+    type_normalized: "@swamp/aws/ec2/instance",
+    source_path:
+      "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/models/instance.ts",
+  }));
+  store.upsert(makeRow({
+    type_normalized: "@myorg/echo",
+    source_path: "/repo/extensions/models/echo.ts",
+  }));
+
+  const rows = store.findBySourcePathPrefix(
+    "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/",
+  );
+  assertEquals(rows.length, 2);
+  assertEquals(rows[0].type_normalized, "@swamp/aws/ec2/instance");
+  assertEquals(rows[1].type_normalized, "@swamp/aws/ec2/vpc");
+
+  const noMatch = store.findBySourcePathPrefix(
+    "/repo/.swamp/pulled-extensions/@swamp/aws/s3/",
+  );
+  assertEquals(noMatch.length, 0);
+
+  store.close();
+});
+
+Deno.test("findBySourcePathPrefix: works when extension_name is empty", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  store.upsert(makeRow({
+    type_normalized: "@swamp/aws/ec2/instance",
+    source_path:
+      "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/models/instance.ts",
+  }));
+  store.upsert(makeRow({
+    type_normalized: "@swamp/aws/ec2/vpc",
+    source_path: "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/models/vpc.ts",
+  }));
+
+  const byExtension = store.findByExtension(
+    "@swamp/aws/ec2",
+    "2026.01.15.1",
+  );
+  assertEquals(
+    byExtension.length,
+    0,
+    "findByExtension should return 0 when extension_name is empty",
+  );
+
+  const byPrefix = store.findBySourcePathPrefix(
+    "/repo/.swamp/pulled-extensions/@swamp/aws/ec2/",
+  );
+  assertEquals(
+    byPrefix.length,
+    2,
+    "findBySourcePathPrefix should find rows regardless of extension_name",
+  );
+
+  store.close();
+});
+
 Deno.test("ExtensionCatalogStore: same type different kinds are separate entries", () => {
   const dbPath = makeTempDbPath();
   const store = new ExtensionCatalogStore(dbPath);


### PR DESCRIPTION
## Summary

- Replace `findByExtension` with `findBySourcePathPrefix` in the serve hot-reload path so it finds catalog rows regardless of whether `extension_name` is populated
- Add `findBySourcePathPrefix` method to `ExtensionCatalogStore` (same LIKE-query pattern as existing `removeBySourcePrefix`)
- Add tests verifying path-prefix queries work when `extension_name` is empty

The hot-reload path (`reloadPulledExtensions`) queried `findByExtension(name, version)` which requires `extension_name` to be populated in catalog rows. When extensions were restored via `swamp extension install` (lockfile restore), the free-function `installExtension` path was used instead of `InstallExtensionService`, so `extension_name` was never written. The subsequent `buildIndex` cold path created rows via `upsert()` which deliberately omits `extension_name`. This caused `findByExtension` to return 0 rows and hot-reload to silently skip all types.

The fix queries by `source_path` prefix instead — the PK always reflects the pulled-extensions directory layout, making it a reliable query key regardless of `extension_name` state.

Closes swamp-club/lab#1149

## Test Plan

- [x] Added unit tests for `findBySourcePathPrefix` (matching, non-matching, ordering)
- [x] Added test proving `findBySourcePathPrefix` succeeds where `findByExtension` returns 0 rows (empty `extension_name`)
- [x] Reproduced the bug: `extension install` → `model type search` → `findByExtension` returns 0 rows; verified `findBySourcePathPrefix` returns all 107 rows
- [x] All 8916 existing tests pass
- [x] Type checks, lint, and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)