### PR TITLE
fix(extensions): warn about untrusted collectives on upgrade; clarify auto-resolve errors (swamp-club#1217)

### DIFF
--- a/design/repo.md
+++ b/design/repo.md
@@ -101,8 +101,9 @@ attributes to control the behaviour of the swamp operations.
   first use. Default: `["swamp"]`. Set to `[]` to disable. Manageable via
   `swamp extension trust list/add/rm`.
 - `trustMemberCollectives`: Whether to auto-trust collectives the user belongs
-  to (cached from `auth login`/`auth whoami`). Default: `true`. Set to `false`
-  to only trust the explicit `trustedCollectives` list. Toggleable via
+  to (cached from `auth login`/`auth whoami`). Default: `false`. Set to `true`
+  to trust all membership collectives in addition to the explicit
+  `trustedCollectives` list. Toggleable via
   `swamp extension trust auto-trust <on|off>`.
 - `autoGc`: Enable automatic garbage collection after model method runs.
   Default: `false`. When `true`, `collectGarbage` runs for the model that just

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -48,6 +48,7 @@ import { ToolResolver } from "./tool_resolver.ts";
 import { readCustomTools } from "../../infrastructure/persistence/custom_tools_repository.ts";
 import { BuiltInToolSkillDirsRepository } from "../../infrastructure/persistence/builtin_tool_skill_dirs_repository.ts";
 import { CustomToolSkillDirsRepository } from "../../infrastructure/persistence/custom_tool_skill_dirs_repository.ts";
+import { readUpstreamExtensions } from "../../infrastructure/persistence/upstream_extensions.ts";
 
 const logger = getLogger(["swamp", "repo", "service"]);
 
@@ -216,6 +217,8 @@ export interface RepoUpgradeResult {
   localSkillCopies: LocalSkillCopy[];
   /** Repo-relative paths of files modified during this upgrade. */
   changedFiles: string[];
+  /** Collectives referenced in the lockfile that are not trusted (swamp-club#1217). */
+  untrustedCollectives: string[];
 }
 
 /**
@@ -511,6 +514,11 @@ export class RepoService {
       );
     }
 
+    const untrustedCollectives = await this.detectUntrustedCollectives(
+      repoPath,
+      updatedMarker,
+    );
+
     return {
       path: repoPath.value,
       previousVersion,
@@ -527,6 +535,7 @@ export class RepoService {
       extensionsToReinstall,
       localSkillCopies,
       changedFiles,
+      untrustedCollectives,
     };
   }
 
@@ -760,6 +769,55 @@ export class RepoService {
     }
     result.sort();
     return result;
+  }
+
+  /**
+   * Reads the lockfile and returns collectives that are referenced but not
+   * trusted (swamp-club#1217). Failures are swallowed — a missing or
+   * corrupt lockfile simply yields an empty list.
+   */
+  private async detectUntrustedCollectives(
+    repoPath: RepoPath,
+    marker: RepoMarkerData,
+  ): Promise<string[]> {
+    const modelsDir = marker.modelsDir ?? "models";
+    const lockfilePath = join(
+      repoPath.value,
+      modelsDir,
+      "upstream_extensions.json",
+    );
+    let entries: Record<string, unknown>;
+    try {
+      entries = await readUpstreamExtensions(lockfilePath);
+    } catch {
+      return [];
+    }
+
+    // When trustMemberCollectives is on, all the user's membership
+    // collectives are trusted at runtime. We don't have auth context
+    // during upgrade to know which those are, so skip the warning
+    // entirely to avoid false positives.
+    if (marker.trustMemberCollectives === true) return [];
+
+    const lockfileCollectives = new Set<string>();
+    for (const name of Object.keys(entries)) {
+      if (name.startsWith("@")) {
+        const slash = name.indexOf("/", 1);
+        if (slash !== -1) {
+          lockfileCollectives.add(name.slice(1, slash));
+        }
+      }
+    }
+
+    if (lockfileCollectives.size === 0) return [];
+
+    const trusted = new Set(
+      marker.trustedCollectives ?? ["swamp"],
+    );
+
+    return [...lockfileCollectives]
+      .filter((c) => !trusted.has(c))
+      .sort();
   }
 
   /**

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -2789,3 +2789,99 @@ Deno.test("removeLocalBundledSkills: no-op when directory already gone", async (
     }]);
   });
 });
+
+Deno.test("RepoService.upgrade: returns untrusted collectives from lockfile", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath);
+
+    // Write a lockfile with extensions from an untrusted collective
+    const modelsDir = join(tempDir, "models");
+    await ensureDir(modelsDir);
+    await Deno.writeTextFile(
+      join(modelsDir, "upstream_extensions.json"),
+      JSON.stringify({
+        "@acme/widgets": { version: "1.0.0", pulledAt: "2026-01-01" },
+        "@swamp/echo": { version: "2.0.0", pulledAt: "2026-01-01" },
+      }),
+    );
+
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.untrustedCollectives, ["acme"]);
+  });
+});
+
+Deno.test("RepoService.upgrade: returns empty when all collectives are trusted", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath);
+
+    // Write the marker with an extra trusted collective
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    marker!.trustedCollectives = ["swamp", "acme"];
+    await markerRepo.write(repoPath, marker!);
+
+    // Write a lockfile with extensions only from trusted collectives
+    const modelsDir = join(tempDir, "models");
+    await ensureDir(modelsDir);
+    await Deno.writeTextFile(
+      join(modelsDir, "upstream_extensions.json"),
+      JSON.stringify({
+        "@acme/widgets": { version: "1.0.0", pulledAt: "2026-01-01" },
+        "@swamp/echo": { version: "2.0.0", pulledAt: "2026-01-01" },
+      }),
+    );
+
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.untrustedCollectives, []);
+  });
+});
+
+Deno.test("RepoService.upgrade: skips untrusted warning when trustMemberCollectives is on", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath);
+
+    // Enable trustMemberCollectives
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    marker!.trustMemberCollectives = true;
+    await markerRepo.write(repoPath, marker!);
+
+    // Write a lockfile with extensions from a collective not in trustedCollectives
+    const modelsDir = join(tempDir, "models");
+    await ensureDir(modelsDir);
+    await Deno.writeTextFile(
+      join(modelsDir, "upstream_extensions.json"),
+      JSON.stringify({
+        "@acme/widgets": { version: "1.0.0", pulledAt: "2026-01-01" },
+      }),
+    );
+
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.untrustedCollectives, []);
+  });
+});
+
+Deno.test("RepoService.upgrade: returns empty when no lockfile exists", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath);
+
+    const newService = new RepoService("0.2.0");
+    const result = await newService.upgrade(repoPath);
+
+    assertEquals(result.untrustedCollectives, []);
+  });
+});

--- a/src/libswamp/repo/init.ts
+++ b/src/libswamp/repo/init.ts
@@ -215,6 +215,8 @@ export interface RepoUpgradeData {
   localSkillCopies: { skillsDir: string; names: string[] }[];
   /** Repo-relative paths of files modified during this upgrade. */
   changedFiles: string[];
+  /** Collectives referenced in the lockfile that are not trusted (swamp-club#1217). */
+  untrustedCollectives: string[];
   /** @deprecated Read `tools` instead. `null` when not single-tool. */
   tool: string | null;
 }
