### PR TITLE
fix(logging): emit RFC3339 timestamps on every log line (swamp-club#1157)

### DIFF
--- a/.claude/skills/terminal-output/references/logtape.md
+++ b/.claude/skills/terminal-output/references/logtape.md
@@ -119,6 +119,22 @@ Configured in `initializeLogging()`:
 The pretty sink uses `@logtape/pretty` with dimmed timestamps/levels, bold green
 categories, and aligned output.
 
+## Timestamp and Line Format
+
+All log lines carry an RFC3339 (ISO-8601 UTC, `Z`) timestamp, e.g.
+`2026-07-15T10:18:15.912Z` — unambiguous about timezone and with a date, so
+long-running daemon logs stay readable across days. The timestamp format is
+defined once in `src/infrastructure/logging/log_format.ts` (`TIMESTAMP_FORMAT`,
+`textFormatter()`) and shared by every text sink so they cannot drift:
+
+- The console (non-TTY / `--no-color`), stderr-only, and persisted run-file
+  sinks all use `textFormatter()`, whose layout is
+  `<timestamp> [<LEVEL>] <category>: <message>` in **plain text** — no ANSI, so
+  piped or redirected output stays clean.
+- The pretty sink (TTY) keeps its richer aligned, colored layout but uses the
+  same RFC3339 timestamp. Colored output is the pretty sink's job; the console
+  sink is never colored.
+
 ## Color Support
 
 Colors for `writeOutput` content come from `@std/fmt/colors`, **not** LogTape:

--- a/integration/json_isolation_test.ts
+++ b/integration/json_isolation_test.ts
@@ -77,13 +77,17 @@ Deno.test("--json: error path emits exactly one JSON document on stderr", async 
 });
 
 Deno.test("--json: stdout has no LogTape pretty-formatted log lines", async () => {
-  // `INF` / `WRN` / `ERR` prefixes are the LogTape pretty formatter's
-  // hallmark. They must never appear on stdout under --json.
+  // A leading RFC3339 timestamp followed by a bracketed `[INF]` / `[WRN]`
+  // level is the hallmark of a swamp log line. They must never appear on
+  // stdout under --json.
   await withTempDir(async (dir) => {
     await initializeTestRepo(dir);
     const { stdout } = await runCliCommand(["data", "list", "--json"], dir);
-    // Must not contain LogTape level prefixes.
-    if (/^\d{2}:\d{2}:\d{2}\.\d{3}\s+(INF|WRN|ERR|DBG|FTL)\s/m.test(stdout)) {
+    // Must not contain swamp log-line prefixes.
+    if (
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\s+\[(INF|WRN|ERR|DBG|FTL)\]\s/m
+        .test(stdout)
+    ) {
       throw new Error(
         `stdout contained LogTape pretty log line:\n${stdout}`,
       );
@@ -119,9 +123,10 @@ Deno.test("--json: model method run stdout is parseable JSON", async () => {
     assertEquals(run.code, 0);
     const result = JSON.parse(run.stdout);
     assertEquals(result.status, "succeeded");
-    // Stdout must not contain LogTape pretty-formatted log lines.
+    // Stdout must not contain swamp log lines.
     if (
-      /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(INF|WRN|ERR|DBG|FTL)\s/m.test(run.stdout)
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\s+\[(INF|WRN|ERR|DBG|FTL)\]\s/m
+        .test(run.stdout)
     ) {
       throw new Error(
         `model method run --json leaked log lines on stdout:\n${run.stdout}`,

--- a/integration/log_timestamp_format_test.ts
+++ b/integration/log_timestamp_format_test.ts
@@ -1,0 +1,126 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Log timestamp format regression tests (swamp-club#1157).
+ *
+ * Drives the real CLI and asserts that log lines carry an unambiguous
+ * RFC3339 (ISO-8601 UTC, `Z`) timestamp followed by a bracketed level —
+ * not the old bare-UTC `HH:MM:SS.mmm` prefix that had no timezone marker or
+ * date. Also asserts the colored and `--no-color` paths share one layout.
+ */
+
+import {
+  assertEquals,
+  assertExists,
+  assertMatch,
+  assertNotMatch,
+} from "@std/assert";
+import { initializeTestRepo, runCliCommand } from "./test_helpers.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-log-ts-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+// A log line in the new format: RFC3339 UTC timestamp + bracketed level.
+const NEW_FORMAT =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\s+\[(TRC|DBG|INF|WRN|ERR|FTL)\]\s/m;
+
+// The old, ambiguous format: bare UTC time, no date, no offset, bare level.
+const OLD_FORMAT = /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(TRC|DBG|INF|WRN|ERR|FTL)\s/m;
+
+// Any ANSI SGR escape sequence. The ESC byte is built via String.fromCharCode
+// so the pattern carries no literal control character.
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+/**
+ * Runs a command that reliably emits log lines (a model method run at debug
+ * level) and returns stdout+stderr combined.
+ *
+ * Passes an (empty) piped stdin so the child's stdin is not a TTY — this
+ * deterministically selects the non-interactive console sink (the daemon /
+ * piped scenario from the bug report) rather than the interactive pretty sink,
+ * which would otherwise be chosen when the test runner's own stdin is a TTY.
+ */
+async function runWithLogs(dir: string, extraArgs: string[]): Promise<string> {
+  const create = await runCliCommand(
+    ["model", "create", "command/shell", "smoke"],
+    dir,
+    "",
+  );
+  assertEquals(create.code, 0, `model create failed: ${create.stderr}`);
+
+  const run = await runCliCommand(
+    [
+      ...extraArgs,
+      "--log-level",
+      "debug",
+      "model",
+      "method",
+      "run",
+      "smoke",
+      "execute",
+      "--input",
+      "run=echo hi",
+    ],
+    dir,
+    "",
+  );
+  assertEquals(run.code, 0, `method run failed: ${run.stderr}`);
+  return `${run.stdout}\n${run.stderr}`;
+}
+
+Deno.test("piped log lines use RFC3339, not the old bare-UTC format", async () => {
+  await withTempDir(async (dir) => {
+    await initializeTestRepo(dir);
+    // Default invocation with output piped (non-TTY), as scripts and daemons
+    // see it — the exact context from the bug report.
+    const output = await runWithLogs(dir, []);
+
+    assertMatch(output, NEW_FORMAT);
+    assertNotMatch(output, OLD_FORMAT);
+
+    // The log lines themselves must carry no ANSI escape codes (report tables
+    // rendered via @std/fmt/colors may still be colored — that is a separate,
+    // NO_COLOR-governed concern). Check a line that is unambiguously a log line.
+    const logLine = output.split("\n").find((l) => NEW_FORMAT.test(l));
+    assertExists(logLine, "expected at least one RFC3339 log line");
+    assertNotMatch(logLine, ANSI);
+  });
+});
+
+Deno.test("--no-color log lines use RFC3339, not the old bare-UTC format", async () => {
+  await withTempDir(async (dir) => {
+    await initializeTestRepo(dir);
+    const output = await runWithLogs(dir, ["--no-color"]);
+
+    assertMatch(output, NEW_FORMAT);
+    assertNotMatch(output, OLD_FORMAT);
+    assertNotMatch(output, ANSI);
+  });
+});

--- a/src/infrastructure/logging/log_format.ts
+++ b/src/infrastructure/logging/log_format.ts
@@ -1,0 +1,47 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getTextFormatter, type TextFormatter } from "@logtape/logtape";
+
+// Leaf module: the single source of truth for swamp's log-line timestamp
+// format. Imported by both logger.ts (console/stderr sinks) and
+// run_file_sink.ts (persisted per-run logs). It imports neither of them, so
+// there is no import cycle — logger.ts already imports run_file_sink.ts.
+
+/**
+ * Timestamp format for every swamp log line. `"rfc3339"` renders a full
+ * ISO-8601 UTC instant with a `Z` marker (e.g. `2026-07-15T09:48:19.080Z`),
+ * so log lines are unambiguous about timezone and carry a date for
+ * long-running daemons whose logs span multiple days.
+ */
+export const TIMESTAMP_FORMAT = "rfc3339" as const;
+
+/**
+ * Plain-text formatter sharing the RFC3339 timestamp. Used by every
+ * non-interactive text sink: the console sink (non-TTY / `--no-color`), the
+ * stderr-only sink (worker dispatch), and the persisted run-file sink.
+ *
+ * `getTextFormatter`'s default layout is already
+ * `<timestamp> [<LEVEL>] <category>: <message>` and renders interpolated
+ * values without ANSI color, so non-interactive output stays clean when piped
+ * or redirected. Colored output is the pretty sink's job (TTY only).
+ */
+export function textFormatter(): TextFormatter {
+  return getTextFormatter({ timestamp: TIMESTAMP_FORMAT });
+}

--- a/src/infrastructure/logging/log_format_test.ts
+++ b/src/infrastructure/logging/log_format_test.ts
@@ -1,0 +1,66 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
+import type { LogRecord } from "@logtape/logtape";
+import { textFormatter, TIMESTAMP_FORMAT } from "./log_format.ts";
+
+// A fixed instant so timestamp assertions are deterministic:
+// 2026-07-15T10:18:15.912Z.
+const FIXED_TS = Date.UTC(2026, 6, 15, 10, 18, 15, 912);
+
+// Matches an RFC3339 UTC timestamp with millisecond precision and a `Z`.
+const RFC3339 = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;
+
+// Any ANSI SGR escape sequence. The ESC byte is built via String.fromCharCode
+// so the pattern carries no literal control character.
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function makeRecord(
+  category: string[],
+  message: string,
+  level: "info" | "debug" | "warning" | "error" = "info",
+): LogRecord {
+  return {
+    category,
+    level,
+    message: [message],
+    rawMessage: message,
+    timestamp: FIXED_TS,
+    properties: {},
+  };
+}
+
+Deno.test("TIMESTAMP_FORMAT is rfc3339", () => {
+  assertEquals(TIMESTAMP_FORMAT, "rfc3339");
+});
+
+Deno.test("textFormatter: renders an RFC3339 timestamp and bracketed level", () => {
+  const line = textFormatter()(makeRecord(["model", "get"], "hello")).trimEnd();
+  assertMatch(line, RFC3339);
+  assertEquals(line, "2026-07-15T10:18:15.912Z [INF] model·get: hello");
+});
+
+Deno.test("textFormatter: emits no ANSI escape codes", () => {
+  // Non-interactive output must stay clean for piping/redirection.
+  const line = textFormatter()(
+    makeRecord(["model", "method", "run"], "acquiring lock", "warning"),
+  );
+  assertNotMatch(line, ANSI);
+});

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -21,11 +21,11 @@ import {
   configure,
   getConsoleSink,
   getLogger,
-  getTextFormatter,
   type LogLevel,
   type Sink,
 } from "@logtape/logtape";
 import { getPrettyFormatter } from "@logtape/pretty";
+import { textFormatter, TIMESTAMP_FORMAT } from "./log_format.ts";
 import { runFileSink } from "./run_file_sink.ts";
 
 export { runFileSink } from "./run_file_sink.ts";
@@ -41,7 +41,7 @@ export interface LoggingOptions {
 }
 
 const stderrEncoder = new TextEncoder();
-const stderrFormatter = getTextFormatter();
+const stderrFormatter = textFormatter();
 
 function createStderrSink(): Sink {
   return (record) => {
@@ -62,11 +62,13 @@ export async function initializeLogging(
 
   const logLevel: LogLevel = options.logLevel ?? "info";
 
+  // The console (non-pretty) sink always renders plain text: it is used for
+  // non-interactive contexts (piped, redirected, `--no-color`, non-TTY stdin),
+  // where ANSI escape codes would pollute the output. Colored output is the
+  // pretty sink's job, selected only when stdin is a TTY.
   const consoleSink: Sink = options.stderrOnly
     ? createStderrSink()
-    : options.noColor
-    ? getConsoleSink({ formatter: getTextFormatter() })
-    : getConsoleSink();
+    : getConsoleSink({ formatter: textFormatter() });
 
   const sinks: Record<string, Sink | (Sink & Disposable)> = {
     console: consoleSink,
@@ -82,7 +84,7 @@ export async function initializeLogging(
   if (options.prettyOutput) {
     const useColors = !(options.noColor ?? false);
     const prettyFormat = getPrettyFormatter({
-      timestamp: "time",
+      timestamp: TIMESTAMP_FORMAT,
       timestampStyle: "dim",
       levelStyle: "dim",
       icons: false,

--- a/src/infrastructure/logging/run_file_sink.ts
+++ b/src/infrastructure/logging/run_file_sink.ts
@@ -17,15 +17,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { getTextFormatter, type LogRecord, type Sink } from "@logtape/logtape";
+import type { LogRecord, Sink } from "@logtape/logtape";
 import { dirname } from "@std/path";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
 import { assertSafePath } from "../persistence/safe_path.ts";
+import { textFormatter } from "./log_format.ts";
 
 /**
- * Formats a LogRecord as a plain text line for file output.
+ * Formats a LogRecord as a plain text line for file output, using the same
+ * RFC3339 timestamp and line layout as the console text sink.
  */
-const formatRecord = getTextFormatter();
+const formatRecord = textFormatter();
 
 /**
  * Checks whether `category` starts with `prefix`.

--- a/src/infrastructure/logging/run_file_sink_test.ts
+++ b/src/infrastructure/logging/run_file_sink_test.ts
@@ -19,6 +19,7 @@
 
 import {
   assertEquals,
+  assertMatch,
   assertNotEquals,
   assertStringIncludes,
 } from "@std/assert";
@@ -76,6 +77,36 @@ Deno.test("RunFileSink writes log records to registered file", async () => {
 
     const content = await Deno.readTextFile(logPath);
     assertStringIncludes(content, "hello world");
+
+    sink.unregister(handle);
+  });
+});
+
+Deno.test("RunFileSink writes lines with an RFC3339 timestamp", async () => {
+  await withTempDir(async (dir) => {
+    const sink = new RunFileSink();
+    const logPath = join(dir, "test.log");
+
+    const handle = await sink.register(
+      ["model", "method", "run", "my-model"],
+      logPath,
+    );
+
+    const sinkFn = sink.sink;
+    sinkFn(
+      makeRecord(
+        ["model", "method", "run", "my-model", "execute"],
+        "hello world",
+      ),
+    );
+
+    const content = await Deno.readTextFile(logPath);
+    // Persisted run-file lines share the console text format: a full
+    // ISO-8601 UTC timestamp with a `Z`, followed by a bracketed level.
+    assertMatch(
+      content,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[INF\] /m,
+    );
 
     sink.unregister(handle);
   });


### PR DESCRIPTION
## Summary

`swamp serve` and the CLI prefixed every log line with a bare UTC `HH:MM:SS.mmm` timestamp — no timezone marker, no date. Because the value is UTC while a machine's local time often differs, lines were easy to misread when correlating against wall-clock time or ISO-8601 timestamps from other systems (the reporter misdiagnosed a webhook as stalled over exactly this). Fixes swamp-club#1157.

Every log surface now emits an unambiguous **RFC3339** timestamp — ISO-8601 UTC with a `Z` and a date:

```
2026-07-15T10:38:08.894Z [INF] model·method·run·smoke·execute: Method "execute" completed on "smoke"
```

### Approach

- New leaf module `src/infrastructure/logging/log_format.ts` holds a single `TIMESTAMP_FORMAT` (`"rfc3339"`) and a shared `textFormatter()`, imported by both the console/stderr sinks (`logger.ts`) and the persisted run-file sink (`run_file_sink.ts`) — one source of truth, no drift, and no import cycle (the module imports neither sibling).
- The non-interactive console sink is **plain text**: `getTextFormatter`'s default layout is already `<timestamp> [<LEVEL>] <category>: <message>` and renders interpolated values without ANSI, so piped/redirected/daemon output stays clean. Colored output remains the pretty (TTY) sink's job — it adopts the same RFC3339 timestamp but keeps its richer layout.
- Updated the `json_isolation_test` leak-detection guards to the new format so they keep catching log lines that leak onto `--json` stdout.

### Note for reviewers

The non-interactive console path deliberately emits **no ANSI** — a real integration test caught that coloring it (via `getAnsiColorFormatter`) emits escape codes unconditionally even when piped, which both polluted redirected logs and broke a content-asserting workflow test. Color stays scoped to the pretty/TTY sink. Interactive terminal output is unchanged.

## Test Plan

- New unit tests (`log_format_test.ts`) assert `textFormatter()` renders an RFC3339 timestamp + bracketed level and emits no ANSI.
- New integration test (`log_timestamp_format_test.ts`) spawns the real CLI and asserts log lines use RFC3339 (not the old bare-UTC format) and carry no ANSI, across default and `--no-color`.
- Extended `run_file_sink_test.ts` to assert persisted run-log lines carry an RFC3339 timestamp.
- `deno check`, `deno lint`, `deno fmt --check`, `deno run compile` all pass. Full suite: 8916 passed; the only failures are pre-existing, environment-dependent tests (auth/config) unrelated to this change and failing identically on `main`.
- Manually verified the real binary across the console (piped → plain RFC3339, no ANSI), `--no-color`, and run-file paths; confirmed the reporter's local-vs-UTC ambiguity is resolved by the `Z` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)