### PR TITLE
feat(auth): add CLI support for collective API tokens (swamp-club#1264)

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -779,6 +779,16 @@ export class ExtensionApiClient {
     }
 
     if (res.status === 403) {
+      const scopeMatch = serverMessage.match(
+        /requires the (.+?) scope/,
+      );
+      if (scopeMatch) {
+        throw new UserError(
+          `Token lacks required scope '${
+            scopeMatch[1]
+          }'. Create a new token with this scope in your collective settings.`,
+        );
+      }
       throw new UserError(serverMessage);
     }
 

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -905,6 +905,49 @@ Deno.test("ExtensionApiClient.downloadArchive does NOT send identity headers to 
   }
 });
 
+Deno.test("ExtensionApiClient.checkResponse surfaces scope-specific 403 message", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response(
+      JSON.stringify({
+        message: "This token requires the extensions:push scope",
+      }),
+      {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const error = await assertRejects(
+    () => client.getLatestVersion("@test/ext", "fake-key"),
+    UserError,
+  );
+  assertStringIncludes(error.message, "extensions:push");
+  assertStringIncludes(error.message, "collective settings");
+  await server.shutdown();
+});
+
+Deno.test("ExtensionApiClient.checkResponse passes through non-scope 403 message", async () => {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
+    return new Response(
+      JSON.stringify({ message: "Forbidden: insufficient permissions" }),
+      {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  });
+  const addr = server.addr;
+  const client = new ExtensionApiClient(`http://localhost:${addr.port}`);
+  const error = await assertRejects(
+    () => client.getLatestVersion("@test/ext", "fake-key"),
+    UserError,
+  );
+  assertStringIncludes(error.message, "insufficient permissions");
+  await server.shutdown();
+});
+
 Deno.test("ExtensionApiClient.checkResponse includes URL in error message", async () => {
   const server = Deno.serve({ port: 0, onListen: () => {} }, (_req) => {
     return new Response(JSON.stringify({ error: "Invalid path" }), {

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -60,6 +60,10 @@ export interface WhoamiResponse {
   email?: string;
   name?: string;
   organizations?: WhoamiOrganization[];
+  collectiveToken?: boolean;
+  collectiveId?: string;
+  collectiveSlug?: string;
+  scopes?: string[];
 }
 
 /**

--- a/src/libswamp/auth/whoami.ts
+++ b/src/libswamp/auth/whoami.ts
@@ -46,6 +46,9 @@ export interface WhoamiIdentity {
   email: string;
   name: string;
   collectives?: string[];
+  collectiveToken?: boolean;
+  collectiveSlug?: string;
+  scopes?: string[];
 }
 
 export type AuthWhoamiEvent =
@@ -135,21 +138,31 @@ export async function* whoami(
 
     const collectives = getCollectives(response);
 
-    // Refresh cached collectives in auth.json so they stay current
-    await deps.saveCredentials({
-      ...credentials,
-      collectives: collectives ?? [],
-    });
+    if (!response.collectiveToken) {
+      // Refresh cached collectives in auth.json so they stay current.
+      // Collective tokens are env-var-based — nothing to cache.
+      await deps.saveCredentials({
+        ...credentials,
+        collectives: collectives ?? [],
+      });
+    }
 
     yield {
       kind: "completed",
       identity: {
         serverUrl,
-        id: response.id!,
-        username: response.username!,
-        email: response.email!,
-        name: response.name!,
+        id: response.id ?? "",
+        username: response.username ?? "",
+        email: response.email ?? "",
+        name: response.name ?? "",
         ...(collectives ? { collectives } : {}),
+        ...(response.collectiveToken
+          ? {
+            collectiveToken: true,
+            collectiveSlug: response.collectiveSlug,
+            scopes: response.scopes,
+          }
+          : {}),
       },
     };
   } catch (error: unknown) {

--- a/src/libswamp/auth/whoami_test.ts
+++ b/src/libswamp/auth/whoami_test.ts
@@ -261,6 +261,93 @@ Deno.test("createAuthDeps: saveCredentials caches identity when SWAMP_API_KEY is
   }
 });
 
+Deno.test("whoami: collective token response includes collectiveToken, collectiveSlug, and scopes", async () => {
+  const ctx = createLibSwampContext();
+  const collectiveWhoami: WhoamiResponse = {
+    authenticated: true,
+    collectiveToken: true,
+    collectiveId: "org-1",
+    collectiveSlug: "myorg",
+    scopes: ["extensions:push", "extensions:yank"],
+    organizations: [
+      { slug: "myorg", name: "My Org", role: "token", personal: false },
+    ],
+  };
+  const deps = makeDeps({
+    credentials: testCredentials,
+    whoamiResponse: collectiveWhoami,
+  });
+
+  const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+
+  const completed = events[events.length - 1] as Extract<
+    AuthWhoamiEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.identity.collectiveToken, true);
+  assertEquals(completed.identity.collectiveSlug, "myorg");
+  assertEquals(completed.identity.scopes, [
+    "extensions:push",
+    "extensions:yank",
+  ]);
+  assertEquals(completed.identity.collectives, ["myorg"]);
+  assertEquals(completed.identity.username, "");
+});
+
+Deno.test("whoami: collective token skips saveCredentials", async () => {
+  const ctx = createLibSwampContext();
+  let saveCalled = false;
+  const collectiveWhoami: WhoamiResponse = {
+    authenticated: true,
+    collectiveToken: true,
+    collectiveId: "org-1",
+    collectiveSlug: "myorg",
+    scopes: ["extensions:push"],
+    organizations: [
+      { slug: "myorg", name: "My Org", role: "token", personal: false },
+    ],
+  };
+  const deps: AuthDeps = {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    saveCredentials: () => {
+      saveCalled = true;
+      return Promise.resolve();
+    },
+    fetchWhoami: () => Promise.resolve(collectiveWhoami),
+    serverUrlOverride: undefined,
+  };
+
+  const events = await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+
+  assertEquals(
+    (events[events.length - 1] as Extract<
+      AuthWhoamiEvent,
+      { kind: "completed" }
+    >).kind,
+    "completed",
+  );
+  assertEquals(saveCalled, false);
+});
+
+Deno.test("whoami: personal key response still saves credentials", async () => {
+  const ctx = createLibSwampContext();
+  let saveCalled = false;
+  const deps: AuthDeps = {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    saveCredentials: () => {
+      saveCalled = true;
+      return Promise.resolve();
+    },
+    fetchWhoami: () => Promise.resolve(testWhoamiResponse),
+    serverUrlOverride: undefined,
+  };
+
+  await collect<AuthWhoamiEvent>(whoami(ctx, deps));
+
+  assertEquals(saveCalled, true);
+});
+
 Deno.test("createAuthDeps: saveCredentials writes file when SWAMP_API_KEY is not set", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -203,6 +203,28 @@ Deno.test("extensionPushPrepare: invalid collective throws SwampError", async ()
   assertEquals(error.code, "validation_failed");
 });
 
+Deno.test("extensionPushPrepare: collective token allows matching collective namespace", async () => {
+  const deps = makePrepareDeps({
+    fetchCollectives: () => Promise.resolve(["testuser"]),
+  });
+  const input = makePrepareInput({ dryRun: false });
+
+  const result = await extensionPushPrepare(ctx, deps, input);
+  assertEquals(result.manifest.name, "@testuser/test-ext");
+});
+
+Deno.test("extensionPushPrepare: collective token rejects mismatched namespace", async () => {
+  const deps = makePrepareDeps({
+    fetchCollectives: () => Promise.resolve(["other-org"]),
+  });
+  const input = makePrepareInput({ dryRun: false });
+
+  const error = await assertRejects(
+    () => extensionPushPrepare(ctx, deps, input),
+  ) as SwampError;
+  assertEquals(error.code, "validation_failed");
+});
+
 Deno.test("extensionPushPrepare: additionalFiles with disallowed extension suggests binaries", async () => {
   const deps = makePrepareDeps();
   const input = makePrepareInput({

--- a/src/presentation/renderers/auth_whoami.ts
+++ b/src/presentation/renderers/auth_whoami.ts
@@ -29,9 +29,18 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
       loading_credentials: () => {},
       contacting_server: () => {},
       completed: (e) => {
-        writeOutput(
-          `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
-        );
+        if (e.identity.collectiveToken) {
+          writeOutput(
+            `Collective token: ${e.identity.collectiveSlug} on ${e.identity.serverUrl}`,
+          );
+          if (e.identity.scopes && e.identity.scopes.length > 0) {
+            writeOutput(`Scopes: ${e.identity.scopes.join(", ")}`);
+          }
+        } else {
+          writeOutput(
+            `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
+          );
+        }
         if (e.identity.collectives && e.identity.collectives.length > 0) {
           writeOutput(`Collectives: ${e.identity.collectives.join(", ")}`);
         }
@@ -53,10 +62,18 @@ class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
           {
             authenticated: true,
             serverUrl: e.identity.serverUrl,
-            id: e.identity.id,
-            username: e.identity.username,
-            email: e.identity.email,
-            name: e.identity.name,
+            ...(e.identity.collectiveToken
+              ? {
+                collectiveToken: true,
+                collectiveSlug: e.identity.collectiveSlug,
+                scopes: e.identity.scopes,
+              }
+              : {
+                id: e.identity.id,
+                username: e.identity.username,
+                email: e.identity.email,
+                name: e.identity.name,
+              }),
             ...(e.identity.collectives
               ? { collectives: e.identity.collectives }
               : {}),

--- a/src/presentation/renderers/auth_whoami_test.ts
+++ b/src/presentation/renderers/auth_whoami_test.ts
@@ -18,11 +18,17 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { type AuthWhoamiEvent, consumeStream } from "../../libswamp/mod.ts";
+import {
+  type AuthWhoamiEvent,
+  consumeStream,
+  type WhoamiIdentity,
+} from "../../libswamp/mod.ts";
 import { createAuthWhoamiRenderer } from "./auth_whoami.ts";
 import { UserError } from "../../domain/errors.ts";
 
-function makeIdentity(opts?: { collectives?: string[] }) {
+function makeIdentity(
+  opts?: { collectives?: string[] },
+): WhoamiIdentity {
   return {
     serverUrl: "https://club.example.com",
     id: "user-1",
@@ -30,6 +36,24 @@ function makeIdentity(opts?: { collectives?: string[] }) {
     email: "alice@example.com",
     name: "Alice",
     ...(opts?.collectives ? { collectives: opts.collectives } : {}),
+  };
+}
+
+function makeCollectiveTokenIdentity(
+  opts?: { scopes?: string[]; collectives?: string[] },
+): WhoamiIdentity {
+  return {
+    serverUrl: "https://club.example.com",
+    id: "",
+    username: "",
+    email: "",
+    name: "",
+    collectiveToken: true,
+    collectiveSlug: "myorg",
+    scopes: opts?.scopes ?? ["extensions:push"],
+    ...(opts?.collectives
+      ? { collectives: opts.collectives }
+      : { collectives: ["myorg"] }),
   };
 }
 
@@ -158,6 +182,52 @@ Deno.test("JsonAuthWhoamiRenderer - error event throws UserError", () => {
     UserError,
     "Not authenticated",
   );
+});
+
+Deno.test("LogAuthWhoamiRenderer - collective token displays slug and scopes", async () => {
+  const renderer = createAuthWhoamiRenderer("log");
+  const events: AuthWhoamiEvent[] = [
+    { kind: "loading_credentials" },
+    {
+      kind: "completed",
+      identity: makeCollectiveTokenIdentity({
+        scopes: ["extensions:push", "extensions:yank"],
+      }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("JsonAuthWhoamiRenderer - collective token serializes correct JSON", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createAuthWhoamiRenderer("json");
+    const events: AuthWhoamiEvent[] = [
+      { kind: "loading_credentials" },
+      {
+        kind: "completed",
+        identity: makeCollectiveTokenIdentity({
+          scopes: ["extensions:push"],
+        }),
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.authenticated, true);
+    assertEquals(parsed.collectiveToken, true);
+    assertEquals(parsed.collectiveSlug, "myorg");
+    assertEquals(parsed.scopes, ["extensions:push"]);
+    assertEquals(parsed.collectives, ["myorg"]);
+    assertEquals(parsed.username, undefined);
+    assertEquals(parsed.email, undefined);
+    assertEquals(parsed.id, undefined);
+  } finally {
+    console.log = originalLog;
+  }
 });
 
 Deno.test("createAuthWhoamiRenderer - factory returns correct type per mode", () => {


### PR DESCRIPTION
## Summary

Phase 3 of #960. Collective tokens created in the web UI now work with the CLI for the first time.

- **Whoami**: detects `collectiveToken: true` responses and displays collective identity, slug, and scopes (both log and JSON modes)
- **Push namespace validation**: verified that existing `getCollectives()` path works with collective token responses (which include `organizations` with `role: "token"`), no code changes needed — added tests confirming
- **Scope-aware 403 errors**: when the server returns a scope-specific 403 (e.g. "requires the extensions:push scope"), the CLI surfaces the scope name and a hint to create a new token in collective settings
- **Identity caching**: skips `saveIdentityCache()` for collective tokens since they are env-var-based (`SWAMP_API_KEY`) and have no username to cache

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint issues
- [x] `deno fmt --check` — formatting clean
- [x] `deno run test` — 82 tests pass across 4 affected test files (9 new tests)
- [x] `deno run compile` — binary compiles successfully
- [ ] Manual: `SWAMP_API_KEY=<collective-token> swamp auth whoami` shows collective identity and scopes
- [ ] Manual: `swamp extension push` with collective token succeeds for matching namespace
- [ ] Manual: `swamp extension push` with insufficient scope shows clear error

Closes swamp-club#1264