### PR TITLE
fix(validation): run appliesTo checks during model validate without --method (swamp-club#1236)

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -489,12 +489,14 @@ checks:
 
 ### model validate Integration
 
-`swamp model validate` runs checks as part of the validation pipeline. It honors
-definition-level `skip` lists in addition to CLI flags. Two flags control check
-execution:
+`swamp model validate` runs checks as part of the validation pipeline. It runs
+all checks regardless of `appliesTo` — ensuring validate surfaces the same
+errors that method execution would. It honors definition-level `skip` lists in
+addition to CLI flags. Two flags narrow check execution:
 
 - `--label <label>` — only run checks matching this label
-- `--method <method>` — simulate validation for a specific method context
+- `--method <method>` — only run checks that apply to this method (skips checks
+  whose `appliesTo` excludes the given method)
 
 ## Data
 

--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -374,13 +374,10 @@ export class DefaultModelValidationService implements ModelValidationService {
         continue;
       }
 
-      // Filter by method: if --method given, only run matching checks.
-      // If no --method given, skip checks that have an explicit appliesTo
-      // (they only make sense in the context of a specific method).
-      if (check.appliesTo) {
-        if (!checkContext.method) {
-          continue;
-        }
+      // Filter by method: if --method given, only run checks that apply to
+      // that method. If no --method given, run all checks so that `model
+      // validate` surfaces the same errors that method execution would.
+      if (check.appliesTo && checkContext.method) {
         if (!check.appliesTo.includes(checkContext.method)) {
           continue;
         }

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1479,14 +1479,13 @@ Deno.test("validateModel check selection on model without checks", async () => {
   assertStringIncludes(selResult?.error ?? "", "nonexistent");
 });
 
-Deno.test("validateModel skips checks with appliesTo when no method specified", async () => {
+Deno.test("validateModel runs checks with appliesTo even when no method specified", async () => {
   const service = new DefaultModelValidationService();
   const definition = Definition.create({
     name: "test-definition",
     globalArguments: { message: "hello" },
   });
 
-  // always-fail has appliesTo: ["create"], so without --method it should be skipped
   const { results } = await service.validateModel(
     definition,
     testModelWithChecks,
@@ -1495,7 +1494,31 @@ Deno.test("validateModel skips checks with appliesTo when no method specified", 
   );
 
   const checkResults = results.filter((r) => r.name.startsWith("Check:"));
-  // always-pass has no appliesTo → runs; always-fail has appliesTo → skipped
+  // Both checks run: always-pass succeeds, always-fail (with appliesTo) also runs
+  assertEquals(checkResults.length, 2);
+  const passResult = checkResults.find((r) => r.name === "Check: always-pass");
+  const failResult = checkResults.find((r) => r.name === "Check: always-fail");
+  assertEquals(passResult?.passed, true);
+  assertEquals(failResult?.passed, false);
+});
+
+Deno.test("validateModel skips checks with appliesTo when --method specifies a different method", async () => {
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { message: "hello" },
+  });
+
+  // always-fail has appliesTo: ["create"], so --method delete should skip it
+  const { results } = await service.validateModel(
+    definition,
+    testModelWithChecks,
+    undefined,
+    createCheckContext({ method: "delete" }),
+  );
+
+  const checkResults = results.filter((r) => r.name.startsWith("Check:"));
+  // always-pass has no appliesTo → runs; always-fail has appliesTo: ["create"] → skipped for "delete"
   assertEquals(checkResults.length, 1);
   assertEquals(checkResults[0].name, "Check: always-pass");
   assertEquals(checkResults[0].passed, true);


### PR DESCRIPTION
## Summary

- `model validate` silently skipped checks with `appliesTo` when no `--method` flag was given, creating a gap where definitions pass validate but fail at start time
- Now `model validate` runs **all** checks regardless of `appliesTo` — surfacing the same errors that method execution would
- `--method` still filters to only matching checks when explicitly provided
- Filed downstream issue #1262 for `@swamp/software-factory`'s `DeclaredSchemaSchema.enum` to accept boolean literals

Fixes swamp-club#1236

## Test Plan

- [x] Updated test: checks with `appliesTo` now run during validate without `--method`
- [x] New test: checks with `appliesTo` still filtered when `--method` specifies a different method
- [x] Full test suite passes (9086 tests)
- [x] Reproduced in scratch repo: `swamp model validate` now catches the error that previously only surfaced at `start` time