### PR TITLE
fix(presentation): use Deno.consoleSize() for reliable terminal dimensions in Ink components (swamp-club#1221)

### DIFF
--- a/integration/otel_logs_batch_flush_test.ts
+++ b/integration/otel_logs_batch_flush_test.ts
@@ -34,13 +34,9 @@ import {
 import { shutdownLogs } from "../src/infrastructure/tracing/mod.ts";
 
 Deno.test("OTel logs (batch mode): a record logged right before shutdown is still flushed", async () => {
-  const savedEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
-  const savedBatch = Deno.env.get("OTEL_BLRP_USE");
   const savedFetch = globalThis.fetch;
   const bodies: string[] = [];
 
-  Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.test");
-  Deno.env.set("OTEL_BLRP_USE", "1");
   // deno-lint-ignore no-explicit-any
   globalThis.fetch = ((input: any, init: any): Promise<Response> => {
     const url = typeof input === "string" ? input : String(input);
@@ -52,7 +48,14 @@ Deno.test("OTel logs (batch mode): a record logged right before shutdown is stil
   }) as any;
 
   try {
-    await initializeLogging({});
+    await shutdownLogs();
+    await initializeLogging({
+      _reset: true,
+      _logsConfig: {
+        endpoint: "http://collector.test",
+        useBatch: true,
+      },
+    });
 
     getSwampLogger(["model", "method", "run", "m", "execute"])
       .info`batched-line-xyz789`;
@@ -67,10 +70,5 @@ Deno.test("OTel logs (batch mode): a record logged right before shutdown is stil
     );
   } finally {
     globalThis.fetch = savedFetch;
-    if (savedEndpoint === undefined) {
-      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
-    } else Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", savedEndpoint);
-    if (savedBatch === undefined) Deno.env.delete("OTEL_BLRP_USE");
-    else Deno.env.set("OTEL_BLRP_USE", savedBatch);
   }
 });

--- a/integration/otel_logs_export_test.ts
+++ b/integration/otel_logs_export_test.ts
@@ -66,11 +66,9 @@ function collectLogRecords(
 }
 
 Deno.test("OTel logs: initializeLogging exports correlated, redacted records to /v1/logs", async () => {
-  const savedEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
   const savedFetch = globalThis.fetch;
   const captured: { url: string; body: string }[] = [];
 
-  Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.test");
   // deno-lint-ignore no-explicit-any
   globalThis.fetch = ((input: any, init: any): Promise<Response> => {
     const url = typeof input === "string" ? input : String(input);
@@ -95,10 +93,19 @@ Deno.test("OTel logs: initializeLogging exports correlated, redacted records to 
   );
 
   try {
+    // Clear any stale provider from a prior test so initLogs() creates a fresh
+    // one that picks up our stubbed fetch.
+    await shutdownLogs();
+
     // initTracing registers the context manager so logs can correlate; --json
     // keeps stdout clean while logs still export (orthogonal to output mode).
-    await initTracing();
-    await initializeLogging({ jsonMode: true });
+    // Pass endpoint via config to avoid racing on Deno.env with parallel tests.
+    await initTracing({ endpoint: "http://collector.test" });
+    await initializeLogging({
+      jsonMode: true,
+      _reset: true,
+      _logsConfig: { endpoint: "http://collector.test" },
+    });
 
     const log = getSwampLogger([
       "model",
@@ -159,10 +166,5 @@ Deno.test("OTel logs: initializeLogging exports correlated, redacted records to 
     runFileSink.unregister(logHandle);
     await Deno.remove(tmpDir, { recursive: true });
     globalThis.fetch = savedFetch;
-    if (savedEndpoint === undefined) {
-      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
-    } else {
-      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", savedEndpoint);
-    }
   }
 });

--- a/integration/otel_logs_no_duplicate_test.ts
+++ b/integration/otel_logs_no_duplicate_test.ts
@@ -59,11 +59,9 @@ function countBodies(
 }
 
 Deno.test("OTel logs (log mode): each record is exported exactly once, never duplicated", async () => {
-  const savedEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
   const savedFetch = globalThis.fetch;
   const captured: { url: string; body: string }[] = [];
 
-  Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.test");
   // deno-lint-ignore no-explicit-any
   globalThis.fetch = ((input: any, init: any): Promise<Response> => {
     if (init?.body) {
@@ -85,7 +83,11 @@ Deno.test("OTel logs (log mode): each record is exported exactly once, never dup
     // _reset clears the once-per-process guard and passes reset:true to
     // LogTape's configure(), so this works even when another test file
     // already called initializeLogging in the same --parallel run.
-    await initializeLogging({ _reset: true });
+    // _logsConfig bypasses Deno.env to avoid races with other parallel tests.
+    await initializeLogging({
+      _reset: true,
+      _logsConfig: { endpoint: "http://collector.test" },
+    });
 
     // A run-category logger: its records reach the root (which holds the otel
     // sink) by inheritance. If the otel sink were also on this logger, the
@@ -101,10 +103,5 @@ Deno.test("OTel logs (log mode): each record is exported exactly once, never dup
     assertEquals(countBodies(captured, "unique-root-line-def456"), 1);
   } finally {
     globalThis.fetch = savedFetch;
-    if (savedEndpoint === undefined) {
-      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
-    } else {
-      Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", savedEndpoint);
-    }
   }
 });

--- a/integration/otel_logs_optout_test.ts
+++ b/integration/otel_logs_optout_test.ts
@@ -32,13 +32,9 @@ import {
 import { shutdownLogs } from "../src/infrastructure/tracing/mod.ts";
 
 Deno.test("OTel logs: OTEL_LOGS_EXPORTER=none exports no log records even with an endpoint", async () => {
-  const savedEndpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
-  const savedExporter = Deno.env.get("OTEL_LOGS_EXPORTER");
   const savedFetch = globalThis.fetch;
   const logPosts: string[] = [];
 
-  Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.test");
-  Deno.env.set("OTEL_LOGS_EXPORTER", "none");
   // deno-lint-ignore no-explicit-any
   globalThis.fetch = ((input: any): Promise<Response> => {
     const url = typeof input === "string" ? input : String(input);
@@ -48,7 +44,14 @@ Deno.test("OTel logs: OTEL_LOGS_EXPORTER=none exports no log records even with a
   }) as any;
 
   try {
-    await initializeLogging({});
+    await shutdownLogs();
+    await initializeLogging({
+      _reset: true,
+      _logsConfig: {
+        endpoint: "http://collector.test",
+        exporterKind: "none",
+      },
+    });
 
     getSwampLogger(["model", "method", "run", "m", "execute"])
       .info`this line must not be exported`;
@@ -58,10 +61,5 @@ Deno.test("OTel logs: OTEL_LOGS_EXPORTER=none exports no log records even with a
     assertEquals(logPosts.length, 0);
   } finally {
     globalThis.fetch = savedFetch;
-    if (savedEndpoint === undefined) {
-      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
-    } else Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", savedEndpoint);
-    if (savedExporter === undefined) Deno.env.delete("OTEL_LOGS_EXPORTER");
-    else Deno.env.set("OTEL_LOGS_EXPORTER", savedExporter);
   }
 });

--- a/integration/otel_logs_worker_correlation_test.ts
+++ b/integration/otel_logs_worker_correlation_test.ts
@@ -89,15 +89,14 @@ Deno.test("worker env: OTEL_* is inherited and TRACEPARENT is overlaid into the 
 });
 
 Deno.test("worker correlation: child logs carry the propagated parent trace id", async () => {
-  const saved: Record<string, string | undefined> = {
-    OTEL_EXPORTER_OTLP_ENDPOINT: Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
-    TRACEPARENT: Deno.env.get("TRACEPARENT"),
-  };
+  const savedTraceparent = Deno.env.get("TRACEPARENT");
   const savedFetch = globalThis.fetch;
   const captured: { url: string; body: string }[] = [];
 
-  // Apply the env the child would have booted with.
-  Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.test");
+  // TRACEPARENT must be in Deno.env because initTracing() reads it from the
+  // process environment (it's how W3C trace propagation works across processes).
+  // The OTel logs endpoint is passed via _logsConfig to avoid racing with other
+  // parallel test files that manipulate OTEL_EXPORTER_OTLP_ENDPOINT.
   Deno.env.set("TRACEPARENT", `00-${PARENT_TRACE}-${PARENT_SPAN}-01`);
   // deno-lint-ignore no-explicit-any
   globalThis.fetch = ((input: any, init: any): Promise<Response> => {
@@ -112,10 +111,17 @@ Deno.test("worker correlation: child logs carry the propagated parent trace id",
   }) as any;
 
   try {
+    await shutdownLogs();
+
     // This mirrors main.ts: initTracing() extracts TRACEPARENT and returns the
     // parent context; runWithParentTrace activates it for the run.
-    const parentCtx = await initTracing();
-    await initializeLogging({ jsonMode: true });
+    // Endpoint passed via config to avoid Deno.env races with parallel tests.
+    const parentCtx = await initTracing({ endpoint: "http://collector.test" });
+    await initializeLogging({
+      jsonMode: true,
+      _reset: true,
+      _logsConfig: { endpoint: "http://collector.test" },
+    });
 
     await runWithParentTrace(parentCtx, async () => {
       await withSpan("swamp.model.method.run", {}, (span) => {
@@ -150,9 +156,7 @@ Deno.test("worker correlation: child logs carry the propagated parent trace id",
     assertEquals(found.traceId, PARENT_TRACE);
   } finally {
     globalThis.fetch = savedFetch;
-    for (const [key, value] of Object.entries(saved)) {
-      if (value === undefined) Deno.env.delete(key);
-      else Deno.env.set(key, value);
-    }
+    if (savedTraceparent === undefined) Deno.env.delete("TRACEPARENT");
+    else Deno.env.set("TRACEPARENT", savedTraceparent);
   }
 });

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -27,7 +27,7 @@ import {
 import { getPrettyFormatter } from "@logtape/pretty";
 import { textFormatter, TIMESTAMP_FORMAT } from "./log_format.ts";
 import { runFileSink } from "./run_file_sink.ts";
-import { initLogs } from "../tracing/mod.ts";
+import { initLogs, type InitLogsConfig } from "../tracing/mod.ts";
 import { createOtelLogRecordSink } from "./otel_log_sink.ts";
 
 export { runFileSink } from "./run_file_sink.ts";
@@ -42,6 +42,8 @@ export interface LoggingOptions {
   stderrOnly?: boolean;
   /** Test-only: clear the once-per-process guard so logging can be reconfigured. */
   _reset?: boolean;
+  /** Test-only: bypass Deno.env for OTel logs config to avoid env var races under --parallel. */
+  _logsConfig?: InitLogsConfig;
 }
 
 const stderrEncoder = new TextEncoder();
@@ -121,7 +123,7 @@ export async function initializeLogging(
   // proceed without the otel sink.
   let otelProvider: Awaited<ReturnType<typeof initLogs>>;
   try {
-    otelProvider = await initLogs();
+    otelProvider = await initLogs(options._logsConfig);
   } catch {
     otelProvider = undefined;
   }

--- a/src/infrastructure/tracing/mod.ts
+++ b/src/infrastructure/tracing/mod.ts
@@ -17,8 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-export { initTracing, shutdownTracing } from "./otel_init.ts";
-export { initLogs, shutdownLogs } from "./otel_logs_init.ts";
+export {
+  initTracing,
+  type InitTracingConfig,
+  shutdownTracing,
+} from "./otel_init.ts";
+export {
+  initLogs,
+  type InitLogsConfig,
+  shutdownLogs,
+} from "./otel_logs_init.ts";
 export {
   getTracer,
   SpanStatusCode,

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -23,15 +23,28 @@ import type { Context } from "@opentelemetry/api";
 let providerRef: { shutdown(): Promise<void> } | undefined;
 
 /**
+ * Test-only configuration that bypasses `Deno.env` for OTel tracing setup.
+ * Production callers omit this — `initTracing` reads env vars by default.
+ */
+export interface InitTracingConfig {
+  endpoint?: string;
+  exporterKind?: string;
+}
+
+/**
  * Initializes OpenTelemetry tracing if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
  *
  * All SDK packages are dynamically imported so they impose zero cost when
  * tracing is disabled. `@opentelemetry/api` is statically imported because it
  * returns no-op implementations by default.
  */
-export async function initTracing(): Promise<Context | undefined> {
-  const endpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
-  const exporterKind = Deno.env.get("OTEL_TRACES_EXPORTER") ?? "otlp";
+export async function initTracing(
+  config?: InitTracingConfig,
+): Promise<Context | undefined> {
+  const endpoint = config?.endpoint ??
+    Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const exporterKind = config?.exporterKind ??
+    Deno.env.get("OTEL_TRACES_EXPORTER") ?? "otlp";
 
   if (!endpoint && exporterKind !== "console") {
     // No endpoint configured and not console mode — tracing stays disabled.

--- a/src/infrastructure/tracing/otel_logs_init.ts
+++ b/src/infrastructure/tracing/otel_logs_init.ts
@@ -74,6 +74,18 @@ class StderrLogRecordExporter implements LogRecordExporter {
 }
 
 /**
+ * Test-only configuration that bypasses `Deno.env` for OTel logs setup.
+ * Production callers omit this — `initLogs` reads env vars by default.
+ * Tests pass config directly to avoid races on the process-wide `Deno.env`
+ * when `deno test --parallel` runs multiple OTel test files concurrently.
+ */
+export interface InitLogsConfig {
+  endpoint?: string;
+  exporterKind?: string;
+  useBatch?: boolean;
+}
+
+/**
  * Initializes the OpenTelemetry **logs** signal, mirroring
  * {@link initTracing}. Returns the {@link LoggerProvider} so the logging layer
  * can build a LogTape sink from it (the bridge sink lives in the logging module
@@ -88,7 +100,9 @@ class StderrLogRecordExporter implements LogRecordExporter {
  * (per-record flush, predictable for short CLI runs); set `OTEL_BLRP_USE=1` for
  * a {@link BatchLogRecordProcessor}, which suits high-volume `swamp serve`.
  */
-export async function initLogs(): Promise<LoggerProvider | undefined> {
+export async function initLogs(
+  config?: InitLogsConfig,
+): Promise<LoggerProvider | undefined> {
   // Idempotent: if logs export is already initialized, return the live provider
   // rather than building (and leaking) a second one. The only production caller
   // (initializeLogging) is already once-per-process, but initLogs is exported,
@@ -97,8 +111,10 @@ export async function initLogs(): Promise<LoggerProvider | undefined> {
     return providerRef;
   }
 
-  const endpoint = Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
-  const exporterKind = Deno.env.get("OTEL_LOGS_EXPORTER") ?? "otlp";
+  const endpoint = config?.endpoint ??
+    Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+  const exporterKind = config?.exporterKind ??
+    Deno.env.get("OTEL_LOGS_EXPORTER") ?? "otlp";
 
   if (exporterKind === "none") {
     // Explicit opt-out — traces may still be on, but logs stay off.
@@ -143,7 +159,8 @@ export async function initLogs(): Promise<LoggerProvider | undefined> {
 
   // Short-lived CLI invocations flush per-record; long-running `swamp serve`
   // can opt into batching via OTEL_BLRP_USE=1 (mirrors OTEL_BSP_USE for spans).
-  const useBatch = Deno.env.get("OTEL_BLRP_USE") === "1";
+  const useBatch = config?.useBatch ??
+    Deno.env.get("OTEL_BLRP_USE") === "1";
   const processor = useBatch
     ? new BatchLogRecordProcessor(exporter)
     : new SimpleLogRecordProcessor(exporter);

--- a/src/presentation/output/hooks/useTerminalSize.ts
+++ b/src/presentation/output/hooks/useTerminalSize.ts
@@ -20,9 +20,29 @@
 import { useEffect, useState } from "react";
 import { useStdout } from "ink";
 
-interface TerminalSize {
+export interface TerminalSize {
   width: number;
   height: number;
+}
+
+/**
+ * Reads current terminal dimensions. Prefers Deno.consoleSize() (TIOCGWINSZ
+ * ioctl) which reliably reports the actual pane size in tmux, multiplexers,
+ * and non-standard emulators. Falls back to Ink's stdout properties, then
+ * to safe defaults.
+ */
+export function getTerminalDimensions(
+  stdout: NodeJS.WriteStream | undefined,
+): TerminalSize {
+  try {
+    const { columns, rows } = Deno.consoleSize();
+    return { width: columns, height: rows };
+  } catch {
+    return {
+      width: stdout?.columns ?? 80,
+      height: stdout?.rows ?? 24,
+    };
+  }
 }
 
 /**
@@ -32,20 +52,16 @@ interface TerminalSize {
 export function useTerminalSize(): TerminalSize {
   const { stdout } = useStdout();
 
-  const getSize = (): TerminalSize => ({
-    width: stdout?.columns ?? 80,
-    height: stdout?.rows ?? 24,
-  });
-
-  const [size, setSize] = useState<TerminalSize>(getSize);
+  const [size, setSize] = useState<TerminalSize>(() =>
+    getTerminalDimensions(stdout)
+  );
 
   useEffect(() => {
     if (!stdout) return;
 
     const updateSize = () => {
-      const newSize = getSize();
+      const newSize = getTerminalDimensions(stdout);
       setSize((prev) => {
-        // Only update if dimensions actually changed
         if (prev.width !== newSize.width || prev.height !== newSize.height) {
           return newSize;
         }
@@ -53,10 +69,7 @@ export function useTerminalSize(): TerminalSize {
       });
     };
 
-    // Listen to resize events
     stdout.on("resize", updateSize);
-
-    // Poll as fallback (every 500ms)
     const interval = setInterval(updateSize, 500);
 
     return () => {

--- a/src/presentation/output/hooks/useTerminalSize_test.ts
+++ b/src/presentation/output/hooks/useTerminalSize_test.ts
@@ -1,0 +1,46 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { getTerminalDimensions } from "./useTerminalSize.ts";
+
+Deno.test("getTerminalDimensions: falls back to stdout properties when Deno.consoleSize() throws", () => {
+  const fakeStdout = {
+    columns: 120,
+    rows: 40,
+  } as unknown as NodeJS.WriteStream;
+  // In test environments Deno.consoleSize() throws (no TTY), so the function
+  // should fall back to stdout properties.
+  const size = getTerminalDimensions(fakeStdout);
+  assertEquals(size.width, 120);
+  assertEquals(size.height, 40);
+});
+
+Deno.test("getTerminalDimensions: falls back to defaults when stdout is undefined", () => {
+  const size = getTerminalDimensions(undefined);
+  assertEquals(size.width, 80);
+  assertEquals(size.height, 24);
+});
+
+Deno.test("getTerminalDimensions: falls back to defaults when stdout has no columns/rows", () => {
+  const fakeStdout = {} as unknown as NodeJS.WriteStream;
+  const size = getTerminalDimensions(fakeStdout);
+  assertEquals(size.width, 80);
+  assertEquals(size.height, 24);
+});


### PR DESCRIPTION
## Summary

- **Fix interactive finder layout instability** in tmux, multiplexers, and non-standard terminal emulators by switching the `useTerminalSize` hook from Ink's `stdout.columns/rows` (Node.js compat layer) to `Deno.consoleSize()` (TIOCGWINSZ ioctl) as the primary terminal dimension source
- Extract `getTerminalDimensions()` as a pure, testable function with a fallback chain: `Deno.consoleSize()` → `stdout.columns/rows` → 80×24 defaults
- **Fix flaky OTel integration tests** by adding config injection (`InitLogsConfig`, `InitTracingConfig`) to `initLogs()` and `initTracing()` so tests pass OTel endpoint config directly instead of racing on process-wide `Deno.env` under `deno test --parallel`

Closes swamp-club#1221

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` passes (full suite)
- [x] `deno check` passes for all consumers (`search_picker.tsx`, `data_query_tui.tsx`, `workflow_run_tree.tsx`)
- [x] All 5 OTel integration tests pass 3/3 consecutive parallel runs (zero flakes)
- [x] Production callers of `initLogs()`, `initTracing()`, and `initializeLogging()` verified unchanged (no args = reads from Deno.env as before)
- [ ] Manual: run `swamp model search` in tmux at various widths (80, 90, 120, 200) and verify preview pane renders consistently
- [ ] Manual: run `swamp data search` back-to-back at width 90 and verify layout is deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)