### PR TITLE
fix(workflows): reject unknown workflow/job/step keys with actionable errors (swamp-club#1240)

### DIFF
--- a/.claude/skills/swamp/references/workflow/references/remote-execution.md
+++ b/.claude/skills/swamp/references/workflow/references/remote-execution.md
@@ -57,6 +57,11 @@ all-busy queues the step, and no eligible worker fails the step fast. `forEach`
 is the fan-out construct — expand a step over a list and the instances spread
 across matching workers (each worker runs one dispatch at a time).
 
+Placement fields are step properties only. Placing them on a job or at the
+workflow top level fails schema validation with an error naming the misplaced
+key and showing the step-level form — as does any other unknown key (with a
+did-you-mean suggestion).
+
 ## Running workflows through the orchestrator
 
 `swamp serve` is the orchestrator, so placed workflows must run through it. From

--- a/design/workflow.md
+++ b/design/workflow.md
@@ -255,6 +255,33 @@ model **instance** which does not exist locally (`model_not_found`) produces a
 it could also be a typo. The warning surfaces the reference without failing
 validation.
 
+### Unknown Keys Are Rejected
+
+The workflow, job, and step schemas reject unknown keys at parse time with an
+actionable error (swamp-club#1240). Zod's default unknown-key stripping is
+disabled by a `rejectUnknownKeys` preprocess hook (chained after the
+removed-driver-fields guard, which keeps its specific migration message):
+
+- A step-level placement property (`labels`, `target`, `platform`,
+  `queueTimeout`) found on a job or workflow names the misplaced key and shows
+  the step-level form. Silent stripping here failed open: the placement intent
+  was discarded and the work ran on the orchestrator.
+- Any other unknown key gets a did-you-mean suggestion (Levenshtein) plus the
+  list of valid keys for that entity.
+
+Because a schema-rejected file is invisible to the repository loader (it is
+skipped with a warning), `workflow validate` and `workflow run` re-scan the raw
+files on a lookup miss and surface the parse error inline — a broken file fails
+validation naming the offending key, and can never make `validate` (or
+validate-all) report green.
+
+**Schema evolution consequence**: persisted evaluated-workflow snapshots and
+suspended approval runs are re-parsed on resume through these same schemas.
+Removing a schema field is therefore a breaking change for data persisted
+before the removal — it now requires an explicit migration or tolerance
+decision (the removed `driver`/`driverConfig` fields chose a hard, actionable
+failure), never a silent strip.
+
 ## Workflow Definition
 
 Workflows are specified in `workflows/workflow-{uuid}.yaml`. They have a unique

--- a/src/cli/commands/workflow_validate.ts
+++ b/src/cli/commands/workflow_validate.ts
@@ -28,6 +28,7 @@ import {
   consumeStream,
   createLibSwampContext,
   createWorkflowValidateDeps,
+  workflowsDirFor,
   workflowValidate,
 } from "../../libswamp/mod.ts";
 import { createWorkflowValidateRenderer } from "../../presentation/renderers/workflow_validate.ts";
@@ -51,7 +52,7 @@ export const workflowValidateCommand = new Command()
       "workflow",
       "validate",
     ]);
