### PR TITLE
fix(workflows): stream run summaries in history/run search to avoid OOM (swamp-club#1173)

### DIFF
--- a/src/cli/commands/workflow_history_search.ts
+++ b/src/cli/commands/workflow_history_search.ts
@@ -177,8 +177,11 @@ export async function workflowHistorySearchAction(
 
   const deps: WorkflowHistorySearchDeps = {
     findAllWorkflows: () => workflowRepo.findAll(),
+    // Use the lightweight summary projection, not the full-aggregate read:
+    // search only displays summary fields, and hydrating every run (with its
+    // inline step outputs) OOMs on workflows with a large run history (#1173).
     findAllRunsByWorkflowId: (id) =>
-      runRepo.findAllByWorkflowId(createWorkflowId(id)),
+      runRepo.findAllSummariesByWorkflowId(createWorkflowId(id)),
   };
 
   const fetchPreview = effectiveMode === "log"

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -192,8 +192,11 @@ export async function workflowRunSearchAction(
 
   const deps: WorkflowRunSearchDeps = {
     findAllWorkflows: () => workflowRepo.findAll(),
+    // Use the lightweight summary projection, not the full-aggregate read:
+    // search only displays summary fields, and hydrating every run (with its
+    // inline step outputs) OOMs on workflows with a large run history (#1173).
     findAllRunsByWorkflowId: (id) =>
-      runRepo.findAllByWorkflowId(createWorkflowId(id)),
+      runRepo.findAllSummariesByWorkflowId(createWorkflowId(id)),
   };
 
   const fetchPreview = effectiveMode === "log"

--- a/src/domain/workflows/workflow_run_summary.ts
+++ b/src/domain/workflows/workflow_run_summary.ts
@@ -1,0 +1,115 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { z } from "zod";
+
+/**
+ * Lightweight read-model (query projection) of a workflow run.
+ *
+ * A `WorkflowRunSummary` is the *listing* view of a run — identity, workflow,
+ * status, timing, tags, and inputs — distinct from the full {@link WorkflowRun}
+ * aggregate. Run-listing/search paths render only these fields, so they must
+ * NOT reconstruct the aggregate: each persisted run YAML carries the full
+ * `jobs[] -> steps[] -> output` tree, and step outputs are unbounded arbitrary
+ * data. Hydrating every run into a full aggregate just to show a summary row
+ * makes peak memory scale with total on-disk run size, which OOMs on workflows
+ * with a large accumulated history. This projection keeps only the displayed
+ * fields and never retains the heavy subtrees.
+ */
+export interface WorkflowRunSummary {
+  id: string;
+  workflowId: string;
+  workflowName: string;
+  status: string;
+  startedAt?: Date;
+  completedAt?: Date;
+  tags: Record<string, string>;
+  inputs: Record<string, unknown>;
+}
+
+/**
+ * Zod schema for the projection. It intentionally declares ONLY the summary
+ * fields — the heavy `jobs`/`steps`/`output`/`dataArtifacts` subtrees are left
+ * out entirely so they are stripped from the result and never validated.
+ *
+ * Field constraints are deliberately lenient (looser than `WorkflowRunSchema`):
+ * `status` is a bare string rather than the run-status enum, and identity
+ * fields are not UUID-validated. A summary read must succeed for any run record
+ * that has the displayed fields, even one whose heavy subtree would fail
+ * full-aggregate validation — the listing should never be blocked by an
+ * unrelated malformed field the summary never looks at.
+ */
+const WorkflowRunSummarySchema = z.object({
+  id: z.string().min(1),
+  workflowId: z.string().min(1),
+  workflowName: z.string().min(1),
+  status: z.string().min(1),
+  startedAt: z.string().optional(),
+  completedAt: z.string().optional(),
+  tags: z.record(z.string(), z.string()).default({}),
+  inputs: z.record(z.string(), z.unknown()).default({}),
+});
+
+/**
+ * Projects raw persisted run data onto a {@link WorkflowRunSummary}.
+ *
+ * This is the memory-safe read path: it never calls `WorkflowRun.fromData` and
+ * never touches the heavy `jobs`/`output` subtrees, so the caller can parse a
+ * run file, extract the summary, and let the full parsed tree be garbage
+ * collected before moving to the next file.
+ *
+ * Critically, the retained string fields are *detached* from the parsed source
+ * via a JSON round-trip. A YAML/JSON parser returns scalar strings as V8
+ * sliced strings that keep a reference to the entire source buffer — so
+ * holding a run's tiny `id` would pin its whole (largely `jobs`) file in
+ * memory, and holding thousands of them reproduces the very OOM this projection
+ * exists to prevent. Round-tripping reallocates each string fresh, dropping the
+ * backing buffer. `startedAt`/`completedAt` become `Date`s (which store a
+ * number, not the source string) so they need no detaching.
+ */
+export function parseWorkflowRunSummary(data: unknown): WorkflowRunSummary {
+  const v = WorkflowRunSummarySchema.parse(data);
+  const detached = JSON.parse(
+    JSON.stringify({
+      id: v.id,
+      workflowId: v.workflowId,
+      workflowName: v.workflowName,
+      status: v.status,
+      tags: v.tags,
+      inputs: v.inputs,
+    }),
+  ) as {
+    id: string;
+    workflowId: string;
+    workflowName: string;
+    status: string;
+    tags: Record<string, string>;
+    inputs: Record<string, unknown>;
+  };
+  return {
+    id: detached.id,
+    workflowId: detached.workflowId,
+    workflowName: detached.workflowName,
+    status: detached.status,
+    startedAt: v.startedAt ? new Date(v.startedAt) : undefined,
+    completedAt: v.completedAt ? new Date(v.completedAt) : undefined,
+    tags: detached.tags,
+    inputs: detached.inputs,
+  };
+}

--- a/src/domain/workflows/workflow_run_summary_test.ts
+++ b/src/domain/workflows/workflow_run_summary_test.ts
@@ -1,0 +1,187 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { parseWorkflowRunSummary } from "./workflow_run_summary.ts";
+
+Deno.test("parseWorkflowRunSummary: projects the displayed fields", () => {
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "succeeded",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:01:00.000Z",
+    tags: { env: "prod" },
+    inputs: { region: "us-east-1" },
+  });
+
+  assertEquals(summary.id, "run-1");
+  assertEquals(summary.workflowId, "wf-1");
+  assertEquals(summary.workflowName, "deploy");
+  assertEquals(summary.status, "succeeded");
+  assertEquals(summary.startedAt?.toISOString(), "2026-01-01T00:00:00.000Z");
+  assertEquals(summary.completedAt?.toISOString(), "2026-01-01T00:01:00.000Z");
+  assertEquals(summary.tags, { env: "prod" });
+  assertEquals(summary.inputs, { region: "us-east-1" });
+});
+
+Deno.test("parseWorkflowRunSummary: defaults tags and inputs to empty objects", () => {
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "running",
+  });
+
+  assertEquals(summary.tags, {});
+  assertEquals(summary.inputs, {});
+  assertEquals(summary.startedAt, undefined);
+  assertEquals(summary.completedAt, undefined);
+});
+
+Deno.test("parseWorkflowRunSummary: never retains the heavy jobs/output subtree", () => {
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "succeeded",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    // A run carries the full job/step tree with unbounded inline step outputs.
+    jobs: [
+      {
+        jobName: "job1",
+        status: "succeeded",
+        steps: [
+          { stepName: "step1", status: "succeeded", output: "x".repeat(10000) },
+        ],
+      },
+    ],
+    workflowDataArtifacts: [{ some: "artifact" }],
+  });
+
+  // The projection keeps only the summary fields — the heavy subtrees are
+  // stripped and never held on the returned object.
+  assert(!("jobs" in summary), "summary must not carry jobs");
+  assert(!("output" in summary), "summary must not carry output");
+  assert(
+    !("workflowDataArtifacts" in summary),
+    "summary must not carry data artifacts",
+  );
+  assertEquals(Object.keys(summary).sort(), [
+    "completedAt",
+    "id",
+    "inputs",
+    "startedAt",
+    "status",
+    "tags",
+    "workflowId",
+    "workflowName",
+  ]);
+});
+
+Deno.test("parseWorkflowRunSummary: succeeds even when the jobs subtree is malformed", () => {
+  // A record whose heavy subtree would fail full WorkflowRunSchema validation
+  // (jobs is not an array; step status is not a valid enum) must still yield a
+  // usable summary — proving the summary path does NOT reconstruct the
+  // aggregate via WorkflowRun.fromData.
+  const summary = parseWorkflowRunSummary({
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "deploy",
+    status: "succeeded",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    jobs: "totally-not-an-array",
+  });
+
+  assertEquals(summary.id, "run-1");
+  assertEquals(summary.status, "succeeded");
+});
+
+Deno.test("parseWorkflowRunSummary: rejects records missing required identity fields", () => {
+  assertThrows(() =>
+    parseWorkflowRunSummary({
+      workflowId: "wf-1",
+      workflowName: "deploy",
+      status: "succeeded",
+    })
+  );
+});
+
+// Regression guard for the OOM in #1173. A YAML parser returns scalar fields as
+// V8 sliced strings that pin the whole source buffer; retaining thousands of
+// summaries would therefore keep every run file (jobs and all) alive and blow
+// the heap. This runs the real parseYaml -> parseWorkflowRunSummary path in a
+// child process under a tight old-space cap: if the projection stops detaching
+// its strings, the child OOMs and this test fails. Run as a subprocess so the
+// heap flag is isolated from the main test runner.
+Deno.test("parseWorkflowRunSummary: does not retain the parsed source buffer (OOM guard)", async () => {
+  const summaryModule = import.meta.resolve("./workflow_run_summary.ts");
+  const denoConfig = fromFileUrl(import.meta.resolve("../../../deno.json"));
+
+  // 6000 runs x ~80 KB source = ~480 MB if the source buffers are retained;
+  // the detached summaries need only a few MB, so a 128 MB old-space cap
+  // passes when detached and OOMs when not.
+  const child = `
+    import { parse as parseYaml } from "@std/yaml";
+    import { parseWorkflowRunSummary } from ${JSON.stringify(summaryModule)};
+    const summaries = [];
+    for (let i = 0; i < 6000; i++) {
+      const source = [
+        "id: run-" + i,
+        "workflowId: wf-1",
+        "workflowName: deploy",
+        "status: succeeded",
+        "startedAt: '2026-01-01T00:00:00.000Z'",
+        "jobs: '" + "x".repeat(80000) + "'",
+        "tags: {}",
+      ].join("\\n") + "\\n";
+      summaries.push(parseWorkflowRunSummary(parseYaml(source)));
+    }
+    if (summaries.length !== 6000) throw new Error("unexpected count");
+    console.log("RETENTION_OK");
+  `;
+
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--config",
+      denoConfig,
+      "--v8-flags=--max-old-space-size=128",
+      "-",
+    ],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const process = command.spawn();
+  const writer = process.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(child));
+  await writer.close();
+  const { code, stdout } = await process.output();
+  const out = new TextDecoder().decode(stdout);
+
+  assertEquals(
+    code,
+    0,
+    "child OOMed or errored — summary projection likely retains parsed source buffers",
+  );
+  assert(out.includes("RETENTION_OK"), "child did not complete the loop");
+});

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -39,6 +39,10 @@ import {
   WorkflowRun,
   type WorkflowRunData,
 } from "../../domain/workflows/workflow_run.ts";