@@ -363,6 +365,7 @@ export async function* repoUpgrade(
         extensionsToReinstall: result.extensionsToReinstall,
         localSkillCopies: result.localSkillCopies,
         changedFiles: result.changedFiles,
+        untrustedCollectives: result.untrustedCollectives,
         tool: legacyToolField(result.tools),
       };
 

--- a/src/libswamp/repo/init_test.ts
+++ b/src/libswamp/repo/init_test.ts
@@ -72,6 +72,7 @@ function makeUpgradeDeps(
         extensionsToReinstall: [],
         localSkillCopies: [],
         changedFiles: [".swamp.yaml", "CLAUDE.md"],
+        untrustedCollectives: [],
       }),
     ...overrides,
   };

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -108,7 +108,7 @@ export function renderAutoResolveNotFound(
     );
   } else {
     logger
-      .error`Auto-resolution failed for type ${type}: no matching extension found in registry.`;
+      .error`Auto-resolution failed for type ${type}: no extension publishes this type. Verify the type name is correct.`;
     logger.error`Install manually with: swamp extension pull <extension-name>`;
   }
 }

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -271,6 +271,25 @@ class LogRepoUpgradeRenderer implements Renderer<RepoUpgradeEvent> {
           }
         }
 
+        if (data.untrustedCollectives.length > 0) {
+          logger.warn(
+            `Extensions from untrusted collectives: ${
+              data.untrustedCollectives.join(", ")
+            }`,
+          );
+          logger.warn(
+            "  These extensions will not auto-resolve until their collectives are trusted.",
+          );
+          for (const collective of data.untrustedCollectives) {
+            logger.warn(
+              `  To trust: swamp extension trust add ${collective}`,
+            );
+          }
+          logger.warn(
+            "  Or trust all membership collectives: swamp extension trust auto-trust on",
+          );
+        }
+
         logger.info("  Skills updated: " + data.skillsUpdated.join(", "));
         logger.info(
           "  Instructions: " +

--- a/src/presentation/renderers/repo_init_test.ts
+++ b/src/presentation/renderers/repo_init_test.ts
@@ -313,6 +313,7 @@ Deno.test(
           extensionsToReinstall: [],
           localSkillCopies: [],
           changedFiles: [],
+          untrustedCollectives: [],
           tool: null,
         },
       },
