### PR TITLE
fix(data): auto-collect expired data on model delete and during autoGc

### DIFF
--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -35,8 +35,12 @@ import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_servic
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
-import type { GarbageCollectionResult } from "../../domain/data/repositories.ts";
+import type {
+  GarbageCollectionResult,
+  UnifiedDataRepository,
+} from "../../domain/data/repositories.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
+import type { DataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
 import { getLogger } from "@logtape/logtape";
 
 /** Preview item for a single expired data entry. */
@@ -193,6 +197,17 @@ export async function* dataGc(
   );
 }
 
+/** Result of auto-GC including both version and lifetime expiration. */
+export interface AutoGcResult extends GarbageCollectionResult {
+  dataEntriesExpired: number;
+}
+
+/** Dependencies for model-scoped lifetime expiration during auto-GC. */
+export interface AutoGcLifecycleDeps {
+  dataRepo: Pick<UnifiedDataRepository, "findAllForModel" | "delete">;
+  lifecycleService: Pick<DataLifecycleService, "isExpired">;
+}
+
 /**
  * Runs garbage collection for a single model. Catches all errors — auto-GC
  * failure must never fail the method run. User-visible output is owned by the
@@ -208,13 +223,37 @@ export async function autoGc(
   },
   type: ModelType,
   modelId: string,
-): Promise<GarbageCollectionResult | null> {
+  lifecycleDeps?: AutoGcLifecycleDeps,
+): Promise<AutoGcResult | null> {
   const logger = getLogger(["swamp", "auto-gc"]);
   try {
     const result = await dataRepo.collectGarbage(type, modelId);
+
+    let dataEntriesExpired = 0;
+    if (lifecycleDeps) {
+      const allData = await lifecycleDeps.dataRepo.findAllForModel(
+        type,
+        modelId,
+      );
+      for (const data of allData) {
+        if (data.isDeleted) continue;
+        try {
+          if (await lifecycleDeps.lifecycleService.isExpired(data)) {
+            await lifecycleDeps.dataRepo.delete(type, modelId, data.name);
+            dataEntriesExpired++;
+          }
+        } catch (err) {
+          logger
+            .warn`Auto-GC lifetime check failed for ${type.normalized}/${modelId}/${data.name}: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+        }
+      }
+    }
+
     logger
-      .debug`Auto-GC for ${type.normalized}/${modelId}: ${result.versionsRemoved} version(s) removed, ${result.bytesReclaimed} bytes reclaimed`;
-    return result;
+      .debug`Auto-GC for ${type.normalized}/${modelId}: ${result.versionsRemoved} version(s) removed, ${dataEntriesExpired} expired entry/entries deleted, ${result.bytesReclaimed} bytes reclaimed`;
+    return { ...result, dataEntriesExpired };
   } catch (error) {
     logger
       .warn`Auto-GC failed for ${type.normalized}/${modelId}: ${

--- a/src/libswamp/data/gc_test.ts
+++ b/src/libswamp/data/gc_test.ts
@@ -22,6 +22,7 @@ import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
   autoGc,
+  type AutoGcLifecycleDeps,
   dataGc,
   type DataGcDeps,
   type DataGcEvent,
@@ -29,6 +30,7 @@ import {
 } from "./gc.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import type { GarbageCollectionResult } from "../../domain/data/repositories.ts";
+import type { Data } from "../../domain/data/data.ts";
 
 function makeDeps(overrides: Partial<DataGcDeps> = {}): DataGcDeps {
   return {
@@ -226,14 +228,22 @@ Deno.test("autoGc: returns result when versions are removed", async () => {
   const repo = makeFakeDataRepo({ versionsRemoved: 10, bytesReclaimed: 4096 });
   const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
 
-  assertEquals(result, { versionsRemoved: 10, bytesReclaimed: 4096 });
+  assertEquals(result, {
+    versionsRemoved: 10,
+    bytesReclaimed: 4096,
+    dataEntriesExpired: 0,
+  });
 });
 
 Deno.test("autoGc: returns result with zero versions when nothing to clean", async () => {
   const repo = makeFakeDataRepo({ versionsRemoved: 0, bytesReclaimed: 0 });
   const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
 
-  assertEquals(result, { versionsRemoved: 0, bytesReclaimed: 0 });
+  assertEquals(result, {
+    versionsRemoved: 0,
+    bytesReclaimed: 0,
+    dataEntriesExpired: 0,
+  });
 });
 
 Deno.test("autoGc: catches errors and returns null", async () => {
@@ -244,4 +254,94 @@ Deno.test("autoGc: catches errors and returns null", async () => {
   const result = await autoGc(repo, ModelType.create("test/type"), "model-1");
 
   assertEquals(result, null);
+});
+
+Deno.test("autoGc: deletes expired data when lifecycle deps provided", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 0, bytesReclaimed: 0 });
+  const deletedNames: string[] = [];
+  const lifecycleDeps: AutoGcLifecycleDeps = {
+    dataRepo: {
+      findAllForModel: () =>
+        Promise.resolve([
+          { name: "expired-cache", isDeleted: false, lifetime: "15m" },
+          { name: "live-data", isDeleted: false, lifetime: "infinite" },
+        ] as unknown as Data[]),
+      delete: (_type, _modelId, name) => {
+        deletedNames.push(name);
+        return Promise.resolve();
+      },
+    },
+    lifecycleService: {
+      isExpired: (data) =>
+        Promise.resolve(
+          (data as unknown as { lifetime: string }).lifetime !== "infinite",
+        ),
+    },
+  };
+
+  const result = await autoGc(
+    repo,
+    ModelType.create("test/type"),
+    "model-1",
+    lifecycleDeps,
+  );
+
+  assertEquals(result?.dataEntriesExpired, 1);
+  assertEquals(deletedNames, ["expired-cache"]);
+});
+
+Deno.test("autoGc: skips deleted data entries", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 0, bytesReclaimed: 0 });
+  const deletedNames: string[] = [];
+  const lifecycleDeps: AutoGcLifecycleDeps = {
+    dataRepo: {
+      findAllForModel: () =>
+        Promise.resolve([
+          { name: "deleted-entry", isDeleted: true, lifetime: "15m" },
+        ] as unknown as Data[]),
+      delete: (_type, _modelId, name) => {
+        deletedNames.push(name);
+        return Promise.resolve();
+      },
+    },
+    lifecycleService: {
+      isExpired: () => Promise.resolve(true),
+    },
+  };
+
+  const result = await autoGc(
+    repo,
+    ModelType.create("test/type"),
+    "model-1",
+    lifecycleDeps,
+  );
+
+  assertEquals(result?.dataEntriesExpired, 0);
+  assertEquals(deletedNames, []);
+});
+
+Deno.test("autoGc: catches per-entry errors without failing the whole run", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 2, bytesReclaimed: 512 });
+  const lifecycleDeps: AutoGcLifecycleDeps = {
+    dataRepo: {
+      findAllForModel: () =>
+        Promise.resolve([
+          { name: "trouble", isDeleted: false },
+        ] as unknown as Data[]),
+      delete: () => Promise.resolve(),
+    },
+    lifecycleService: {
+      isExpired: () => Promise.reject(new Error("network timeout")),
+    },
+  };
+
+  const result = await autoGc(
+    repo,
+    ModelType.create("test/type"),
+    "model-1",
+    lifecycleDeps,
+  );
+
+  assertEquals(result?.versionsRemoved, 2);
+  assertEquals(result?.dataEntriesExpired, 0);
 });

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1120,6 +1120,8 @@ export {
 
 // Data GC operations
 export {
+  type AutoGcLifecycleDeps,
+  type AutoGcResult,
   createDataGcDeps,
   dataGc,
   type DataGcData,

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -19,6 +19,7 @@
 
 import type { Definition } from "../../domain/definitions/definition.ts";
 import type { DefinitionId } from "../../domain/definitions/definition.ts";
+import type { Data } from "../../domain/data/data.ts";
 import type { ModelType } from "../../domain/models/model_type.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
@@ -32,10 +33,14 @@ import {
   namespaceFromResolver,
 } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import { createModelOutputId } from "../../domain/models/model_output.ts";
+import { DefaultDataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
+import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
+import { getLogger } from "@logtape/logtape";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Preview data returned before confirmation. */
@@ -59,6 +64,7 @@ export interface ModelDeleteData {
   outputsDeleted: number;
   evaluatedInputDeleted: boolean;
   dataDeleted: boolean;
+  expiredDataAutoCollected: number;
 }
 
 export type ModelDeleteEvent =
