### PR TITLE
feat(doctor): expose bundled deno path in doctor extensions --json

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -87,10 +87,18 @@ scorer runs `deno doc --lint` in a hermetic sandbox that strips the repo's
 `deno.json` and writes its own with no imports map, so bare specifiers resolve
 locally but fail at score time.
 
+Bundled deno lives at `~/.swamp/deno/deno` (not on `PATH`) — invoke it by full
+path for type-checking, testing, and linting extension code. To discover the
+resolved path programmatically, run `swamp doctor extensions --json` and read
+the `denoPath` field.
+
 ## Quick Reference
 
 | Task                | Command/Action                                 |
 | ------------------- | ---------------------------------------------- |
+| Type-check          | `~/.swamp/deno/deno check <file>`              |
+| Run tests           | `~/.swamp/deno/deno test <file>`               |
+| Show deno path      | `swamp doctor extensions --json` → `denoPath`  |
 | Search community    | `swamp extension search <query> --json`        |
 | Verify registration | `swamp model type search --json`               |
 | Verify it loads     | `swamp doctor extensions --json`               |

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -284,9 +284,19 @@ export const doctorExtensionsCommand = withRemoteOptions(
       relative(repoDir, d)
     );
 
+    let denoPath: string | undefined;
+    try {
+      denoPath = await new EmbeddedDenoRuntime().ensureDeno();
+    } catch {
+      // Best-effort — path resolution can fail in dev mode or when
+      // the embedded binary extraction fails. The field is omitted
+      // from JSON output in that case.
+    }
+
     const controller = new AbortController();
     const renderer = createDoctorExtensionsRenderer(cliCtx.outputMode, {
       verbose,
+      denoPath,
     });
 
     const doctorLockfileRepo = await LockfileRepository.create(lockfilePath);

--- a/src/presentation/renderers/doctor_extensions.ts
+++ b/src/presentation/renderers/doctor_extensions.ts
@@ -50,6 +50,7 @@ export interface DoctorExtensionsRenderer {
 
 export interface DoctorExtensionsRendererOptions {
   verbose?: boolean;
+  denoPath?: string;
 }
 
 function iconFor(status: DoctorRegistryResult["status"]): string {
@@ -389,6 +390,11 @@ class LogDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
 
 class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
   overallStatus: DoctorOverallStatus = "pass";
+  readonly #denoPath: string | undefined;
+
+  constructor(options: DoctorExtensionsRendererOptions) {
+    this.#denoPath = options.denoPath;
+  }
 
   handlers(): EventHandlers<DoctorExtensionsEvent> {
     return {
@@ -431,6 +437,9 @@ class JsonDoctorExtensionsRenderer implements DoctorExtensionsRenderer {
           toState: t.toState,
           reason: t.reason,
         }));
+        if (this.#denoPath) {
+          output.denoPath = this.#denoPath;
+        }
         console.log(JSON.stringify(output, null, 2));
       },
       error: (e) => {
@@ -447,7 +456,7 @@ export function createDoctorExtensionsRenderer(
   const opts = options ?? {};
   switch (mode) {
     case "json":
-      return new JsonDoctorExtensionsRenderer();
+      return new JsonDoctorExtensionsRenderer(opts);
     case "log":
       return new LogDoctorExtensionsRenderer(opts);
   }

--- a/src/presentation/renderers/doctor_extensions_test.ts
+++ b/src/presentation/renderers/doctor_extensions_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertFalse } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import type {
   DoctorExtensionsReport,
@@ -350,5 +350,41 @@ Deno.test(
       parsed.recentTransitions[0].reason,
       "source file deleted from disk",
     );
+  },
+);
+
+Deno.test(
+  "doctor_extensions json renderer: denoPath included when provided",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("json", {
+        denoPath: "/home/user/.swamp/deno/deno",
+      });
+      const handlers = r.handlers();
+      await handlers.completed({
+        kind: "completed",
+        report: buildPassReport(),
+      });
+    });
+
+    const parsed = JSON.parse(out);
+    assertEquals(parsed.denoPath, "/home/user/.swamp/deno/deno");
+  },
+);
+
+Deno.test(
+  "doctor_extensions json renderer: denoPath omitted when not provided",
+  async () => {
+    const out = await captureStdout(async () => {
+      const r = createDoctorExtensionsRenderer("json");
+      const handlers = r.handlers();
+      await handlers.completed({
+        kind: "completed",
+        report: buildPassReport(),
+      });
+    });
+
+    const parsed = JSON.parse(out);
+    assertFalse("denoPath" in parsed);
   },
 );


### PR DESCRIPTION
## Summary

Closes swamp-club#1167.

- Add `denoPath` field to `swamp doctor extensions --json` output, resolved from the existing `EmbeddedDenoRuntime.ensureDeno()` at the CLI layer
- Add bundled deno path (`~/.swamp/deno/deno`) to the extension guide's Quick Reference table (Type-check, Run tests, Show deno path rows) and a note near Import Rules
- Path resolution is best-effort — `denoPath` is omitted from JSON output when resolution fails (e.g. dev mode)

## Test Plan

- [x] New unit tests: `denoPath` included when provided, omitted when not
- [x] All 8920 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt --check` clean
- [x] Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)