-    const { repoContext } = await requireInitializedRepoReadOnly({
+    const { repoContext, repoDir } = await requireInitializedRepoReadOnly({
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     });
@@ -66,6 +67,7 @@ export const workflowValidateCommand = new Command()
     const deps = createWorkflowValidateDeps(
       repoContext.workflowRepo,
       repoContext.definitionRepo,
+      workflowsDirFor(repoDir),
     );
 
     const renderer = createWorkflowValidateRenderer(cliCtx.outputMode);

--- a/src/domain/workflows/job.ts
+++ b/src/domain/workflows/job.ts
@@ -25,6 +25,7 @@ import {
 } from "./trigger_condition.ts";
 import { Step, type StepData, StepSchema } from "./step.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
+import { rejectUnknownKeys } from "./unknown_keys.ts";
 
 /**
  * Schema for job dependency with condition.
@@ -71,11 +72,16 @@ const JobObjectSchema = z.object({
 
 /**
  * Zod schema for Job entity. Rejects the removed `driver`/`driverConfig`
- * fields with an actionable error (see design/remote-execution.md).
+ * fields with an actionable error (see design/remote-execution.md), and
+ * rejects unknown keys — Zod's silent stripping would otherwise discard
+ * misplaced placement blocks like a job-level `labels:` (swamp-club#1240).
  */
 export const JobSchema = z.preprocess(
   rejectRemovedDriverFields,
-  JobObjectSchema,
+  z.preprocess(
+    rejectUnknownKeys("job", Object.keys(JobObjectSchema.shape)),
+    JobObjectSchema,
+  ),
 );
 
 /**

--- a/src/domain/workflows/job_test.ts
+++ b/src/domain/workflows/job_test.ts
@@ -238,6 +238,54 @@ Deno.test("Job.fromData and toData roundtrip correctly", () => {
   assertEquals(restored.weight, original.weight);
 });
 
+// Unknown-key rejection tests (swamp-club#1240)
+
+Deno.test("JobSchema rejects job-level labels with step-property message", () => {
+  // Exact shape from swamp-club#1240 variant A: the labels block sits on
+  // the job, which previously passed and was silently dropped.
+  const error = assertThrows(
+    () =>
+      JobSchema.parse({
+        name: "placed",
+        labels: { fb28: "probe" },
+        steps: [{
+          name: "echo",
+          task: {
+            type: "model_method",
+            modelIdOrName: "fb28-probe",
+            methodName: "execute",
+            inputs: { run: 'echo "hello"' },
+          },
+        }],
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "'labels' is a step property");
+  assertStringIncludes(error.message, "job 'placed'");
+  assertStringIncludes(error.message, "Move it onto the step");
+});
+
+Deno.test("JobSchema rejects unknown key with did-you-mean suggestion", () => {
+  const error = assertThrows(
+    () =>
+      JobSchema.parse({
+        name: "build",
+        descripton: "typo",
+        steps: [{
+          name: "step1",
+          task: {
+            type: "model_method",
+            modelIdOrName: "my-model",
+            methodName: "run",
+          },
+        }],
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Unknown key 'descripton'");
+  assertStringIncludes(error.message, "Did you mean 'description'?");
+});
+
 Deno.test("JobSchema throws clear error for string dependsOn entries", () => {
   assertThrows(
     () => {

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -27,6 +27,7 @@ import { StepTask, StepTaskSchema } from "./step_task.ts";
 import { DataOutputOverrideSchema } from "../models/data_output_override.ts";
 import type { DataOutputOverride } from "../models/data_output_override.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
+import { rejectUnknownKeys } from "./unknown_keys.ts";
 
 /**
  * Schema for step dependency with condition.
@@ -96,11 +97,17 @@ const StepObjectSchema = z.object({
 
 /**
  * Zod schema for Step entity. Rejects the removed `driver`/`driverConfig`
- * fields with an actionable error (see design/remote-execution.md).
+ * fields with an actionable error (see design/remote-execution.md), and
+ * rejects unknown keys — Zod's silent stripping would otherwise discard a
+ * typo'd placement key (e.g. `lables:`) and run the step locally
+ * (swamp-club#1240).
  */
 export const StepSchema = z.preprocess(
   rejectRemovedDriverFields,
-  StepObjectSchema,
+  z.preprocess(
+    rejectUnknownKeys("step", Object.keys(StepObjectSchema.shape)),
+    StepObjectSchema,
+  ),
 );
 
 /**

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -375,6 +375,45 @@ Deno.test("StepSchema throws clear error for string dependsOn entries", () => {
   );
 });
 
+// Unknown-key rejection tests (swamp-club#1240)
+
+Deno.test("StepSchema rejects typo'd placement key with did-you-mean suggestion", () => {
+  // 'lables' would previously be stripped silently, discarding the
+  // placement intent and running the step locally.
+  const error = assertThrows(
+    () =>
+      StepSchema.parse({
+        name: "echo",
+        lables: { fb28: "probe" },
+        task: {
+          type: "model_method",
+          modelIdOrName: "fb28-probe",
+          methodName: "execute",
+        },
+      }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Unknown key 'lables' on step 'echo'");
+  assertStringIncludes(error.message, "Did you mean 'labels'?");
+});
+
+Deno.test("StepSchema accepts all placement keys at step level", () => {
+  const data = StepSchema.parse({
+    name: "placed",
+    task: {
+      type: "model_method",
+      modelIdOrName: "my-model",
+      methodName: "run",
+    },
+    target: "worker-1",
+    labels: { env: "prod" },
+    platform: "linux/amd64",
+    queueTimeout: 30,
+  });
+  assertEquals(data.labels, { env: "prod" });
+  assertEquals(data.target, "worker-1");
+});
+
 Deno.test("Step placement: undefined when no placement fields are set", () => {
   const step = Step.fromData({
     name: "local",

--- a/src/domain/workflows/unknown_keys.ts
+++ b/src/domain/workflows/unknown_keys.ts
@@ -1,0 +1,122 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * User-facing authoring guard that rejects unknown keys on workflow, job,
+ * and step objects.
+ *
+ * Zod strips unknown keys silently by default, which turns authoring
+ * mistakes into fail-open behavior: a `labels:` block placed on a job
+ * instead of a step passes validation and the placement intent is
+ * discarded, so the work runs on the orchestrator (swamp-club#1240).
+ * Like removed_driver_fields.ts, this hook runs in a `z.preprocess`
+ * wrapper so the raw keys are seen before unknown-key stripping drops
+ * them.
+ */
+
+import { findClosestMatch } from "../string_distance.ts";
+
+/** Entities whose schemas reject unknown keys. */
+export type WorkflowEntity = "workflow" | "job" | "step";
+
+/**
+ * Step-level remote-placement properties (see design/remote-execution.md).
+ * Misplacing these on a job or workflow is the dangerous authoring mistake:
+ * the placement intent is silently dropped and the step runs locally.
+ */
+const STEP_PLACEMENT_KEYS = ["labels", "target", "platform", "queueTimeout"];
+
+/**
+ * Fields owned by rejectRemovedDriverFields, which runs before this hook
+ * and produces its own migration message.
+ */
+const REMOVED_DRIVER_FIELDS = ["driver", "driverConfig"];
+
+/**
+ * Builds the error message for a step placement property found on a
+ * workflow or job.
+ */
+export function misplacedPlacementKeyMessage(
+  field: string,
+  entity: WorkflowEntity,
+  entityName: string | undefined,
+): string {
+  const where = entityName ? `${entity} '${entityName}'` : `a ${entity}`;
+  return `'${field}' is a step property, not a ${entity} property — ` +
+    `remote placement is declared per step (see design/remote-execution.md). ` +
+    `The key was found on ${where}.\n\n` +
+    `Move it onto the step:\n` +
+    `  steps:\n` +
+    `    - name: <step-name>\n` +
+    `      ${field}: ...\n` +
+    `      task:\n` +
+    `        ...`;
+}
+
+/**
+ * Builds the error message for an unknown key, with a did-you-mean
+ * suggestion when a known key is close enough.
+ */
+export function unknownKeyMessage(
+  field: string,
+  entity: WorkflowEntity,
+  entityName: string | undefined,
+  knownKeys: readonly string[],
+): string {
+  const where = entityName ? `${entity} '${entityName}'` : `${entity}`;
+  const suggestion = findClosestMatch(field, [...knownKeys]);
+  const didYouMean = suggestion ? ` Did you mean '${suggestion}'?` : "";
+  return `Unknown key '${field}' on ${where}.${didYouMean} ` +
+    `Valid ${entity} keys: ${knownKeys.join(", ")}`;
+}
+
+/**
+ * Creates a Zod preprocess hook that rejects unknown keys on a workflow,
+ * job, or step object with an actionable error. Chain it after
+ * rejectRemovedDriverFields so `driver`/`driverConfig` keep their specific
+ * migration message:
+ * `z.preprocess(rejectRemovedDriverFields, z.preprocess(rejectUnknownKeys(...), schema))`.
+ */
+export function rejectUnknownKeys(
+  entity: WorkflowEntity,
+  knownKeys: readonly string[],
+): (data: unknown) => unknown {
+  const known = new Set(knownKeys);
+  return (data: unknown): unknown => {
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      return data;
+    }
+    const record = data as Record<string, unknown>;
+    const entityName = typeof record.name === "string"
+      ? record.name
+      : undefined;
+    for (const field of Object.keys(record)) {
+      if (known.has(field) || REMOVED_DRIVER_FIELDS.includes(field)) {
+        continue;
+      }
+      if (entity !== "step" && STEP_PLACEMENT_KEYS.includes(field)) {
+        throw new Error(
+          misplacedPlacementKeyMessage(field, entity, entityName),
+        );
+      }
+      throw new Error(unknownKeyMessage(field, entity, entityName, knownKeys));
+    }
+    return data;
+  };
+}

--- a/src/domain/workflows/unknown_keys_test.ts
+++ b/src/domain/workflows/unknown_keys_test.ts
@@ -1,0 +1,112 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { rejectUnknownKeys } from "./unknown_keys.ts";
+
+const JOB_KEYS = [
+  "name",
+  "description",
+  "steps",
+  "dependsOn",
+  "weight",
+  "concurrency",
+];
+
+Deno.test("rejectUnknownKeys: passes through objects with only known keys", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  const data = { name: "build", steps: [], weight: 1 };
+  assertEquals(hook(data), data);
+});
+
+Deno.test("rejectUnknownKeys: passes through non-object values", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  assertEquals(hook(null), null);
+  assertEquals(hook(undefined), undefined);
+  assertEquals(hook("string"), "string");
+  assertEquals(hook(42), 42);
+  const arr = [{ unknown: true }];
+  assertEquals(hook(arr), arr);
+});
+
+Deno.test("rejectUnknownKeys: rejects job-level labels as a misplaced step property", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  const error = assertThrows(
+    () => hook({ name: "placed", labels: { fb28: "probe" }, steps: [] }),
+    Error,
+  );
+  assertStringIncludes(error.message, "'labels' is a step property");
+  assertStringIncludes(error.message, "job 'placed'");
+  assertStringIncludes(error.message, "Move it onto the step");
+});
+
+Deno.test("rejectUnknownKeys: rejects all placement keys on non-step entities", () => {
+  const hook = rejectUnknownKeys("workflow", ["name", "jobs"]);
+  for (const key of ["labels", "target", "platform", "queueTimeout"]) {
+    const error = assertThrows(
+      () => hook({ name: "wf", jobs: [], [key]: "x" }),
+      Error,
+    );
+    assertStringIncludes(error.message, `'${key}' is a step property`);
+    assertStringIncludes(error.message, "workflow 'wf'");
+  }
+});
+
+Deno.test("rejectUnknownKeys: placement keys on a step get the generic unknown-key message", () => {
+  // 'labels' etc. ARE step keys; a hook for steps must never see them as
+  // unknown. But if a placement-adjacent typo appears, it is a plain
+  // unknown key with a suggestion — not the misplaced-property message.
+  const hook = rejectUnknownKeys("step", ["name", "task", "labels"]);
+  const error = assertThrows(
+    () => hook({ name: "echo", task: {}, lables: { a: "b" } }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Unknown key 'lables' on step 'echo'");
+  assertStringIncludes(error.message, "Did you mean 'labels'?");
+});
+
+Deno.test("rejectUnknownKeys: unknown key without close match lists valid keys", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  const error = assertThrows(
+    () => hook({ name: "build", steps: [], zzz_bogus_zzz: 1 }),
+    Error,
+  );
+  assertStringIncludes(error.message, "Unknown key 'zzz_bogus_zzz'");
+  assertStringIncludes(
+    error.message,
+    "Valid job keys: name, description, steps, dependsOn, weight, concurrency",
+  );
+});
+
+Deno.test("rejectUnknownKeys: leaves driver/driverConfig for the removed-fields hook", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  const data = { name: "build", steps: [], driver: "docker" };
+  // Must pass through so rejectRemovedDriverFields (chained first in the
+  // schemas) produces its specific migration message.
+  assertEquals(hook(data), data);
+});
+
+Deno.test("rejectUnknownKeys: omits entity name when data has no string name", () => {
+  const hook = rejectUnknownKeys("job", JOB_KEYS);
+  const error = assertThrows(
+    () => hook({ steps: [], labels: {} }),
+    Error,
+  );
+  assertStringIncludes(error.message, "found on a job");
+});

