### PR TITLE
fix(datastore): add --timeout to setup extension and decouple type commit from push success (swamp-club#1247)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -179,20 +179,32 @@ enforced in the coordinator, so a stuck or slow extension cannot hang the CLI
 indefinitely. The effective timeout is resolved from the first source that
 yields a positive value:
 
-1. `swamp datastore sync --timeout <seconds>` — per-invocation override, capped
-   at 21,600 seconds (6 hours). Preferred escape hatch for one-off large syncs.
+1. `--timeout <seconds>` CLI flag — per-invocation override, capped at 21,600
+   seconds (6 hours). Available on `swamp datastore sync` and
+   `swamp datastore setup extension`. Preferred escape hatch for one-off large
+   syncs or initial setup of large repos.
 2. `CustomDatastoreConfig.syncTimeoutMs` — per-datastore config in
    `.swamp.yaml`. Applies to both explicit `swamp datastore sync` calls and
-   the implicit syncs triggered by write commands.
+   the implicit syncs triggered by write commands. Not used by
+   `datastore setup extension` (setup runs outside the flush coordinator).
 3. `SWAMP_DATASTORE_SYNC_TIMEOUT_MS` — environment variable, uncapped. Useful
-   for shell-session-scoped overrides during long-haul migrations.
+   for shell-session-scoped overrides during long-haul migrations. Applies to
+   both sync and setup extension.
 4. `DEFAULT_SYNC_TIMEOUT_MS` — 5 minutes.
 
 The deadline fires a `SyncTimeoutError` regardless of whether the extension
-honored the `AbortSignal` passed to `pushChanged(options)` / `pullChanged(options)`.
-Timeouts propagate as a non-zero CLI exit so the user sees that data did not
-make it to the remote; other push errors still warn-downgrade (preserves
-historical behavior where a transient S3 blip does not kill a run).
+honored the `AbortSignal` passed to `pushChanged(options)` /
+`pullChanged(options)`. Timeouts propagate as a non-zero CLI exit so the user
+sees that data did not make it to the remote; other push errors still
+warn-downgrade (preserves historical behavior where a transient S3 blip does not
+kill a run).
+
+**Setup timeout behavior.** During `datastore setup extension`, a push or pull
+timeout is treated as recoverable: the datastore type is still committed to
+`.swamp.yaml` so the user can resume with `swamp datastore sync --push
+--timeout <big>`. Hard failures (auth errors, network errors, config errors)
+still block the type commit. This avoids the scenario where a slow first push
+leaves the repo un-migrated despite valid credentials and config.
 
 The `SyncTimeoutError` message lists every available remedy inline
 (`--timeout`, the env var, updating the datastore extension, releasing a stuck
@@ -203,7 +215,8 @@ version that would rot across releases.
 See `src/domain/datastore/datastore_config.ts` (`DEFAULT_SYNC_TIMEOUT_MS`,
 `SYNC_TIMEOUT_ENV_VAR`, `resolveSyncTimeoutMs`),
 `src/domain/datastore/datastore_sync_service.ts` (`SyncTimeoutError`),
-`src/cli/commands/datastore_sync.ts` (`--timeout` flag), and
+`src/cli/commands/datastore_sync.ts` (`--timeout` flag),
+`src/cli/commands/datastore_setup.ts` (`--timeout` flag on setup extension), and
 `src/infrastructure/persistence/datastore_sync_coordinator.ts`
 (`runBoundedSync`).
 

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -47,6 +47,7 @@ import { resolveDatastoreType } from "../../domain/extensions/extension_auto_res
 import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { RENAMED_DATASTORE_TYPES } from "../resolve_datastore.ts";
 import { UserError } from "../../domain/errors.ts";
+import { parseTimeoutFlag } from "./datastore_sync.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { dim, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
@@ -169,6 +170,12 @@ const datastoreSetupExtensionCommand = new Command()
     "--hydration-strategy <strategy:string>",
     'Content download strategy: "full" (default, download everything) or "lazy" (metadata only, download content on demand)',
   )
+  .option(
+    "--timeout <seconds:integer>",
+    "Override the sync timeout for the initial push and hydration pull (seconds, " +
+      "max 21600). Wins over SWAMP_DATASTORE_SYNC_TIMEOUT_MS. " +
+      "Preferred escape hatch for large first-time setups.",
+  )
   .action(async function (options: AnyOptions, type: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
@@ -233,6 +240,10 @@ const datastoreSetupExtensionCommand = new Command()
       );
     }
 
+    const syncTimeoutMsOverride = options.timeout != null
+      ? parseTimeoutFlag(options.timeout)
+      : undefined;
+
     const namespace = typeof configNamespace === "string"
       ? configNamespace
       : marker?.datastore?.namespace;
@@ -246,6 +257,7 @@ const datastoreSetupExtensionCommand = new Command()
         skipMigration: !!options.skipMigration,
         hydrationStrategy,
         namespace,
+        syncTimeoutMsOverride,
       }),
       renderer.handlers(),
     );

