### PR TITLE
fix(issues): stop submission redactor from corrupting report bodies (swamp-club#1241)

### DIFF
--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -134,6 +134,10 @@ export const issueBugCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
   )
+  .option(
+    "--no-redact",
+    "Skip automatic redaction of sensitive content (use when the content is deliberately sanitized)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "bug"]);
     ctx.logger.debug`Submitting bug report`;
@@ -225,6 +229,7 @@ export const issueBugCommand = new Command()
         type: "bug",
         title,
         body,
+        noRedact: options.redact === false,
       });
       return;
     }
@@ -233,6 +238,7 @@ export const issueBugCommand = new Command()
       type: "bug",
       title,
       body,
+      noRedact: options.redact === false,
       swampLabTarget: extensionTarget?.kind === "swamp-lab"
         ? extensionTarget
         : undefined,

--- a/src/cli/commands/issue_edit.ts
+++ b/src/cli/commands/issue_edit.ts
@@ -27,14 +27,13 @@ import {
 } from "../../libswamp/mod.ts";
 import {
   renderIssueCancelled,
+  renderRedactionNotice,
+  renderRedactionSkipped,
 } from "../../presentation/renderers/issue_create.ts";
 import { createIssueEditRenderer } from "../../presentation/renderers/issue_edit.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
-import {
-  formatRedactionSummary,
-  redactIssueTitleAndBody,
-} from "../../domain/issues/content_redactor.ts";
+import { redactIssueTitleAndBody } from "../../domain/issues/content_redactor.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
 import { loadIdentity } from "../load_identity.ts";
@@ -126,6 +125,10 @@ export const issueEditCommand = new Command()
   .option(
     "--type <type:string>",
     "Change issue type (bug, feature, or security); escalating to security restricts visibility and cannot be reversed by non-admins",
+  )
+  .option(
+    "--no-redact",
+    "Skip automatic redaction of sensitive content (use when the content is deliberately sanitized)",
   )
   .action(async function (options: AnyOptions, issueNumber: number) {
     const ctx = createContext(options as GlobalOptions, ["issue", "edit"]);
@@ -234,16 +237,17 @@ export const issueEditCommand = new Command()
     }
 
     // Redact sensitive content before submission.
-    const redacted = redactIssueTitleAndBody(title, body);
-    if (redacted.summary.totalRedactions > 0) {
-      const msg = formatRedactionSummary(redacted.summary);
-      ctx.logger.info`${msg}`;
-      if (ctx.outputMode === "json") {
-        console.error(msg);
-      }
+    if (options.redact === false) {
+      renderRedactionSkipped(ctx.outputMode);
+    } else {
+      const redacted = redactIssueTitleAndBody(title, body);
+      renderRedactionNotice(redacted.summary, [
+        { label: "title", result: redacted.title },
+        { label: "body", result: redacted.body },
+      ], ctx.outputMode);
+      title = redacted.title.text;
+      body = redacted.body.text;
     }
-    title = redacted.title.text;
-    body = redacted.body.text;
 
     const libCtx = createLibSwampContext({ logger: ctx.logger });
     const renderer = createIssueEditRenderer(ctx.outputMode);

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -133,6 +133,10 @@ export const issueFeatureCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
   )
+  .option(
+    "--no-redact",
+    "Skip automatic redaction of sensitive content (use when the content is deliberately sanitized)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "feature"]);
     ctx.logger.debug`Submitting feature request`;
@@ -219,6 +223,7 @@ export const issueFeatureCommand = new Command()
         type: "feature",
         title,
         body,
+        noRedact: options.redact === false,
       });
       return;
     }
@@ -227,6 +232,7 @@ export const issueFeatureCommand = new Command()
       type: "feature",
       title,
       body,