--- a/src/domain/workflows/workflow.ts
+++ b/src/domain/workflows/workflow.ts
@@ -25,6 +25,7 @@ import {
   InputsSchemaSchema,
 } from "../definitions/definition.ts";
 import { rejectRemovedDriverFields } from "../removed_driver_fields.ts";
+import { rejectUnknownKeys } from "./unknown_keys.ts";
 import { deepMerge } from "../inputs/input_merge.ts";
 import {
   type ReportSelection,
@@ -77,11 +78,16 @@ const WorkflowObjectSchema = z.object({
 /**
  * Zod schema for Workflow aggregate root. Rejects the removed
  * `driver`/`driverConfig` fields with an actionable error (see
- * design/remote-execution.md).
+ * design/remote-execution.md), and rejects unknown keys — Zod's silent
+ * stripping would otherwise discard misplaced or typo'd top-level keys
+ * (swamp-club#1240).
  */
 export const WorkflowSchema = z.preprocess(
   rejectRemovedDriverFields,
-  WorkflowObjectSchema,
+  z.preprocess(
+    rejectUnknownKeys("workflow", Object.keys(WorkflowObjectSchema.shape)),
+    WorkflowObjectSchema,
+  ),
 );
 
 /**

--- a/src/domain/workflows/workflow_test.ts
+++ b/src/domain/workflows/workflow_test.ts
@@ -535,6 +535,66 @@ Deno.test("WorkflowSchema rejects removed driverConfig field with actionable err
   );
 });
 
+// Unknown-key rejection tests (swamp-club#1240)
+
+Deno.test("WorkflowSchema rejects workflow-level labels with step-property message", () => {
+  const error = assertThrows(
+    () =>
+      Workflow.fromData({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "test-workflow",
+        labels: { env: "prod" },
+        jobs: [createTestJob("job1").toData()],
+      } as unknown as WorkflowInput),
+    Error,
+  );
+  assertStringIncludes(error.message, "'labels' is a step property");
+  assertStringIncludes(error.message, "workflow 'test-workflow'");
+});
+
+Deno.test("WorkflowSchema rejects unknown top-level key with did-you-mean suggestion", () => {
+  const error = assertThrows(
+    () =>
+      Workflow.fromData({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "test-workflow",
+        verion: 1,
+        jobs: [createTestJob("job1").toData()],
+      } as unknown as WorkflowInput),
+    Error,
+  );
+  assertStringIncludes(error.message, "Unknown key 'verion'");
+  assertStringIncludes(error.message, "Did you mean 'version'?");
+});
+
+Deno.test("Workflow YAML with job-level labels fails to parse naming the key", () => {
+  // swamp-club#1240 variant A verbatim: previously passed validation and
+  // silently ran locally, discarding the placement intent.
+  const yaml = `
+id: 550e8400-e29b-41d4-a716-446655440000
+name: variant-a-job-labels
+jobs:
+  - name: placed
+    labels:
+      fb28: probe
+    steps:
+      - name: echo
+        task:
+          type: model_method
+          modelIdOrName: fb28-probe
+          methodName: execute
+          inputs:
+            run: echo "hello"
+`;
+  const data = parseYaml(yaml);
+  const error = assertThrows(
+    () => Workflow.fromData(data as WorkflowInput),
+    Error,
+  );
+  assertStringIncludes(error.message, "'labels' is a step property");
+  assertStringIncludes(error.message, "job 'placed'");
+});
+
 // Reports field tests
 
 Deno.test("Workflow.create creates workflow with reports", () => {

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -587,6 +587,14 @@ export {
   type WorkflowSchemaEvent,
 } from "./workflows/schema.ts";
 
+// Broken workflow file scanning
+export {
+  type BrokenWorkflow,
+  findBrokenWorkflow,
+  listBrokenWorkflows,
+  workflowsDirFor,
+} from "./workflows/broken_workflow.ts";
+
 // Workflow validate operations
 export {
   createWorkflowValidateDeps,

--- a/src/libswamp/workflows/broken_workflow.ts
+++ b/src/libswamp/workflows/broken_workflow.ts
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Raw-file scan for workflow files that fail schema parsing.
+ *
+ * The workflow repository skips unparseable files with a logged warning,
+ * so a schema-rejected workflow (e.g. one carrying an unknown key,
+ * swamp-club#1240) would otherwise surface as "Workflow not found" in
+ * `workflow validate` and `workflow run`. This helper re-reads the raw
+ * YAML the same way the doctor flow does, so those callers can surface
+ * the actual parse error inline.
+ */
+
+import { join } from "@std/path";
+import { parse as parseYaml } from "@std/yaml";
+import {
+  Workflow,
+  type WorkflowInput,
+} from "../../domain/workflows/workflow.ts";
+
+/** A workflow file that failed YAML parsing or schema validation. */
+export interface BrokenWorkflow {
+  /** Absolute path of the offending file. */
+  file: string;
+  /** Raw `name` from the YAML, when readable. */
+  name: string | null;
+  /** Raw `id` from the YAML, when readable. */
+  id: string | null;
+  /** The parse or schema error message. */
+  error: string;
+}
+
+/** Returns the workflows directory for a repo. */
+export function workflowsDirFor(repoDir: string): string {
+  return join(repoDir, "workflows");
+}
+
+/**
+ * Scans the workflows directory for `workflow-*.yaml` files (the set the
+ * repository loader reads) that fail to load, returning one entry per
+ * broken file. A missing directory yields an empty list.
+ */
+export async function listBrokenWorkflows(
+  workflowsDir: string,
+): Promise<BrokenWorkflow[]> {
+  const broken: BrokenWorkflow[] = [];
+
+  let entries: Deno.DirEntry[];
+  try {
+    entries = [];
+    for await (const entry of Deno.readDir(workflowsDir)) {
+      entries.push(entry);
+    }
+  } catch {
+    return broken;
+  }
+
+  const yamlFiles = entries
+    .filter((e) =>
+      e.isFile && e.name.startsWith("workflow-") && e.name.endsWith(".yaml")
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of yamlFiles) {
+    const file = join(workflowsDir, entry.name);
+    let content: string;
+    try {
+      content = await Deno.readTextFile(file);
+    } catch (readError) {
+      broken.push({
+        file,
+        name: null,
+        id: null,
+        error: readError instanceof Error
+          ? readError.message
+          : String(readError),
+      });
+      continue;
+    }
+
+    let raw: { name?: unknown; id?: unknown } | null = null;
+    try {
+      const parsed = parseYaml(content);
+      raw = parsed !== null && typeof parsed === "object"
+        ? parsed as { name?: unknown; id?: unknown }
+        : null;
+      Workflow.fromData(parsed as WorkflowInput);
+    } catch (parseError) {
+      broken.push({
+        file,
+        name: typeof raw?.name === "string" ? raw.name : null,
+        id: typeof raw?.id === "string" ? raw.id : null,
+        error: parseError instanceof Error
+          ? parseError.message
+          : String(parseError),
+      });
+    }
+  }
+
+  return broken;
+}
+
+/**
+ * Finds the broken workflow file whose raw `name` or `id` matches the
+ * given identifier, or null when every file loads (or none matches).
+ */
+export async function findBrokenWorkflow(
+  workflowsDir: string,
+  idOrName: string,
+): Promise<BrokenWorkflow | null> {
+  const broken = await listBrokenWorkflows(workflowsDir);
+  return broken.find((b) => b.name === idOrName || b.id === idOrName) ?? null;
+}

--- a/src/libswamp/workflows/broken_workflow_test.ts
+++ b/src/libswamp/workflows/broken_workflow_test.ts
@@ -1,0 +1,137 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import {
+  findBrokenWorkflow,
+  listBrokenWorkflows,
+  workflowsDirFor,
+} from "./broken_workflow.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      // Best-effort: EBUSY can fire when V8 hasn't GC'd native handles
+      // yet. Temp dir is ephemeral, OS reclaims.
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+const VALID_WORKFLOW = `
+id: 550e8400-e29b-41d4-a716-446655440000
+name: valid-workflow
+jobs:
+  - name: job1
+    steps:
+      - name: step1
+        task:
+          type: model_method
+          modelIdOrName: my-model
+          methodName: run
+`;
+
+const JOB_LABELS_WORKFLOW = `
+id: 74ae52ba-5f3f-4937-a4fd-c1de950572e7
+name: variant-a-job-labels
+jobs:
+  - name: placed
+    labels:
+      fb28: probe
+    steps:
+      - name: echo
+        task:
+          type: model_method
+          modelIdOrName: fb28-probe
+          methodName: execute
+          inputs:
+            run: echo "hello"
+`;
+
+Deno.test("workflowsDirFor: appends workflows to the repo dir", () => {
+  assertEquals(workflowsDirFor("/repo"), join("/repo", "workflows"));
+});
+
+Deno.test("listBrokenWorkflows: returns empty for a missing directory", async () => {
+  await withTempDir(async (dir) => {
+    const broken = await listBrokenWorkflows(join(dir, "does-not-exist"));
+    assertEquals(broken, []);
+  });
+});
+
+Deno.test("listBrokenWorkflows: skips valid files and reports schema-rejected ones", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      join(dir, "workflow-550e8400-e29b-41d4-a716-446655440000.yaml"),
+      VALID_WORKFLOW,
+    );
+    await Deno.writeTextFile(
+      join(dir, "workflow-74ae52ba-5f3f-4937-a4fd-c1de950572e7.yaml"),
+      JOB_LABELS_WORKFLOW,
+    );
+    // Files without the workflow- prefix are not loaded by the repository
+    // and must not be scanned.
+    await Deno.writeTextFile(join(dir, "notes.yaml"), "labels: nope");
+
+    const broken = await listBrokenWorkflows(dir);
+    assertEquals(broken.length, 1);
+    assertEquals(broken[0].name, "variant-a-job-labels");
+    assertEquals(broken[0].id, "74ae52ba-5f3f-4937-a4fd-c1de950572e7");
+    assertStringIncludes(broken[0].error, "'labels' is a step property");
+  });
+});
+
+Deno.test("listBrokenWorkflows: reports files with invalid YAML", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      join(dir, "workflow-bad.yaml"),
+      "id: [unclosed",
+    );
+    const broken = await listBrokenWorkflows(dir);
+    assertEquals(broken.length, 1);
+    assertEquals(broken[0].name, null);
+  });
+});
+
+Deno.test("findBrokenWorkflow: matches by raw name and by raw id", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      join(dir, "workflow-74ae52ba-5f3f-4937-a4fd-c1de950572e7.yaml"),
+      JOB_LABELS_WORKFLOW,
+    );
+
+    const byName = await findBrokenWorkflow(dir, "variant-a-job-labels");
+    assertEquals(byName?.name, "variant-a-job-labels");
+
+    const byId = await findBrokenWorkflow(
+      dir,
+      "74ae52ba-5f3f-4937-a4fd-c1de950572e7",
+    );
+    assertEquals(byId?.id, "74ae52ba-5f3f-4937-a4fd-c1de950572e7");
+
+    const miss = await findBrokenWorkflow(dir, "other-workflow");
+    assertEquals(miss, null);
+  });
+});

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -57,6 +57,7 @@ import {
   withGeneratorTraceContext,
 } from "../../infrastructure/tracing/mod.ts";
 import { WorkflowTelemetryBridge } from "./telemetry_bridge.ts";
