### PR TITLE
fix(vault): resolve correct path in vault edit command (swamp-club#1224)

### DIFF
--- a/src/libswamp/vaults/edit.ts
+++ b/src/libswamp/vaults/edit.ts
@@ -18,10 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
+import { join } from "@std/path";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -76,12 +73,7 @@ export function createVaultEditDeps(repoDir: string): VaultEditDeps {
     findById: (type, id) => repo.findById(type, id),
     findAll: () => repo.findAll(),
     getVaultPath: (config) =>
-      swampPath(
-        repoDir,
-        SWAMP_SUBDIRS.vault,
-        config.type,
-        `${config.id}.yaml`,
-      ),
+      join(repoDir, "vaults", config.type, `${config.id}.yaml`),
     fileExists: async (path) => {
       try {
         await Deno.stat(path);

--- a/src/libswamp/vaults/edit_test.ts
+++ b/src/libswamp/vaults/edit_test.ts
@@ -59,7 +59,7 @@ Deno.test("vaultEdit: yields error when vault not found", async () => {
 Deno.test("vaultEdit: opens editor when vault found by name", async () => {
   const deps = makeDeps({
     findByName: () => Promise.resolve(testVaultConfig),
-    getVaultPath: () => "/repo/.swamp/vault/env/vault-1.yaml",
+    getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
     openEditor: () => Promise.resolve({ editor: "Neovim" }),
   });
 
@@ -74,7 +74,7 @@ Deno.test("vaultEdit: opens editor when vault found by name", async () => {
     {
       kind: "completed",
       data: {
-        path: "/repo/.swamp/vault/env/vault-1.yaml",
+        path: "/repo/vaults/env/vault-1.yaml",
         editor: "Neovim",
         status: "opened",
         name: "my-vault",
@@ -88,7 +88,7 @@ Deno.test("vaultEdit: finds vault by ID when name lookup fails", async () => {
   const deps = makeDeps({
     findByName: () => Promise.resolve(null),
     findAll: () => Promise.resolve([testVaultConfig]),
-    getVaultPath: () => "/repo/.swamp/vault/env/vault-1.yaml",
+    getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
     openEditor: () => Promise.resolve({ editor: "VS Code" }),
   });
 
@@ -114,7 +114,7 @@ Deno.test("vaultEdit: finds vault by ID with type hint", async () => {
       }
       return Promise.resolve(null);
     },
-    getVaultPath: () => "/repo/.swamp/vault/env/vault-1.yaml",
+    getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
     openEditor: () => Promise.resolve({ editor: "VS Code" }),
   });
 
@@ -152,7 +152,7 @@ Deno.test("vaultEdit: yields error when vault type mismatch", async () => {
 Deno.test("vaultEdit: yields error when vault file not found", async () => {
   const deps = makeDeps({
     findByName: () => Promise.resolve(testVaultConfig),
-    getVaultPath: () => "/repo/.swamp/vault/env/vault-1.yaml",
+    getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
     fileExists: () => Promise.resolve(false),
   });
 


### PR DESCRIPTION
## Summary

- `vault edit` used `swampPath(repoDir, SWAMP_SUBDIRS.vault, ...)` which resolved to `{repoDir}/.swamp/vault/{type}/{id}.yaml`, but vault configs live at `{repoDir}/vaults/{type}/{id}.yaml`
- Replace with `join(repoDir, "vaults", ...)` to match all other vault commands (get, describe, search)
- Update test expectations accordingly

## Test Plan

- [x] Unit tests updated and passing (6/6)
- [x] `deno check` clean
- [x] `deno lint` clean
- [x] `deno fmt` clean
- [x] Reproduced bug in scratch repo (`/tmp/swamp-repro-issue-1224`)
- [x] Verified fix with compiled binary — `vault edit` now opens the correct file

Closes swamp-club#1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)