### PR TITLE
fix(auth): fix login prompt issues — honor --username, support piped stdin (swamp-club#1194)

### DIFF
--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -119,10 +119,10 @@ export class SwampClubClient {
     username: string,
     password: string,
   ): Promise<SignInResponse> {
-    const res = await this.fetch("/api/auth/sign-in/email", {
+    const res = await this.fetch("/api/auth/sign-in/credential", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: username, password }),
+      body: JSON.stringify({ credential: username, password }),
     });
 
     if (!res.ok) {

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -82,8 +82,11 @@ export interface AuthLoginDeps {
     username: string,
     password: string,
   ) => Promise<{ token: string; username: string }>;
-  /** Read credentials from user (for interactive stdin flow). */
-  readCredentials: () => Promise<{ username: string; password: string }>;
+  /** Read credentials from user (for interactive stdin flow). Skips prompts for prefilled fields. */
+  readCredentials: (prefilled?: {
+    username?: string;
+    password?: string;
+  }) => Promise<{ username: string; password: string }>;
   /** Create API key for CLI use. */
   createApiKey: (
     serverUrl: string,
@@ -129,10 +132,10 @@ async function readLine(prompt: string): Promise<string> {
   return decoder.decode(buf.subarray(0, n)).trim();
 }
 
-/** Read a password from stdin without echoing. */
+/** Read a password from stdin without echoing. Falls back to readLine for piped stdin. */
 async function readPassword(prompt: string): Promise<string> {
   if (!Deno.stdin.isTerminal()) {
-    return "";
+    return await readLine(prompt);
   }
   try {
     return await readSecretFromTty(prompt);
@@ -176,9 +179,11 @@ export function createAuthLoginDeps(
       const result = await client.signIn(username, password);
       return { token: result.token, username: result.user.username };
     },
-    readCredentials: async () => {
-      const username = await readLine("Username or email: ");
-      const password = await readPassword("Password: ");
+    readCredentials: async (prefilled) => {
+      const username = prefilled?.username ??
+        await readLine("Username or email: ");
+      const password = prefilled?.password ??
+        await readPassword("Password: ");
       return { username, password };
     },
     createApiKey: async (
@@ -252,9 +257,9 @@ export async function* authLogin(
         let username = input.username;
         let password = input.password;
         if (!username || !password) {
-          const creds = await deps.readCredentials();
-          username = username ?? creds.username;
-          password = password ?? creds.password;
+          const creds = await deps.readCredentials({ username, password });
+          username = creds.username;
+          password = creds.password;
         }
 
         if (!username || !password) {

--- a/src/libswamp/auth/login_test.ts
+++ b/src/libswamp/auth/login_test.ts
@@ -37,7 +37,7 @@ function makeDeps(overrides: Partial<AuthLoginDeps> = {}): AuthLoginDeps {
     }),
     signIn: (_serverUrl: string, _username: string, _password: string) =>
       Promise.resolve({ token: "session-token-abc", username: "testuser" }),
-    readCredentials: () =>
+    readCredentials: (_prefilled) =>
       Promise.resolve({ username: "testuser", password: "testpass" }),
     createApiKey: (
       _serverUrl: string,
@@ -167,7 +167,7 @@ Deno.test("authLogin: successful stdin flow with provided credentials", async ()
 Deno.test("authLogin: stdin flow reads credentials when not provided", async () => {
   let readCalled = false;
   const deps = makeDeps({
-    readCredentials: () => {
+    readCredentials: (_prefilled) => {
       readCalled = true;
       return Promise.resolve({ username: "interactive", password: "secret" });
     },
@@ -195,7 +195,8 @@ Deno.test("authLogin: stdin flow reads credentials when not provided", async () 
 
 Deno.test("authLogin: stdin flow missing credentials yields validation error", async () => {
   const deps = makeDeps({
-    readCredentials: () => Promise.resolve({ username: "", password: "" }),
+    readCredentials: (_prefilled) =>
+      Promise.resolve({ username: "", password: "" }),
   });
   const input = makeInput({ useBrowserFlow: false });
 
@@ -214,6 +215,87 @@ Deno.test("authLogin: stdin flow missing credentials yields validation error", a
     errorEvent.error.message,
     "Username and password are required.",
   );
+});
+
+Deno.test("authLogin: stdin flow with --username skips username prompt", async () => {
+  let prefilledArg: { username?: string; password?: string } | undefined;
+  const deps = makeDeps({
+    readCredentials: (prefilled) => {
+      prefilledArg = prefilled;
+      return Promise.resolve({
+        username: prefilled?.username ?? "prompted",
+        password: "prompted-pass",
+      });
+    },
+  });
+  const input = makeInput({
+    useBrowserFlow: false,
+    username: "alice",
+  });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(prefilledArg?.username, "alice");
+  assertEquals(prefilledArg?.password, undefined);
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, ["securing_session", "completed"]);
+});
+
+Deno.test("authLogin: stdin flow with --password skips password prompt", async () => {
+  let prefilledArg: { username?: string; password?: string } | undefined;
+  const deps = makeDeps({
+    readCredentials: (prefilled) => {
+      prefilledArg = prefilled;
+      return Promise.resolve({
+        username: "prompted-user",
+        password: prefilled?.password ?? "prompted",
+      });
+    },
+  });
+  const input = makeInput({
+    useBrowserFlow: false,
+    password: "secret",
+  });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(prefilledArg?.username, undefined);
+  assertEquals(prefilledArg?.password, "secret");
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, ["securing_session", "completed"]);
+});
+
+Deno.test("authLogin: stdin flow with both --username and --password skips all prompts", async () => {
+  let readCalled = false;
+  const deps = makeDeps({
+    readCredentials: (_prefilled) => {
+      readCalled = true;
+      return Promise.resolve({
+        username: "should-not-be-called",
+        password: "x",
+      });
+    },
+  });
+  const input = makeInput({
+    useBrowserFlow: false,
+    username: "alice",
+    password: "secret",
+  });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(readCalled, false);
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds, ["securing_session", "completed"]);
 });
 
 Deno.test("authLogin: callback server is shut down after browser flow", async () => {


### PR DESCRIPTION
## Summary

Fixes three UX bugs in `swamp auth login` reported in swamp-club#1194:

- **Username support**: Switch `signIn()` from `/api/auth/sign-in/email` to `/api/auth/sign-in/credential` (shipped in swamp-club/swamp-club#906) so both usernames and emails work with the "Username or email:" prompt
- **`--username` flag honored**: `readCredentials()` now accepts optional prefilled fields and only prompts for missing ones — `--username alice` skips the username prompt and only asks for password
- **Piped stdin works**: `readPassword()` falls back to `readLine()` for non-TTY stdin instead of returning empty string — `printf 'pass\n' | swamp auth login --username alice` now works

## Test Plan

- [x] 9 unit tests pass (6 existing + 3 new) in `login_test.ts`
- [x] Full test suite passes (9030 tests)
- [x] Compiled binary verified: `--username alice` only prompts for password
- [x] Compiled binary verified: `echo "pass" | swamp auth login --username alice` reads piped password
- [x] Type check, lint, and format all pass

## Follow-up

- File docs issue in swamp-club/swamp-club to update `content/manual/how-to/authenticate-with-api-keys.md` with username support and piped password examples