+      noRedact: options.redact === false,
       swampLabTarget: extensionTarget?.kind === "swamp-lab"
         ? extensionTarget
         : undefined,

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -29,13 +29,12 @@ import {
 import {
   createIssueCommentRenderer,
   renderIssueCancelled,
+  renderRedactionNotice,
+  renderRedactionSkipped,
 } from "../../presentation/renderers/issue_create.ts";
 import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import { UserError } from "../../domain/errors.ts";
-import {
-  formatRedactionSummary,
-  redactIssueContent,
-} from "../../domain/issues/content_redactor.ts";
+import { redactIssueContent } from "../../domain/issues/content_redactor.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
 import { loadIdentity } from "../load_identity.ts";
@@ -88,6 +87,10 @@ export const issueRippleCommand = new Command()
   .option("--reopen", "Reopen the issue after posting the ripple", {
     conflicts: ["close"],
   })
+  .option(
+    "--no-redact",
+    "Skip automatic redaction of sensitive content (use when the content is deliberately sanitized)",
+  )
   .action(async function (options: AnyOptions, issueNumber: number) {
     const ctx = createContext(options as GlobalOptions, ["issue", "ripple"]);
 
@@ -143,15 +146,17 @@ export const issueRippleCommand = new Command()
     }
 
     // Redact sensitive content before submission.
-    const redacted = redactIssueContent(body);
-    if (redacted.summary.totalRedactions > 0) {
-      const msg = formatRedactionSummary(redacted.summary);
-      ctx.logger.info`${msg}`;
-      if (ctx.outputMode === "json") {
-        console.error(msg);
-      }
+    if (options.redact === false) {
+      renderRedactionSkipped(ctx.outputMode);
+    } else {
+      const redacted = redactIssueContent(body);
+      renderRedactionNotice(
+        redacted.summary,
+        [{ result: redacted }],
+        ctx.outputMode,
+      );
+      body = redacted.text;
     }
-    body = redacted.text;
 
     const statusTransition: IssueStatusTransition | undefined = options.close
       ? "closed"

--- a/src/cli/commands/issue_security.ts
+++ b/src/cli/commands/issue_security.ts
@@ -139,6 +139,10 @@ export const issueSecurityCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR) — only used with --extension",
   )
+  .option(
+    "--no-redact",
+    "Skip automatic redaction of sensitive content (use when the content is deliberately sanitized)",
+  )
   .action(async function (options: AnyOptions) {
     const ctx = createContext(options as GlobalOptions, ["issue", "security"]);
     ctx.logger.debug`Submitting security report`;
@@ -225,6 +229,7 @@ export const issueSecurityCommand = new Command()
         type: "security",
         title,
         body,
+        noRedact: options.redact === false,
       });
       return;
     }
@@ -233,6 +238,7 @@ export const issueSecurityCommand = new Command()
       type: "security",
       title,
       body,
+      noRedact: options.redact === false,
       swampLabTarget: extensionTarget?.kind === "swamp-lab"
         ? extensionTarget
         : undefined,

--- a/src/cli/commands/issue_submit.ts
+++ b/src/cli/commands/issue_submit.ts
@@ -40,6 +40,8 @@ import {
   createIssueCreateRenderer,
   renderExtensionRefusal,
   renderExtensionRepositoryHandoff,
+  renderRedactionNotice,
+  renderRedactionSkipped,
 } from "../../presentation/renderers/issue_create.ts";
 import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
@@ -47,10 +49,7 @@ import { loadIdentity } from "../load_identity.ts";
 import { openBrowser } from "../../infrastructure/process/browser.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
