### PR TITLE
docs(telemetry): document user-global spool, telemetry.yaml opt-out, and migration (swamp-club#1129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,17 @@ Swamp collects anonymous usage telemetry to help us understand which commands
 are used, how long they take, and what errors occur. All user-identifiable
 values are redacted before transmission — nothing sensitive is ever sent.
 
+Telemetry is **user-global** — events are spooled to a single directory
+regardless of which repository (if any) you are working in:
+
+```
+~/.config/swamp/telemetry/
+```
+
+The path is XDG-aware: if `$XDG_CONFIG_HOME` is set, the spool lives at
+`$XDG_CONFIG_HOME/swamp/telemetry/` instead. Setting `$SWAMP_HOME` overrides
+both (`$SWAMP_HOME/config/telemetry/`).
+
 Here is a complete example of a telemetry event:
 
 ```json
@@ -425,6 +436,16 @@ queries) are replaced with `<REDACTED>`. Only categorical values defined by
 swamp itself (like model types) are recorded. Option values are never recorded —
 only the option keys.
 
+### Viewing Telemetry Stats
+
+`swamp telemetry stats` reads the user-global spool and summarizes recent
+activity. It does not require a repository context:
+
+```bash
+swamp telemetry stats           # last 2 days (default)
+swamp telemetry stats --days 7  # last 7 days
+```
+
 ### Disabling Telemetry
 
 Per-invocation:
@@ -446,8 +467,28 @@ Permanently for a repository — add to `.swamp.yaml`:
 telemetryDisabled: true
 ```
 
+Permanently for all repo-less runs — create `~/.config/swamp/telemetry.yaml`:
+
+```yaml
+disabled: true
+```
+
+This suppresses telemetry when running swamp outside any repository (e.g.
+`swamp telemetry stats`, `swamp auth login`). Inside a repository the
+`.swamp.yaml` `telemetryDisabled` field takes precedence.
+
 Priority order (highest to lowest): `--no-telemetry` flag → `SWAMP_NO_TELEMETRY`
-env var → `.swamp.yaml` `telemetryDisabled: true`.
+env var → `.swamp.yaml` `telemetryDisabled: true` (per-repo) →
+`~/.config/swamp/telemetry.yaml` `disabled: true` (user-global, repo-less runs).
+
+### Migrating from Repo-Local Telemetry
+
+Older versions of swamp stored telemetry in `.swamp/telemetry/` inside each
+repository. Running `swamp repo upgrade` automatically migrates unflushed
+entries from the legacy repo-local spool to the user-global spool. Repositories
+that have telemetry disabled (`telemetryDisabled: true` in `.swamp.yaml`) are
+skipped. The old `.swamp/telemetry/` directory is left in place but is no longer
+used.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Update README.md telemetry section to reflect user-global telemetry changes from #1125: spool location (`~/.config/swamp/telemetry/`, XDG-aware), `telemetry.yaml` persistent opt-out for repo-less runs, `swamp telemetry stats` behavior (no `--repo-dir`), `swamp repo upgrade` migration, and full four-layer priority order
- Filed swamp-club#1233 for corresponding manual reference page updates in `content/manual/reference/repository-configuration.md`

Closes swamp-club#1129

## Test Plan

- Documentation-only change — no code modified
- `deno fmt`, `deno lint`, `deno run test` all pass
- Verified every claim in the README against source: `paths.ts` (`getSwampConfigDir`, `globalTelemetryDir`), `telemetry_preferences_file_repository.ts` (`telemetry.yaml` schema), `telemetry_stats.ts` (no `--repo-dir`), `telemetry_spool_migration.ts` and `repo_service.ts` (migration behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)