### PR TITLE
test(tracing): add co-located tests for parseOtlpHeaders (swamp-club#1158)

### DIFF
--- a/src/infrastructure/tracing/otel_config_test.ts
+++ b/src/infrastructure/tracing/otel_config_test.ts
@@ -1,0 +1,89 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { parseOtlpHeaders } from "./otel_config.ts";
+
+function withHeaders(
+  value: string | undefined,
+  fn: () => void,
+): void {
+  const saved = Deno.env.get("OTEL_EXPORTER_OTLP_HEADERS");
+  try {
+    if (value === undefined) Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
+    else Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", value);
+    fn();
+  } finally {
+    if (saved === undefined) Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
+    else Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", saved);
+  }
+}
+
+Deno.test("parseOtlpHeaders: returns an empty record when unset", () => {
+  withHeaders(undefined, () => {
+    assertEquals(parseOtlpHeaders(), {});
+  });
+});
+
+Deno.test("parseOtlpHeaders: returns an empty record for an empty string", () => {
+  withHeaders("", () => {
+    assertEquals(parseOtlpHeaders(), {});
+  });
+});
+
+Deno.test("parseOtlpHeaders: parses a single key=value pair", () => {
+  withHeaders("x-honeycomb-team=abc123", () => {
+    assertEquals(parseOtlpHeaders(), { "x-honeycomb-team": "abc123" });
+  });
+});
+
+Deno.test("parseOtlpHeaders: parses multiple comma-separated pairs", () => {
+  withHeaders("a=1,b=2,c=3", () => {
+    assertEquals(parseOtlpHeaders(), { a: "1", b: "2", c: "3" });
+  });
+});
+
+Deno.test("parseOtlpHeaders: trims whitespace around keys and values", () => {
+  withHeaders(" a = 1 , b = 2 ", () => {
+    assertEquals(parseOtlpHeaders(), { a: "1", b: "2" });
+  });
+});
+
+Deno.test("parseOtlpHeaders: only the first '=' splits, so values may contain '='", () => {
+  withHeaders("Authorization=Basic dXNlcj1wYXNz=", () => {
+    assertEquals(parseOtlpHeaders(), {
+      Authorization: "Basic dXNlcj1wYXNz=",
+    });
+  });
+});
+
+Deno.test("parseOtlpHeaders: drops entries with no '='", () => {
+  withHeaders("valid=1,garbage,also-valid=2", () => {
+    assertEquals(parseOtlpHeaders(), { valid: "1", "also-valid": "2" });
+  });
+});
+
+Deno.test("parseOtlpHeaders: splits on commas (values with literal commas are not supported per OTel spec)", () => {
+  // The OTel env-var spec requires comma-containing values to be
+  // percent-encoded; a raw comma is treated as a delimiter. This documents that
+  // known behavior rather than endorsing it.
+  withHeaders("Authorization=Bearer a,b,c", () => {
+    assertEquals(parseOtlpHeaders(), { Authorization: "Bearer a" });
+  });
+});

--- a/src/infrastructure/tracing/otel_logs_init.ts
+++ b/src/infrastructure/tracing/otel_logs_init.ts
@@ -24,6 +24,9 @@ import type {
 } from "@opentelemetry/sdk-logs";
 import { ExportResultCode } from "@opentelemetry/core";
 import type { ExportResult } from "@opentelemetry/core";
+// Static import is deliberate: otel_config.ts is a tiny leaf with no SDK deps,
+// so it costs nothing eagerly. (otel_init.ts imports it dynamically only because
+// it already batches all its SDK imports inside the function body.)
 import { parseOtlpHeaders } from "./otel_config.ts";
 
 /**


### PR DESCRIPTION
## Summary

Closes the one actionable suggestion from the #1859 review: the extracted shared OTLP header parser (`otel_config.ts`) had no co-located `_test.ts`, against the repo convention that unit tests live next to source.

- Adds `otel_config_test.ts` with edge-case coverage for `parseOtlpHeaders`: unset/empty input, single and multiple pairs, whitespace trimming, first-`=`-only splitting (values may contain `=`), dropped entries without `=`, and the documented comma-splitting behavior (comma-containing values are unsupported per the OTel env-var spec — they must be percent-encoded).
- Adds a one-line comment on the deliberate static import of `otel_config.ts` in `otel_logs_init.ts` so a future contributor doesn't "fix" it to match `otel_init.ts`'s dynamic pattern.

The two adversarial-review lows on #1859 were explicitly *no action needed* (a TOCTOU that can't occur with the single awaited caller; the comma-in-value behavior, which is per-spec and unchanged by the extraction) and are covered by the new documenting test.

## Test Plan

- 8 new `parseOtlpHeaders` unit tests, all passing.
- `deno check`, `deno lint`, `deno fmt --check` clean.

Refs swamp-club#1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)