+import { findBrokenWorkflow, workflowsDirFor } from "./broken_workflow.ts";
 
 /**
  * Events emitted by the libswamp workflow run generator.
@@ -498,9 +499,18 @@ export async function* workflowRun(
           input.workflowIdOrName,
         );
         if (!workflow) {
+          // A file carrying the requested name/id may exist but fail
+          // schema parsing, making it invisible to the repository lookup.
+          // Surface the parse error instead of a misleading "not found".
+          const broken = await findBrokenWorkflow(
+            workflowsDirFor(deps.repoDir),
+            input.workflowIdOrName,
+          );
           yield {
             kind: "error",
-            error: workflowNotFound(input.workflowIdOrName),
+            error: broken
+              ? workflowLoadFailed(input.workflowIdOrName, broken)
+              : workflowNotFound(input.workflowIdOrName),
           };
           return;
         }
@@ -675,6 +685,21 @@ export function workflowNotFound(idOrName: string): SwampError {
     message: `Workflow not found: ${idOrName}.\n` +
       `Create it with 'swamp workflow create ${idOrName}', ` +
       `or run 'swamp doctor workflows --json' to check for broken workflow files`,
+  };
+}
+
+/**
+ * Creates a SwampError for a workflow whose file exists but fails schema
+ * parsing (e.g. an unknown key, swamp-club#1240).
+ */
+export function workflowLoadFailed(
+  idOrName: string,
+  broken: { file: string; error: string },
+): SwampError {
+  return {
+    code: "workflow_load_failed",
+    message: `Workflow '${idOrName}' exists but failed to load: ` +
+      `${broken.error}\n(file: ${broken.file})`,
   };
 }
 

