### PR TITLE
fix(extensions): warn when extension update types are shadowed by local sources

### DIFF
--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -88,6 +88,18 @@ export type ExtensionKind =
   | "report";
 
 /**
+ * Reported when {@link ExtensionCatalogStore.resolveOriginConflicts}
+ * clears a pulled entry's `type_normalized` because a local source
+ * already claims that `(kind, type)` pair.
+ */
+export interface OriginConflict {
+  readonly type: string;
+  readonly kind: ExtensionKind;
+  readonly pulledSourcePath: string;
+  readonly localSourcePath: string;
+}
+
+/**
  * A single row in the bundle_types table.
  */
 export interface ExtensionTypeRow {
@@ -1271,7 +1283,7 @@ export class ExtensionCatalogStore {
    *
    * Idempotent: running twice produces the same result.
    */
-  resolveOriginConflicts(repoRoot: string): void {
+  resolveOriginConflicts(repoRoot: string): OriginConflict[] {
     const canonical = canonicalizePath(repoRoot);
     const pulledPrefix = canonical.endsWith("/")
       ? `${canonical}.swamp/pulled-extensions/`
@@ -1286,8 +1298,9 @@ export class ExtensionCatalogStore {
         break;
       }
     }
-    if (!hasPulled) return;
+    if (!hasPulled) return [];
 
+    const conflicts: OriginConflict[] = [];
     const occupants = new Map<
       string,
       { sourcePath: string; isPulled: boolean }
@@ -1306,15 +1319,29 @@ export class ExtensionCatalogStore {
 
       if (prior) {
         if (prior.isPulled && !isPulled) {
+          conflicts.push({
+            type: row.type_normalized,
+            kind: row.kind,
+            pulledSourcePath: prior.sourcePath,
+            localSourcePath: row.source_path,
+          });
           this.clearTypeNormalized(prior.sourcePath);
           occupants.set(key, { sourcePath: row.source_path, isPulled });
         } else if (!prior.isPulled && isPulled) {
+          conflicts.push({
+            type: row.type_normalized,
+            kind: row.kind,
+            pulledSourcePath: row.source_path,
+            localSourcePath: prior.sourcePath,
+          });
           this.clearTypeNormalized(row.source_path);
         }
       } else {
         occupants.set(key, { sourcePath: row.source_path, isPulled });
       }
     }
+
+    return conflicts;
   }
 
   private clearTypeNormalized(sourcePath: string): void {

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -2181,11 +2181,12 @@ Deno.test("resolveOriginConflicts: no-op when no pulled rows exist", () => {
     }),
   );
 
-  store.resolveOriginConflicts(repoRoot);
+  const conflicts = store.resolveOriginConflicts(repoRoot);
 
   const rows = store.findAll();
   assertEquals(rows.length, 1);
   assertEquals(rows[0].type_normalized, "@ns/a");
+  assertEquals(conflicts.length, 0);
   store.close();
 });
 
@@ -2212,12 +2213,17 @@ Deno.test("resolveOriginConflicts: clears pulled type when local claims same typ
     kind: "model",
   }));
 
-  store.resolveOriginConflicts(repoRoot);
+  const conflicts = store.resolveOriginConflicts(repoRoot);
 
   const local = store.findBySourcePath(localPath);
   const pulled = store.findBySourcePath(pulledPath);
   assertEquals(local?.type_normalized, "@ns/foo");
   assertEquals(pulled?.type_normalized, "");
+  assertEquals(conflicts.length, 1);
+  assertEquals(conflicts[0].type, "@ns/foo");
+  assertEquals(conflicts[0].kind, "model");
+  assertEquals(conflicts[0].pulledSourcePath, pulledPath);
+  assertEquals(conflicts[0].localSourcePath, localPath);
   store.close();
 });
 
@@ -2339,13 +2345,15 @@ Deno.test("resolveOriginConflicts: idempotent", () => {
     kind: "model",
   }));
 
-  store.resolveOriginConflicts(repoRoot);
-  store.resolveOriginConflicts(repoRoot);
+  const first = store.resolveOriginConflicts(repoRoot);
+  const second = store.resolveOriginConflicts(repoRoot);
 
   const local = store.findBySourcePath(localPath);
   const pulled = store.findBySourcePath(pulledPath);
   assertEquals(local?.type_normalized, "@ns/foo");
   assertEquals(pulled?.type_normalized, "");
