### PR TITLE
fix(sources): restore warn-on-stale-sources instead of fatal error

### DIFF
--- a/integration/stale_source_test.ts
+++ b/integration/stale_source_test.ts
@@ -1,0 +1,53 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { initializeTestRepo, runCliCommand } from "./test_helpers.ts";
+import { stringify as stringifyYaml } from "@std/yaml";
+
+Deno.test("stale source in .swamp-sources.yaml does not brick non-extension commands (#1181)", async () => {
+  const repoDir = await Deno.makeTempDir({
+    prefix: "swamp_it_stale_source_",
+  });
+  try {
+    await initializeTestRepo(repoDir);
+
+    const ghostDir = join(repoDir, "nonexistent-source");
+    await Deno.writeTextFile(
+      join(repoDir, ".swamp-sources.yaml"),
+      stringifyYaml({
+        sources: [{ path: ghostDir }],
+      } as Record<string, unknown>),
+    );
+
+    const result = await runCliCommand(
+      ["model", "search", "--json"],
+      repoDir,
+    );
+
+    assertEquals(
+      result.code,
+      0,
+      `Expected exit 0 but got ${result.code}. stderr: ${result.stderr}`,
+    );
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -167,7 +167,6 @@ import type {
   ExtensionKind,
   ResolvedSourceDirs,
 } from "../domain/repo/swamp_sources.ts";
-import { isGlobPattern } from "../domain/repo/swamp_sources.ts";
 import { discoverManifestCrossKindDirs } from "../domain/extensions/manifest_cross_kind_discovery.ts";
 
 // Import models barrel to trigger self-registration
@@ -1272,25 +1271,10 @@ export async function runCli(args: string[]): Promise<void> {
         repoDir,
         sourceBaseDir,
       );
-      const { resolved, warnings } = await resolveSourceExtensionDirs(
+      const { resolved } = await resolveSourceExtensionDirs(
         expanded,
       );
       resolvedSources = resolved;
-
-      const missingConcrete = warnings.filter(
-        (w) => !isGlobPattern(w.sourcePath),
-      );
-      const isSourceManagementCommand = commandInfo.command === "extension" &&
-        commandInfo.subcommand === "source";
-      if (missingConcrete.length > 0 && !isSourceManagementCommand) {
-        const paths = missingConcrete.map((w) => `  - ${w.sourcePath}`);
-        throw new UserError(
-          `Declared extension source(s) in .swamp-sources.yaml cannot be resolved:\n${
-            paths.join("\n")
-          }\n\n` +
-            "Remove stale entries with 'swamp extension source rm <path>' or fix the path.",
-        );
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes swamp-club#1181 — an unreachable path in `.swamp-sources.yaml` bricked every CLI command, including `swamp version` and `swamp quest`.

- Removed the `throw new UserError()` block added in df9fc306 that made missing concrete source paths fatal for all non-`extension source` commands
- `resolveSourceExtensionDirs` already logs `logger.warn` for missing paths — restoring that as the only signal matches pre-regression behavior
- Added integration test verifying stale sources don't cause fatal exit

## Regression

Introduced in df9fc306 (`fix(sources): resolve .swamp-sources.yaml relative paths against git main working tree root`). That commit added source-path resolution against the git main worktree root (correct) but also escalated missing-path warnings to fatal errors for all commands (incorrect).

## Verified

Compiled the binary and tested against a repo with a stale source entry (`/tmp/ghost` after `rm -rf`):

| Command | Before fix | After fix |
|---|---|---|
| `swamp version` | exit 1 | exit 0 |
| `swamp quest --json` | exit 1 | exit 0 |
| `swamp model search --json` | exit 1 | exit 0 |
| `swamp vault list --json` | exit 1 | exit 0 |

## Test Plan

- [x] Integration test: `integration/stale_source_test.ts` — stale source exits 0
- [x] Existing tests: `swamp_sources_repository_test.ts` (34 pass), `mod_test.ts` (67 pass)
- [x] Manual verification with compiled binary against reproduction repo
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)