+import {
+  parseWorkflowRunSummary,
+  type WorkflowRunSummary,
+} from "../../domain/workflows/workflow_run_summary.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
 import {
   createWorkflowRunCompleted,
@@ -153,6 +157,71 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
     // Sort by startedAt descending (most recent first)
     return runs.sort((a, b) => {
+      const aTime = a.startedAt?.getTime() ?? 0;
+      const bTime = b.startedAt?.getTime() ?? 0;
+      return bTime - aTime;
+    });
+  }
+
+  /**
+   * Lists lightweight {@link WorkflowRunSummary} projections for a workflow's
+   * runs, for listing/search paths that only display summary fields.
+   *
+   * Unlike {@link findAllByWorkflowId}, this never reconstructs the full
+   * WorkflowRun aggregate: each file is read and parsed one at a time, projected
+   * to a small summary via `parseWorkflowRunSummary`, and the parsed YAML tree
+   * (including the unbounded inline step `output` blobs) is released before the
+   * next file. Peak memory is therefore O(one file) + O(N small summaries)
+   * rather than O(total on-disk run size), which is what OOMs the full read on
+   * workflows with a large accumulated run history.
+   *
+   * This is a projection method on the concrete repository, deliberately NOT on
+   * the `WorkflowRunRepository` port: only the run/history search command paths
+   * (which reference the concrete class) need it, so keeping it here avoids
+   * forcing every implementer and test double to grow.
+   */
+  async findAllSummariesByWorkflowId(
+    workflowId: WorkflowId,
+  ): Promise<WorkflowRunSummary[]> {
+    const dir = this.getRunsDir(workflowId);
+    const summaries: WorkflowRunSummary[] = [];
+
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        if (
+          !entry.isFile || !entry.name.startsWith("workflow-run-") ||
+          !entry.name.endsWith(".yaml")
+        ) {
+          continue;
+        }
+        const path = join(dir, entry.name);
+
+        // Per-file try/catch closes the TOCTOU window: a concurrent delete
+        // (deleteAllByWorkflowId, GC) can remove the file between readDir and
+        // readTextFile. NotFound on a single file means "skip it" — never
+        // "abandon the rest of the workflow." Mirrors findAllByWorkflowId.
+        try {
+          const content = await Deno.readTextFile(path);
+          // parseWorkflowRunSummary keeps only the displayed fields; the heavy
+          // jobs/output subtree in `parseYaml`'s result is dropped and GC'd.
+          summaries.push(parseWorkflowRunSummary(parseYaml(content)));
+        } catch (error) {
+          if (error instanceof Deno.errors.NotFound) continue;
+          throw error;
+        }
+      }
+    } catch (error) {
+      // Outer catch handles "directory itself doesn't exist" (no runs yet
+      // for this workflow). Per-file NotFound is handled above.
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+
+    // Sort by startedAt descending (most recent first) — identical ordering to
+    // findAllByWorkflowId so listing order is unchanged.
+    return summaries.sort((a, b) => {
       const aTime = a.startedAt?.getTime() ?? 0;
       const bTime = b.startedAt?.getTime() ?? 0;
       return bTime - aTime;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -17,14 +17,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals } from "@std/assert";
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { dirname } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
 import { YamlWorkflowRunRepository } from "./yaml_workflow_run_repository.ts";
 import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { Workflow } from "../../domain/workflows/workflow.ts";
 import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import { StepTask } from "../../domain/workflows/step_task.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  createWorkflowId,
+  createWorkflowRunId,
+  type WorkflowId,
+} from "../../domain/workflows/workflow_id.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const tempDir = await Deno.makeTempDir();
@@ -576,6 +583,192 @@ Deno.test(
 
       assertEquals(found.length, 1);
       assertEquals(found[0].id, keep.id);
+    });
+  },
+);
+
+// Writes a raw run YAML directly (bypassing save/toData) so tests can exercise
+// records the summary read must tolerate — e.g. huge inline outputs or a
+// malformed jobs subtree that full-aggregate validation would reject.
+async function writeRawRun(
+  repo: YamlWorkflowRunRepository,
+  workflowId: WorkflowId,
+  runId: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const path = repo.getPath(workflowId, createWorkflowRunId(runId));
+  await ensureDir(dirname(path));
+  await Deno.writeTextFile(path, stringifyYaml(data));
+}
+
+const WF_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+Deno.test(
+  "findAllSummariesByWorkflowId: returns projections sorted startedAt desc",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlWorkflowRunRepository(dir);
+      const workflowId = createWorkflowId(WF_ID);
+
+      await writeRawRun(
+        repo,
+        workflowId,
+        "11111111-1111-1111-1111-111111111111",
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          workflowId: WF_ID,
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          completedAt: "2026-01-01T00:01:00.000Z",
+          jobs: [],
+          tags: { env: "prod" },
+          inputs: { region: "us-east-1" },
+        },
+      );
+      await writeRawRun(
+        repo,
+        workflowId,
+        "22222222-2222-2222-2222-222222222222",
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          workflowId: WF_ID,
+          workflowName: "deploy",
+          status: "failed",
+          startedAt: "2026-01-02T00:00:00.000Z",
+          jobs: [],
+          tags: {},
+        },
+      );
+
+      const summaries = await repo.findAllSummariesByWorkflowId(workflowId);
+
+      assertEquals(summaries.length, 2);
+      // Most recent first.
+      assertEquals(summaries[0].id, "22222222-2222-2222-2222-222222222222");
+      assertEquals(summaries[1].id, "11111111-1111-1111-1111-111111111111");
+      assertEquals(summaries[1].tags, { env: "prod" });
+      assertEquals(summaries[1].inputs, { region: "us-east-1" });
+      assertEquals(
+        summaries[1].startedAt?.toISOString(),
+        "2026-01-01T00:00:00.000Z",
+      );
+    });
+  },
+);
+
+Deno.test(
+  "findAllSummariesByWorkflowId: returns empty for a workflow with no runs",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlWorkflowRunRepository(dir);
+      const summaries = await repo.findAllSummariesByWorkflowId(
+        createWorkflowId(WF_ID),
+      );
+      assertEquals(summaries, []);
+    });
+  },
+);
+
+Deno.test(
+  "findAllSummariesByWorkflowId: does not retain heavy inline step outputs",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlWorkflowRunRepository(dir);
+      const workflowId = createWorkflowId(WF_ID);
+
+      await writeRawRun(
+        repo,
+        workflowId,
+        "33333333-3333-3333-3333-333333333333",
+        {
+          id: "33333333-3333-3333-3333-333333333333",
+          workflowId: WF_ID,
+          workflowName: "deploy",
+          status: "succeeded",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          jobs: [
+            {
+              jobName: "job1",
+              status: "succeeded",
+              steps: [
+                {
+                  stepName: "step1",
+                  status: "succeeded",
+                  output: "x".repeat(100000),
+                },
+              ],
+            },
+          ],
+          tags: {},
+        },
+      );
+
+      const summaries = await repo.findAllSummariesByWorkflowId(workflowId);
+
+      assertEquals(summaries.length, 1);
+      assert(!("jobs" in summaries[0]), "summary must not carry jobs");
+      assert(!("output" in summaries[0]), "summary must not carry output");
+      assertEquals(summaries[0].status, "succeeded");
+    });
+  },
+);
+
+Deno.test(
+  "findAllSummariesByWorkflowId: tolerates a malformed jobs subtree (no aggregate rebuild)",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlWorkflowRunRepository(dir);
+      const workflowId = createWorkflowId(WF_ID);
+
+      // jobs is not an array and the step status is invalid — WorkflowRunSchema
+      // (used by findAllByWorkflowId via fromData) would reject this, but the
+      // summary read only looks at the displayed fields.
+      await writeRawRun(
+        repo,
+        workflowId,
+        "44444444-4444-4444-4444-444444444444",
+        {
+          id: "44444444-4444-4444-4444-444444444444",
+          workflowId: WF_ID,
+          workflowName: "deploy",
+          status: "running",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          jobs: "totally-not-an-array",
+          tags: {},
+        },
+      );
+
+      const summaries = await repo.findAllSummariesByWorkflowId(workflowId);
+
+      assertEquals(summaries.length, 1);
+      assertEquals(summaries[0].id, "44444444-4444-4444-4444-444444444444");
+      assertEquals(summaries[0].status, "running");
+    });
+  },
+);
+
+Deno.test(
+  "findAllSummariesByWorkflowId: file deleted mid-iteration is skipped, not fatal",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlWorkflowRunRepository(dir);
+      const workflow = createTestWorkflow();
+
+      const keep = WorkflowRun.create(workflow);
+      keep.start();
+      await repo.save(workflow.id, keep);
+
+      const doomed = WorkflowRun.create(workflow);
+      doomed.start();
+      await repo.save(workflow.id, doomed);
+
+      await Deno.remove(repo.getPath(workflow.id, doomed.id));
+
+      const summaries = await repo.findAllSummariesByWorkflowId(workflow.id);
+
+      assertEquals(summaries.length, 1);
+      assertEquals(summaries[0].id, keep.id);
     });
   },
 );