--- a/src/libswamp/workflows/run_test.ts
+++ b/src/libswamp/workflows/run_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   extractStepArtifacts,
   inputValidationFailed,
@@ -240,6 +240,52 @@ Deno.test("workflowRun yields error for missing workflow", async () => {
   assertEquals(last.kind, "error");
   if (last.kind === "error") {
     assertEquals(last.error.code, "workflow_not_found");
+  }
+});
+
+Deno.test("workflowRun surfaces the parse error for a schema-rejected workflow file", async () => {
+  // swamp-club#1240: a workflow file carrying an unknown key fails schema
+  // parsing, so the repository lookup misses — run must report the parse
+  // error inline instead of a misleading "not found".
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+  try {
+    await Deno.mkdir(join(repoDir, "workflows"));
+    await Deno.writeTextFile(
+      join(
+        repoDir,
+        "workflows",
+        "workflow-74ae52ba-5f3f-4937-a4fd-c1de950572e7.yaml",
+      ),
+      `
+id: 74ae52ba-5f3f-4937-a4fd-c1de950572e7
+name: variant-a-job-labels
+jobs:
+  - name: placed
+    labels:
+      fb28: probe
+    steps:
+      - name: echo
+        task:
+          type: model_method
+          modelIdOrName: fb28-probe
+          methodName: execute
+`,
+    );
+
+    const deps = { ...createTestDeps(null, []), repoDir };
+    const ctx = createLibSwampContext();
+    const events = await collect(workflowRun(ctx, deps, {
+      workflowIdOrName: "variant-a-job-labels",
+    }));
+
+    const last = events[events.length - 1];
+    assertEquals(last.kind, "error");
+    if (last.kind === "error") {
+      assertEquals(last.error.code, "workflow_load_failed");
+      assertStringIncludes(last.error.message, "'labels' is a step property");
+    }
+  } finally {
+    await Deno.remove(repoDir, { recursive: true }).catch(() => {});
   }
 });
 

