### PR TITLE
fix(docs): comprehensive design doc refresh

### DIFF
--- a/design/audit-doctor.md
+++ b/design/audit-doctor.md
@@ -25,7 +25,7 @@ silently.
 Run in fixed order so output is stable:
 
 1. **`binary-on-path`** — the AI tool's own binary (`claude`, `cursor`,
-   `kiro-cli`, `opencode`) is resolvable on PATH.
+   `kiro-cli`, `opencode`, `copilot`) is resolvable on PATH.
 2. **`swamp-binary-on-path`** — swamp is on PATH (all four tools invoke
    `swamp audit record --from-hook` from their hook configs). For Kiro
    only, also verifies the absolute swamp path baked into
@@ -49,7 +49,7 @@ Run in fixed order so output is stable:
 ```
 src/domain/audit/doctor/
 ├── check.ts                       — PreflightCheck interface, CheckResult, SpawnFn, NoToolConfiguredError
-├── doctor_service.ts              — auditDoctor() streaming service; DEFAULT_CHECK_ORDER
+├── doctor_service.ts              — auditDoctor() streaming service; defaultCheckOrder()
 ├── synthetic_payloads.ts          — per-tool fixture payloads; imports DIAGNOSTIC_COMMAND_PREFIX
 └── checks/
     ├── resolve_binary.ts          — ResolveBinary port + POSIX `which` implementation
@@ -57,7 +57,7 @@ src/domain/audit/doctor/
     ├── swamp_binary_on_path.ts    — includes Kiro baked-path sub-check
     ├── agent_config_loadable.ts   — tool-dispatched parser
     ├── default_agent_set.ts       — Kiro-only
-    └── recording_smoke_test.ts    — uses ctx.spawnSwamp + reads today's JSONL
+    └── recording_smoke.ts         — uses ctx.spawnSwamp + reads today's JSONL
 ```
 
 The service emits four event kinds: `check-started`, `check-completed`,

--- a/design/audit.md
+++ b/design/audit.md
@@ -1,7 +1,7 @@
 # Audit subdomain
 
 Records and reports the bash/tool-use commands the user's AI coding agent
-(Claude Code, Cursor, Kiro, OpenCode) invokes while working in a
+(Claude Code, Cursor, Kiro, OpenCode, Copilot) invokes while working in a
 swamp-initialized repository. Acts as an append-only activity log —
 useful for reviewing what an agent has been doing and for correlating
 agent actions with swamp workflow runs.
@@ -40,7 +40,7 @@ agent actions with swamp workflow runs.
 
 ## Repo layout of audit config
 
-The four supported tools wire their audit hook into tool-specific config
+The five supported tools wire their audit hook into tool-specific config
 files that `swamp init --tool <tool>` generates. Locations summarized:
 
 | Tool     | Hook config                              | Default-agent config    |
@@ -49,11 +49,13 @@ files that `swamp init --tool <tool>` generates. Locations summarized:
 | Cursor   | `.cursor/hooks.json`                     | n/a                     |
 | Kiro     | `.kiro/hooks/swamp-audit.kiro.hook` + `.kiro/agents/swamp.json` | `.kiro/settings/cli.json` |
 | OpenCode | `.opencode/plugins/swamp-audit.ts`       | n/a                     |
+| Copilot  | `.github/hooks/`                         | n/a                     |
 
 See `src/domain/repo/repo_service.ts` for the exact generators
 (`updateClaudeSettings`, `updateCursorHooks`, `updateKiroHooks`,
 `updateKiroAgentConfig`, `ensureKiroCliDefaultAgent`,
-`updateOpenCodePlugin`).
+`updateOpenCodePlugin`, `updateCopilotHooks`,
+`createCopilotHooksIfNotExists`).
 
 ## Reserved session / command prefixes
 