--- a/src/libswamp/workflows/history_search.ts
+++ b/src/libswamp/workflows/history_search.ts
@@ -22,6 +22,7 @@ import type { SwampError } from "../errors.ts";
 import type { WorkflowRunSearchItem } from "./run_search.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { collectBounded, RUN_FANOUT_CONCURRENCY } from "./run_fanout.ts";
 /**
  * Re-export the shared item type for history search consumers.
  */
@@ -88,13 +89,16 @@ export async function* workflowHistorySearch(
 
       const allWorkflows = await deps.findAllWorkflows();
 
-      // Fetch all runs for all workflows in parallel
-      const runsPerWorkflow = await Promise.all(
-        allWorkflows.map((workflow) =>
-          deps.findAllRunsByWorkflowId(workflow.id)
-        ),
+      // Fetch run summaries for all workflows with bounded concurrency. Each
+      // per-workflow read streams one run file at a time; the bound keeps at
+      // most RUN_FANOUT_CONCURRENCY of those in flight so peak memory does not
+      // scale with the number of workflows. Summaries are lightweight, so
+      // holding them all before filtering is cheap (see WorkflowRunSummary).
+      const allRuns = await collectBounded(
+        allWorkflows,
+        RUN_FANOUT_CONCURRENCY,
+        (workflow) => deps.findAllRunsByWorkflowId(workflow.id),
       );
-      const allRuns = runsPerWorkflow.flat();
 
       // Sort by startedAt descending (most recent first)
       allRuns.sort((a, b) => {

--- a/src/libswamp/workflows/run_fanout.ts
+++ b/src/libswamp/workflows/run_fanout.ts
@@ -1,0 +1,51 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Default cap on how many workflows are read concurrently when collecting run
+ * summaries across all workflows. Bounds peak transient memory: an unbounded
+ * `Promise.all` over every workflow would have one in-flight file parse per
+ * workflow simultaneously; a modest cap keeps that to `concurrency` at a time.
+ */
+export const RUN_FANOUT_CONCURRENCY = 8;
+
+/**
+ * Maps `items` to arrays via `fn` with bounded concurrency and flattens the
+ * results into a single array, preserving no particular order (callers sort
+ * afterward). At most `concurrency` invocations of `fn` are in flight at once.
+ */
+export async function collectBounded<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R[]>,
+): Promise<R[]> {
+  const out: R[] = [];
+  let next = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      const part = await fn(items[index]);
+      for (const r of part) out.push(r);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}

--- a/src/libswamp/workflows/run_fanout_test.ts
+++ b/src/libswamp/workflows/run_fanout_test.ts
@@ -1,0 +1,54 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertEquals } from "@std/assert";
+import { collectBounded } from "./run_fanout.ts";
+
+Deno.test("collectBounded: flattens all per-item results", async () => {
+  const out = await collectBounded(
+    [1, 2, 3],
+    2,
+    (n) => Promise.resolve([n, n * 10]),
+  );
+  assertEquals(out.sort((a, b) => a - b), [1, 2, 3, 10, 20, 30]);
+});
+
+Deno.test("collectBounded: returns empty for empty input", async () => {
+  const out = await collectBounded([], 4, () => Promise.resolve([1]));
+  assertEquals(out, []);
+});
+
+Deno.test("collectBounded: never exceeds the concurrency bound", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const items = Array.from({ length: 20 }, (_, i) => i);
+
+  await collectBounded(items, 3, async (n) => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((r) => setTimeout(r, 1));
+    inFlight--;
+    return [n];
+  });
+
+  assert(
+    maxInFlight <= 3,
+    `expected at most 3 concurrent, saw ${maxInFlight}`,
+  );
+});

