### PR TITLE
feat(extensions): surface foreign-type grafts in contentMetadata and extension info/pull (swamp-club#1101)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -97,10 +97,12 @@ the next CalVer version for an extension.
 beta) when they exist. No flag needed — info always shows all channels.
 
 The info command also displays content metadata for the latest version: model
-types with their methods, workflows, vaults, datastores, drivers, reports, and
-skills. By default, models show the type name and method names. With
-`--verbose`, each method's arguments and descriptions are also displayed. JSON
-output (`--json`) includes the full `contentMetadata` object with all detail.
+types with their methods, extensions (foreign-type grafts with their methods),
+workflows, vaults, datastores, drivers, reports, and skills. By default, models
+show the type name and method names; extensions show the target type and grafted
+method names. With `--verbose`, each method's arguments and descriptions are
+also displayed. JSON output (`--json`) includes the full `contentMetadata`
+object with all detail.
 
 ### Promotion
 

--- a/src/domain/extensions/extension_collective_validator_test.ts
+++ b/src/domain/extensions/extension_collective_validator_test.ts
@@ -26,6 +26,7 @@ function makeMetadata(
 ): ExtensionContentMetadata {
   return {
     models: [],
+    extensions: [],
     workflows: [],
     vaults: [],
     drivers: [],

--- a/src/domain/extensions/extension_content.ts
+++ b/src/domain/extensions/extension_content.ts
@@ -121,6 +121,14 @@ export interface ExtractedReport {
   labels: string[];
 }
 
+/** Metadata extracted from an extension file that grafts methods onto a foreign type. */
+export interface ExtractedExtension {
+  fileName: string;
+  extendsType: string;
+  methods: ExtractedMethod[];
+  resources: ExtractedResource[];
+}
+
 /** Metadata extracted from a skill directory. */
 export interface ExtractedSkill {
   dirName: string;
@@ -133,6 +141,7 @@ export interface ExtractedSkill {
 /** Content metadata extracted from all models, workflows, vaults, drivers, datastores, reports, and skills in an extension. */
 export interface ExtensionContentMetadata {
   models: ExtractedModel[];
+  extensions: ExtractedExtension[];
   workflows: ExtractedWorkflow[];
   vaults: ExtractedVault[];
   drivers: ExtractedDriver[];

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -24,6 +24,7 @@ import type {
   ExtractedArgument,
   ExtractedDatastore,
   ExtractedDriver,
+  ExtractedExtension,
   ExtractedFile,
   ExtractedMethod,
   ExtractedModel,
@@ -58,6 +59,7 @@ export async function extractContentMetadata(
   reportsDir = "",
 ): Promise<ExtensionContentMetadata> {
   const models: ExtractedModel[] = [];
+  const extensions: ExtractedExtension[] = [];
   const workflows: ExtractedWorkflow[] = [];
   const vaults: ExtractedVault[] = [];
   const drivers: ExtractedDriver[] = [];
@@ -70,6 +72,11 @@ export async function extractContentMetadata(
       const model = extractModelFromSource(content, filePath, modelsDir);
       if (model) {
         models.push(model);
+      } else {
+        const ext = extractExtensionFromSource(content, filePath, modelsDir);
+        if (ext) {
+          extensions.push(ext);
+        }
       }
     } catch {
       // Non-fatal: skip files that can't be read or parsed
@@ -142,6 +149,7 @@ export async function extractContentMetadata(
 
   return {
     models,
+    extensions,
     workflows,
     vaults,
     drivers,
@@ -180,6 +188,98 @@ function extractModelFromSource(
     resources,
     files,
   };
+}
+
+/**
+ * Extracts extension metadata from a TypeScript source file that uses
+ * `export const extension = { type: "...", methods: [...] }`.
+ * Returns null if the file doesn't contain a recognizable extension definition.
+ */
+function extractExtensionFromSource(
+  content: string,
+  filePath: string,
+  modelsDir: string,
+): ExtractedExtension | null {
+  const extensionMatch = content.match(
+    /export\s+const\s+extension\s*=\s*\{/,
+  );
+  if (!extensionMatch || extensionMatch.index === undefined) return null;
+
+  const bodyStart = extensionMatch.index + extensionMatch[0].length;
+  const body = extractBalancedBraces(content, bodyStart);
+  if (!body) return null;
+
+  const typeMatch = body.match(/type:\s*["']([^"']+)["']/);
+  if (!typeMatch) return null;
+
+  const methods = extractExtensionMethods(body, content);
+  const resources = extractResources(body);
+
+  return {
+    fileName: relative(modelsDir, filePath),
+    extendsType: typeMatch[1],
+    methods,
+    resources,
+  };
+}
+
+/**
+ * Extracts methods from an extension's `methods` array.
+ * Extension methods use an array-of-records pattern: `methods: [{ name: { ... } }]`.
+ */
+function extractExtensionMethods(
+  extensionBody: string,
+  fullContent: string,
+): ExtractedMethod[] {
+  const methods: ExtractedMethod[] = [];
+
+  const methodsBlockMatch = extensionBody.match(/methods:\s*\[/);
+  if (!methodsBlockMatch || methodsBlockMatch.index === undefined) {
+    return methods;
+  }
+
+  const arrayStart = methodsBlockMatch.index + methodsBlockMatch[0].length;
+  const arrayBody = extractBalancedBrackets(extensionBody, arrayStart);
+  if (!arrayBody) return methods;
+
+  const methodPattern =
+    /(\w+)\s*:\s*\{[^}]*?description:\s*(?:"([^"]*?)"|'([^']*?)'|`([^`]*?)`)/gs;
+  let match;
+  while ((match = methodPattern.exec(arrayBody)) !== null) {
+    const name = match[1];
+    const description = match[2] ?? match[3] ?? match[4] ?? "";
+
+    const methodEntry = extractMethodEntry(arrayBody, name);
+    const args = methodEntry
+      ? extractMethodArguments(methodEntry, fullContent)
+      : [];
+
+    methods.push({ name, description, arguments: args });
+  }
+
+  return methods;
+}
+
+/**
+ * Extracts the content between balanced square brackets, starting after an
+ * opening bracket. Returns the content between the brackets (excluding the
+ * outer brackets themselves).
+ */
+function extractBalancedBrackets(
+  text: string,
+  startAfterBracket: number,
+): string | null {
+  let depth = 1;
+  let i = startAfterBracket;
+
+  while (i < text.length && depth > 0) {
+    if (text[i] === "[") depth++;
+    else if (text[i] === "]") depth--;
+    i++;
+  }
+
+  if (depth !== 0) return null;
+  return text.slice(startAfterBracket, i - 1);
 }
 
 /**

--- a/src/domain/extensions/extension_content_extractor_test.ts
+++ b/src/domain/extensions/extension_content_extractor_test.ts
@@ -27,6 +27,7 @@ Deno.test("extractContentMetadata returns empty for no inputs", async () => {
   const result = await extractContentMetadata([], "/tmp/models", []);
   assertEquals(result, {
     models: [],
+    extensions: [],
     workflows: [],
     vaults: [],
     drivers: [],
@@ -1541,6 +1542,190 @@ Deno.test("extractContentMetadata: ignores type: inside string literal before mo
     const result = await extractContentMetadata([modelFile], modelsDir, []);
     assertEquals(result.models.length, 1);
     assertEquals(result.models[0].type, "@keeb/mms/organizer");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata: extracts extension with inline methods array", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const extFile = join(modelsDir, "grafana_ext.ts");
+    await Deno.writeTextFile(
+      extFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const extension = {",
+        '  type: "@keeb/grafana/instance",',
+        "  methods: [",
+        "    {",
+        "      queryLogs: {",
+        '        description: "Query Grafana Loki logs",',
+        "        arguments: z.object({",
+        '          query: z.string().describe("LogQL query"),',
+        "        }),",
+        "        execute: async () => ({ dataHandles: [] }),",
+        "      },",
+        "    },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([extFile], modelsDir, []);
+    assertEquals(result.models.length, 0);
+    assertEquals(result.extensions.length, 1);
+    assertEquals(result.extensions[0].extendsType, "@keeb/grafana/instance");
+    assertEquals(result.extensions[0].fileName, "grafana_ext.ts");
+    assertEquals(result.extensions[0].methods.length, 1);
+    assertEquals(result.extensions[0].methods[0].name, "queryLogs");
+    assertEquals(
+      result.extensions[0].methods[0].description,
+      "Query Grafana Loki logs",
+    );
+    assertEquals(result.extensions[0].methods[0].arguments.length, 1);
+    assertEquals(result.extensions[0].methods[0].arguments[0].name, "query");
+    assertEquals(result.extensions[0].methods[0].arguments[0].type, "string");
+    assertEquals(result.extensions[0].methods[0].arguments[0].required, true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata: extracts extension with multiple methods", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const extFile = join(modelsDir, "multi_ext.ts");
+    await Deno.writeTextFile(
+      extFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const extension = {",
+        '  type: "@other/service",',
+        "  methods: [",
+        "    {",
+        "      methodA: {",
+        '        description: "First method",',
+        "        arguments: z.object({}),",
+        "        execute: async () => ({ dataHandles: [] }),",
+        "      },",
+        "    },",
+        "    {",
+        "      methodB: {",
+        '        description: "Second method",',
+        "        arguments: z.object({}),",
+        "        execute: async () => ({ dataHandles: [] }),",
+        "      },",
+        "    },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([extFile], modelsDir, []);
+    assertEquals(result.extensions.length, 1);
+    assertEquals(result.extensions[0].extendsType, "@other/service");
+    assertEquals(result.extensions[0].methods.length, 2);
+    assertEquals(result.extensions[0].methods[0].name, "methodA");
+    assertEquals(result.extensions[0].methods[1].name, "methodB");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata: skips extension without type", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const extFile = join(modelsDir, "bad_ext.ts");
+    await Deno.writeTextFile(
+      extFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const extension = {",
+        "  methods: [",
+        "    {",
+        "      run: {",
+        '        description: "Run",',
+        "        arguments: z.object({}),",
+        "        execute: async () => ({ dataHandles: [] }),",
+        "      },",
+        "    },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata([extFile], modelsDir, []);
+    assertEquals(result.extensions.length, 0);
+    assertEquals(result.models.length, 0);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("extractContentMetadata: extracts both models and extensions from same file list", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const modelsDir = join(tmpDir, "models");
+    await Deno.mkdir(modelsDir, { recursive: true });
+
+    const modelFile = join(modelsDir, "instance.ts");
+    await Deno.writeTextFile(
+      modelFile,
+      [
+        "export const model = {",
+        '  type: "@test/instance",',
+        '  version: "2026.03.01.1",',
+        "  methods: {",
+        "    run: {",
+        '      description: "Run",',
+        "      arguments: z.object({}),",
+        "      execute: async () => ({ dataHandles: [] }),",
+        "    },",
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+
+    const extFile = join(modelsDir, "ext.ts");
+    await Deno.writeTextFile(
+      extFile,
+      [
+        'import { z } from "npm:zod@4";',
+        "export const extension = {",
+        '  type: "@test/instance",',
+        "  methods: [",
+        "    {",
+        "      extra: {",
+        '        description: "Extra method",',
+        "        arguments: z.object({}),",
+        "        execute: async () => ({ dataHandles: [] }),",
+        "      },",
+        "    },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const result = await extractContentMetadata(
+      [modelFile, extFile],
+      modelsDir,
+      [],
+    );
+    assertEquals(result.models.length, 1);
+    assertEquals(result.models[0].type, "@test/instance");
+    assertEquals(result.extensions.length, 1);
+    assertEquals(result.extensions[0].extendsType, "@test/instance");
+    assertEquals(result.extensions[0].methods[0].name, "extra");
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -294,6 +294,7 @@ export class ExtensionApiClient {
       channel: detail.channel,
       contentMetadata: {
         models: detail.models ?? [],
+        extensions: detail.extensions ?? [],
         workflows: detail.workflows ?? [],
         vaults: detail.vaults ?? [],
         drivers: detail.drivers ?? [],

--- a/src/libswamp/extensions/info_test.ts
+++ b/src/libswamp/extensions/info_test.ts
@@ -87,6 +87,7 @@ function makeVersionDetail(
           files: [],
         },
       ],
+      extensions: [],
       workflows: [],
       vaults: [],
       drivers: [],

--- a/src/libswamp/extensions/install_extension_service_test.ts
+++ b/src/libswamp/extensions/install_extension_service_test.ts
@@ -126,6 +126,7 @@ function makeStubInstallResult(
     skillFiles: [],
     dependencies: [],
     dependencyResults: [],
+    extendsTypes: [],
     pruned: [],
     shadowedTypes: [],
   };

--- a/src/libswamp/extensions/install_test.ts
+++ b/src/libswamp/extensions/install_test.ts
@@ -595,6 +595,7 @@ function makeInstallWithPruned(
       skillFiles: [],
       dependencies: [],
       dependencyResults: [],
+      extendsTypes: [],
       pruned: prunedPaths,
       shadowedTypes: [],
     };

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -106,6 +106,13 @@ export interface InstallResult {
   dependencies: string[];
   dependencyResults: InstallResult[];
   /**
+   * Foreign types this extension grafts methods onto via
+   * `export const extension`. Each entry names the target type and
+   * the methods added to it. Empty when the extension defines only
+   * its own types or when source files are unavailable.
+   */
+  extendsTypes: Array<{ type: string; methods: string[] }>;
+  /**
    * Repo-relative paths that were declared in the prior version's
    * lockfile entry but absent from the current version's
    * `extractedFiles`, and which were actually removed from disk by
@@ -1223,6 +1230,8 @@ export async function installExtension(
       }
     }
 
+    const extendsTypes = await scanForExtensionGrafts(absoluteModelsDir);
+
     return {
       name: ref.name,
       version,
@@ -1240,6 +1249,7 @@ export async function installExtension(
       skillFiles,
       dependencies: manifest.dependencies,
       dependencyResults,
+      extendsTypes,
       pruned,
       shadowedTypes: [],
     };
@@ -1346,6 +1356,44 @@ export async function* extensionPull(
       }
     })(),
   );
+}
+
+async function scanForExtensionGrafts(
+  modelsDir: string,
+): Promise<Array<{ type: string; methods: string[] }>> {
+  const results: Array<{ type: string; methods: string[] }> = [];
+  try {
+    for await (const entry of Deno.readDir(modelsDir)) {
+      if (!entry.isFile || !entry.name.endsWith(".ts")) continue;
+      try {
+        const content = await Deno.readTextFile(join(modelsDir, entry.name));
+        const extMatch = content.match(
+          /export\s+const\s+extension\s*=\s*\{/,
+        );
+        if (!extMatch) continue;
+
+        const typeMatch = content.match(
+          /export\s+const\s+extension\s*=\s*\{[\s\S]*?type:\s*["']([^"']+)["']/,
+        );
+        if (!typeMatch) continue;
+
+        const methodNames: string[] = [];
+        const methodPattern =
+          /(\w+)\s*:\s*\{[^}]*?description:\s*(?:"[^"]*?"|'[^']*?'|`[^`]*?`)/g;
+        let match;
+        while ((match = methodPattern.exec(content)) !== null) {
+          methodNames.push(match[1]);
+        }
+
+        results.push({ type: typeMatch[1], methods: methodNames });
+      } catch {
+        // Non-fatal: skip unreadable files
+      }
+    }
+  } catch {
+    // modelsDir may not exist (e.g., extension has no models)
+  }
+  return results;
 }
 
 /**

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -209,6 +209,7 @@ function makeStubInstallResult(
     skillFiles: [],
     dependencies: [],
     dependencyResults: [],
+    extendsTypes: [],
     pruned,
     shadowedTypes: [],
   };

--- a/src/libswamp/extensions/push_pull_roundtrip_test.ts
+++ b/src/libswamp/extensions/push_pull_roundtrip_test.ts
@@ -76,6 +76,7 @@ function makePrepareDeps(
     extractContentMetadata: () =>
       Promise.resolve({
         models: [],
+        extensions: [],
         workflows: [],
         vaults: [],
         drivers: [],

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -107,6 +107,7 @@ function makePrepareDeps(
     extractContentMetadata: () =>
       Promise.resolve({
         models: [],
+        extensions: [],
         workflows: [],
         vaults: [],
         drivers: [],

--- a/src/libswamp/extensions/remove_extension_service_test.ts
+++ b/src/libswamp/extensions/remove_extension_service_test.ts
@@ -120,6 +120,7 @@ function makeStubInstallResult(
     skillFiles: [],
     dependencies: [],
     dependencyResults: [],
+    extendsTypes: [],
     pruned: [],
     shadowedTypes: [],
   };

--- a/src/libswamp/extensions/update_test.ts
+++ b/src/libswamp/extensions/update_test.ts
@@ -261,6 +261,7 @@ function buildInstallResult(
     skillFiles: [],
     dependencies: [],
     dependencyResults: [],
+    extendsTypes: [],
     pruned,
     shadowedTypes,
   };

--- a/src/libswamp/extensions/upgrade_extension_service_test.ts
+++ b/src/libswamp/extensions/upgrade_extension_service_test.ts
@@ -111,6 +111,7 @@ function makeStubInstallResult(
     skillFiles: [],
     dependencies: [],
     dependencyResults: [],
+    extendsTypes: [],
     pruned: [],
     shadowedTypes: [],
   };

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -847,6 +847,7 @@ export type {
   ExtractedArgument,
   ExtractedDatastore,
   ExtractedDriver,
+  ExtractedExtension,
   ExtractedMethod,
   ExtractedModel,
   ExtractedReport,

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -21,6 +21,7 @@ import type {
   EventHandlers,
   ExtensionContentMetadata,
   ExtensionInfoEvent,
+  ExtractedExtension,
   ExtractedModel,
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
@@ -47,6 +48,18 @@ function renderContentMetadata(
       logger.info`  ${name} — methods: ${methods || "none"}`;
       if (verbose) {
         renderModelDetail(logger, model);
+      }
+    }
+  }
+
+  if (meta.extensions && meta.extensions.length > 0) {
+    logger.info``;
+    logger.info`Extends (${meta.extensions.length}):`;
+    for (const ext of meta.extensions) {
+      const methods = ext.methods.map((m) => m.name).join(", ");
+      logger.info`  ${ext.extendsType} — methods: ${methods || "none"}`;
+      if (verbose) {
+        renderExtensionDetail(logger, ext);
       }
     }
   }
@@ -105,6 +118,21 @@ function renderModelDetail(
   model: ExtractedModel,
 ): void {
   for (const method of model.methods) {
+    const args = method.arguments
+      .map((a) => `${a.name}${a.required ? "" : "?"}:${a.type}`)
+      .join(", ");
+    logger.info`    ${method.name}(${args})`;
+    if (method.description) {
+      logger.info`      ${method.description}`;
+    }
+  }
+}
+
+function renderExtensionDetail(
+  logger: ReturnType<typeof getSwampLogger>,
+  ext: ExtractedExtension,
+): void {
+  for (const method of ext.methods) {
     const args = method.arguments
       .map((a) => `${a.name}${a.required ? "" : "?"}:${a.type}`)
       .join(", ");

--- a/src/presentation/renderers/extension_info_test.ts
+++ b/src/presentation/renderers/extension_info_test.ts
@@ -115,12 +115,38 @@ const sampleContentMetadata: ExtensionContentMetadata = {
       files: [],
     },
   ],
+  extensions: [],
   workflows: [],
   vaults: [],
   drivers: [],
   datastores: [],
   reports: [],
   skills: [],
+};
+
+const sampleContentMetadataWithExtensions: ExtensionContentMetadata = {
+  ...sampleContentMetadata,
+  extensions: [
+    {
+      fileName: "grafana_ext.ts",
+      extendsType: "@keeb/grafana/instance",
+      methods: [
+        {
+          name: "queryLogs",
+          description: "Query Grafana Loki logs",
+          arguments: [
+            {
+              name: "query",
+              type: "string",
+              description: "LogQL query",
+              required: true,
+            },
+          ],
+        },
+      ],
+      resources: [],
+    },
+  ],
 };
 
 async function* toStream(
@@ -206,6 +232,67 @@ Deno.test("JsonExtensionInfoRenderer: null contentMetadata in JSON output", asyn
     assertEquals(logs.length, 1);
     const parsed = JSON.parse(logs[0]);
     assertEquals(parsed.contentMetadata, null);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("LogExtensionInfoRenderer: renders extensions (type grafts) without error", async () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({
+        contentMetadata: sampleContentMetadataWithExtensions,
+      }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("LogExtensionInfoRenderer: verbose renders extension detail without error", async () => {
+  const renderer = createExtensionInfoRenderer("log", true);
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({
+        contentMetadata: sampleContentMetadataWithExtensions,
+      }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("JsonExtensionInfoRenderer: includes extensions in JSON output", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createExtensionInfoRenderer("json");
+    const events: ExtensionInfoEvent[] = [
+      { kind: "resolving" },
+      {
+        kind: "completed",
+        data: makeInfoData({
+          contentMetadata: sampleContentMetadataWithExtensions,
+        }),
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.contentMetadata.extensions.length, 1);
+    assertEquals(
+      parsed.contentMetadata.extensions[0].extendsType,
+      "@keeb/grafana/instance",
+    );
+    assertEquals(
+      parsed.contentMetadata.extensions[0].methods[0].name,
+      "queryLogs",
+    );
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/renderers/extension_pull.ts
+++ b/src/presentation/renderers/extension_pull.ts
@@ -92,6 +92,15 @@ function renderInstallResultLog(result: InstallResult): void {
       .info`  This extension invokes models from the above extensions via context.runModel()`;
   }
 
+  if (result.extendsTypes && result.extendsTypes.length > 0) {
+    logger
+      .warn`This extension adds methods to types it does not define:`;
+    for (const ext of result.extendsTypes) {
+      const methods = ext.methods.join(", ");
+      logger.warn`  ${ext.type}: ${methods}`;
+    }
+  }
+
   logger.info`Pulled ${result.name}@${result.version}`;
   logger.info`Extracted ${result.extractedFiles.length} files:`;
   for (const f of result.extractedFiles) {
@@ -175,6 +184,10 @@ function renderInstallResultJson(result: InstallResult): void {
     console.log(
       JSON.stringify({ dependencies: result.dependencies }, null, 2),
     );
+  }
+
+  if (result.extendsTypes && result.extendsTypes.length > 0) {
+    console.log(JSON.stringify({ extendsTypes: result.extendsTypes }, null, 2));
   }
 
   if (result.hasSkills) {


### PR DESCRIPTION
## Summary

- Add `ExtractedExtension` interface and `extensions` field to `ExtensionContentMetadata` so the content extractor captures `export const extension` files that graft methods onto foreign types
- Teach `extractContentMetadata()` to fall back to `extractExtensionFromSource()` when a model file doesn't match `export const model`
- Show an "Extends" section in `swamp extension info` (log + JSON modes) listing the target type and grafted methods
- Warn during `swamp extension pull` when an extension adds methods to types it does not define
- Update `design/extension.md` to document the new content metadata field

Closes swamp-club/lab#1101

## Test Plan

- 4 new unit tests for `extractExtensionFromSource()`: inline methods, multiple methods, missing type, mixed model+extension file lists
- 3 new unit tests for the extension info renderer: log rendering, verbose detail, JSON output with extensions
- All 9076 existing tests pass
- Manual verification: content extractor now correctly identifies reproduction file (`export const extension` grafting `queryLogs` onto `@keeb/grafana/instance`) — previously silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)