### PR TITLE
fix(skills): remove stale .swamp/telemetry/ from repo-structure reference (swamp-club#1229)

### DIFF
--- a/.claude/skills/swamp/references/repo/references/structure.md
+++ b/.claude/skills/swamp/references/repo/references/structure.md
@@ -58,9 +58,6 @@ my-swamp-repo/
 │   │       └── {vault-name}/
 │   │           ├── .key         # Encryption key (NEVER commit)
 │   │           └── {secret-key} # Encrypted secret data
-│   │
-│   └── telemetry/               # Local telemetry data
-│       └── events.jsonl
 │
 ├── models/                      # Model definitions by type
 │   └── {normalized-type}/
@@ -231,16 +228,20 @@ These files contain sensitive data and are included in `.gitignore`:
 | ------------------------ | ------------------------------- |
 | `.swamp/secrets/keyfile` | Encryption key for local vaults |
 | `.swamp/secrets/**`      | Encrypted secret data           |
-| `.swamp/telemetry/`      | Local telemetry events          |
 | `.claude/`               | Claude Code local config        |
 
 ### Recommended .gitignore
 
-Auto-generated on `swamp repo init`:
+Auto-generated on `swamp repo init` as a managed section:
 
 ```gitignore
-# Swamp managed defaults
-.swamp/telemetry/
-.swamp/secrets/keyfile
-.claude/
+# BEGIN swamp managed section - DO NOT EDIT
+
+# Runtime data (not needed in version control)
+.swamp/
+
+# Local extension sources (developer-specific, not shared)
+.swamp-sources.yaml
+
+# END swamp managed section
 ```


### PR DESCRIPTION
## Summary

- Removes `.swamp/telemetry/` (with `events.jsonl`) from the directory layout diagram — telemetry moved to user-global `~/.config/swamp/telemetry/` in PR #1842
- Removes the `.swamp/telemetry/` row from the "Files to Never Commit" table (already covered by `.swamp/` gitignore)
- Updates the "Recommended .gitignore" section from the legacy format to the current managed-section format (`# BEGIN/END` markers, `.swamp/`, `.swamp-sources.yaml`)

## Test Plan

- `deno fmt --check` passes
- `deno lint` passes
- `deno run test` passes (9085 tests)
- `npx tessl skill review .claude/skills/swamp` scores 98%

Closes swamp-club/lab#1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)