@@ -81,7 +87,7 @@ export interface ModelDeleteDeps {
   findDataArtifacts: (
     type: ModelType,
     id: DefinitionId,
-  ) => Promise<{ name: string }[]>;
+  ) => Promise<Data[]>;
   findOutputs: (
     type: ModelType,
     id: DefinitionId,
@@ -98,6 +104,7 @@ export interface ModelDeleteDeps {
     name: string,
   ) => Promise<void>;
   deleteDefinition: (type: ModelType, id: DefinitionId) => Promise<void>;
+  isExpired?: (data: Data) => Promise<boolean>;
 }
 
 /** Wires real infrastructure into ModelDeleteDeps. */
@@ -105,6 +112,7 @@ export function createModelDeleteDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
+  markDirty?: MarkDirtyHook,
 ): ModelDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -118,13 +126,22 @@ export function createModelDeleteDeps(
       repoDir,
       dsPath(SWAMP_SUBDIRS.data),
       createCatalogStore(repoDir, datastoreResolver),
-      undefined,
+      markDirty,
       undefined,
       namespaceFromResolver(datastoreResolver),
     );
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
+  );
+  const workflowRunRepo = new YamlWorkflowRunRepository(
+    repoDir,
+    undefined,
+    dsPath(SWAMP_SUBDIRS.workflowRuns),
+  );
+  const lifecycleService = new DefaultDataLifecycleService(
+    unifiedDataRepo,
+    workflowRunRepo,
   );
   return {
     lookupDefinition: (idOrName) =>
@@ -138,6 +155,7 @@ export function createModelDeleteDeps(
     deleteData: (type, defId, name) =>
       unifiedDataRepo.delete(type, defId, name),
     deleteDefinition: (type, id) => definitionRepo.delete(type, id),
+    isExpired: (data) => lifecycleService.isExpired(data),
   };
 }
 
