### PR TITLE
fix(signals): force-exit on second SIGINT when model method is stuck (swamp-club#1156)

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -387,6 +387,7 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
         const exitSuppress = suppressSyncExitOnSignal();
         const shutdownHandle = registerShutdownHandler({
           handler: () => abort.abort(),
+          forceExitOnRepeat: true,
         });
         const baseLibCtx = createLibSwampContext({ signal: abort.signal });
         const libCtx = timeoutMs !== undefined
@@ -570,6 +571,7 @@ async function runMethodViaServer(
   }
   const shutdown = registerShutdownHandler({
     handler: () => abort.abort(),
+    forceExitOnRepeat: true,
   });
 
   const inputSets: Record<string, unknown>[] = stdinItems

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -390,6 +390,7 @@ export const workflowRunCommand = new Command()
         : undefined;
       shutdownHandle = registerShutdownHandler({
         handler: () => abort.abort(),
+        forceExitOnRepeat: true,
       });
       const baseLibCtx = createLibSwampContext({ signal: abort.signal });
       const libCtx = timeoutMs !== undefined
@@ -543,6 +544,7 @@ async function runWorkflowViaServer(
   }
   const shutdown = registerShutdownHandler({
     handler: () => abort.abort(),
+    forceExitOnRepeat: true,
   });
 
   const inputSets: Record<string, unknown>[] = stdinItems

--- a/src/infrastructure/process/shutdown_handlers.ts
+++ b/src/infrastructure/process/shutdown_handlers.ts
@@ -45,6 +45,13 @@ export interface ShutdownHandlerOptions {
    * Has no effect on Windows where only `SIGINT` is registered regardless.
    */
   includePosixSignals?: boolean;
+  /**
+   * When true, the first signal invokes the handler normally; a second
+   * signal force-exits the process with code 130. Prevents stuck
+   * processes when the handler fires an AbortSignal that the in-flight
+   * work ignores.
+   */
+  forceExitOnRepeat?: boolean;
 }
 
 /** Disposer returned by {@link registerShutdownHandler}. */
@@ -75,34 +82,46 @@ const POSIX_ONLY_SIGNALS: readonly Deno.Signal[] = ["SIGTERM", "SIGHUP"];
 export function registerShutdownHandler(
   options: ShutdownHandlerOptions,
 ): ShutdownHandlerHandle {
-  const { handler, includePosixSignals = true } = options;
+  const { handler, includePosixSignals = true, forceExitOnRepeat = false } =
+    options;
 
   const registered: Deno.Signal[] = [];
 
-  // SIGINT is always safe — both POSIX and Windows support it.
-  Deno.addSignalListener("SIGINT", handler);
+  let fired = false;
+  const wrappedHandler = forceExitOnRepeat
+    ? () => {
+      if (fired) {
+        Deno.exit(130);
+      }
+      fired = true;
+      handler();
+    }
+    : handler;
+
+  Deno.addSignalListener("SIGINT", wrappedHandler);
   registered.push("SIGINT");
 
   if (includePosixSignals && Deno.build.os !== "windows") {
     for (const signal of POSIX_ONLY_SIGNALS) {
-      Deno.addSignalListener(signal, handler);
+      Deno.addSignalListener(signal, wrappedHandler);
       registered.push(signal);
     }
   }
 
   let disposed = false;
-  return {
-    dispose: () => {
-      if (disposed) return;
-      disposed = true;
-      for (const signal of registered) {
-        try {
-          Deno.removeSignalListener(signal, handler);
-        } catch {
-          // Listener may have already been removed (e.g. if Deno's
-          // signal infrastructure tore it down). Best-effort cleanup.
-        }
+
+  function removeAll(): void {
+    if (disposed) return;
+    disposed = true;
+    for (const signal of registered) {
+      try {
+        Deno.removeSignalListener(signal, wrappedHandler);
+      } catch {
+        // Listener may have already been removed (e.g. if Deno's
+        // signal infrastructure tore it down). Best-effort cleanup.
       }
-    },
-  };
+    }
+  }
+
+  return { dispose: removeAll };
 }

--- a/src/infrastructure/process/shutdown_handlers_test.ts
+++ b/src/infrastructure/process/shutdown_handlers_test.ts
@@ -155,3 +155,86 @@ Deno.test("registerShutdownHandler: SIGINT-only mode registers without throwing"
   });
   handle.dispose();
 });
