### PR TITLE
fix(install): fail with actionable error when /usr/local/bin missing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -320,6 +320,10 @@ symlink_to_system_path() {
   local prompt="[sudo required to link $bin under $system_path]"
   prompt="$prompt Password for %u: "
 
+  if [ ! -d "$system_path" ]; then
+    die "Directory '$system_path' does not exist. Create it with 'sudo mkdir -p $system_path' or re-run the installer with '-d <path>' to choose a different destination."
+  fi
+
   info "Symlinking '$dest' to $system_path/$bin"
   sudo -p "$prompt" ln -snf "$dest" "$system_path/$bin"
 }


### PR DESCRIPTION
## Summary

- Fixes swamp-club#1202 — installer fails with confusing `ln` error on fresh Linux installs where `/usr/local/bin` doesn't exist
- Adds a directory existence check in `symlink_to_system_path()` that dies with a clear message suggesting `sudo mkdir -p /usr/local/bin` or re-running with `-d <path>`

## Test Plan

- Verified the logic: `[ ! -d "/usr/local/bin" ]` correctly detects missing directory
- The `die` function is the existing fatal-error handler used throughout the script
- On systems where `/usr/local/bin` exists, the check is a no-op and the symlink proceeds as before

Closes swamp-club#1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Sven Dowideit <SvenDowideit@home.org.au>