### PR TITLE
fix(vaults): include specName and instanceName in sensitive field vault keys (swamp-club#1169)

### DIFF
--- a/integration/otel_logs_no_duplicate_test.ts
+++ b/integration/otel_logs_no_duplicate_test.ts
@@ -34,6 +34,11 @@ import {
 } from "../src/infrastructure/logging/logger.ts";
 import { shutdownLogs } from "../src/infrastructure/tracing/mod.ts";
 
+// With --parallel, other test files may have already called initializeLogging,
+// setting both the module-level isInitialized guard and LogTape's own
+// configure guard. We must clear both before this test can reconfigure
+// logging with a stubbed fetch.
+
 function countBodies(
   captured: { url: string; body: string }[],
   needle: string,
@@ -72,8 +77,15 @@ Deno.test("OTel logs (log mode): each record is exported exactly once, never dup
   }) as any;
 
   try {
+    // Clear any prior OTel logs provider so initLogs() creates a fresh one
+    // that picks up our stubbed fetch.
+    await shutdownLogs();
+
     // Log (non-JSON) mode — the path where run loggers inherit root sinks.
-    await initializeLogging({});
+    // _reset clears the once-per-process guard and passes reset:true to
+    // LogTape's configure(), so this works even when another test file
+    // already called initializeLogging in the same --parallel run.
+    await initializeLogging({ _reset: true });
 
     // A run-category logger: its records reach the root (which holds the otel
     // sink) by inheritance. If the otel sink were also on this logger, the

--- a/integration/sensitive_field_vault_test.ts
+++ b/integration/sensitive_field_vault_test.ts
@@ -67,6 +67,8 @@ Deno.test("Integration: sensitive output fields stored in vault with references 
     modelType,
     modelId,
     methodName,
+    "keypair",
+    "main",
   );
 
   // Non-sensitive fields unchanged
@@ -80,7 +82,8 @@ Deno.test("Integration: sensitive output fields stored in vault with references 
   assertStringIncludes(keyMaterialRef, "${{ vault.get('test-vault'");
 
   // Verify the actual secret was stored in the vault
-  const vaultKey = `test-sensitive-output-${modelId}-${methodName}-keyMaterial`;
+  const vaultKey =
+    `test-sensitive-output-${modelId}-${methodName}-keypair-main-keyMaterial`;
   const storedSecret = await vaultService.get("test-vault", vaultKey);
   assertEquals(
     storedSecret,
@@ -129,6 +132,8 @@ Deno.test("Integration: sensitiveOutput flag vaults all fields", async () => {
     modelType,
     modelId,
     methodName,
+    "secrets",
+    "main",
   );
 
   // Both fields should be vault references
@@ -136,8 +141,10 @@ Deno.test("Integration: sensitiveOutput flag vaults all fields", async () => {
   assertStringIncludes(data.field2 as string, "vault.get");
 
   // Verify values stored in vault
-  const key1 = `test-all-sensitive-${modelId}-${methodName}-field1`;
-  const key2 = `test-all-sensitive-${modelId}-${methodName}-field2`;
+  const key1 =
+    `test-all-sensitive-${modelId}-${methodName}-secrets-main-field1`;
+  const key2 =
+    `test-all-sensitive-${modelId}-${methodName}-secrets-main-field2`;
   assertEquals(
     await vaultService.get("test-vault", key1),
     "secret-value-1",
@@ -180,6 +187,8 @@ Deno.test("Integration: custom vaultKey from schema metadata", async () => {
     modelType,
     modelId,
     methodName,
+    "apikeys",
+    "main",
   );
 
   // Verify vault reference uses custom key with quoted strings

--- a/src/domain/data/data_record_mapper.ts
+++ b/src/domain/data/data_record_mapper.ts
@@ -262,6 +262,8 @@ export async function fromResourceHandle(
   modelId: string,
   fallbackModelName: string,
   dataRepo: UnifiedDataRepository,
+  vaultService?: VaultService,
+  redactor?: SecretRedactor,
 ): Promise<DataRecord> {
   let attributes: Record<string, unknown> = {};
   if (handle.metadata.contentType === "application/json") {
@@ -278,6 +280,13 @@ export async function fromResourceHandle(
       }
     } catch {
       // Not valid JSON, skip attributes
+    }
+  }
+  if (vaultService && Object.keys(attributes).length > 0) {
+    try {
+      await resolveVaultRefsInData(attributes, vaultService, redactor);
+    } catch {
+      // Vault unavailable or specific keys failed — leave unresolved
     }
   }
 

--- a/src/domain/data/data_record_mapper_test.ts
+++ b/src/domain/data/data_record_mapper_test.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { fromData, fromRow } from "./data_record_mapper.ts";
+import { fromData, fromResourceHandle, fromRow } from "./data_record_mapper.ts";
+import { VaultService } from "../vaults/vault_service.ts";
+import type { DataHandle } from "../models/model.ts";
+import type { DataId } from "./data_id.ts";
 import type { CatalogRow } from "../../infrastructure/persistence/catalog_store.ts";
 import type { UnifiedDataRepository } from "./repositories.ts";
 import { Data } from "./data.ts";
@@ -376,4 +379,85 @@ Deno.test("fromData: handles null content bytes", async () => {
 
   assertEquals(record!.attributes, {});
   assertEquals(record!.content, "");
+});
+
+// ============================================================================
+// fromResourceHandle — vault reference resolution
+// ============================================================================
+
+Deno.test("fromResourceHandle: resolves vault references in attributes when vaultService is provided", async () => {
+  const vaultService = new VaultService();
+  vaultService.registerVault({ name: "myvault", type: "mock", config: {} });
+  await vaultService.put("myvault", "secret-key", "resolved-secret-value");
+
+  const data = {
+    apiKey: "${{ vault.get('myvault', 'secret-key') }}",
+    label: "test",
+  };
+  const repo = stubRepo(null, encoder.encode(JSON.stringify(data)));
+
+  const handle: DataHandle = {
+    name: "instance-1",
+    specName: "creds",
+    kind: "resource",
+    dataId: "data-id-1" as DataId,
+    version: 1,
+    size: 100,
+    tags: { type: "resource", modelName: "test-model" },
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: {},
+      ownerDefinition: { ownerType: "model-method", ownerRef: "ref-1" },
+    },
+  };
+
+  const record = await fromResourceHandle(
+    handle,
+    ModelType.create("test/model"),
+    "model-123",
+    "test-model",
+    repo,
+    vaultService,
+  );
+
+  assertEquals(record.attributes.apiKey, "resolved-secret-value");
+  assertEquals(record.attributes.label, "test");
+});
+
+Deno.test("fromResourceHandle: returns raw vault refs when vaultService is omitted", async () => {
+  const vaultRef = "${{ vault.get('myvault', 'secret-key') }}";
+  const data = { apiKey: vaultRef, label: "test" };
+  const repo = stubRepo(null, encoder.encode(JSON.stringify(data)));
+
+  const handle: DataHandle = {
+    name: "instance-1",
+    specName: "creds",
+    kind: "resource",
+    dataId: "data-id-1" as DataId,
+    version: 1,
+    size: 100,
+    tags: { type: "resource", modelName: "test-model" },
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: {},
+      ownerDefinition: { ownerType: "model-method", ownerRef: "ref-1" },
+    },
+  };
+
+  const record = await fromResourceHandle(
+    handle,
+    ModelType.create("test/model"),
+    "model-123",
+    "test-model",
+    repo,
+  );
+
+  assertEquals(record.attributes.apiKey, vaultRef);
+  assertEquals(record.attributes.label, "test");
 });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -336,6 +336,8 @@ export async function processSensitiveResourceData(
   modelType: ModelType,
   modelId: string,
   methodName: string,
+  specName: string,
+  instanceName: string,
   callbacks?: DataWriterCallbacks,
 ): Promise<void> {
   const sensitiveFields = extractSensitiveFields(spec.schema);
@@ -383,7 +385,7 @@ export async function processSensitiveResourceData(
     const targetVault = field.vaultName ?? spec.vaultName ?? vaultNames[0];
     const vaultKey = field.vaultKey ??
       sanitizeVaultKey(
-        `${modelType.normalized}/${modelId}/${methodName}/${field.path}`,
+        `${modelType.normalized}/${modelId}/${methodName}/${specName}/${instanceName}/${field.path}`,
       );
 
     const stringValue = typeof originalValue === "string"
@@ -592,6 +594,8 @@ export function createResourceWriter(
         modelType,
         modelId,
         methodName,
+        specName,
+        name,
         { onEvent },
       );
     }

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -565,6 +565,8 @@ Deno.test("processSensitiveResourceData: replaces sensitive field with vault ref
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertEquals(data.name, "public-value");
@@ -590,9 +592,11 @@ Deno.test("processSensitiveResourceData: stores actual value in vault", async ()
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
-  const vaultKey = `swamp-test-${modelId}-create-apiKey`;
+  const vaultKey = `swamp-test-${modelId}-create-creds-main-apiKey`;
   const storedValue = await vaultService.get("test-vault", vaultKey);
   assertEquals(storedValue, "sk-live-abc123");
 });
@@ -615,11 +619,13 @@ Deno.test("processSensitiveResourceData: uses single-quoted strings for CEL comp
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   const ref = data.token as string;
   assertStringIncludes(ref, "vault.get('test-vault'");
-  assertStringIncludes(ref, `'swamp-test-${modelId}-create-token'`);
+  assertStringIncludes(ref, `'swamp-test-${modelId}-create-creds-main-token'`);
 });
 
 Deno.test("processSensitiveResourceData: handles non-string values with JSON.stringify", async () => {
@@ -641,9 +647,11 @@ Deno.test("processSensitiveResourceData: handles non-string values with JSON.str
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
-  const vaultKey = `swamp-test-${modelId}-create-config`;
+  const vaultKey = `swamp-test-${modelId}-create-creds-main-config`;
   const storedValue = await vaultService.get("test-vault", vaultKey);
   assertEquals(storedValue, JSON.stringify(configValue));
 });
@@ -669,6 +677,8 @@ Deno.test("processSensitiveResourceData: throws error when no vault configured",
         modelType,
         modelId,
         "create",
+        "creds",
+        "main",
       ),
     Error,
     "no vault is configured",
@@ -698,13 +708,15 @@ Deno.test("processSensitiveResourceData: sensitiveOutput flag treats all fields 
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertStringIncludes(data.field1 as string, "vault.get");
   assertStringIncludes(data.field2 as string, "vault.get");
 
-  const key1 = `swamp-test-${modelId}-create-field1`;
-  const key2 = `swamp-test-${modelId}-create-field2`;
+  const key1 = `swamp-test-${modelId}-create-creds-main-field1`;
+  const key2 = `swamp-test-${modelId}-create-creds-main-field2`;
   assertEquals(await vaultService.get("test-vault", key1), "value1");
   assertEquals(await vaultService.get("test-vault", key2), "value2");
 });
@@ -741,6 +753,8 @@ Deno.test("processSensitiveResourceData: uses custom vaultName from field metada
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertStringIncludes(data.secret as string, "'special-vault'");
@@ -767,6 +781,8 @@ Deno.test("processSensitiveResourceData: uses custom vaultKey from field metadat
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertStringIncludes(data.apiKey as string, "'my-custom-key'");
@@ -795,6 +811,8 @@ Deno.test("processSensitiveResourceData: skips fields with null/undefined values
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertStringIncludes(data.required as string, "vault.get");
@@ -820,6 +838,8 @@ Deno.test("processSensitiveResourceData: no-op when no sensitive fields", async 
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertEquals(data.name, "test");
@@ -852,6 +872,8 @@ Deno.test("processSensitiveResourceData: spec vaultName overrides default vault"
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertStringIncludes(data.secret as string, "'spec-vault'");
@@ -882,6 +904,8 @@ Deno.test("processSensitiveResourceData: handles nested sensitive fields", async
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   assertEquals(data.name, "my-service");
@@ -890,7 +914,7 @@ Deno.test("processSensitiveResourceData: handles nested sensitive fields", async
   assertStringIncludes(creds.apiKey as string, "vault.get");
   assertEquals(data["credentials.apiKey"], undefined);
 
-  const vaultKey = `swamp-test-${modelId}-create-credentials.apiKey`;
+  const vaultKey = `swamp-test-${modelId}-create-creds-main-credentials.apiKey`;
   assertEquals(
     await vaultService.get("test-vault", vaultKey),
     "secret-key-123",
@@ -921,25 +945,115 @@ Deno.test("processSensitiveResourceData: snapshots values before mutation", asyn
     modelType,
     modelId,
     "create",
+    "creds",
+    "main",
   );
 
   // Top-level "credentials" should also be a vault ref
   assertStringIncludes(data.credentials as string, "vault.get");
 
   // The nested apiKey's original value should be stored
-  const nestedKey = `swamp-test-${modelId}-create-credentials.apiKey`;
+  const nestedKey =
+    `swamp-test-${modelId}-create-creds-main-credentials.apiKey`;
   assertEquals(
     await vaultService.get("test-vault", nestedKey),
     "original-secret",
   );
 
   // The top-level object stored should contain ORIGINAL values
-  const topKey = `swamp-test-${modelId}-create-credentials`;
+  const topKey = `swamp-test-${modelId}-create-creds-main-credentials`;
   const storedObject = JSON.parse(
     await vaultService.get("test-vault", topKey),
   );
   assertEquals(storedObject.apiKey, "original-secret");
   assertEquals(storedObject.region, "us-east-1");
+});
+
+Deno.test("processSensitiveResourceData: different instance names produce distinct vault keys", async () => {
+  const spec: ResourceOutputSpec = {
+    schema: z.object({
+      secret: z.string().meta({ sensitive: true }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+
+  const dataA: Record<string, unknown> = { secret: "AAAA" };
+  const dataB: Record<string, unknown> = { secret: "BBBB" };
+  const vaultService = createTestVaultService();
+
+  await processSensitiveResourceData(
+    dataA,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "instance-a",
+  );
+  await processSensitiveResourceData(
+    dataB,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "instance-b",
+  );
+
+  const keyA = `swamp-test-${modelId}-create-creds-instance-a-secret`;
+  const keyB = `swamp-test-${modelId}-create-creds-instance-b-secret`;
+  assertEquals(await vaultService.get("test-vault", keyA), "AAAA");
+  assertEquals(await vaultService.get("test-vault", keyB), "BBBB");
+});
+
+Deno.test("processSensitiveResourceData: different spec names produce distinct vault keys", async () => {
+  const specA: ResourceOutputSpec = {
+    schema: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+  const specB: ResourceOutputSpec = {
+    schema: z.object({
+      apiKey: z.string().meta({ sensitive: true }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+
+  const dataA: Record<string, unknown> = { apiKey: "key-from-spec-a" };
+  const dataB: Record<string, unknown> = { apiKey: "key-from-spec-b" };
+  const vaultService = createTestVaultService();
+
+  await processSensitiveResourceData(
+    dataA,
+    specA,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "specA",
+    "main",
+  );
+  await processSensitiveResourceData(
+    dataB,
+    specB,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "specB",
+    "main",
+  );
+
+  const keyA = `swamp-test-${modelId}-create-specA-main-apiKey`;
+  const keyB = `swamp-test-${modelId}-create-specB-main-apiKey`;
+  assertEquals(await vaultService.get("test-vault", keyA), "key-from-spec-a");
+  assertEquals(await vaultService.get("test-vault", keyB), "key-from-spec-b");
 });
 
 // --- sanitizeVaultKey tests ---
@@ -1276,10 +1390,13 @@ Deno.test("processSensitiveResourceData: handles namespaced model types (#447)",
     namespacedType,
     id,
     "create",
+    "keypair",
+    "main",
   );
 
   // Should not throw — key is sanitized
-  const expectedKey = `user-aws-ec2-keypair-${id}-create-KeyMaterial`;
+  const expectedKey =
+    `user-aws-ec2-keypair-${id}-create-keypair-main-KeyMaterial`;
   assertStringIncludes(data.KeyMaterial as string, expectedKey);
 
   const stored = await vaultService.get("test-vault", expectedKey);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -891,6 +891,7 @@ export class DefaultStepExecutor implements StepExecutor {
           outputRepo,
           unifiedDataRepo,
           definitionRepo,
+          vaultService,
           modelType,
           modelDef,
           originalDefinition,
@@ -1151,6 +1152,7 @@ export class DefaultStepExecutor implements StepExecutor {
     outputRepo: OutputRepository;
     unifiedDataRepo: UnifiedDataRepository;
     definitionRepo: DefinitionRepository;
+    vaultService: VaultService;
     modelType: ModelType;
     modelDef: ModelDefinition;
     originalDefinition: Definition;
@@ -1173,6 +1175,7 @@ export class DefaultStepExecutor implements StepExecutor {
       outputRepo,
       unifiedDataRepo,
       definitionRepo,
+      vaultService,
       modelType,
       modelDef,
       originalDefinition,
@@ -1220,6 +1223,8 @@ export class DefaultStepExecutor implements StepExecutor {
             evaluatedDefinition.id,
             evaluatedDefinition.name,
             unifiedDataRepo,
+            vaultService,
+            ctx.secretRedactor,
           );
         } else if (handle.kind === "file") {
           const fileRecord = await fromFileHandle(

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -40,6 +40,8 @@ export interface LoggingOptions {
   noColor?: boolean;
   /** Write all log output to stderr only (for dispatch runners where stdout carries RPC frames). */
   stderrOnly?: boolean;
+  /** Test-only: clear the once-per-process guard so logging can be reconfigured. */
+  _reset?: boolean;
 }
 
 const stderrEncoder = new TextEncoder();
@@ -57,7 +59,9 @@ let isInitialized = false;
 export async function initializeLogging(
   options: LoggingOptions,
 ): Promise<void> {
-  // LogTape can only be configured once per process
+  if (options._reset) {
+    isInitialized = false;
+  }
   if (isInitialized) {
     return;
   }
@@ -188,6 +192,7 @@ export async function initializeLogging(
         parentSinks: jsonMode ? "override" : "inherit",
       },
     ],
+    ...(options._reset ? { reset: true } : {}),
   });
 
   isInitialized = true;


### PR DESCRIPTION
## Summary

- **Vault key collision fix**: `processSensitiveResourceData` generated vault keys as `modelType/modelId/methodName/fieldPath`, omitting specName and instanceName. Two `writeResource` calls with different instance names but the same sensitive field silently collided — the second write overwrote the first's secret. The vault key now includes both `specName` and `instanceName` so each resource instance gets its own vault entry.
- **Workflow vault ref resolution**: `fromResourceHandle` in `data_record_mapper.ts` (used by the workflow execution service to build CEL expression contexts) did not resolve `${{ vault.get(...) }}` references. Added optional `vaultService`/`redactor` params and vault resolution, matching the pattern already used by `fromData` in the same file.

Closes swamp-club#1169

## Test Plan

- Updated all existing `processSensitiveResourceData` tests to include `specName`/`instanceName` in vault key assertions
- Added collision test: two instances with same sensitive field produce distinct vault keys
- Added cross-spec collision test: two specs with same field produce distinct vault keys
- Added `fromResourceHandle` vault resolution tests (with and without vault service)
- Updated integration tests (`sensitive_field_vault_test.ts`) for new function signature
- Verified end-to-end with reproduction scratch repo: instance-a retains "AAAA", instance-b retains "BBBB" (previously both resolved to "BBBB")
- `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass (8986 passed, 1 pre-existing flaky SIGINT test)