### PR TITLE
fix(serve): wire grant auto-reload to repoContext.eventBus (swamp-club#1177)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -96,7 +96,6 @@ import {
   type PolicyReloadMode,
   PolicySnapshotLoader,
 } from "../../domain/access/policy_snapshot_loader.ts";
-import { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createAdminGrantStore,
   materializeAdmins,
@@ -1013,8 +1012,6 @@ export const serveCommand = new Command()
       );
     }
 
-    const serveEventBus = new EventBus();
-
     const modelsDir = join(resolvedRepoDir, "models");
     const autoDefDir = repoContext.autoDefinitionsDir;
     const grantTypeDir = GRANT_MODEL_TYPE.toDirectoryPath();
@@ -1338,7 +1335,7 @@ export const serveCommand = new Command()
 
     const policySnapshotLoader = new PolicySnapshotLoader(
       repoContext.unifiedDataRepo,
-      serveEventBus,
+      repoContext.eventBus,
       grantReloadMode as PolicyReloadMode,
     );
     await policySnapshotLoader.load();

--- a/src/domain/access/policy_snapshot_loader.ts
+++ b/src/domain/access/policy_snapshot_loader.ts
@@ -22,7 +22,12 @@ import { Environment } from "cel-js";
 import { registerArithmeticOverloads } from "../../infrastructure/cel/cel_evaluator.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
 import type { EventBus } from "../events/event_bus.ts";