@@ -351,6 +352,7 @@ Deno.test(
           extensionsToReinstall: [],
           localSkillCopies: [],
           changedFiles: [],
+          untrustedCollectives: [],
           tool: null,
         },
       },
@@ -389,6 +391,7 @@ Deno.test(
             },
           ],
           changedFiles: [],
+          untrustedCollectives: [],
           tool: null,
         },
       },
@@ -403,5 +406,120 @@ Deno.test(
       output,
       "/home/user/.claude/skills/swamp-getting-started",
     );
+  },
+);
+
+Deno.test(
+  "LogRepoUpgradeRenderer: warns about untrusted collectives",
+  () => {
+    const output = captureUpgradeLogOutput([
+      { kind: "upgrading" },
+      {
+        kind: "completed",
+        data: {
+          path: "/tmp/x",
+          previousVersion: "0.1.0",
+          newVersion: "0.1.1",
+          upgradedAt: "2026-04-24T00:00:00Z",
+          skillsUpdated: [],
+          instructionsUpdated: false,
+          settingsUpdated: false,
+          gitignoreAction: "unchanged",
+          previousTools: ["claude"],
+          tools: ["claude"],
+          addedTools: [],
+          removedTools: [],
+          extensionsToReinstall: [],
+          localSkillCopies: [],
+          changedFiles: [],
+          untrustedCollectives: ["acme", "dougschaefer"],
+          tool: null,
+        },
+      },
+    ]);
+
+    assertStringIncludes(
+      output,
+      "Extensions from untrusted collectives: acme, dougschaefer",
+    );
+    assertStringIncludes(
+      output,
+      "swamp extension trust add acme",
+    );
+    assertStringIncludes(
+      output,
+      "swamp extension trust add dougschaefer",
+    );
+    assertStringIncludes(
+      output,
+      "swamp extension trust auto-trust on",
+    );
+  },
+);
+
+Deno.test(
+  "LogRepoUpgradeRenderer: no untrusted warning when list is empty",
+  () => {
+    const output = captureUpgradeLogOutput([
+      { kind: "upgrading" },
+      {
+        kind: "completed",
+        data: {
+          path: "/tmp/x",
+          previousVersion: "0.1.0",
+          newVersion: "0.1.1",
+          upgradedAt: "2026-04-24T00:00:00Z",
+          skillsUpdated: [],
+          instructionsUpdated: false,
+          settingsUpdated: false,
+          gitignoreAction: "unchanged",
+          previousTools: ["claude"],
+          tools: ["claude"],
+          addedTools: [],
+          removedTools: [],
+          extensionsToReinstall: [],
+          localSkillCopies: [],
+          changedFiles: [],
+          untrustedCollectives: [],
+          tool: null,
+        },
+      },
+    ]);
+
+    assertEquals(output.includes("untrusted collectives"), false);
+  },
+);
+
+Deno.test(
+  "JsonRepoUpgradeRenderer: includes untrustedCollectives in JSON output",
+  () => {
+    const output = captureStdout([
+      { kind: "upgrading" },
+      {
+        kind: "completed",
+        data: {
+          path: "/tmp/x",
+          previousVersion: "0.1.0",
+          newVersion: "0.1.1",
+          upgradedAt: "2026-04-24T00:00:00Z",
+          skillsUpdated: [],
+          instructionsUpdated: false,
+          settingsUpdated: false,
+          gitignoreAction: "unchanged",
+          previousTools: [],
+          tools: [],
+          addedTools: [],
+          removedTools: [],
+          extensionsToReinstall: [],
+          localSkillCopies: [],
+          changedFiles: [],
+          untrustedCollectives: ["acme"],
+          tool: null,
+        },
+      },
+    ]);
+
+    const parsed = JSON.parse(output);
+    assertEquals(parsed.untrustedCollectives, ["acme"]);
   },
 );


### PR DESCRIPTION
## Summary

- `swamp repo upgrade` now detects when the lockfile references extensions from collectives not in the trusted list and warns with actionable `swamp extension trust add` instructions. Warning is suppressed when `trustMemberCollectives: true` to avoid false positives.
- Auto-resolve "not found" error reworded from "no matching extension found in registry" to "no extension publishes this type. Verify the type name is correct." — distinguishes a non-existent type from a registry outage.
- Fixed `design/repo.md` documenting `trustMemberCollectives` default as `true` when code default is `false`.

Closes swamp-club#1217

## Test Plan

- 4 new unit tests for untrusted-collective detection: detects untrusted, skips when all trusted, skips when no lockfile, skips when `trustMemberCollectives` is on
- 3 new renderer tests: log warning renders with collective names and trust commands, suppressed when empty, JSON output includes the field
- All 9054 existing tests pass with no regressions
- `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)