+  assertEquals(first.length, 1);
+  assertEquals(second.length, 0);
   store.close();
 });
 

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -24,6 +24,7 @@ import type {
   ExtensionCatalogStore,
   ExtensionKind,
   ExtensionTypeRow,
+  OriginConflict,
 } from "./extension_catalog_store.ts";
 import { DuplicateTypeError } from "./duplicate_type_error.ts";
 import type { LocalManifestIdentity } from "./local_manifest_reader.ts";
@@ -120,6 +121,7 @@ export class ExtensionRepository {
    * concurrent loadByName calls before the UPDATE lands).
    */
   private readonly fallbackLoggedSourcePaths: Set<string>;
+  private _lastOriginConflicts: OriginConflict[] = [];
 
   constructor(args: {
     catalog: ExtensionCatalogStore;
@@ -132,6 +134,10 @@ export class ExtensionRepository {
     this.repoRoot = canonicalizePath(args.repoRoot);
     this.localManifestIdentity = args.localManifestIdentity ?? null;
     this.fallbackLoggedSourcePaths = new Set();
+  }
+
+  get lastOriginConflicts(): readonly OriginConflict[] {
+    return this._lastOriginConflicts;
   }
 
   /**
@@ -237,7 +243,9 @@ export class ExtensionRepository {
         logger
           .info`Pruned ${pruned.length} catalog row(s) with unreachable source path(s)`;
       }
-      this.catalog.resolveOriginConflicts(this.repoRoot);
+      this._lastOriginConflicts = this.catalog.resolveOriginConflicts(
+        this.repoRoot,
+      );
       this.assertIRepo1();
     });
   }

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -1092,3 +1092,120 @@ Deno.test("saveAll: upsertWithIdentity canonicalizes source_path preventing ghos
     assertEquals(rows[0].extension_name, "@local/test");
   });
 });
+
+// ===== lastOriginConflicts: pulled shadowed by local =====
+Deno.test(
+  "ExtensionRepository: saveAll populates lastOriginConflicts when pulled type is shadowed by local source",
+  () => {
+    withRepository((repo, catalog, repoRoot) => {
+      const localPath = canonicalizePath(
+        join(repoRoot, "extensions/models/my_model.ts"),
+      );
+      catalog.upsert({
+        source_path: localPath,
+        type_normalized: "@ns/my-model",
+        kind: "model",
+        bundle_path: join(repoRoot, ".swamp/bundles/models/local/my_model.js"),
+        version: "2026.01.01.1",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "fp-local",
+      });
+
+      const pulled = pulledExtension({
+        repoRoot,
+        name: "@ns/my-ext",
+        version: "2026.03.01.1",
+        sources: [{ relPath: "models/my_model.ts", type: "@ns/my-model" }],
+      });
+
+      assertEquals(repo.lastOriginConflicts.length, 0);
+
+      repo.saveAll([pulled]);
+
+      const conflicts = repo.lastOriginConflicts;
+      assertEquals(conflicts.length, 1);
+      assertEquals(conflicts[0].type, "@ns/my-model");
+      assertEquals(conflicts[0].kind, "model");
+      assertEquals(conflicts[0].localSourcePath, localPath);
+      assertStringIncludes(conflicts[0].pulledSourcePath, "pulled-extensions");
+
+      const localRow = catalog.findBySourcePath(localPath);
+      assertEquals(localRow?.type_normalized, "@ns/my-model");
+
+      const pulledRow = catalog.findBySourcePath(
+        canonicalizePath(
+          join(
+            repoRoot,
+            ".swamp/pulled-extensions/@ns/my-ext/models/my_model.ts",
+          ),
+        ),
+      );
+      assertEquals(pulledRow?.type_normalized, "");
+    });
+  },
+);
+
+Deno.test(
+  "ExtensionRepository: saveAll returns empty lastOriginConflicts when no local source shadows",
+  () => {
+    withRepository((repo, _cat, repoRoot) => {
+      const pulled = pulledExtension({
+        repoRoot,
+        name: "@ns/only-pulled",
+        version: "1.0.0",
+        sources: [{ relPath: "models/foo.ts", type: "@ns/only-pulled" }],
+      });
+
+      repo.saveAll([pulled]);
+
+      assertEquals(repo.lastOriginConflicts.length, 0);
+    });
+  },
+);
+
+Deno.test(
+  "ExtensionRepository: saveAll with tombstone + new version populates lastOriginConflicts for shadowed new version",
+  () => {
+    withRepository((repo, catalog, repoRoot) => {
+      const localPath = canonicalizePath(
+        join(repoRoot, "extensions/models/model.ts"),
+      );
+      catalog.upsert({
+        source_path: localPath,
+        type_normalized: "@ns/ext-type",
+        kind: "model",
+        bundle_path: join(repoRoot, ".swamp/bundles/models/local/model.js"),
+        version: "2026.01.01.1",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "fp-local",
+      });
+
+      const v1 = pulledExtension({
+        repoRoot,
+        name: "@ns/ext",
+        version: "2026.01.01.1",
+        sources: [{ relPath: "models/model.ts", type: "@ns/ext-type" }],
+      });
+      repo.saveAll([v1]);
+
+      const v2 = pulledExtension({
+        repoRoot,
+        name: "@ns/ext",
+        version: "2026.03.01.1",
+        sources: [{ relPath: "models/model.ts", type: "@ns/ext-type" }],
+      });
+      repo.saveAll([tombstoneAll(v1), v2]);
+
+      const conflicts = repo.lastOriginConflicts;
+      assertEquals(conflicts.length, 1);
+      assertEquals(conflicts[0].type, "@ns/ext-type");
+      assertEquals(conflicts[0].localSourcePath, localPath);
+    }, {
+      lockedVersions: fixedLockedVersions({ "@ns/ext": "2026.03.01.1" }),
+    });
+  },
+);

--- a/src/libswamp/extensions/install_extension_service.ts
+++ b/src/libswamp/extensions/install_extension_service.ts
@@ -179,6 +179,15 @@ export class InstallExtensionService {
         }
       }
       this.repository.saveAll([...tombstones, ...newExtensions]);
+
+      const conflicts = this.repository.lastOriginConflicts;
+      if (conflicts.length > 0) {
+        result.shadowedTypes = conflicts.map((c) => ({
+          type: c.type,
+          kind: c.kind,
+          localSourcePath: c.localSourcePath,
+        }));
+      }
     } catch (error) {
       if (error instanceof DuplicateTypeError) {
         await this.rollbackOnCollision(result, priorEntry, ctx);

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -127,6 +127,7 @@ function makeStubInstallResult(
     dependencies: [],
     dependencyResults: [],
     pruned: [],
+    shadowedTypes: [],
   };
 }
 

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -596,6 +596,7 @@ function makeInstallWithPruned(
       dependencies: [],
       dependencyResults: [],
       pruned: prunedPaths,
+      shadowedTypes: [],
     };
   };
 }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -81,6 +81,12 @@ export interface ExtensionRegistryInfo {
   supersededBy?: string | null;
 }
 
+export interface ShadowedTypeInfo {
+  readonly type: string;
+  readonly kind: string;
+  readonly localSourcePath: string;
+}
+
 /** Result of installing a single extension (no rendering). */
 export interface InstallResult {
   name: string;
@@ -109,6 +115,14 @@ export interface InstallResult {
    * included.
    */
   pruned: string[];
+  /**
+   * Types whose pulled catalog entry was cleared by
+   * {@link resolveOriginConflicts} because a local source claims the
+   * same `(kind, type_normalized)` pair. Populated by
+   * {@link InstallExtensionService} after the catalog save. Absent or
+   * empty when no local source shadows the pulled extension's types.
+   */
+  shadowedTypes?: ShadowedTypeInfo[];
 }
 
 /**
@@ -1227,6 +1241,7 @@ export async function installExtension(
       dependencies: manifest.dependencies,
       dependencyResults,
       pruned,
+      shadowedTypes: [],
     };
   } finally {
     try {

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -210,6 +210,7 @@ function makeStubInstallResult(
     dependencies: [],
     dependencyResults: [],
     pruned,
+    shadowedTypes: [],
   };
 }
 

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -121,6 +121,7 @@ function makeStubInstallResult(
     dependencies: [],
     dependencyResults: [],
     pruned: [],
+    shadowedTypes: [],
   };
 }
 

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -29,7 +29,7 @@ import { LockfileRepository } from "../../infrastructure/persistence/lockfile_re
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
-import type { InstallResult } from "./pull.ts";
+import type { InstallResult, ShadowedTypeInfo } from "./pull.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
@@ -49,6 +49,11 @@ export type ExtensionUpdateEvent =
     from: string;
     to: string;
     paths: string[];
+  }
+  | {
+    kind: "shadowed-by-local";
+    name: string;
+    types: ShadowedTypeInfo[];
   }
   | { kind: "completed"; data: ExtensionUpdateResult; mode: "check" | "update" }
   | { kind: "error"; error: SwampError };
@@ -255,6 +260,13 @@ export async function* extensionUpdate(
                 from: s.installedVersion,
                 to: s.latestVersion,
                 paths: result.pruned,
+              };
+            }
+            if (result?.shadowedTypes && result.shadowedTypes.length > 0) {
+              yield {
+                kind: "shadowed-by-local",
+                name: s.name,
+                types: result.shadowedTypes,
               };
             }
             finalStatuses.push({

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -236,12 +236,13 @@ Deno.test("extensionUpdate: registry fetch failure records not_found", async () 
   }
 });
 
-import type { InstallResult } from "./pull.ts";
+import type { InstallResult, ShadowedTypeInfo } from "./pull.ts";
 
 function buildInstallResult(
   name: string,
   version: string,
   pruned: string[],
+  shadowedTypes: ShadowedTypeInfo[] = [],
 ): InstallResult {
   return {
     name,
@@ -261,8 +262,98 @@ function buildInstallResult(
     dependencies: [],
     dependencyResults: [],
     pruned,
+    shadowedTypes,
   };
 }
+
+Deno.test(
+  "extensionUpdate: emits shadowed-by-local event when installExtension returns shadowedTypes",
+  async () => {
+    const deps = makeDeps({
+      upstream: { "@ns/a": "2026.01.01.1" },
+      getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+      installExtension: (name, version) =>
+        Promise.resolve(
+          buildInstallResult(name, version, [], [
+            {
+              type: "@ns/a",
+              kind: "model",
+              localSourcePath: "/repo/extensions/models/a.ts",
+            },
+          ]),
+        ),
+    });
+    const input: ExtensionUpdateInput = { checkOnly: false };
+
+    const events = await collect<ExtensionUpdateEvent>(
+      extensionUpdate(makeCtx(), deps, input),
+    );
+
+    const shadowed = events.find((e) => e.kind === "shadowed-by-local");
+    if (shadowed?.kind !== "shadowed-by-local") {
+      throw new Error(
+        `expected shadowed-by-local event, got: ${
+          events.map((e) => e.kind).join(", ")
+        }`,
+      );
+    }
+    assertEquals(shadowed.name, "@ns/a");
+    assertEquals(shadowed.types.length, 1);
+    assertEquals(shadowed.types[0].type, "@ns/a");
+    assertEquals(shadowed.types[0].kind, "model");
+    assertEquals(
+      shadowed.types[0].localSourcePath,
+      "/repo/extensions/models/a.ts",
+    );
+  },
+);
+
+Deno.test(
+  "extensionUpdate: no shadowed-by-local event when shadowedTypes is empty",
+  async () => {
+    const deps = makeDeps({
+      upstream: { "@ns/a": "2026.01.01.1" },
+      getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+      installExtension: (name, version) =>
+        Promise.resolve(buildInstallResult(name, version, [])),
+    });
+    const input: ExtensionUpdateInput = { checkOnly: false };
+
+    const events = await collect<ExtensionUpdateEvent>(
+      extensionUpdate(makeCtx(), deps, input),
+    );
+
+    assertEquals(
+      events.find((e) => e.kind === "shadowed-by-local"),
+      undefined,
+    );
+  },
+);
+
+Deno.test(
+  "extensionUpdate: no shadowed-by-local event when shadowedTypes is undefined",
+  async () => {
+    const deps = makeDeps({
+      upstream: { "@ns/a": "2026.01.01.1" },
+      getExtension: () => Promise.resolve({ latestVersion: "2026.03.01.1" }),
+      installExtension: (name, version) => {
+        const r = buildInstallResult(name, version, []);
+        r.shadowedTypes = undefined;
+        return Promise.resolve(r);
+      },
+    });
+    const input: ExtensionUpdateInput = { checkOnly: false };
+
+    const events = await collect<ExtensionUpdateEvent>(
+      extensionUpdate(makeCtx(), deps, input),
+    );
+
+    assertEquals(
+      events.find((e) => e.kind === "shadowed-by-local"),
+      undefined,
+    );
+  },
+);
 
 Deno.test(
   "extensionUpdate: emits orphans-pruned event when installExtension returns pruned paths",

--- a/src/libswamp/extensions/upgrade_extension_service_test.ts
+++ b/src/libswamp/extensions/upgrade_extension_service_test.ts
@@ -112,6 +112,7 @@ function makeStubInstallResult(
     dependencies: [],
     dependencyResults: [],
     pruned: [],
+    shadowedTypes: [],
   };
 }
 

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -906,6 +906,7 @@ export {
   isVersionConstraint,
   parseExtensionRef,
   resolveServerUrl,
+  type ShadowedTypeInfo,
   validateExtensionName,
 } from "./extensions/pull.ts";
 export {

--- a/src/presentation/renderers/extension_update.ts
+++ b/src/presentation/renderers/extension_update.ts
@@ -58,6 +58,22 @@ class LogExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
           logger.info("  {path}", { path: p });
         }
       },
+      "shadowed-by-local": (e) => {
+        logger.warn(
+          "{name} was updated but {count} type(s) are shadowed by local sources and will not take effect:",
+          { name: e.name, count: e.types.length },
+        );
+        for (const t of e.types) {
+          logger.warn("  {kind} type {type} — local source: {path}", {
+            kind: t.kind,
+            type: t.type,
+            path: t.localSourcePath,
+          });
+        }
+        logger.warn(
+          "Update your local source or remove it to use the pulled version.",
+        );
+      },
       completed: (e) => {
         if (e.mode === "check") {
           renderCheckLog(e.data, logger);
@@ -104,6 +120,19 @@ class JsonExtensionUpdateRenderer implements Renderer<ExtensionUpdateEvent> {
               from: e.from,
               to: e.to,
               paths: e.paths,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      "shadowed-by-local": (e) => {
+        console.log(
+          JSON.stringify(
+            {
+              status: "shadowed_by_local",
+              name: e.name,
+              types: e.types,
             },
             null,
             2,

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -700,6 +700,7 @@ export async function handleExtensionOutdated(
         checking: () => {},
         updating: () => {},
         "orphans-pruned": () => {},
+        "shadowed-by-local": () => {},
         completed: (e) => {
           result = e.data as unknown as Record<string, unknown>;
         },


### PR DESCRIPTION
## Summary

Fixes swamp-club#1165.

- When a user has an extension both locally developed (source in a local models dir or `.swamp-sources.yaml` mount) **and** pulled from the registry, `resolveOriginConflicts` silently clears the pulled entry's `type_normalized` so the local source wins. After `swamp extension update`, the local (old) source still takes priority — new methods show as `Unknown method` with no feedback about why.
- `resolveOriginConflicts` now returns `OriginConflict[]` describing which pulled types were cleared and which local source won.
- The install service threads this through `InstallResult.shadowedTypes` (optional field — no breaking change for out-of-tree constructors).
- The update generator emits a new `shadowed-by-local` event, rendered as a warning with the local source path and actionable guidance to update or remove the local source.

## Test Plan

- [x] `deno check` clean (only pre-existing `getDenoEnv` error)
- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] 9013 tests pass (6 new), 0 failures from this change
- [x] 514 integration tests pass
- [x] `resolveOriginConflicts` returns correct conflicts for both iteration orders (pulled-first and local-first)
- [x] `resolveOriginConflicts` returns `[]` on no-op (no pulled rows)
- [x] Idempotent: first call returns 1 conflict, second returns 0 (type already cleared)
- [x] `saveAll` populates `lastOriginConflicts` on real SQLite catalog when pulled type is shadowed
- [x] `saveAll` returns empty conflicts when no local source shadows
- [x] `saveAll` with tombstone + new version (the actual upgrade path) populates conflicts
- [x] Generator emits `shadowed-by-local` event with correct payload
- [x] Generator emits no event when `shadowedTypes` is empty or `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)