--- a/src/cli/commands/datastore_setup_test.ts
+++ b/src/cli/commands/datastore_setup_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 
 // Initialize logging for tests
@@ -64,4 +64,17 @@ Deno.test("datastoreSetupCommand has parent action for interactive mode", async 
   const commands = datastoreSetupCommand.getCommands();
   const names = commands.map((c) => c.getName()).sort();
   assertEquals(names, ["extension", "filesystem", "s3"]);
+});
+
+Deno.test("datastoreSetupExtensionCommand has --timeout option", async () => {
+  const { datastoreSetupCommand } = await import("./datastore_setup.ts");
+  const extCmd = datastoreSetupCommand.getCommand("extension");
+  assertEquals(extCmd !== undefined, true);
+  const opt = extCmd?.getOption("timeout");
+  assertEquals(opt !== undefined, true, "--timeout option should exist");
+  assertStringIncludes(
+    opt?.description ?? "",
+    "sync timeout",
+    "--timeout description should mention sync timeout",
+  );
 });

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -431,10 +431,9 @@ export class SyncTimeoutError extends UserError {
       `  • Set SWAMP_DATASTORE_SYNC_TIMEOUT_MS for the duration of your ` +
       `shell session — applies to every command that triggers sync, ` +
       `including the implicit pull/push around write commands.\n` +
-      `  • If the timeout fired on an explicit 'swamp datastore sync', ` +
-      `rerun with --timeout <seconds> (e.g. --timeout 1800 for large ` +
-      `one-off syncs). The flag is not available on other commands; use ` +
-      `the env var above for those.\n` +
+      `  • Rerun with --timeout <seconds> (e.g. --timeout 1800 for large ` +
+      `one-off syncs). Available on 'swamp datastore sync' and ` +
+      `'swamp datastore setup extension'.\n` +
       `  • If you are on @swamp/s3-datastore or @swamp/gcs-datastore at ` +
       `scale, update to the latest extension — the fingerprint fast path ` +
       `short-circuits zero-diff syncs.\n` +

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -390,6 +390,7 @@ export async function* datastoreSetupExtension(
           config,
         );
         errors.push(...result.errors);
+        if (result.errors.length > 0) onlyTimeouts = false;
         filesCopied = result.filesCopied;
         migrationResult = result;
 

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -38,6 +38,7 @@ import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/fi
 import { getSwampDataDir } from "../../infrastructure/persistence/paths.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { summarizeSyncError } from "../../infrastructure/persistence/sync_error_diagnostic.ts";
+import { SyncTimeoutError } from "../../domain/datastore/datastore_sync_service.ts";
 import { writeNamespaceManifest } from "../../infrastructure/persistence/namespace_manifest.ts";
 import { runBoundedSync } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import type { LibSwampContext } from "../context.ts";
@@ -245,6 +246,7 @@ export interface DatastoreSetupExtensionInput {
   skipMigration: boolean;
   hydrationStrategy?: "full" | "lazy";
   namespace?: string;
+  syncTimeoutMsOverride?: number;
 }
 
 /** Sets up an extension-provided datastore. */
@@ -326,15 +328,22 @@ export async function* datastoreSetupExtension(
       const errors: string[] = [];
       let filesCopied = 0;
       let filesPulled = 0;
+      let onlyTimeouts = true;
 
       // Setup runs outside the flush coordinator, so it does not pick up
-      // per-config syncTimeoutMs. Env override applies if set, else fall
-      // back to the default.
-      const envValue = Deno.env.get(SYNC_TIMEOUT_ENV_VAR);
-      const parsedTimeout = envValue ? Number.parseInt(envValue, 10) : NaN;
-      const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0
-        ? parsedTimeout
-        : DEFAULT_SYNC_TIMEOUT_MS;
+      // per-config syncTimeoutMs. Resolution: CLI --timeout > env var > default.
+      const timeoutMs = (() => {
+        if (
+          input.syncTimeoutMsOverride != null && input.syncTimeoutMsOverride > 0
+        ) {
+          return input.syncTimeoutMsOverride;
+        }
+        const envValue = Deno.env.get(SYNC_TIMEOUT_ENV_VAR);
+        const parsedTimeout = envValue ? Number.parseInt(envValue, 10) : NaN;
+        return Number.isFinite(parsedTimeout) && parsedTimeout > 0
+          ? parsedTimeout
+          : DEFAULT_SYNC_TIMEOUT_MS;
+      })();
 
       const cachePath = provider.resolveCachePath?.(input.repoDir) ??
         join(getSwampDataDir(), "repos", input.repoId ?? "unknown");
@@ -400,6 +409,7 @@ export async function* datastoreSetupExtension(
             );
             ctx.logger.debug`Push complete`;
           } catch (error) {
+            if (!(error instanceof SyncTimeoutError)) onlyTimeouts = false;
             const { summary } = summarizeSyncError(
               "push",
               input.type,
@@ -443,6 +453,7 @@ export async function* datastoreSetupExtension(
           filesPulled = typeof pulled === "number" ? pulled : 0;
           ctx.logger.debug`Hydration complete: ${filesPulled} file(s) pulled`;
         } catch (error) {
+          if (!(error instanceof SyncTimeoutError)) onlyTimeouts = false;
           const { summary } = summarizeSyncError(
             "pull",
             input.type,
@@ -467,10 +478,12 @@ export async function* datastoreSetupExtension(
         );
       }
 
-      // Update .swamp.yaml only after migration and hydration succeed
-      // (or are skipped). This avoids leaving the config pointing at an
-      // extension datastore when data movement failed.
-      if (errors.length === 0) {
+      // Update .swamp.yaml when data movement succeeded OR when only
+      // timeouts occurred. A timeout means the datastore is correctly
+      // configured but the data transfer was slow — the user can resume
+      // with `swamp datastore sync --push --timeout <big>`. Hard failures
+      // (auth, network, config) still block the type commit.
+      if (errors.length === 0 || onlyTimeouts) {
         await deps.updateRepoConfig(input.repoDir, {
           type: input.type,
           config: input.config,
@@ -483,7 +496,7 @@ export async function* datastoreSetupExtension(
 
       // Register namespace manifest after config is persisted.
       // provider.registerNamespace handles conflict detection internally.
-      if (errors.length === 0 && ns && input.repoId) {
+      if ((errors.length === 0 || onlyTimeouts) && ns && input.repoId) {
         const datastorePath = provider.resolveDatastorePath(input.repoDir);
         if (provider.registerNamespace) {
           try {

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -32,7 +32,10 @@ import {
 } from "./setup.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import type { DatastoreProvider } from "../../domain/datastore/datastore_provider.ts";
-import type { DatastoreSyncOptions } from "../../domain/datastore/datastore_sync_service.ts";
+import {
+  type DatastoreSyncOptions,
+  SyncTimeoutError,
+} from "../../domain/datastore/datastore_sync_service.ts";
 import { readNamespaceManifest } from "../../infrastructure/persistence/namespace_manifest.ts";
 
 function makeDeps(
@@ -1068,6 +1071,104 @@ Deno.test("datastoreSetupExtension: rejects invalid namespace slug", async () =>
 // ============================================================================
 // Namespace manifest cache materialization tests (swamp-club#834)
 // ============================================================================
+
+Deno.test("datastoreSetupExtension: push timeout commits type (decoupled from push success)", async () => {
+  ensureTestExtensionType("test-ext-push-timeout", {
+    pushResult: () =>
+      Promise.reject(new SyncTimeoutError("test", "push", 1000)),
+  });
+  let configUpdated = false;
+  let cleanupCalled = false;
+  const deps = makeDeps({
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+    cleanupSourceDirs: () => {
+      cleanupCalled = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-push-timeout",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "timed out");
+  assertEquals(
+    configUpdated,
+    true,
+    "push timeout must still commit the datastore type",
+  );
+  assertEquals(
+    cleanupCalled,
+    false,
+    "push timeout must keep migrated .swamp/ dirs intact for retry",
+  );
+});
+
+Deno.test("datastoreSetupExtension: hard push failure still blocks type commit", async () => {
+  ensureTestExtensionType("test-ext-push-hard-fail", {
+    pushResult: () => Promise.reject(new Error("AccessDenied")),
+  });
+  let configUpdated = false;
+  const deps = makeDeps({
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-push-hard-fail",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertEquals(
+    configUpdated,
+    false,
+    "hard push failure must prevent .swamp.yaml writeback",
+  );
+});
+
+Deno.test("datastoreSetupExtension: syncTimeoutMsOverride is honored", async () => {
+  ensureTestExtensionType("test-ext-timeout-override");
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-timeout-override",
+    syncTimeoutMsOverride: 60_000,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 0);
+});
 
 Deno.test("datastoreSetupExtension: materializes namespace manifest in local cache", async () => {
   const tmpDir = await Deno.makeTempDir({ prefix: "swamp-setup-834-" });

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -1150,6 +1150,45 @@ Deno.test("datastoreSetupExtension: hard push failure still blocks type commit",
   );
 });
 
+Deno.test("datastoreSetupExtension: migration errors block type commit even when push succeeds", async () => {
+  ensureTestExtensionType("test-ext-migrate-err");
+  let configUpdated = false;
+  const deps = makeDeps({
+    migrateData: () =>
+      Promise.resolve({
+        filesCopied: 3,
+        bytesCopied: 512,
+        directoriesMigrated: ["data"],
+        errors: ["failed to copy data/foo.bin: ENOSPC"],
+      }),
+    updateRepoConfig: () => {
+      configUpdated = true;
+      return Promise.resolve();
+    },
+  });
+  const input = makeExtensionInput({
+    type: "test-ext-migrate-err",
+    skipMigration: false,
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.errors.length, 1);
+  assertStringIncludes(completed.data.errors[0], "ENOSPC");
+  assertEquals(
+    configUpdated,
+    false,
+    "migration errors must prevent .swamp.yaml writeback",
+  );
+});
+
 Deno.test("datastoreSetupExtension: syncTimeoutMsOverride is honored", async () => {
   ensureTestExtensionType("test-ext-timeout-override");
   const deps = makeDeps();


### PR DESCRIPTION
## Summary

- Add `--timeout <seconds>` flag to `datastore setup extension` (same validation as `datastore sync`, max 21600s)
- Decouple type commit from push success: timeout-only errors still commit the datastore type to `.swamp.yaml` (user can resume with `sync --push --timeout <big>`), hard failures still block
- Update `SyncTimeoutError` message to reflect `--timeout` availability on setup extension
- Update `design/datastores.md` sync timeout documentation

Fixes swamp-club#1247. SIGTERM span/flush (ask #3) deferred to swamp-club#1250.

## Test Plan

- [x] Unit tests: push timeout commits type, hard push failure blocks type commit, `syncTimeoutMsOverride` honored, `--timeout` option exists on CLI command (4 new tests)
- [x] Minio-based end-to-end reproduction: `--timeout 2` triggers 2000ms timeout, `.swamp.yaml` correctly shows `type: @swamp/s3-datastore` (previously reverted to `filesystem`)
- [x] `deno check`, `deno lint`, `deno fmt`, all 9089 tests pass
- [x] Compiled binary verified against reproduction scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)