### PR TITLE
feat(issue): surface ripple bodies in swamp issue get

### DIFF
--- a/src/cli/commands/issue_get.ts
+++ b/src/cli/commands/issue_get.ts
@@ -62,7 +62,8 @@ export const issueGetCommand = new Command()
     };
 
     const libCtx = createLibSwampContext({ logger: ctx.logger });
-    const renderer = createIssueGetRenderer(ctx.outputMode);
+    const verbose = ctx.verbosity === "verbose";
+    const renderer = createIssueGetRenderer(ctx.outputMode, verbose);
 
     await consumeStream(
       issueGet(libCtx, deps, { issueNumber }),

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -73,6 +73,13 @@ export function getCollectives(
   return whoami.organizations.map((org) => org.slug);
 }
 
+/** A single comment (ripple) on a Lab issue. */
+export interface IssueCommentRecord {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
 /** Response from fetching a Lab issue by number. */
 export interface FetchIssueResponse {
   number: number;
@@ -83,6 +90,7 @@ export interface FetchIssueResponse {
   body: string;
   assignees: string[];
   commentCount: number;
+  comments: IssueCommentRecord[];
 }
 
 /** Filters for the issue search endpoint. */
@@ -452,6 +460,7 @@ export class SwampClubClient {
 
     const data = await res.json();
     const issue = data.issue;
+    const rawComments: Record<string, unknown>[] = data.comments ?? [];
     return {
       number: issue.number,
       title: issue.title ?? "",
@@ -464,7 +473,13 @@ export class SwampClubClient {
           (a: Record<string, unknown>) => typeof a.username === "string",
         )
         .map((a: Record<string, string>) => a.username),
-      commentCount: (data.comments ?? []).length,
+      commentCount: rawComments.length,
+      comments: rawComments.map((c: Record<string, unknown>) => ({
+        author: (c.authorUsername as string | undefined) ??
+          (c.author as string | undefined) ?? "unknown",
+        body: (c.body as string | undefined) ?? "",
+        createdAt: (c.createdAt as string | undefined) ?? "",
+      })),
     };
   }
 

--- a/src/infrastructure/http/swamp_club_client_test.ts
+++ b/src/infrastructure/http/swamp_club_client_test.ts
@@ -605,6 +605,51 @@ Deno.test("fetchIssue: reads commentCount from top-level comments array", async 
   }
 });
 
+Deno.test("fetchIssue: returns comment bodies with author and createdAt", async () => {
+  const mock = startMockServer((_req) =>
+    Response.json({
+      issue: {
+        number: 42,
+        title: "Test issue",
+        type: "bug",
+        status: "open",
+        authorUsername: "alice",
+      },
+      comments: [
+        {
+          id: "c1",
+          authorUsername: "bob",
+          body: "first reply",
+          createdAt: "2026-07-01T10:00:00Z",
+        },
+        {
+          id: "c2",
+          author: "carol",
+          body: "second reply",
+          createdAt: "2026-07-02T12:00:00Z",
+        },
+      ],
+    })
+  );
+  try {
+    const client = new SwampClubClient(`http://localhost:${mock.port}`);
+    const result = await client.fetchIssue(undefined, 42);
+    assertEquals(result.comments.length, 2);
+    assertEquals(result.comments[0], {
+      author: "bob",
+      body: "first reply",
+      createdAt: "2026-07-01T10:00:00Z",
+    });
+    assertEquals(result.comments[1], {
+      author: "carol",
+      body: "second reply",
+      createdAt: "2026-07-02T12:00:00Z",
+    });
+  } finally {
+    await mock.shutdown();
+  }
+});
+
 Deno.test("fetchIssue: commentCount is 0 when no comments array in response", async () => {
   const mock = startMockServer((_req) =>
     Response.json({
@@ -615,6 +660,7 @@ Deno.test("fetchIssue: commentCount is 0 when no comments array in response", as
     const client = new SwampClubClient(`http://localhost:${mock.port}`);
     const result = await client.fetchIssue(undefined, 1);
     assertEquals(result.commentCount, 0);
+    assertEquals(result.comments, []);
   } finally {
     await mock.shutdown();
   }

--- a/src/libswamp/issues/get.ts
+++ b/src/libswamp/issues/get.ts
@@ -21,6 +21,12 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
+export interface IssueGetComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
 export interface IssueGetData {
   number: number;
   title: string;
@@ -30,6 +36,7 @@ export interface IssueGetData {
   body: string;
   assignees: string[];
   commentCount: number;
+  comments: IssueGetComment[];
   url: string;
 }
 

--- a/src/libswamp/issues/get_test.ts
+++ b/src/libswamp/issues/get_test.ts
@@ -34,6 +34,23 @@ function makeDeps(overrides: Partial<IssueGetDeps> = {}): IssueGetDeps {
         body: "Something is broken.",
         assignees: ["alice"],
         commentCount: 3,
+        comments: [
+          {
+            author: "alice",
+            body: "I can reproduce this.",
+            createdAt: "2026-07-01T10:00:00Z",
+          },
+          {
+            author: "bob",
+            body: "Working on a fix.",
+            createdAt: "2026-07-02T12:00:00Z",
+          },
+          {
+            author: "alice",
+            body: "Thanks!",
+            createdAt: "2026-07-03T14:00:00Z",
+          },
+        ],
         url: "https://swamp-club.com/lab/42",
       }),
     ...overrides,
@@ -56,6 +73,9 @@ Deno.test("issueGet: yields completed with fetched issue data", async () => {
   assertEquals(completed.data.body, "Something is broken.");
   assertEquals(completed.data.assignees, ["alice"]);
   assertEquals(completed.data.commentCount, 3);
+  assertEquals(completed.data.comments.length, 3);
+  assertEquals(completed.data.comments[0].author, "alice");
+  assertEquals(completed.data.comments[0].body, "I can reproduce this.");
   assertEquals(completed.data.url, "https://swamp-club.com/lab/42");
 });
 
@@ -73,6 +93,7 @@ Deno.test("issueGet: passes issueNumber to fetchIssue dep", async () => {
         body: "A feature.",
         assignees: [],
         commentCount: 0,
+        comments: [],
         url: "https://swamp-club.com/lab/42",
       });
     },

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1329,6 +1329,7 @@ export {
 } from "./issues/comment.ts";
 export {
   issueGet,
+  type IssueGetComment,
   type IssueGetData,
   type IssueGetDeps,
   type IssueGetEvent,

--- a/src/presentation/renderers/issue_get.ts
+++ b/src/presentation/renderers/issue_get.ts
@@ -26,7 +26,14 @@ import { bold, cyan, dim } from "@std/fmt/colors";
 import { renderMarkdownToTerminal } from "../markdown_renderer.ts";
 
 class LogIssueGetRenderer implements Renderer<IssueGetEvent> {
+  #verbose: boolean;
+
+  constructor(verbose: boolean) {
+    this.#verbose = verbose;
+  }
+
   handlers(): EventHandlers<IssueGetEvent> {
+    const verbose = this.#verbose;
     return {
       completed: (e) => {
         const d = e.data;
@@ -43,6 +50,18 @@ class LogIssueGetRenderer implements Renderer<IssueGetEvent> {
         if (d.body.length > 0) {
           writeOutput("");
           writeOutput(renderMarkdownToTerminal(d.body));
+        }
+        if (verbose && d.comments.length > 0) {
+          writeOutput("");
+          writeOutput(bold("── Ripples ─────────────────────────────"));
+          for (const c of d.comments) {
+            const ts = c.createdAt ? dim(` ${c.createdAt}`) : "";
+            writeOutput(`${bold(c.author)}${ts}`);
+            if (c.body.length > 0) {
+              writeOutput(renderMarkdownToTerminal(c.body));
+            }
+            writeOutput("");
+          }
         }
         writeOutput("");
         writeOutput(dim(`View at: ${d.url}`));
@@ -69,11 +88,12 @@ class JsonIssueGetRenderer implements Renderer<IssueGetEvent> {
 
 export function createIssueGetRenderer(
   mode: OutputMode,
+  verbose = false,
 ): Renderer<IssueGetEvent> {
   switch (mode) {
     case "json":
       return new JsonIssueGetRenderer();
     case "log":
-      return new LogIssueGetRenderer();
+      return new LogIssueGetRenderer(verbose);
   }
 }


### PR DESCRIPTION
## Summary

- Thread comment/ripple data through `SwampClubClient.fetchIssue()` → `IssueGetData` → renderers so users can read ripple bodies from the CLI
- `--json` mode always includes a `comments` array with `author`, `body`, `createdAt`
- `--verbose` mode renders ripple bodies inline (author, timestamp, markdown body) under a `── Ripples ──` section
- Default log output unchanged — compact `Comments: N` line

Closes swamp-club#1191

## Test Plan

- Unit tests: `SwampClubClient.fetchIssue` returns comment bodies with correct author fallback (`authorUsername` → `author` → `"unknown"`)
- Unit tests: `issueGet` libswamp generator flows comments through `IssueGetData`
- Manual: `./swamp issue get 1193` (normal) shows `Comments: 1` without bodies
- Manual: `./swamp issue get 1193 --verbose` shows ripple body with author and timestamp
- Manual: `./swamp issue get 1193 --json` includes full `comments` array
- Full test suite: 9009 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)