### PR TITLE
fix(sources): resolve .swamp-sources.yaml relative paths against git main working tree root

### DIFF
--- a/src/cli/commands/doctor_workflows.ts
+++ b/src/cli/commands/doctor_workflows.ts
@@ -40,6 +40,7 @@ import {
   readSwampSources,
   resolveSourceExtensionDirs,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../../infrastructure/persistence/git_worktree.ts";
 import {
   requestServerResponse,
   resolveServerToken,
@@ -54,8 +55,13 @@ type AnyOptions = any;
 async function getSourceWorkflowDirs(repoDir: string): Promise<string[]> {
   const sourcesConfig = await readSwampSources(repoDir);
   if (!sourcesConfig) return [];
-  const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-  const resolved = await resolveSourceExtensionDirs(expanded);
+  const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
+  const expanded = await expandSourcePaths(
+    sourcesConfig,
+    repoDir,
+    sourceBaseDir,
+  );
+  const { resolved } = await resolveSourceExtensionDirs(expanded);
   return collectDirsForKind(resolved, "workflows");
 }
 

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -84,7 +84,7 @@ export const extensionSourceAddCommand = new Command()
     const marker = await markerRepo.read(RepoPath.create(repoDir));
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
-    const deps = createSourceAddDeps(repoDir, tools, skillsDirs);
+    const deps = await createSourceAddDeps(repoDir, tools, skillsDirs);
 
     let only: ExtensionKind[] | undefined;
     if (options.only) {

--- a/src/cli/commands/extension_source_list.ts
+++ b/src/cli/commands/extension_source_list.ts
@@ -50,7 +50,7 @@ export const extensionSourceListCommand = new Command()
     ]);
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createSourceListDeps(resolveRepoDir(options.repoDir));
+    const deps = await createSourceListDeps(resolveRepoDir(options.repoDir));
 
     const renderer = createSourceListRenderer(cliCtx.outputMode);
     await consumeStream(sourceList(ctx, deps), renderer.handlers());

--- a/src/cli/commands/extension_source_rm.ts
+++ b/src/cli/commands/extension_source_rm.ts
@@ -63,7 +63,7 @@ export const extensionSourceRmCommand = new Command()
     const marker = await markerRepo.read(RepoPath.create(repoDir));
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
-    const deps = createSourceRemoveDeps(repoDir, skillsDirs);
+    const deps = await createSourceRemoveDeps(repoDir, skillsDirs);
 
     const renderer = createSourceModifyRenderer(cliCtx.outputMode);
     await consumeStream(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -162,10 +162,12 @@ import {
   readSwampSources,
   resolveSourceExtensionDirs,
 } from "../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../infrastructure/persistence/git_worktree.ts";
 import type {
   ExtensionKind,
   ResolvedSourceDirs,
 } from "../domain/repo/swamp_sources.ts";
+import { isGlobPattern } from "../domain/repo/swamp_sources.ts";
 import { discoverManifestCrossKindDirs } from "../domain/extensions/manifest_cross_kind_discovery.ts";
 
 // Import models barrel to trigger self-registration
@@ -1258,12 +1260,37 @@ export async function runCli(args: string[]): Promise<void> {
 
   // Read extension sources (additional extension directories from
   // .swamp-sources.yaml). Resolved once and shared across all loaders.
+  // Relative paths resolve against the git main working tree root so
+  // worktrees see the same sibling sources as the main checkout.
   let resolvedSources: ResolvedSourceDirs[] = [];
   if (!hookMode) {
     const sourcesConfig = await readSwampSources(repoDir);
     if (sourcesConfig) {
-      const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-      resolvedSources = await resolveSourceExtensionDirs(expanded);
+      const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
+      const expanded = await expandSourcePaths(
+        sourcesConfig,
+        repoDir,
+        sourceBaseDir,
+      );
+      const { resolved, warnings } = await resolveSourceExtensionDirs(
+        expanded,
+      );
+      resolvedSources = resolved;
+
+      const missingConcrete = warnings.filter(
+        (w) => !isGlobPattern(w.sourcePath),
+      );
+      const isSourceManagementCommand = commandInfo.command === "extension" &&
+        commandInfo.subcommand === "source";
+      if (missingConcrete.length > 0 && !isSourceManagementCommand) {
+        const paths = missingConcrete.map((w) => `  - ${w.sourcePath}`);
+        throw new UserError(
+          `Declared extension source(s) in .swamp-sources.yaml cannot be resolved:\n${
+            paths.join("\n")
+          }\n\n` +
+            "Remove stale entries with 'swamp extension source rm <path>' or fix the path.",
+        );
+      }
     }
   }
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -91,6 +91,7 @@ import {
   readSwampSources,
   resolveSourceExtensionDirs,
 } from "../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../infrastructure/persistence/git_worktree.ts";
 
 /**
  * Resolves source workflow directories from `.swamp-sources.yaml`.
@@ -107,8 +108,13 @@ async function getSourceWorkflowDirs(repoDir: string): Promise<string[]> {
     sourceWorkflowDirCache.set(repoDir, []);
     return [];
   }
-  const expanded = await expandSourcePaths(sourcesConfig, repoDir);
-  const resolved = await resolveSourceExtensionDirs(expanded);
+  const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
+  const expanded = await expandSourcePaths(
+    sourcesConfig,
+    repoDir,
+    sourceBaseDir,
+  );
+  const { resolved } = await resolveSourceExtensionDirs(expanded);
   const dirs = collectDirsForKind(resolved, "workflows");
   sourceWorkflowDirCache.set(repoDir, dirs);
   return dirs;

--- a/src/infrastructure/persistence/git_worktree.ts
+++ b/src/infrastructure/persistence/git_worktree.ts
@@ -1,0 +1,63 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname } from "@std/path";
+
+const cache = new Map<string, string>();
+
+/**
+ * Resolves the git main working tree root for a directory.
+ *
+ * In a worktree, this returns the main checkout root (not the worktree
+ * root). In the main checkout or a non-worktree repo, this returns the
+ * repo root. Falls back to `dir` when git is unavailable or `dir` is
+ * not inside a git repository.
+ */
+export async function resolveGitMainWorktreeRoot(
+  dir: string,
+): Promise<string> {
+  const cached = cache.get(dir);
+  if (cached !== undefined) return cached;
+
+  try {
+    const command = new Deno.Command("git", {
+      args: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      cwd: dir,
+      stdout: "piped",
+      stderr: "null",
+    });
+    const { code, stdout } = await command.output();
+    if (code !== 0) {
+      cache.set(dir, dir);
+      return dir;
+    }
+    const gitCommonDir = new TextDecoder().decode(stdout).trim();
+    const root = dirname(gitCommonDir);
+    cache.set(dir, root);
+    return root;
+  } catch {
+    cache.set(dir, dir);
+    return dir;
+  }
+}
+
+/** Clears the internal cache. Exposed for tests only. */
+export function clearGitWorktreeCache(): void {
+  cache.clear();
+}

--- a/src/infrastructure/persistence/git_worktree_test.ts
+++ b/src/infrastructure/persistence/git_worktree_test.ts
@@ -1,0 +1,133 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import {
+  clearGitWorktreeCache,
+  resolveGitMainWorktreeRoot,
+} from "./git_worktree.ts";
+import { assertPathEquals } from "./path_test_helpers.ts";
+
+Deno.test("resolveGitMainWorktreeRoot: returns main checkout from main checkout", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_git_wt_" });
+  clearGitWorktreeCache();
+  try {
+    const cmd = new Deno.Command("git", {
+      args: ["init"],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    const { code } = await cmd.output();
+    assertEquals(code, 0);
+
+    const root = await resolveGitMainWorktreeRoot(tmp);
+    assertPathEquals(root, await Deno.realPath(tmp));
+  } finally {
+    clearGitWorktreeCache();
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveGitMainWorktreeRoot: returns main checkout from worktree", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_git_wt_" });
+  clearGitWorktreeCache();
+  try {
+    // Init repo and create an initial commit (worktree add requires a commit)
+    let cmd = new Deno.Command("git", {
+      args: ["init"],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+    await Deno.writeTextFile(join(tmp, "f.txt"), "x");
+    cmd = new Deno.Command("git", {
+      args: ["add", "."],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+    cmd = new Deno.Command("git", {
+      args: ["commit", "-m", "init"],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output();
+
+    // Create a nested worktree
+    const wtDir = join(tmp, ".claude", "worktrees", "test-wt");
+    cmd = new Deno.Command("git", {
+      args: ["worktree", "add", "--detach", wtDir, "HEAD"],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    const { code } = await cmd.output();
+    assertEquals(code, 0);
+
+    const root = await resolveGitMainWorktreeRoot(wtDir);
+    assertPathEquals(root, await Deno.realPath(tmp));
+  } finally {
+    clearGitWorktreeCache();
+    // Remove worktree first to avoid git lock issues
+    const cmd = new Deno.Command("git", {
+      args: [
+        "worktree",
+        "remove",
+        "--force",
+        join(tmp, ".claude", "worktrees", "test-wt"),
+      ],
+      cwd: tmp,
+      stdout: "null",
+      stderr: "null",
+    });
+    await cmd.output().catch(() => {});
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveGitMainWorktreeRoot: falls back to dir for non-git directory", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_git_wt_" });
+  clearGitWorktreeCache();
+  try {
+    const root = await resolveGitMainWorktreeRoot(tmp);
+    assertEquals(root, tmp);
+  } finally {
+    clearGitWorktreeCache();
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveGitMainWorktreeRoot: caches result per directory", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "swamp_git_wt_" });
+  clearGitWorktreeCache();
+  try {
+    const r1 = await resolveGitMainWorktreeRoot(tmp);
+    const r2 = await resolveGitMainWorktreeRoot(tmp);
+    assertEquals(r1, r2);
+    assertEquals(r1, tmp);
+  } finally {
+    clearGitWorktreeCache();
+    await Deno.remove(tmp, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/infrastructure/persistence/git_worktree_test.ts
+++ b/src/infrastructure/persistence/git_worktree_test.ts
@@ -68,9 +68,13 @@ Deno.test("resolveGitMainWorktreeRoot: returns main checkout from worktree", asy
     await cmd.output();
     cmd = new Deno.Command("git", {
       args: [
-        "-c", "user.name=test",
-        "-c", "user.email=test@test.com",
-        "commit", "-m", "init",
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@test.com",
+        "commit",
+        "-m",
+        "init",
       ],
       cwd: tmp,
       stdout: "null",

--- a/src/infrastructure/persistence/git_worktree_test.ts
+++ b/src/infrastructure/persistence/git_worktree_test.ts
@@ -67,7 +67,11 @@ Deno.test("resolveGitMainWorktreeRoot: returns main checkout from worktree", asy
     });
     await cmd.output();
     cmd = new Deno.Command("git", {
-      args: ["commit", "-m", "init"],
+      args: [
+        "-c", "user.name=test",
+        "-c", "user.email=test@test.com",
+        "commit", "-m", "init",
+      ],
       cwd: tmp,
       stdout: "null",
       stderr: "null",

--- a/src/infrastructure/persistence/swamp_sources_repository.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository.ts
@@ -92,18 +92,24 @@ export async function removeSwampSources(repoDir: string): Promise<void> {
  * a flat list of concrete (non-glob) sources.
  *
  * Each expanded path inherits the `only` filter from its parent source entry.
+ *
+ * @param sourceBaseDir - Base directory for resolving relative paths.
+ *   Defaults to `repoDir`. In a worktree, pass the git main working tree
+ *   root so relative paths resolve the same as from the main checkout.
  */
 export async function expandSourcePaths(
   sources: SwampSourcesConfig,
   repoDir: string,
+  sourceBaseDir?: string,
 ): Promise<SwampSource[]> {
   const expanded: SwampSource[] = [];
+  const baseDir = sourceBaseDir ?? repoDir;
 
   for (const source of sources.sources) {
     const expandedPath = expandEnvVars(source.path);
     const absolutePath = isAbsolute(expandedPath)
       ? expandedPath
-      : resolve(repoDir, expandedPath);
+      : resolve(baseDir, expandedPath);
 
     if (isGlobPattern(absolutePath)) {
       for await (const entry of expandGlob(absolutePath, { globstar: true })) {
@@ -325,10 +331,21 @@ async function contentPreScan(
  * layout always wins over pre-scan when both are present (prevents
  * double-loading in transitional repos).
  */
+export interface SourceResolutionResult {
+  resolved: ResolvedSourceDirs[];
+  warnings: SourceResolutionWarning[];
+}
+
+export interface SourceResolutionWarning {
+  sourcePath: string;
+  reason: "not_found" | "not_a_directory";
+}
+
 export async function resolveSourceExtensionDirs(
   expandedSources: SwampSource[],
-): Promise<ResolvedSourceDirs[]> {
+): Promise<SourceResolutionResult> {
   const results: ResolvedSourceDirs[] = [];
+  const warnings: SourceResolutionWarning[] = [];
 
   for (const source of expandedSources) {
     const sourceDir = source.path;
@@ -340,11 +357,13 @@ export async function resolveSourceExtensionDirs(
       const stat = await Deno.stat(sourceDir);
       if (!stat.isDirectory) {
         logger.warn`Source path is not a directory: ${sourceDir}`;
+        warnings.push({ sourcePath: sourceDir, reason: "not_a_directory" });
         results.push(resolved);
         continue;
       }
     } catch {
       logger.warn`Source path does not exist: ${sourceDir}`;
+      warnings.push({ sourcePath: sourceDir, reason: "not_found" });
       results.push(resolved);
       continue;
     }
@@ -372,7 +391,7 @@ export async function resolveSourceExtensionDirs(
     results.push(resolved);
   }
 
-  return results;
+  return { resolved: results, warnings };
 }
 
 /**

--- a/src/infrastructure/persistence/swamp_sources_repository_test.ts
+++ b/src/infrastructure/persistence/swamp_sources_repository_test.ts
@@ -110,6 +110,48 @@ Deno.test("expandSourcePaths: expands non-glob path as-is", async () => {
   }
 });
 
+Deno.test("expandSourcePaths: resolves relative paths against sourceBaseDir when provided", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
+  try {
+    const mainRoot = join(tmpDir, "main-checkout");
+    const worktreeRoot = join(
+      tmpDir,
+      "main-checkout",
+      ".claude",
+      "worktrees",
+      "test",
+    );
+    const siblingDir = join(tmpDir, "sibling-repo");
+    await Deno.mkdir(siblingDir, { recursive: true });
+    await Deno.mkdir(worktreeRoot, { recursive: true });
+    await Deno.mkdir(mainRoot, { recursive: true });
+
+    const result = await expandSourcePaths(
+      { sources: [{ path: "../sibling-repo" }] },
+      worktreeRoot,
+      mainRoot,
+    );
+    assertEquals(result.length, 1);
+    assertPathEquals(result[0].path, siblingDir);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("expandSourcePaths: falls back to repoDir when sourceBaseDir not provided", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
+  try {
+    const result = await expandSourcePaths(
+      { sources: [{ path: "../sibling" }] },
+      tmpDir,
+    );
+    assertEquals(result.length, 1);
+    assertPathEquals(result[0].path, join(tmpDir, "..", "sibling"));
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 Deno.test("expandSourcePaths: expands glob to matching directories", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
   try {
@@ -157,7 +199,7 @@ Deno.test("resolveSourceExtensionDirs: finds extensions/models/ in source", asyn
       recursive: true,
     });
 
-    const result = await resolveSourceExtensionDirs([
+    const { resolved: result } = await resolveSourceExtensionDirs([
       { path: sourceDir },
     ]);
     assertEquals(result.length, 1);
@@ -182,7 +224,7 @@ Deno.test("resolveSourceExtensionDirs: respects only filter", async () => {
       recursive: true,
     });
 
-    const result = await resolveSourceExtensionDirs([
+    const { resolved: result } = await resolveSourceExtensionDirs([
       { path: sourceDir, only: ["vaults"] },
     ]);
     assertEquals(result[0].modelsDir, undefined);
@@ -196,12 +238,55 @@ Deno.test("resolveSourceExtensionDirs: respects only filter", async () => {
 });
 
 Deno.test("resolveSourceExtensionDirs: handles missing source path gracefully", async () => {
-  const result = await resolveSourceExtensionDirs([
+  const { resolved: result } = await resolveSourceExtensionDirs([
     { path: "/nonexistent/path" },
   ]);
   assertEquals(result.length, 1);
   assertPathEquals(result[0].sourcePath, "/nonexistent/path");
   assertEquals(result[0].modelsDir, undefined);
+});
+
+Deno.test("resolveSourceExtensionDirs: returns warning for missing source path", async () => {
+  const { warnings } = await resolveSourceExtensionDirs([
+    { path: "/nonexistent/path/for/warning/test" },
+  ]);
+  assertEquals(warnings.length, 1);
+  assertPathEquals(
+    warnings[0].sourcePath,
+    "/nonexistent/path/for/warning/test",
+  );
+  assertEquals(warnings[0].reason, "not_found");
+});
+
+Deno.test("resolveSourceExtensionDirs: returns warning for non-directory source path", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
+  try {
+    const filePath = join(tmpDir, "not-a-dir");
+    await Deno.writeTextFile(filePath, "");
+    const { warnings } = await resolveSourceExtensionDirs([
+      { path: filePath },
+    ]);
+    assertEquals(warnings.length, 1);
+    assertEquals(warnings[0].reason, "not_a_directory");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("resolveSourceExtensionDirs: no warnings for valid source", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp_sources_test_" });
+  try {
+    const sourceDir = join(tmpDir, "valid-ext");
+    await Deno.mkdir(join(sourceDir, "extensions", "models"), {
+      recursive: true,
+    });
+    const { warnings } = await resolveSourceExtensionDirs([
+      { path: sourceDir },
+    ]);
+    assertEquals(warnings.length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
 });
 
 Deno.test("resolveSourceExtensionDirs: reads source .swamp.yaml for custom dirs", async () => {
@@ -214,7 +299,7 @@ Deno.test("resolveSourceExtensionDirs: reads source .swamp.yaml for custom dirs"
       'swampVersion: "1.0.0"\ninitializedAt: "2026-01-01"\nmodelsDir: custom-models\n',
     );
 
-    const result = await resolveSourceExtensionDirs([
+    const { resolved: result } = await resolveSourceExtensionDirs([
       { path: sourceDir },
     ]);
     assertEquals(
@@ -299,7 +384,9 @@ Deno.test("resolveSourceExtensionDirs snapshot: all six kinds present", async ()
     ) {
       await Deno.mkdir(join(src, "extensions", kind), { recursive: true });
     }
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(snapshotResolved(result, tmp), [
       {
         sourcePath: "/all",
@@ -321,7 +408,9 @@ Deno.test("resolveSourceExtensionDirs snapshot: models-only root", async () => {
   try {
     const src = join(tmp, "models-only");
     await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(snapshotResolved(result, tmp), [
       {
         sourcePath: "/models-only",
@@ -338,7 +427,9 @@ Deno.test("resolveSourceExtensionDirs snapshot: workflows-only root", async () =
   try {
     const src = join(tmp, "wf");
     await Deno.mkdir(join(src, "extensions", "workflows"), { recursive: true });
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(snapshotResolved(result, tmp), [
       {
         sourcePath: "/wf",
@@ -359,7 +450,9 @@ Deno.test("resolveSourceExtensionDirs snapshot: marker overrides modelsDir", asy
       join(src, ".swamp.yaml"),
       'swampVersion: "1.0.0"\ninitializedAt: "2026-01-01"\nmodelsDir: custom/models\n',
     );
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(snapshotResolved(result, tmp), [
       {
         sourcePath: "/overridden",
@@ -372,7 +465,7 @@ Deno.test("resolveSourceExtensionDirs snapshot: marker overrides modelsDir", asy
 });
 
 Deno.test("resolveSourceExtensionDirs snapshot: non-existent path yields empty", async () => {
-  const result = await resolveSourceExtensionDirs([
+  const { resolved: result } = await resolveSourceExtensionDirs([
     { path: "/definitely/does/not/exist/v139" },
   ]);
   assertEquals(result.length, 1);
@@ -391,7 +484,7 @@ Deno.test("resolveSourceExtensionDirs snapshot: only filter narrows kinds", asyn
     const src = join(tmp, "filtered");
     await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
     await Deno.mkdir(join(src, "extensions", "vaults"), { recursive: true });
-    const result = await resolveSourceExtensionDirs([
+    const { resolved: result } = await resolveSourceExtensionDirs([
       { path: src, only: ["vaults"] },
     ]);
     assertEquals(snapshotResolved(result, tmp), [
@@ -419,7 +512,9 @@ Deno.test("resolveSourceExtensionDirs snapshot: non-standard layout via content 
       join(src, "m.ts"),
       'export const model = { type: "@r/m" };',
     );
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(result.length, 1);
     assertEquals(result[0].sourcePath, src);
     // Post-fix: pre-scan detects the model export and sets modelsDir to
@@ -448,7 +543,9 @@ Deno.test("resolveSourceExtensionDirs: large YAML file is skipped during pre-sca
       join(src, "big-fixture.yaml"),
       `${padding}\njobs:\n  one:\n    steps: []\n`,
     );
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     // Because the large YAML was skipped, the source contributes no
     // kinds — no workflow detected.
     assertEquals(result[0].workflowsDir, undefined);
@@ -473,7 +570,9 @@ Deno.test("resolveSourceExtensionDirs: detects export beyond 64 KiB in large .ts
         `Test file must exceed 64 KiB to exercise the fix (got ${stat.size})`,
       );
     }
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(result.length, 1);
     assertPathEquals(result[0].reportsDir!, src);
   } finally {
@@ -531,7 +630,7 @@ Deno.test("parity: resolveExtensionKindsForSource matches resolveSourceExtension
       await Deno.mkdir(join(src, "extensions", kind), { recursive: true });
     }
     const fromDirs = kindsFromResolved(
-      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+      (await resolveSourceExtensionDirs([{ path: src }])).resolved[0],
     );
     const fromHelper = await resolveExtensionKindsForSource(
       { path: src },
@@ -557,7 +656,7 @@ Deno.test("parity: non-standard (content pre-scan) layout", async () => {
       'export const vault = { type: "@r/v" };',
     );
     const fromDirs = kindsFromResolved(
-      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+      (await resolveSourceExtensionDirs([{ path: src }])).resolved[0],
     );
     const fromHelper = await resolveExtensionKindsForSource(
       { path: src },
@@ -579,7 +678,7 @@ Deno.test("parity: marker-override layout", async () => {
       'swampVersion: "1.0.0"\ninitializedAt: "2026-01-01"\nmodelsDir: custom/models\n',
     );
     const fromDirs = kindsFromResolved(
-      (await resolveSourceExtensionDirs([{ path: src }]))[0],
+      (await resolveSourceExtensionDirs([{ path: src }])).resolved[0],
     );
     const fromHelper = await resolveExtensionKindsForSource(
       { path: src },
@@ -598,7 +697,8 @@ Deno.test("parity: --only filter respected identically", async () => {
     await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
     await Deno.mkdir(join(src, "extensions", "vaults"), { recursive: true });
     const fromDirs = kindsFromResolved(
-      (await resolveSourceExtensionDirs([{ path: src, only: ["vaults"] }]))[0],
+      (await resolveSourceExtensionDirs([{ path: src, only: ["vaults"] }]))
+        .resolved[0],
     );
     const fromHelper = await resolveExtensionKindsForSource(
       { path: src, only: ["vaults"] },
@@ -614,7 +714,7 @@ Deno.test("parity: non-existent path returns empty from both", async () => {
   const fromDirs = kindsFromResolved(
     (await resolveSourceExtensionDirs([
       { path: "/definitely/not/there/v139/parity" },
-    ]))[0],
+    ])).resolved[0],
   );
   const fromHelper = await resolveExtensionKindsForSource(
     { path: "/definitely/not/there/v139/parity" },
@@ -673,7 +773,9 @@ Deno.test("resolveSourceExtensionDirs: standard layout wins over loose root file
       join(src, "loose.ts"),
       'export const model = { type: "@r/loose" };',
     );
-    const result = await resolveSourceExtensionDirs([{ path: src }]);
+    const { resolved: result } = await resolveSourceExtensionDirs([{
+      path: src,
+    }]);
     assertEquals(result.length, 1);
     assertEquals(result[0].modelsDir, join(src, "extensions", "models"));
     // Loose root file NOT surfaced — standard layout precedence.

--- a/src/libswamp/extensions/reconcile_from_disk_service.ts
+++ b/src/libswamp/extensions/reconcile_from_disk_service.ts
@@ -70,6 +70,7 @@ import {
   readSwampSources,
   resolveSourceExtensionDirs,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../../infrastructure/persistence/git_worktree.ts";
 
 const logger = getLogger(["swamp", "extensions", "reconcile"]);
 
@@ -365,8 +366,13 @@ export class ReconcileFromDiskService {
     // Source-mounted extensions from .swamp-sources.yaml
     const config = await readSwampSources(this.repoDir);
     if (config) {
-      const expanded = await expandSourcePaths(config, this.repoDir);
-      const resolved = await resolveSourceExtensionDirs(expanded);
+      const sourceBaseDir = await resolveGitMainWorktreeRoot(this.repoDir);
+      const expanded = await expandSourcePaths(
+        config,
+        this.repoDir,
+        sourceBaseDir,
+      );
+      const { resolved } = await resolveSourceExtensionDirs(expanded);
       for (const sourceDirs of resolved) {
         for (const kindDir of KIND_DIRS) {
           const dirs = collectDirsForKind([sourceDirs], kindDir);

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -33,6 +33,7 @@ import {
   resolveExtensionKindsForSource,
   writeSwampSources,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../../infrastructure/persistence/git_worktree.ts";
 import {
   copySourceSkills,
   removeSourceSkills,
@@ -59,18 +60,21 @@ export interface SourceAddDeps {
 }
 
 /** Wires real infrastructure into SourceAddDeps. */
-export function createSourceAddDeps(
+export async function createSourceAddDeps(
   repoDir: string,
   tools?: string[],
   skillsDirs?: string[],
-): SourceAddDeps {
+): Promise<SourceAddDeps> {
   const resolvedTools = tools?.length ? tools : ["claude"];
   const dirs = skillsDirs?.length ? skillsDirs : [];
+  const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
-    resolveKinds: (source) => resolveExtensionKindsForSource(source, repoDir),
-    expandSource: (source) => expandSourcePaths({ sources: [source] }, repoDir),
+    resolveKinds: (source) =>
+      resolveExtensionKindsForSource(source, sourceBaseDir),
+    expandSource: (source) =>
+      expandSourcePaths({ sources: [source] }, repoDir, sourceBaseDir),
     resolveSkills: (sourcePath) =>
       resolveSourceSkills(sourcePath, resolvedTools),
     copySkills: async (skills) => {

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -292,7 +292,7 @@ Deno.test("sourceAdd e2e: standard-layout repo with extensions/models/", async (
       join(src, "extensions", "models", "m.ts"),
       'export const model = { type: "@r/m" };',
     );
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(sourceAdd(ctx, deps, src));
     assertEquals(findCompleted(events)?.kind, "completed");
   });
@@ -306,7 +306,7 @@ Deno.test("sourceAdd e2e: non-standard layout — loose model.ts at root", async
       join(src, "m.ts"),
       'export const model = { type: "@r/m" };',
     );
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(sourceAdd(ctx, deps, src));
     assertEquals(findCompleted(events)?.kind, "completed");
   });
@@ -322,7 +322,7 @@ Deno.test("sourceAdd e2e: reporter's case — extensions/models/ as source path"
       join(src, "m.ts"),
       'export const model = { type: "@r/m" };',
     );
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(sourceAdd(ctx, deps, src));
     assertEquals(
       findCompleted(events)?.kind,
@@ -336,7 +336,7 @@ Deno.test("sourceAdd e2e: empty directory is rejected", async () => {
   await withTempRepo(async (repo) => {
     const src = join(repo, "empty");
     await Deno.mkdir(src, { recursive: true });
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(sourceAdd(ctx, deps, src));
     const error = findError(events);
     assertEquals(error?.kind, "error");
@@ -347,7 +347,7 @@ Deno.test("sourceAdd e2e: --only mismatch against models-only source is rejected
   await withTempRepo(async (repo) => {
     const src = join(repo, "m-only");
     await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(
       sourceAdd(ctx, deps, src, ["vaults"]),
     );
@@ -371,7 +371,7 @@ Deno.test("sourceAdd e2e: mixed layout — standard wins, loose files ignored", 
       join(src, "loose.ts"),
       'export const model = { type: "@r/loose" };',
     );
-    const deps = createSourceAddDeps(repo);
+    const deps = await createSourceAddDeps(repo);
     const events = await collectEvents(sourceAdd(ctx, deps, src));
     // Should succeed — standard layout has content; loose file ignored.
     assertEquals(findCompleted(events)?.kind, "completed");

--- a/src/libswamp/sources/list.ts
+++ b/src/libswamp/sources/list.ts
@@ -30,6 +30,7 @@ import {
   readSwampSources,
   resolveExtensionKindsForSource,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../../infrastructure/persistence/git_worktree.ts";
 import { expandEnvVars } from "../../infrastructure/persistence/env_path.ts";
 import { isAbsolute, resolve } from "@std/path";
 
@@ -37,16 +38,23 @@ import { isAbsolute, resolve } from "@std/path";
 export interface SourceListDeps {
   readSources: () => Promise<SwampSourcesConfig | null>;
   repoDir: string;
+  /** Base directory for resolving relative source paths. */
+  sourceBaseDir: string;
   /** Returns the kinds a source contributes. Injectable for unit tests. */
   resolveKinds: (source: SwampSource) => Promise<ExtensionKind[]>;
 }
 
 /** Wires real infrastructure into SourceListDeps. */
-export function createSourceListDeps(repoDir: string): SourceListDeps {
+export async function createSourceListDeps(
+  repoDir: string,
+): Promise<SourceListDeps> {
+  const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
   return {
     readSources: () => readSwampSources(repoDir),
     repoDir,
-    resolveKinds: (source) => resolveExtensionKindsForSource(source, repoDir),
+    sourceBaseDir,
+    resolveKinds: (source) =>
+      resolveExtensionKindsForSource(source, sourceBaseDir),
   };
 }
 
@@ -81,6 +89,7 @@ export async function* sourceList(
         const expanded = await expandSourcePaths(
           { sources: [source] },
           deps.repoDir,
+          deps.sourceBaseDir,
         );
         entry.expandedPaths = expanded.map((s) => s.path);
         if (expanded.length === 0) {
@@ -98,7 +107,7 @@ export async function* sourceList(
         const expandedPath = expandEnvVars(source.path);
         const absolutePath = isAbsolute(expandedPath)
           ? expandedPath
-          : resolve(deps.repoDir, expandedPath);
+          : resolve(deps.sourceBaseDir, expandedPath);
         entry.expandedPaths = [absolutePath];
 
         let exists = false;

--- a/src/libswamp/sources/list_test.ts
+++ b/src/libswamp/sources/list_test.ts
@@ -54,7 +54,7 @@ async function writeSourcesYaml(repo: string, body: string) {
 
 Deno.test("sourceList: returns empty when no config", async () => {
   await withRepo(async (repo) => {
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources, []);
   });
@@ -65,7 +65,7 @@ Deno.test("sourceList: concrete valid source shows valid + resolvedKinds", async
     const src = join(repo, "s");
     await Deno.mkdir(join(src, "extensions", "models"), { recursive: true });
     await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources.length, 1);
     assertEquals(data.sources[0].status, "valid");
@@ -78,7 +78,7 @@ Deno.test("sourceList: concrete path that exists but resolves to zero kinds → 
     const src = join(repo, "empty");
     await Deno.mkdir(src, { recursive: true });
     await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "no_extensions");
     assertEquals(data.sources[0].resolvedKinds, undefined);
@@ -91,7 +91,7 @@ Deno.test("sourceList: missing path → path_not_found", async () => {
       repo,
       `sources:\n  - path: ${repo}/does-not-exist\n`,
     );
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "path_not_found");
   });
@@ -103,7 +103,7 @@ Deno.test("sourceList: glob that matches nothing → path_not_found", async () =
       repo,
       `sources:\n  - path: ${repo}/no-match/*\n`,
     );
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "path_not_found");
   });
@@ -117,7 +117,7 @@ Deno.test("sourceList: glob expanding to dirs with no kinds → no_extensions", 
       repo,
       `sources:\n  - path: ${repo}/parent/*\n`,
     );
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "no_extensions");
   });
@@ -135,7 +135,7 @@ Deno.test("sourceList: glob with mixed expansions (1 valid of 3) → valid + res
       repo,
       `sources:\n  - path: ${parent}/*\n`,
     );
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "valid");
     assertEquals(data.sources[0].resolvedKinds, ["vaults"]);
@@ -151,7 +151,7 @@ Deno.test("sourceList: non-standard layout (content pre-scan) shows resolvedKind
       'export const model = { type: "@r/m" };',
     );
     await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].status, "valid");
     assertEquals(data.sources[0].resolvedKinds, ["models"]);
@@ -166,7 +166,7 @@ Deno.test("sourceList: resolvedKinds is sorted by EXTENSION_KINDS declaration or
       await Deno.mkdir(join(src, "extensions", k), { recursive: true });
     }
     await writeSourcesYaml(repo, `sources:\n  - path: ${src}\n`);
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     assertEquals(data.sources[0].resolvedKinds, [
       "models",
@@ -185,7 +185,7 @@ Deno.test("sourceList: preserves existing fields (path, only, expandedPaths, sta
       repo,
       `sources:\n  - path: ${src}\n    only: [models]\n`,
     );
-    const deps = createSourceListDeps(repo);
+    const deps = await createSourceListDeps(repo);
     const data = completedData(await collect(sourceList(ctx, deps)));
     const entry = data.sources[0];
     assertEquals(entry.path, src);

--- a/src/libswamp/sources/remove.ts
+++ b/src/libswamp/sources/remove.ts
@@ -27,6 +27,7 @@ import {
   removeSwampSources,
   writeSwampSources,
 } from "../../infrastructure/persistence/swamp_sources_repository.ts";
+import { resolveGitMainWorktreeRoot } from "../../infrastructure/persistence/git_worktree.ts";
 import { existsSync } from "@std/fs/exists";
 import { ExtensionCatalogStore } from "../../infrastructure/persistence/extension_catalog_store.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
@@ -44,11 +45,12 @@ export interface SourceRemoveDeps {
 }
 
 /** Wires real infrastructure into SourceRemoveDeps. */
-export function createSourceRemoveDeps(
+export async function createSourceRemoveDeps(
   repoDir: string,
   skillsDirs?: string[],
-): SourceRemoveDeps {
+): Promise<SourceRemoveDeps> {
   const dirs = skillsDirs?.length ? skillsDirs : [];
+  const sourceBaseDir = await resolveGitMainWorktreeRoot(repoDir);
   return {
     readSources: () => readSwampSources(repoDir),
     writeSources: (config) => writeSwampSources(repoDir, config),
@@ -67,6 +69,7 @@ export function createSourceRemoveDeps(
       const expanded = await expandSourcePaths(
         { sources: [{ path }] },
         repoDir,
+        sourceBaseDir,
       );
       return expanded.map((s) => s.path);
     },


### PR DESCRIPTION
## Summary

Fixes swamp-club#1174.

- **Worktree path resolution**: Relative `path:` entries in a committed `.swamp-sources.yaml` now resolve against the git main working tree root instead of the process cwd. Uses `git rev-parse --path-format=absolute --git-common-dir` + dirname, with graceful fallback for non-git directories.
- **Hard error on missing sources**: A declared source that cannot be resolved now exits non-zero with a clear error message and remediation hint (`swamp extension source rm`). Source management commands (`extension source list/rm`) are exempted so users can fix stale entries.

## Test Plan

- Reproduced the bug: created a repo with `.swamp-sources.yaml` pointing to `../sibling-repo`, created a nested worktree, verified the source resolved incorrectly (path not found). After the fix, both main checkout and worktree resolve the sibling source correctly.
- Verified hard error: removed a previously valid source directory, confirmed `model list` exits 1 with error, while `extension source list` and `extension source rm` still work (exempted).
- 8992 tests pass (0 failures), including 9 new tests:
  - `git_worktree_test.ts`: main checkout resolution, worktree resolution, non-git fallback, caching
  - `swamp_sources_repository_test.ts`: sourceBaseDir parameter, warning collection for missing/non-directory sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)