@@ -172,6 +190,34 @@ function findWorkflowsReferencingModel(
   return names;
 }
 
+/**
+ * Partitions data artifacts into live and expired, using the isExpired
+ * predicate when available. Expired artifacts don't block model deletion.
+ */
+async function partitionExpired(
+  dataArtifacts: Data[],
+  isExpired?: (data: Data) => Promise<boolean>,
+): Promise<{ live: Data[]; expired: Data[] }> {
+  if (!isExpired) return { live: dataArtifacts, expired: [] };
+  const logger = getLogger(["swamp", "model", "delete"]);
+  const live: Data[] = [];
+  const expired: Data[] = [];
+  for (const data of dataArtifacts) {
+    try {
+      if (await isExpired(data)) {
+        expired.push(data);
+      } else {
+        live.push(data);
+      }
+    } catch {
+      logger
+        .warn`Failed to check expiration for ${data.name}, treating as live`;
+      live.push(data);
+    }
+  }
+  return { live, expired };
+}
+
 /** Gathers preview info for the model delete operation. */
 export async function modelDeletePreview(
   ctx: LibSwampContext,
@@ -196,6 +242,7 @@ export async function modelDeletePreview(
     modelType,
     definition.id,
   );
+  const { live } = await partitionExpired(dataArtifacts, deps.isExpired);
   const outputs = await deps.findOutputs(modelType, definition.id);
 
   return {
@@ -204,7 +251,7 @@ export async function modelDeletePreview(
     type: modelType.normalized,
     definitionPath: deps.getDefinitionPath(modelType, definition.id),
     referencingWorkflows,
-    dataArtifactCount: dataArtifacts.length,
+    dataArtifactCount: live.length,
     outputCount: outputs.length,
   };
 }
@@ -248,16 +295,20 @@ export async function* modelDelete(
         return;
       }
 
-      // Check data artifacts
+      // Check data artifacts — expired data is auto-collected, not a blocker
       const dataArtifacts = await deps.findDataArtifacts(
         modelType,
         definition.id,
       );
-      if (dataArtifacts.length > 0 && !input.force) {
+      const { live, expired } = await partitionExpired(
+        dataArtifacts,
+        deps.isExpired,
+      );
+      if (live.length > 0 && !input.force) {
         yield {
           kind: "error",
           error: validationFailed(
-            `Model '${definition.name}' has ${dataArtifacts.length} associated data artifact(s). ` +
+            `Model '${definition.name}' has ${live.length} associated data artifact(s). ` +
               `Delete the data first, or use --force to delete all.`,
           ),
         };
@@ -275,9 +326,17 @@ export async function* modelDelete(
         outputsDeleted++;
       }
 
-      // Delete data artifacts
+      // Auto-collect expired data artifacts
+      let expiredDataAutoCollected = 0;
+      for (const data of expired) {
+        ctx.logger.debug`Auto-collecting expired data: ${data.name}`;
+        await deps.deleteData(modelType, definition.id, data.name);
+        expiredDataAutoCollected++;
+      }
+
+      // Delete remaining data artifacts (force mode)
       let dataDeleted = false;
-      for (const data of dataArtifacts) {
+      for (const data of live) {
         ctx.logger.debug`Deleting data artifact: ${data.name}`;
         await deps.deleteData(modelType, definition.id, data.name);
         dataDeleted = true;
@@ -298,6 +357,7 @@ export async function* modelDelete(
           outputsDeleted,
           evaluatedInputDeleted: false,
           dataDeleted,
+          expiredDataAutoCollected,
         },
       };
     })(),

--- a/src/libswamp/models/delete_test.ts
+++ b/src/libswamp/models/delete_test.ts
@@ -30,6 +30,7 @@ import {
 import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
+import type { Data } from "../../domain/data/data.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
@@ -80,6 +81,15 @@ Deno.test(
   },
 );
 
+function mockData(name: string, opts?: { lifetime?: string }): Data {
+  return {
+    name,
+    lifetime: opts?.lifetime ?? "infinite",
+    createdAt: new Date("2026-06-01T00:00:00Z"),
+    isDeleted: false,
+  } as unknown as Data;
+}
+
 const testDefinition = {
   id: "550e8400-e29b-41d4-a716-446655440000",
   name: "my-model",
@@ -107,7 +117,7 @@ function makeDeps(overrides: Partial<ModelDeleteDeps> = {}): ModelDeleteDeps {
 Deno.test("modelDeletePreview: returns preview data", async () => {
   const deps = makeDeps({
     findDataArtifacts: () =>
-      Promise.resolve([{ name: "data1" }, { name: "data2" }]),
+      Promise.resolve([mockData("data1"), mockData("data2")]),
     findOutputs: () => Promise.resolve([{ id: "o1", methodName: "validate" }]),
   });
 
@@ -202,7 +212,7 @@ Deno.test("modelDelete: yields error when model referenced by workflows", async 
 
 Deno.test("modelDelete: yields error when data exists without force", async () => {
   const deps = makeDeps({
-    findDataArtifacts: () => Promise.resolve([{ name: "data1" }]),
+    findDataArtifacts: () => Promise.resolve([mockData("data1")]),
   });
 
   const events = await collect<ModelDeleteEvent>(
@@ -223,7 +233,7 @@ Deno.test("modelDelete: yields error when data exists without force", async () =
 Deno.test("modelDelete: force deletes data artifacts", async () => {
   let dataDeletedCount = 0;
   const deps = makeDeps({
-    findDataArtifacts: () => Promise.resolve([{ name: "d1" }, { name: "d2" }]),
+    findDataArtifacts: () => Promise.resolve([mockData("d1"), mockData("d2")]),
     deleteData: () => {
       dataDeletedCount++;
       return Promise.resolve();
@@ -243,4 +253,80 @@ Deno.test("modelDelete: force deletes data artifacts", async () => {
   >;
   assertEquals(completed.data.dataDeleted, true);
   assertEquals(dataDeletedCount, 2);
+});
+
+Deno.test("modelDelete: auto-collects expired data without requiring force", async () => {
+  const deletedNames: string[] = [];
+  const deps = makeDeps({
+    findDataArtifacts: () =>
+      Promise.resolve([
+        mockData("expired-cache", { lifetime: "15m" }),
+        mockData("another-expired", { lifetime: "1h" }),
+      ]),
+    isExpired: () => Promise.resolve(true),
+    deleteData: (_type, _id, name) => {
+      deletedNames.push(name);
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<ModelDeleteEvent>(
+    modelDelete(createLibSwampContext(), deps, {
+      modelIdOrName: "my-model",
+      force: false,
+    }),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    ModelDeleteEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.expiredDataAutoCollected, 2);
+  assertEquals(completed.data.dataDeleted, false);
+  assertEquals(deletedNames, ["expired-cache", "another-expired"]);
+});
+
+Deno.test("modelDelete: blocks on live data even when some are expired", async () => {
+  const deps = makeDeps({
+    findDataArtifacts: () =>
+      Promise.resolve([
+        mockData("expired-cache", { lifetime: "15m" }),
+        mockData("live-data", { lifetime: "infinite" }),
+      ]),
+    isExpired: (data) => Promise.resolve(data.lifetime !== "infinite"),
+  });
+
+  const events = await collect<ModelDeleteEvent>(
+    modelDelete(createLibSwampContext(), deps, {
+      modelIdOrName: "my-model",
+      force: false,
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    ModelDeleteEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("modelDeletePreview: excludes expired data from artifact count", async () => {
+  const deps = makeDeps({
+    findDataArtifacts: () =>
+      Promise.resolve([
+        mockData("expired-cache", { lifetime: "15m" }),
+        mockData("live-data", { lifetime: "infinite" }),
+      ]),
+    isExpired: (data) => Promise.resolve(data.lifetime !== "infinite"),
+  });
+
+  const preview = await modelDeletePreview(
+    createLibSwampContext(),
+    deps,
+    { modelIdOrName: "my-model", force: false },
+  );
+
+  assertEquals(preview.dataArtifactCount, 1);
 });

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -77,7 +77,8 @@ import {
   withGeneratorTraceContext,
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
-import { autoGc } from "../data/gc.ts";
+import { autoGc, type AutoGcLifecycleDeps } from "../data/gc.ts";
+import { DefaultDataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
 import { ActiveRun } from "../../domain/models/active_run.ts";
 import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
 import { hostname } from "node:os";
@@ -157,6 +158,7 @@ export type ModelMethodRunEvent =
     kind: "auto_gc_completed";
     versionsDeleted: number;
     bytesReclaimed: number;
+    dataEntriesExpired: number;
   }
   | { kind: "error"; error: SwampError };
 
@@ -1123,16 +1125,32 @@ export async function* modelMethodRun(
           yield { kind: "completed", run: view };
 
           if (input.autoGc) {
+            let lifecycleDeps: AutoGcLifecycleDeps | undefined;
+            if (deps.workflowRunRepo) {
+              const lifecycleService = new DefaultDataLifecycleService(
+                deps.dataRepo,
+                deps.workflowRunRepo,
+              );
+              lifecycleDeps = {
+                dataRepo: deps.dataRepo,
+                lifecycleService,
+              };
+            }
             const gcResult = await autoGc(
               deps.dataRepo,
               modelType,
               definition.id,
+              lifecycleDeps,
             );
-            if (gcResult && gcResult.versionsRemoved > 0) {
+            if (
+              gcResult &&
+              (gcResult.versionsRemoved > 0 || gcResult.dataEntriesExpired > 0)
+            ) {
               yield {
                 kind: "auto_gc_completed" as const,
                 versionsDeleted: gcResult.versionsRemoved,
                 bytesReclaimed: gcResult.bytesReclaimed,
+                dataEntriesExpired: gcResult.dataEntriesExpired,
               };
             }
           }

--- a/src/presentation/renderers/model_delete.ts
+++ b/src/presentation/renderers/model_delete.ts
@@ -29,6 +29,12 @@ class LogModelDeleteRenderer implements Renderer<ModelDeleteEvent> {
     return {
       deleting: () => {},
       completed: (e) => {
+        if (e.data.expiredDataAutoCollected > 0) {
+          logger.info(
+            "Auto-collected {count} expired data artifact(s)",
+            { count: e.data.expiredDataAutoCollected },
+          );
+        }
         logger.info("Deleted model: {name} ({type})", {
           name: e.data.name,
           type: e.data.type,
@@ -57,6 +63,7 @@ class JsonModelDeleteRenderer implements Renderer<ModelDeleteEvent> {
           outputsDeleted: e.data.outputsDeleted,
           evaluatedInputDeleted: e.data.evaluatedInputDeleted,
           dataDeleted: e.data.dataDeleted,
+          expiredDataAutoCollected: e.data.expiredDataAutoCollected,
         };
         console.log(JSON.stringify(output, null, 2));
       },

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -201,13 +201,25 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
           });
       },
       auto_gc_completed: (e) => {
-        getRunLogger(this.modelName, this.methodName).info(
-          "Auto-GC: removed {versionsDeleted} version(s), reclaimed {bytesReclaimed} bytes",
-          {
-            versionsDeleted: e.versionsDeleted,
-            bytesReclaimed: e.bytesReclaimed,
-          },
-        );
+        const logger = getRunLogger(this.modelName, this.methodName);
+        if (e.dataEntriesExpired > 0) {
+          logger.info(
+            "Auto-GC: expired {dataEntriesExpired} data entry/entries, removed {versionsDeleted} version(s), reclaimed {bytesReclaimed} bytes",
+            {
+              dataEntriesExpired: e.dataEntriesExpired,
+              versionsDeleted: e.versionsDeleted,
+              bytesReclaimed: e.bytesReclaimed,
+            },
+          );
+        } else {
+          logger.info(
+            "Auto-GC: removed {versionsDeleted} version(s), reclaimed {bytesReclaimed} bytes",
+            {
+              versionsDeleted: e.versionsDeleted,
+              bytesReclaimed: e.bytesReclaimed,
+            },
+          );
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message, e.error.code);

--- a/src/presentation/renderers/model_method_run_test.ts
+++ b/src/presentation/renderers/model_method_run_test.ts
@@ -450,6 +450,7 @@ Deno.test("JsonModelMethodRunRenderer - auto_gc_completed does not write to stdo
         kind: "auto_gc_completed",
         versionsDeleted: 3,
         bytesReclaimed: 4096,
+        dataEntriesExpired: 0,
       },
     ];
     await consumeStream(toStream(events), renderer.handlers());


### PR DESCRIPTION
## Summary

Fixes swamp-club#1218 — expired short-lifetime data artifacts were never GC'd when their owning model went idle, and then blocked `swamp model delete`.

- **autoGc lifetime expiration**: After version-based GC, `autoGc()` now iterates the model's data entries and deletes any that are past their lifetime. This is model-scoped (not a global scan), so it adds negligible overhead to method runs.
- **Model delete auto-collection**: `swamp model delete` now partitions data into live vs expired using `DataLifecycleService.isExpired()`. Expired artifacts are silently auto-collected — they no longer block deletion or require `--force`. The renderer reports how many were auto-collected.
- **Preview accuracy**: `modelDeletePreview()` also excludes expired data from the artifact count, so the confirmation prompt reflects only live data.

## Test Plan

- 6 new unit tests covering both autoGc lifetime expiration (3 tests: expired data deleted, deleted entries skipped, per-entry errors caught) and model delete auto-collection (3 tests: auto-collect without force, blocks on live data with mixed expired, preview excludes expired)
- All existing tests updated for the new `AutoGcResult.dataEntriesExpired` field and `Data[]` return type on `findDataArtifacts`
- Verified against a scratch reproduction repo: `swamp model delete` now succeeds with "Auto-collected 4 expired data artifact(s)" instead of blocking
- `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass