### PR TITLE
fix(worker): strip control-plane credentials from dispatch runner environment

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -618,7 +618,11 @@ Each dispatch spawns a **dispatch runner** — a child process of the same swamp
 binary (`swamp worker exec-dispatch`, a hidden subcommand). The environment
 snapshot is applied as the child's spawn environment via `overlayEnvironment`
 (no global mutation of `Deno.env`). W3C trace context headers are overlaid on
-top of the snapshot at spawn time.
+top of the snapshot at spawn time. Worker control-plane credentials
+(`SWAMP_WORKER_TOKEN`, `SWAMP_SERVER_TOKEN`, `SWAMP_ORCHESTRATOR_URL`) are
+stripped from the spawn environment before the child is started — the runner
+receives its data-plane credential via `RunnerBootstrapParams` over stdio and
+has no need for worker enrollment or server authentication tokens.
 
 The supervisor (worker process) communicates with the runner over
 length-prefixed stdio frames (`StdioTransport`), using the same `RpcChannel`

--- a/src/domain/remote/environment_snapshot.ts
+++ b/src/domain/remote/environment_snapshot.ts
@@ -32,6 +32,14 @@
 /** An immutable name→value capture of environment variables. */
 export type EnvironmentSnapshot = Readonly<Record<string, string>>;
 
+// Worker control-plane credentials that must never reach a dispatch runner.
+// Canonical sources: collectWorkerEnv (worker_daemon.ts), worker_connect.ts.
+const WORKER_CREDENTIAL_VARS: ReadonlySet<string> = new Set([
+  "SWAMP_WORKER_TOKEN",
+  "SWAMP_SERVER_TOKEN",
+  "SWAMP_ORCHESTRATOR_URL",
+]);
+
 const DENYLIST_EXACT: ReadonlySet<string> = new Set([
   "HOME",
   "USER",
@@ -81,6 +89,22 @@ export function captureEnvironmentSnapshot(
     }
   }
   return snapshot;
+}
+
+/**
+ * Strip worker control-plane credentials from an environment record so they
+ * are not inherited by dispatch runner child processes.
+ */
+export function stripWorkerCredentials(
+  env: Record<string, string>,
+): Record<string, string> {
+  const cleaned: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (!WORKER_CREDENTIAL_VARS.has(name)) {
+      cleaned[name] = value;
+    }
+  }
+  return cleaned;
 }
 
 /**

--- a/src/domain/remote/environment_snapshot_test.ts
+++ b/src/domain/remote/environment_snapshot_test.ts
@@ -22,6 +22,7 @@ import {
   captureEnvironmentSnapshot,
   isDeniedEnvVar,
   overlayEnvironment,
+  stripWorkerCredentials,
 } from "./environment_snapshot.ts";
 
 Deno.test("isDeniedEnvVar: denies process-identity variables", () => {
@@ -100,5 +101,35 @@ Deno.test("overlayEnvironment: worker base survives for denylisted names even fr
     HOME: "/home/worker",
     PATH: "/worker/bin",
     EXTRA: "1",
+  });
+});
+
+Deno.test("stripWorkerCredentials: removes worker control-plane credentials", () => {
+  const env = {
+    SWAMP_WORKER_TOKEN: "tok.secret",
+    SWAMP_SERVER_TOKEN: "srv.secret",
+    SWAMP_ORCHESTRATOR_URL: "wss://orch:4000",
+    DEPLOY_ENV: "prod",
+    AWS_ACCESS_KEY_ID: "AKIA123",
+  };
+  assertEquals(stripWorkerCredentials(env), {
+    DEPLOY_ENV: "prod",
+    AWS_ACCESS_KEY_ID: "AKIA123",
+  });
+});
+
+Deno.test("stripWorkerCredentials: preserves SWAMP_SERVE_EXTRA_HEADERS and worker config vars", () => {
+  const env = {
+    SWAMP_WORKER_TOKEN: "tok.secret",
+    SWAMP_SERVE_EXTRA_HEADERS: "Tunnel-Token: abc123",
+    SWAMP_WORKER_LABELS: "gpu=true",
+    SWAMP_WORKER_CACHE_DIR: "/var/cache/swamp",
+    HOME: "/home/worker",
+  };
+  assertEquals(stripWorkerCredentials(env), {
+    SWAMP_SERVE_EXTRA_HEADERS: "Tunnel-Token: abc123",
+    SWAMP_WORKER_LABELS: "gpu=true",
+    SWAMP_WORKER_CACHE_DIR: "/var/cache/swamp",
+    HOME: "/home/worker",
   });
 });

--- a/src/worker/dispatch_handler.ts
+++ b/src/worker/dispatch_handler.ts
@@ -31,7 +31,10 @@
  * Capacity 1 is byte-for-byte identical to the prior serial behavior.
  */
 
-import { overlayEnvironment } from "../domain/remote/environment_snapshot.ts";
+import {
+  overlayEnvironment,
+  stripWorkerCredentials,
+} from "../domain/remote/environment_snapshot.ts";
 import {
   DispatchParamsSchema,
   type DispatchResult,
@@ -179,6 +182,7 @@ async function handleDispatch(
     }
     spawnEnv = overlayEnvironment(spawnEnv, traceSnapshot);
   }
+  spawnEnv = stripWorkerCredentials(spawnEnv);
 
   const rawParams2 = rawParams as Record<string, unknown>;
   const dispatchCredential = rawParams2.dispatchCredential as

--- a/src/worker/dispatch_handler_test.ts
+++ b/src/worker/dispatch_handler_test.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { overlayEnvironment } from "../domain/remote/environment_snapshot.ts";
+import {
+  overlayEnvironment,
+  stripWorkerCredentials,
+} from "../domain/remote/environment_snapshot.ts";
 import { RpcChannel, type RpcError } from "../domain/remote/rpc_channel.ts";
 import {
   REMOTE_PROTOCOL_VERSION,
@@ -115,6 +118,27 @@ Deno.test("registerDispatchHandler: draining rejects with worker_draining", asyn
     drainError = error as RpcError;
   }
   assertEquals(drainError?.code, "worker_draining");
+});
+
+Deno.test("dispatch spawn env: worker credentials are stripped after overlay", () => {
+  const base: Record<string, string> = {
+    SWAMP_WORKER_TOKEN: "tok.secret",
+    SWAMP_SERVER_TOKEN: "srv.secret",
+    SWAMP_ORCHESTRATOR_URL: "wss://orch:4000",
+    SWAMP_SERVE_EXTRA_HEADERS: "Tunnel-Token: abc123",
+    SWAMP_WORKER_LABELS: "gpu=true",
+    DEPLOY_ENV: "dev",
+  };
+  const snapshot = { DEPLOY_ENV: "prod", API_KEY: "key123" };
+  const spawnEnv = stripWorkerCredentials(overlayEnvironment(base, snapshot));
+
+  assertEquals(spawnEnv["SWAMP_WORKER_TOKEN"], undefined);
+  assertEquals(spawnEnv["SWAMP_SERVER_TOKEN"], undefined);
+  assertEquals(spawnEnv["SWAMP_ORCHESTRATOR_URL"], undefined);
+  assertEquals(spawnEnv["SWAMP_SERVE_EXTRA_HEADERS"], "Tunnel-Token: abc123");
+  assertEquals(spawnEnv["SWAMP_WORKER_LABELS"], "gpu=true");
+  assertEquals(spawnEnv["DEPLOY_ENV"], "prod");
+  assertEquals(spawnEnv["API_KEY"], "key123");
 });
 
 Deno.test("registerDispatchHandler: drain() resolves immediately when idle", async () => {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1222 — worker control-plane credentials (`SWAMP_WORKER_TOKEN`, `SWAMP_SERVER_TOKEN`, `SWAMP_ORCHESTRATOR_URL`) leaked into dispatch runner child processes via the inherited worker environment. These credentials are unused by the runner (it receives its data-plane credential via `RunnerBootstrapParams` over stdio) and expose the worker's enrollment and server auth tokens to dispatched extension code.

- Add `stripWorkerCredentials()` to `environment_snapshot.ts` that removes the three credential vars from a spawn environment record
- Call it in `dispatch_handler.ts` after overlaying the orchestrator snapshot and trace headers, before spawning the runner
- Other `SWAMP_*` vars (`SWAMP_SERVE_EXTRA_HEADERS`, `SWAMP_WORKER_LABELS`, etc.) are preserved — they are either needed by the runner or harmless configuration
- Update `design/remote-execution.md` to document the credential stripping at the dispatch trust boundary

## Test Plan

- Unit tests for `stripWorkerCredentials` verify credential vars are stripped while `SWAMP_SERVE_EXTRA_HEADERS`, `SWAMP_WORKER_LABELS`, and non-`SWAMP_` vars survive
- Dispatch handler test verifies the full overlay → strip flow produces a clean spawn environment
- End-to-end verified: started a local `swamp serve`, enrolled a worker using the patched binary, ran `swamp worker verify` — the fleet probe (dispatch + capability RPC + data plane) passed with all three seams verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)