### PR TITLE
feat(auth): resolve identity for SWAMP_API_KEY users on first use (swamp-club#1178)

### DIFF
--- a/src/cli/commands/quest.ts
+++ b/src/cli/commands/quest.ts
@@ -56,9 +56,9 @@ export const questCommand = new Command()
 
     const client = new SwampClubClient(serverUrl, identity);
 
-    // Authenticated → your own pass, claimable on the web. Otherwise the ghost
-    // read: the progress this device accrued, keyed by its distinct_id, every
-    // reward unclaimed until `swamp auth login` binds it to an account.
+    // Authenticated → your own pass. Otherwise the ghost read: the progress
+    // this device accrued, keyed by its distinct_id, unclaimed until an
+    // authenticated session (swamp auth login or SWAMP_API_KEY) binds it.
     let deps: QuestPassDeps;
     if (credentials?.apiKey) {
       const apiKey = credentials.apiKey;
@@ -68,7 +68,9 @@ export const questCommand = new Command()
           const who = await client.whoami(apiKey);
           if (!who.authenticated || !who.username) {
             throw new UserError(
-              "Could not resolve your identity. Run `swamp auth login` again.",
+              Deno.env.get("SWAMP_API_KEY")
+                ? "Could not resolve your identity. Your SWAMP_API_KEY may be invalid or expired."
+                : "Could not resolve your identity. Run `swamp auth login` again.",
             );
           }
           return client.fetchGenesisPass(who.username);

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -105,7 +105,10 @@ import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.
 import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
 import { loadIdentity, USER_AGENT } from "./load_identity.ts";
 import { isAuthenticated, setAuthenticated } from "./auth_context.ts";
-import { DEFAULT_SWAMP_CLUB_URL } from "../domain/auth/auth_credentials.ts";
+import {
+  apiKeyFingerprint,
+  DEFAULT_SWAMP_CLUB_URL,
+} from "../domain/auth/auth_credentials.ts";
 import { setAutoResolver } from "./auto_resolver_context.ts";
 import {
   createAutoResolveInstallerAdapter,
@@ -127,6 +130,10 @@ import type { CommandInvocationData } from "../domain/telemetry/command_invocati
 import { UserIdentityRepository } from "../infrastructure/persistence/user_identity_repository.ts";
 import { TelemetryPreferencesFileRepository } from "../infrastructure/persistence/telemetry_preferences_file_repository.ts";
 import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
+import {
+  getCollectives,
+  SwampClubClient,
+} from "../infrastructure/http/swamp_club_client.ts";
 import type { DatastorePathResolver } from "../domain/datastore/datastore_path_resolver.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { resolveDatastoreConfig } from "./resolve_datastore.ts";
@@ -1313,6 +1320,33 @@ export async function runCli(args: string[]): Promise<void> {
       extensionsDir,
     );
     loaderSpan.end();
+  }
+
+  // Resolve identity for SWAMP_API_KEY users on first use (or key rotation).
+  // Must run before the authCollectives read so the first invocation gets
+  // cached collectives for extension trust.
+  if (!hookMode && Deno.env.get("SWAMP_API_KEY")) {
+    try {
+      const authRepo = new AuthRepository();
+      const creds = await authRepo.load();
+      if (creds && !creds.username) {
+        const identity = await loadIdentity();
+        const client = new SwampClubClient(creds.serverUrl, identity);
+        const signal = AbortSignal.timeout(10_000);
+        const response = await client.whoami(creds.apiKey, signal);
+        if (response.authenticated && response.username) {
+          const collectives = getCollectives(response) ?? [];
+          await authRepo.saveIdentityCache(
+            creds.serverUrl,
+            response.username,
+            collectives,
+            apiKeyFingerprint(creds.apiKey),
+          );
+        }
+      }
+    } catch {
+      // Best-effort — don't block CLI startup
+    }
   }
 
   // Load cached auth collectives for membership-based trust

--- a/src/domain/auth/auth_credentials.ts
+++ b/src/domain/auth/auth_credentials.ts
@@ -24,6 +24,11 @@ export const DEFAULT_SWAMP_CLUB_URL = "https://swamp-club.com";
  * old domain can be transparently migrated on load. */
 export const LEGACY_SWAMP_CLUB_URL = "https://swamp.club";
 
+/** First 12 characters of an API key, used for stale-cache detection. */
+export function apiKeyFingerprint(apiKey: string): string {
+  return apiKey.slice(0, 12);
+}
+
 /** Stored authentication credentials for swamp-club API access. */
 export interface AuthCredentials {
   /** The swamp-club server URL (e.g., "https://swamp-club.com") */
@@ -36,4 +41,7 @@ export interface AuthCredentials {
   username: string;
   /** Cached collective memberships (slugs) from the last login/whoami */
   collectives?: string[];
+  /** Prefix of the API key that was active when identity was cached.
+   *  Used to detect key rotation for SWAMP_API_KEY users. */
+  apiKeyFingerprint?: string;
 }

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -562,7 +562,8 @@ export class SwampClubClient {
    * Fetch the UNAUTHENTICATED (ghost) Genesis pass — the progress this device
    * has accrued in the event stream, keyed by its `Swamp-Distinct-Id` (attached
    * automatically from the client identity). Every reward reads unclaimed until
-   * the distinct_id is bound to an account via `swamp auth login`.
+   * the distinct_id is bound to an account via an authenticated session
+   * (`swamp auth login` or `SWAMP_API_KEY`).
    */
   async fetchGhostGenesisPass(
     signal?: AbortSignal,

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -21,6 +21,7 @@ import { join } from "@std/path";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { getSwampConfigDir } from "./paths.ts";
 import {
+  apiKeyFingerprint,
   type AuthCredentials,
   DEFAULT_SWAMP_CLUB_URL,
   LEGACY_SWAMP_CLUB_URL,
@@ -79,20 +80,38 @@ export class AuthRepository {
    * Read auth credentials. Checks SWAMP_API_KEY env var first,
    * then falls back to auth.json file. Returns null if neither exists.
    *
-   * Note: SWAMP_API_KEY is also checked in two other places that need
-   * different behavior for env-var auth:
-   * - src/libswamp/auth/whoami.ts createAuthDeps() — skips saveCredentials
-   * - src/cli/commands/auth_login.ts / auth_logout.ts — bail early with
-   *   a UserError since login/logout don't apply to env-var auth
+   * When SWAMP_API_KEY is set, cached identity (username, collectives)
+   * is merged from auth.json if the server URL and key fingerprint match.
+   * This gives API-key users the same identity resolution as login users.
    */
   async load(): Promise<AuthCredentials | null> {
     const envApiKey = this.getApiKey();
     if (envApiKey) {
+      const serverUrl = this.getServerUrl() ?? DEFAULT_SWAMP_CLUB_URL;
+      const fingerprint = apiKeyFingerprint(envApiKey);
+
+      let username = "";
+      let collectives: string[] | undefined;
+      try {
+        const content = await Deno.readTextFile(this.getAuthPath());
+        const cached = JSON.parse(content) as AuthCredentials;
+        if (
+          cached.apiKeyFingerprint === fingerprint &&
+          (cached.serverUrl === serverUrl || !cached.serverUrl)
+        ) {
+          username = cached.username ?? "";
+          collectives = cached.collectives;
+        }
+      } catch {
+        // No cached identity — will be populated on first whoami
+      }
+
       return {
-        serverUrl: this.getServerUrl() ?? DEFAULT_SWAMP_CLUB_URL,
+        serverUrl,
         apiKey: envApiKey,
         apiKeyId: "",
-        username: "",
+        username,
+        collectives,
       };
     }
 
@@ -124,6 +143,35 @@ export class AuthRepository {
       JSON.stringify(credentials, null, 2) + "\n",
       { mode: 0o600 },
     );
+  }
+
+  /**
+   * Cache identity fields (username, collectives, fingerprint) without
+   * overwriting an existing apiKey/apiKeyId from a login session.
+   */
+  async saveIdentityCache(
+    serverUrl: string,
+    username: string,
+    collectives: string[],
+    fingerprint: string,
+  ): Promise<void> {
+    let existing: AuthCredentials | undefined;
+    try {
+      const content = await Deno.readTextFile(this.getAuthPath());
+      existing = JSON.parse(content) as AuthCredentials;
+    } catch {
+      // No existing file
+    }
+
+    const merged: AuthCredentials = {
+      serverUrl,
+      apiKey: existing?.apiKey ?? "",
+      apiKeyId: existing?.apiKeyId ?? "",
+      username,
+      collectives,
+      apiKeyFingerprint: fingerprint,
+    };
+    await this.save(merged);
   }
 
   /** Delete stored auth credentials. */

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -231,6 +231,152 @@ Deno.test("AuthRepository - empty SWAMP_API_KEY is treated as unset", async () =
   }
 });
 
+// ── SWAMP_API_KEY identity cache merging ────────────────────────────────
+
+Deno.test("AuthRepository - load merges cached identity when fingerprint matches", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const fileRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => undefined,
+    });
+    await fileRepo.save({
+      ...TEST_CREDENTIALS,
+      apiKeyFingerprint: "swamp_env_ke",
+      collectives: ["myorg"],
+    });
+
+    const envRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => "swamp_env_key_123",
+      getServerUrl: () => undefined,
+    });
+    const loaded = await envRepo.load();
+
+    assertExists(loaded);
+    assertEquals(loaded.apiKey, "swamp_env_key_123");
+    assertEquals(loaded.username, "testuser");
+    assertEquals(loaded.collectives, ["myorg"]);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - load does not merge when fingerprint mismatches (key rotation)", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const fileRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => undefined,
+    });
+    await fileRepo.save({
+      ...TEST_CREDENTIALS,
+      apiKeyFingerprint: "swamp_old_ke",
+      collectives: ["stale-org"],
+    });
+
+    const envRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => "swamp_new_key_456",
+      getServerUrl: () => undefined,
+    });
+    const loaded = await envRepo.load();
+
+    assertExists(loaded);
+    assertEquals(loaded.apiKey, "swamp_new_key_456");
+    assertEquals(loaded.username, "");
+    assertEquals(loaded.collectives, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - load does not merge when no fingerprint cached", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const fileRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => undefined,
+    });
+    await fileRepo.save(TEST_CREDENTIALS);
+
+    const envRepo = new AuthRepository({
+      configDir,
+      getApiKey: () => "swamp_env_key_123",
+      getServerUrl: () => undefined,
+    });
+    const loaded = await envRepo.load();
+
+    assertExists(loaded);
+    assertEquals(loaded.username, "");
+    assertEquals(loaded.collectives, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+// ── saveIdentityCache ──────────────────────────────────────────────────
+
+Deno.test("AuthRepository - saveIdentityCache preserves existing login apiKey/apiKeyId", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const repo = new AuthRepository({
+      configDir,
+      getApiKey: () => undefined,
+    });
+
+    await repo.save(TEST_CREDENTIALS);
+    await repo.saveIdentityCache(
+      "https://swamp-club.com",
+      "envuser",
+      ["envorg"],
+      "swamp_env_ke",
+    );
+
+    const loaded = await repo.load();
+    assertExists(loaded);
+    assertEquals(loaded.apiKey, TEST_CREDENTIALS.apiKey);
+    assertEquals(loaded.apiKeyId, TEST_CREDENTIALS.apiKeyId);
+    assertEquals(loaded.username, "envuser");
+    assertEquals(loaded.collectives, ["envorg"]);
+    assertEquals(loaded.apiKeyFingerprint, "swamp_env_ke");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - saveIdentityCache creates file when none exists", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const repo = new AuthRepository({
+      configDir,
+      getApiKey: () => undefined,
+    });
+
+    await repo.saveIdentityCache(
+      "https://swamp-club.com",
+      "newuser",
+      ["org1"],
+      "swamp_new_ke",
+    );
+
+    const loaded = await repo.load();
+    assertExists(loaded);
+    assertEquals(loaded.apiKey, "");
+    assertEquals(loaded.apiKeyId, "");
+    assertEquals(loaded.username, "newuser");
+    assertEquals(loaded.collectives, ["org1"]);
+    assertEquals(loaded.apiKeyFingerprint, "swamp_new_ke");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 // ── Domain migration: legacy swamp.club → swamp-club.com ─────────────
 
 Deno.test("AuthRepository - load rewrites legacy https://swamp.club to new domain and persists", async () => {

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import {
+  apiKeyFingerprint,
+  type AuthCredentials,
+} from "../../domain/auth/auth_credentials.ts";
 import type { WhoamiResponse } from "../../infrastructure/http/swamp_club_client.ts";
 import {
   getCollectives,
@@ -78,16 +81,22 @@ export interface CreateAuthDepsOptions {
 /** Wires real infrastructure into AuthDeps. */
 export function createAuthDeps(options: CreateAuthDepsOptions = {}): AuthDeps {
   const repo = new AuthRepository(options.repo);
-  // When SWAMP_API_KEY is set, skip writing credentials to disk — env-var
-  // auth is ephemeral and shouldn't create/update auth.json. Checked
-  // lazily through the same getApiKey hook the repo uses, so test
-  // overrides flow through here too.
   const getApiKey = options.repo?.getApiKey ??
     (() => Deno.env.get("SWAMP_API_KEY"));
   return {
     loadCredentials: () => repo.load(),
-    saveCredentials: (credentials) =>
-      getApiKey() ? Promise.resolve() : repo.save(credentials),
+    saveCredentials: (credentials) => {
+      const envKey = getApiKey();
+      if (envKey) {
+        return repo.saveIdentityCache(
+          credentials.serverUrl,
+          credentials.username,
+          credentials.collectives ?? [],
+          apiKeyFingerprint(envKey),
+        );
+      }
+      return repo.save(credentials);
+    },
     fetchWhoami: (serverUrl, apiKey, signal) => {
       const client = new SwampClubClient(serverUrl, options.identity);
       return client.whoami(apiKey, signal);

--- a/src/libswamp/auth/whoami_test.ts
+++ b/src/libswamp/auth/whoami_test.ts
@@ -233,13 +233,9 @@ Deno.test("whoami does not persist credentials when saveCredentials is a no-op",
   assertEquals(saveCalled, false);
 });
 
-Deno.test("createAuthDeps: saveCredentials is a no-op when SWAMP_API_KEY is set", async () => {
+Deno.test("createAuthDeps: saveCredentials caches identity when SWAMP_API_KEY is set", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {
-    // Inject overrides instead of mutating Deno.env — `deno test --parallel`
-    // runs whoami_test and logout_test in different files concurrently and
-    // both touch SWAMP_API_KEY / XDG_CONFIG_HOME. Going through the deps
-    // options keeps this test hermetic.
     const deps = createAuthDeps({
       repo: {
         configDir: `${tmpDir}/swamp`,
@@ -247,17 +243,19 @@ Deno.test("createAuthDeps: saveCredentials is a no-op when SWAMP_API_KEY is set"
       },
     });
 
-    // saveCredentials should be a no-op — no file should be written
-    await deps.saveCredentials(testCredentials);
-    const files = [];
-    try {
-      for await (const entry of Deno.readDir(`${tmpDir}/swamp`)) {
-        files.push(entry.name);
-      }
-    } catch {
-      // Directory doesn't exist — expected, since save was a no-op
-    }
-    assertEquals(files.includes("auth.json"), false);
+    await deps.saveCredentials({
+      ...testCredentials,
+      collectives: ["myorg"],
+    });
+
+    const raw = await Deno.readTextFile(`${tmpDir}/swamp/auth.json`);
+    const saved = JSON.parse(raw) as AuthCredentials;
+    assertEquals(saved.username, "adam");
+    assertEquals(saved.collectives, ["myorg"]);
+    assertEquals(saved.apiKeyFingerprint, "swamp_test_e");
+    // apiKey/apiKeyId should be empty — not the env var key
+    assertEquals(saved.apiKey, "");
+    assertEquals(saved.apiKeyId, "");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

- Make `SWAMP_API_KEY` a first-class auth path equivalent to `swamp auth login` for identity resolution
- On first CLI invocation with a new API key (or after key rotation), call `whoami` to resolve username/collectives and cache them with a key fingerprint
- `AuthRepository.load()` now merges cached identity from `auth.json` when `SWAMP_API_KEY` is set, matching on both server URL and key fingerprint
- Add `saveIdentityCache()` to `AuthRepository` — caches identity fields without overwriting existing login credentials
- Fix quest pass error message that told API-key users to run `swamp auth login` (which is blocked when `SWAMP_API_KEY` is set)
- Update comments/JSDoc to reflect `SWAMP_API_KEY` as an equivalent auth path

Server-side ghost device binding on `whoami` tracked in swamp-club lab issue #1188.

Closes swamp-club#1178

## Test Plan

- [x] `AuthRepository.load()` merges cached identity when fingerprint matches
- [x] `AuthRepository.load()` rejects stale cache on key rotation (fingerprint mismatch)
- [x] `AuthRepository.load()` returns empty identity when no fingerprint cached
- [x] `saveIdentityCache()` preserves existing login `apiKey`/`apiKeyId`
- [x] `saveIdentityCache()` creates file from scratch when none exists
- [x] `createAuthDeps` caches identity when `SWAMP_API_KEY` is set
- [x] `deno check`, `deno lint`, `deno fmt` pass