### PR TITLE
fix(logging): harden OTel logs init per review (swamp-club#1158)

### DIFF
--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -110,7 +110,17 @@ export async function initializeLogging(
   // this returns a LoggerProvider we bridge into LogTape via a sink. The sink
   // exports over the network only — never stdout/stderr — so it is orthogonal
   // to the CLI output mode. Zero cost when logs export is disabled.
-  const otelProvider = await initLogs();
+  //
+  // Guarded: a telemetry init failure (e.g. a dynamic import of the OTel SDK
+  // rejecting) must never take down core logging — "telemetry must never
+  // interfere with the CLI", as elsewhere in this codebase. On failure we simply
+  // proceed without the otel sink.
+  let otelProvider: Awaited<ReturnType<typeof initLogs>>;
+  try {
+    otelProvider = await initLogs();
+  } catch {
+    otelProvider = undefined;
+  }
   const otelSinks: string[] = [];
   if (otelProvider) {
     sinks["otel"] = createOtelLogRecordSink(otelProvider);

--- a/src/infrastructure/logging/otel_log_sink.ts
+++ b/src/infrastructure/logging/otel_log_sink.ts
@@ -52,6 +52,30 @@ function toSeverityNumber(level: LogRecord["level"]): SeverityNumber {
   }
 }
 
+/**
+ * Maps a LogTape level to the OTel `severityText`. Follows the OTel log data
+ * model's short names (notably `WARN`, not LogTape's `warning`) so records
+ * group consistently with other services' logs in the backend.
+ */
+function toSeverityText(level: LogRecord["level"]): string {
+  switch (level) {
+    case "trace":
+      return "TRACE";
+    case "debug":
+      return "DEBUG";
+    case "info":
+      return "INFO";
+    case "warning":
+      return "WARN";
+    case "error":
+      return "ERROR";
+    case "fatal":
+      return "FATAL";
+    default:
+      return "INFO";
+  }
+}
+
 /** Renders a single non-string message part into a readable string. */
 function renderValue(value: unknown): string {
   if (typeof value === "string") return value;
@@ -116,7 +140,7 @@ export function createOtelLogRecordSink(provider: LoggerProvider): Sink {
 
     otelLogger.emit({
       severityNumber: toSeverityNumber(record.level),
-      severityText: record.level.toUpperCase(),
+      severityText: toSeverityText(record.level),
       body: runFileSink.redactActive(renderBody(record.message)),
       timestamp: record.timestamp,
       attributes,

--- a/src/infrastructure/logging/otel_log_sink_test.ts
+++ b/src/infrastructure/logging/otel_log_sink_test.ts
@@ -69,13 +69,14 @@ Deno.test("otel_log_sink: maps every LogTape level to the right SeverityNumber",
   const { exporter, provider } = newCapture();
   const sink = createOtelLogRecordSink(provider);
 
-  const cases: Array<[LogRecord["level"], SeverityNumber]> = [
-    ["trace", SeverityNumber.TRACE],
-    ["debug", SeverityNumber.DEBUG],
-    ["info", SeverityNumber.INFO],
-    ["warning", SeverityNumber.WARN],
-    ["error", SeverityNumber.ERROR],
-    ["fatal", SeverityNumber.FATAL],
+  // severityText follows the OTel short names — note "warning" -> "WARN".
+  const cases: Array<[LogRecord["level"], SeverityNumber, string]> = [
+    ["trace", SeverityNumber.TRACE, "TRACE"],
+    ["debug", SeverityNumber.DEBUG, "DEBUG"],
+    ["info", SeverityNumber.INFO, "INFO"],
+    ["warning", SeverityNumber.WARN, "WARN"],
+    ["error", SeverityNumber.ERROR, "ERROR"],
+    ["fatal", SeverityNumber.FATAL, "FATAL"],
   ];
   for (const [level] of cases) {
     sink(makeRecord(level, [`level ${level}`]));
@@ -84,7 +85,7 @@ Deno.test("otel_log_sink: maps every LogTape level to the right SeverityNumber",
   const recs = exporter.getFinishedLogRecords();
   for (let i = 0; i < cases.length; i++) {
     assertEquals(recs[i].severityNumber, cases[i][1]);
-    assertEquals(recs[i].severityText, cases[i][0].toUpperCase());
+    assertEquals(recs[i].severityText, cases[i][2]);
   }
 });
 

--- a/src/infrastructure/tracing/otel_config.ts
+++ b/src/infrastructure/tracing/otel_config.ts
@@ -1,0 +1,37 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Parses the `OTEL_EXPORTER_OTLP_HEADERS` env var (`key=val,key=val`) into a
+ * record. Shared by the trace and log exporters so both signals authenticate to
+ * the collector identically. Returns an empty record when the var is unset.
+ */
+export function parseOtlpHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const raw = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
+  if (raw) {
+    for (const pair of raw.split(",")) {
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx > 0) {
+        headers[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim();
+      }
+    }
+  }
+  return headers;
+}

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -86,17 +86,9 @@ export async function initTracing(): Promise<Context | undefined> {
     // Fetch-based OTLP/HTTP exporter — uses Deno's native fetch instead of
     // Node.js http/https modules, which fail TLS in compiled binaries.
     const { FetchOtlpExporter } = await import("./fetch_otlp_exporter.ts");
+    const { parseOtlpHeaders } = await import("./otel_config.ts");
 
-    const headers: Record<string, string> = {};
-    const rawHeaders = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
-    if (rawHeaders) {
-      for (const pair of rawHeaders.split(",")) {
-        const eqIdx = pair.indexOf("=");
-        if (eqIdx > 0) {
-          headers[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim();
-        }
-      }
-    }
+    const headers = parseOtlpHeaders();
 
     const exporter = new FetchOtlpExporter({
       url: `${endpoint!.replace(/\/+$/, "")}/v1/traces`,

--- a/src/infrastructure/tracing/otel_logs_init.ts
+++ b/src/infrastructure/tracing/otel_logs_init.ts
@@ -24,9 +24,17 @@ import type {
 } from "@opentelemetry/sdk-logs";
 import { ExportResultCode } from "@opentelemetry/core";
 import type { ExportResult } from "@opentelemetry/core";
+import { parseOtlpHeaders } from "./otel_config.ts";
 
-/** Handle to the provider so we can flush on shutdown. */
-let providerRef: { shutdown(): Promise<void> } | undefined;
+/**
+ * Handle to the provider so we can flush on shutdown and short-circuit a
+ * repeat {@link initLogs} call (returning the live provider rather than leaking
+ * a second one). The concrete SDK provider is both a {@link LoggerProvider} and
+ * carries `shutdown()`.
+ */
+let providerRef:
+  | (LoggerProvider & { shutdown(): Promise<void> })
+  | undefined;
 
 /**
  * Debug-only log exporter that writes each record to **stderr**. Used for
@@ -62,21 +70,6 @@ class StderrLogRecordExporter implements LogRecordExporter {
   }
 }
 
-/** Parses `OTEL_EXPORTER_OTLP_HEADERS` (`key=val,key=val`) into a record. */
-function parseOtlpHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {};
-  const raw = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
-  if (raw) {
-    for (const pair of raw.split(",")) {
-      const eqIdx = pair.indexOf("=");
-      if (eqIdx > 0) {
-        headers[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim();
-      }
-    }
-  }
-  return headers;
-}
-
 /**
  * Initializes the OpenTelemetry **logs** signal, mirroring
  * {@link initTracing}. Returns the {@link LoggerProvider} so the logging layer
@@ -93,6 +86,14 @@ function parseOtlpHeaders(): Record<string, string> {
  * a {@link BatchLogRecordProcessor}, which suits high-volume `swamp serve`.
  */
 export async function initLogs(): Promise<LoggerProvider | undefined> {
+  // Idempotent: if logs export is already initialized, return the live provider
+  // rather than building (and leaking) a second one. The only production caller
+  // (initializeLogging) is already once-per-process, but initLogs is exported,
+  // so this keeps the contract self-enforcing for any future caller.
+  if (providerRef) {
+    return providerRef;
+  }
+
   const endpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
   const exporterKind = Deno.env.get("OTEL_LOGS_EXPORTER") ?? "otlp";
 

--- a/src/infrastructure/tracing/otel_logs_init_test.ts
+++ b/src/infrastructure/tracing/otel_logs_init_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertStrictEquals } from "@std/assert";
 import { initLogs, shutdownLogs } from "./otel_logs_init.ts";
 
 const ENV_KEYS = [
@@ -110,4 +110,18 @@ Deno.test("shutdownLogs: no-op and safe to call when logs were never initialized
     await shutdownLogs();
     await shutdownLogs(); // double shutdown must not throw
   });
+});
+
+Deno.test("initLogs: idempotent — a second call returns the same provider, not a new one", async () => {
+  await withEnv(
+    { OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318" },
+    async () => {
+      const first = await initLogs();
+      const second = await initLogs();
+      assertExists(first);
+      // Same instance — no second provider was built (and leaked).
+      assertStrictEquals(second, first);
+      await shutdownLogs();
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Follow-up to #1858 (OTel logs signal), addressing the non-blocking findings from the automated code review and adversarial review on that PR. Both reviews approved with no blocking issues; these harden the narrow gaps they flagged.

| Finding | Severity | Fix |
|---|---|---|
| `initLogs()` failure would take down all logging | **Medium** (adversarial) | `logger.ts` wraps `initLogs()` in try/catch — a telemetry SDK init failure now degrades gracefully (no otel sink) instead of leaving the CLI with no logging at all. |
| `severityText` emitted `"WARNING"` | Low (adversarial) | `otel_log_sink.ts` maps to the OTel short names (`warning` → `WARN`) so records group with other services' logs. |
| `initLogs()` had no double-init guard | Low (adversarial) | `otel_logs_init.ts` is now idempotent — a repeat call returns the live provider instead of building and leaking a second one. |
| `OTEL_EXPORTER_OTLP_HEADERS` parsing duplicated | Suggestion (code review) | Extracted to a shared `otel_config.ts` used by both `otel_init.ts` and `otel_logs_init.ts`. |

**Declined suggestion** (with reasoning): passing the `Uint8Array` directly to `fetch` instead of `.buffer as ArrayBuffer`. Deno's `fetch` typing rejects the bare view (`ArrayBufferLike` vs `ArrayBuffer`), and changing only the log exporter would diverge from the pre-existing span exporter. Better as a separate cleanup touching both exporters.

## Test Plan

- New unit tests: `initLogs()` idempotency (second call returns the same provider); `severityText` short-name mapping (asserts `warning` → `WARN`).
- All existing OTel unit + integration tests still pass (89 in the two dirs plus the integration suite).
- `deno check`, `deno lint`, `deno fmt --check` clean.

Refs swamp-club#1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)