-import type { ModelCreated, ModelUpdated } from "../events/types.ts";
+import type {
+  DefinitionCreated,
+  DefinitionUpdated,
+  ModelCreated,
+  ModelUpdated,
+} from "../events/types.ts";
 import {
   type Grant,
   GRANT_MODEL_TYPE,
@@ -124,6 +129,22 @@ export class PolicySnapshotLoader {
 
       this.#unsubscribers.push(
         eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
+          if (this.#isAccessModel(event.modelType)) {
+            this.#scheduleRebuild();
+          }
+        }),
+      );
+
+      this.#unsubscribers.push(
+        eventBus.subscribe<DefinitionCreated>("DefinitionCreated", (event) => {
+          if (this.#isAccessModel(event.modelType)) {
+            this.#scheduleRebuild();
+          }
+        }),
+      );
+
+      this.#unsubscribers.push(
+        eventBus.subscribe<DefinitionUpdated>("DefinitionUpdated", (event) => {
           if (this.#isAccessModel(event.modelType)) {
             this.#scheduleRebuild();
           }

--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -22,7 +22,12 @@ import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import { Data } from "../data/data.ts";
 import type { UnifiedDataRepository } from "../data/repositories.ts";
 import { EventBus } from "../events/event_bus.ts";
-import { createModelCreated, createModelUpdated } from "../events/types.ts";
+import {
+  createDefinitionCreated,
+  createDefinitionUpdated,
+  createModelCreated,
+  createModelUpdated,
+} from "../events/types.ts";
 import type { Grant } from "../models/access/grant_model.ts";
 import { GRANT_MODEL_TYPE } from "../models/access/grant_model.ts";
 import type { Group } from "../models/access/group_model.ts";
@@ -396,6 +401,131 @@ Deno.test("PolicySnapshotLoader: auto mode subscribes to EventBus", async () => 
 
   await delay(700);
   assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  await loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: rebuilds snapshot on DefinitionCreated for grant model", async () => {
+  let callCount = 0;
+  const grant = makeGrant();
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized) {
+        callCount++;
+        if (callCount > 1) {
+          return Promise.resolve([{
+            data: makeData("grant-main"),
+            modelType: type,
+            modelId: "g1",
+          }]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    },
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized && callCount > 1) {
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(grant)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
+
+  await loader.load();
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
+
+  await eventBus.publish(
+    createDefinitionCreated("swamp/grant", "def-123", "my-grant"),
+  );
+
+  await delay(700);
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  await loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: rebuilds snapshot on DefinitionUpdated for group model", async () => {
+  let callCount = 0;
+  const group = makeGroup("devs", ["adam"]);
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GROUP_MODEL_TYPE.normalized) {
+        callCount++;
+        if (callCount > 1) {
+          return Promise.resolve([{
+            data: makeData("group-main"),
+            modelType: type,
+            modelId: "grp1",
+          }]);
+        }
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    },
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GROUP_MODEL_TYPE.normalized && callCount > 1) {
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(group)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
+
+  await loader.load();
+  assertEquals(loader.snapshot.groupsForPrincipal("user:adam").length, 0);
+
+  await eventBus.publish(
+    createDefinitionUpdated("swamp/group", "def-456", "devs"),
+  );
+
+  await delay(700);
+  assertEquals([...loader.snapshot.groupsForPrincipal("user:adam")], ["devs"]);
+
+  await loader.dispose();
+});
+
+Deno.test("PolicySnapshotLoader: ignores DefinitionCreated for non-access models", async () => {
+  let findAllCallCount = 0;
+  const dataRepo = {
+    findAllForType() {
+      findAllCallCount++;
+      return Promise.resolve([]);
+    },
+    getContent() {
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
+
+  await loader.load();
+  const initialCount = findAllCallCount;
+
+  await eventBus.publish(
+    createDefinitionCreated("swamp/echo", "def-789", "my-echo"),
+  );
+
+  assertEquals(findAllCallCount, initialCount);
 
   await loader.dispose();
 });

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -108,7 +108,7 @@ export async function createServerTokenRunDeps(
     createAndSaveDefinition: async (type, definition) => {
       const autoDefRepo = new YamlDefinitionRepository(
         repoDir,
-        undefined,
+        repoContext.eventBus,
         repoContext.autoDefinitionsDir,
         false,
       );

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -128,7 +128,7 @@ export async function createWorkflowRunDeps(
         }
         const autoDefRepo = new YamlDefinitionRepository(
           dir,
-          undefined,
+          repoContext.eventBus,
           repoContext.autoDefinitionsDir,
           false,
         );
@@ -253,7 +253,7 @@ export async function createModelMethodRunDeps(
       ? async (type, definition) => {
         const autoDefRepo = new YamlDefinitionRepository(
           repoDir,
-          undefined,
+          repoContext.eventBus,
           repoContext.autoDefinitionsDir,
           false,
         );

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -444,7 +444,7 @@ export async function handleAccessReload(
     const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
     const autoDefRepo = new YamlDefinitionRepository(
       ctx.repoDir,
-      undefined,
+      ctx.repoContext.eventBus,
       autoDefDir,
       false,
     );


### PR DESCRIPTION
## Summary

Fixes swamp-club#1177. `--grant-reload auto` was a complete no-op due to three compounding wiring issues:

1. **Wrong EventBus instance** — `serve.ts` created a standalone `serveEventBus = new EventBus()` and passed it to `PolicySnapshotLoader`, but no repository ever publishes to that bus. The real bus is `repoContext.eventBus`.

2. **Wrong event types** — `PolicySnapshotLoader` subscribed to `ModelCreated`/`ModelUpdated`, but `YamlDefinitionRepository.save()` emits `DefinitionCreated`/`DefinitionUpdated`. No production code ever emits `ModelCreated`.

3. **Missing eventBus on auto-definition repos** — Server-side grant creation flows through auto-definition repos in `serve/deps.ts`, `libswamp/access/run_deps.ts`, and `serve/handlers/access_handlers.ts` that were constructed with `undefined` as the eventBus, so no events fired even when the correct bus was listening.

### Changes

- **`src/cli/commands/serve.ts`** — Pass `repoContext.eventBus` instead of standalone `serveEventBus`; remove unused `EventBus` import
- **`src/domain/access/policy_snapshot_loader.ts`** — Subscribe to `DefinitionCreated`/`DefinitionUpdated` alongside existing `ModelCreated`/`ModelUpdated`
- **`src/domain/access/policy_snapshot_loader_test.ts`** — 3 new tests for Definition event auto-reload
- **`src/serve/deps.ts`** — Wire `repoContext.eventBus` to auto-definition repos (2 sites)
- **`src/libswamp/access/run_deps.ts`** — Wire `repoContext.eventBus` to auto-definition repo
- **`src/serve/handlers/access_handlers.ts`** — Wire `repoContext.eventBus` to auto-definition repo

## Test Plan

- Unit tests: 12 passing (8 existing + 3 new Definition event tests + 1 loadWithCounts)
- End-to-end verification: started patched server with `--grant-reload auto`, created grant via `--server` with token auth, observed server log auto-reload from 1 → 2 active grants without manual `swamp access reload`
- `deno check`, `deno lint`, `deno fmt --check` all clean