### PR TITLE
fix(data): validate instance name is a string before .trim() in writeResource and createFileWriter (swamp-club#1266)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -48,6 +48,7 @@
     "npm:marked-terminal@^7.3.0": "7.3.0_marked@14.1.4",
     "npm:marked@^14.1.4": "14.1.4",
     "npm:react@^19.2.5": "19.2.5",
+    "npm:zod@3.24.4": "3.24.4",
     "npm:zod@^4.3.6": "4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
   },
@@ -1549,6 +1550,9 @@
     },
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
+    },
+    "zod@3.24.4": {
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="
     },
     "zod@4.4.3": {
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -505,11 +505,11 @@ export function createResourceWriter(
       });
     }
 
-    // Validate name is non-empty
-    if (name.trim() === "") {
+    // Validate name is a non-empty string
+    if (typeof name !== "string" || name.trim() === "") {
       throw new Error(
-        `Resource name must be a non-empty string for spec '${specName}' ` +
-          `in model '${modelType.normalized}'`,
+        `writeResource: instance name must be a non-empty string for spec '${specName}' ` +
+          `in model '${modelType.normalized}', got ${typeof name}`,
       );
     }
 
@@ -842,11 +842,11 @@ export function createFileWriterFactory(
       );
     }
 
-    // Validate name is non-empty
-    if (name.trim() === "") {
+    // Validate name is a non-empty string
+    if (typeof name !== "string" || name.trim() === "") {
       throw new Error(
-        `File name must be a non-empty string for spec '${specName}' ` +
-          `in model '${modelType.normalized}'`,
+        `createFileWriter: instance name must be a non-empty string for spec '${specName}' ` +
+          `in model '${modelType.normalized}', got ${typeof name}`,
       );
     }
 

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -393,6 +393,99 @@ Deno.test("createFileWriterFactory: populates ownerDefinition.jobName and stepNa
   assertEquals(handle.metadata.ownerDefinition.workflowName, "my-wf");
 });
 
+Deno.test("createResourceWriter: rejects undefined instance name", async () => {
+  const repo = createMockRepo();
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+  );
+
+  await assertRejects(
+    () =>
+      writeResource(
+        "item",
+        undefined as unknown as string,
+        { value: "hello" },
+      ),
+    Error,
+    "instance name must be a non-empty string",
+  );
+});
+
+Deno.test("createResourceWriter: rejects null instance name", async () => {
+  const repo = createMockRepo();
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+  );
+
+  await assertRejects(
+    () => writeResource("item", null as unknown as string, { value: "hello" }),
+    Error,
+    "instance name must be a non-empty string",
+  );
+});
+
+Deno.test("createResourceWriter: rejects numeric instance name", async () => {
+  const repo = createMockRepo();
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+  );
+
+  await assertRejects(
+    () => writeResource("item", 42 as unknown as string, { value: "hello" }),
+    Error,
+    "instance name must be a non-empty string",
+  );
+});
+
+Deno.test("createFileWriterFactory: rejects undefined instance name", () => {
+  const repo = createMockRepo();
+  const { createFileWriter } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+  );
+
+  try {
+    createFileWriter("log", undefined as unknown as string);
+    throw new Error("Expected validation error");
+  } catch (e) {
+    assertStringIncludes(
+      (e as Error).message,
+      "instance name must be a non-empty string",
+    );
+  }
+});
+
+Deno.test("createFileWriterFactory: rejects null instance name", () => {
+  const repo = createMockRepo();
+  const { createFileWriter } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+  );
+
+  try {
+    createFileWriter("log", null as unknown as string);
+    throw new Error("Expected validation error");
+  } catch (e) {
+    assertStringIncludes(
+      (e as Error).message,
+      "instance name must be a non-empty string",
+    );
+  }
+});
+
 Deno.test("createResourceWriter: rejects reserved data name 'latest'", async () => {
   const repo = createMockRepo();
   const { writeResource } = createResourceWriter(


### PR DESCRIPTION
## Summary

- Add `typeof name !== "string"` guard before `.trim()` in `writeResource` (data_writer.ts:509) and `createFileWriter` (data_writer.ts:846)
- When an extension passes a non-string instance name (e.g. `undefined` from unresolved globalArgs), core now throws `"writeResource: instance name must be a non-empty string for spec '...' in model '...', got undefined"` instead of crashing on `undefined.trim()`
- Add 5 unit tests covering undefined, null, and numeric instance names for both writers

Closes swamp-club#1266

## Test Plan

- [x] Unit tests pass (`deno run test src/domain/models/data_writer_test.ts` — 76 tests, 0 failures)
- [x] Type check passes (`deno check`)
- [x] Lint and fmt clean
- [x] Reproduced the crash with `writeResource("state", undefined, data)` — now produces clear error message