--- a/design/data-query.md
+++ b/design/data-query.md
@@ -98,10 +98,15 @@ interface DataRecord {
   id: string;
   name: string;
   version: number;
+  isLatest: boolean;
   createdAt: string;
+  // Provenance namespace (giga-swamp Phase 2). Identifies which repo produced
+  // this data within a shared datastore. Empty string ('') in solo mode.
+  namespace: string;
   attributes: Record<string, unknown>;
   tags: Record<string, string>;
   modelName: string;
+  modelId: string;
   modelType: string;
   specName: string;
   dataType: string;
@@ -112,8 +117,8 @@ interface DataRecord {
   size: number;
   content: string;
 
-  // Provenance fields — promoted from tags/ownerDefinition.
-  // Empty string when data was not produced inside a workflow.
+  // Provenance fields — promoted from tags/ownerDefinition to first-class.
+  // Empty string when the data was not produced inside a workflow.
   ownerRef: string;
   workflowRunId: string;
   workflowName: string;
@@ -123,9 +128,11 @@ interface DataRecord {
 }
 ```
 
-All `DataRecord` fields are populated by a unified `DataRecordMapper`
-(`fromRow()` for catalog-backed queries, `fromData()` for version lookups).
-This is backward-compatible: existing code that reads `record.name` or
+All `DataRecord` fields are populated by standalone exported mapper functions
+in `data_record_mapper.ts`: `fromRow()` for catalog-backed queries,
+`fromData()` for version lookups, `fromResourceHandle()` for workflow step
+resource outputs, and `fromFileHandle()` for file-kind outputs. This is
+backward-compatible: existing code that reads `record.name` or
 `record.attributes` continues to work; the provenance fields are additive.
 
 For JSON resources (`contentType == "application/json"`), `attributes` contains
@@ -145,7 +152,8 @@ filterable fields:
 | --- | --- | --- |
 | `id` | string | Data artifact UUID |
 | `name` | string | Data artifact name |
-| `version` | int | Latest version number |
+| `version` | int | Version number |
+| `isLatest` | bool | Whether this is the latest version of the artifact |
 | `createdAt` | string | ISO-8601 timestamp |
 | `attributes` | map | Parsed JSON content (lazy-loaded, resources only) |
 | `tags` | map | All tags as key-value pairs |
@@ -223,26 +231,31 @@ identifiers are known query record fields. Unknown fields produce an error:
 
 ```
 Error: Unknown field "model" in query predicate.
-Available: id, name, version, createdAt, attributes, tags, modelName,
-  modelType, specName, dataType, contentType, lifetime, ownerType, streaming, size
+Available: id, name, version, isLatest, createdAt, attributes, tags, modelName,
+  modelType, specName, dataType, contentType, lifetime, ownerType, streaming,
+  size, content, ownerRef, workflowRunId, workflowName, jobName, stepName,
+  source, ns
 ```
 
 ## Catalog
 
 Query performance is backed by a SQLite metadata catalog at
 `.swamp/data/_catalog.db`, using `node:sqlite` (built into the Deno runtime).
-The catalog stores one row per artifact (latest version only) containing all
-metadata fields from the query record except `attributes`.
+The catalog stores one row per artifact version, with an `is_latest` column
+distinguishing the current version. It contains all metadata fields from the
+query record except `attributes`.
 
 ### Schema
 
 ```sql
 CREATE TABLE catalog (
+  namespace       TEXT NOT NULL DEFAULT '',
   type_normalized TEXT NOT NULL,
   model_id        TEXT NOT NULL,
   data_name       TEXT NOT NULL,
   id              TEXT NOT NULL,
   version         INTEGER NOT NULL,
+  is_latest       INTEGER NOT NULL DEFAULT 1,
   model_name      TEXT NOT NULL,
   spec_name       TEXT NOT NULL DEFAULT '',
   data_type       TEXT NOT NULL DEFAULT '',
@@ -259,15 +272,18 @@ CREATE TABLE catalog (
   job_name        TEXT NOT NULL DEFAULT '',
   step_name       TEXT NOT NULL DEFAULT '',
   source          TEXT NOT NULL DEFAULT '',
-  PRIMARY KEY (type_normalized, model_id, data_name)
+  PRIMARY KEY (namespace, type_normalized, model_id, data_name, version)
 );
 
-CREATE INDEX idx_model_name      ON catalog(model_name);
-CREATE INDEX idx_spec_name       ON catalog(spec_name);
-CREATE INDEX idx_data_type       ON catalog(data_type);
-CREATE INDEX idx_created_at      ON catalog(created_at);
-CREATE INDEX idx_workflow_run_id ON catalog(workflow_run_id);
-CREATE INDEX idx_step_name       ON catalog(step_name);
+CREATE INDEX idx_catalog_model_name      ON catalog(model_name);
+CREATE INDEX idx_catalog_spec_name       ON catalog(spec_name);
+CREATE INDEX idx_catalog_data_type       ON catalog(data_type);
+CREATE INDEX idx_catalog_created_at      ON catalog(created_at);
+CREATE INDEX idx_catalog_workflow_run_id ON catalog(workflow_run_id);
+CREATE INDEX idx_catalog_step_name       ON catalog(step_name);
+CREATE INDEX idx_namespace               ON catalog(namespace);
+CREATE INDEX idx_catalog_is_latest       ON catalog(namespace, type_normalized, model_id, data_name, is_latest);
+CREATE INDEX idx_catalog_latest_lookup   ON catalog(model_name, data_name, is_latest, namespace);
 
 CREATE TABLE catalog_meta (
   key   TEXT PRIMARY KEY,
@@ -296,8 +312,9 @@ Every mutation in `UnifiedDataRepository` updates the catalog inline:
 | `removeLatestMarker()` | Remove row |
 | `collectGarbage()` | Update version or remove row |
 
-The `CatalogStore` is a required constructor parameter on
-`UnifiedDataRepository`. Every repository instance maintains write-through
+`UnifiedDataRepository` is an interface (in `repositories.ts`). The concrete
+`FileSystemUnifiedDataRepository` takes `CatalogStore` as a required
+constructor parameter. Every repository instance maintains write-through
 catalog consistency. Use `createCatalogStore()` from `repository_factory.ts`
 to construct one from a repo directory.
 
@@ -335,19 +352,10 @@ On cold start (new machine, empty cache), the initial pull downloads all files.
 The catalog doesn't exist yet, so the first query triggers a backfill from the
 freshly-pulled cache.
 
-The `DatastoreSyncService` interface returns the diff:
-
-```typescript
-interface SyncDiff {
-  changed: string[];
-  deleted: string[];
-}
-
-interface DatastoreSyncService {
-  pullChanged(): Promise<SyncDiff>;
-  pushChanged(): Promise<void>;
-}
-```
+The `DatastoreSyncService.pullChanged()` method returns
+`Promise<number | void>` — it reports the count of changed files (or void) but
+does not return a structured diff. Catalog updates after a pull are driven by
+the sync implementation internally.
 
 ## Query Execution
 
@@ -359,7 +367,7 @@ and CEL handles all filtering semantics.
 1. Parse predicate into AST
 2. Validate field references
 3. Detect whether predicate references `attributes`
-4. SELECT metadata columns from catalog (via stmt.iterate())
+4. SELECT metadata columns from catalog (via paged LIMIT/OFFSET queries using stmt.all())
 5. For each row:
    a. Project row into query record
    b. If predicate references `attributes`:
@@ -370,9 +378,9 @@ and CEL handles all filtering semantics.
 6. Return results
 ```
 
-Iteration uses `stmt.iterate()` so that only one row is in memory at a time.
-Content is loaded per-row only when needed. The query stops as soon as the
-limit is reached.
+Iteration uses paged `stmt.all()` with `LIMIT/OFFSET` so that rows are fetched
+in bounded batches. Content is loaded per-row only when needed. The query stops
+as soon as the limit is reached.
 
 When the predicate does not reference `attributes`, the SELECT omits content
 loading entirely. This is detected by walking the AST for the `attributes`

--- a/design/datastores.md
+++ b/design/datastores.md
@@ -64,8 +64,8 @@ ship with.
 The `DatastoreTypeRegistry` is a Map-backed singleton
 (`datastoreTypeRegistry`). The built-in type (filesystem) is registered at
 startup. Extension types (e.g., `@swamp/s3-datastore`) are loaded from
-`extensions/datastores/` via `UserDatastoreLoader` or auto-resolved from the
-registry on first use. Types must follow the `@collective/name` or
+`extensions/datastores/` via `ExtensionLoader` with `datastoreKindAdapter` or
+auto-resolved from the registry on first use. Types must follow the `@collective/name` or
 `collective/name` pattern (e.g., `@myorg/redis-store`). Duplicate type
 registrations are rejected with an error.
 
@@ -85,12 +85,13 @@ See `src/domain/datastore/datastore_provider.ts` for the full interface.
 
 ### Loading & Bundling
 
-`UserDatastoreLoader` discovers `.ts` files recursively in the datastores
-directory (excluding `_test.ts` files), bundles each via Deno with zod
-externalized, and validates the export against `UserDatastoreSchema` — a Zod
-schema requiring `type`, `name`, `description`, an optional `configSchema`, and
-a `createProvider` factory function. Files without a `datastore` export are
-silently skipped. Bundles are cached in `.swamp/datastore-bundles/` with
+`ExtensionLoader` (with `datastoreKindAdapter`) discovers `.ts` files
+recursively in the datastores directory (excluding `_test.ts` files), bundles
+each via Deno with zod externalized, and validates the export against
+`UserDatastoreSchema` — a Zod schema requiring `type`, `name`, `description`,
+an optional `configSchema`, and a `createProvider` factory function. Files
+without a `datastore` export are silently skipped. Bundles are cached in
+`.swamp/datastore-bundles/` with
 content-fingerprint invalidation (sha-256 over the entry point plus every
 local `.ts` dep) to avoid redundant compilation — mtime-based freshness was
 unreliable under atomic-rename saves, mtime-preserving sync tools, and
@@ -122,7 +123,8 @@ defined by the extension.
 |------|---------|
 | `src/domain/datastore/datastore_provider.ts` | `DatastoreProvider` interface |
 | `src/domain/datastore/datastore_type_registry.ts` | Type registry singleton |
-| `src/domain/datastore/user_datastore_loader.ts` | Loader, validator, bundler |
+| `src/domain/extensions/extension_loader.ts` | Generic extension loader (used with kind adapters) |
+| `src/domain/extensions/datastore_kind_adapter.ts` | Datastore-specific kind adapter for ExtensionLoader |
 | `src/domain/datastore/datastore_sync_service.ts` | `DatastoreSyncService` interface |
 
 ## Configuration
@@ -402,7 +404,7 @@ deduplicated models. When `twoPhaseSync` is `true`, the push is split into
 
 **Catalog rebuild invariant.** `synced = true` is set after `pullChanged()`
 succeeds on both the scoped and full paths. This boolean is returned in
-`{ flush, synced }` and checked at 8 call sites across the codebase to trigger
+`{ flush, synced }` and checked at 19 call sites across the codebase to trigger
 `catalogStore.invalidate()`. It must never be skipped or moved.
 
 ### Namespace-Scoped Sync
@@ -994,8 +996,8 @@ rewrites even when the file size doesn't change.
 
 All pull and push operations download/upload files concurrently in batches of
 10. This reduces wall-clock time for syncs with many files by overlapping S3
-round trips. The concurrency limit (`MAX_CONCURRENCY = 10`) prevents
-overwhelming the network or hitting S3 request rate limits.
+round trips. The concurrency limit prevents overwhelming the network or hitting
+S3 request rate limits.
 
 ### Offline Behavior
 
@@ -1039,7 +1041,8 @@ Lock metadata (`LockInfo`) is stored as JSON:
   "hostname": "hostname",
   "pid": 12345,
   "acquiredAt": "2026-03-10T12:00:00.000Z",
-  "ttlMs": 30000
+  "ttlMs": 30000,
+  "nonce": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 }
 ```
 
@@ -1346,4 +1349,13 @@ and exclude patterns.
 | `src/cli/commands/datastore_setup.ts` | `swamp datastore setup` (filesystem + extension) |
 | `src/cli/commands/datastore_sync.ts` | `swamp datastore sync` (manual) |
 | `src/cli/commands/datastore_lock.ts` | `swamp datastore lock` (status + release) |
-| `src/presentation/output/datastore_output.ts` | Datastore command rendering (log + json) |
+| `src/presentation/renderers/datastore_status.ts` | `swamp datastore status` rendering |
+| `src/presentation/renderers/datastore_sync.ts` | `swamp datastore sync` rendering |
+| `src/presentation/renderers/datastore_lock.ts` | `swamp datastore lock` rendering |
+| `src/presentation/renderers/datastore_setup.ts` | `swamp datastore setup` rendering |
+| `src/presentation/renderers/datastore_compact.ts` | `swamp datastore compact` rendering |
+| `src/presentation/renderers/datastore_migrate_index.ts` | `swamp datastore migrate-index` rendering |
+| `src/presentation/renderers/datastore_namespace_set.ts` | `swamp datastore namespace set` rendering |
+| `src/presentation/renderers/datastore_namespace_unset.ts` | `swamp datastore namespace unset` rendering |
+| `src/presentation/renderers/datastore_namespace_migrate.ts` | `swamp datastore namespace migrate` rendering |
+| `src/presentation/renderers/datastore_namespace_list.ts` | `swamp datastore namespace list` rendering |

--- a/design/expressions.md
+++ b/design/expressions.md
@@ -234,7 +234,7 @@ attributes:
 ### data.listVersions(modelName, dataName)
 
 Returns an array of available version numbers for a data artifact, sorted in
-descending order (newest first):
+ascending order (oldest first):
 
 ```yaml
 attributes:

--- a/design/extension.md
+++ b/design/extension.md
@@ -7,11 +7,12 @@ others can pull into their repositories.
 
 ## Name
 
-Every extension has a scoped name in the format `@collective/name`. The collective
-identifies the collective, and the name identifies the extension. Additional
-path segments are allowed for organizing related extensions hierarchically.
-All parts must be lowercase and may contain alphanumeric characters, hyphens,
-and underscores. The pattern is `@[a-z0-9_-]+/[a-z0-9_-]+(/[a-z0-9_-]+)*`.
+Every extension has a scoped name in the format `@collective/name`. The
+collective identifies the collective, and the name identifies the extension.
+Additional path segments are allowed for organizing related extensions
+hierarchically. All parts must be lowercase and may contain alphanumeric
+characters, hyphens, and underscores. The pattern is
+`@[a-z0-9_-]+/[a-z0-9_-]+(/[a-z0-9_-]+)*`.
 
 The collectives `@swamp` and `@si` are reserved for built-in extensions and
 cannot be used by external authors.
@@ -23,8 +24,8 @@ Examples: `@keeb/ssh`, `@acme/deploy`, `@myorg/aws-helpers`, `@swamp/aws/ec2`,
 
 ## Version
 
-Extensions use **CalVer** format `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`).
-The micro counter allows multiple versions per day and resets for each new date.
+Extensions use **CalVer** format `YYYY.MM.DD.MICRO` (e.g., `2026.02.26.1`). The
+micro counter allows multiple versions per day and resets for each new date.
 This is the same versioning scheme used by models (see [./models.md]).
 
 The registry enforces unique name+version tuples. If a version conflict occurs
@@ -41,9 +42,9 @@ human-readable; the epoch suffix handles uniqueness and encodes the exact
 publish time.
 
 Use `swamp extension version <name>` to query the registry for the latest
-published version and compute the next CalVer version. Accepts an extension
-name directly or `--manifest <path>` to read the name from a manifest file.
-Does not require a swamp repository — works from any directory.
+published version and compute the next CalVer version. Accepts an extension name
+directly or `--manifest <path>` to read the name from a manifest file. Does not
+require a swamp repository — works from any directory.
 
 ## Release Channels
 
@@ -83,12 +84,12 @@ are globally unique.
 
 ### Search and Versions
 
-`swamp extension search --channel rc --channel beta` filters to extensions
-with versions in either channel. `--channel` is a collect flag (multiple
-allowed). No `--channel` shows stable-only results.
+`swamp extension search --channel rc --channel beta` filters to extensions with
+versions in either channel. `--channel` is a collect flag (multiple allowed). No
+`--channel` shows stable-only results.
 
-`swamp extension versions @name --channel rc` lists version history filtered
-by channel. No `--channel` shows all versions.
+`swamp extension version @name` shows the latest published version and computes
+the next CalVer version for an extension.
 
 ### Info
 
@@ -97,9 +98,9 @@ beta) when they exist. No flag needed — info always shows all channels.
 
 The info command also displays content metadata for the latest version: model
 types with their methods, workflows, vaults, datastores, drivers, reports, and
-skills. By default, models show the type name and method names. With `--verbose`,
-each method's arguments and descriptions are also displayed. JSON output
-(`--json`) includes the full `contentMetadata` object with all detail.
+skills. By default, models show the type name and method names. With
+`--verbose`, each method's arguments and descriptions are also displayed. JSON
+output (`--json`) includes the full `contentMetadata` object with all detail.
 
 ### Promotion
 
@@ -120,14 +121,14 @@ re-uploaded. The server recalculates per-channel latest after promotion.
 ### Auto-resolve safety
 
 Beta and rc versions are never auto-resolved via trusted collectives. Only
-stable versions participate in auto-resolution. Lockfile-pinned restores
-fetch by exact version regardless of channel.
+stable versions participate in auto-resolution. Lockfile-pinned restores fetch
+by exact version regardless of channel.
 
 ### Lockfile
 
 The `upstream_extensions.json` entry records the channel the extension was
-installed from (`channel` field). Pre-channel entries default to `"stable"`
-on read. The update service checks for updates within the installed channel.
+installed from (`channel` field). Pre-channel entries default to `"stable"` on
+read. The update service checks for updates within the installed channel.
 
 ### Update cache
 
@@ -137,146 +138,132 @@ non-stable uses `name:channel` (e.g. `@swamp/aws:rc`).
 
 ## Freshness
 
-Two opt-in user-facing surfaces report whether installed extensions are
-behind the registry's latest version. There is no passive on-load
-warning — extension freshness is surfaced only when the user explicitly
-asks for it.
+Two opt-in user-facing surfaces report whether installed extensions are behind
+the registry's latest version. There is no passive on-load warning — extension
+freshness is surfaced only when the user explicitly asks for it.
 
 ### `swamp extension list`
 
-Augments the installed-extensions table with a "latest" column when
-stdout is a terminal. Outdated rows are marked `(update available)`;
-rows where the registry could not be reached are marked
-`(offline — last check failed)`. Two flags control the behavior:
+Augments the installed-extensions table with a "latest" column when stdout is a
+terminal. Outdated rows are marked `(update available)`; rows where the registry
+could not be reached are marked `(offline — last check failed)`. Two flags
+control the behavior:
 
-- `--check-updates` forces enrichment on regardless of stdout type
-  (useful in CI when the user explicitly wants the side-by-side view
-  in JSON output).
+- `--check-updates` forces enrichment on regardless of stdout type (useful in CI
+  when the user explicitly wants the side-by-side view in JSON output).
 - `--no-check-updates` forces enrichment off.
 
-Default behavior: enrichment runs when stdout is a terminal AND output
-mode is `log`. JSON output and piped invocations skip enrichment by
-default to keep scripted use of `extension list` cheap and offline.
+Default behavior: enrichment runs when stdout is a terminal AND output mode is
+`log`. JSON output and piped invocations skip enrichment by default to keep
+scripted use of `extension list` cheap and offline.
 
-JSON output: when enrichment ran, each entry carries optional
-`latestVersion` and `updateStatus` fields. `updateStatus` is one of
-`up_to_date`, `update_available`, or `unknown_offline`. Consumers can
-distinguish "didn't try" (fields absent) from "tried and failed"
-(`updateStatus: "unknown_offline"`, `latestVersion: null`).
+JSON output: when enrichment ran, each entry carries optional `latestVersion`
+and `updateStatus` fields. `updateStatus` is one of `up_to_date`,
+`update_available`, or `unknown_offline`. Consumers can distinguish "didn't try"
+(fields absent) from "tried and failed" (`updateStatus: "unknown_offline"`,
+`latestVersion: null`).
 
 ### `swamp extension outdated`
 
-A dedicated subcommand intended for CI gates and scheduled checks.
-Renders all non-up_to_date statuses (update_available, not_found,
-failed) so users see them, but the EXIT CODE depends only on
-update_available presence:
+A dedicated subcommand intended for CI gates and scheduled checks. Renders all
+non-up_to_date statuses (update_available, not_found, failed) so users see them,
+but the EXIT CODE depends only on update_available presence:
 
 - Exit 1 if at least one extension has status `update_available`.
-- Exit 0 otherwise (including when only `not_found` or `failed` are
-  present).
+- Exit 0 otherwise (including when only `not_found` or `failed` are present).
 
-This deliberate semantic means a CI gate
-`swamp extension outdated && deploy` fails only on a clear
-newer-version-exists signal, not on transient registry errors. The
-exit-code semantic is a public contract: broadening it later (to also
-fail on not_found/failed) would silently break pipelines built on the
+This deliberate semantic means a CI gate `swamp extension outdated && deploy`
+fails only on a clear newer-version-exists signal, not on transient registry
+errors. The exit-code semantic is a public contract: broadening it later (to
+also fail on not_found/failed) would silently break pipelines built on the
 strict semantic.
 
 ### Deprecation
 
-Extensions can be deprecated in the registry without being yanked.
-Deprecation is a soft lifecycle state: deprecated extensions remain
-pullable and resolvable — existing workflows don't break.
+Extensions can be deprecated in the registry without being yanked. Deprecation
+is a soft lifecycle state: deprecated extensions remain pullable and resolvable
+— existing workflows don't break.
 
-`swamp extension deprecate` marks an entire extension (not individual
-versions) as deprecated. An optional `--superseded-by` flag points
-users to a replacement extension. `swamp extension undeprecate` reverses
-the state.
+`swamp extension deprecate` marks an entire extension (not individual versions)
+as deprecated. An optional `--superseded-by` flag points users to a replacement
+extension. `swamp extension undeprecate` reverses the state.
 
 Deprecation surfaces in five places:
 
-- `swamp extension search` shows a `[deprecated]` indicator next to
-  deprecated extensions.
-- `swamp extension info` displays deprecation timestamp, reason, and
-  successor (if set).
-- `swamp extension pull` prints a warning when pulling a deprecated
-  extension, including the successor pointer.
+- `swamp extension search` shows a `[deprecated]` indicator next to deprecated
+  extensions.
+- `swamp extension info` displays deprecation timestamp, reason, and successor
+  (if set).
+- `swamp extension pull` prints a warning when pulling a deprecated extension,
+  including the successor pointer.
 - `swamp extension outdated` includes a `deprecated` status alongside
-  `update_available`, `not_found`, and `failed`. Deprecated extensions
-  do NOT fail the exit code (same rationale as not_found/failed: the
-  extension still works, it's informational).
-- `swamp extension list --check-updates` marks deprecated extensions
-  with `(deprecated)` when the enrichment status is available.
+  `update_available`, `not_found`, and `failed`. Deprecated extensions do NOT
+  fail the exit code (same rationale as not_found/failed: the extension still
+  works, it's informational).
+- `swamp extension list --check-updates` marks deprecated extensions with
+  `(deprecated)` when the enrichment status is available.
 
-Registry API endpoints: `POST /api/v1/extensions/{name}/deprecate`
-(body: `{reason, supersededBy?}`) and
-`POST /api/v1/extensions/{name}/undeprecate` (no body). The extension
-info view returns `deprecatedAt`, `deprecatedByUserId`,
+Registry API endpoints: `POST /api/v1/extensions/{name}/deprecate` (body:
+`{reason, supersededBy?}`) and `POST /api/v1/extensions/{name}/undeprecate` (no
+body). The extension info view returns `deprecatedAt`, `deprecatedByUserId`,
 `deprecationReason`, and `supersededBy` fields.
 
 ### Cache and registry behavior
 
 Both surfaces share a 24-hour on-disk cache stored at
-`.swamp/extension-update-checks.json`. The TTL matches the
-`CHECK_INTERVAL_MS` constant in `src/domain/update/update_check_cache.ts`.
-These surfaces only ever read the registry to report available updates —
-no extension kind is auto-pulled or upgraded as a side effect. Within
-the 24h window, freshness data is served from cache without contacting
-the registry.
+`.swamp/extension-update-checks.json`. The TTL matches the `CHECK_INTERVAL_MS`
+constant in `src/domain/update/update_check_cache.ts`. These surfaces only ever
+read the registry to report available updates — no extension kind is auto-pulled
+or upgraded as a side effect. Within the 24h window, freshness data is served
+from cache without contacting the registry.
 
 On registry failure for a stale entry, the cache is stamped with
-`latestVersion: installedVersion` to suppress retries for the next
-24h. This is a deliberate trade-off: during that 24h window, a
-stamped entry will read as `up_to_date` even though the latest
-version is genuinely unknown — the alternative (every command
-hammering an unreachable registry) is worse for advisory data. The
-in-memory enriched entry returned by the list composer additionally
-carries `updateStatus: "unknown_offline"` so the user can distinguish
-"freshly failed" from "cache-fresh up_to_date" within the same
-invocation. After 24h, the cache entry expires and the next command
-re-attempts the registry call.
+`latestVersion: installedVersion` to suppress retries for the next 24h. This is
+a deliberate trade-off: during that 24h window, a stamped entry will read as
+`up_to_date` even though the latest version is genuinely unknown — the
+alternative (every command hammering an unreachable registry) is worse for
+advisory data. The in-memory enriched entry returned by the list composer
+additionally carries `updateStatus: "unknown_offline"` so the user can
+distinguish "freshly failed" from "cache-fresh up_to_date" within the same
+invocation. After 24h, the cache entry expires and the next command re-attempts
+the registry call.
 
-The cache file itself is written atomically via `atomicWriteTextFile`,
-so concurrent writers cannot corrupt the file. The repository uses
-read-modify-write on the whole map, so under parallel invocations one
-writer's individual mutations may be lost (last-writer-wins on the
-whole map). For a 24h advisory cache where each entry is
-self-contained, lost mutations simply re-occur on the next stale
-check — never file corruption. A per-extension keyed file or kvstore
-would eliminate the trade-off and is a future improvement.
+The cache file itself is written atomically via `atomicWriteTextFile`, so
+concurrent writers cannot corrupt the file. The repository uses
+read-modify-write on the whole map, so under parallel invocations one writer's
+individual mutations may be lost (last-writer-wins on the whole map). For a 24h
+advisory cache where each entry is self-contained, lost mutations simply
+re-occur on the next stale check — never file corruption. A per-extension keyed
+file or kvstore would eliminate the trade-off and is a future improvement.
 
 ### Why no passive on-load warning
 
-The original feature request (issue #199) proposed a per-extension
-warning emitted on every command that resolves an extension bundle.
-After research into how comparable tools handle this, swamp ships
-the explicit-only design instead:
+The original feature request (issue #199) proposed a per-extension warning
+emitted on every command that resolves an extension bundle. After research into
+how comparable tools handle this, swamp ships the explicit-only design instead:
 
-- Terraform, OpenTofu, and Ansible all explicitly chose against
-  passive nags for plugin/provider staleness, treating it as user
-  opt-in. OpenTofu re-litigated the design (issue #2032, closed
-  not-planned) citing CI-breakage concerns.
-- Pulumi ships a passive nag (for the CLI itself, not plugins) and
-  has documented user pain at length: per-invocation noise (issue
-  #5576), wrong severity level (issue #10578), unactionable warnings
-  when package managers haven't caught up (issue #2426).
-- No surveyed tool has shipped a generally-loved per-extension
-  passive warning. gh's extension version checker is the closest
-  attempt and is the documented cautionary tale (issue #10235:
-  blocking PostRun call hangs commands for minutes).
+- Terraform, OpenTofu, and Ansible all explicitly chose against passive nags for
+  plugin/provider staleness, treating it as user opt-in. OpenTofu re-litigated
+  the design (issue #2032, closed not-planned) citing CI-breakage concerns.
+- Pulumi ships a passive nag (for the CLI itself, not plugins) and has
+  documented user pain at length: per-invocation noise (issue #5576), wrong
+  severity level (issue #10578), unactionable warnings when package managers
+  haven't caught up (issue #2426).
+- No surveyed tool has shipped a generally-loved per-extension passive warning.
+  gh's extension version checker is the closest attempt and is the documented
+  cautionary tale (issue #10235: blocking PostRun call hangs commands for
+  minutes).
 
-If real demand for a passive surface emerges, the path forward is
-documented but not implemented: an end-of-command, single-line,
-aggregated, info-level (not warn) advisory with 24h display
-cooldown, TTY gating, env-var suppression
-(`SWAMP_NO_UPDATE_NOTIFIER`), and non-blocking time-budgeted
-registry calls. Per-extension warnings at the start of every command
-are explicitly out.
+If real demand for a passive surface emerges, the path forward is documented but
+not implemented: an end-of-command, single-line, aggregated, info-level (not
+warn) advisory with 24h display cooldown, TTY gating, env-var suppression
+(`SWAMP_NO_UPDATE_NOTIFIER`), and non-blocking time-budgeted registry calls.
+Per-extension warnings at the start of every command are explicitly out.
 
 ## Manifest
 
-Every extension is defined by a `manifest.yaml` file. The manifest declares
-what the extension contains and how it should be packaged.
+Every extension is defined by a `manifest.yaml` file. The manifest declares what
+the extension contains and how it should be packaged.
 
 ### Required Fields
 
@@ -299,24 +286,24 @@ containing `..` or starting with `/`.
 - `description`: Human-readable description of the extension.
 - `paths.base`: Path resolution mode for the typed keys below. `"typedDir"`
   (default) resolves typed entries relative to their configured directory
-  (`modelsDir`, `vaultsDir`, etc.). `"manifest"` resolves every typed entry
-  plus `additionalFiles` relative to the manifest's own directory — pick
-  this for per-extension-subdir layouts where manifest, source, README,
-  and LICENSE all sit alongside each other. See "Path resolution" below.
+  (`modelsDir`, `vaultsDir`, etc.). `"manifest"` resolves every typed entry plus
+  `additionalFiles` relative to the manifest's own directory — pick this for
+  per-extension-subdir layouts where manifest, source, README, and LICENSE all
+  sit alongside each other. See "Path resolution" below.
 - `models`: Array of relative paths to TypeScript model files (e.g.,
   `["aws/ec2/instance.ts"]`). Resolved via `paths.base`.
-- `workflows`: Array of relative paths to YAML workflow files. Resolved
-  via `paths.base`. Under `paths.base: manifest`, workflows resolve
-  relative to the manifest's own directory first, falling back to the
-  repo-root `workflows/` and `extensions/workflows/` directories.
-- `vaults`: Array of relative paths to TypeScript vault files. Resolved
+- `workflows`: Array of relative paths to YAML workflow files. Resolved via
+  `paths.base`. Under `paths.base: manifest`, workflows resolve relative to the
+  manifest's own directory first, falling back to the repo-root `workflows/` and
+  `extensions/workflows/` directories.
+- `vaults`: Array of relative paths to TypeScript vault files. Resolved via
+  `paths.base`.
+- `drivers`: Array of relative paths to TypeScript driver files. Resolved via
+  `paths.base`.
+- `datastores`: Array of relative paths to TypeScript datastore files. Resolved
   via `paths.base`.
-- `drivers`: Array of relative paths to TypeScript driver files. Resolved
-  via `paths.base`.
-- `datastores`: Array of relative paths to TypeScript datastore files.
-  Resolved via `paths.base`.
-- `reports`: Array of relative paths to TypeScript report files. Resolved
-  via `paths.base`.
+- `reports`: Array of relative paths to TypeScript report files. Resolved via
+  `paths.base`.
 - `skills`: Array of skill directory names. Each directory must contain a
   `SKILL.md` with YAML frontmatter declaring `name` and `description`. Skills
   are passive markdown guidance documents — swamp never executes them. Under
@@ -325,16 +312,20 @@ containing `..` or starting with `/`.
   repo-root skill directory and global user-level directory. Under the default
   `paths.base: typedDir`, skills resolve from repo-root and global only. In
   multi-tool repos, all enrolled tools' skill directories are searched.
-- `include`: Array of relative paths to TypeScript files that should be
-  included in the archive alongside models but not bundled. Used for
-  helper scripts that are executed via `Deno.Command` subprocess rather
-  than imported directly. Resolved via `paths.base`.
-- `additionalFiles`: Array of relative paths to non-model files (README,
-  config, etc.). Always resolved relative to the manifest's own directory.
+- `repository`: URL of the extension's source repository (e.g.,
+  `"https://github.com/org/repo"`).
+- `releaseNotes`: Free-form release notes for the current version (max 5000
+  characters).
+- `include`: Array of relative paths to files that should be included in the
+  archive alongside models but not bundled. Used for helper scripts that are
+  executed via `Deno.Command` subprocess rather than imported directly. Resolved
+  via `paths.base`.
+- `additionalFiles`: Array of relative paths to non-model files (README, config,
+  etc.). Always resolved relative to the manifest's own directory.
 - `platforms`: Array of platform identifiers the extension supports (e.g.,
   `["darwin-aarch64", "linux-x86_64"]`). Informational only — displayed during
   pull.
-- `tags`: Array of categorization labels (e.g., `["aws", "kubernetes"]`).
+- `labels`: Array of categorization labels (e.g., `["aws", "kubernetes"]`).
 - `dependencies`: Array of extension names (`@collective/name`) that this
   extension requires. Dependencies are pulled automatically.
 
@@ -358,76 +349,69 @@ dependencies:
 platforms:
   - darwin-aarch64
   - linux-x86_64
-tags:
+labels:
   - ssh
   - networking
 ```
 
 ### Path Resolution
 
-The `paths.base` field selects the directory typed-key entries
-(`models`, `vaults`, `drivers`, `datastores`, `reports`, `include`) plus
-`additionalFiles` resolve against during push. Two modes:
+The `paths.base` field selects the directory typed-key entries (`models`,
+`vaults`, `drivers`, `datastores`, `reports`, `include`) plus `additionalFiles`
+resolve against during push. Two modes:
 
-- **`typedDir` (default)** — typed entries resolve relative to their
-  configured directory from the repo marker (`modelsDir`, `vaultsDir`,
-  etc., or environment overrides like `SWAMP_MODELS_DIR`).
-  `additionalFiles` resolves relative to the manifest's own directory.
-  This is the historical behavior; every existing manifest without an
-  explicit `paths.base` keeps these semantics.
-- **`manifest`** — every typed entry plus `additionalFiles` resolves
-  relative to the manifest's own directory. Pick this for
-  per-extension-subdir layouts where manifest, source, README, and
-  LICENSE all live alongside each other (e.g.
+- **`typedDir` (default)** — typed entries resolve relative to their configured
+  directory from the repo marker (`modelsDir`, `vaultsDir`, etc., or environment
+  overrides like `SWAMP_MODELS_DIR`). `additionalFiles` resolves relative to the
+  manifest's own directory. This is the historical behavior; every existing
+  manifest without an explicit `paths.base` keeps these semantics.
+- **`manifest`** — every typed entry plus `additionalFiles` resolves relative to
+  the manifest's own directory. Pick this for per-extension-subdir layouts where
+  manifest, source, README, and LICENSE all live alongside each other (e.g.
   `extensions/models/myext/manifest.yaml` next to `myext/echo.ts` and
   `myext/README.md`).
 
-Workflows honour `paths.base: manifest` — when set, the manifest's own
-directory is searched first, falling back to the repo-root `workflows/`
-and `extensions/workflows/` directories. Under the default
-`paths.base: typedDir`, workflows resolve only from the repo-root
-locations.
+Workflows honour `paths.base: manifest` — when set, the manifest's own directory
+is searched first, falling back to the repo-root `workflows/` and
+`extensions/workflows/` directories. Under the default `paths.base: typedDir`,
+workflows resolve only from the repo-root locations.
 
-Skills honour `paths.base: manifest` — when set, the manifest's own
-directory is searched first (e.g. `sub/.claude/skills/<name>/`), then
-project-local, then global. All enrolled tools are searched, not just
-the primary tool.
+Skills honour `paths.base: manifest` — when set, the manifest's own directory is
+searched first (e.g. `sub/.claude/skills/<name>/`), then project-local, then
+global. All enrolled tools are searched, not just the primary tool.
 
-Local source-loading honours `paths.base: manifest` — at startup, the
-loader scans all known extension directories for manifests with
-`paths.base: manifest`. When a manifest declares components of a kind
-different from its parent directory (e.g. a `reports:` entry in a
-manifest under `extensions/models/myext/`), the manifest's directory is
-added as an additional source directory for that kind. This closes the
-dev/prod parity gap where published bundles loaded all declared
-components but local source loading only discovered components matching
-their kind directory.
+Local source-loading honours `paths.base: manifest` — at startup, the loader
+scans all known extension directories for manifests with `paths.base: manifest`.
+When a manifest declares components of a kind different from its parent
+directory (e.g. a `reports:` entry in a manifest under
+`extensions/models/myext/`), the manifest's directory is added as an additional
+source directory for that kind. This closes the dev/prod parity gap where
+published bundles loaded all declared components but local source loading only
+discovered components matching their kind directory.
 
 ### Source-Path Skill Installation
 
-Source-path extensions (configured via `.swamp-sources.yaml`) can provide
-skills just like registry-pulled extensions. When `extension source add`
-records a new source, it reads the source's `manifest.yaml` and — if
-the manifest declares a `skills` field — resolves and copies those skill
-directories into the repo's tool-specific skills directory (e.g.
-`.claude/skills/`). Skill resolution uses the same `paths.base` strategy
-as `extension push` and `extension quality`: under
-`paths.base: manifest`, skills are found relative to the manifest
-directory; otherwise they are found under the source root's tool-specific
-skill directories.
+Source-path extensions (configured via `.swamp-sources.yaml`) can provide skills
+just like registry-pulled extensions. When `extension source add` records a new
+source, it reads the source's `manifest.yaml` and — if the manifest declares a
+`skills` field — resolves and copies those skill directories into the repo's
+tool-specific skills directory (e.g. `.claude/skills/`). Skill resolution uses
+the same `paths.base` strategy as `extension push` and `extension quality`:
+under `paths.base: manifest`, skills are found relative to the manifest
+directory; otherwise they are found under the source root's tool-specific skill
+directories.
 
-The installed skill names are tracked in the `installedSkills` field on
-the source entry in `.swamp-sources.yaml`. When `extension source rm`
-removes a source, it reads this field and deletes the corresponding
-skill directories from the repo. This ensures cleanup does not depend
-on the source directory still being accessible at removal time.
+The installed skill names are tracked in the `installedSkills` field on the
+source entry in `.swamp-sources.yaml`. When `extension source rm` removes a
+source, it reads this field and deletes the corresponding skill directories from
+the repo. This ensures cleanup does not depend on the source directory still
+being accessible at removal time.
 
-The on-wire manifest in the archive preserves the field strings
-verbatim — no path rewriting, no normalization. WYSIWYG between what
-the author pushes and what the registry stores. The archive layout
-under each typed-key directory mirrors the entry strings: under
-`paths.base: manifest` with `models: [echo.ts]`, the archive contains
-`extension/models/echo.ts` directly.
+The on-wire manifest in the archive preserves the field strings verbatim — no
+path rewriting, no normalization. WYSIWYG between what the author pushes and
+what the registry stores. The archive layout under each typed-key directory
+mirrors the entry strings: under `paths.base: manifest` with
+`models: [echo.ts]`, the archive contains `extension/models/echo.ts` directly.
 
 ## Archive Structure
 
@@ -467,18 +451,19 @@ structure from the active base (the configured `modelsDir` under
 `connection.ts` imports `./helpers.ts`, both files are included.
 
 Files listed in the manifest's `include` field are also copied to `models/` in
-the archive, preserving their relative paths from the active base. Include
-files are not bundled — they are raw TypeScript files intended to be executed
-as subprocesses or used as standalone utilities.
+the archive, preserving their relative paths from the active base. Include files
+are not bundled — they are raw TypeScript files intended to be executed as
+subprocesses or used as standalone utilities.
 
 ### Loader pre-check
 
 At runtime, loaders discover `.ts` files in their respective directories and
 attempt to bundle each one. Before bundling, the loader reads the source and
-checks for the expected named export (`export const model`, `export const vault`,
-etc.). Files that don't declare the expected export are skipped — no bundling
-attempted, no error. This avoids failing on helper scripts with unbundleable
-dependencies (e.g., native modules used via `Deno.Command` subprocess).
+checks for the expected named export (`export const model`,
+`export const vault`, etc.). Files that don't declare the expected export are
+skipped — no bundling attempted, no error. This avoids failing on helper scripts
+with unbundleable dependencies (e.g., native modules used via `Deno.Command`
+subprocess).
 
 ### Bundles
 
@@ -492,9 +477,9 @@ must be static top-level imports. Bundles are JavaScript files stored alongside
 their source counterparts under `bundles/`.
 
 **First-class specifier kinds:** `npm:`, `jsr:`, and `https:` are peers —
-`deno bundle` resolves all three natively with identical treatment (all
-inlined, all cached by Deno's module cache, all subject to the same
-externalization rules for zod). No per-specifier-kind configuration is required.
+`deno bundle` resolves all three natively with identical treatment (all inlined,
+all cached by Deno's module cache, all subject to the same externalization rules
+for zod). No per-specifier-kind configuration is required.
 
 **Pin versions on all non-local specifiers** (`npm:`, `jsr:`, `https:`) for
 reproducibility. An unpinned specifier resolves to the registry's current
@@ -522,18 +507,18 @@ treated as the extension's project config.
 
 #### Bundling permutations
 
-| Scenario | `deno bundle` flags | Quality check flags | Notes |
-|----------|-------------------|-------------------|-------|
-| **`deno.json` found** | `--config <deno.json>` | `--config <deno.json>` | Import map governs resolution; project lint/fmt rules apply |
-| **`package.json` found, bare specifiers** | `--node-modules-dir=auto`, `cwd` set to package.json dir | `--no-config` | Deno auto-detects package.json; `node_modules/` must exist from `npm install` or `deno install`; `--node-modules-dir=auto` initializes `.deno/` metadata if needed |
-| **`package.json` found, `npm:` imports** | `--no-lock --node-modules-dir=none` | `--no-config` | Package.json is ignored (extension doesn't need it); `--node-modules-dir=none` prevents ambient package.json from poisoning resolution |
-| **No config found** | `--no-lock --node-modules-dir=none` | `--no-config` | Default behavior; `--node-modules-dir=none` prevents any package.json in the directory tree from interfering |
+| Scenario                                  | `deno bundle` flags                                      | Quality check flags    | Notes                                                                                                                                                              |
+| ----------------------------------------- | -------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`deno.json` found**                     | `--config <deno.json>`                                   | `--config <deno.json>` | Import map governs resolution; project lint/fmt rules apply                                                                                                        |
+| **`package.json` found, bare specifiers** | `--node-modules-dir=auto`, `cwd` set to package.json dir | `--no-config`          | Deno auto-detects package.json; `node_modules/` must exist from `npm install` or `deno install`; `--node-modules-dir=auto` initializes `.deno/` metadata if needed |
+| **`package.json` found, `npm:` imports**  | `--no-lock --node-modules-dir=none`                      | `--no-config`          | Package.json is ignored (extension doesn't need it); `--node-modules-dir=none` prevents ambient package.json from poisoning resolution                             |
+| **No config found**                       | `--no-lock --node-modules-dir=none`                      | `--no-config`          | Default behavior; `--node-modules-dir=none` prevents any package.json in the directory tree from interfering                                                       |
 
 The `--node-modules-dir=none` flag is critical for the last two cases: without
 it, an unrelated `package.json` anywhere in the directory tree causes Deno to
 switch to `node_modules/` resolution mode, breaking `npm:` prefixed imports with
-errors like "Could not find a matching package for 'npm:@octokit/rest@22.0.1'
-in the node_modules directory."
+errors like "Could not find a matching package for 'npm:@octokit/rest@22.0.1' in
+the node_modules directory."
 
 `jsr:` and `https:` specifiers work identically across all four rows — they
 don't require `deno.json` or `package.json` to resolve, so the project-config
@@ -542,13 +527,13 @@ module cache on first use and reused offline thereafter.
 
 #### Zod externalization
 
-Zod is externalized using `--external` flags that match the specifier as
-written in source. The bundler handles:
+Zod is externalized using `--external` flags that match the specifier as written
+in source. The bundler handles:
 
 - `npm:zod@4` and `npm:zod` (base patterns, always applied)
 - Fully-pinned versions like `npm:zod@4.3.6` (detected by scanning the source)
-- Bare `"zod"` specifier via `deno.json` (when the import map maps it to
-  zod 4.x, both the resolved specifier and bare `"zod"` are externalized)
+- Bare `"zod"` specifier via `deno.json` (when the import map maps it to zod
+  4.x, both the resolved specifier and bare `"zod"` are externalized)
 - Bare `"zod"` specifier via `package.json` (when `dependencies` or
   `devDependencies` lists zod 4.x)
 
@@ -578,23 +563,21 @@ loaders fall back to the local `.swamp/` path.
 
 ### Vaults, Drivers, Datastores, and Reports
 
-Vault, driver, datastore, and report entry points are bundled with the same
-strategy as models — deno bundle with zod externalized. Each entry point gets a
-compiled `.js` file in its corresponding `-bundles/` directory
-(`vault-bundles/`, `driver-bundles/`, `datastore-bundles/`,
-`report-bundles/`). Local imports are resolved recursively within the directory
-boundary.
+Vault, datastore, and report entry points are bundled with the same strategy as
+models — deno bundle with zod externalized. Each entry point gets a compiled
+`.js` file in its corresponding `-bundles/` directory (`vault-bundles/`,
+`datastore-bundles/`, `report-bundles/`). Local imports are resolved recursively
+within the directory boundary. The install-time `KIND_DIRS` array covers
+`["models", "vaults", "datastores", "reports"]` — drivers are excluded.
 
 The export from each bundle is validated against a Zod schema:
 
 - **Vaults**: `export const vault` — must have `type`, `name`, `description`,
   optional `configSchema`, and `createProvider`
-- **Drivers**: `export const driver` — must have `type`, `name`, `description`,
-  optional `configSchema`, and `createDriver`
 - **Datastores**: `export const datastore` — must have `type`, `name`,
   `description`, optional `configSchema`, and `createProvider`
-- **Reports**: `export const report` — must have `name`, `description`,
-  `scope`, optional `labels`, and `execute`
+- **Reports**: `export const report` — must have `name`, `description`, `scope`,
+  optional `labels`, and `execute`
 
 ### Collective Validation
 
@@ -611,28 +594,27 @@ directory path to avoid collisions.
 ### Additional Files
 
 Files listed in `additionalFiles` are included under the `files/` directory
-preserving their relative paths. A manifest entry `prompts/review.md` lands
-at `files/prompts/review.md` in the archive; pulled consumers find it at
+preserving their relative paths. A manifest entry `prompts/review.md` lands at
+`files/prompts/review.md` in the archive; pulled consumers find it at
 `.swamp/pulled-extensions/<name>/files/prompts/review.md`.
 
 Push rejects:
 
-- Duplicate entries (case-insensitive, NFC-normalized) — two entries that
-  would resolve to the same archive path fail with a clear error naming
-  both offenders.
-- Symlinks — to prevent archive bloat and path escapes, entries pointing
-  at symlinks are rejected. Copy the target file into the extension tree
-  instead.
+- Duplicate entries (case-insensitive, NFC-normalized) — two entries that would
+  resolve to the same archive path fail with a clear error naming both
+  offenders.
+- Symlinks — to prevent archive bloat and path escapes, entries pointing at
+  symlinks are rejected. Copy the target file into the extension tree instead.
 
 ### Runtime access
 
-Model method `execute` functions and report functions receive a context
-with an `extensionFile(relPath)` helper that resolves a relative path
-from `additionalFiles` to an absolute filesystem path. The helper
-abstracts the source-vs-pulled layout divergence — the same code works
-whether the extension was added via `swamp extension source add` (files
-resolve relative to the manifest) or pulled from the registry (files
-resolve under `.swamp/pulled-extensions/<name>/files/`).
+Model method `execute` functions and report functions receive a context with an
+`extensionFile(relPath)` helper that resolves a relative path from
+`additionalFiles` to an absolute filesystem path. The helper abstracts the
+source-vs-pulled layout divergence — the same code works whether the extension
+was added via `swamp extension source add` (files resolve relative to the
+manifest) or pulled from the registry (files resolve under
+`.swamp/pulled-extensions/<name>/files/`).
 
 ```ts
 export const model = {
@@ -651,37 +633,36 @@ export const model = {
 };
 ```
 
-The helper throws a typed `UserError` when the path is unsafe (contains
-`..`, starts with `/`), when the file is missing, or when called on a
-model that isn't shipped via an extension manifest. The missing-file
-error is mode-aware: pulled-mode archives get a re-publish hint;
-source-mode callers get the absolute path and a pointer at the manifest
-entry.
+The helper throws a typed `UserError` when the path is unsafe (contains `..`,
+starts with `/`), when the file is missing, or when called on a model that isn't
+shipped via an extension manifest. The missing-file error is mode-aware:
+pulled-mode archives get a re-publish hint; source-mode callers get the absolute
+path and a pointer at the manifest entry.
 
 ## Import Resolution
 
 When packaging an extension, the CLI resolves all local TypeScript imports
-starting from each entry point (model, vault, driver, datastore, or report).
-The resolver follows relative `import`/`export` statements (e.g.,
-`./helpers.ts`, `../shared.ts`) and includes all transitively imported files.
-Only files within the respective directory boundary are included. Non-local
-imports (`npm:`, `jsr:`, `https:`) are skipped here — they are resolved and
-inlined at bundle time by `deno bundle`, not by the local-import resolver.
+starting from each entry point (model, vault, driver, datastore, or report). The
+resolver follows relative `import`/`export` statements (e.g., `./helpers.ts`,
+`../shared.ts`) and includes all transitively imported files. Only files within
+the respective directory boundary are included. Non-local imports (`npm:`,
+`jsr:`, `https:`) are skipped here — they are resolved and inlined at bundle
+time by `deno bundle`, not by the local-import resolver.
 
 ## Per-Subdirectory Extension Identity
 
-By default, all files under `extensions/<kind>/` are grouped into a single
-local extension aggregate (`@local/<repo-basename>@0.0.0`, or the identity
-from the top-level `extensions/manifest.yaml` if present).
+By default, all files under `extensions/<kind>/` are grouped into a single local
+extension aggregate (`@local/<repo-basename>@0.0.0`, or the identity from the
+top-level `extensions/manifest.yaml` if present).
 
 When a subdirectory directly under `extensions/<kind>/` contains its own
 `manifest.yaml` declaring both `name` and `version`, that subdirectory is
-treated as an independent extension aggregate. Files under that subdirectory
-are claimed by the manifest-declared identity instead of the default
-`@local/<repo>` aggregate.
+treated as an independent extension aggregate. Files under that subdirectory are
+claimed by the manifest-declared identity instead of the default `@local/<repo>`
+aggregate.
 
-This enables multi-extension repos where sibling directories host
-independently published extensions:
+This enables multi-extension repos where sibling directories host independently
+published extensions:
 
 ```
 extensions/models/
@@ -694,27 +675,24 @@ extensions/models/
   shared.ts          → claimed by @local/<repo>@0.0.0
 ```
 
-**Precedence:** When a top-level `extensions/manifest.yaml` exists, it
-claims the entire `extensions/` tree — per-subdirectory manifests are
-ignored. Per-subdirectory discovery only activates when no top-level
-manifest is present.
+**Precedence:** When a top-level `extensions/manifest.yaml` exists, it claims
+the entire `extensions/` tree — per-subdirectory manifests are ignored.
+Per-subdirectory discovery only activates when no top-level manifest is present.
 
 ### Origin Precedence Enforcement
 
-When both a local source and a pulled extension provide the same
-`(kind, type)`, the local source wins. The pulled row's `type_normalized`
-is cleared to empty in the catalog so it no longer occupies the type
-namespace — the same treatment as `ValidationFailed` or
-`EntryPointUnreadable` states. The pulled files remain on disk for
-reference (diffing, version comparison) but are not registered as active
-types.
+When both a local source and a pulled extension provide the same `(kind, type)`,
+the local source wins. The pulled row's `type_normalized` is cleared to empty in
+the catalog so it no longer occupies the type namespace — the same treatment as
+`ValidationFailed` or `EntryPointUnreadable` states. The pulled files remain on
+disk for reference (diffing, version comparison) but are not registered as
+active types.
 
-This applies to the push/pull development loop: when editing a local
-extension source that is also pulled from the registry, `extension pull`
-succeeds and the local source's types take precedence. The in-memory
-registry has always respected this ordering (`load()` processes local
-directories first and deduplicates via `hasType()`); the catalog now
-matches.
+This applies to the push/pull development loop: when editing a local extension
+source that is also pulled from the registry, `extension pull` succeeds and the
+local source's types take precedence. The in-memory registry has always
+respected this ordering (`load()` processes local directories first and
+deduplicates via `hasType()`); the catalog now matches.
 
 To re-activate pulled types after removing a local source, run
 `swamp doctor extensions` or any command that triggers a catalog rescan.
@@ -723,8 +701,8 @@ To re-activate pulled types after removing a local source, run
 
 By default, swamp discovers local extension sources from `extensions/<kind>/`
 relative to the repository root (`--repo-dir` / `SWAMP_REPO_DIR`). The
-`--extensions-dir` flag (or `SWAMP_EXTENSIONS_DIR` env var) overrides only
-the local source scanning root while keeping all data at the repository root.
+`--extensions-dir` flag (or `SWAMP_EXTENSIONS_DIR` env var) overrides only the
+local source scanning root while keeping all data at the repository root.
 
 This enables **git worktree** workflows where the working tree (code plane) is
 separate from the `.swamp/` data directory (data plane):
@@ -768,17 +746,16 @@ SWAMP_EXTENSIONS_DIR=~/repo/trees/feature-branch \
 
 ### Validation
 
-The CLI rejects `--extensions-dir` values that point inside `.swamp/` to
-prevent accidental reads of data-plane files as extension sources. The
-directory must exist and must be a real directory (not a file).
+The CLI rejects `--extensions-dir` values that point inside `.swamp/` to prevent
+accidental reads of data-plane files as extension sources. The directory must
+exist and must be a real directory (not a file).
 
 ## Adversarial Review Directory (`SWAMP_EXTENSION_REVIEW_DIR`)
 
 The adversarial review gate in `swamp extension push` looks for a
-content-hash-bound report at
-`<base>/swamp-extension-review/<name>-<hash>.json`. By default `<base>` is
-the OS temp directory (`TMPDIR` / `TMP` / `TEMP` / `/tmp`), which works for
-local development but is ephemeral on CI runners.
+content-hash-bound report at `<base>/swamp-extension-review/<name>-<hash>.json`.
+By default `<base>` is the OS temp directory (`TMPDIR` / `TMP` / `TEMP` /
+`/tmp`), which works for local development but is ephemeral on CI runners.
 
 Set `SWAMP_EXTENSION_REVIEW_DIR` to override the base directory. This lets CI
 workflows store review reports in a durable, repo-local path that survives
@@ -794,9 +771,9 @@ steps:
   - run: swamp extension push extensions/my-ext/manifest.yaml --yes
 ```
 
-Precedence: `SWAMP_EXTENSION_REVIEW_DIR` > `TMPDIR` > `TMP` > `TEMP` >
-`/tmp`. The explicit `baseTmpDir` parameter on `reviewReportPath()` (used by
-tests) overrides all env vars.
+Precedence: `SWAMP_EXTENSION_REVIEW_DIR` > `TMPDIR` > `TMP` > `TEMP` > `/tmp`.
+The explicit `baseTmpDir` parameter on `reviewReportPath()` (used by tests)
+overrides all env vars.
 
 ## Dependencies
 
@@ -815,10 +792,10 @@ dependencies are resolved and pulled automatically if not already installed.
 
 ### Workflow Dependency Resolution
 
-During push, the CLI also resolves which models a workflow references. It
-parses workflow YAML to find `model_method` and `workflow` step tasks, then
-looks up the corresponding model source files. Only user-collective models
-(types starting with `@`) are bundled — built-in models are skipped.
+During push, the CLI also resolves which models a workflow references. It parses
+workflow YAML to find `model_method` and `workflow` step tasks, then looks up
+the corresponding model source files. Only user-collective models (types
+starting with `@`) are bundled — built-in models are skipped.
 
 ## Automatic Resolution
 
@@ -836,9 +813,9 @@ Default trusted collectives: `["swamp"]`.
 
 **Membership collectives are NOT trusted automatically** (swamp-club#465).
 Belonging to a collective lets you _publish_ to it; it does not silently grant
-_install_ consent on the consumer side. A compromised or careless member
-publish must not be able to execute code in every repo that references the
-collective's types. To use a collective's extensions, trust it explicitly:
+_install_ consent on the consumer side. A compromised or careless member publish
+must not be able to execute code in every repo that references the collective's
+types. To use a collective's extensions, trust it explicitly:
 
 ```bash
 swamp extension trust add myorg
@@ -908,52 +885,58 @@ resolves.
 
 ### Safety: never overwrite on-disk extensions
 
-Auto-resolution will never overwrite an extension that is already installed
-on disk. If the type failed to register despite the extension being present,
-something is wrong locally (commonly a user's in-progress edit introducing
-a syntax error) and a silent force-pull would destroy that work.
+Auto-resolution will never overwrite an extension that is already installed on
+disk. If the type failed to register despite the extension being present,
+something is wrong locally (commonly a user's in-progress edit introducing a
+syntax error) and a silent force-pull would destroy that work.
 
 The resolver inspects the pulled tree and classifies it into one of three
 states, driving the auto-resolve decision:
 
-- **Missing** — no entry in `upstream_extensions.json`, or the
-  per-extension directory under `.swamp/pulled-extensions/<name>/` is
-  absent. A clean install proceeds.
-- **Intact** — the lockfile entry exists, the directory exists, and
-  every file the lockfile lists for this extension is present on disk.
-  If the type still failed to register, the cause is local. The resolver
-  surfaces `alreadyInstalledButFailed` with the install path and the
-  `--force` recovery command.
-- **Truncated** — the lockfile entry and directory both exist, but one
-  or more files the lockfile lists are missing from disk
-  (swamp-club#133). This is the "present but incomplete" state that
-  used to produce misleading `Unknown <kind> type` errors downstream.
-  The resolver now surfaces `alreadyInstalledTruncated` naming the
-  missing files, exits with an error, and does **not** attempt to
-  repair. In JSON mode the event shape is:
+- **Missing** — no entry in `upstream_extensions.json`, or the per-extension
+  directory under `.swamp/pulled-extensions/<name>/` is absent. A clean install
+  proceeds.
+- **Intact** — the lockfile entry exists, the directory exists, and every file
+  the lockfile lists for this extension is present on disk. If the type still
+  failed to register, the cause is local. The resolver surfaces
+  `alreadyInstalledButFailed` with the install path and the `--force` recovery
+  command.
+- **Truncated** — the lockfile entry and directory both exist, but one or more
+  files the lockfile lists are missing from disk (swamp-club#133). This is the
+  "present but incomplete" state that used to produce misleading
+  `Unknown <kind> type` errors downstream. The resolver now surfaces
+  `alreadyInstalledTruncated` naming the missing files, exits with an error, and
+  does **not** attempt to repair. In JSON mode the event shape is:
   ```json
-  {"event":"auto_resolve","status":"failed","extension":"...","path":"...","reason":"truncated","missing":["..."]}
+  {
+    "event": "auto_resolve",
+    "status": "failed",
+    "extension": "...",
+    "path": "...",
+    "reason": "truncated",
+    "missing": ["..."]
+  }
   ```
 
 Both "intact-but-fails" and "truncated" surface the same
-`swamp extension pull <name> --force` recovery — that command is the
-only way auto-installation state can overwrite a pulled extension. No
-other auto-resolve, validate, or run command will ever clobber local
-edits or silently re-fetch a broken tree.
+`swamp extension pull <name> --force` recovery — that command is the only way
+auto-installation state can overwrite a pulled extension. No other auto-resolve,
+validate, or run command will ever clobber local edits or silently re-fetch a
+broken tree.
 
-The truncation predicate is file-level: any file listed in the lockfile
-entry for an extension that cannot be stat'd on disk. The check stops
-at presence — it does not verify file contents, only that the paths the
-lockfile says should exist actually do.
+The truncation predicate is file-level: any file listed in the lockfile entry
+for an extension that cannot be stat'd on disk. The check stops at presence — it
+does not verify file contents, only that the paths the lockfile says should
+exist actually do.
 
 Paths under `.swamp/bundles/`, `.swamp/vault-bundles/`,
 `.swamp/driver-bundles/`, `.swamp/datastore-bundles/`, and
-`.swamp/report-bundles/` are excluded from this check. Those are
-regenerable build artifacts: clearing the bundle cache is a normal
-hygiene operation and must not flip an extension with intact source
-into the truncated branch (which would steal the user-WIP path from
-issue #121). Only source-tree files — the per-extension subtree under
-`.swamp/pulled-extensions/<name>/` — drive truncation.
+`.swamp/report-bundles/` are excluded from this check. Those are regenerable
+build artifacts: clearing the bundle cache is a normal hygiene operation and
+must not flip an extension with intact source into the truncated branch (which
+would steal the user-WIP path from issue #121). Only source-tree files — the
+per-extension subtree under `.swamp/pulled-extensions/<name>/` — drive
+truncation.
 
 ### Hot-Loading
 
@@ -961,10 +944,10 @@ After installation, swamp re-runs model and vault discovery with
 `skipAlreadyRegistered` to load only the newly installed types. This avoids
 re-registering types that were already loaded at startup.
 
-User extensions under `extensions/models/` that `extend` a newly-installed
-base type are also re-attached during hot-loading. The installer walks
-catalog-recorded extension rows and calls the extension-attach primitive
-for each base that is now fully registered, so a user extension targeting
+User extensions under `extensions/models/` that `extend` a newly-installed base
+type are also re-attached during hot-loading. The installer walks
+catalog-recorded extension rows and calls the extension-attach primitive for
+each base that is now fully registered, so a user extension targeting
 `@swamp/aws/ec2/instance` becomes callable as soon as auto-resolve pulls
 `@swamp/aws` — no separate command needed.
 
@@ -976,8 +959,8 @@ a type, subsequent resolution attempts for that type are skipped.
 ### Architecture
 
 `ExtensionAutoResolver` is a domain service with port interfaces. Adapters in
-the CLI layer provide the concrete implementations for registry access, extension
-installation, and model/vault discovery.
+the CLI layer provide the concrete implementations for registry access,
+extension installation, and model/vault discovery.
 
 ### Output
 
@@ -1012,10 +995,11 @@ after pull.
 
 ### Binaries
 
-Extensions can declare executable host helpers via the `binaries` manifest field.
-These files are exempt from the file-extension allowlist but still subject to all
-other safety checks (hidden files, symlinks, size limits, file count). Executable
-mode bits are preserved through the publish/pull cycle on POSIX systems.
+Extensions can declare executable host helpers via the `binaries` manifest
+field. These files are exempt from the file-extension allowlist but still
+subject to all other safety checks (hidden files, symlinks, size limits, file
+count). Executable mode bits are preserved through the publish/pull cycle on
+POSIX systems.
 
 At pull time, if the extension declares binaries, the CLI warns the user to
 inspect them before use. The binaries list is also sent as push metadata to
@@ -1062,14 +1046,15 @@ gates (no hard-error blockers).
 
 ## Registry
 
-Extensions are distributed through the swamp registry at `https://swamp-club.com`.
+Extensions are distributed through the swamp registry at
+`https://swamp-club.com`.
 
 ### Authentication
 
 Push operations require authentication via an API key (Bearer token). Pull
 operations are unauthenticated. Users can only push extensions to their own
-collective. You need to authenticate to Swamp Club via the CLI `swamp auth login`
-to get the correct API Key used for push.
+collective. You need to authenticate to Swamp Club via the CLI
+`swamp auth login` to get the correct API Key used for push.
 
 ### Push Protocol
 
@@ -1078,8 +1063,8 @@ Push uses a three-phase protocol:
 1. **Initiate**: `POST /api/v1/extensions/push` — declares intent, receives a
    presigned S3 upload URL.
 2. **Upload**: `PUT {uploadUrl}` — uploads the tar.gz archive directly to S3.
-3. **Confirm**: `POST /api/v1/extensions/confirm` — finalizes the version in
-   the registry.
+3. **Confirm**: `POST /api/v1/extensions/confirm` — finalizes the version in the
+   registry.
 
 ### Pull Protocol
 
@@ -1087,8 +1072,8 @@ Push uses a three-phase protocol:
    version.
 2. **Download**: `GET /api/v1/extensions/{name}@{version}/download` — follows a
    302 redirect to download the archive.
-3. **Verify**: `GET /api/v1/extensions/{name}@{version}/checksum` — retrieve
-   the SHA-256 checksum for integrity verification.
+3. **Verify**: `GET /api/v1/extensions/{name}@{version}/checksum` — retrieve the
+   SHA-256 checksum for integrity verification.
 
 ## Upstream Extensions Tracking
 
@@ -1121,16 +1106,16 @@ enables clean removal, conflict detection, and **integrity-anchored restore**
 Every lockfile entry records the SHA-256 of the extension archive at install
 time (`checksum`). On any lockfile-restore flow (`swamp extension install`,
 phase-two migration re-pull), the freshly-downloaded archive is verified
-byte-for-byte against this stored value. On mismatch, the restore fails
-loudly with a message offering the user a choice: accept current registry
-content (`swamp extension pull <name>`) or pin an older version. This turns
-the lockfile into an integrity manifest rather than just a version record —
-restores cannot silently accept drifted registry bytes. Entries predating
-checksum tracking (pre-commit `f4dfc083`) skip verification gracefully.
+byte-for-byte against this stored value. On mismatch, the restore fails loudly
+with a message offering the user a choice: accept current registry content
+(`swamp extension pull <name>`) or pin an older version. This turns the lockfile
+into an integrity manifest rather than just a version record — restores cannot
+silently accept drifted registry bytes. Entries predating checksum tracking
+(pre-commit `f4dfc083`) skip verification gracefully.
 
 Explicit `swamp extension pull <name>` is the user's opt-in path to accept
-whatever bytes the registry currently serves; integrity verification is
-scoped strictly to lockfile-restore flows.
+whatever bytes the registry currently serves; integrity verification is scoped
+strictly to lockfile-restore flows.
 
 ### Concurrency Safety
 
@@ -1145,40 +1130,40 @@ Each installed extension owns a dedicated on-disk subtree at
 scoped name (e.g. `@swamp/aws/ec2`). Inside that subtree, per-type directories
 mirror the archive structure:
 
-| Archive directory    | Destination                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `manifest.yaml`      | `.swamp/pulled-extensions/<ext-name>/manifest.yaml` (ro)     |
-| `models/`            | `.swamp/pulled-extensions/<ext-name>/models/`                |
-| `workflows/`         | `.swamp/pulled-extensions/<ext-name>/workflows/`             |
-| `vaults/`            | `.swamp/pulled-extensions/<ext-name>/vaults/`                |
-| `drivers/`           | `.swamp/pulled-extensions/<ext-name>/drivers/`               |
-| `datastores/`        | `.swamp/pulled-extensions/<ext-name>/datastores/`            |
-| `reports/`           | `.swamp/pulled-extensions/<ext-name>/reports/`               |
-| `files/`             | `.swamp/pulled-extensions/<ext-name>/files/`                 |
+| Archive directory    | Destination                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `manifest.yaml`      | `.swamp/pulled-extensions/<ext-name>/manifest.yaml` (ro)       |
+| `models/`            | `.swamp/pulled-extensions/<ext-name>/models/`                  |
+| `workflows/`         | `.swamp/pulled-extensions/<ext-name>/workflows/`               |
+| `vaults/`            | `.swamp/pulled-extensions/<ext-name>/vaults/`                  |
+| `drivers/`           | `.swamp/pulled-extensions/<ext-name>/drivers/`                 |
+| `datastores/`        | `.swamp/pulled-extensions/<ext-name>/datastores/`              |
+| `reports/`           | `.swamp/pulled-extensions/<ext-name>/reports/`                 |
+| `files/`             | `.swamp/pulled-extensions/<ext-name>/files/`                   |
 | `bundles/`           | `.swamp/bundles/<bundleNamespace(per-extension models dir)>/`  |
-| `vault-bundles/`     | `.swamp/vault-bundles/<bundleNamespace(…vaults dir)>/`       |
-| `driver-bundles/`    | `.swamp/driver-bundles/<bundleNamespace(…drivers dir)>/`     |
+| `vault-bundles/`     | `.swamp/vault-bundles/<bundleNamespace(…vaults dir)>/`         |
+| `driver-bundles/`    | `.swamp/driver-bundles/<bundleNamespace(…drivers dir)>/`       |
 | `datastore-bundles/` | `.swamp/datastore-bundles/<bundleNamespace(…datastores dir)>/` |
-| `report-bundles/`    | `.swamp/report-bundles/<bundleNamespace(…reports dir)>/`     |
+| `report-bundles/`    | `.swamp/report-bundles/<bundleNamespace(…reports dir)>/`       |
 | `skills/`            | Every enrolled tool's skills dir (deduplicated)                |
 
 ### Multi-tool skill materialization
 
 In repos enrolled for multiple AI tools (`marker.tools` has 2+ entries),
 `extension pull`, `extension update`, `extension install`, and
-`extension source add` extract skills to **every** enrolled tool's
-project-local skills directory. The directories are deduplicated so
-shared-path tools (codex/cursor/opencode/copilot, all mapping to
-`.agents/skills/`) are written only once.
+`extension source add` extract skills to **every** enrolled tool's project-local
+skills directory. The directories are deduplicated so shared-path tools
+(codex/cursor/opencode/copilot, all mapping to `.agents/skills/`) are written
+only once.
 
-All skill directory roots are tracked in the lockfile's `files[]` array,
-so `extension rm` and orphan pruning correctly handle multi-tool repos:
-removal deletes all copies, and re-pulling after a tool change prunes the
-old tool's stale skill paths.
+All skill directory roots are tracked in the lockfile's `files[]` array, so
+`extension rm` and orphan pruning correctly handle multi-tool repos: removal
+deletes all copies, and re-pulling after a tool change prunes the old tool's
+stale skill paths.
 
-The `resolveUniqueLocalSkillsDirs(repoDir, tools)` helper mirrors the
-existing `resolveUniqueGlobalSkillsDirs(tools)` pattern used for
-user-level skill directories.
+The `resolveUniqueLocalSkillsDirs(repoDir, tools)` helper mirrors the existing
+`resolveUniqueGlobalSkillsDirs(tools)` pattern used for user-level skill
+directories.
 
 ### Why extension-first?
 
@@ -1188,36 +1173,36 @@ helpers under `_lib/`, boilerplate like `README.md` and `LICENSE.txt`, and
 occasional type-coincidences like `cluster.ts`. In a type-first (flat) layout,
 these collide at extraction time: the second pull either errors with
 `ConflictError` or silently overwrites the first with `--force`. The silent
-overwrite is the dangerous case — `_lib/*` helpers are imported transitively
-by model bundles, so a swap of `_lib/aws.ts` between ec2 and eks produces
-incorrect runtime behavior with no type or load error.
+overwrite is the dangerous case — `_lib/*` helpers are imported transitively by
+model bundles, so a swap of `_lib/aws.ts` between ec2 and eks produces incorrect
+runtime behavior with no type or load error.
 
-Extension-first layout eliminates this entirely: each extension's files live
-in a disjoint subtree keyed on its scoped name. The scoped name is already
-a value object the registry uses for identity, so promoting it to the
-filesystem aggregate root costs nothing beyond joining a path segment.
+Extension-first layout eliminates this entirely: each extension's files live in
+a disjoint subtree keyed on its scoped name. The scoped name is already a value
+object the registry uses for identity, so promoting it to the filesystem
+aggregate root costs nothing beyond joining a path segment.
 
 ### manifest.yaml colocation
 
 Each extension's archive manifest is extracted to
 `.swamp/pulled-extensions/<ext-name>/manifest.yaml` with file mode `0o444`
-(read-only) and prefixed with a `# Read-only; regenerate via 'swamp
-extension pull'` header. Colocation makes every installed extension
-self-describing on disk: `extension rm`'s dependent-resolution reads the
-tracked manifest directly rather than re-fetching or re-parsing the
-archive. The read-only mode is advisory on some filesystems (notably
-Windows); it is documented via the header, not enforced as a security
+(read-only) and prefixed with a
+`# Read-only; regenerate via 'swamp
+extension pull'` header. Colocation makes
+every installed extension self-describing on disk: `extension rm`'s
+dependent-resolution reads the tracked manifest directly rather than re-fetching
+or re-parsing the archive. The read-only mode is advisory on some filesystems
+(notably Windows); it is documented via the header, not enforced as a security
 boundary.
 
 ### Bundle cache isolation
 
 `bundleNamespace(baseDir, repoDir)` hashes its input relative path. With
-per-extension models dirs, each extension's hash is unique, so every
-extension ends up in its own namespace under `.swamp/bundles/…` — bundle
-keys are disjoint per extension without any additional logic. For
-datastore-backed repos where `bundles/` is tiered to S3 (see
-`DEFAULT_DATASTORE_SUBDIRS`), this means team members' bundle caches are
-cleanly separated per extension.
+per-extension models dirs, each extension's hash is unique, so every extension
+ends up in its own namespace under `.swamp/bundles/…` — bundle keys are disjoint
+per extension without any additional logic. For datastore-backed repos where
+`bundles/` is tiered to S3 (see `DEFAULT_DATASTORE_SUBDIRS`), this means team
+members' bundle caches are cleanly separated per extension.
 
 If files already exist at the destination and `--force` is not set, the user is
 prompted to confirm overwriting. Because every extension has its own subtree,
@@ -1250,8 +1235,8 @@ Recovery paths:
   including its pre-built bundle.
 - **User-facing warning:** `registerLazyFromCatalog` warns when extensions are
   skipped due to failure states, directing users to the recovery commands. The
-  warning checks source file existence before firing — stale catalog entries
-  for deleted source files are silently skipped (swamp-club#894).
+  warning checks source file existence before firing — stale catalog entries for
+  deleted source files are silently skipped (swamp-club#894).
 
 `BUNDLE_LAYOUT_VERSION` must be bumped whenever a change to the bundler, runtime
 interface, or zod global shape would make existing bundles incompatible.
@@ -1261,153 +1246,146 @@ interface, or zod global shape would make existing bundles incompatible.
 Existing repos that installed extensions under older layouts migrate via
 `swamp repo upgrade`. Three generations are recognised:
 
-- **gen-1 (pre-`.swamp/`):** files under `extensions/<type>/...`. `repo
-  upgrade` renames them to `.swamp/pulled-extensions/<type>/...` and rewrites
-  lockfile paths in place. Safe because the same bytes just move.
+- **gen-1 (pre-`.swamp/`):** files under `extensions/<type>/...`.
+  `repo
+  upgrade` renames them to `.swamp/pulled-extensions/<type>/...` and
+  rewrites lockfile paths in place. Safe because the same bytes just move.
 - **gen-2 (flat under `.swamp/`):** files under
-  `.swamp/pulled-extensions/<type>/<file>`. Because filenames collide
-  across extensions in this layout, prior installs may have silently
-  overwritten each other, so rename cannot recover authentic content.
-  `repo upgrade` instead selectively deletes each gen-2 entry's tracked
-  files (leaving the lockfile unchanged); the next
-  `swamp extension install` re-pulls each affected extension into its new
-  per-extension subtree, with integrity verified against the lockfile's
-  stored checksum.
+  `.swamp/pulled-extensions/<type>/<file>`. Because filenames collide across
+  extensions in this layout, prior installs may have silently overwritten each
+  other, so rename cannot recover authentic content. `repo upgrade` instead
+  selectively deletes each gen-2 entry's tracked files (leaving the lockfile
+  unchanged); the next `swamp extension install` re-pulls each affected
+  extension into its new per-extension subtree, with integrity verified against
+  the lockfile's stored checksum.
 - **current (per-extension):** files under
   `.swamp/pulled-extensions/<ext-name>/<type>/...`. No migration needed.
 
-The lockfile tolerates mixed-generation state: each entry stands alone, and
-the warn-not-block guard at the CLI layer proceeds with a one-line
-reminder rather than hard-failing so that already-migrated extensions stay
-usable during a partial upgrade. The migration is **resumable**:
-`Deno.errors.NotFound` during selective delete is treated as success
-(expected on a retry after an interrupted prior pass); any other IO error
-aborts the upgrade before any further mutations, leaving the lockfile
-intact so retry starts from a consistent state.
+The lockfile tolerates mixed-generation state: each entry stands alone, and the
+warn-not-block guard at the CLI layer proceeds with a one-line reminder rather
+than hard-failing so that already-migrated extensions stay usable during a
+partial upgrade. The migration is **resumable**: `Deno.errors.NotFound` during
+selective delete is treated as success (expected on a retry after an interrupted
+prior pass); any other IO error aborts the upgrade before any further mutations,
+leaving the lockfile intact so retry starts from a consistent state.
 
-Skill directory entries (tracked as a single dir path in `entry.files[]`,
-e.g. `.claude/skills/<name>`, `.cursor/skills/<name>`, or
-`.swamp/pulled-extensions/skills/<name>` for the `tool=none` fallback)
-are **always** treated as current-layout regardless of physical location.
-The install flow filters them via the skillsDir wired through
-`ExtensionInstallDeps` before classification runs, so they neither
-trigger migration on their own nor get touched by the post-migration
-sweep — without that filter, the `tool=none` fallback shape would be
-indistinguishable from a gen-2 path and the freshly-restored skill dir
-would be destructively removed. The path-only `classifyExtensionFile`
-helper on its own only flags paths matching the documented gen-1 shape
-(`extensions/<known-type>/...` where `<known-type>` is in
-`PULLED_TYPE_DIRS`); arbitrary non-`.swamp/` paths and any path the
-classifier doesn't recognise fall through to current-layout and are
-ignored by migration rather than swept.
+Skill directory entries (tracked as a single dir path in `entry.files[]`, e.g.
+`.claude/skills/<name>`, `.cursor/skills/<name>`, or
+`.swamp/pulled-extensions/skills/<name>` for the `tool=none` fallback) are
+**always** treated as current-layout regardless of physical location. The
+install flow filters them via the skillsDir wired through `ExtensionInstallDeps`
+before classification runs, so they neither trigger migration on their own nor
+get touched by the post-migration sweep — without that filter, the `tool=none`
+fallback shape would be indistinguishable from a gen-2 path and the
+freshly-restored skill dir would be destructively removed. The path-only
+`classifyExtensionFile` helper on its own only flags paths matching the
+documented gen-1 shape (`extensions/<known-type>/...` where `<known-type>` is in
+`PULLED_TYPE_DIRS`); arbitrary non-`.swamp/` paths and any path the classifier
+doesn't recognise fall through to current-layout and are ignored by migration
+rather than swept.
 
 ## Removal
 
 Installed extensions can be removed with `extension rm`. Removal first
 tombstones the extension's catalog rows (so its `(kind, type)` slots are
-released atomically in one SQLite transaction), then removes the lockfile
-entry, then deletes the on-disk files tracked in
-`upstream_extensions.json` and prunes empty parent directories.
+released atomically in one SQLite transaction), then removes the lockfile entry,
+then deletes the on-disk files tracked in `upstream_extensions.json` and prunes
+empty parent directories.
 
 If other installed extensions list the target as a dependency (detected by
 scanning their `manifest.yaml` files on disk), a warning is displayed before
 proceeding.
 
-A double-rm yields a clean `Extension <name> is not installed.` user
-error on the second call — the lifecycle service decides "not installed"
-when both the catalog AND the lockfile confirm absence, so partial-state
-extensions still rm cleanly.
+A double-rm yields a clean `Extension <name> is not installed.` user error on
+the second call — the lifecycle service decides "not installed" when both the
+catalog AND the lockfile confirm absence, so partial-state extensions still rm
+cleanly.
 
-Extensions pulled before file tracking was added cannot be removed cleanly —
-the user is prompted to re-pull with `--force` to populate the file list first.
+Extensions pulled before file tracking was added cannot be removed cleanly — the
+user is prompted to re-pull with `--force` to populate the file list first.
 
 ## Lifecycle Services
 
 `InstallExtensionService`, `RemoveExtensionService`, and
-`UpgradeExtensionService` (in `src/libswamp/extensions/`) are the three
-narrow seams through which the catalog gets written. The CLI command
-files do not call the catalog directly — they construct the appropriate
-service and call `execute(...)`. This is the W2 split that closed
-[swamp-club#201](https://swamp-club.com/issues/201) (rm now prunes
-catalog rows) and unblocks the W3+ unified-loader work.
+`UpgradeExtensionService` (in `src/libswamp/extensions/`) are the three narrow
+seams through which the catalog gets written. The CLI command files do not call
+the catalog directly — they construct the appropriate service and call
+`execute(...)`. This is the W2 split that closed
+[swamp-club#201](https://swamp-club.com/issues/201) (rm now prunes catalog rows)
+and unblocks the W3+ unified-loader work.
 
 ### Asymmetric ordering
 
-Install is **filesystem → lockfile → catalog**. Remove is the
-**inverse**: **catalog → lockfile → filesystem**.
+Install is **filesystem → lockfile → catalog**. Remove is the **inverse**:
+**catalog → lockfile → filesystem**.
 
-The asymmetry is not aesthetic. If rm went filesystem-first, the catalog
-would briefly point at deleted bundle files and any concurrent type
-resolution would crash for that window. Catalog-first means a mid-rm
-crash leaves files on disk but the catalog clean — the next loader pass
-surfaces the orphans via `findStaleFiles`. Symmetrically, install
-catalog-last means a mid-install crash leaves on-disk files + lockfile
-entry but no catalog rows; the next loader pass rebuilds the catalog
-from the on-disk content via the existing cold-start path.
+The asymmetry is not aesthetic. If rm went filesystem-first, the catalog would
+briefly point at deleted bundle files and any concurrent type resolution would
+crash for that window. Catalog-first means a mid-rm crash leaves files on disk
+but the catalog clean — the next loader pass surfaces the orphans via
+`findStaleFiles`. Symmetrically, install catalog-last means a mid-install crash
+leaves on-disk files + lockfile entry but no catalog rows; the next loader pass
+rebuilds the catalog from the on-disk content via the existing cold-start path.
 
 ### Phase 8: synchronous type extraction at install
 
-After the install service has written files to disk and the lockfile
-entry, **phase 8** walks the per-extension subtree, calls each loader's
-`bundleAndIndexOne(args)` for every source file, builds an `Extension`
-aggregate whose Sources land in `Indexed` state with
-`(kind, typeNormalized, bundlePath)` populated, and commits via
-`repository.saveAll([extension])` in one SQLite transaction. The
-repository's I-Repo-1 invariant — no two non-tombstoned Sources may
-share `(kind, typeNormalized)` — fires synchronously at install time
-rather than at the next steady-state loader pass. This is the
-user-visible payoff of the W2 split: a cross-extension type collision
-surfaces as a clean `DuplicateTypeUserError` *before* the user sees a
-"successfully pulled" message.
+After the install service has written files to disk and the lockfile entry,
+**phase 8** walks the per-extension subtree, calls each loader's
+`bundleAndIndexOne(args)` for every source file, builds an `Extension` aggregate
+whose Sources land in `Indexed` state with `(kind, typeNormalized, bundlePath)`
+populated, and commits via `repository.saveAll([extension])` in one SQLite
+transaction. The repository's I-Repo-1 invariant — no two non-tombstoned Sources
+may share `(kind, typeNormalized)` — fires synchronously at install time rather
+than at the next steady-state loader pass. This is the user-visible payoff of
+the W2 split: a cross-extension type collision surfaces as a clean
+`DuplicateTypeUserError` _before_ the user sees a "successfully pulled" message.
 
 `bundleAndIndexOne` is a strict per-loader contract: it bundles + type-
 extracts + returns metadata, but **does not write to the catalog**. The
-lifecycle service is the catalog-write owner — keeping it that way is
-what lets I-Repo-1 fire on every install consistently.
+lifecycle service is the catalog-write owner — keeping it that way is what lets
+I-Repo-1 fire on every install consistently.
 
 ### Unreachable-path pre-flight prune
 
 Before I-Repo-1 evaluates, `saveAll` prunes non-Tombstoned rows whose
-`source_path` is not under the canonical repo root. This handles stale
-rows left by container sessions that bind-mounted the repo at a
-different path (e.g. `/workspace/...` vs `/Users/...`). Without the
-prune, these phantom rows form cross-aggregate `(kind, typeNormalized)`
-collisions that block *every* catalog write — including `rm` of
-unrelated extensions.
+`source_path` is not under the canonical repo root. This handles stale rows left
+by container sessions that bind-mounted the repo at a different path (e.g.
+`/workspace/...` vs `/Users/...`). Without the prune, these phantom rows form
+cross-aggregate `(kind, typeNormalized)` collisions that block _every_ catalog
+write — including `rm` of unrelated extensions.
 
 ### Atomic upgrade pattern
 
-For every new aggregate the install service is about to save, it
-tombstones any existing aggregate with the *same name* but a *different
-version*, then submits everything to `saveAll` in one transaction:
+For every new aggregate the install service is about to save, it tombstones any
+existing aggregate with the _same name_ but a _different version_, then submits
+everything to `saveAll` in one transaction:
 
 ```
 saveAll([tombstoneAll(v1), ..., v2])
 ```
 
-I-Repo-1 evaluates the **post-save** state, so the slot is held by
-exactly one occupant: the new version. Without this pattern,
-force-pulling an already-installed extension (or any version-bump pull)
-would fail with `DuplicateTypeError` even though the only "conflict" is
-the user's own prior version. Re-installs of the same version skip the
-tombstone — the diff-save in `saveAll` handles overwrite semantics.
+I-Repo-1 evaluates the **post-save** state, so the slot is held by exactly one
+occupant: the new version. Without this pattern, force-pulling an
+already-installed extension (or any version-bump pull) would fail with
+`DuplicateTypeError` even though the only "conflict" is the user's own prior
+version. Re-installs of the same version skip the tombstone — the diff-save in
+`saveAll` handles overwrite semantics.
 
 `UpgradeExtensionService` is a thin facade over
-`InstallExtensionService.execute(...)` that lets call sites express
-upgrade intent at the call site; the atomic-tombstone logic lives
-inside the install service's phase 8.
+`InstallExtensionService.execute(...)` that lets call sites express upgrade
+intent at the call site; the atomic-tombstone logic lives inside the install
+service's phase 8.
 
 ### FS rollback on DuplicateTypeError
 
-A genuine cross-extension `DuplicateTypeError` (two different extensions
-trying to claim the same `(kind, typeNormalized)`) triggers an explicit
-filesystem rollback before the error propagates: extracted files are
-deleted and the lockfile entry is restored to its pre-install state.
-SQLite ROLLBACK does not undo filesystem mutations, so the service does
-this work explicitly. The error then propagates as a
-`DuplicateTypeUserError` (a `UserError` subclass) so the top-level CLI
-handler renders a clean single-line message in log mode and a structured
-`duplicateType` object in `--json` mode:
+A genuine cross-extension `DuplicateTypeError` (two different extensions trying
+to claim the same `(kind, typeNormalized)`) triggers an explicit filesystem
+rollback before the error propagates: extracted files are deleted and the
+lockfile entry is restored to its pre-install state. SQLite ROLLBACK does not
+undo filesystem mutations, so the service does this work explicitly. The error
+then propagates as a `DuplicateTypeUserError` (a `UserError` subclass) so the
+top-level CLI handler renders a clean single-line message in log mode and a
+structured `duplicateType` object in `--json` mode:
 
 ```json
 {
@@ -1415,149 +1393,153 @@ handler renders a clean single-line message in log mode and a structured
   "duplicateType": {
     "kind": "model",
     "type": "@scope/foo",
-    "existing":    { "extensionName": "...", "extensionVersion": "...", "canonicalPath": "..." },
-    "conflicting": { "extensionName": "...", "extensionVersion": "...", "canonicalPath": "..." }
+    "existing": {
+      "extensionName": "...",
+      "extensionVersion": "...",
+      "canonicalPath": "..."
+    },
+    "conflicting": {
+      "extensionName": "...",
+      "extensionVersion": "...",
+      "canonicalPath": "..."
+    }
   }
 }
 ```
 
-The user-visible message points the user at
-`swamp extension rm <existing-name>` to recover. When the conflict is caused
-by a **ghost catalog row** (an entry whose source file was deleted outside
-swamp), the service detects the missing path via `Deno.stat` and instead
-suggests `swamp doctor extensions` — the correct recovery for orphaned rows.
-The `isGhostRow` flag on `DuplicateTypeUserError` is `true` in this case and
-is included in the `--json` output's `duplicateType` object.
+The user-visible message points the user at `swamp extension rm <existing-name>`
+to recover. When the conflict is caused by a **ghost catalog row** (an entry
+whose source file was deleted outside swamp), the service detects the missing
+path via `Deno.stat` and instead suggests `swamp doctor extensions` — the
+correct recovery for orphaned rows. The `isGhostRow` flag on
+`DuplicateTypeUserError` is `true` in this case and is included in the `--json`
+output's `duplicateType` object.
 
 ### Bounded atomicity
 
-Each `execute(...)` is its own transaction. Bulk operations
-(`extension update` over N extensions) run N independent transactions —
-not one all-or-nothing batch. If extension A's upgrade rolls back due
-to a collision with unchanged extension B, every other extension
-already-upgraded in the bulk run **stays upgraded**. This is the
-explicit bounded-atomicity contract: the unit of atomicity is the
-single extension, never a multi-extension run.
+Each `execute(...)` is its own transaction. Bulk operations (`extension update`
+over N extensions) run N independent transactions — not one all-or-nothing
+batch. If extension A's upgrade rolls back due to a collision with unchanged
+extension B, every other extension already-upgraded in the bulk run **stays
+upgraded**. This is the explicit bounded-atomicity contract: the unit of
+atomicity is the single extension, never a multi-extension run.
 
 ### Crash-state recovery
 
-A generic non-`DuplicateTypeError` failure inside `repository.saveAll`
-(SQLite I/O error, OOM, process kill mid-commit) leaves the catalog in
-its pre-save state via SQLite ROLLBACK. The filesystem and lockfile are
-**not** auto-rolled-back — only `DuplicateTypeError` triggers FS
-rollback. A retry succeeds: the diff-save in `saveAll` reconciles the
-catalog against the on-disk + lockfile state.
+A generic non-`DuplicateTypeError` failure inside `repository.saveAll` (SQLite
+I/O error, OOM, process kill mid-commit) leaves the catalog in its pre-save
+state via SQLite ROLLBACK. The filesystem and lockfile are **not**
+auto-rolled-back — only `DuplicateTypeError` triggers FS rollback. A retry
+succeeds: the diff-save in `saveAll` reconciles the catalog against the
+on-disk + lockfile state.
 
-For rm, the catalog tombstone is the **first** mutation, so a fault
-inside that `saveAll` leaves all three layers (catalog, lockfile, FS)
-in their pre-rm state — a retry is a clean re-rm.
+For rm, the catalog tombstone is the **first** mutation, so a fault inside that
+`saveAll` leaves all three layers (catalog, lockfile, FS) in their pre-rm state
+— a retry is a clean re-rm.
 
-The cross-process composition of these per-extension atomicity claims —
-that `saveAll`'s SQLite WAL transaction, the lockfile advisory-lock retry,
-and the asymmetric ordering above all hold under concurrent invocation
-from independent OS processes against the same repository — is verified
-by `integration/lifecycle_concurrent_stress_test.ts` (swamp-club#254). The
-test runs 50 iterations of four concurrent `swamp` subprocesses each
-(`extension pull` × 2 distinct extensions, `extension rm`, `extension
-update`) and asserts catalog↔lockfile↔FS bijection, well-formed lockfile
-JSON, no `DuplicateTypeError` leakage across distinct fixture types, and
-no lockfile-retry-budget or SQLite-busy exhaustion at iteration end.
+The cross-process composition of these per-extension atomicity claims — that
+`saveAll`'s SQLite WAL transaction, the lockfile advisory-lock retry, and the
+asymmetric ordering above all hold under concurrent invocation from independent
+OS processes against the same repository — should be verified by a concurrent
+stress test (swamp-club#254). The test would run multiple iterations of
+concurrent `swamp` subprocesses (`extension pull`, `extension rm`,
+`extension update`) and assert catalog/lockfile/FS bijection, well-formed
+lockfile JSON, no `DuplicateTypeError` leakage across distinct fixture types,
+and no lockfile-retry-budget or SQLite-busy exhaustion at iteration end.
 
 ### W3+ inheritance
 
-The lifecycle services' shape is W4-stable. The unified
-`ExtensionLoader` (parameterized by `KindAdapter`) collapsed the five
-per-loader `bundleAndIndexOne` methods to one dispatch, but the install/remove/
-upgrade services keep their current public surface. CLI command files'
-direct service construction (in `extension_pull.ts`,
-`extension_update.ts`, `extension_rm.ts`, etc.) persists past W4.
+The lifecycle services' shape is W4-stable. The unified `ExtensionLoader`
+(parameterized by `KindAdapter`) collapsed the five per-loader
+`bundleAndIndexOne` methods to one dispatch, but the install/remove/ upgrade
+services keep their current public surface. CLI command files' direct service
+construction (in `extension_pull.ts`, `extension_update.ts`, `extension_rm.ts`,
+etc.) persists past W4.
 
 ### W3: ReconcileFromDisk + freshness as aggregate query
 
 W3 introduces `ReconcileFromDiskService`
-(`src/libswamp/extensions/reconcile_from_disk_service.ts`) and rewrites
-the freshness contract as a two-layer model.
+(`src/libswamp/extensions/reconcile_from_disk_service.ts`) and rewrites the
+freshness contract as a two-layer model.
 
-**Two-layer freshness model.** The freshness contract has two distinct
-concerns:
+**Two-layer freshness model.** The freshness contract has two distinct concerns:
 
 1. **Type resolution layer** (W3 makes this trivial):
-   `isFresh(state) = state === "Indexed"`. Constant-time aggregate
-   query. All other RowState tags are not visible to type resolution.
+   `isFresh(state) = state === "Indexed"`. Constant-time aggregate query. All
+   other RowState tags are not visible to type resolution.
 
 2. **State maintenance layer** (split between two paths):
-   - **Cold-start / explicit reconcile:** `ReconcileFromDiskService`.
-     Full disk walk across all three origin types (locals, pulled,
-     source-mounted). Post-hoc state repair. Fires when
-     `anyKindNeedsInvalidation()` returns true (i.e. any kind's
-     `isPopulated` flag is false).
-   - **Warm-start / hot path:** `findStaleFiles` (preserved from
-     pre-W3). Incremental fingerprint comparison. Fires per-loader
-     `buildIndex` when the catalog is already populated. A
-     fingerprint-matched `BundleBuildFailed` row is treated as **stale**
-     (re-attempted on the next scan), not a satisfied cache hit — a
-     transient build failure (e.g. npm deps unreachable on a cold cache at
-     first load) must recover once conditions change rather than pin the
-     type permanently across restarts (issue #424). Deterministic
+   - **Cold-start / explicit reconcile:** `ReconcileFromDiskService`. Full disk
+     walk across all three origin types (locals, pulled, source-mounted).
+     Post-hoc state repair. Fires when `anyKindNeedsInvalidation()` returns true
+     (i.e. any kind's `isPopulated` flag is false).
+   - **Warm-start / hot path:** `findStaleFiles` (preserved from pre-W3).
+     Incremental fingerprint comparison. Fires per-loader `buildIndex` when the
+     catalog is already populated. A fingerprint-matched `BundleBuildFailed` row
+     is treated as **stale** (re-attempted on the next scan), not a satisfied
+     cache hit — a transient build failure (e.g. npm deps unreachable on a cold
+     cache at first load) must recover once conditions change rather than pin
+     the type permanently across restarts (issue #424). Deterministic
      `ValidationFailed` rows stay excluded — re-bundling them only thrashes.
 
 The original W3 plan targeted slimming `findStaleFiles` to a ~20 LOC
-deletion-sweep shim. Ground truth showed that warm-start incremental
-detection is load-bearing for the development workflow — 12 loader
-tests exercise this path. `findStaleFiles` retains its fingerprint
-comparison. The scope change is deliberate.
+deletion-sweep shim. Ground truth showed that warm-start incremental detection
+is load-bearing for the development workflow — 12 loader tests exercise this
+path. `findStaleFiles` retains its fingerprint comparison. The scope change is
+deliberate.
 
 **ReconcileFromDisk semantics.** The service:
 
 - Walks on-disk source trees for all origin types.
 - Loads current aggregate state via `repository.loadAll()`.
-- Diffs disk vs aggregate and emits RowState transitions using the
-  existing Extension aggregate methods.
-- Delegates to per-loader `bundleAndIndexOne` for type extraction —
-  NOT `InstallExtensionService`. The source is already on disk and the
-  lockfile already exists; reconcile is post-hoc state repair.
+- Diffs disk vs aggregate and emits RowState transitions using the existing
+  Extension aggregate methods.
+- Delegates to per-loader `bundleAndIndexOne` for type extraction — NOT
+  `InstallExtensionService`. The source is already on disk and the lockfile
+  already exists; reconcile is post-hoc state repair.
 - Saves via `repository.saveAll()` inside a single SQLite transaction.
 
 **Locals vs pulled reconcile matrix:**
 
-| Origin | Source on disk | Source in aggregate | Transition |
-|--------|---------------|--------------------|-|
-| Local | present | absent | `bundleAndIndexOne` → `Indexed` |
-| Local | absent | present | `markSourceMissing` → `OrphanedBundleOnly` or `Tombstoned` |
-| Pulled | present | absent | `bundleAndIndexOne` → `Indexed` |
-| Pulled | absent | lockfile present | `recordEntryPointUnreadable` (re-fetch is W4) |
-| Pulled | absent | lockfile absent | `Tombstoned` (orphan from failed rm) |
-| Source-mounted | — | — | Follows local semantics |
+| Origin         | Source on disk | Source in aggregate | Transition                                                 |
+| -------------- | -------------- | ------------------- | ---------------------------------------------------------- |
+| Local          | present        | absent              | `bundleAndIndexOne` → `Indexed`                            |
+| Local          | absent         | present             | `markSourceMissing` → `OrphanedBundleOnly` or `Tombstoned` |
+| Pulled         | present        | absent              | `bundleAndIndexOne` → `Indexed`                            |
+| Pulled         | absent         | lockfile present    | `recordEntryPointUnreadable` (re-fetch is W4)              |
+| Pulled         | absent         | lockfile absent     | `Tombstoned` (orphan from failed rm)                       |
+| Source-mounted | —              | —                   | Follows local semantics                                    |
 
-**Trigger points:** cold-start (when `anyKindNeedsInvalidation()`
-returns true) + explicit `swamp doctor extensions` call. NOT on every
-command — reconcile would dominate the hot-path performance.
+**Trigger points:** cold-start (when `anyKindNeedsInvalidation()` returns
+true) + explicit `swamp doctor extensions` call. NOT on every command —
+reconcile would dominate the hot-path performance.
 
-**dryRun mode:** `execute({ dryRun: true })` collects transitions
-without calling `repository.saveAll()`. Returns structured
-`ReconcileTransition` records (`{ source, fromState, toState, reason }`)
-that W6's `swamp doctor extensions` will render directly.
+**dryRun mode:** `execute({ dryRun: true })` collects transitions without
+calling `repository.saveAll()`. Returns structured `ReconcileTransition` records
+(`{ source, fromState, toState, reason }`) that W6's `swamp doctor extensions`
+will render directly.
 
 **Transition-count guardrail:** if a reconcile run would transition
-> 50% of existing rows (minimum 10 rows), the run aborts and returns
-the transitions without applying them. Catches mass-tombstone bugs.
 
-**enforceI2 transform.** W3 replaces the `IntraExtensionDuplicateType`
-throw in the Extension aggregate's I2 enforcement with a
-deterministic-winner + tombstone-loser transform. The Source with the
-lexicographically smaller `canonicalPath` wins; the loser is tombstoned
-with reason `"renamed"`. Cross-aggregate uniqueness (I-Repo-1) still
-throws `DuplicateTypeError` at the repository layer.
+> 50% of existing rows (minimum 10 rows), the run aborts and returns the
+> transitions without applying them. Catches mass-tombstone bugs.
 
-**UNREADABLE_DEP_SENTINEL removal.** The sentinel constant was renamed
-to `UNREADABLE_PLACEHOLDER` (internal to `computeSourceFingerprint`).
-No external code compares against it. Broken transitive deps produce a
-stable fingerprint; the failure surfaces at `bundleAndIndexOne` as
-`BundleBuildFailed`. Zod schema validation failures (bundle built
-successfully but export rejected) surface as `ValidationFailed` via a
-`ValidationError` subclass that carries the bundle path and fingerprint
-(see `validation_error.ts`). Existing catalog rows with the old sentinel
-value are caught by the first reconcile run — no schema migration needed.
+**enforceI2 transform.** W3 replaces the `IntraExtensionDuplicateType` throw in
+the Extension aggregate's I2 enforcement with a deterministic-winner +
+tombstone-loser transform. The Source with the lexicographically smaller
+`canonicalPath` wins; the loser is tombstoned with reason `"renamed"`.
+Cross-aggregate uniqueness (I-Repo-1) still throws `DuplicateTypeError` at the
+repository layer.
+
+**UNREADABLE_DEP_SENTINEL removal.** The sentinel constant was renamed to
+`UNREADABLE_PLACEHOLDER` (internal to `computeSourceFingerprint`). No external
+code compares against it. Broken transitive deps produce a stable fingerprint;
+the failure surfaces at `bundleAndIndexOne` as `BundleBuildFailed`. Zod schema
+validation failures (bundle built successfully but export rejected) surface as
+`ValidationFailed` via a `ValidationError` subclass that carries the bundle path
+and fingerprint (see `validation_error.ts`). Existing catalog rows with the old
+sentinel value are caught by the first reconcile run — no schema migration
+needed.
 
 **Forward-only revert posture.** Same as W1b/W2: revert means deleting
 `_extension_catalog.db` and rebuilding from disk on the next cold-start.
@@ -1571,35 +1553,35 @@ value are caught by the first reconcile run — no schema migration needed.
 
 Extends `swamp doctor extensions` with two capabilities:
 
-1. **Aggregate-state rendering** — surfaces per-extension RowState
-   distribution, orphan detection, and summary rollups in both `log` and
-   `json` modes. Always runs after the existing invalidation-guard checks.
+1. **Aggregate-state rendering** — surfaces per-extension RowState distribution,
+   orphan detection, and summary rollups in both `log` and `json` modes. Always
+   runs after the existing invalidation-guard checks.
 
-2. **Repair surface** — `--repair` enters repair mode (`--dry-run` by
-   default), `--repair --apply` performs cleanup. Catalog row pruning
-   (Tombstoned/OrphanedBundleOnly) and bundle file eviction (unreferenced
-   `.js` files in `<kind>-bundles/`).
+2. **Repair surface** — `--repair` enters repair mode (`--dry-run` by default),
+   `--repair --apply` performs cleanup. Catalog row pruning
+   (Tombstoned/OrphanedBundleOnly) and bundle file eviction (unreferenced `.js`
+   files in `<kind>-bundles/`).
 
 **Bundle naming convention:** overwrite-on-rebundle (not content-addressed).
-Orphans accumulate linearly per deleted source. The `bundle_path` column is
-the source of truth for which files are referenced.
+Orphans accumulate linearly per deleted source. The `bundle_path` column is the
+source of truth for which files are referenced.
 
 **Event model:** `DoctorExtensionsReport` extended with additive
-`aggregateState`, `repairReport`, and `recentTransitions` fields. No new
-event kinds. Backward compatible for existing `--json` consumers.
+`aggregateState`, `repairReport`, and `recentTransitions` fields. No new event
+kinds. Backward compatible for existing `--json` consumers.
 
 **`recentTransitions`**: Always-present array (empty when no transitions
-occurred) populated from `ReconcileResult.transitions[]`. Each entry
-serializes `sourcePath` (from `SourceLocation.canonicalPath`, matching
+occurred) populated from `ReconcileResult.transitions[]`. Each entry serializes
+`sourcePath` (from `SourceLocation.canonicalPath`, matching
 `sourceDetails[].sourcePath`), `fromState`, `toState`, and `reason`. No
-timestamp — post-#334 every `doctor extensions` invocation triggers
-reconcile, so all transitions are current-process. In JSON mode the array
-is unconditionally present; in log mode it renders only with `--verbose`.
-Surfaced via `DoctorExtensionsDeps.getRecentTransitions` callback so the
-generator stays infrastructure-free.
+timestamp — post-#334 every `doctor extensions` invocation triggers reconcile,
+so all transitions are current-process. In JSON mode the array is
+unconditionally present; in log mode it renders only with `--verbose`. Surfaced
+via `DoctorExtensionsDeps.getRecentTransitions` callback so the generator stays
+infrastructure-free.
 
-**Repair safety:** `--dry-run` is the default. Only `--repair --apply`
-performs destructive operations. Indexed and Bundled rows are NEVER touched.
+**Repair safety:** `--dry-run` is the default. Only `--repair --apply` performs
+destructive operations. Indexed and Bundled rows are NEVER touched.
 
 **Absorbed:** swamp-club#267 (extension layer garbage collection).
 
@@ -1615,14 +1597,14 @@ how many extensions are installed.
 indexes all known bundle types. Each entry stores the type name, bundle path,
 source path, source mtime, source fingerprint (sha-256 content hash), version,
 and (for extensions) the base type it targets. Freshness is decided by the
-content fingerprint; `source_mtime` is retained for observability only. The catalog lives at the `.swamp` root level because it is shared
-across all registry types (models, vaults, drivers, datastores, reports). It
-is completely independent of the data catalog (`_catalog.db`) used for data
-queries.
+content fingerprint; `source_mtime` is retained for observability only. The
+catalog lives at the `.swamp` root level because it is shared across all
+registry types (models, vaults, drivers, datastores, reports). It is completely
+independent of the data catalog (`_catalog.db`) used for data queries.
 
 The schema includes a `kind` column (`model`, `extension`, `vault`, `driver`,
-`datastore`, `report`) so a single catalog supports all registry types. Only
-the model registry is wired up initially.
+`datastore`, `report`) so a single catalog supports all registry types. Only the
+model registry is wired up initially.
 
 **Loading Flow**:
 
@@ -1633,50 +1615,47 @@ the model registry is wired up initially.
      fingerprint over each entry point plus its transitive local `.ts`
      dependencies, compares that against the catalog's stored fingerprint,
      rebundles only changed files, then registers lazy entries for all types
-     from the catalog (no bundle imports). Fingerprint-based freshness
-     replaced mtime-based freshness in issue #125 — mtime was fragile under
-     atomic-rename saves, mtime-preserving sync tools, and sub-millisecond
-     edits. The fingerprint is **total**: when a transitive dep is currently
-     unreadable (broken symlink, deleted file, FilesystemLoop), its hash
-     entry is replaced with a stable sentinel rather than throwing — so a
-     stable broken state produces a stable fingerprint and the entry is not
-     marked permanently stale (#208). Repairing the dep flips the sentinel
-     back to a real hash and triggers a rebundle correctly. This property
-     holds uniformly across all five extension kinds (models, drivers,
-     vaults, datastores, reports) since they share the freshness service.
-     Symmetrically, when an extension's source bundles and imports cleanly
-     but fails schema validation (e.g. a required field was removed), the
-     catalog row is upserted with the new fingerprint and a
-     `validation_failed = true` marker (#209). Freshness comparison still
+     from the catalog (no bundle imports). Fingerprint-based freshness replaced
+     mtime-based freshness in issue #125 — mtime was fragile under atomic-rename
+     saves, mtime-preserving sync tools, and sub-millisecond edits. The
+     fingerprint is **total**: when a transitive dep is currently unreadable
+     (broken symlink, deleted file, FilesystemLoop), its hash entry is replaced
+     with a stable sentinel rather than throwing — so a stable broken state
+     produces a stable fingerprint and the entry is not marked permanently stale
+     (#208). Repairing the dep flips the sentinel back to a real hash and
+     triggers a rebundle correctly. This property holds uniformly across all
+     five extension kinds (models, drivers, vaults, datastores, reports) since
+     they share the freshness service. Symmetrically, when an extension's source
+     bundles and imports cleanly but fails schema validation (e.g. a required
+     field was removed), the catalog row is upserted with the new fingerprint
+     and a `validation_failed = true` marker (#209). Freshness comparison still
      works via fingerprint equality — the broken row is visible to
-     `findStaleFiles` so a stable broken source produces a stable
-     not-stale state. Registration paths filter on `validation_failed`,
-     so the broken extension is correctly absent from the registry until
-     the source is fixed. Editing the source to a different shape
-     produces a new fingerprint, marks the file stale, triggers a
-     rebundle, and flips the row back to `validation_failed = false`.
-     This fix is scoped to the steady-state `rebundleAndUpdateCatalog`
-     hot path — the cold-start parses (initial `loadModels` Pass 1, the
-     by-name `loadSingleType`, and the extension-attach predicate)
-     retain their existing failure semantics because they are not in
+     `findStaleFiles` so a stable broken source produces a stable not-stale
+     state. Registration paths filter on `validation_failed`, so the broken
+     extension is correctly absent from the registry until the source is fixed.
+     Editing the source to a different shape produces a new fingerprint, marks
+     the file stale, triggers a rebundle, and flips the row back to
+     `validation_failed = false`. This fix is scoped to the steady-state
+     `rebundleAndUpdateCatalog` hot path — the cold-start parses (initial
+     `loadModels` Pass 1, the by-name `loadSingleType`, and the extension-attach
+     predicate) retain their existing failure semantics because they are not in
      the read-only steady-state loop.
    - **Fingerprint preservation on build failure (issue #265).** When
-     `bundleWithCache` cannot regenerate a bundle (bare specifiers without
-     a project `deno.json`, or a transient build error) and falls back to
-     the cached `.js`, the `rebundleAndUpdateCatalog` caller preserves the
-     catalog's _stored_ `source_fingerprint` instead of writing the new
-     one. This keeps the file "stale" so `findStaleFiles` retries on the
-     next warm-start invocation. Without this, the new fingerprint would
-     be written alongside the old bundle content, permanently masking the
-     staleness — `findStaleFiles` would see matching fingerprints and
-     never retry. The warning log fires only on the fallback case
-     (`fromCache && newFingerprint !== catalogFingerprint`), not on
-     legitimate cache hits where the source hasn't changed.
-     `findStaleFiles` uses fingerprint comparison, not RowState, for
-     staleness decisions. `BundleBuildFailed` rows are skipped when
-     fingerprints match (source unchanged) and retried when they mismatch
-     (source changed) — warm-start and reconcile operate on orthogonal
-     axes.
+     `bundleWithCache` cannot regenerate a bundle (bare specifiers without a
+     project `deno.json`, or a transient build error) and falls back to the
+     cached `.js`, the `rebundleAndUpdateCatalog` caller preserves the catalog's
+     _stored_ `source_fingerprint` instead of writing the new one. This keeps
+     the file "stale" so `findStaleFiles` retries on the next warm-start
+     invocation. Without this, the new fingerprint would be written alongside
+     the old bundle content, permanently masking the staleness —
+     `findStaleFiles` would see matching fingerprints and never retry. The
+     warning log fires only on the fallback case
+     (`fromCache && newFingerprint !== catalogFingerprint`), not on legitimate
+     cache hits where the source hasn't changed. `findStaleFiles` uses
+     fingerprint comparison, not RowState, for staleness decisions.
+     `BundleBuildFailed` rows are skipped when fingerprints match (source
+     unchanged) and retried when they mismatch (source changed) — warm-start and
+     reconcile operate on orthogonal axes.
 
    - If not populated (first run or DB deleted): falls back to the existing
      full-import path, then populates the catalog from the loaded registry
@@ -1690,29 +1669,28 @@ the model registry is wired up initially.
    type.
 
 4. Concurrent callers requesting the same type share a single load promise
-   (per-type memoization). Additionally, `ensureTypeLoaded` awaits any
-   pending load promise even when the type is already in the registry —
-   `loadSingleType` registers the base type via `promoteFromLazy` before
-   attaching extensions, so a concurrent caller arriving between those two
-   steps must wait for extensions to be merged (swamp-club#521).
+   (per-type memoization). Additionally, `ensureTypeLoaded` awaits any pending
+   load promise even when the type is already in the registry — `loadSingleType`
+   registers the base type via `promoteFromLazy` before attaching extensions, so
+   a concurrent caller arriving between those two steps must wait for extensions
+   to be merged (swamp-club#521).
 
 ### Self-Healing
 
 The catalog self-heals: deleting `_extension_catalog.db` triggers a full import
-on next access (same behavior as before lazy loading was added). The
-`populated` flag follows the same pattern as the data catalog's backfill
-mechanism.
+on next access (same behavior as before lazy loading was added). The `populated`
+flag follows the same pattern as the data catalog's backfill mechanism.
 
 ### Roadmap
 
-Per-bundle lazy loading for vault, driver, datastore, and report registries
-will follow the same pattern using the shared `kind` column in the bundle
-catalog schema.
+Per-bundle lazy loading for vault, driver, datastore, and report registries will
+follow the same pattern using the shared `kind` column in the bundle catalog
+schema.
 
 ## Reporting Issues Against Extensions
 
-Users can file reports against a specific extension with `--extension <name>`
-on the `swamp issue bug|feature|security` commands. The CLI routes the report
+Users can file reports against a specific extension with `--extension <name>` on
+the `swamp issue bug|feature|security` commands. The CLI routes the report
 according to the extension's collective and its declared `repository`:
 
 1. **`@swamp/*` extensions** — routed to the existing swamp-club Lab (the same
@@ -1722,9 +1700,10 @@ according to the extension's collective and its declared `repository`:
 
 2. **Third-party extensions with `repository` set** — routed to the declared
    upstream repository. When the `gh` CLI is installed and authenticated
-   (`GH_TOKEN` or `gh auth login`), the report is created via `gh issue
-   create`. Otherwise the CLI opens the provider's new-issue URL in the
-   browser with title and body pre-filled (GitHub and GitLab supported;
+   (`GH_TOKEN` or `gh auth login`), the report is created via
+   `gh issue
+   create`. Otherwise the CLI opens the provider's new-issue URL in
+   the browser with title and body pre-filled (GitHub and GitLab supported;
    other hosts open the repo root and the prepared body is printed to the
    terminal for manual pasting).
 
@@ -1737,32 +1716,31 @@ according to the extension's collective and its declared `repository`:
 
 For `swamp issue security --extension <name>` against a third-party GitHub
 repository, the CLI first checks whether the repository has enabled GitHub's
-Private Vulnerability Reporting (PVR) feature via `gh api
+Private Vulnerability Reporting (PVR) feature via
+`gh api
 repos/<owner>/<repo>/private-vulnerability-reporting`:
 
 - **PVR enabled** — open the GitHub advisory form
-  (`<repo>/security/advisories/new`). The form is structured and doesn't
-  accept URL prefill; the user fills it in manually.
-- **PVR disabled** — **refuse**. This is a load-bearing security guardrail:
-  the CLI never falls back to creating a public issue for a security report,
-  because that would silently publish the vulnerability. The refusal guidance
-  tells the reporter to contact the publisher privately and tells the
-  publisher to enable PVR at `<repo>/settings/security_analysis`.
-- **PVR check failed or gh unavailable** — open the advisory URL with a
-  fallback issue URL surfaced in the output. The user decides after seeing
-  what GitHub responds with.
+  (`<repo>/security/advisories/new`). The form is structured and doesn't accept
+  URL prefill; the user fills it in manually.
+- **PVR disabled** — **refuse**. This is a load-bearing security guardrail: the
+  CLI never falls back to creating a public issue for a security report, because
+  that would silently publish the vulnerability. The refusal guidance tells the
+  reporter to contact the publisher privately and tells the publisher to enable
+  PVR at `<repo>/settings/security_analysis`.
+- **PVR check failed or gh unavailable** — open the advisory URL with a fallback
+  issue URL surfaced in the output. The user decides after seeing what GitHub
+  responds with.
 
-The asymmetry between GitHub (hard refusal when PVR is off) and GitLab
-(routes to the normal issue form with a "toggle confidential" warning) is
-intentional: GitLab's confidential-issues feature is universal and
-reliable, so the user always has a safe in-form path. GitHub's PVR is
-opt-in per repo, so the CLI refuses rather than trust the reporter to
-remember not to file publicly.
+The asymmetry between GitHub (hard refusal when PVR is off) and GitLab (routes
+to the normal issue form with a "toggle confidential" warning) is intentional:
+GitLab's confidential-issues feature is universal and reliable, so the user
+always has a safe in-form path. GitHub's PVR is opt-in per repo, so the CLI
+refuses rather than trust the reporter to remember not to file publicly.
 
 ### Publish-Time Nudge
 
 When `swamp extension push` runs against a manifest without a `repository`
-field, the CLI emits a non-blocking warning reminding the publisher that
-users will not be able to file issues via `--extension`. The warning never
-blocks the push — some publishers may deliberately omit `repository`.
-
+field, the CLI emits a non-blocking warning reminding the publisher that users
+will not be able to file issues via `--extension`. The warning never blocks the
+push — some publishers may deliberately omit `repository`.

--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -41,14 +41,17 @@ built-in tool:
 
 ```typescript
 const GLOBAL_SKILL_DIRS: Record<string, string> = {
-  claude: "~/.claude/skills",
-  cursor: "~/.agents/skills",
-  opencode: "~/.agents/skills",
-  codex: "~/.agents/skills",
-  copilot: "~/.agents/skills",
-  kiro: "~/.kiro/skills",
+  claude: ".claude/skills",
+  cursor: ".agents/skills",
+  opencode: ".agents/skills",
+  codex: ".agents/skills",
+  copilot: ".agents/skills",
+  kiro: ".kiro/skills",
 };
 ```
+
+These are relative paths resolved against the user's home directory at
+runtime.
 
 After deduplication, swamp writes to at most three directories:
 
@@ -64,8 +67,7 @@ an optional `globalSkillsDir` field:
 ```typescript
 interface CustomToolDefinition {
   name: string;
-  skillsDir: string;            // project-local path (kept for instructions)
-  globalSkillsDir?: string;     // global path, defaults to "~/.agents/skills"
+  skillsDir: string;
   instructionsFile: string;
   instructionsMode: "shared" | "owned";
   frontmatter?: string;

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -8,7 +8,7 @@ can then validate are correct. Each model has a Type, which specifies metadata,
 attributes, methods, and inputs (variables/parameters as JsonSchema). Model
 definitions contain attributes and can be configured using inputs (variables).
 Methods take the definition and produce data (with data tags like "resource",
-"log", or "file"). Model definitions are stored as YAML files in the top-level
+"file", "log", "data", or "output"). Model definitions are stored as YAML files in the top-level
 `models/` directory, while runtime data is stored in the datastore (default
 `.swamp/`). Definitions support a CEL expression language for dynamic
 configuration.
@@ -19,7 +19,8 @@ Workflows can also define inputs (workflow inputs) for parameterization.
 
 Swamp allows for organizing model definitions and data into applications and
 environments, which can be used to compare data and definitions to detect
-configuration drift.
+configuration drift. (Aspirational/planned -- applications, environments, and
+drift detection are not yet implemented.)
 
 All this is stored in a 'swamp repo', which is a git repository.
 

--- a/design/inputs.md
+++ b/design/inputs.md
@@ -67,7 +67,6 @@ jobs:
           - step: first-env
             condition:
               type: succeeded
-              ref: first-env
         weight: 0
 ```
 
@@ -111,7 +110,6 @@ jobs:
           - step: first-env
             condition:
               type: succeeded
-              ref: first-env
         weight: 0
 ```
 

--- a/design/libswamp.md
+++ b/design/libswamp.md
@@ -2,10 +2,11 @@
 
 ## Problem
 
-Swamp's domain logic is currently invoked directly by CLI command handlers. While
-the existing separation between domain, infrastructure, and presentation layers
-is clean, the CLI is the only entry point — there is no reusable library layer
-that other interfaces (web UI, networked API, embedded usage) can call into.
+Swamp's domain logic is currently invoked directly by CLI command handlers.
+While the existing separation between domain, infrastructure, and presentation
+layers is clean, the CLI is the only entry point — there is no reusable library
+layer that other interfaces (web UI, networked API, embedded usage) can call
+into.
 
 Adding a new presentation layer today requires either duplicating the
 orchestration logic in each command handler, or importing and calling CLI
@@ -63,10 +64,11 @@ caller pulls events at its own pace and renders them however it chooses.
 
 ### Why uniform AsyncIterable (not Promise for simple operations)
 
-Every operation uses `AsyncIterable`, even operations that today produce a single
-result. This eliminates a decision point for adapter authors ("is this a stream
-or a promise?") and allows any operation to grow intermediate events (validation
-warnings, progress, deprecation notices) without breaking the API contract.
+Every operation uses `AsyncIterable`, even operations that today produce a
+single result. This eliminates a decision point for adapter authors ("is this a
+stream or a promise?") and allows any operation to grow intermediate events
+(validation warnings, progress, deprecation notices) without breaking the API
+contract.
 
 ## Core Types
 
@@ -94,7 +96,9 @@ interface LibSwampContext {
   withSignal(signal: AbortSignal): LibSwampContext;
 }
 
-function createLibSwampContext(options?: { signal?: AbortSignal; logger?: Logger }): LibSwampContext {
+function createLibSwampContext(
+  options?: { signal?: AbortSignal; logger?: Logger },
+): LibSwampContext {
   const signal = options?.signal ?? new AbortController().signal;
   const logger = options?.logger ?? getSwampLogger(["libswamp"]);
   return {
@@ -127,8 +131,8 @@ function createLibSwampContext(options?: { signal?: AbortSignal; logger?: Logger
 - **Always present.** Because `ctx` is required, generators never need
   `if (options?.signal)` guards. The signal is always there — it's simply
   never-aborted if the caller doesn't need cancellation.
-- **Familiar pattern.** Mirrors Go's `context.Context`, which is
-  well-understood for exactly this problem space.
+- **Familiar pattern.** Mirrors Go's `context.Context`, which is well-understood
+  for exactly this problem space.
 
 #### Cancellation semantics
 
@@ -167,23 +171,115 @@ interface WhoamiIdentity {
 ```
 
 ```typescript
-// libswamp/workflows/run.ts
+// libswamp/workflows/run.ts — 24 variants
 type WorkflowRunEvent =
   | { kind: "validating_inputs" }
   | { kind: "evaluating_workflow" }
-  | { kind: "started"; runId: string; workflowName: string }
+  | {
+    kind: "started";
+    runId: string;
+    workflowName: string;
+    jobs: WorkflowRunJobInfo[];
+  }
   | { kind: "job_started"; jobId: string }
   | { kind: "job_completed"; jobId: string; status: string }
   | { kind: "job_skipped"; jobId: string }
   | { kind: "step_started"; jobId: string; stepId: string }
-  | { kind: "step_completed"; jobId: string; stepId: string }
+  | { kind: "step_completed"; jobId: string; stepId: string; executor?: string }
   | { kind: "step_skipped"; jobId: string; stepId: string }
-  | { kind: "step_failed"; jobId: string; stepId: string; error: string; allowedFailure?: boolean }
-  | { kind: "model_resolved"; jobId: string; stepId: string; modelName: string; modelType: string; methodName: string }
-  | { kind: "method_executing"; jobId: string; stepId: string; modelName: string; methodName: string }
-  | { kind: "method_output"; jobId: string; stepId: string; modelName: string; methodName: string; stream: "stdout" | "stderr"; line: string }
-  | { kind: "method_event"; jobId: string; stepId: string; modelName: string; methodName: string; event: MethodExecutionEvent }
+  | {
+    kind: "approval_requested";
+    runId: string;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
+  | {
+    kind: "step_failed";
+    jobId: string;
+    stepId: string;
+    error: string;
+    allowedFailure?: boolean;
+    modelName?: string;
+    methodName?: string;
+  }
+  | {
+    kind: "model_resolved";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    modelType: string;
+    modelId: string;
+    methodName: string;
+  }
+  | {
+    kind: "env_var_warning";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    envVars: EnvVarUsageDetail[];
+    message: string;
+  }
+  | {
+    kind: "method_executing";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+  }
+  | {
+    kind: "method_output";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+    stream: "stdout" | "stderr";
+    line: string;
+  }
+  | { kind: "step_queued"; jobId: string; stepId: string; requirement: string }
+  | {
+    kind: "method_event";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+    event: MethodExecutionEvent;
+  }
+  | {
+    kind: "report_started";
+    reportName: string;
+    scope: string;
+    jobId?: string;
+    stepId?: string;
+  }
+  | {
+    kind: "report_completed";
+    reportName: string;
+    scope: string;
+    markdown: string;
+    json: Record<string, unknown>;
+    jobId?: string;
+    stepId?: string;
+  }
+  | {
+    kind: "report_failed";
+    reportName: string;
+    scope: string;
+    error: string;
+    jobId?: string;
+    stepId?: string;
+  }
   | { kind: "completed"; run: WorkflowRunView }
+  | { kind: "cancelled"; run: WorkflowRunView; reason?: string }
+  | {
+    kind: "suspended";
+    run: WorkflowRunView;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
   | { kind: "error"; error: SwampError };
 ```
 
@@ -215,9 +311,9 @@ type HasTerminals<E extends StreamEvent> =
 
 ## Exhaustiveness-Checked Event Handlers
 
-The key mechanism for compile-time safety. Instead of `switch` statements
-(which silently ignore unhandled cases), callers pass a handler object where
-every event kind is a required key.
+The key mechanism for compile-time safety. Instead of `switch` statements (which
+silently ignore unhandled cases), callers pass a handler object where every
+event kind is a required key.
 
 ### EventHandlers type
 
@@ -247,12 +343,12 @@ The primary consumption function:
 
 ```typescript
 async function consumeStream<E extends StreamEvent>(
-  stream: AsyncIterable<E>,
+  stream: AsyncIterable<HasTerminals<E>>,
   handlers: EventHandlers<E>,
 ): Promise<void> {
   for await (const event of stream) {
     const handler = handlers[event.kind as E["kind"]];
-    await handler(event as Parameters<typeof handler>[0]);
+    await handler(event as any);
   }
 }
 ```
@@ -265,10 +361,12 @@ ignoring progress), it must be explicit:
 ```typescript
 // Option 1: no-op handler — visible in code review
 await consumeStream(stream, {
-  loading_credentials: () => {},        // intentional no-op
-  contacting_server: () => {},          // intentional no-op
+  loading_credentials: () => {}, // intentional no-op
+  contacting_server: () => {}, // intentional no-op
   completed: (e) => console.log(JSON.stringify(e.identity, null, 2)),
-  error: (e) => { throw e.error; },
+  error: (e) => {
+    throw e.error;
+  },
 });
 
 // Option 2: withDefaults helper for bulk opt-out
@@ -278,10 +376,15 @@ function withDefaults<E extends StreamEvent>(
 ): EventHandlers<E>;
 
 // Usage: only handle what you need, rest are explicitly defaulted
-await consumeStream(stream, withDefaults<AuthWhoamiEvent>({
-  completed: (e) => console.log(JSON.stringify(e.identity, null, 2)),
-  error: (e) => { throw e.error; },
-}));
+await consumeStream(
+  stream,
+  withDefaults<AuthWhoamiEvent>({
+    completed: (e) => console.log(JSON.stringify(e.identity, null, 2)),
+    error: (e) => {
+      throw e.error;
+    },
+  }),
+);
 ```
 
 `withDefaults` fills missing handlers with no-ops (or a provided fallback). The
@@ -346,34 +449,26 @@ workflow generator ── merge() ◄─────┤                 │─�
 
 ### The merge utility
 
-`merge()` combines multiple `AsyncIterable` streams into one, yielding events
-in arrival order:
+`merge()` combines multiple `AsyncIterable` streams into one, yielding events in
+arrival order:
 
 ```typescript
-// libswamp/stream/merge.ts
-async function* merge<E extends StreamEvent>(
-  streams: AsyncIterable<E>[],
-): AsyncIterable<E> {
+// infrastructure/stream/merge.ts (re-exported from libswamp/stream/merge.ts)
+async function* merge<T>(
+  streams: AsyncIterable<T>[],
+  signal?: AbortSignal,
+): AsyncGenerator<T> {
   if (streams.length === 0) return;
   if (streams.length === 1) {
     yield* streams[0];
     return;
   }
 
-  const queue = new AsyncQueue<E>();
-  let active = streams.length;
+  const queue = new AsyncQueue<T>();
+  let remaining = streams.length;
 
-  for (const stream of streams) {
-    (async () => {
-      try {
-        for await (const event of stream) {
-          queue.push(event);
-        }
-      } finally {
-        if (--active === 0) queue.close();
-      }
-    })();
-  }
+  // ... each stream pushes to queue, last one closes it
+  // signal support allows early abort
 
   for await (const event of queue) {
     yield event;
@@ -381,37 +476,58 @@ async function* merge<E extends StreamEvent>(
 }
 ```
 
-`AsyncQueue` is an internal async-iterable queue that supports `push()`,
-`close()`, and `for await` consumption. It bridges the gap between multiple
-concurrent push-based producers and a single pull-based consumer.
+`AsyncQueue` is an internal async-iterable queue in
+`infrastructure/stream/async_queue.ts` that supports `push()`, `close()`,
+`abort()`, and `for await` consumption. It bridges the gap between multiple
+concurrent push-based producers and a single pull-based consumer. It uses
+`IteratorResult<T>` signaling internally to distinguish values from
+end-of-stream.
 
 ```typescript
-// libswamp/stream/async_queue.ts
+// infrastructure/stream/async_queue.ts
 class AsyncQueue<T> implements AsyncIterable<T> {
   private buffer: T[] = [];
-  private resolve: ((done: boolean) => void) | null = null;
   private closed = false;
+  private waiting: ((value: IteratorResult<T>) => void) | null = null;
 
   push(item: T): void {
-    this.buffer.push(item);
-    this.resolve?.(false);
-    this.resolve = null;
+    if (this.closed) throw new Error("Cannot push to a closed AsyncQueue");
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: item, done: false });
+    } else {
+      this.buffer.push(item);
+    }
   }
 
   close(): void {
+    if (this.closed) return;
     this.closed = true;
-    this.resolve?.(true);
-    this.resolve = null;
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  abort(_reason?: unknown): void {
+    this.close();
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<T> {
     while (true) {
-      while (this.buffer.length > 0) {
+      if (this.buffer.length > 0) {
         yield this.buffer.shift()!;
+      } else if (this.closed) {
+        return;
+      } else {
+        const result = await new Promise<IteratorResult<T>>((resolve) => {
+          this.waiting = resolve;
+        });
+        if (result.done) return;
+        yield result.value;
       }
-      if (this.closed) return;
-      const done = await new Promise<boolean>((r) => { this.resolve = r; });
-      if (done && this.buffer.length === 0) return;
     }
   }
 }
@@ -445,8 +561,8 @@ A workflow with two parallel jobs (`build` and `test`) produces events like:
 ```
 
 Events from `build` and `test` interleave in arrival order. The exact ordering
-between jobs is non-deterministic — two runs may produce different interleavings.
-Within a single job, events are always in causal order.
+between jobs is non-deterministic — two runs may produce different
+interleavings. Within a single job, events are always in causal order.
 
 ### Consuming interleaved events
 
@@ -465,9 +581,12 @@ await consumeStream(workflowRun(ctx, deps, input), {
   step_started: (e) => console.log(`  [${e.jobId}] ${e.stepId} started`),
   step_completed: (e) => console.log(`  [${e.jobId}] ${e.stepId} completed`),
   step_skipped: (e) => console.log(`  [${e.jobId}] ${e.stepId} skipped`),
-  step_failed: (e) => console.log(`  [${e.jobId}] ${e.stepId} FAILED: ${e.error}`),
+  step_failed: (e) =>
+    console.log(`  [${e.jobId}] ${e.stepId} FAILED: ${e.error}`),
   completed: (e) => console.log(`Done: ${e.run.status}`),
-  error: (e) => { throw new UserError(e.error.message); },
+  error: (e) => {
+    throw new UserError(e.error.message);
+  },
 });
 ```
 
@@ -520,11 +639,18 @@ infrastructure:
 
 ```typescript
 // Auth operation signatures
-async function* whoami(ctx: LibSwampContext, deps: AuthDeps): AsyncIterable<AuthWhoamiEvent>;
+async function* whoami(
+  ctx: LibSwampContext,
+  deps: AuthDeps,
+): AsyncIterable<AuthWhoamiEvent>;
 function createAuthDeps(options?: { serverUrlOverride?: string }): AuthDeps;
 
 // Workflow operation signatures
-async function* workflowRun(ctx: LibSwampContext, deps: WorkflowRunDeps, input: WorkflowRunInput): AsyncGenerator<WorkflowRunEvent>;
+async function* workflowRun(
+  ctx: LibSwampContext,
+  deps: WorkflowRunDeps,
+  input: WorkflowRunInput,
+): AsyncGenerator<WorkflowRunEvent>;
 ```
 
 ### Why standalone functions, not a facade object
@@ -575,14 +701,26 @@ type AuthWhoamiEvent =
 
 interface AuthDeps {
   loadCredentials: () => Promise<AuthCredentials | null>;
-  fetchWhoami: (serverUrl: string, apiKey: string, signal: AbortSignal) => Promise<WhoamiResponse>;
+  saveCredentials: (credentials: AuthCredentials) => Promise<void>;
+  fetchWhoami: (
+    serverUrl: string,
+    apiKey: string,
+    signal: AbortSignal,
+  ) => Promise<WhoamiResponse>;
   serverUrlOverride?: string;
 }
 
-function createAuthDeps(options?: { serverUrlOverride?: string }): AuthDeps {
-  const repo = new AuthRepository();
+interface CreateAuthDepsOptions {
+  serverUrlOverride?: string;
+  repo?: AuthRepositoryOptions;
+  identity?: ClientIdentity;
+}
+
+function createAuthDeps(options: CreateAuthDepsOptions = {}): AuthDeps {
+  const repo = new AuthRepository(options.repo);
   return {
     loadCredentials: () => repo.load(),
+    saveCredentials: (credentials) => repo.save(credentials),
     fetchWhoami: (serverUrl, apiKey, signal) => {
       const client = new SwampClubClient(serverUrl);
       return client.whoami(apiKey, signal);
@@ -591,7 +729,10 @@ function createAuthDeps(options?: { serverUrlOverride?: string }): AuthDeps {
   };
 }
 
-async function* whoami(ctx: LibSwampContext, deps: AuthDeps): AsyncIterable<AuthWhoamiEvent> {
+async function* whoami(
+  ctx: LibSwampContext,
+  deps: AuthDeps,
+): AsyncIterable<AuthWhoamiEvent> {
   yield { kind: "loading_credentials" };
 
   const credentials = await deps.loadCredentials();
@@ -604,7 +745,11 @@ async function* whoami(ctx: LibSwampContext, deps: AuthDeps): AsyncIterable<Auth
   yield { kind: "contacting_server", serverUrl };
 
   try {
-    const response = await deps.fetchWhoami(serverUrl, credentials.apiKey, ctx.signal);
+    const response = await deps.fetchWhoami(
+      serverUrl,
+      credentials.apiKey,
+      ctx.signal,
+    );
 
     if (!response.authenticated) {
       yield { kind: "error", error: invalidApiKey() };
@@ -638,8 +783,11 @@ async function* whoami(ctx: LibSwampContext, deps: AuthDeps): AsyncIterable<Auth
 ```typescript
 // src/cli/commands/auth_whoami.ts
 import {
-  type AuthWhoamiEvent, consumeStream, createAuthDeps,
-  createLibSwampContext, whoami,
+  type AuthWhoamiEvent,
+  consumeStream,
+  createAuthDeps,
+  createLibSwampContext,
+  whoami,
 } from "../../libswamp/mod.ts";
 
 export const authWhoamiCommand = new Command()
@@ -661,17 +809,25 @@ export const authWhoamiCommand = new Command()
       },
       completed: (e) => {
         if (cliCtx.outputMode === "json") {
-          console.log(JSON.stringify({
-            authenticated: true,
-            serverUrl: e.identity.serverUrl,
-            id: e.identity.id,
-            username: e.identity.username,
-            email: e.identity.email,
-            name: e.identity.name,
-            ...(e.identity.collectives ? { collectives: e.identity.collectives } : {}),
-          }, null, 2));
+          console.log(JSON.stringify(
+            {
+              authenticated: true,
+              serverUrl: e.identity.serverUrl,
+              id: e.identity.id,
+              username: e.identity.username,
+              email: e.identity.email,
+              name: e.identity.name,
+              ...(e.identity.collectives
+                ? { collectives: e.identity.collectives }
+                : {}),
+            },
+            null,
+            2,
+          ));
         } else {
-          console.log(`${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`);
+          console.log(
+            `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
+          );
           if (e.identity.collectives && e.identity.collectives.length > 0) {
             console.log(`Collectives: ${e.identity.collectives.join(", ")}`);
           }
@@ -743,7 +899,10 @@ Deno.test("whoami yields cancelled error when signal is already aborted", async 
   };
 
   const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
-  const last = events[events.length - 1] as Extract<AuthWhoamiEvent, { kind: "error" }>;
+  const last = events[events.length - 1] as Extract<
+    AuthWhoamiEvent,
+    { kind: "error" }
+  >;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "cancelled");
 });
@@ -761,18 +920,18 @@ than thrown exceptions:
 
 ```typescript
 interface SwampError {
-  readonly code: string;        // machine-readable (e.g., "not_authenticated", "cancelled")
-  readonly message: string;     // human-readable
-  readonly cause?: Error;       // original exception for stack traces
-  readonly details?: unknown;   // optional structured data for debugging
+  readonly code: string; // machine-readable (e.g., "not_authenticated", "cancelled")
+  readonly message: string; // human-readable
+  readonly cause?: Error; // original exception for stack traces
+  readonly details?: unknown; // optional structured data for debugging
 }
 ```
 
 Errors that originate within the generator (domain logic) are **yielded** as
 `{ kind: "error", error: SwampError }` events. This keeps the stream protocol
-uniform — consumers never need `try/catch` around `for await` to handle
-expected errors. Cancellation is also an error event with
-`code: "cancelled"`, not a special case.
+uniform — consumers never need `try/catch` around `for await` to handle expected
+errors. Cancellation is also an error event with `code: "cancelled"`, not a
+special case.
 
 Unexpected errors (bugs, infrastructure failures) may still throw and should be
 caught at the adapter boundary.
@@ -781,40 +940,40 @@ caught at the adapter boundary.
 
 Codes used across libswamp generators and the CLI error boundary:
 
-| Code                       | Origin             | Meaning                                              |
-| -------------------------- | ------------------ | ---------------------------------------------------- |
-| `not_authenticated`        | `libswamp/errors`  | No valid auth credentials                            |
-| `invalid_api_key`          | `libswamp/errors`  | Stored API key is no longer valid                    |
-| `cancelled`                | `libswamp/errors`  | Operation cancelled (e.g. Ctrl+C, AbortSignal)       |
-| `not_found`                | `libswamp/errors`  | Generic entity not found                             |
-| `already_exists`           | `libswamp/errors`  | Entity already exists                                |
-| `validation_failed`        | `libswamp/errors`  | Input or configuration validation failed             |
-| `lock_timeout`             | `distributed_lock` | Lock held by another process; timed out waiting      |
-| `model_not_found`          | `models/run`       | No model matches the given name                      |
-| `unknown_model_type`       | `models/run`       | Type prefix does not match any installed type         |
-| `unknown_method`           | `models/run`       | Model does not define the requested method            |
-| `no_evaluated_definition`  | `models/run`       | No evaluated definition exists                       |
-| `method_execution_failed`  | `models/run`       | Execution driver returned an error                   |
-| `missing_deps`             | `models/run`       | Required extension dependencies not installed         |
-| `workflow_not_found`       | `workflows/run`    | No workflow matches the given name                   |
-| `workflow_execution_failed`| `workflows/run`    | Workflow step execution failed                       |
-| `input_validation_failed`  | `workflows/run`    | Workflow input validation failed                     |
+| Code                        | Origin             | Meaning                                         |
+| --------------------------- | ------------------ | ----------------------------------------------- |
+| `not_authenticated`         | `libswamp/errors`  | No valid auth credentials                       |
+| `invalid_api_key`           | `libswamp/errors`  | Stored API key is no longer valid               |
+| `cancelled`                 | `libswamp/errors`  | Operation cancelled (e.g. Ctrl+C, AbortSignal)  |
+| `not_found`                 | `libswamp/errors`  | Generic entity not found                        |
+| `already_exists`            | `libswamp/errors`  | Entity already exists                           |
+| `validation_failed`         | `libswamp/errors`  | Input or configuration validation failed        |
+| `lock_timeout`              | `distributed_lock` | Lock held by another process; timed out waiting |
+| `model_not_found`           | `models/run`       | No model matches the given name                 |
+| `unknown_model_type`        | `models/run`       | Type prefix does not match any installed type   |
+| `unknown_method`            | `models/run`       | Model does not define the requested method      |
+| `no_evaluated_definition`   | `models/run`       | No evaluated definition exists                  |
+| `method_execution_failed`   | `models/run`       | Execution driver returned an error              |
+| `missing_deps`              | `models/run`       | Required extension dependencies not installed   |
+| `workflow_not_found`        | `workflows/run`    | No workflow matches the given name              |
+| `workflow_execution_failed` | `workflows/run`    | Workflow step execution failed                  |
+| `input_validation_failed`   | `workflows/run`    | Workflow input validation failed                |
 
 This table is not exhaustive — generators may define additional codes for
 domain-specific errors. The `code` field is always a `snake_case` string.
 
 ### CLI exit codes
 
-| Exit code | Meaning                                                    |
-| --------- | ---------------------------------------------------------- |
-| `0`       | Success                                                    |
-| `1`       | General error (default for all unrecognized error codes)   |
-| `2`       | Unknown command                                            |
+| Exit code | Meaning                                                                                  |
+| --------- | ---------------------------------------------------------------------------------------- |
+| `0`       | Success                                                                                  |
+| `1`       | General error (default for all unrecognized error codes)                                 |
+| `2`       | Unknown command                                                                          |
 | `75`      | Lock contention / temporary failure (`lock_timeout`) — callers should retry with backoff |
 
-Callers that only need pass/fail should check `$? -ne 0`. Callers that
-want to handle specific failure modes (e.g. retry on lock contention)
-should match the numeric exit code.
+Callers that only need pass/fail should check `$? -ne 0`. Callers that want to
+handle specific failure modes (e.g. retry on lock contention) should match the
+numeric exit code.
 
 ### Error handling by adapters
 

--- a/design/license-compliance.md
+++ b/design/license-compliance.md
@@ -81,5 +81,7 @@ view the report in the FOSSA web app, to inspect violations.
 
 ## Related
 
-- [audit.md](audit.md) — the separate OSV-based vulnerability audit
-  (`deno run audit`), which scans the same dependency set for known CVEs.
+- `scripts/audit_deps.ts` (`deno run audit`) — the separate OSV-based
+  vulnerability audit, which scans the same dependency set for known CVEs.
+  Note: `design/audit.md` documents the AI agent activity audit, not the OSV
+  scanner.

--- a/design/models.md
+++ b/design/models.md
@@ -348,7 +348,9 @@ override this value — it is enforced for audit integrity.
 Pre-flight checks are optional guards that run automatically before any
 _mutating_ method invocation. Mutating methods are those that change real
 resource state: `create`, `update`, `delete`, and `action`. Read-only methods
-(`sync`, `get`, etc.) do not trigger checks.
+(`get`, `read`, `describe`, `show`, `list`, `search`, `find`) do not trigger
+checks. Method names not in the recognized list (e.g. `sync`) default to
+mutating — set `kind: "read"` explicitly to suppress checks for those.
 
 Checks give models a way to enforce invariants — policy constraints, dependency
 readiness, quota availability — before execution begins, avoiding
@@ -553,10 +555,11 @@ The raw data will be written to the datastore at
 The metadata will be written to the datastore at
 `data/{normalized-type}/{model-id}/{data-name}/{version}/metadata.yaml`.
 
-There will be a symlink to the latest version at
-`data/{normalized-type}/{model-id}/{data-name}/latest/`.
+The latest version is tracked by a plain text marker file at
+`data/{normalized-type}/{model-id}/{data-name}/latest` containing the version
+number (e.g. `2`).
 
-See [./datastores.md] for how the datastore path is resolved.
+See [datastores.md](./datastores.md) for how the datastore path is resolved.
 
 ## Data Output API
 
@@ -636,5 +639,6 @@ The ModelRepository emits domain events when model data changes:
 - `ModelUpdated` - Emitted when a model definition or data is modified
 - `ModelDeleted` - Emitted when a model is deleted
 
-The RepoIndexService subscribes to these events (currently a noop
-implementation). See [./repo.md] for details on domain events.
+A `NoopRepoIndexService` is instantiated but not wired to the event bus —
+no handler currently receives these events. See [repo.md](./repo.md) for
+details on domain events.

--- a/design/quests.md
+++ b/design/quests.md
@@ -56,6 +56,9 @@ Model 'risk-assessment' created successfully.
   Row 1 BINGO! +100 bonus points
 ```
 
+> **Planned.** These event types are defined in the design but not yet present
+> in the codebase.
+
 ## Quest Event Types
 
 These map to existing CLI commands. Each fires after successful completion:
@@ -149,6 +152,9 @@ Season 1: Swamp Genesis (ends Aug 31, 2026)
 
 JSON mode outputs the structured progress object.
 
+> **Not yet implemented.** The current CLI only provides `swamp quest` (linear
+> pass view).
+
 ### `swamp quest board`
 
 Shows the full bingo card with per-objective progress.
@@ -183,6 +189,8 @@ For incomplete count-based objectives, show current/target below the title.
 ### `swamp quest history`
 
 Shows past seasons and their final status.
+
+> **Not yet implemented.** Quest event emission is planned but not wired up.
 
 ## Quest Event Emission Pattern
 
@@ -222,6 +230,7 @@ The backend needs:
 4. **Event processing** — receive quest events, match against current season's
    objectives, update progress, detect line/board completion
 5. **API endpoints**:
+   > **Not yet implemented.**
    - `POST /api/v1/quest/events` — receive + process quest event
    - `GET /api/v1/quest/progress` — current season summary
    - `GET /api/v1/quest/board?season=<slug>` — full board with progress

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -60,7 +60,7 @@ Three properties drove the design:
 | **Capability**       | A side-effecting function a running method reaches through its context, proxied back to the orchestrator. A finite, closed set. |
 | **Step lease**       | The orchestrator's record that a given step is in flight on a given worker. A built-in model.                               |
 | **Environment snapshot** | The orchestrator's full process environment, shipped with each dispatch and held in worker memory only for the step's duration. |
-| **Spool file**       | The worker-local file backing `getFilePath()` on a remote executor; uploaded to the orchestrator as one streamed `PUT` on `finalize()`. |
+| **Spool file**       | The worker-local file backing `getFilePath()` on a remote executor; uploaded to the orchestrator as one streamed `POST` on `finalize()`. |
 | **Fleet probe**      | A built-in model (`swamp/fleet-probe`) whose single `verify` method exercises every seam between worker and orchestrator: dispatch metadata (`probeMarker`), capability RPC (`queryData`), and the HTTP data plane (`writeResource`/`readResource`). Used by `swamp worker verify` and `--verify-on-enroll`. |
 | **Probe marker**     | A dispatch-level string (`probeMarker` on `DispatchParams`) that the worker merges into the method's args. Confirms dispatch-level metadata arrives intact. Travels via `DispatchParams`, not the environment snapshot (which denylists `SWAMP_*` variables). |
 | **Verify-on-enroll** | Opt-in orchestrator flag (`--verify-on-enroll`) that dispatches the fleet probe to each enrolling worker before it becomes schedulable. Workers that fail enter `unverified` status and are excluded from scheduling. |
@@ -176,14 +176,15 @@ The full set of client protocol frame types:
 | Model validate | `model.validate`, `model.evaluate`                                                                             | read    |
 | Workflow       | `workflow.get`, `workflow.search`, `workflow.run`, `workflow.resume`, `workflow.schema`                         | read/run |
 | Workflow history | `workflow.history.get`, `workflow.history.logs`, `workflow.history.search`, `workflow.run.search`             | read    |
-| Workflow approval | `workflow.approve`, `workflow.reject`                                                                       | run     |
+| Workflow approval | `workflow.approvals`, `workflow.approve`, `workflow.reject`                                                  | run     |
 | Vault          | `vault.get`, `vault.put`, `vault.delete`, `vault.describe`, `vault.inspect`, `vault.list-keys`, `vault.search`, `vault.annotate` | read/write |
 | Access         | `access.grant.list`, `access.group.list`, `access.check`, `access.can-i`, `access.reload`                     | admin   |
 | Audit/summary  | `audit.timeline`, `summarise`                                                                                  | read    |
 | Reports        | `report.get`, `report.search`, `report.describe`, `report.type.search`                                        | read    |
 | Extensions     | `extension.list`, `extension.search`, `extension.info`, `extension.install`, `extension.rm`, `extension.outdated` | read/admin |
-| Doctor         | `doctor.vaults`, `doctor.secrets`, `doctor.workflows`, `doctor.extensions`                                     | admin   |
-| Server admin   | `worker.list`, `datastore.status`                                                                              | admin   |
+| Doctor         | `doctor.vaults`, `doctor.datastores`, `doctor.secrets`, `doctor.workflows`, `doctor.extensions`                 | admin   |
+| Server admin   | `worker.list`, `worker.queue.list`, `worker.verify`, `datastore.status`                                        | admin   |
+| Run            | `run.history`, `run.doctor`                                                                                    | admin   |
 | Control        | `cancel`                                                                                                       | —       |
 
 The CLI consumes this protocol via `--server <url>` on each command:
@@ -362,7 +363,9 @@ system. Each token is:
   member without a freshly minted token.
 
 The token is a built-in **enrollment-token** model whose instances are swamp data,
-with states `unused → enrolled → expired`; the `unused → enrolled` transition
+with states `unused → enrolled → expired` (plus `revoked` reachable from any
+non-terminal state via `swamp worker token revoke`); the `unused → enrolled`
+transition
 appends a binding (`machineId` + `enrolledAt`) to the token's `bindings` list,
 and concurrent enrollment attempts are serialized by the orchestrator. The datastore itself provides no compare-and-swap — concurrent saves to
 one data item simply land as successive versions — so atomicity comes from the
@@ -407,7 +410,14 @@ model method's output:
   workers share one definition-name namespace; the pool-addressable `name`
   inside the data stays bare.);
 - an **enrollment-token** model — the token lifecycle aggregate above;
-- a **step-lease** model — which step is in flight on which worker.
+- a **step-lease** model — which step is in flight on which worker;
+- a **pending-dispatch** model (`swamp/pending-dispatch`) — queued demand
+  records for steps awaiting a matching worker, with states
+  `waiting → dispatched | timed_out | cancelled | orphaned`;
+- a **fleet-probe** model (`swamp/fleet-probe`) — a lightweight model whose
+  single `verify` method exercises every seam between worker and orchestrator
+  (dispatch metadata, capability RPC, and data plane); used by
+  `swamp worker verify` and `--verify-on-enroll`.
 
 These ship with swamp and are registered at startup like its other built-ins.
 This is not incidental — it is *why* the rest of the design composes:
@@ -663,13 +673,13 @@ runners to finish (`activeRunners === 0`).
 A worker resolves no extensions of its own. The dispatch references the extension
 bundle by fingerprint; on a cache miss the worker fetches it from the
 orchestrator's HTTP/2 data plane (`GET /bundle/{fingerprint}`) and loads it
-**in-process** in its own swamp runtime. The bundle is the same `bundleSource`
-swamp already builds (see
+**in-process** in its own swamp runtime. The bundle is the same
+`bundleSourceFactory` swamp already builds (see
 [execution-drivers.md](./execution-drivers.md#self-contained-bundling)); the
 worker needs nothing pre-installed.
 
-The fingerprint comes from the existing content-fingerprint cache
-(`.swamp/driver-bundles/`, sha-256 over the bundle), and a worker caches what it
+The fingerprint is computed inline as `sha256Hex(js)` over the bundled source at
+dispatch time (see `DispatchService.#ensureBundle`), and a worker caches what it
 has already fetched — so a bundle is shipped at most once per worker per version.
 This mirrors the versioned-handle data cache — code and data both cache by
 content/version identity and travel over the same h2 data plane.
@@ -709,14 +719,14 @@ current code.
 
 `context.writeResource` / `createFileWriter` call `repo.save()`
 (`src/domain/models/data_writer.ts`, `unified_data_repository.ts`), which writes
-the version directory, metadata, content, `latest` symlink, and catalog entry
+the version directory, metadata, content, `latest` marker, and catalog entry
 *before the `await` resolves*. There is no buffer-and-commit-at-end model — and
 the system depends on this: `method_execution_service.ts` deliberately collects
 handles for data written **before a throw**, so a write-then-throw method (e.g.
 a code-review `verdict=FAIL`, the issue-lifecycle model) leaves its data visible.
 
 Consequences for the proxy model: a `persistResource` / `persistFile` is an
-HTTP/2 `PUT` that completes only once `repo.save()` has persisted at the
+HTTP/2 `POST` that completes only once `repo.save()` has persisted at the
 orchestrator. There is **no staging layer to build**. A worker that writes 3 of 5
 outputs then dies leaves 3 durable writes — exactly what a local process crash
 does today.
@@ -730,7 +740,7 @@ Two `DataWriter` modes need an explicit remote shape:
 - **`getFilePath` (direct file I/O)** hands the method a real path, typically so
   a subprocess can write output straight to it. There is no orchestrator path on
   a worker, so remotely the path is a **worker-local spool file**; `finalize()`
-  uploads it as one streamed `PUT`. For this one mode, durability moves from
+  uploads it as one streamed `POST`. For this one mode, durability moves from
   write-time to finalize-time — a worker that dies mid-spool leaves *no* write
   rather than a partial file, the safer of the two divergences. Local behavior
   is unchanged.
@@ -747,7 +757,7 @@ This sets the **worker cache rule** precisely:
 
 - **Cacheable:** artifact bytes keyed by `(dataId, version)`. Once fetched, that
   version never changes — safe to cache for the life of the worker, and a strong
-  `ETag` on `GET /data/{dataId}/{version}` lets the runtime honor it for free.
+  `ETag` on `GET /data/{type}/{modelId}/{dataName}/{version}` lets the runtime honor it for free.
 - **Always live:** `latest` resolution and `queryData` results. `latest`
   resolution is a small control-plane RPC that yields a concrete version, which
   the worker then fetches (and caches) over h2.
@@ -772,7 +782,7 @@ server-push is needed.
   `resolveModel`, `log`). This is the symmetric two-registry protocol above.
 - **Data plane — HTTP/2** (worker-initiated request/response, streamed): the
   byte-heavy operations only — read artifact content
-  (`GET /data/{dataId}/{version}`), write artifact content (`PUT /data/...` →
+  (`GET /data/{type}/{modelId}/{dataName}/{version}`), write artifact content (`POST /data/resource` →
   `repo.save()`), and bundle fetch on a cache miss (`GET /bundle/{fingerprint}`).
   HTTP/2 supplies multiplexing and per-stream flow control natively, so the
   chunking, credit accounting, and priority queues we would otherwise hand-roll
@@ -793,7 +803,7 @@ HTTP/1.1-based on both the server-upgrade and outbound-client sides and does not
 implement RFC 8441 today, so v1 runs two worker-initiated connections that can
 share one port via ALPN. Collapsing them to a single connection is a clean future
 optimization if Deno gains RFC 8441 support. Versioned-immutable data is a natural
-fit for h2: `GET /data/{dataId}/{version}` is an immutable, strongly-`ETag`'d
+fit for h2: `GET /data/{type}/{modelId}/{dataName}/{version}` is an immutable, strongly-`ETag`'d
 resource, freely cacheable by the worker and any intermediary.
 
 ### Authenticating the data plane
@@ -815,7 +825,7 @@ single-host semantics and needs almost no new code:
   Schema validation is deliberately *warn-only* in the writer today — it emits a
   `schema_validation_warning` event rather than rejecting — so spec-name
   enforcement, not schema enforcement, is the write-scoping guarantee. Because
-  the orchestrator persists a worker's `PUT` through that same writer, a worker
+  the orchestrator persists a worker's `POST` through that same writer, a worker
   can only write to specs its model declares — no new authorization layer
   required.
 - **Reads are unrestricted** — the status quo for `getData` / `queryData` on a
@@ -971,7 +981,7 @@ provisioning credentials and extensions onto workers:
 | -------------------------------- | --------------------------------------------------------------------------------------- |
 | Control protocol + multiplexing  | **Reuse** `src/serve/protocol.ts`, `connection.ts`, `serializer.ts`                     |
 | Serializable execution envelope  | **Reuse** `ExecutionRequest` / `ExecutionResult` (serialize `followUpActions`; the envelope never carried driver fields) |
-| Extension bundle + fingerprint   | **Reuse** `bundleSource` + `.swamp/driver-bundles/` cache; fetched over h2 on miss; report bundles + co-located assets ship the same way |
+| Extension bundle + fingerprint   | **Reuse** `bundleSourceFactory` + inline `sha256Hex` fingerprint; fetched over h2 on miss; report bundles + co-located assets ship the same way |
 | Checks and reports pipeline      | **Reuse** — run on the executor unchanged, over the proxied context                      |
 | Pure injectable operations       | **Reuse** libswamp `*Deps` + `MethodContext` injection seam                             |
 | Worker/token/lease persistence   | **Reuse** the datastore + catalog — built-in models, not a private registry             |
@@ -1075,7 +1085,7 @@ On SIGHUP, `reloadPulledExtensions()` performs a READ-ONLY scan:
 
 1. Opens a fresh `ExtensionCatalogStore` (reads `_extension_catalog.db`)
 2. Reads the lockfile via `LockfileRepository` for extension names/versions
-3. Queries `catalog.findByExtension(name, version)` for type rows
+3. Queries `catalog.findBySourcePathPrefix(sourcePrefix)` for type rows
 4. For each type across all four kinds (model, vault, datastore, report):
    - `invalidateType()` — removes from the registry's loaded and lazy maps
    - `registerLazy()` — re-adds with updated `source_fingerprint`
@@ -1087,8 +1097,10 @@ On SIGHUP, `reloadPulledExtensions()` performs a READ-ONLY scan:
 
 The reload path never calls `ExtensionCatalogStore.invalidate()`,
 `ExtensionLoader.buildIndex()`, `resetLoadedFlag()`, or `ensureLoaded()`. Only
-the per-type path (`loadSingleType` and its sub-calls) is permitted — these
-perform zero catalog writes.
+the per-type path (`loadSingleType` and its sub-calls) is permitted. The one
+catalog write is `catalog.updateSourceFingerprint()`, called after a successful
+re-bundle to record the new fingerprint so subsequent reloads skip unchanged
+sources.
 
 ### Concurrency
 

--- a/design/rendering.md
+++ b/design/rendering.md
@@ -10,8 +10,8 @@ from command handlers, ensuring that:
    checking results) — no formatting, logging, or serialization.
 2. Each output mode has its own renderer class that translates libswamp event
    streams into user-facing output.
-3. Adding a new output mode is a matter of adding a new renderer implementation —
-   no changes to libswamp or command handlers.
+3. Adding a new output mode is a matter of adding a new renderer implementation
+   — no changes to libswamp or command handlers.
 4. libswamp logs at debug/trace only; renderers own all info/warn/error output.
 
 Previously, presentation logic lived inline in command handlers via
@@ -82,12 +82,16 @@ Each operation has a factory that selects the right renderer based on mode:
 // presentation/renderers/workflow_run.ts
 export function createWorkflowRunRenderer(
   mode: OutputMode,
-  opts: WorkflowRunRenderOpts,
+  opts: WorkflowRunRenderOpts, // includes isAuthenticated?: boolean
 ): WorkflowRunRenderer {
   switch (mode) {
     case "json":
       return new JsonWorkflowRunRenderer();
     case "log":
+      // When stdout is a TTY, use the Ink-based TUI renderer
+      if (!opts.forceLog && isStdoutTty()) {
+        return new InkWorkflowRunRenderer(opts);
+      }
       return new LogWorkflowRunRenderer(opts);
   }
 }
@@ -100,42 +104,39 @@ pick a renderer, consume the stream, check the result.
 
 ## JSON Mode Output Contract
 
-When a command runs with `--json`, swamp guarantees the following invariants
-to JSON consumers (`jq`, AI agents, CI scripts):
+When a command runs with `--json`, swamp guarantees the following invariants to
+JSON consumers (`jq`, AI agents, CI scripts):
 
-1. **stdout contains exactly one valid JSON document** for the command's
-   primary output, OR a stream of newline-delimited JSON (NDJSON) documents
-   for streaming commands. No trailing whitespace, no log lines, no
-   prompts.
-2. **stderr is reserved for log records** at the configured log level. It
-   may be empty, may contain LogTape pretty-formatted lines, but never
-   doubles as a structured-output channel.
+1. **stdout contains exactly one valid JSON document** for the command's primary
+   output, OR a stream of newline-delimited JSON (NDJSON) documents for
+   streaming commands. No trailing whitespace, no log lines, no prompts.
+2. **stderr is reserved for log records** at the configured log level. It may be
+   empty, may contain LogTape pretty-formatted lines, but never doubles as a
+   structured-output channel.
 3. **Errors emit a structured JSON object on stdout** with the shape
-   `{ error: string, stack?: string, code?: string }` and a non-zero
-   process exit. The `code` field is OPTIONAL — consumers MUST tolerate
-   its presence or absence. When present, it carries a machine-readable
-   identifier (e.g. `"cancelled"`, `"timeout"`, `"not_found"`,
-   `"validation_failed"`) suitable for programmatic dispatch.
-4. **Commands MUST NOT prompt interactively in JSON mode.** Any
-   confirmation gate must be bypassed when the output mode is `json`.
-   Use `Deno.stdin.isTerminal()` to detect non-interactive contexts in
-   addition to `outputMode`.
+   `{ error: string, stack?: string, code?: string }` and a non-zero process
+   exit. The `code` field is OPTIONAL — consumers MUST tolerate its presence or
+   absence. When present, it carries a machine-readable identifier (e.g.
+   `"cancelled"`, `"timeout"`, `"not_found"`, `"validation_failed"`) suitable
+   for programmatic dispatch.
+4. **Commands MUST NOT prompt interactively in JSON mode.** Any confirmation
+   gate must be bypassed when the output mode is `json`. Use
+   `Deno.stdin.isTerminal()` to detect non-interactive contexts in addition to
+   `outputMode`.
 
-Renderer implementations for new commands MUST preserve these
-guarantees. The regression test suite at `integration/json_isolation_test.ts`
-exercises the contract across representative commands and is the
-authoritative gate.
+Renderer implementations for new commands MUST preserve these guarantees. The
+regression test suite at `integration/json_isolation_test.ts` exercises the
+contract across representative commands and is the authoritative gate.
 
 This contract is enforced at the logging layer by
 `initializeLogging({ jsonMode: true })` in
 `src/infrastructure/logging/logger.ts`, which configures the
 `["model","method","run"]`, `["workflow","run"]`, and `["logtape","meta"]`
-category loggers with `parentSinks: "override"` so they cannot inherit
-the root logger's sinks. The single emitter for fatal output in JSON
-mode is `renderError` in
-`src/presentation/output/error_output.ts` — it writes to stdout and
-skips `logger.fatal`, so log-mode sinks cannot produce a duplicate
-entry.
+category loggers with `parentSinks: "override"` so they cannot inherit the root
+logger's sinks. The single emitter for fatal output in JSON mode is
+`renderError` in `src/presentation/output/error_output.ts` — it writes to stderr
+(`console.error`) and skips `logger.fatal`, so log-mode sinks cannot produce a
+duplicate entry.
 
 ## Logging Boundaries
 
@@ -162,15 +163,15 @@ the renderer decides whether and how to present it:
 
 ```typescript
 // Log-mode renderer
-step_failed: (e) => {
+step_failed: ((e) => {
   getWorkflowRunLogger(this.workflowName, e.jobId, e.stepId).error(
     "Step failed: {error}",
     { error: e.error },
   );
-}
+});
 
 // JSON-mode renderer
-step_failed: () => {}  // no-op — the completed event has the full summary
+step_failed: (() => {}); // no-op — the completed event has the full summary
 ```
 
 This separation ensures that log levels are a presentation concern, not a domain
@@ -183,8 +184,8 @@ During `workflow run`, step execution output (model discovery, method execution,
 process stdout/stderr) flows through the event stream via `model_resolved`,
 `method_executing`, and `method_output` events. The domain layer
 (`DefaultStepExecutor`) pushes these events through a callback on
-`StepExecutionContext`, and `runStep()` uses `withEventBridge()` to yield
-them into the parent event stream.
+`StepExecutionContext`, and `runStep()` uses `withEventBridge()` to yield them
+into the parent event stream.
 
 `withEventBridge()` (in `infrastructure/stream/event_bridge.ts`) is a reusable
 utility that bridges Promise-returning code into an AsyncGenerator. It creates
@@ -199,24 +200,44 @@ layers emit topology-agnostic `MethodExecutionEvent` values via an `onEvent`
 callback on `MethodContext`.
 
 ```typescript
-// domain/models/method_events.ts
+// domain/models/method_events.ts — 6 variants
 type MethodExecutionEvent =
-  | { type: "vault_secret_stored"; fieldPath: string; vaultName: string; vaultKey: string }
-  | { type: "schema_validation_warning"; specName: string; instanceName: string; error: string };
+  | { type: "output"; line: string; stream: "stdout" | "stderr" }
+  | {
+    type: "vault_secret_stored";
+    fieldPath: string;
+    vaultName: string;
+    vaultKey: string;
+  }
+  | {
+    type: "schema_validation_warning";
+    specName: string;
+    instanceName: string;
+    error: string;
+  }
+  | { type: "vault_single_quote_warning"; message: string }
+  | { type: "step_queued"; requirement: string }
+  | {
+    type: "nested_model_invocation";
+    targetModelType: string;
+    targetMethod: string;
+    callerModelType: string;
+    callerMethod: string;
+  };
 ```
 
-The workflow execution layer wraps these into `method_event` workflow events
-by adding the topology context (jobId, stepId, modelName, methodName). The
-callback chain is:
+The workflow execution layer wraps these into `method_event` workflow events by
+adding the topology context (jobId, stepId, modelName, methodName). The callback
+chain is:
 
 ```
 StepExecutionContext.emitEvent → MethodContext.onEvent → DataWriter/VaultStorage
 ```
 
 The `LogWorkflowRunRenderer` uses `getRunLogger(modelName, methodName)` to
-present these events — preserving the existing `model·method·run·<name>·<method>`
-log category. The `JsonWorkflowRunRenderer` ignores them (no-ops), keeping
-stdout clean for machine consumption.
+present these events — preserving the existing
+`model·method·run·<name>·<method>` log category. The `JsonWorkflowRunRenderer`
+ignores them (no-ops), keeping stdout clean for machine consumption.
 
 Internal phase transitions (expression evaluation, definition caching, data
 persistence) are logged at `debug` level for log file capture only — they are
@@ -328,22 +349,115 @@ A long-running operation with streaming progress from parallel jobs and steps.
 ### libswamp event type (existing)
 
 ```typescript
+// 24 variants — see libswamp.md for full details
 type WorkflowRunEvent =
   | { kind: "validating_inputs" }
   | { kind: "evaluating_workflow" }
-  | { kind: "started"; runId: string; workflowName: string }
+  | {
+    kind: "started";
+    runId: string;
+    workflowName: string;
+    jobs: WorkflowRunJobInfo[];
+  }
   | { kind: "job_started"; jobId: string }
   | { kind: "job_completed"; jobId: string; status: string }
   | { kind: "job_skipped"; jobId: string }
   | { kind: "step_started"; jobId: string; stepId: string }
-  | { kind: "step_completed"; jobId: string; stepId: string }
+  | { kind: "step_completed"; jobId: string; stepId: string; executor?: string }
   | { kind: "step_skipped"; jobId: string; stepId: string }
-  | { kind: "step_failed"; jobId: string; stepId: string; error: string; allowedFailure?: boolean }
-  | { kind: "model_resolved"; jobId: string; stepId: string; modelName: string; modelType: string; methodName: string }
-  | { kind: "method_executing"; jobId: string; stepId: string; modelName: string; methodName: string }
-  | { kind: "method_output"; jobId: string; stepId: string; modelName: string; methodName: string; stream: "stdout" | "stderr"; line: string }
-  | { kind: "method_event"; jobId: string; stepId: string; modelName: string; methodName: string; event: MethodExecutionEvent }
+  | {
+    kind: "approval_requested";
+    runId: string;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
+  | {
+    kind: "step_failed";
+    jobId: string;
+    stepId: string;
+    error: string;
+    allowedFailure?: boolean;
+    modelName?: string;
+    methodName?: string;
+  }
+  | {
+    kind: "model_resolved";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    modelType: string;
+    modelId: string;
+    methodName: string;
+  }
+  | {
+    kind: "env_var_warning";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    envVars: EnvVarUsageDetail[];
+    message: string;
+  }
+  | {
+    kind: "method_executing";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+  }
+  | {
+    kind: "method_output";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+    stream: "stdout" | "stderr";
+    line: string;
+  }
+  | { kind: "step_queued"; jobId: string; stepId: string; requirement: string }
+  | {
+    kind: "method_event";
+    jobId: string;
+    stepId: string;
+    modelName: string;
+    methodName: string;
+    event: MethodExecutionEvent;
+  }
+  | {
+    kind: "report_started";
+    reportName: string;
+    scope: string;
+    jobId?: string;
+    stepId?: string;
+  }
+  | {
+    kind: "report_completed";
+    reportName: string;
+    scope: string;
+    markdown: string;
+    json: Record<string, unknown>;
+    jobId?: string;
+    stepId?: string;
+  }
+  | {
+    kind: "report_failed";
+    reportName: string;
+    scope: string;
+    error: string;
+    jobId?: string;
+    stepId?: string;
+  }
   | { kind: "completed"; run: WorkflowRunView }
+  | { kind: "cancelled"; run: WorkflowRunView; reason?: string }
+  | {
+    kind: "suspended";
+    run: WorkflowRunView;
+    jobId: string;
+    stepId: string;
+    prompt: string;
+    timeout?: number;
+  }
   | { kind: "error"; error: SwampError };
 ```
 
@@ -423,12 +537,16 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
         const logger = getRunLogger(e.modelName, e.methodName);
         switch (e.event.type) {
           case "vault_secret_stored":
-            logger.info("Stored sensitive field '{fieldPath}' in vault '{vaultName}'",
-              { fieldPath: e.event.fieldPath, vaultName: e.event.vaultName });
+            logger.info(
+              "Stored sensitive field '{fieldPath}' in vault '{vaultName}'",
+              { fieldPath: e.event.fieldPath, vaultName: e.event.vaultName },
+            );
             break;
           case "schema_validation_warning":
-            logger.warn("Resource '{specName}' data does not match schema: {error}",
-              { specName: e.event.specName, error: e.event.error });
+            logger.warn(
+              "Resource '{specName}' data does not match schema: {error}",
+              { specName: e.event.specName, error: e.event.error },
+            );
             break;
         }
       },
@@ -579,8 +697,13 @@ src/presentation/
   renderer.ts                          # Renderer<E> interface
   renderers/
     auth_whoami.ts                     # factory + Log/Json renderers
-    workflow_run.ts                    # factory + Log/Json renderers
-    ...
+    workflow_run.ts                    # factory + Log/Json/Ink renderers
+    data_get.ts
+    data_list.ts
+    extension_push.ts
+    extension_version.ts
+    repo_init.ts
+    ...                                # 180+ files total (including tests)
 ```
 
 Each file in `renderers/` contains the factory function, mode-specific renderer
@@ -588,13 +711,10 @@ classes, and any shared rendering helpers for that operation.
 
 ## Migration Status
 
-Two commands have been migrated to the renderer pattern:
-
-- **`auth whoami`** — `presentation/renderers/auth_whoami.ts`
-- **`workflow run`** — `presentation/renderers/workflow_run.ts`
-
-Remaining commands still use the existing `presentation/output/` files. To
-migrate a command:
+The renderer pattern has been widely adopted across the codebase. The
+`src/presentation/renderers/` directory now contains 180+ files covering the
+majority of CLI commands. Some remaining commands still use the existing
+`presentation/output/` files. To migrate a command:
 
 1. Create a new file in `presentation/renderers/` with Log and Json renderer
    classes implementing `Renderer<E>`.
@@ -642,9 +762,9 @@ do not need to truncate manually.
 ### Log-mode renderers (non-interactive)
 
 Use `getTerminalColumns()` from `presentation/output/terminal_size.ts` to query
-the terminal width synchronously. Apply width constraints only to `writeOutput()`
-calls (which have no prefix). `logger.info()` calls are left unconstrained —
-LogTape's formatter handles its own line formatting.
+the terminal width synchronously. Apply width constraints only to
+`writeOutput()` calls (which have no prefix). `logger.info()` calls are left
+unconstrained — LogTape's formatter handles its own line formatting.
 
 Guidelines:
 

--- a/design/repo.md
+++ b/design/repo.md
@@ -55,7 +55,7 @@ cli.
 
 When the CLI binary is upgraded but `swamp repo upgrade` is not run, the
 repo retains old skill directories that have been consolidated in the new
-version. The `SUPERSEDED_SKILLS` constant in `repo_service.ts` lists these
+version. The `SUPERSEDED_SKILLS` constant in `superseded_skills.ts` lists these
 directory names.
 
 On every CLI startup (for repo-scoped commands), the CLI checks all enrolled
@@ -85,7 +85,7 @@ Source-of-truth files live in top-level directories tracked in git:
 Runtime data (versioned model data, workflow runs, method outputs, secrets) is
 stored through a datastore abstraction. The default datastore uses the `.swamp/`
 directory, but it can be configured to use an external filesystem path or S3.
-See [./datastores.md] for details.
+See [datastores.md](./datastores.md) for details.
 
 ## Configuration
 
@@ -98,7 +98,7 @@ attributes to control the behaviour of the swamp operations.
   sent to and retrieved from when evaluating and running workflow steps.
   Multitple vaults can be specified for a each swamp repository.
 - `trustedCollectives`: List of collectives whose extensions auto-resolve on
-  first use. Default: `["swamp", "si"]`. Set to `[]` to disable. Manageable via
+  first use. Default: `["swamp"]`. Set to `[]` to disable. Manageable via
   `swamp extension trust list/add/rm`.
 - `trustMemberCollectives`: Whether to auto-trust collectives the user belongs
   to (cached from `auth login`/`auth whoami`). Default: `true`. Set to `false`
@@ -111,6 +111,24 @@ attributes to control the behaviour of the swamp operations.
   duration-based retention). Errors are logged but never fail the method run.
   The sync push includes GC deletions so the current push benefits immediately.
   `swamp data gc` remains available for repo-wide manual GC.
+
+### Run Garbage Collection
+
+`swamp run gc` garbage-collects old workflow-run records
+(`.swamp/workflow-runs/`) and model method outputs (`.swamp/outputs/`). These
+two runtime artifact stores are not covered by `data gc`, which handles
+`.swamp/data/` (versioned data with lifetime/version policies).
+
+- **Default retention**: 30 days (`DEFAULT_WORKFLOW_RUN_RETENTION_DAYS` and
+  `DEFAULT_OUTPUT_RETENTION_DAYS` in
+  `src/domain/data/run_lifecycle_service.ts`)
+- **Terminal runs only**: Only runs in a terminal state (succeeded, failed,
+  cancelled) are deleted. Running and suspended workflow runs are never deleted
+  regardless of age.
+- **Flags**: `--dry-run`, `--force`, `--older-than <duration>` (reuses
+  `parseDuration` -- units: m, h, d, w, mo, y)
+- **Manual-only**: There is no automated or post-run GC for these stores yet.
+  `swamp run gc` is currently the only way to clean them up.
 
 ## RepoIndexService
 
@@ -130,6 +148,12 @@ Aggregate repositories emit domain events when data changes:
 - `ModelUpdated` - A model definition or data was modified
 - `ModelDeleted` - A model was deleted
 
+**Definition Events:**
+
+- `DefinitionCreated` - A new definition was created
+- `DefinitionUpdated` - A definition was modified
+- `DefinitionDeleted` - A definition was deleted
+
 **Workflow Events:**
 
 - `WorkflowCreated` - A new workflow definition was created
@@ -141,6 +165,16 @@ Aggregate repositories emit domain events when data changes:
 - `WorkflowRunStarted` - A workflow run began execution
 - `WorkflowRunCompleted` - A workflow run completed successfully
 - `WorkflowRunFailed` - A workflow run failed
+
+**Vault Events:**
+
+- `VaultCreated` - A new vault was created
+- `VaultUpdated` - A vault configuration was modified
+- `VaultDeleted` - A vault was deleted
+- `VaultSecretUpdated` - A secret was stored or updated in a vault
+- `VaultSecretDeleted` - A secret was deleted from a vault
+- `VaultSecretRead` - A secret was read from a vault
+- `VaultSecretAnnotated` - A secret's annotation was updated
 
 ### Event Handling
 
@@ -174,7 +208,10 @@ These are real files (not symlinks) tracked in git.
 ```
 .swamp/data/{normalized-type}/{model-id}/{data-name}/{version}/
 .swamp/outputs/{normalized-type}/{method}/{definition-id}-{timestamp}.yaml
-.swamp/workflow-runs/{workflow-id}/{run-id}.yaml
+.swamp/workflow-runs/{workflow-id}/workflow-run-{run-id}.yaml
 ```
 
-See [./datastores.md] for how the datastore path is resolved.
+The `workflow-runs/` and `outputs/` directories are covered by `swamp run gc`
+(see [Run Garbage Collection](#run-garbage-collection) above).
+
+See [datastores.md](./datastores.md) for how the datastore path is resolved.

--- a/design/reports.md
+++ b/design/reports.md
@@ -70,10 +70,12 @@ scope. See `src/domain/reports/report_context.ts`.
 | `logger`               | `Logger`                   | LogTape logger for report output         |
 | `dataRepository`       | `UnifiedDataRepository`    | Read/query persisted data                |
 | `definitionRepository` | `DefinitionRepository`     | Read model definitions                   |
+| `swampSha?`            | `string`                   | Git commit sha of the swamp repo at execution time |
 
 ### MethodReportContext / ModelReportContext
 
-Both method and model scope contexts carry the same fields:
+Both method and model scope contexts carry the same core fields. Method-scope
+contexts additionally carry `extensionFile`.
 
 | Field             | Type                         | Description                                  |
 | ----------------- | ---------------------------- | -------------------------------------------- |
@@ -85,7 +87,10 @@ Both method and model scope contexts carry the same fields:
 | `methodArgs`      | `Record<string, unknown>`    | Per-method arguments                         |
 | `methodName`      | `string`                     | Which method was invoked                     |
 | `executionStatus` | `"succeeded"` / `"failed"`   | Method outcome                               |
+| `errorMessage?`   | `string`                     | Error message when execution failed          |
 | `dataHandles`     | `DataHandle[]`               | Data artifacts produced by the method        |
+| `outputSpecs?`    | `OutputSpecInfo[]`           | Output spec schemas from the model type definition |
+| `extensionFile`   | `(relPath: string) => string`| Resolve extension asset path (method-scope only) |
 
 ### WorkflowReportContext
 
@@ -149,7 +154,8 @@ content-fingerprint invalidation (sha-256 over the entry point plus every
 local `.ts` dep) — mtime-based freshness was unreliable under atomic-rename
 saves, mtime-preserving sync tools, and sub-millisecond edits (issue #125).
 
-See `src/domain/reports/user_report_loader.ts`.
+See `src/domain/extensions/extension_loader.ts` (with
+`src/domain/extensions/report_kind_adapter.ts`).
 
 ## Report Registry
 
@@ -355,8 +361,9 @@ final view.
 
 ## Error Handling
 
-Report `execute()` throws are **advisory** — they do not fail the workflow or
-change the exit code. A broken report must not mask a successful workflow run.
+Report `execute()` throws **flip the run status to "failed"** and change the
+exit code. A report failure counts as a run failure — the final
+`ModelMethodRunView.status` is set to `"failed"` when `reportFailures > 0`.
 
 When `execute()` throws, swamp generates a fallback error artifact using the
 built-in `buildReportErrorResult` function
@@ -504,7 +511,7 @@ Reports support two output modes, consistent with the rest of the CLI:
 - **JSON mode** — emits a single JSON object with the full `ModelReportView`
   containing all report results (name, scope, success, markdown, json, error).
 
-See `src/presentation/renderers/model_report.ts`.
+See `src/presentation/renderers/model_method_run.ts`.
 
 ## Reports Directory Resolution
 

--- a/design/skills.md
+++ b/design/skills.md
@@ -153,7 +153,7 @@ Promptfoo tests whether an LLM correctly routes user queries to the right skill.
 It reads all `trigger_evals.json` files, presents each query to the model as a
 tool-selection task, and asserts that the correct skill was (or was not) called.
 
-**Run against the default model (sonnet):**
+**Run against the default model (opus):**
 
 ```bash
 export ANTHROPIC_API_KEY=<your-key>
@@ -164,10 +164,10 @@ deno run eval-skill-triggers
 
 ```bash
 export ANTHROPIC_API_KEY=<your-key>
-deno run eval-skill-triggers --model opus
+deno run eval-skill-triggers --model sonnet
 
 export OPENAI_API_KEY=<your-key>
-deno run eval-skill-triggers --model gpt-4.1
+deno run eval-skill-triggers --model gpt-5.4
 
 export GOOGLE_API_KEY=<your-key>
 deno run eval-skill-triggers --model gemini-2.5-pro
@@ -203,7 +203,7 @@ Two jobs run in parallel on every PR that touches skill files:
 Fails the PR if any skill scores below 90%.
 
 **skill-trigger-eval** — runs `deno run eval-skill-triggers` (promptfoo) with
-the default sonnet model. Fails the PR if the pass rate drops below 90%.
+the default opus model. Fails the PR if the pass rate drops below 90%.
 
 Both jobs write detailed results to the GitHub Actions step summary for easy
 review.
@@ -211,14 +211,16 @@ review.
 ### Weekly Multi-Model Regression
 
 A scheduled workflow (`multi-model-eval.yml`) runs every Saturday at 08:00 UTC.
-It tests trigger routing against four models in parallel:
+It tests trigger routing against six models in parallel:
 
 | Model          | Provider  | Concurrency | API Key Env        |
 | -------------- | --------- | ----------- | ------------------ |
-| sonnet         | Anthropic | 20          | `ANTHROPIC_API_KEY` |
 | opus           | Anthropic | 20          | `ANTHROPIC_API_KEY` |
-| gpt-4.1        | OpenAI    | 5           | `OPENAI_API_KEY`   |
+| sonnet         | Anthropic | 20          | `ANTHROPIC_API_KEY` |
+| gpt-5.4        | OpenAI    | 1           | `OPENAI_API_KEY`   |
 | gemini-2.5-pro | Google    | 20          | `GOOGLE_API_KEY`   |
+| gemini-3.1-pro | Google    | 20          | `GOOGLE_API_KEY`   |
+| fable          | Anthropic | 20          | `ANTHROPIC_API_KEY` |
 
 This catches model-specific regressions that the single-model PR check would
 miss. It can also be triggered manually via `workflow_dispatch` with a model

--- a/design/vaults.md
+++ b/design/vaults.md
@@ -604,6 +604,9 @@ vaults:
 
 ## Vault Model
 
+> **Planned -- not yet implemented.** The `swamp/lets-get-sensitive` vault model
+> described below is a design target. It is not yet present in the codebase.
+
 A dedicated `swamp/lets-get-sensitive` model provides direct vault operations in
 workflows:
 

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -223,7 +223,7 @@ is used with zero overhead.
 Workflows are specified in YAML files, that are validated with Zod, in the
 top-level `workflows/` directory of the repository, as
 `workflows/workflow-{uuid}.yaml`. Workflow run output is stored in the datastore
-at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
+at `workflow-runs/{workflow-uuid}/workflow-run-{run-uuid}.yaml` (default path:
 `.swamp/workflow-runs/`).
 
 ## Validation
@@ -528,7 +528,7 @@ data/scanner/{id}/
     latest → 1
 ```
 
-Each environment gets its own versioning and `latest` symlink, preventing
+Each environment gets its own versioning and `latest` marker, preventing
 cross-environment data interleaving.
 
 ### Accessing Varied Data
@@ -571,8 +571,8 @@ not vary between identical inputs. (If the inputs are identical, the run order
 should be deterministic.)
 
 The output of the run will be written to a workflow run log, kept in the
-datastore at `workflow-runs/{workflow-uuid}/{run-uuid}.yaml` (default path:
-`.swamp/workflow-runs/`).
+datastore at `workflow-runs/{workflow-uuid}/workflow-run-{run-uuid}.yaml`
+(default path: `.swamp/workflow-runs/`).
 
 ### Run Statuses
 
@@ -602,7 +602,7 @@ across all execution paths (scheduled, WebSocket ad-hoc, webhook). The cancel
 API checks both the registry and the `ScheduledExecutionService` running map.
 
 The same mechanism applies to model method runs via
-`swamp model cancel <model> [--run <id>]`.
+`swamp model cancel <model> [--all] [--reason <reason>]`.
 
 ## Domain Events
 
@@ -638,7 +638,7 @@ workflowContext:
   jobName: build
   stepName: validate-config
   modelType: command/shell
-  driver: local
+  executor: loopback
 ```
 
 Children use the same `cli_invocation` event shape as a direct
@@ -646,7 +646,7 @@ Children use the same `cli_invocation` event shape as a direct
 redactions: `command="model"`, `subcommand="method"`,
 `args=["run", "<REDACTED>", <methodName>]`. Analytics that aggregate by
 command/method roll up direct invocations and workflow-internal
-invocations uniformly; per-driver and per-model-type queries read
+invocations uniformly; per-executor and per-model-type queries read
 `workflowContext` directly without joining through the parent.
 
 ### Failure Semantics
@@ -682,8 +682,8 @@ invocations uniformly; per-driver and per-model-type queries read
   completion" message.
 
 The bridge lives in `src/libswamp/workflows/telemetry_bridge.ts`. The
-domain `step_failed` event carries optional `modelName`, `methodName`, and
-`driver` fields populated only at the model-method failure site (other
-yield sites — nesting depth, cycle detection, nested-workflow failure —
-leave them undefined so the bridge can distinguish structural failures
-from method failures).
+domain `step_failed` event carries optional `modelName` and `methodName`
+fields populated only at the model-method failure site (other yield
+sites — nesting depth, cycle detection, nested-workflow failure — leave
+them undefined so the bridge can distinguish structural failures from
+method failures).

--- a/integration/data_versioning_test.ts
+++ b/integration/data_versioning_test.ts
@@ -178,7 +178,7 @@ Deno.test("Data Versioning: retrieve specific versions", async () => {
   });
 });
 
-Deno.test("Data Versioning: latest symlink points to newest version", async () => {
+Deno.test("Data Versioning: latest marker points to newest version", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
     const repo = new FileSystemUnifiedDataRepository(

--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -237,7 +237,7 @@ export interface UnifiedDataRepository {
   ): Promise<void>;
 
   /**
-   * Removes the latest symlink for expired data (soft delete).
+   * Removes the latest marker for expired data (soft delete).
    * Version directories remain on disk but data becomes inaccessible.
    *
    * @param type - The model type

--- a/src/domain/repo/repo_index_service.ts
+++ b/src/domain/repo/repo_index_service.ts
@@ -153,13 +153,13 @@ export interface RepoIndexService {
 
   /**
    * Handles a WorkflowRunStarted event.
-   * Creates the run directory and updates the latest symlink.
+   * Creates the run directory and updates the latest marker.
    */
   handleWorkflowRunStarted(event: WorkflowRunStarted): Promise<void>;
 
   /**
    * Handles a WorkflowRunCompleted event.
-   * Updates step output symlinks.
+   * Updates step output markers.
    */
   handleWorkflowRunCompleted(event: WorkflowRunCompleted): Promise<void>;
 

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -77,7 +77,7 @@ function looksLikeModelId(name: string): boolean {
  *   2/
  *     raw
  *     metadata.yaml
- *   latest/            # Symlink -> 2/
+ *   latest             # Text file containing current version (e.g. "2")
  */
 export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   private readonly baseDir: string;
@@ -249,7 +249,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
    * Walks .swamp/data/{type-segments...}/{model-id}/{data-name}/ structure.
    *
    * When a directory contains a subdirectory with numeric version directories
-   * (or a "latest" symlink), we've reached a data-name level. The path segments
+   * (or a "latest" marker file), we've reached a data-name level. The path segments
    * before the model-id form the model type.
    */
   private async collectAllData(
@@ -370,7 +370,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
 
   /**
    * Checks if a directory looks like a model-id directory by examining
-   * if its children contain version subdirectories or a "latest" symlink.
+   * if its children contain version subdirectories or a "latest" marker file.
    */
   private async isModelIdDirectory(dir: string): Promise<boolean> {
     try {
@@ -622,7 +622,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     await assertSafePath(contentPath, boundary);
     await atomicWriteFile(contentPath, content);
 
-    // Update latest symlink
+    // Update latest marker
     await this.updateLatestMarker(type, modelId, data.name, newVersion);
 
     this.catalogUpsert(type, modelId, dataToSave);
@@ -796,7 +796,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         version,
       );
 
-      // Update latest symlink if needed
+      // Update latest marker if needed
       const versions = await this.listVersions(type, modelId, dataName);
       if (versions.length > 0) {
         const newLatest = Math.max(...versions);
@@ -832,7 +832,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   }
 
   /**
-   * Removes the latest symlink for expired data (soft delete).
+   * Removes the latest marker for expired data (soft delete).
    * Version directories remain on disk but data becomes inaccessible.
    */
   async removeLatestMarker(
@@ -843,15 +843,15 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const dataNameDir = this.getDataNameDir(type, modelId, dataName);
     await this.notifyDirty(dataNameDir);
 
-    const latestSymlink = join(dataNameDir, "latest");
+    const latestMarker = join(dataNameDir, "latest");
 
     try {
-      await Deno.remove(latestSymlink);
+      await Deno.remove(latestMarker);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
       }
-      // Symlink already missing is OK
+      // Marker already missing is OK
     }
 
     this.catalogRemove(type, modelId, dataName);
@@ -1108,7 +1108,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
     await atomicWriteTextFile(metadataPath, metadataContent);
 
-    // Update latest symlink
+    // Update latest marker
     await this.updateLatestMarker(type, modelId, data.name, version);
 
     this.catalogUpsert(type, modelId, dataToSave);


### PR DESCRIPTION
## Summary

- Fixes all 75+ verified stale/misleading claims across 20 of 27 design docs, bringing documentation in line with the current codebase
- Replaces stale "symlink" references with "marker" (latest marker is now a plain text file since PR #669)
- Removes references to deleted files/classes, fixes incorrect behavioral claims, updates event type listings, and documents the new `swamp run gc` feature
- Single code change: renames `latestSymlink` variable to `latestMarker` in `unified_data_repository.ts`

Every finding was identified by an initial audit agent, then independently verified by a separate verification agent (74/75 confirmed, 0 refuted, 3 minor count corrections).

Closes swamp-club#1198

## Test Plan

- [x] `deno check` passes (variable rename compiles)
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno run test` — 9035 passed, 1 pre-existing flaky failure in `resolve_datastore_test.ts` (unrelated to this change, passes when run in isolation)
- [x] `integration/data_versioning_test.ts` — all 16 tests pass including the renamed "latest marker points to newest version" test

🤖 Generated with [Claude Code](https://claude.com/claude-code)