### PR TITLE
feat(run): add `swamp run gc` to garbage-collect workflow runs and outputs

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -38,6 +38,7 @@ import {
   writeModelRunsLog,
 } from "../../presentation/output/model_runs_output.ts";
 import { groupCommandAction } from "../group_action.ts";
+import { runGcCommand } from "./run_gc.ts";
 import {
   requestServerResponse,
   resolveServerToken,
@@ -244,4 +245,5 @@ export const runCommand = new Command()
   .description("Track and diagnose in-flight model method and workflow runs")
   .action(groupCommandAction)
   .command("history", runHistoryCommand)
-  .command("doctor", runDoctorCommand);
+  .command("doctor", runDoctorCommand)
+  .command("gc", runGcCommand);

--- a/src/cli/commands/run_gc.ts
+++ b/src/cli/commands/run_gc.ts
@@ -103,7 +103,7 @@ export const runGcCommand = new Command()
       if (
         preview.workflowRunsToDelete === 0 && preview.outputsToDelete === 0
       ) {
-        console.log("Nothing to clean up.");
+        cliCtx.logger.info("Nothing to clean up.");
         return;
       }
 

--- a/src/cli/commands/run_gc.ts
+++ b/src/cli/commands/run_gc.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import {
+  consumeStream,
+  createLibSwampContext,
+  createRunGcDeps,
+  parseDuration,
+  runGc,
+  runGcPreview,
+} from "../../libswamp/mod.ts";
+import {
+  createRunGcRenderer,
+  renderRunGcCancelled,
+  renderRunGcPreview,
+} from "../../presentation/renderers/run_gc.ts";
+import {
+  createContext,
+  type GlobalOptions,
+  resolveRepoDir,
+} from "../context.ts";
+import {
+  requireInitializedRepo,
+  requireInitializedRepoReadOnly,
+} from "../repo_context.ts";
+import { promptConfirmation } from "../prompt_helpers.ts";
+import { DEFAULT_WORKFLOW_RUN_RETENTION_DAYS } from "../../domain/data/run_lifecycle_service.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const runGcCommand = new Command()
+  .name("gc")
+  .description(
+    "Garbage-collect old workflow runs and model method outputs",
+  )
+  .example("Preview what would be collected", "swamp run gc --dry-run")
+  .example("Run GC with default 30-day retention", "swamp run gc --force")
+  .example("Delete runs older than 7 days", "swamp run gc --older-than 7d")
+  .example(
+    "Non-interactive JSON output",
+    "swamp run gc --json --older-than 14d",
+  )
+  .option(
+    "--repo-dir <dir:string>",
+    "Repository directory (env: SWAMP_REPO_DIR)",
+  )
+  .option("--dry-run", "Show what would be deleted without deleting")
+  .option("-f, --force", "Skip confirmation prompt")
+  .option(
+    "--older-than <duration:string>",
+    `Retention period (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, ["run", "gc"]);
+
+    const repoOpts = {
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    };
+    const { repoDir, repoContext, datastoreResolver } = options.dryRun
+      ? await requireInitializedRepoReadOnly(repoOpts)
+      : await requireInitializedRepo(repoOpts);
+
+    let retentionDays = DEFAULT_WORKFLOW_RUN_RETENTION_DAYS;
+    if (options.olderThan) {
+      const ms = parseDuration(options.olderThan);
+      retentionDays = ms / (24 * 60 * 60 * 1000);
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const deps = createRunGcDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.markDirty,
+    );
+
+    const gcInput = {
+      dryRun: !!options.dryRun,
+      workflowRunRetentionDays: retentionDays,
+      outputRetentionDays: retentionDays,
+    };
+
+    if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {
+      const preview = await runGcPreview(ctx, deps, gcInput);
+      if (
+        preview.workflowRunsToDelete === 0 && preview.outputsToDelete === 0
+      ) {
+        console.log("Nothing to clean up.");
+        return;
+      }
+
+      renderRunGcPreview(preview, cliCtx.outputMode);
+      const confirmed = await promptConfirmation(
+        "Proceed with run garbage collection?",
+      );
+      if (!confirmed) {
+        renderRunGcCancelled(cliCtx.outputMode);
+        return;
+      }
+    }
+
+    const renderer = createRunGcRenderer(cliCtx.outputMode);
+    await consumeStream(
+      runGc(ctx, deps, gcInput),
+      renderer.handlers(),
+    );
+  });

--- a/src/cli/commands/run_gc.ts
+++ b/src/cli/commands/run_gc.ts
@@ -22,6 +22,7 @@ import {
   consumeStream,
   createLibSwampContext,
   createRunGcDeps,
+  DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   parseDuration,
   runGc,
   runGcPreview,
@@ -41,7 +42,6 @@ import {
   requireInitializedRepoReadOnly,
 } from "../repo_context.ts";
 import { promptConfirmation } from "../prompt_helpers.ts";
-import { DEFAULT_WORKFLOW_RUN_RETENTION_DAYS } from "../../domain/data/run_lifecycle_service.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -49,13 +49,13 @@ type AnyOptions = any;
 export const runGcCommand = new Command()
   .name("gc")
   .description(
-    "Garbage-collect old workflow runs and model method outputs",
+    "Garbage-collect old workflow runs and model method outputs. Running and suspended runs are never deleted regardless of age.",
   )
   .example("Preview what would be collected", "swamp run gc --dry-run")
   .example("Run GC with default 30-day retention", "swamp run gc --force")
   .example("Delete runs older than 7 days", "swamp run gc --older-than 7d")
   .example(
-    "Non-interactive JSON output",
+    "Run non-interactively in JSON mode (no prompt, structured output)",
     "swamp run gc --json --older-than 14d",
   )
   .option(
@@ -66,7 +66,7 @@ export const runGcCommand = new Command()
   .option("-f, --force", "Skip confirmation prompt")
   .option(
     "--older-than <duration:string>",
-    `Retention period (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
+    `Retention period. Units: m=minutes, h=hours, d=days, w=weeks, mo=months, y=years (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["run", "gc"]);

--- a/src/domain/data/run_lifecycle_service.ts
+++ b/src/domain/data/run_lifecycle_service.ts
@@ -1,0 +1,102 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { WorkflowRunRepository } from "../workflows/repositories.ts";
+import type { OutputRepository } from "../models/repositories.ts";
+
+export const DEFAULT_WORKFLOW_RUN_RETENTION_DAYS = 30;
+export const DEFAULT_OUTPUT_RETENTION_DAYS = 30;
+
+export interface RunGcResult {
+  workflowRunsDeleted: number;
+  workflowRunBytesReclaimed: number;
+  outputsDeleted: number;
+  outputBytesReclaimed: number;
+  dryRun: boolean;
+}
+
+export interface RunLifecycleService {
+  gcWorkflowRuns(options: {
+    retentionDays: number;
+    dryRun: boolean;
+  }): Promise<{ deleted: number; bytesReclaimed: number }>;
+
+  gcOutputs(options: {
+    retentionDays: number;
+    dryRun: boolean;
+  }): Promise<{ deleted: number; bytesReclaimed: number }>;
+
+  gcAll(options: {
+    workflowRunRetentionDays: number;
+    outputRetentionDays: number;
+    dryRun: boolean;
+  }): Promise<RunGcResult>;
+}
+
+export class DefaultRunLifecycleService implements RunLifecycleService {
+  constructor(
+    private readonly workflowRunRepo: WorkflowRunRepository,
+    private readonly outputRepo: OutputRepository,
+  ) {}
+
+  async gcWorkflowRuns(options: {
+    retentionDays: number;
+    dryRun: boolean;
+  }): Promise<{ deleted: number; bytesReclaimed: number }> {
+    const cutoffMs = Date.now() - options.retentionDays * 86_400_000;
+    return await this.workflowRunRepo.deleteOlderThan(new Date(cutoffMs), {
+      dryRun: options.dryRun,
+    });
+  }
+
+  async gcOutputs(options: {
+    retentionDays: number;
+    dryRun: boolean;
+  }): Promise<{ deleted: number; bytesReclaimed: number }> {
+    const cutoffMs = Date.now() - options.retentionDays * 86_400_000;
+    return await this.outputRepo.deleteOlderThan(new Date(cutoffMs), {
+      dryRun: options.dryRun,
+    });
+  }
+
+  async gcAll(options: {
+    workflowRunRetentionDays: number;
+    outputRetentionDays: number;
+    dryRun: boolean;
+  }): Promise<RunGcResult> {
+    const [workflowRuns, outputs] = await Promise.all([
+      this.gcWorkflowRuns({
+        retentionDays: options.workflowRunRetentionDays,
+        dryRun: options.dryRun,
+      }),
+      this.gcOutputs({
+        retentionDays: options.outputRetentionDays,
+        dryRun: options.dryRun,
+      }),
+    ]);
+
+    return {
+      workflowRunsDeleted: workflowRuns.deleted,
+      workflowRunBytesReclaimed: workflowRuns.bytesReclaimed,
+      outputsDeleted: outputs.deleted,
+      outputBytesReclaimed: outputs.bytesReclaimed,
+      dryRun: options.dryRun,
+    };
+  }
+}

--- a/src/domain/data/run_lifecycle_service_test.ts
+++ b/src/domain/data/run_lifecycle_service_test.ts
@@ -1,0 +1,180 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { DefaultRunLifecycleService } from "./run_lifecycle_service.ts";
+import type { WorkflowRunRepository } from "../workflows/repositories.ts";
+import type { OutputRepository } from "../models/repositories.ts";
+
+function createMockWorkflowRunRepo(
+  result: { deleted: number; bytesReclaimed: number } = {
+    deleted: 0,
+    bytesReclaimed: 0,
+  },
+): WorkflowRunRepository & { lastCutoff?: Date; lastDryRun?: boolean } {
+  const mock = {
+    lastCutoff: undefined as Date | undefined,
+    lastDryRun: undefined as boolean | undefined,
+    findById: () => Promise.resolve(null),
+    findAllByWorkflowId: () => Promise.resolve([]),
+    findLatestByWorkflowId: () => Promise.resolve(null),
+    findAllGlobal: () => Promise.resolve([]),
+    findAllGlobalSince: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    nextId: () => "mock-id" as ReturnType<WorkflowRunRepository["nextId"]>,
+    getPath: () => "",
+    deleteAllByWorkflowId: () => Promise.resolve(0),
+    deleteOlderThan: (cutoff: Date, options?: { dryRun?: boolean }) => {
+      mock.lastCutoff = cutoff;
+      mock.lastDryRun = options?.dryRun;
+      return Promise.resolve(result);
+    },
+  };
+  return mock;
+}
+
+function createMockOutputRepo(
+  result: { deleted: number; bytesReclaimed: number } = {
+    deleted: 0,
+    bytesReclaimed: 0,
+  },
+): OutputRepository & { lastCutoff?: Date; lastDryRun?: boolean } {
+  const mock = {
+    lastCutoff: undefined as Date | undefined,
+    lastDryRun: undefined as boolean | undefined,
+    findById: () => Promise.resolve(null),
+    findByDefinition: () => Promise.resolve([]),
+    findLatestByDefinition: () => Promise.resolve(null),
+    findAll: () => Promise.resolve([]),
+    findAllGlobal: () => Promise.resolve([]),
+    findAllGlobalSince: () => Promise.resolve([]),
+    save: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    deleteOlderThan: (cutoff: Date, options?: { dryRun?: boolean }) => {
+      mock.lastCutoff = cutoff;
+      mock.lastDryRun = options?.dryRun;
+      return Promise.resolve(result);
+    },
+    nextId: () => "mock-id" as ReturnType<OutputRepository["nextId"]>,
+    getPath: () => "",
+  };
+  return mock;
+}
+
+Deno.test("gcAll: delegates to both repos with correct cutoffs", async () => {
+  const workflowRunRepo = createMockWorkflowRunRepo({
+    deleted: 5,
+    bytesReclaimed: 1000,
+  });
+  const outputRepo = createMockOutputRepo({
+    deleted: 3,
+    bytesReclaimed: 500,
+  });
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+
+  const result = await service.gcAll({
+    workflowRunRetentionDays: 7,
+    outputRetentionDays: 14,
+    dryRun: false,
+  });
+
+  assertEquals(result.workflowRunsDeleted, 5);
+  assertEquals(result.workflowRunBytesReclaimed, 1000);
+  assertEquals(result.outputsDeleted, 3);
+  assertEquals(result.outputBytesReclaimed, 500);
+  assertEquals(result.dryRun, false);
+  assertEquals(workflowRunRepo.lastDryRun, false);
+  assertEquals(outputRepo.lastDryRun, false);
+});
+
+Deno.test("gcAll: passes dryRun flag through to repos", async () => {
+  const workflowRunRepo = createMockWorkflowRunRepo();
+  const outputRepo = createMockOutputRepo();
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+
+  await service.gcAll({
+    workflowRunRetentionDays: 30,
+    outputRetentionDays: 30,
+    dryRun: true,
+  });
+
+  assertEquals(workflowRunRepo.lastDryRun, true);
+  assertEquals(outputRepo.lastDryRun, true);
+});
+
+Deno.test("gcAll: computes cutoff correctly from retention days", async () => {
+  const workflowRunRepo = createMockWorkflowRunRepo();
+  const outputRepo = createMockOutputRepo();
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+
+  const before = Date.now();
+  await service.gcAll({
+    workflowRunRetentionDays: 7,
+    outputRetentionDays: 14,
+    dryRun: true,
+  });
+  const _after = Date.now();
+
+  const wfCutoff = workflowRunRepo.lastCutoff!.getTime();
+  const outCutoff = outputRepo.lastCutoff!.getTime();
+
+  const expectedWfCutoff = before - 7 * 86_400_000;
+  const expectedOutCutoff = before - 14 * 86_400_000;
+
+  // Allow 100ms tolerance for test execution time
+  assertEquals(Math.abs(wfCutoff - expectedWfCutoff) < 100, true);
+  assertEquals(Math.abs(outCutoff - expectedOutCutoff) < 100, true);
+  assertEquals(wfCutoff > outCutoff, true);
+});
+
+Deno.test("gcWorkflowRuns: calls repo with correct parameters", async () => {
+  const workflowRunRepo = createMockWorkflowRunRepo({
+    deleted: 10,
+    bytesReclaimed: 2048,
+  });
+  const outputRepo = createMockOutputRepo();
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+
+  const result = await service.gcWorkflowRuns({
+    retentionDays: 3,
+    dryRun: true,
+  });
+
+  assertEquals(result.deleted, 10);
+  assertEquals(result.bytesReclaimed, 2048);
+  assertEquals(workflowRunRepo.lastDryRun, true);
+});
+
+Deno.test("gcOutputs: calls repo with correct parameters", async () => {
+  const workflowRunRepo = createMockWorkflowRunRepo();
+  const outputRepo = createMockOutputRepo({
+    deleted: 7,
+    bytesReclaimed: 4096,
+  });
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+
+  const result = await service.gcOutputs({
+    retentionDays: 1,
+    dryRun: false,
+  });
+
+  assertEquals(result.deleted, 7);
+  assertEquals(result.bytesReclaimed, 4096);
+  assertEquals(outputRepo.lastDryRun, false);
+});

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -3301,6 +3301,7 @@ function createMockOutputRepo(): {
         return Promise.resolve();
       },
       delete: () => Promise.resolve(),
+      deleteOlderThan: () => Promise.resolve({ deleted: 0, bytesReclaimed: 0 }),
       nextId: () => createModelOutputId(crypto.randomUUID()),
       getPath: () => "",
     },

--- a/src/domain/models/repositories.ts
+++ b/src/domain/models/repositories.ts
@@ -128,4 +128,13 @@ export interface OutputRepository {
    * @returns The file path
    */
   getPath(type: ModelType, method: string, output: ModelOutput): string;
+
+  /**
+   * Deletes all outputs older than the cutoff.
+   * Returns the number of outputs deleted and bytes reclaimed.
+   */
+  deleteOlderThan(
+    cutoff: Date,
+    options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }>;
 }

--- a/src/domain/summary/summary_service_test.ts
+++ b/src/domain/summary/summary_service_test.ts
@@ -135,6 +135,7 @@ function createMockOutputRepo(
     findAll: () => Promise.resolve([]),
     save: () => Promise.resolve(),
     delete: () => Promise.resolve(),
+    deleteOlderThan: () => Promise.resolve({ deleted: 0, bytesReclaimed: 0 }),
     nextId: () => "mock-id" as ReturnType<OutputRepository["nextId"]>,
     getPath: () => "",
   };
@@ -158,6 +159,8 @@ function createMockWorkflowRunRepo(
     nextId: () => "mock-id" as ReturnType<WorkflowRunRepository["nextId"]>,
     getPath: () => "",
     deleteAllByWorkflowId: () => Promise.resolve(0),
+    delete: () => Promise.resolve(),
+    deleteOlderThan: () => Promise.resolve({ deleted: 0, bytesReclaimed: 0 }),
   };
 }
 

--- a/src/domain/summary/summary_service_test.ts
+++ b/src/domain/summary/summary_service_test.ts
@@ -159,7 +159,6 @@ function createMockWorkflowRunRepo(
     nextId: () => "mock-id" as ReturnType<WorkflowRunRepository["nextId"]>,
     getPath: () => "",
     deleteAllByWorkflowId: () => Promise.resolve(0),
-    delete: () => Promise.resolve(),
     deleteOlderThan: () => Promise.resolve({ deleted: 0, bytesReclaimed: 0 }),
   };
 }

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -193,6 +193,17 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     this.runs.delete(workflowId);
     return Promise.resolve(count);
   }
+
+  delete(_workflowId: WorkflowId, _runId: WorkflowRunId): Promise<void> {
+    return Promise.resolve();
+  }
+
+  deleteOlderThan(
+    _cutoff: Date,
+    _options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    return Promise.resolve({ deleted: 0, bytesReclaimed: 0 });
+  }
 }
 
 function createSimpleWorkflow(): Workflow {
@@ -3220,6 +3231,17 @@ class TrackingRunRepository implements WorkflowRunRepository {
 
   deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {
     return this.inner.deleteAllByWorkflowId(workflowId);
+  }
+
+  delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void> {
+    return this.inner.delete(workflowId, runId);
+  }
+
+  deleteOlderThan(
+    cutoff: Date,
+    options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    return this.inner.deleteOlderThan(cutoff, options);
   }
 }
 

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -194,10 +194,6 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     return Promise.resolve(count);
   }
 
-  delete(_workflowId: WorkflowId, _runId: WorkflowRunId): Promise<void> {
-    return Promise.resolve();
-  }
-
   deleteOlderThan(
     _cutoff: Date,
     _options?: { dryRun?: boolean },
@@ -3231,10 +3227,6 @@ class TrackingRunRepository implements WorkflowRunRepository {
 
   deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {
     return this.inner.deleteAllByWorkflowId(workflowId);
-  }
-
-  delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void> {
-    return this.inner.delete(workflowId, runId);
   }
 
   deleteOlderThan(

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -121,11 +121,6 @@ export interface WorkflowRunRepository {
   deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number>;
 
   /**
-   * Deletes a single workflow run and its associated log file.
-   */
-  delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void>;
-
-  /**
    * Deletes all terminal runs (succeeded/failed/cancelled) older than the
    * cutoff. Running and suspended runs are never deleted regardless of age.
    * Returns the number of runs deleted.

--- a/src/domain/workflows/repositories.ts
+++ b/src/domain/workflows/repositories.ts
@@ -119,4 +119,19 @@ export interface WorkflowRunRepository {
    * Deletes all runs for a workflow.
    */
   deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number>;
+
+  /**
+   * Deletes a single workflow run and its associated log file.
+   */
+  delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void>;
+
+  /**
+   * Deletes all terminal runs (succeeded/failed/cancelled) older than the
+   * cutoff. Running and suspended runs are never deleted regardless of age.
+   * Returns the number of runs deleted.
+   */
+  deleteOlderThan(
+    cutoff: Date,
+    options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }>;
 }

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -372,6 +372,7 @@ export class YamlOutputRepository implements OutputRepository {
     cutoff: Date,
     options?: { dryRun?: boolean },
   ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
     const cutoffMs = cutoff.getTime();
     let deleted = 0;
     let bytesReclaimed = 0;
@@ -385,10 +386,14 @@ export class YamlOutputRepository implements OutputRepository {
 
         const content = await Deno.readTextFile(yamlPath);
         const data = parseYaml(content) as ModelOutputData;
+        if (!TERMINAL_STATUSES.has(data.status)) continue;
         const startedAt = data.startedAt
           ? new Date(data.startedAt).getTime()
           : undefined;
-        if (startedAt === undefined || startedAt >= cutoffMs) continue;
+        if (
+          startedAt === undefined || Number.isNaN(startedAt) ||
+          startedAt >= cutoffMs
+        ) continue;
 
         const logPath = yamlPath.replace(/\.yaml$/, ".log");
         let fileBytes = stat.size ?? 0;

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -368,6 +368,80 @@ export class YamlOutputRepository implements OutputRepository {
     return join(this.getMethodDir(type, method), filename);
   }
 
+  async deleteOlderThan(
+    cutoff: Date,
+    options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    const cutoffMs = cutoff.getTime();
+    let deleted = 0;
+    let bytesReclaimed = 0;
+
+    const yamlFiles = await this.collectYamlFiles(this.baseDir);
+    for (const yamlPath of yamlFiles) {
+      try {
+        const stat = await Deno.stat(yamlPath);
+        const mtimeMs = stat.mtime?.getTime();
+        if (mtimeMs !== undefined && mtimeMs >= cutoffMs) continue;
+
+        const content = await Deno.readTextFile(yamlPath);
+        const data = parseYaml(content) as ModelOutputData;
+        const startedAt = data.startedAt
+          ? new Date(data.startedAt).getTime()
+          : undefined;
+        if (startedAt === undefined || startedAt >= cutoffMs) continue;
+
+        const logPath = yamlPath.replace(/\.yaml$/, ".log");
+        let fileBytes = stat.size ?? 0;
+        try {
+          const logStat = await Deno.stat(logPath);
+          fileBytes += logStat.size ?? 0;
+        } catch {
+          // log file may not exist
+        }
+
+        if (!options?.dryRun) {
+          await this.notifyDirty(yamlPath);
+          try {
+            await Deno.remove(yamlPath);
+          } catch (error) {
+            if (!(error instanceof Deno.errors.NotFound)) throw error;
+          }
+          try {
+            await Deno.remove(logPath);
+          } catch (error) {
+            if (!(error instanceof Deno.errors.NotFound)) throw error;
+          }
+          await cleanupEmptyParentDirs(yamlPath, this.baseDir);
+        }
+
+        deleted++;
+        bytesReclaimed += fileBytes;
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) continue;
+        throw error;
+      }
+    }
+
+    return { deleted, bytesReclaimed };
+  }
+
+  private async collectYamlFiles(dir: string): Promise<string[]> {
+    const files: string[] = [];
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory) {
+          files.push(...await this.collectYamlFiles(path));
+        } else if (entry.isFile && entry.name.endsWith(".yaml")) {
+          files.push(path);
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+    return files;
+  }
+
   private getOutputsDir(): string {
     return this.baseDir;
   }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -406,4 +406,115 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
     return count;
   }
+
+  async delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void> {
+    const yamlPath = this.getPath(workflowId, runId);
+    const logPath = yamlPath.replace(/\.yaml$/, ".log");
+
+    await this.notifyDirty(yamlPath);
+
+    try {
+      await Deno.remove(yamlPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    try {
+      await Deno.remove(logPath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+  }
+
+  async deleteOlderThan(
+    cutoff: Date,
+    options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
+    const cutoffMs = cutoff.getTime();
+    let deleted = 0;
+    let bytesReclaimed = 0;
+
+    try {
+      for await (const entry of Deno.readDir(this.baseDir)) {
+        if (!entry.isDirectory) continue;
+        const workflowId = entry.name as WorkflowId;
+        const dir = this.getRunsDir(workflowId);
+
+        try {
+          for await (const fileEntry of Deno.readDir(dir)) {
+            if (
+              !fileEntry.isFile ||
+              !fileEntry.name.startsWith("workflow-run-") ||
+              !fileEntry.name.endsWith(".yaml")
+            ) {
+              continue;
+            }
+            const yamlPath = join(dir, fileEntry.name);
+
+            try {
+              const stat = await Deno.stat(yamlPath);
+              const mtimeMs = stat.mtime?.getTime();
+              if (mtimeMs !== undefined && mtimeMs >= cutoffMs) continue;
+
+              const content = await Deno.readTextFile(yamlPath);
+              const data = parseYaml(content) as WorkflowRunData;
+              if (!TERMINAL_STATUSES.has(data.status)) continue;
+
+              const completedAt = data.completedAt
+                ? new Date(data.completedAt).getTime()
+                : undefined;
+              const startedAt = data.startedAt
+                ? new Date(data.startedAt).getTime()
+                : undefined;
+              const timestamp = completedAt ?? startedAt;
+              if (timestamp === undefined || timestamp >= cutoffMs) continue;
+
+              const logPath = yamlPath.replace(/\.yaml$/, ".log");
+              let fileBytes = stat.size ?? 0;
+              try {
+                const logStat = await Deno.stat(logPath);
+                fileBytes += logStat.size ?? 0;
+              } catch {
+                // log file may not exist
+              }
+
+              if (!options?.dryRun) {
+                await this.notifyDirty(yamlPath);
+                try {
+                  await Deno.remove(yamlPath);
+                } catch (error) {
+                  if (!(error instanceof Deno.errors.NotFound)) throw error;
+                }
+                try {
+                  await Deno.remove(logPath);
+                } catch (error) {
+                  if (!(error instanceof Deno.errors.NotFound)) throw error;
+                }
+              }
+
+              deleted++;
+              bytesReclaimed += fileBytes;
+            } catch (error) {
+              if (error instanceof Deno.errors.NotFound) continue;
+              throw error;
+            }
+          }
+        } catch (error) {
+          if (error instanceof Deno.errors.NotFound) continue;
+          throw error;
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    return { deleted, bytesReclaimed };
+  }
 }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -21,6 +21,7 @@ import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
+import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
 import type { WorkflowRunRepository } from "../../domain/workflows/repositories.ts";
 import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import {
@@ -407,29 +408,6 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     return count;
   }
 
-  async delete(workflowId: WorkflowId, runId: WorkflowRunId): Promise<void> {
-    const yamlPath = this.getPath(workflowId, runId);
-    const logPath = yamlPath.replace(/\.yaml$/, ".log");
-
-    await this.notifyDirty(yamlPath);
-
-    try {
-      await Deno.remove(yamlPath);
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
-      }
-    }
-
-    try {
-      await Deno.remove(logPath);
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
-      }
-    }
-  }
-
   async deleteOlderThan(
     cutoff: Date,
     options?: { dryRun?: boolean },
@@ -472,7 +450,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
                 ? new Date(data.startedAt).getTime()
                 : undefined;
               const timestamp = completedAt ?? startedAt;
-              if (timestamp === undefined || timestamp >= cutoffMs) continue;
+              if (
+                timestamp === undefined || Number.isNaN(timestamp) ||
+                timestamp >= cutoffMs
+              ) continue;
 
               const logPath = yamlPath.replace(/\.yaml$/, ".log");
               let fileBytes = stat.size ?? 0;
@@ -495,6 +476,7 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
                 } catch (error) {
                   if (!(error instanceof Deno.errors.NotFound)) throw error;
                 }
+                await cleanupEmptyParentDirs(yamlPath, this.baseDir);
               }
 
               deleted++;

--- a/src/libswamp/data/run_gc.ts
+++ b/src/libswamp/data/run_gc.ts
@@ -1,0 +1,151 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import {
+  DEFAULT_OUTPUT_RETENTION_DAYS,
+  DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
+  DefaultRunLifecycleService,
+  type RunGcResult,
+} from "../../domain/data/run_lifecycle_service.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
+import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
+import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
+import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
+import type { LibSwampContext } from "../context.ts";
+import type { SwampError } from "../errors.ts";
+import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface RunGcData {
+  workflowRunsDeleted: number;
+  workflowRunBytesReclaimed: number;
+  outputsDeleted: number;
+  outputBytesReclaimed: number;
+  totalBytesReclaimed: number;
+  dryRun: boolean;
+}
+
+export type RunGcEvent =
+  | { kind: "collecting" }
+  | { kind: "completed"; data: RunGcData }
+  | { kind: "error"; error: SwampError };
+
+export interface RunGcInput {
+  dryRun: boolean;
+  workflowRunRetentionDays?: number;
+  outputRetentionDays?: number;
+}
+
+export interface RunGcPreview {
+  workflowRunsToDelete: number;
+  workflowRunBytesReclaimable: number;
+  outputsToDelete: number;
+  outputBytesReclaimable: number;
+  totalBytesReclaimable: number;
+}
+
+export interface RunGcDeps {
+  gcAll: (options: {
+    workflowRunRetentionDays: number;
+    outputRetentionDays: number;
+    dryRun: boolean;
+  }) => Promise<RunGcResult>;
+}
+
+export function createRunGcDeps(
+  repoDir: string,
+  datastoreResolver?: DatastorePathResolver,
+  markDirty?: MarkDirtyHook,
+): RunGcDeps {
+  const dsPath = (subdir: string): string | undefined =>
+    datastoreResolver?.resolvePath(subdir);
+  const workflowRunRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+    markDirty,
+  );
+  const outputRepo = new YamlOutputRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.outputs),
+    markDirty,
+  );
+  const service = new DefaultRunLifecycleService(workflowRunRepo, outputRepo);
+  return {
+    gcAll: (options) => service.gcAll(options),
+  };
+}
+
+export async function runGcPreview(
+  ctx: LibSwampContext,
+  deps: RunGcDeps,
+  input: RunGcInput,
+): Promise<RunGcPreview> {
+  ctx.logger.debug`Previewing run GC`;
+  const result = await deps.gcAll({
+    workflowRunRetentionDays: input.workflowRunRetentionDays ??
+      DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
+    outputRetentionDays: input.outputRetentionDays ??
+      DEFAULT_OUTPUT_RETENTION_DAYS,
+    dryRun: true,
+  });
+  return {
+    workflowRunsToDelete: result.workflowRunsDeleted,
+    workflowRunBytesReclaimable: result.workflowRunBytesReclaimed,
+    outputsToDelete: result.outputsDeleted,
+    outputBytesReclaimable: result.outputBytesReclaimed,
+    totalBytesReclaimable: result.workflowRunBytesReclaimed +
+      result.outputBytesReclaimed,
+  };
+}
+
+export async function* runGc(
+  _ctx: LibSwampContext,
+  deps: RunGcDeps,
+  input: RunGcInput,
+): AsyncIterable<RunGcEvent> {
+  yield* withGeneratorSpan(
+    "swamp.run.gc",
+    { "gc.dry_run": input.dryRun },
+    (async function* () {
+      yield { kind: "collecting" } as const;
+
+      const result = await deps.gcAll({
+        workflowRunRetentionDays: input.workflowRunRetentionDays ??
+          DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
+        outputRetentionDays: input.outputRetentionDays ??
+          DEFAULT_OUTPUT_RETENTION_DAYS,
+        dryRun: input.dryRun,
+      });
+
+      yield {
+        kind: "completed" as const,
+        data: {
+          workflowRunsDeleted: result.workflowRunsDeleted,
+          workflowRunBytesReclaimed: result.workflowRunBytesReclaimed,
+          outputsDeleted: result.outputsDeleted,
+          outputBytesReclaimed: result.outputBytesReclaimed,
+          totalBytesReclaimed: result.workflowRunBytesReclaimed +
+            result.outputBytesReclaimed,
+          dryRun: result.dryRun,
+        },
+      };
+    })(),
+  );
+}

--- a/src/libswamp/data/run_gc.ts
+++ b/src/libswamp/data/run_gc.ts
@@ -23,6 +23,8 @@ import {
   DefaultRunLifecycleService,
   type RunGcResult,
 } from "../../domain/data/run_lifecycle_service.ts";
+
+export { DEFAULT_OUTPUT_RETENTION_DAYS, DEFAULT_WORKFLOW_RUN_RETENTION_DAYS };
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";

--- a/src/libswamp/data/run_gc_test.ts
+++ b/src/libswamp/data/run_gc_test.ts
@@ -1,0 +1,118 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { runGc, type RunGcDeps, runGcPreview } from "./run_gc.ts";
+import { createLibSwampContext } from "../context.ts";
+import { getLogger } from "@logtape/logtape";
+
+function createMockCtx() {
+  return createLibSwampContext({ logger: getLogger(["test"]) });
+}
+
+function createMockDeps(result: {
+  workflowRunsDeleted: number;
+  workflowRunBytesReclaimed: number;
+  outputsDeleted: number;
+  outputBytesReclaimed: number;
+  dryRun: boolean;
+}): RunGcDeps {
+  return {
+    gcAll: () => Promise.resolve(result),
+  };
+}
+
+Deno.test("runGcPreview: returns preview with dryRun=true", async () => {
+  const deps = createMockDeps({
+    workflowRunsDeleted: 10,
+    workflowRunBytesReclaimed: 5000,
+    outputsDeleted: 5,
+    outputBytesReclaimed: 2000,
+    dryRun: true,
+  });
+
+  const preview = await runGcPreview(createMockCtx(), deps, {
+    dryRun: false,
+    workflowRunRetentionDays: 7,
+    outputRetentionDays: 7,
+  });
+
+  assertEquals(preview.workflowRunsToDelete, 10);
+  assertEquals(preview.workflowRunBytesReclaimable, 5000);
+  assertEquals(preview.outputsToDelete, 5);
+  assertEquals(preview.outputBytesReclaimable, 2000);
+  assertEquals(preview.totalBytesReclaimable, 7000);
+});
+
+Deno.test("runGc: yields collecting then completed events", async () => {
+  const deps = createMockDeps({
+    workflowRunsDeleted: 3,
+    workflowRunBytesReclaimed: 1500,
+    outputsDeleted: 2,
+    outputBytesReclaimed: 800,
+    dryRun: false,
+  });
+
+  const events = [];
+  for await (
+    const event of runGc(createMockCtx(), deps, {
+      dryRun: false,
+      workflowRunRetentionDays: 30,
+      outputRetentionDays: 30,
+    })
+  ) {
+    events.push(event);
+  }
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0].kind, "collecting");
+  assertEquals(events[1].kind, "completed");
+  if (events[1].kind === "completed") {
+    assertEquals(events[1].data.workflowRunsDeleted, 3);
+    assertEquals(events[1].data.outputsDeleted, 2);
+    assertEquals(events[1].data.totalBytesReclaimed, 2300);
+    assertEquals(events[1].data.dryRun, false);
+  }
+});
+
+Deno.test("runGc: uses default retention when not specified", async () => {
+  let capturedOptions: Record<string, unknown> | undefined;
+  const deps: RunGcDeps = {
+    gcAll: (options) => {
+      capturedOptions = options;
+      return Promise.resolve({
+        workflowRunsDeleted: 0,
+        workflowRunBytesReclaimed: 0,
+        outputsDeleted: 0,
+        outputBytesReclaimed: 0,
+        dryRun: true,
+      });
+    },
+  };
+
+  for await (
+    const _event of runGc(createMockCtx(), deps, { dryRun: true })
+  ) {
+    // consume
+  }
+
+  assertEquals(capturedOptions?.workflowRunRetentionDays, 30);
+  assertEquals(capturedOptions?.outputRetentionDays, 30);
+  assertEquals(capturedOptions?.dryRun, true);
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1147,6 +1147,8 @@ export {
 // Run GC operations (workflow-runs + outputs)
 export {
   createRunGcDeps,
+  DEFAULT_OUTPUT_RETENTION_DAYS,
+  DEFAULT_WORKFLOW_RUN_RETENTION_DAYS,
   runGc,
   type RunGcData,
   type RunGcDeps,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1144,6 +1144,18 @@ export {
   type DataPrunePreviewItem,
 } from "./data/prune.ts";
 
+// Run GC operations (workflow-runs + outputs)
+export {
+  createRunGcDeps,
+  runGc,
+  type RunGcData,
+  type RunGcDeps,
+  type RunGcEvent,
+  type RunGcInput,
+  type RunGcPreview,
+  runGcPreview,
+} from "./data/run_gc.ts";
+
 // Model create operations
 export {
   createModelCreateDeps,

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -134,6 +134,15 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     this.runs.delete(wfId);
     return Promise.resolve(runs.length);
   }
+  delete(_wfId: WorkflowId, _runId: WorkflowRunId): Promise<void> {
+    return Promise.resolve();
+  }
+  deleteOlderThan(
+    _cutoff: Date,
+    _options?: { dryRun?: boolean },
+  ): Promise<{ deleted: number; bytesReclaimed: number }> {
+    return Promise.resolve({ deleted: 0, bytesReclaimed: 0 });
+  }
 }
 
 /**

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -134,9 +134,6 @@ class InMemoryWorkflowRunRepository implements WorkflowRunRepository {
     this.runs.delete(wfId);
     return Promise.resolve(runs.length);
   }
-  delete(_wfId: WorkflowId, _runId: WorkflowRunId): Promise<void> {
-    return Promise.resolve();
-  }
   deleteOlderThan(
     _cutoff: Date,
     _options?: { dryRun?: boolean },

--- a/src/presentation/renderers/run_gc.ts
+++ b/src/presentation/renderers/run_gc.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  EventHandlers,
+  RunGcEvent,
+  RunGcPreview,
+} from "../../libswamp/mod.ts";
+import type { Renderer } from "../renderer.ts";
+import type { OutputMode } from "../output/output.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { UserError } from "../../domain/errors.ts";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+class LogRunGcRenderer implements Renderer<RunGcEvent> {
+  handlers(): EventHandlers<RunGcEvent> {
+    const logger = getSwampLogger(["run", "gc"]);
+    return {
+      collecting: () => {},
+      completed: (e) => {
+        const total = e.data.workflowRunsDeleted + e.data.outputsDeleted;
+        const totalBytes = formatBytes(e.data.totalBytesReclaimed);
+        if (e.data.dryRun) {
+          logger
+            .info`Run GC dry run: would delete ${e.data.workflowRunsDeleted} workflow run(s) (${
+            formatBytes(e.data.workflowRunBytesReclaimed)
+          }), ${e.data.outputsDeleted} output(s) (${
+            formatBytes(e.data.outputBytesReclaimed)
+          }), total: ${total} items (${totalBytes})`;
+          return;
+        }
+        logger
+          .info`Run GC complete: deleted ${e.data.workflowRunsDeleted} workflow run(s) (${
+          formatBytes(e.data.workflowRunBytesReclaimed)
+        }), ${e.data.outputsDeleted} output(s) (${
+          formatBytes(e.data.outputBytesReclaimed)
+        }), total: ${total} items (${totalBytes})`;
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonRunGcRenderer implements Renderer<RunGcEvent> {
+  handlers(): EventHandlers<RunGcEvent> {
+    return {
+      collecting: () => {},
+      completed: (e) => {
+        console.log(JSON.stringify(
+          {
+            workflowRunsDeleted: e.data.workflowRunsDeleted,
+            workflowRunBytesReclaimed: e.data.workflowRunBytesReclaimed,
+            outputsDeleted: e.data.outputsDeleted,
+            outputBytesReclaimed: e.data.outputBytesReclaimed,
+            totalBytesReclaimed: e.data.totalBytesReclaimed,
+            dryRun: e.data.dryRun,
+          },
+          null,
+          2,
+        ));
+      },
+      error: (e) => {
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createRunGcRenderer(
+  mode: OutputMode,
+): Renderer<RunGcEvent> {
+  switch (mode) {
+    case "json":
+      return new JsonRunGcRenderer();
+    case "log":
+      return new LogRunGcRenderer();
+  }
+}
+
+export function renderRunGcPreview(
+  preview: RunGcPreview,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(
+      {
+        workflowRunsToDelete: preview.workflowRunsToDelete,
+        workflowRunBytesReclaimable: preview.workflowRunBytesReclaimable,
+        outputsToDelete: preview.outputsToDelete,
+        outputBytesReclaimable: preview.outputBytesReclaimable,
+        totalBytesReclaimable: preview.totalBytesReclaimable,
+      },
+      null,
+      2,
+    ));
+  } else {
+    const logger = getSwampLogger(["run", "gc"]);
+    const total = preview.workflowRunsToDelete + preview.outputsToDelete;
+    if (total === 0) return;
+    logger
+      .info`Run GC preview: ${preview.workflowRunsToDelete} workflow run(s) (${
+      formatBytes(preview.workflowRunBytesReclaimable)
+    }), ${preview.outputsToDelete} output(s) (${
+      formatBytes(preview.outputBytesReclaimable)
+    }), total: ${formatBytes(preview.totalBytesReclaimable)} reclaimable`;
+  }
+}
+
+export function renderRunGcCancelled(mode: OutputMode): void {
+  if (mode === "json") {
+    console.log(JSON.stringify({ cancelled: true }, null, 2));
+  } else {
+    const logger = getSwampLogger(["run", "gc"]);
+    logger.info("Run GC cancelled.");
+  }
+}


### PR DESCRIPTION
## Summary

Closes swamp-club#1172.

- Adds `swamp run gc` command that deletes old workflow-run records (`.swamp/workflow-runs/`) and model method outputs (`.swamp/outputs/`) older than a configurable retention period
- Default retention is 30 days; override with `--older-than` (e.g. `7d`, `2w`, `1mo`)
- Supports `--dry-run` to preview what would be deleted, `--force` to skip confirmation, and `--json` for structured output
- Never deletes running or suspended workflow runs regardless of age
- Reports bytes reclaimed, broken down by workflow-runs vs outputs

## Test Plan

- Verified against a scratch repo with 21 workflow runs and 27 model outputs accumulated via `swamp workflow run` and `swamp model method run`
- `swamp run gc --dry-run --older-than 0d --json` correctly identifies all terminal runs
- `swamp run gc --force --older-than 0d` deletes all workflow-run YAML + log file pairs
- `swamp run gc --force --older-than 1m` deletes all outputs older than 1 minute
- Confirmed `swamp data gc` and `swamp data prune` still do NOT see these stores (gap preserved until this command fills it)
- All 9003 existing tests pass; 1 pre-existing unrelated failure in http_update_checker_test