--- a/src/libswamp/workflows/schema_test.ts
+++ b/src/libswamp/workflows/schema_test.ts
@@ -66,3 +66,40 @@ Deno.test("workflowSchema exposes trigger.inputs in the workflow schema", async 
     "workflow schema trigger should expose an 'inputs' property",
   );
 });
+
+Deno.test("workflowSchema exposes object properties through the preprocess layers", async () => {
+  // The workflow/job/step schemas are wrapped in two z.preprocess layers
+  // (removed driver fields + unknown-key rejection, swamp-club#1240); the
+  // emitted JSON schema must still surface the object properties.
+  const ctx = createLibSwampContext();
+  const events = await collect<WorkflowSchemaEvent>(workflowSchema(ctx));
+  const completed = events[0] as Extract<
+    WorkflowSchemaEvent,
+    { kind: "completed" }
+  >;
+
+  const asRecord = (value: unknown): Record<string, unknown> => {
+    assert(
+      typeof value === "object" && value !== null,
+      "expected an object node in the generated schema",
+    );
+    return value as Record<string, unknown>;
+  };
+
+  const jobProperties = asRecord(asRecord(completed.data.job).properties);
+  for (const key of ["name", "steps", "dependsOn", "weight"]) {
+    assert(key in jobProperties, `job schema should expose '${key}'`);
+  }
+
+  const stepProperties = asRecord(asRecord(completed.data.step).properties);
+  for (const key of ["name", "task", "labels", "target", "platform"]) {
+    assert(key in stepProperties, `step schema should expose '${key}'`);
+  }
+
+  const workflowProperties = asRecord(
+    asRecord(completed.data.workflow).properties,
+  );
+  for (const key of ["id", "name", "jobs", "version"]) {
+    assert(key in workflowProperties, `workflow schema should expose '${key}'`);
+  }
+});

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -36,6 +36,7 @@ import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.t
 import { zodToJsonSchema } from "../types/schema_helpers.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+import { type BrokenWorkflow, listBrokenWorkflows } from "./broken_workflow.ts";
 /** UUID v4 regex pattern for detecting if an argument is a UUID. */
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -89,6 +90,13 @@ export interface WorkflowValidateDeps {
   findWorkflowByName: (name: string) => Promise<Workflow | null>;
   findAllWorkflows: () => Promise<Workflow[]>;
   validate: (workflow: Workflow) => Promise<WorkflowValidationResult[]>;
+  /**
+   * Raw-scans workflow files that fail schema parsing (and are therefore
+   * invisible to the repository lookups above), so validate can report
+   * the parse error instead of "Workflow not found". Optional for
+   * backwards compatibility with callers that lack a workflows directory.
+   */
+  listBrokenWorkflows?: () => Promise<BrokenWorkflow[]>;
 }
 
 /**
@@ -197,6 +205,7 @@ async function resolveByType(
 export function createWorkflowValidateDeps(
   workflowRepo: WorkflowRepository,
   definitionRepo?: YamlDefinitionRepository,
+  workflowsDir?: string,
 ): WorkflowValidateDeps {
   const methodResolver = definitionRepo
     ? createModelMethodResolver(definitionRepo)
@@ -210,6 +219,26 @@ export function createWorkflowValidateDeps(
     findWorkflowByName: (name) => workflowRepo.findByName(name),
     findAllWorkflows: () => workflowRepo.findAll(),
     validate: (workflow) => validationService.validate(workflow),
+    ...(workflowsDir
+      ? { listBrokenWorkflows: () => listBrokenWorkflows(workflowsDir) }
+      : {}),
+  };
+}
+
+/** Converts a broken workflow file into a failed validation result. */
+function toBrokenValidateData(broken: BrokenWorkflow): WorkflowValidateData {
+  return {
+    workflowId: broken.id ?? "",
+    workflowName: broken.name ?? broken.file,
+    validations: [
+      {
+        name: "Schema validation",
+        passed: false,
+        error: `${broken.error} (file: ${broken.file})`,
+      },
+    ],
+    totalWarnings: 0,
+    passed: false,
   };
 }
 
