### PR TITLE
fix(extensions): compute next version for prerelease-only extensions (swamp-club#1272)

### DIFF
--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -25,12 +25,31 @@ import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
+/** Latest published version on a single prerelease channel. */
+export interface ChannelVersionInfo {
+  latest: string;
+}
+
+/**
+ * Per-channel latest prerelease versions. A channel key is present only when
+ * that channel has a published version — never with a null latest.
+ */
+export type PrereleaseChannels = Partial<
+  Record<"beta" | "rc", ChannelVersionInfo>
+>;
+
 /** Data payload for the completed event. */
 export interface ExtensionVersionData {
   extensionName: string;
   currentPublished: string | null;
   publishedAt: string | null;
   nextVersion: string;
+  /**
+   * Latest prerelease versions per channel. Present only when at least one
+   * prerelease exists, and carries only the channels that have a published
+   * latest. Omitted entirely for never-published and stable-only extensions.
+   */
+  channels?: PrereleaseChannels;
 }
 
 export type ExtensionVersionEvent =
@@ -43,15 +62,22 @@ export interface ExtensionVersionInput {
   extensionName: string;
 }
 
-/** Version info resolved from the public extension metadata endpoint. */
-export interface LatestVersionInfo {
-  version: string;
-  publishedAt: string | null;
+/**
+ * Latest published version on each channel, as reported by the registry.
+ * Any field is null when that channel has no published version. Extension
+ * versions are globally unique per extension across channels (a version
+ * document carries one channel and promotion just updates it).
+ */
+export interface PublishedVersions {
+  stable: string | null;
+  beta: string | null;
+  rc: string | null;
 }
 
 /** Dependencies for the extension version operation. */
 export interface ExtensionVersionDeps {
-  getLatestVersion: (name: string) => Promise<LatestVersionInfo | null>;
+  /** Resolves per-channel latest versions, or null when the extension does not exist. */
+  getPublishedVersions: (name: string) => Promise<PublishedVersions | null>;
 }
 
 /** Wires real infrastructure into ExtensionVersionDeps. No authentication required. */
@@ -61,10 +87,16 @@ export function createExtensionVersionDeps(
   const serverUrl = resolveServerUrl();
   const client = new ExtensionApiClient(serverUrl, identity);
   return {
-    getLatestVersion: async (name: string) => {
+    getPublishedVersions: async (name: string) => {
       const info = await client.getExtension(name);
       if (!info) return null;
-      return { version: info.latestVersion, publishedAt: null };
+      // latestVersion is typed `string` but the registry returns null for
+      // prerelease-only extensions, so read it null-safely at the boundary.
+      return {
+        stable: info.latestVersion ?? null,
+        beta: info.latestBeta ?? null,
+        rc: info.latestRc ?? null,
+      };
     },
   };
 }
@@ -82,20 +114,38 @@ export async function* extensionVersion(
       yield { kind: "resolving" };
 
       try {
-        const latest = await deps.getLatestVersion(input.extensionName);
+        const published = await deps.getPublishedVersions(input.extensionName);
 
-        const previousCalVer = latest
-          ? CalVer.create(latest.version)
+        // The next publishable version must exceed the max across all channels,
+        // since versions are globally unique per extension. Filter to valid
+        // CalVers and pick the highest as the bump baseline.
+        const baseline = published
+          ? [published.stable, published.beta, published.rc]
+            .filter((v): v is string => v !== null && CalVer.isValid(v))
+            .map((v) => CalVer.create(v))
+            .reduce(
+              (max: CalVer | undefined, v) =>
+                max === undefined || CalVer.compare(v, max) > 0 ? v : max,
+              undefined,
+            )
           : undefined;
-        const nextVersion = CalVer.bump(previousCalVer);
+        const nextVersion = CalVer.bump(baseline);
+
+        // Surface latest prerelease versions per channel, omitting channels
+        // with no published latest. Undefined when no prerelease exists.
+        const channels: PrereleaseChannels = {};
+        if (published?.beta) channels.beta = { latest: published.beta };
+        if (published?.rc) channels.rc = { latest: published.rc };
+        const hasPrerelease = Object.keys(channels).length > 0;
 
         yield {
           kind: "completed",
           data: {
             extensionName: input.extensionName,
-            currentPublished: latest?.version ?? null,
-            publishedAt: latest?.publishedAt ?? null,
+            currentPublished: published?.stable ?? null,
+            publishedAt: null,
             nextVersion: nextVersion.value,
+            ...(hasPrerelease ? { channels } : {}),
           },
         };
       } catch (error) {

--- a/src/libswamp/extensions/version_test.ts
+++ b/src/libswamp/extensions/version_test.ts
@@ -30,9 +30,18 @@ function makeDeps(
   overrides?: Partial<ExtensionVersionDeps>,
 ): ExtensionVersionDeps {
   return {
-    getLatestVersion: () => Promise.resolve(null),
+    getPublishedVersions: () => Promise.resolve(null),
     ...overrides,
   };
+}
+
+function completedData(events: ExtensionVersionEvent[]) {
+  const completed = events[1] as Extract<
+    ExtensionVersionEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  return completed.data;
 }
 
 function todayPrefix(): string {
@@ -43,7 +52,7 @@ function todayPrefix(): string {
   return `${yyyy}.${mm}.${dd}`;
 }
 
-Deno.test("extensionVersion: never-published extension returns null published and today.1", async () => {
+Deno.test("extensionVersion: never-published extension returns null published, no channels, and today.1", async () => {
   const deps = makeDeps();
   const events = await collect<ExtensionVersionEvent>(
     extensionVersion(createLibSwampContext(), deps, {
@@ -54,23 +63,21 @@ Deno.test("extensionVersion: never-published extension returns null published an
   assertEquals(events.length, 2);
   assertEquals(events[0], { kind: "resolving" });
 
-  const completed = events[1] as Extract<
-    ExtensionVersionEvent,
-    { kind: "completed" }
-  >;
-  assertEquals(completed.kind, "completed");
-  assertEquals(completed.data.extensionName, "@myorg/new-ext");
-  assertEquals(completed.data.currentPublished, null);
-  assertEquals(completed.data.publishedAt, null);
-  assertEquals(completed.data.nextVersion, `${todayPrefix()}.1`);
+  const data = completedData(events);
+  assertEquals(data.extensionName, "@myorg/new-ext");
+  assertEquals(data.currentPublished, null);
+  assertEquals(data.publishedAt, null);
+  assertEquals(data.nextVersion, `${todayPrefix()}.1`);
+  assertEquals(data.channels, undefined);
 });
 
-Deno.test("extensionVersion: same-day bump increments micro", async () => {
+Deno.test("extensionVersion: same-day bump increments micro, no channels for stable-only", async () => {
   const deps = makeDeps({
-    getLatestVersion: () =>
+    getPublishedVersions: () =>
       Promise.resolve({
-        version: `${todayPrefix()}.3`,
-        publishedAt: "2026-03-30T10:00:00Z",
+        stable: `${todayPrefix()}.3`,
+        beta: null,
+        rc: null,
       }),
   });
   const events = await collect<ExtensionVersionEvent>(
@@ -79,21 +86,16 @@ Deno.test("extensionVersion: same-day bump increments micro", async () => {
     }),
   );
 
-  const completed = events[1] as Extract<
-    ExtensionVersionEvent,
-    { kind: "completed" }
-  >;
-  assertEquals(completed.data.currentPublished, `${todayPrefix()}.3`);
-  assertEquals(completed.data.nextVersion, `${todayPrefix()}.4`);
+  const data = completedData(events);
+  assertEquals(data.currentPublished, `${todayPrefix()}.3`);
+  assertEquals(data.nextVersion, `${todayPrefix()}.4`);
+  assertEquals(data.channels, undefined);
 });
 
 Deno.test("extensionVersion: different-day bump resets micro to 1", async () => {
   const deps = makeDeps({
-    getLatestVersion: () =>
-      Promise.resolve({
-        version: "2020.01.01.5",
-        publishedAt: "2020-01-01T10:00:00Z",
-      }),
+    getPublishedVersions: () =>
+      Promise.resolve({ stable: "2020.01.01.5", beta: null, rc: null }),
   });
   const events = await collect<ExtensionVersionEvent>(
     extensionVersion(createLibSwampContext(), deps, {
@@ -101,18 +103,75 @@ Deno.test("extensionVersion: different-day bump resets micro to 1", async () => 
     }),
   );
 
-  const completed = events[1] as Extract<
-    ExtensionVersionEvent,
-    { kind: "completed" }
-  >;
-  assertEquals(completed.data.currentPublished, "2020.01.01.5");
-  assertEquals(completed.data.publishedAt, "2020-01-01T10:00:00Z");
-  assertEquals(completed.data.nextVersion, `${todayPrefix()}.1`);
+  const data = completedData(events);
+  assertEquals(data.currentPublished, "2020.01.01.5");
+  assertEquals(data.publishedAt, null);
+  assertEquals(data.nextVersion, `${todayPrefix()}.1`);
+  assertEquals(data.channels, undefined);
+});
+
+Deno.test("extensionVersion: prerelease-only extension computes next from today without throwing", async () => {
+  const deps = makeDeps({
+    getPublishedVersions: () =>
+      Promise.resolve({ stable: null, beta: "2020.01.01.3", rc: null }),
+  });
+  const events = await collect<ExtensionVersionEvent>(
+    extensionVersion(createLibSwampContext(), deps, {
+      extensionName: "@shrug/mercury",
+    }),
+  );
+
+  const data = completedData(events);
+  assertEquals(data.currentPublished, null);
+  assertEquals(data.nextVersion, `${todayPrefix()}.1`);
+  assertEquals(data.channels, { beta: { latest: "2020.01.01.3" } });
+});
+
+Deno.test("extensionVersion: bumps past a prerelease published today to avoid collision", async () => {
+  const deps = makeDeps({
+    getPublishedVersions: () =>
+      Promise.resolve({ stable: null, beta: `${todayPrefix()}.3`, rc: null }),
+  });
+  const events = await collect<ExtensionVersionEvent>(
+    extensionVersion(createLibSwampContext(), deps, {
+      extensionName: "@shrug/mercury",
+    }),
+  );
+
+  const data = completedData(events);
+  assertEquals(data.currentPublished, null);
+  assertEquals(data.nextVersion, `${todayPrefix()}.4`);
+  assertEquals(data.channels, { beta: { latest: `${todayPrefix()}.3` } });
+});
+
+Deno.test("extensionVersion: baseline is the highest version across all channels", async () => {
+  // stable is older; rc is the newest published version.
+  const deps = makeDeps({
+    getPublishedVersions: () =>
+      Promise.resolve({
+        stable: "2020.01.01.1",
+        beta: "2020.02.01.1",
+        rc: `${todayPrefix()}.9`,
+      }),
+  });
+  const events = await collect<ExtensionVersionEvent>(
+    extensionVersion(createLibSwampContext(), deps, {
+      extensionName: "@shrug/mercury",
+    }),
+  );
+
+  const data = completedData(events);
+  assertEquals(data.currentPublished, "2020.01.01.1");
+  assertEquals(data.nextVersion, `${todayPrefix()}.10`);
+  assertEquals(data.channels, {
+    beta: { latest: "2020.02.01.1" },
+    rc: { latest: `${todayPrefix()}.9` },
+  });
 });
 
 Deno.test("extensionVersion: registry error yields error event", async () => {
   const deps = makeDeps({
-    getLatestVersion: () => Promise.reject(new Error("Network error")),
+    getPublishedVersions: () => Promise.reject(new Error("Network error")),
   });
   const events = await collect<ExtensionVersionEvent>(
     extensionVersion(createLibSwampContext(), deps, {

--- a/src/presentation/renderers/extension_version.ts
+++ b/src/presentation/renderers/extension_version.ts
@@ -40,6 +40,14 @@ class LogExtensionVersionRenderer implements Renderer<ExtensionVersionEvent> {
         } else {
           logger.info("Current published: (none — not yet published)");
         }
+        const beta = e.data.channels?.beta;
+        if (beta) {
+          logger.info("Latest beta: {version}", { version: beta.latest });
+        }
+        const rc = e.data.channels?.rc;
+        if (rc) {
+          logger.info("Latest rc: {version}", { version: rc.latest });
+        }
         logger.info("Next version (today): {version}", {
           version: e.data.nextVersion,
         });


### PR DESCRIPTION
## Summary

`swamp extension version` crashed with `Invalid CalVer version: "null"` for any extension that had a **prerelease** (beta/rc) version published but **no stable** version. The null stable `latestVersion` was passed straight into `CalVer.create`, because the wiring wrapped it in a truthy `{ version: null }` object.

This fixes the crash and aligns the output with the documented per-channel contract:

- The dep now returns per-channel versions (`PublishedVersions { stable, beta, rc }`), `null` only when the extension doesn't exist.
- The generator filters to valid CalVers, picks the **highest across all channels** as the bump baseline, and computes a single **collision-safe** `nextVersion`. Extension versions are globally unique per extension (a version doc carries one channel; promotion just updates it), so the next publishable version must exceed the max across channels.
- Per-channel latest is surfaced via an optional nested `channels` object, present only when a prerelease exists:

```json
{
  "extensionName": "@shrug/mercury",
  "currentPublished": null,
  "publishedAt": null,
  "nextVersion": "2026.07.19.2",
  "channels": { "beta": { "latest": "2026.07.18.3" }, "rc": { "latest": "2026.07.19.1" } }
}
```

Never-published and stable-only extensions are unchanged (no `channels` key).

## Test Plan

- New unit tests in `version_test.ts`: prerelease-only (no crash), same-day collision avoidance, highest-across-channels selection, plus adapted not-found/stable-only/error cases (7/7 pass).
- `deno run check`, `deno lint`, `deno fmt --check` (changed files), broader renderer + extensions suites (425 pass), `deno run compile`.
- **Live smoke test** of the compiled binary against the issue's own extension `@shrug/mercury`: now returns `nextVersion 2026.07.19.2` with nested beta/rc channels instead of crashing, and correctly bumps *past* the rc published today. A stable-only extension omits `channels`.

## Follow-ups (tracked separately)

- swamp-club manual doc (`content/manual/reference/extensions/management.md`) updated to the nested `channels` shape — separate swamp-club PR, sequenced after this lands.
- `ExtensionInfo.latestVersion` is typed `string` but the registry returns `null`; repo-wide type honesty + pull/resolve hardening tracked as a follow-up.
- swamp-uat CLI-gap test for prerelease-only version compute.

Fixes swamp-club#1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)