-import {
-  formatRedactionSummary,
-  redactIssueTitleAndBody,
-} from "../../domain/issues/content_redactor.ts";
+import { redactIssueTitleAndBody } from "../../domain/issues/content_redactor.ts";
 import {
   dispatchRepositoryReport,
   type ExtensionTarget,
@@ -104,6 +103,11 @@ export interface SubmitIssueInput {
   type: "bug" | "feature" | "security";
   title: string;
   body: string;
+  /**
+   * Skip automatic redaction (--no-redact). For reporters who have
+   * deliberately sanitized their content and need it submitted as written.
+   */
+  noRedact?: boolean;
   /**
    * Pre-resolved `@swamp/*` target (from {@link resolveExtensionOrRefuse}).
    * Only passed on the `@swamp/*` extension path — third-party targets
@@ -188,16 +192,26 @@ export async function resolveExtensionOrRefuse(
 export async function dispatchExtensionRepositoryReport(
   ctx: CommandContext,
   target: Extract<UsableExtensionTarget, { kind: "repository" }>,
-  input: { type: "bug" | "feature" | "security"; title: string; body: string },
+  input: {
+    type: "bug" | "feature" | "security";
+    title: string;
+    body: string;
+    noRedact?: boolean;
+  },
 ): Promise<void> {
   // Redact sensitive content before dispatching to a third-party repo.
-  const redacted = redactIssueTitleAndBody(input.title, input.body);
-  if (redacted.summary.totalRedactions > 0) {
-    const msg = formatRedactionSummary(redacted.summary);
-    ctx.logger.info`${msg}`;
-    if (ctx.outputMode === "json") {
-      console.error(msg);
-    }
+  let title = input.title;
+  let body = input.body;
+  if (input.noRedact) {
+    renderRedactionSkipped(ctx.outputMode);
+  } else {
+    const redacted = redactIssueTitleAndBody(input.title, input.body);
+    renderRedactionNotice(redacted.summary, [
+      { label: "title", result: redacted.title },
+      { label: "body", result: redacted.body },
+    ], ctx.outputMode);
+    title = redacted.title.text;
+    body = redacted.body.text;
   }
 
   const reporterContext = collectReporterContext({
@@ -209,8 +223,8 @@ export async function dispatchExtensionRepositoryReport(
     target,
     {
       type: input.type,
-      title: redacted.title.text,
-      body: redacted.body.text,
+      title,
+      body,
       reporterContext,
       outputMode: ctx.outputMode,
     },
@@ -239,21 +253,22 @@ export async function submitIssue(
   const libCtx = createLibSwampContext({ logger: ctx.logger });
   const renderer = createIssueCreateRenderer(ctx.outputMode);
 
-  // Redact sensitive content before any submission path.
-  const redacted = redactIssueTitleAndBody(input.title, input.body);
-  if (redacted.summary.totalRedactions > 0) {
-    const msg = formatRedactionSummary(redacted.summary);
-    libCtx.logger.info`${msg}`;
-    if (ctx.outputMode === "json") {
-      console.error(msg);
-    }
-  }
-  input = { ...input, title: redacted.title.text, body: redacted.body.text };
-
   if (destination.method === "abort") {
     libCtx.logger
       .info`Run "swamp auth login" first, then retry this command.`;
     return;
+  }
+
+  // Redact sensitive content before any submission path.
+  if (input.noRedact) {
+    renderRedactionSkipped(ctx.outputMode);
+  } else {
+    const redacted = redactIssueTitleAndBody(input.title, input.body);
+    renderRedactionNotice(redacted.summary, [
+      { label: "title", result: redacted.title },
+      { label: "body", result: redacted.body },
+    ], ctx.outputMode);
+    input = { ...input, title: redacted.title.text, body: redacted.body.text };
   }
 
   if (destination.method === "email") {

--- a/src/domain/issues/content_redactor.ts
+++ b/src/domain/issues/content_redactor.ts
@@ -45,10 +45,23 @@ export interface RedactionSummary {
   readonly categories: ReadonlyMap<string, number>;
 }
 
+/**
+ * A single line-level change produced by redaction, so the reporter can
+ * see exactly what was altered before the content leaves their machine.
+ * When a redaction consumes newlines, one change spans the affected block
+ * and `original`/`redacted` hold the joined multi-line text.
+ */
+export interface RedactionLineChange {
+  readonly lineNumber: number;
+  readonly original: string;
+  readonly redacted: string;
+}
+
 /** Result of redacting issue content. */
 export interface RedactionResult {
   readonly text: string;
   readonly summary: RedactionSummary;
+  readonly changes: readonly RedactionLineChange[];
 }
 
 const PUBLIC_HOST_ALLOWLIST = new Set([
@@ -94,8 +107,10 @@ const GITHUB_TOKEN_RE = /\b(?:ghp|gho|ghs|ghu|ghr)_[A-Za-z0-9_]{36,}\b/g;
 
 // Generic API keys / bearer tokens: long base64-ish strings with a prefix.
 // Use lookahead instead of \b after =* since = is non-word and \b fails
-// between two non-word characters (e.g. "==" followed by space).
-const BEARER_RE = /\bBearer\s+[A-Za-z0-9_\-.~+/]+=*(?=\s|$)/g;
+// between two non-word characters (e.g. "==" followed by space). The
+// separator is spaces/tabs only — \s would let the match cross a newline
+// and consume the first token of the following line.
+const BEARER_RE = /\bBearer[ \t]+([A-Za-z0-9_\-.~+/]+=*)(?=\s|$)/g;
 const PREFIXED_KEY_RE =
   /\b(?:sk|pk|rk|ak|key|token|secret)[-_][a-zA-Z0-9_\-]{20,}\b/gi;
 
@@ -106,13 +121,26 @@ const LONG_HEX_RE = /\b[0-9a-fA-F]{40,}\b/g;
 // Same =* lookahead fix as BEARER_RE.
 const LONG_BASE64_RE = /\b[A-Za-z0-9+/]{32,}={0,2}(?=\s|$)/g;
 
-// env-var style secrets: VAR_NAME=value where name contains sensitive keywords
+// env-var style secrets: VAR_NAME=value where name contains sensitive
+// keywords. The value is either an explicitly quoted span (matched as a
+// unit so the interior can be redacted with the delimiters preserved) or
+// an unquoted run that stops before a closing quote/backtick — a bare \S+
+// would consume the delimiter and break surrounding shell/YAML syntax.
 const ENV_SECRET_RE =
-  /\b([A-Z_]*(?:PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|PRIVATE_KEY|ACCESS_KEY|AUTH)[A-Z_]*)=(\S+)/gi;
+  /\b([A-Z_]*(?:PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|PRIVATE_KEY|ACCESS_KEY|AUTH)[A-Z_]*)=("[^"\n]*"|'[^'\n]*'|`[^`\n]*`|[^\s"'`]+)/gi;
 
-// Connection strings with credentials
+// Values that contain no secret material and must survive redaction:
+// already-masked values (all asterisks) and shell variable references —
+// exactly the "before" side of masking-bug evidence.
+const NON_SECRET_VALUE_RE = /^(?:\*+|\$\{[^}]*\})$/;
+
+// Connection strings with credentials. RFC 3986 forbids whitespace and "/"
+// in the userinfo component, so the user and password groups exclude them —
+// otherwise the password group can swallow everything (across lines) up to
+// an unrelated later "@", e.g. a ws://host:port URL followed by an
+// @scope/package mention.
 const CONNECTION_STRING_RE =
-  /(\w+:\/\/)([^:/?#]+):([^@]+)@([^/:?#]+)(:\d+)?(\/[^\s?#]*)?(\?[^\s#]*)?(#\S*)?/g;
+  /(\w+:\/\/)([^:/?#@\s]+):([^@/\s]+)@([^/:?#\s]+)(:\d+)?(\/[^\s?#]*)?(\?[^\s#]*)?(#\S*)?/g;
 
 // IPv4
 const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
@@ -197,34 +225,48 @@ function applyRedactions(
     },
   );
 
-  // 2. Env-var style secrets
-  result = result.replace(ENV_SECRET_RE, (_match, name: string) => {
-    count("secret");
-    return `${name}=[REDACTED-SECRET]`;
-  });
+  // 2. Env-var style secrets. Quoted values are redacted inside their
+  //    delimiters; masked (***) and ${VAR} values pass through untouched.
+  //    Distinct values get distinct indexed placeholders so before/after
+  //    evidence (e.g. a masked-vs-unmasked comparison table) keeps its
+  //    contrast instead of collapsing to identical rows.
+  result = result.replace(
+    ENV_SECRET_RE,
+    (match, name: string, value: string) => {
+      const first = value[0];
+      const quote = first === '"' || first === "'" || first === "`"
+        ? first
+        : "";
+      const inner = quote ? value.slice(1, -1) : value;
+      if (inner.length === 0 || NON_SECRET_VALUE_RE.test(inner)) return match;
+      count("secret");
+      const placeholder = placeholders.get("REDACTED-SECRET", inner);
+      return `${name}=${quote}${placeholder}${quote}`;
+    },
+  );
 
   // 3. AWS keys
-  result = result.replace(AWS_KEY_RE, () => {
+  result = result.replace(AWS_KEY_RE, (match) => {
     count("secret");
-    return "[REDACTED-SECRET]";
+    return placeholders.get("REDACTED-SECRET", match);
   });
 
   // 4. GitHub tokens
-  result = result.replace(GITHUB_TOKEN_RE, () => {
+  result = result.replace(GITHUB_TOKEN_RE, (match) => {
     count("secret");
-    return "[REDACTED-SECRET]";
+    return placeholders.get("REDACTED-SECRET", match);
   });
 
   // 5. Bearer tokens
-  result = result.replace(BEARER_RE, () => {
+  result = result.replace(BEARER_RE, (_match, token: string) => {
     count("secret");
-    return "Bearer [REDACTED-SECRET]";
+    return `Bearer ${placeholders.get("REDACTED-SECRET", token)}`;
   });
 
   // 6. Prefixed API keys (sk_live_..., token-..., etc.)
-  result = result.replace(PREFIXED_KEY_RE, () => {
+  result = result.replace(PREFIXED_KEY_RE, (match) => {
     count("secret");
-    return "[REDACTED-SECRET]";
+    return placeholders.get("REDACTED-SECRET", match);
   });
 
   // 7. Email addresses
@@ -299,21 +341,63 @@ function applyRedactions(
   });
 
   // 16. Long hex strings (likely tokens/hashes — after all specific patterns)
-  result = result.replace(LONG_HEX_RE, () => {
+  result = result.replace(LONG_HEX_RE, (match) => {
     count("secret");
-    return "[REDACTED-SECRET]";
+    return placeholders.get("REDACTED-SECRET", match);
   });
 
   // 17. Long base64 strings
   result = result.replace(LONG_BASE64_RE, (match) => {
     if (/[a-z]/.test(match) && /[A-Z]/.test(match)) {
       count("secret");
-      return "[REDACTED-SECRET]";
+      return placeholders.get("REDACTED-SECRET", match);
     }
     return match;
   });
 
   return result;
+}
+
+function diffLines(
+  original: string,
+  redacted: string,
+): RedactionLineChange[] {
+  if (original === redacted) return [];
+  const before = original.split("\n");
+  const after = redacted.split("\n");
+  if (before.length === after.length) {
+    const changes: RedactionLineChange[] = [];
+    for (let i = 0; i < before.length; i++) {
+      if (before[i] !== after[i]) {
+        changes.push({
+          lineNumber: i + 1,
+          original: before[i],
+          redacted: after[i],
+        });
+      }
+    }
+    return changes;
+  }
+  // Line counts differ (a redaction consumed newlines): align matching
+  // head/tail lines and report the middle as a single block change.
+  let head = 0;
+  while (
+    head < before.length && head < after.length && before[head] === after[head]
+  ) {
+    head++;
+  }
+  let tail = 0;
+  while (
+    tail < before.length - head && tail < after.length - head &&
+    before[before.length - 1 - tail] === after[after.length - 1 - tail]
+  ) {
+    tail++;
+  }
+  return [{
+    lineNumber: head + 1,
+    original: before.slice(head, before.length - tail).join("\n"),
+    redacted: after.slice(head, after.length - tail).join("\n"),
+  }];
 }
 
 function buildSummary(counts: Map<string, number>): RedactionSummary {
@@ -335,7 +419,11 @@ export function redactIssueContent(text: string): RedactionResult {
   const placeholders = new PlaceholderMap();
   const counts = new Map<string, number>();
   const redacted = applyRedactions(text, placeholders, counts);
-  return { text: redacted, summary: buildSummary(counts) };
+  return {
+    text: redacted,
+    summary: buildSummary(counts),
+    changes: diffLines(text, redacted),
+  };
 }
 
 /**
@@ -368,8 +456,16 @@ export function redactIssueTitleAndBody(
   }
 
   return {
-    title: { text: titleText, summary: buildSummary(titleCounts) },
-    body: { text: bodyText, summary: buildSummary(bodyCounts) },
+    title: {
+      text: titleText,
+      summary: buildSummary(titleCounts),
+      changes: diffLines(title, titleText),
+    },
+    body: {
+      text: bodyText,
+      summary: buildSummary(bodyCounts),
+      changes: diffLines(body, bodyText),
+    },
     summary: buildSummary(counts),
   };
 }
@@ -388,4 +484,29 @@ export function formatRedactionSummary(summary: RedactionSummary): string {
     parts.push(`${count} ${pluralize(category, count)}`);
   }
   return `Redacted ${parts.join(", ")} from issue content.`;
+}
+
+const MAX_DETAIL_LENGTH = 160;
+
+function inlineTruncate(text: string): string {
+  const flat = text.replaceAll("\n", "\\n");
+  if (flat.length <= MAX_DETAIL_LENGTH) return flat;
+  return flat.slice(0, MAX_DETAIL_LENGTH - 1) + "…";
+}
+
+/**
+ * Formats per-line redaction changes into human-readable detail lines
+ * ("line N: <original> -> <redacted>"), so the reporter can verify their
+ * evidence survived redaction. `label` prefixes the location (e.g. "title").
+ */
+export function formatRedactionDetails(
+  changes: readonly RedactionLineChange[],
+  label?: string,
+): string[] {
+  const prefix = label ? `${label} line` : "line";
+  return changes.map((change) =>
+    `${prefix} ${change.lineNumber}: ${inlineTruncate(change.original)} -> ${
+      inlineTruncate(change.redacted)
+    }`
+  );
 }

--- a/src/domain/issues/content_redactor_test.ts
+++ b/src/domain/issues/content_redactor_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  formatRedactionDetails,
   formatRedactionSummary,
   redactIssueContent,
   redactIssueTitleAndBody,
@@ -43,7 +44,7 @@ Deno.test("redactIssueContent: redacts AWS access key IDs", () => {
   const result = redactIssueContent(
     "The key AKIAIOSFODNN7EXAMPLE was exposed",
   );
-  assertEquals(result.text, "The key [REDACTED-SECRET] was exposed");
+  assertEquals(result.text, "The key [REDACTED-SECRET-1] was exposed");
   assertEquals(result.summary.categories.get("secret"), 1);
 });
 
@@ -53,7 +54,7 @@ Deno.test("redactIssueContent: redacts GitHub tokens", () => {
   );
   assertEquals(
     result.text,
-    "Token [REDACTED-SECRET] was in the log",
+    "Token [REDACTED-SECRET-1] was in the log",
   );
 });
 
@@ -61,28 +62,87 @@ Deno.test("redactIssueContent: redacts Bearer tokens", () => {
   const result = redactIssueContent(
     "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test",
   );
-  assertStringIncludes(result.text, "Bearer [REDACTED-SECRET]");
+  assertStringIncludes(result.text, "Bearer [REDACTED-SECRET-1]");
 });
 
 Deno.test("redactIssueContent: redacts padded Bearer tokens", () => {
   const result = redactIssueContent(
     "Bearer dG9rZW5WYWx1ZTEyMzQ1Njc4OTAxMjM0NTY3ODkw== next",
   );
-  assertEquals(result.text, "Bearer [REDACTED-SECRET] next");
+  assertEquals(result.text, "Bearer [REDACTED-SECRET-1] next");
+});
+
+Deno.test("redactIssueContent: Bearer at end of line leaves the next line alone", () => {
+  const result = redactIssueContent(
+    "The header was Bearer\nRestart the daemon",
+  );
+  assertEquals(result.text, "The header was Bearer\nRestart the daemon");
 });
 
 Deno.test("redactIssueContent: redacts prefixed API keys", () => {
   const result = redactIssueContent(
     "API key sk_test_00000000000000000000",
   );
-  assertEquals(result.text, "API key [REDACTED-SECRET]");
+  assertEquals(result.text, "API key [REDACTED-SECRET-1]");
 });
 
 Deno.test("redactIssueContent: redacts env-var style secrets", () => {
   const result = redactIssueContent(
     "DATABASE_PASSWORD=hunter2 was in .env",
   );
-  assertEquals(result.text, "DATABASE_PASSWORD=[REDACTED-SECRET] was in .env");
+  assertEquals(
+    result.text,
+    "DATABASE_PASSWORD=[REDACTED-SECRET-1] was in .env",
+  );
+});
+
+Deno.test("redactIssueContent: env-var values keep their closing quote", () => {
+  const result = redactIssueContent(
+    'run: echo "MY_TOKEN=hunter2" in the shell',
+  );
+  assertEquals(
+    result.text,
+    'run: echo "MY_TOKEN=[REDACTED-SECRET-1]" in the shell',
+  );
+});
+
+Deno.test("redactIssueContent: quote-initial env-var values are redacted inside their delimiters", () => {
+  const result = redactIssueContent('MY_TOKEN="real secret value"');
+  assertEquals(result.text, 'MY_TOKEN="[REDACTED-SECRET-1]"');
+});
+
+Deno.test("redactIssueContent: masked env-var values pass through untouched", () => {
+  const result = redactIssueContent("| case A | MY_TOKEN=*** |");
+  assertEquals(result.text, "| case A | MY_TOKEN=*** |");
+  assertEquals(result.summary.totalRedactions, 0);
+});
+
+Deno.test("redactIssueContent: variable-reference env-var values pass through untouched", () => {
+  const input = 'run: echo "MY_TOKEN=${FROM_VAULT}"';
+  const result = redactIssueContent(input);
+  assertEquals(result.text, input);
+  assertEquals(result.summary.totalRedactions, 0);
+});
+
+Deno.test("redactIssueContent: masked-vs-unmasked evidence table keeps its contrast", () => {
+  const input = [
+    "| case A | MY_TOKEN=*** |",
+    "| case B | MY_TOKEN=the-actual-value |",
+  ].join("\n");
+  const result = redactIssueContent(input);
+  const [rowA, rowB] = result.text.split("\n");
+  assertEquals(rowA, "| case A | MY_TOKEN=*** |");
+  assertEquals(rowB, "| case B | MY_TOKEN=[REDACTED-SECRET-1] |");
+});
+
+Deno.test("redactIssueContent: distinct env-var values get distinct placeholders, same value the same one", () => {
+  const result = redactIssueContent(
+    "MY_TOKEN=first-value OTHER_SECRET=second-value AGAIN_TOKEN=first-value",
+  );
+  assertEquals(
+    result.text,
+    "MY_TOKEN=[REDACTED-SECRET-1] OTHER_SECRET=[REDACTED-SECRET-2] AGAIN_TOKEN=[REDACTED-SECRET-1]",
+  );
 });
 
 Deno.test("redactIssueContent: redacts SSN patterns", () => {
@@ -261,7 +321,21 @@ Deno.test("redactIssueContent: handles multiple categories in one text", () => {
 Deno.test("redactIssueContent: long hex strings are redacted", () => {
   const hex = "a".repeat(40);
   const result = redactIssueContent(`Token was ${hex} in header`);
-  assertEquals(result.text, "Token was [REDACTED-SECRET] in header");
+  assertEquals(result.text, "Token was [REDACTED-SECRET-1] in header");
+});
+
+Deno.test("redactIssueContent: scheme URL without credentials does not swallow following lines", () => {
+  const input = [
+    "Steps:",
+    "1. Point the client at ws://gateway:9000/socket",
+    "2. Observe the reconnect loop",
+    "3. Expected: single connection",
+    "",
+    "Uses the @swamp/issue-lifecycle package.",
+  ].join("\n");
+  const result = redactIssueContent(input);
+  assertEquals(result.text, input);
+  assertEquals(result.summary.totalRedactions, 0);
 });
 
 Deno.test("redactIssueContent: IPv6 addresses are redacted", () => {
@@ -300,6 +374,72 @@ Deno.test("redactIssueTitleAndBody: returns combined summary", () => {
     (result.summary.categories.get("IP address") ?? 0) >= 2,
     true,
   );
+});
+
+// --- line-level changes ---
+
+Deno.test("redactIssueContent: reports per-line changes with line numbers", () => {
+  const input = [
+    "First line is fine",
+    "DATABASE_PASSWORD=hunter2 leaked here",
+    "Third line is fine",
+    "Contact admin@corp.com about it",
+  ].join("\n");
+  const result = redactIssueContent(input);
+  assertEquals(result.changes.length, 2);
+  assertEquals(result.changes[0].lineNumber, 2);
+  assertEquals(
+    result.changes[0].original,
+    "DATABASE_PASSWORD=hunter2 leaked here",
+  );
+  assertEquals(
+    result.changes[0].redacted,
+    "DATABASE_PASSWORD=[REDACTED-SECRET-1] leaked here",
+  );
+  assertEquals(result.changes[1].lineNumber, 4);
+});
+
+Deno.test("redactIssueContent: reports no changes when nothing was redacted", () => {
+  const result = redactIssueContent("Nothing sensitive here");
+  assertEquals(result.changes.length, 0);
+});
+
+Deno.test("redactIssueTitleAndBody: reports changes per field", () => {
+  const result = redactIssueTitleAndBody(
+    "Error contacting 10.0.3.47",
+    "All good in the body",
+  );
+  assertEquals(result.title.changes.length, 1);
+  assertEquals(result.title.changes[0].lineNumber, 1);
+  assertEquals(result.body.changes.length, 0);
+});
+
+// --- formatRedactionDetails ---
+
+Deno.test("formatRedactionDetails: formats line number and before/after", () => {
+  const lines = formatRedactionDetails([
+    { lineNumber: 3, original: "TOKEN=abc", redacted: "TOKEN=[X-1]" },
+  ]);
+  assertEquals(lines, ["line 3: TOKEN=abc -> TOKEN=[X-1]"]);
+});
+
+Deno.test("formatRedactionDetails: prefixes the label when given", () => {
+  const lines = formatRedactionDetails(
+    [{ lineNumber: 1, original: "a", redacted: "b" }],
+    "title",
+  );
+  assertEquals(lines, ["title line 1: a -> b"]);
+});
+
+Deno.test("formatRedactionDetails: escapes newlines and truncates long content", () => {
+  const long = "x".repeat(500);
+  const lines = formatRedactionDetails([
+    { lineNumber: 2, original: `one\ntwo\n${long}`, redacted: "gone" },
+  ]);
+  assertStringIncludes(lines[0], "one\\ntwo\\n");
+  assertEquals(lines[0].includes("\n"), false);
+  assertStringIncludes(lines[0], "…");
+  assertStringIncludes(lines[0], "-> gone");
 });
 
 // --- formatRedactionSummary ---

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -30,6 +30,12 @@ import type {
   RefusalReason,
   RepositoryDispatchResult,
 } from "../../cli/commands/extension_report_dispatcher.ts";
+import {
+  formatRedactionDetails,
+  formatRedactionSummary,
+  type RedactionResult,
+  type RedactionSummary,
+} from "../../domain/issues/content_redactor.ts";
 
 class LogIssueCreateRenderer implements Renderer<IssueCreateEvent> {
   handlers(): EventHandlers<IssueCreateEvent> {
@@ -137,6 +143,70 @@ export function renderIssueCancelled(
       logger.info(`${action} cancelled`);
     }
   }
+}
+
+// ---- Redaction notice rendering ----
+
+/**
+ * Pre-submission redaction notice: one labelled field (title/body for
+ * submissions and edits, unlabelled for ripples) with its redaction result.
+ */
+export interface RedactionNoticeField {
+  label?: "title" | "body";
+  result: RedactionResult;
+}
+
+/**
+ * Renders what redaction changed before content leaves the machine, so the
+ * reporter can tell a harmless redaction from a destroyed finding. Log mode
+ * prints the summary plus one "line N: <original> -> <redacted>" entry per
+ * change; json mode emits the structured detail on stderr (stdout carries
+ * the command's primary JSON). No-op when nothing was redacted.
+ */
+export function renderRedactionNotice(
+  summary: RedactionSummary,
+  fields: RedactionNoticeField[],
+  mode: OutputMode,
+): void {
+  if (summary.totalRedactions === 0) return;
+  const message = formatRedactionSummary(summary);
+  if (mode === "json") {
+    const changes = fields.flatMap((field) =>
+      field.result.changes.map((change) => ({
+        ...(field.label ? { field: field.label } : {}),
+        ...change,
+      }))
+    );
+    console.error(JSON.stringify({
+      redaction: { message, total: summary.totalRedactions, changes },
+    }));
+    return;
+  }
+  const logger = getSwampLogger(["issue", "redact"]);
+  // Tagged-template form: detail lines carry user content that must not be
+  // parsed for {placeholder} syntax.
+  logger.info`${message}`;
+  for (const field of fields) {
+    for (
+      const line of formatRedactionDetails(field.result.changes, field.label)
+    ) {
+      logger.info`${line}`;
+    }
+  }
+}
+
+/**
+ * Renders the notice that redaction was deliberately skipped via
+ * --no-redact, so the choice is visible and auditable in both modes.
+ */
+export function renderRedactionSkipped(mode: OutputMode): void {
+  if (mode === "json") {
+    console.error(JSON.stringify({ redaction: { skipped: true } }));
+    return;
+  }
+  getSwampLogger(["issue", "redact"]).info(
+    "Redaction skipped (--no-redact); content submitted as written.",
+  );
 }
 
 // ---- Ripple (comment) rendering ----

--- a/src/presentation/renderers/issue_create_test.ts
+++ b/src/presentation/renderers/issue_create_test.ts
@@ -23,8 +23,11 @@ import {
   createIssueCreateRenderer,
   renderExtensionRefusal,
   renderExtensionRepositoryHandoff,
+  renderRedactionNotice,
+  renderRedactionSkipped,
 } from "./issue_create.ts";
 import type { RepositoryDispatchResult } from "../../cli/commands/extension_report_dispatcher.ts";
+import { redactIssueTitleAndBody } from "../../domain/issues/content_redactor.ts";
 
 /** Captures console.log calls during `fn` and returns the concatenated output. */
 async function captureConsoleLog(
@@ -235,4 +238,82 @@ Deno.test("renderExtensionRepositoryHandoff (json): refused result delegates to 
   const parsed = JSON.parse(out);
   assertEquals(parsed.status, "refused");
   assertEquals(parsed.reason, "pvr-disabled");
+});
+
+// ---- renderRedactionNotice / renderRedactionSkipped ----
+
+/** Captures console.error calls during `fn` and returns the concatenated output. */
+function captureConsoleError(fn: () => void): string {
+  const original = console.error;
+  const lines: string[] = [];
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.error = original;
+  }
+  return lines.join("\n");
+}
+
+Deno.test("renderRedactionNotice (json): emits structured changes on stderr", () => {
+  const redacted = redactIssueTitleAndBody(
+    "Clean title",
+    "line one\nDATABASE_PASSWORD=hunter2\nline three",
+  );
+  const out = captureConsoleError(() => {
+    renderRedactionNotice(redacted.summary, [
+      { label: "title", result: redacted.title },
+      { label: "body", result: redacted.body },
+    ], "json");
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.redaction.total, 1);
+  assertEquals(parsed.redaction.changes.length, 1);
+  assertEquals(parsed.redaction.changes[0].field, "body");
+  assertEquals(parsed.redaction.changes[0].lineNumber, 2);
+  assertEquals(
+    parsed.redaction.changes[0].original,
+    "DATABASE_PASSWORD=hunter2",
+  );
+  assertEquals(
+    parsed.redaction.changes[0].redacted,
+    "DATABASE_PASSWORD=[REDACTED-SECRET-1]",
+  );
+  assertStringIncludes(parsed.redaction.message, "1 secret");
+});
+
+Deno.test("renderRedactionNotice (json): silent when nothing was redacted", () => {
+  const redacted = redactIssueTitleAndBody("Clean title", "Clean body");
+  const out = captureConsoleError(() => {
+    renderRedactionNotice(redacted.summary, [
+      { label: "title", result: redacted.title },
+      { label: "body", result: redacted.body },
+    ], "json");
+  });
+  assertEquals(out, "");
+});
+
+Deno.test("renderRedactionNotice (log): runs without error", () => {
+  const redacted = redactIssueTitleAndBody(
+    "Error contacting 10.0.3.47",
+    "DATABASE_PASSWORD=hunter2",
+  );
+  renderRedactionNotice(redacted.summary, [
+    { label: "title", result: redacted.title },
+    { label: "body", result: redacted.body },
+  ], "log");
+});
+
+Deno.test("renderRedactionSkipped (json): emits skipped marker on stderr", () => {
+  const out = captureConsoleError(() => {
+    renderRedactionSkipped("json");
+  });
+  const parsed = JSON.parse(out);
+  assertEquals(parsed.redaction.skipped, true);
+});
+
+Deno.test("renderRedactionSkipped (log): runs without error", () => {
+  renderRedactionSkipped("log");
 });


### PR DESCRIPTION
## Summary

Fixes swamp-club#1241: the issue-submission redactor silently corrupted report bodies in ways that could invert a report's meaning, and reported only a bare count.

Two matcher defects, both reproduced from the report:

- `ENV_SECRET_RE` captured values as `\S+`, consuming the closing quote/backtick after the value (breaking quoted YAML lines and code fences) and rewriting every sensitive-keyword `NAME=value` pair to the same flat placeholder — so a masked-vs-unmasked evidence table collapsed to two identical rows, turning proof of a masking bug into proof of nothing.
- `CONNECTION_STRING_RE`'s password group `([^@]+)` had no line or character bound, so a credential-free `scheme://host:port/path` URL matched as a credential URL and swallowed everything — across lines — up to an unrelated later `@scope/package` mention (the swamp-club#1213 failure).

Changes:

- Quoted env-var values are matched as a unit and redacted inside their delimiters; unquoted values stop before closing delimiters. Values with no secret material (all-asterisk masks, `${VAR}` references) pass through untouched.
- Secret redactions emit indexed `[REDACTED-SECRET-N]` placeholders via the existing `PlaceholderMap`, so distinct values stay distinguishable and before/after evidence keeps its contrast.
- Connection-string user/password/host groups are bounded to RFC-3986-legal characters (no whitespace, no `/`), and `Bearer`'s separator is spaces/tabs only — no matcher can span lines.
- Redaction is now visible: log mode prints `line N: <original> -> <redacted>` per change (truncated); `--json` mode emits structured detail on stderr, leaving the stdout JSON contract untouched.
- New `--no-redact` flag on `issue bug/feature/security/edit/ripple` for deliberately sanitized content, with an explicit notice in both modes.

Deliberate non-goal: no blanket redaction exemption for fenced code blocks/tables (the issue's top-ranked ask) — fences are where accidental secrets most often appear; the changes above fix every reported corruption without weakening that protection.

## Test Plan

- 50 unit tests in `content_redactor_test.ts` including regressions lifted from the report: masked/unmasked table rows keep contrast, quoted YAML keeps its closing quote, quote-initial secrets still redact, `${VAR}`/`***` pass through, `ws://host:port` steps survive a later `@`-mention, Bearer at end-of-line leaves the next line alone, per-line change records carry correct line numbers.
- Renderer tests for the structured stderr detail, the silent-when-clean path, and the `--no-redact` notice in both output modes.
- Full suite: 9103 passed, 0 failed. `deno check`/`lint`/`fmt` clean; binary recompiled and the original reproduction re-run against it — both triggers now produce faithful output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)