### PR TITLE
fix(extensions): distinct ruleId for issue-verdict adversarial review (swamp-club#1273)

### DIFF
--- a/.claude/skills/swamp/references/extension/references/adversarial-review.md
+++ b/.claude/skills/swamp/references/extension/references/adversarial-review.md
@@ -37,8 +37,13 @@ Workflow:
    they survive across runners).
 3. Write the skeleton to the printed path, setting each dimension's `verdict`:
    - `pass` — the dimension is satisfied.
-   - `issue` — a problem was found; add a `note`. (Surfaces as a push warning,
-     does not block.)
+   - `issue` — a problem was found; add a `note`. (Surfaces as a push warning
+     under the distinct ruleId `adversarial-review-dimension-issue` — separate
+     from the `adversarial-review-report` ruleId used when a review is
+     missing/stale/incomplete — so a CI gate keying on
+     `reviewRuleWarnings[].ruleId == "adversarial-review-report"` passes a
+     completed review regardless of verdict while still surfacing the note. Does
+     not block.)
    - `na` — the dimension does not apply (e.g. `api-contracts` for an extension
      making no HTTP calls).
    - Leave none as `pending` — a `pending` or missing verdict surfaces as a push

--- a/src/domain/extensions/extension_review_rules.ts
+++ b/src/domain/extensions/extension_review_rules.ts
@@ -543,6 +543,19 @@ export interface ReviewReportContext {
 }
 
 const REVIEW_REPORT_RULE = "adversarial-review-report";
+/**
+ * Distinct ruleId for the "review is present and complete, but a dimension
+ * honestly recorded an `issue` verdict" finding. Keeping it separate from
+ * {@link REVIEW_REPORT_RULE} — which covers a review that is owed, stale, or
+ * incomplete (missing file, name/version mismatch, missing/pending verdicts,
+ * parse error) — lets a downstream CI gate keying on
+ * `reviewRuleWarnings[].ruleId === "adversarial-review-report"` pass a
+ * completed, hash-matching review regardless of its dimension verdicts, while
+ * the honest `issue` note still surfaces under this id. Without the split the
+ * two states are indistinguishable and an honest `issue` verdict reads as a
+ * missing review, pressuring reviewers to launder findings into `pass`.
+ */
+const REVIEW_ISSUE_VERDICT_RULE = "adversarial-review-dimension-issue";
 const REVIEW_REPORT_DIMENSION = "Adversarial review";
 
 /**
@@ -643,7 +656,10 @@ export function evaluateReviewReport(
   for (const entry of ctx.report.dimensions) {
     if (entry.verdict === "issue") {
       findings.push({
-        ruleId: REVIEW_REPORT_RULE,
+        // Distinct ruleId so a gate on REVIEW_REPORT_RULE treats a completed
+        // review as clean regardless of verdict; `file` still points at the
+        // review (where the note lives), not a remediation target.
+        ruleId: REVIEW_ISSUE_VERDICT_RULE,
         dimension: REVIEW_REPORT_DIMENSION,
         severity: "medium",
         file: ctx.reportPath,

--- a/src/domain/extensions/extension_review_rules_test.ts
+++ b/src/domain/extensions/extension_review_rules_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { join, SEPARATOR } from "@std/path";
 import {
   applicableDimensions,
@@ -633,6 +633,10 @@ Deno.test("evaluateReviewReport: pending verdicts warn, issue warns, all-pass is
   const passFindings = evaluateReviewReport(reportCtx(passReport, dims));
   assertEquals(passFindings.length, 1);
   assertEquals(passFindings[0].severity, "medium");
+  // The issue-verdict finding carries its own ruleId, distinct from the
+  // review-owed/stale ruleId, so a CI gate can tell the two states apart.
+  assertEquals(passFindings[0].ruleId, "adversarial-review-dimension-issue");
+  assert(passFindings[0].ruleId !== "adversarial-review-report");
 
   // Fully clean report → no findings.
   const cleanReport: ExtensionReviewReport = {
@@ -642,6 +646,31 @@ Deno.test("evaluateReviewReport: pending verdicts warn, issue warns, all-pass is
     dimensions: dims.map((d) => ({ id: d.id, verdict: "pass" as const })),
   };
   assertEquals(evaluateReviewReport(reportCtx(cleanReport, dims)).length, 0);
+});
+
+Deno.test("evaluateReviewReport: a completed review with an issue verdict is distinguishable from a missing/stale review", () => {
+  const dims = applicableDimensions(["vault"]);
+  // Present, name/version-matching, fully-verdicted review whose only "problem"
+  // is one honest `issue` verdict.
+  const report: ExtensionReviewReport = {
+    extension: "@a/b",
+    version: "1",
+    reviewedAt: "now",
+    dimensions: dims.map((d, i) => ({
+      id: d.id,
+      verdict: i === 0 ? ("issue" as const) : ("pass" as const),
+      note: i === 0 ? "delete swallows 404" : undefined,
+    })),
+  };
+  const findings = evaluateReviewReport(reportCtx(report, dims));
+
+  // Gate-distinguishability: a gate keying on the review-owed ruleId sees this
+  // completed review as clean — no `adversarial-review-report` finding.
+  assert(findings.every((f) => f.ruleId !== "adversarial-review-report"));
+  // The honest note still surfaces, under the distinct ruleId, with the note.
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].ruleId, "adversarial-review-dimension-issue");
+  assertStringIncludes(findings[0].message, "delete swallows 404");
 });
 
 Deno.test("checkReviewRules: validates report when a report request is supplied", async () => {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1273 (reported by @jentz).

`swamp extension push` emitted the `adversarial-review-report` `reviewRuleWarnings` entry — with a `.file` path — for a review that is **present and content-hash-matching** but whose only "problem" is that a dimension honestly recorded `"verdict": "issue"`. It used the **same `ruleId` and `.file`** as the genuinely actionable "review missing / stale" case, so a downstream CI gate keying on `reviewRuleWarnings[].ruleId == "adversarial-review-report"` could not tell the two states apart. An honest `issue` verdict read as a missing review, structurally pressuring reviewers to launder real findings into `pass`.

### Fix

The issue-verdict finding now emits a distinct `ruleId`: **`adversarial-review-dimension-issue`**. The four review-owed/stale states (missing report, name/version mismatch, missing/pending verdicts, parse error) keep `adversarial-review-report`. A gate can now pass a completed, hash-matching review regardless of dimension verdicts while the honest note still surfaces under its own id. Severity stays `medium`; `.file` still points at the review (where the note lives), which is no longer a false remediation target once the ruleId differs.

Files:
- `src/domain/extensions/extension_review_rules.ts` — new `REVIEW_ISSUE_VERDICT_RULE`; issue-verdict emission uses it.
- `src/domain/extensions/extension_review_rules_test.ts` — assert the distinct ruleId + a gate-distinguishability test.
- `.claude/skills/.../adversarial-review.md` — documents the two-ruleId contract.

## Test Plan

- `deno check` / `deno lint` / `deno fmt --check` — pass.
- `deno run test` — **9154 passed, 0 failed**.
- **Live** `swamp extension push --dry-run --json` against a minimal extension with a committed review (freshly compiled binary):
  - missing report → `ruleId: adversarial-review-report`
  - all `pass` → gate clean (no `reviewRuleWarnings`)
  - one `issue` verdict (content hash unchanged) → `ruleId: adversarial-review-dimension-issue`, **no** `adversarial-review-report` finding, note preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)