### PR TITLE
fix(serve): emit ModelUpdated on data writes so grant revoke triggers auto-reload (swamp-club#1213)

### DIFF
--- a/src/domain/access/policy_snapshot_loader_test.ts
+++ b/src/domain/access/policy_snapshot_loader_test.ts
@@ -530,6 +530,54 @@ Deno.test("PolicySnapshotLoader: ignores DefinitionCreated for non-access models
   await loader.dispose();
 });
 
+Deno.test("PolicySnapshotLoader: rebuilds snapshot on ModelUpdated for grant revoke", async () => {
+  let callCount = 0;
+  const activeGrant = makeGrant({ state: "active" });
+  const revokedGrant = makeGrant({ ...activeGrant, state: "revoked" });
+
+  const dataRepo = {
+    findAllForType(type: ModelType) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized) {
+        callCount++;
+        return Promise.resolve([{
+          data: makeData("grant-main"),
+          modelType: type,
+          modelId: "g1",
+        }]);
+      }
+      return Promise.resolve([]);
+    },
+    getContent(
+      type: ModelType,
+      _modelId: string,
+      _dataName: string,
+    ) {
+      if (type.normalized === GRANT_MODEL_TYPE.normalized) {
+        const grant = callCount <= 1 ? activeGrant : revokedGrant;
+        return Promise.resolve(
+          new TextEncoder().encode(JSON.stringify(grant)),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  } as unknown as UnifiedDataRepository;
+
+  const eventBus = new EventBus();
+  const loader = new PolicySnapshotLoader(dataRepo, eventBus);
+
+  await loader.load();
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 1);
+
+  await eventBus.publish(
+    createModelUpdated("swamp/grant", "g1", "my-grant"),
+  );
+
+  await delay(700);
+  assertEquals(loader.snapshot.grantsForSubjects(["user:adam"]).length, 0);
+
+  await loader.dispose();
+});
+
 Deno.test("PolicySnapshotLoader.loadWithCounts: returns counts", async () => {
   const grant = makeGrant();
   const group = makeGroup("devs", ["adam"]);

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -21,6 +21,8 @@ import { cancelled, type SwampError, validationFailed } from "../errors.ts";
 import { inputValidationFailed } from "../workflows/run.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { MethodExecutionEvent } from "../../domain/models/method_events.ts";
+import type { EventBus } from "../../domain/events/event_bus.ts";
+import { createModelUpdated } from "../../domain/events/types.ts";
 import {
   executeReports,
   type ReportExecutionResult,
@@ -207,6 +209,7 @@ export interface ModelMethodRunDeps {
   ) => Promise<void>;
   getDefinitionPath?: (type: ModelType, id: string) => string;
   runTracker?: RunTrackerRepository;
+  eventBus?: EventBus;
   workflowRepo?:
     import("../../domain/workflows/repositories.ts").WorkflowRepository;
   workflowRunRepo?:
@@ -955,6 +958,19 @@ export async function* modelMethodRun(
           await deps.outputRepo.save(modelType, input.methodName, output);
           if (deps.runTracker) {
             deps.runTracker.complete(output.id, "completed");
+          }
+
+          if (
+            deps.eventBus &&
+            execResult.dataHandles && execResult.dataHandles.length > 0
+          ) {
+            deps.eventBus.publish(
+              createModelUpdated(
+                modelType.normalized,
+                definition.id,
+                definition.name,
+              ),
+            );
           }
 
           // --- Post-run reports ---

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -964,7 +964,7 @@ export async function* modelMethodRun(
             deps.eventBus &&
             execResult.dataHandles && execResult.dataHandles.length > 0
           ) {
-            deps.eventBus.publish(
+            await deps.eventBus.publish(
               createModelUpdated(
                 modelType.normalized,
                 definition.id,

--- a/src/libswamp/models/run_test.ts
+++ b/src/libswamp/models/run_test.ts
@@ -39,6 +39,10 @@ import { VaultSecretBag } from "../../domain/vaults/vault_secret_bag.ts";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import type { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { SecretRedactor } from "../../domain/secrets/secret_redactor.ts";
+import { EventBus } from "../../domain/events/event_bus.ts";
+import type { ModelUpdated } from "../../domain/events/types.ts";
+import type { DataHandle } from "../../domain/models/model.ts";
+import { generateDataId } from "../../domain/data/data_id.ts";
 
 await initializeLogging({});
 
@@ -753,4 +757,69 @@ Deno.test("modelMethodRun: does not yield auto_gc_completed when autoGc is false
 
   const gcEvent = events.find((e) => e.kind === "auto_gc_completed");
   assertEquals(gcEvent, undefined);
+});
+
+// --- EventBus ModelUpdated emission tests ---
+
+Deno.test("modelMethodRun: publishes ModelUpdated when method writes data and eventBus is provided", async () => {
+  const definition = createTestDefinition("test-model", "run");
+  const dataHandle = {
+    dataId: generateDataId(),
+    name: "grant-main",
+    specName: "grant",
+    kind: "resource" as const,
+    version: 1,
+    size: 42,
+    tags: {},
+    metadata: { contentType: "application/json" },
+  } as DataHandle;
+  const modelDef = createTestModelDef("run");
+
+  const eventBus = new EventBus();
+  const published: ModelUpdated[] = [];
+  eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
+    published.push(event);
+  });
+
+  const deps: ModelMethodRunDeps = {
+    ...createTestDeps(definition, modelDef),
+    createExecutionService: () =>
+      ({
+        executeWorkflow: () => Promise.resolve({ dataHandles: [dataHandle] }),
+        // deno-lint-ignore no-explicit-any
+      }) as any,
+    eventBus,
+  };
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
+  );
+
+  assertEquals(published.length, 1);
+  assertEquals(published[0].modelType, "test/model");
+  assertEquals(published[0].modelName, "test-model");
+});
+
+Deno.test("modelMethodRun: does not publish ModelUpdated when method writes no data", async () => {
+  const definition = createTestDefinition("test-model", "run");
+  const modelDef = createTestModelDef("run");
+
+  const eventBus = new EventBus();
+  const published: ModelUpdated[] = [];
+  eventBus.subscribe<ModelUpdated>("ModelUpdated", (event) => {
+    published.push(event);
+  });
+
+  const deps: ModelMethodRunDeps = {
+    ...createTestDeps(definition, modelDef),
+    eventBus,
+  };
+
+  const ctx = createLibSwampContext();
+  await collect(
+    modelMethodRun(ctx, deps, createTestInput("test-model", "run")),
+  );
+
+  assertEquals(published.length, 0);
 });

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -270,6 +270,7 @@ export async function createModelMethodRunDeps(
       }
       : undefined,
     runTracker: options?.runTracker,
+    eventBus: repoContext.eventBus,
     workflowRepo: repoContext.workflowRepo,
     workflowRunRepo: repoContext.workflowRunRepo,
   };


### PR DESCRIPTION
## Summary

- Grant revoke under `--grant-reload auto` never triggered a policy snapshot
  reload because the revoke path writes data via `UnifiedDataRepository` (no
  event bus), while grant create triggers `DefinitionCreated` through the direct
  execution path
- Emit `ModelUpdated` from the `modelMethodRun` pipeline after any method
  successfully writes data, so `PolicySnapshotLoader` rebuilds the snapshot
- Also fixes the same gap for group `add-member` / `remove-member` operations

Fixes swamp-club#1213

## Test Plan

- [x] Unit test: `ModelUpdated` for a revoked grant triggers snapshot rebuild
  that removes the grant from the policy snapshot
- [x] Pipeline test: `modelMethodRun` emits `ModelUpdated` when data is written
- [x] Pipeline test: `modelMethodRun` does NOT emit `ModelUpdated` when no data
  is written
- [x] All 13 `PolicySnapshotLoader` tests pass (including new grant revoke test)
- [x] All 25 `modelMethodRun` tests pass (including 2 new EventBus tests)
- [x] Full test suite: 9041 passed, 1 pre-existing flaky failure (unrelated
  `WorkflowRunTree` Ink rendering test)
- [x] `deno check`, `deno lint`, `deno fmt --check` all clean
- [x] Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)