+
+Deno.test({
+  name:
+    "registerShutdownHandler: forceExitOnRepeat removes listeners after first signal so second falls through (POSIX)",
+  ignore: Deno.build.os === "windows",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const moduleUrl = new URL("./shutdown_handlers.ts", import.meta.url).href;
+    const program = `
+      import { registerShutdownHandler } from "${moduleUrl}";
+
+      let handlerCalls = 0;
+      registerShutdownHandler({
+        handler: () => {
+          handlerCalls++;
+          console.log(JSON.stringify({ handlerCalls }));
+        },
+        forceExitOnRepeat: true,
+        includePosixSignals: false,
+      });
+
+      // First SIGINT: handler fires normally.
+      setTimeout(() => Deno.kill(Deno.pid, "SIGINT"), 50);
+
+      // Second SIGINT after 150ms: forceExitOnRepeat calls
+      // Deno.exit(130) immediately.
+      setTimeout(() => Deno.kill(Deno.pid, "SIGINT"), 150);
+
+      // Block forever — exit happens via Deno.exit(130) in the handler.
+      await new Promise(() => {});
+    `;
+
+    const cmd = new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", "-"],
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const child = cmd.spawn();
+    const writer = child.stdin.getWriter();
+    try {
+      await writer.write(new TextEncoder().encode(program));
+    } finally {
+      await writer.close();
+    }
+
+    const status = await Promise.race([
+      child.status,
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("child did not exit within 5s")),
+          5_000,
+        );
+      }),
+    ]);
+
+    const stdout = new TextDecoder().decode(
+      await new Response(child.stdout).arrayBuffer(),
+    );
+    await child.stderr.cancel();
+
+    // Second SIGINT triggers Deno.exit(130) inside the handler —
+    // proves the escalation fires on repeat.
+    assertEquals(
+      status.code,
+      130,
+      `expected child to exit 130 (default SIGINT); got ${status.code}; stdout=${stdout}`,
+    );
+
+    const lines = stdout.split("\n").filter((l) => l.trim().length > 0);
+    assertEquals(
+      lines.length,
+      1,
+      `handler should fire exactly once: ${stdout}`,
+    );
+    assertEquals(
+      lines[0],
+      '{"handlerCalls":1}',
+      `unexpected handler output: ${stdout}`,
+    );
+  },
+});


### PR DESCRIPTION
## Summary

- Add `forceExitOnRepeat` option to `registerShutdownHandler` — first signal runs the handler normally, second signal calls `Deno.exit(130)` to force-exit
- Enable `forceExitOnRepeat: true` in `model method run` and `workflow run` commands (both local and server execution paths)
- Fixes stuck processes when a model method blocks on an uncancellable call: previously `abort.abort()` was idempotent and `suppressSyncExitOnSignal()` prevented the coordinator's force-exit, so repeated Ctrl-C had no effect

Closes swamp-club/lab#1156

## Test Plan

- [x] New unit test: `forceExitOnRepeat removes listeners after first signal so second falls through (POSIX)` — spawns child process, sends two SIGINTs, verifies handler fires exactly once and process exits 130
- [x] All existing shutdown handler tests pass (8919 total, 0 failures)
- [x] Reproduced the bug: `swamp model method run hang-test execute --input "run=trap '' INT TERM; sleep 999999"` — 3 SIGINTs, process stuck, only SIGKILL worked
- [x] Verified the fix: same scenario, second SIGINT exits with code 130
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)