@@ -238,7 +267,14 @@ async function* validateAll(
 ): AsyncIterable<WorkflowValidateEvent> {
   const allWorkflows = await deps.findAllWorkflows();
 
-  if (allWorkflows.length === 0) {
+  // Files the repository skipped because they fail schema parsing must
+  // count as failures — otherwise a broken file makes validate-all report
+  // all-green while the workflow silently no longer loads.
+  const brokenWorkflows = deps.listBrokenWorkflows
+    ? await deps.listBrokenWorkflows()
+    : [];
+
+  if (allWorkflows.length === 0 && brokenWorkflows.length === 0) {
     yield {
       kind: "error",
       error: validationFailed("No workflows found"),
@@ -247,6 +283,9 @@ async function* validateAll(
   }
 
   const results: WorkflowValidateData[] = [];
+  for (const broken of brokenWorkflows) {
+    results.push(toBrokenValidateData(broken));
+  }
   for (const workflow of allWorkflows) {
     const validationResults = await deps.validate(workflow);
     const validations = toValidationItemData(validationResults);
@@ -292,6 +331,18 @@ async function* validateSingle(
   }
 
   if (!workflow) {
+    // The file may exist but fail schema parsing, making it invisible to
+    // the repository. Surface the parse error as a failed schema check
+    // instead of a misleading "not found".
+    if (deps.listBrokenWorkflows) {
+      const broken = (await deps.listBrokenWorkflows()).find(
+        (b) => b.name === workflowIdOrName || b.id === workflowIdOrName,
+      );
+      if (broken) {
+        yield { kind: "completed", data: toBrokenValidateData(broken) };
+        return;
+      }
+    }
     yield {
       kind: "error",
       error: notFound("Workflow", workflowIdOrName),

--- a/src/libswamp/workflows/validate_test.ts
+++ b/src/libswamp/workflows/validate_test.ts
@@ -172,3 +172,95 @@ Deno.test("workflowValidate yields error when not found", async () => {
 
   assertEquals(events[1].kind, "error");
 });
+
+// Broken-file surfacing (swamp-club#1240): a workflow file that fails
+// schema parsing is invisible to the repository, so validate must report
+// the parse error rather than "not found" or an all-green aggregate.
+
+const BROKEN = {
+  file: "/repo/workflows/workflow-74ae52ba.yaml",
+  name: "variant-a-job-labels",
+  id: "74ae52ba-5f3f-4937-a4fd-c1de950572e7",
+  error: "'labels' is a step property, not a job property",
+};
+
+Deno.test("workflowValidate single: schema-rejected file fails Schema validation instead of not-found", async () => {
+  const deps = makeDeps({
+    findWorkflowByName: () => Promise.resolve(null),
+    listBrokenWorkflows: () => Promise.resolve([BROKEN]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {
+      workflowIdOrName: "variant-a-job-labels",
+    }),
+  );
+
+  assertEquals(events[1].kind, "completed");
+  const completed = events[1] as Extract<
+    WorkflowValidateEvent,
+    { kind: "completed" }
+  >;
+  const data = completed.data as WorkflowValidateData;
+  assertEquals(data.passed, false);
+  assertEquals(data.workflowName, "variant-a-job-labels");
+  assertEquals(data.validations[0].name, "Schema validation");
+  assertEquals(data.validations[0].passed, false);
+  assertEquals(
+    data.validations[0].error?.includes("'labels' is a step property"),
+    true,
+  );
+});
+
+Deno.test("workflowValidate single: still not-found when no broken file matches", async () => {
+  const deps = makeDeps({
+    findWorkflowByName: () => Promise.resolve(null),
+    listBrokenWorkflows: () => Promise.resolve([BROKEN]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {
+      workflowIdOrName: "some-other-workflow",
+    }),
+  );
+
+  assertEquals(events[1].kind, "error");
+});
+
+Deno.test("workflowValidate all: broken files count as failures", async () => {
+  const deps = makeDeps({
+    listBrokenWorkflows: () => Promise.resolve([BROKEN]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowValidateEvent,
+    { kind: "completed" }
+  >;
+  if (!isWorkflowValidateAllData(completed.data)) {
+    throw new Error("expected aggregate data");
+  }
+  assertEquals(completed.data.passed, false);
+  assertEquals(completed.data.totalFailed, 1);
+  assertEquals(completed.data.totalPassed, 1);
+});
+
+Deno.test("workflowValidate all: broken files alone still yield results, not no-workflows error", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([]),
+    listBrokenWorkflows: () => Promise.resolve([BROKEN]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {}),
+  );
+
+  const completed = events[1] as Extract<
+    WorkflowValidateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  if (!isWorkflowValidateAllData(completed.data)) {
+    throw new Error("expected aggregate data");
+  }
+  assertEquals(completed.data.totalFailed, 1);
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1240: a `labels:` block placed on a **job** (instead of a step) passed `swamp workflow validate` with zero errors/warnings and was silently dropped — Zod's default unknown-key stripping discarded the placement intent, so the work ran locally on the orchestrator. Anything relying on placement for isolation failed open, and nothing in validate, run output, or logs said so.

- New `rejectUnknownKeys` Zod preprocess hook (modeled on the removed driver-fields guard), chained into the Workflow/Job/Step schemas with known keys derived from each schema's shape.
  - Misplaced placement keys (`labels`/`target`/`platform`/`queueTimeout` on a job or workflow) get an error naming the key and showing the step-level form.
  - Any other unknown key gets a did-you-mean suggestion (Levenshtein) plus the list of valid keys.
- A schema-rejected file is invisible to the repository loader, so `workflow validate` and `workflow run` now raw-scan on a lookup miss and surface the parse error inline (new `workflow_load_failed` error code) instead of "Workflow not found". Validate-all counts broken files as failures — it can never report green while a file fails to load.
- `design/workflow.md` documents the rejection policy and the schema-evolution consequence: field removals now require an explicit migration/tolerance decision because persisted snapshots re-parse through these schemas. The swamp skill's remote-execution reference notes placement is step-only.

## Behavior change (release-notes worthy)

Workflow YAML carrying stray keys (typos, copy-paste remnants, keys from other CI systems) previously loaded silently with the keys stripped; it now fails loudly with an actionable error. `swamp doctor workflows` enumerates offenders. This also applies to extension-pulled workflows.

## Test Plan

- Unit: `unknown_keys_test.ts` (hook semantics, driver-field precedence, non-object pass-through), issue's exact variant-A YAML in `job_test.ts`/`workflow_test.ts`, step-typo suggestion in `step_test.ts`, JSON-schema emission guard in `schema_test.ts`, broken-file scan in `broken_workflow_test.ts`, validate/run surfacing in `validate_test.ts`/`run_test.ts`.
- Full suite: 9110 passed / 0 failed; `deno lint` and `deno fmt --check` clean; binary recompiled.
- E2E against the issue's reproduction with the compiled binary: variant A (job-level labels) now fails validate naming `labels` and refuses to run with the same inline error; variant B (step-level labels) is unchanged (validate passes, run fails with the worker-dispatcher placement error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)