--- a/src/libswamp/workflows/run_search.ts
+++ b/src/libswamp/workflows/run_search.ts
@@ -22,6 +22,7 @@ import type { SwampError } from "../errors.ts";
 import { parseDuration } from "../data/search.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { collectBounded, RUN_FANOUT_CONCURRENCY } from "./run_fanout.ts";
 /**
  * A single workflow run search result item.
  */
@@ -103,13 +104,16 @@ export async function* workflowRunSearch(
 
       const allWorkflows = await deps.findAllWorkflows();
 
-      // Fetch all runs for all workflows in parallel
-      const runsPerWorkflow = await Promise.all(
-        allWorkflows.map((workflow) =>
-          deps.findAllRunsByWorkflowId(workflow.id)
-        ),
+      // Fetch run summaries for all workflows with bounded concurrency. Each
+      // per-workflow read streams one run file at a time; the bound keeps at
+      // most RUN_FANOUT_CONCURRENCY of those in flight so peak memory does not
+      // scale with the number of workflows. Summaries are lightweight, so
+      // holding them all before filtering is cheap (see WorkflowRunSummary).
+      const allRuns = await collectBounded(
+        allWorkflows,
+        RUN_FANOUT_CONCURRENCY,
+        (workflow) => deps.findAllRunsByWorkflowId(workflow.id),
       );
-      const allRuns = runsPerWorkflow.flat();
 
       // Sort by startedAt descending (most recent first)
       allRuns.sort((a, b) => {


### PR DESCRIPTION
## Summary

`swamp workflow history search` (and its twin `workflow run search`) crashed the
CLI with a V8 **"Fatal JavaScript out of memory: Ineffective mark-compacts near
heap limit"** on workflows with a large accumulated run history
(swamp-club#1173), instead of returning results.

**Root cause:** both search paths loaded *every* run for *every* workflow as a
fully-hydrated `WorkflowRun` aggregate — including unbounded inline step
`output` blobs — via an unbounded `Promise.all`, then mapped to a second array,
all before any filtering. Peak heap scaled with total on-disk run size.

**Fix:**
- New `WorkflowRunSummary` read-model + `parseWorkflowRunSummary` — a query
  projection that keeps only the fields search displays and never reconstructs
  the aggregate (no `jobs`/`output`).
- Crucially, it **detaches** its retained strings via a JSON round-trip: YAML
  scalars are returned as V8 *sliced strings* that pin the entire parsed source
  file, so holding a run's tiny `id` would otherwise keep its whole ~80 KB file
  alive. This was the real driver of the OOM's persistence.
- `findAllSummariesByWorkflowId` on the concrete `YamlWorkflowRunRepository`
  (interface untouched → no test-double churn) streams run files one at a time,
  TOCTOU-safe.
- Both search generators now collect summaries with **bounded concurrency**
  (`run_fanout.ts`) instead of an unbounded fan-out. The single-selected-run log
  preview stays on the full read.

## Test Plan

- New unit tests: repository projection (sort, empty dir, heavy-output not
  retained, malformed-jobs still yields a summary, TOCTOU delete), the
  `WorkflowRunSummary` parser, and the bounded fan-out helper.
- **Subprocess OOM regression guard**: runs the real `parseYaml →
  parseWorkflowRunSummary` path under a 128 MB heap cap; fails if the
  string-detach regresses.
- `deno check`, `deno lint`, `deno fmt`, `deno run compile`: green.
- **End-to-end against real data** (3.7 GB / 12,470-run datastore cache incl. an
  11,687-run workflow), driving the production `workflowHistorySearch` generator
  through the real repository:
  - old path: >1.5 GB, **OOM** at a 768 MB heap cap
  - new path: **84 MB** at 768 MB; completes at a **256 MB** cap with no OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)