### PR TITLE
fix(extensions): type ExtensionInfo.latestVersion as string | null and harden prerelease-only paths (swamp-club#1276)

### DIFF
--- a/design/extension.md
+++ b/design/extension.md
@@ -76,7 +76,9 @@ unchanged.
 
 ### Pull
 
-`swamp extension pull @name` resolves the latest stable version.
+`swamp extension pull @name` resolves the latest stable version. If no stable
+version exists (prerelease-only extension), pull errors with an actionable
+message suggesting the available `--channel` flag.
 `swamp extension pull @name --channel rc` resolves the latest rc version.
 `swamp extension pull @name --channel beta` resolves the latest beta version.
 Explicit version pinning (`@name@2026.06.10.1`) ignores channel since versions

--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -51,6 +51,7 @@ import {
   renderAutoResolveInstalled,
   renderAutoResolveInstalling,
   renderAutoResolveNetworkError,
+  renderAutoResolveNoStableVersion,
   renderAutoResolveNotFound,
   renderAutoResolveSearching,
   renderAutoResolveTruncated,
@@ -383,6 +384,9 @@ export function createAutoResolveOutputAdapter(
     },
     collectiveNotTrusted(collective: string, type: string) {
       renderAutoResolveCollectiveNotTrusted(collective, type, mode);
+    },
+    noStableVersion(extension: string) {
+      renderAutoResolveNoStableVersion(extension, mode);
     },
   };
 }

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -31,7 +31,7 @@ const logger = getLogger(["swamp", "extensions", "auto-resolver"]);
 export interface ExtensionLookupInfo {
   name: string;
   description: string;
-  latestVersion: string;
+  latestVersion: string | null;
 }
 
 /**
@@ -150,6 +150,7 @@ export interface AutoResolveOutputPort {
    * caller fail with an opaque "unknown type" error.
    */
   collectiveNotTrusted(collective: string, type: string): void;
+  noStableVersion(extension: string): void;
 }
 
 /**
@@ -391,7 +392,10 @@ export class ExtensionAutoResolver {
     if (!extInfo) return false;
 
     const version = extInfo.latestVersion;
-    if (!version) return false;
+    if (!version) {
+      output.noStableVersion(extensionName);
+      return false;
+    }
 
     // Inspect the on-disk state before deciding to install. Issue #121
     // introduced the "never overwrite on-disk extensions without --force"

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   type AutoResolveOutputPort,
   ExtensionAutoResolver,
@@ -65,6 +65,9 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
     collectiveNotTrusted(collective: string, type: string) {
       calls.push(`collectiveNotTrusted:${collective}:${type}`);
     },
+    noStableVersion(extension: string) {
+      calls.push(`noStableVersion:${extension}`);
+    },
   };
 }
 
@@ -72,7 +75,7 @@ function createMockOutput(): AutoResolveOutputPort & { calls: string[] } {
 function createMockLookup(
   extensions: Record<
     string,
-    { description: string; latestVersion: string }
+    { description: string; latestVersion: string | null }
   > = {},
   searchResults: string[] = [],
 ): ExtensionLookupPort {
@@ -706,4 +709,26 @@ Deno.test("ExtensionAutoResolver - installing message reports the pinned version
   // "installing" must show the pinned version (from the lockfile), not latest.
   assertEquals(output.calls[1], "installing:@swamp/aws@2026.01.01.1");
   assertEquals(output.calls[2], "installed:@swamp/aws@2026.01.01.1:3");
+});
+
+Deno.test("installAndLoad: emits noStableVersion when latestVersion is null", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["shrug"],
+    extensionLookup: createMockLookup(
+      { "@shrug/mercury": { description: "Mercury", latestVersion: null } },
+      ["@shrug/mercury"],
+    ),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result = await resolver.resolve("@shrug/mercury/bank/txn");
+  assertEquals(result, false);
+  assertStringIncludes(
+    output.calls.join(","),
+    "noStableVersion:@shrug/mercury",
+  );
+  assertEquals(installer.installCalls.length, 0);
 });

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -100,7 +100,7 @@ export interface ExtensionInfo {
   labels: string[];
   contentTypes: string[];
   contentNames: string[];
-  latestVersion: string;
+  latestVersion: string | null;
   author: ExtensionAuthor | null;
   createdAt: string;
   updatedAt: string;
@@ -144,7 +144,7 @@ export interface ExtensionSearchEntry {
   platforms: string[];
   labels: string[];
   contentTypes?: string[];
-  latestVersion: string;
+  latestVersion: string | null;
   createdAt: string;
   updatedAt: string;
   deprecatedAt?: string | null;

--- a/src/libswamp/extensions/info.ts
+++ b/src/libswamp/extensions/info.ts
@@ -43,7 +43,7 @@ export interface ExtensionInfoData {
   labels: string[];
   contentTypes: string[];
   contentNames: string[];
-  latestVersion: string;
+  latestVersion: string | null;
   latestRc: string | null;
   latestBeta: string | null;
   author: ExtensionAuthor | null;

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -73,7 +73,7 @@ export interface ExtensionSafetyWarning {
 export interface ExtensionRegistryInfo {
   name: string;
   description: string;
-  latestVersion: string;
+  latestVersion: string | null;
   latestRc?: string | null;
   latestBeta?: string | null;
   deprecatedAt?: string | null;
@@ -724,6 +724,16 @@ export async function installExtension(
 
   const version = ref.version ?? extInfo.latestVersion;
   if (!version) {
+    const channels: string[] = [];
+    if (extInfo.latestRc) channels.push("rc");
+    if (extInfo.latestBeta) channels.push("beta");
+    if (channels.length > 0) {
+      throw new UserError(
+        `Extension ${ref.name} has no stable version. Use --channel ${
+          channels[0]
+        } to pull the latest ${channels[0]}.`,
+      );
+    }
     throw new UserError(
       `Extension ${ref.name} has no published versions.`,
     );

--- a/src/libswamp/extensions/pull_test.ts
+++ b/src/libswamp/extensions/pull_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
 import { join } from "@std/path";
 import {
@@ -26,7 +26,9 @@ import {
   type ExtensionPullDeps,
   type ExtensionPullEvent,
   type ExtensionRef,
+  type ExtensionRegistryInfo,
   type InstallContext,
+  installExtension,
   type InstallResult,
   isVersionConstraint,
   parseExtensionRef,
@@ -454,5 +456,85 @@ Deno.test(
     const ref = parseExtensionRef("@swamp/factory@^2026.06.16.1");
     assertEquals(ref.name, "@swamp/factory");
     assertEquals(ref.version, "^2026.06.16.1");
+  },
+);
+
+Deno.test(
+  "installExtension: actionable error when latestVersion is null but rc exists",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "swamp_pull_nostable_test_",
+    });
+    try {
+      const extInfo: ExtensionRegistryInfo = {
+        name: "@shrug/mercury",
+        description: "Mercury",
+        latestVersion: null,
+        latestRc: "2026.07.19.1",
+        latestBeta: "2026.07.18.3",
+      };
+      const ctx: InstallContext = {
+        getExtension: () => Promise.resolve(extInfo),
+        downloadArchive: () => Promise.reject(new Error("should not download")),
+        getChecksum: () => Promise.resolve(null),
+        lockfileRepository: await LockfileRepository.create(
+          join(tmpDir, "upstream_extensions.json"),
+        ),
+        skillsDirs: [join(tmpDir, "skills")],
+        repoDir: tmpDir,
+        alreadyPulled: new Set(),
+        depth: 0,
+        force: false,
+      };
+      const ref: ExtensionRef = { name: "@shrug/mercury", version: null };
+      const error = await assertRejects(
+        () => installExtension(ref, ctx),
+        UserError,
+      );
+      assertStringIncludes(error.message, "has no stable version");
+      assertStringIncludes(error.message, "--channel rc");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    }
+  },
+);
+
+Deno.test(
+  "installExtension: actionable error mentions only beta when rc is absent",
+  async () => {
+    const tmpDir = await Deno.makeTempDir({
+      prefix: "swamp_pull_nostable2_test_",
+    });
+    try {
+      const extInfo: ExtensionRegistryInfo = {
+        name: "@shrug/mercury",
+        description: "Mercury",
+        latestVersion: null,
+        latestRc: null,
+        latestBeta: "2026.07.18.3",
+      };
+      const ctx: InstallContext = {
+        getExtension: () => Promise.resolve(extInfo),
+        downloadArchive: () => Promise.reject(new Error("should not download")),
+        getChecksum: () => Promise.resolve(null),
+        lockfileRepository: await LockfileRepository.create(
+          join(tmpDir, "upstream_extensions.json"),
+        ),
+        skillsDirs: [join(tmpDir, "skills")],
+        repoDir: tmpDir,
+        alreadyPulled: new Set(),
+        depth: 0,
+        force: false,
+      };
+      const ref: ExtensionRef = { name: "@shrug/mercury", version: null };
+      const error = await assertRejects(
+        () => installExtension(ref, ctx),
+        UserError,
+      );
+      assertStringIncludes(error.message, "has no stable version");
+      assertStringIncludes(error.message, "--channel beta");
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    }
   },
 );

--- a/src/libswamp/extensions/search.ts
+++ b/src/libswamp/extensions/search.ts
@@ -28,7 +28,7 @@ export interface ExtensionSearchItem {
   repository: string | null;
   repositoryVerified: boolean | null;
   repositoryVerifiedUrl: string | null;
-  latestVersion: string;
+  latestVersion: string | null;
   platforms: string[];
   labels: string[];
   contentTypes: string[];
@@ -85,7 +85,7 @@ export interface ExtensionSearchDeps {
       repository?: string | null;
       repositoryVerified?: boolean | null;
       repositoryVerifiedUrl?: string | null;
-      latestVersion: string;
+      latestVersion: string | null;
       platforms: string[];
       labels: string[];
       contentTypes?: string[];

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -90,8 +90,6 @@ export function createExtensionVersionDeps(
     getPublishedVersions: async (name: string) => {
       const info = await client.getExtension(name);
       if (!info) return null;
-      // latestVersion is typed `string` but the registry returns null for
-      // prerelease-only extensions, so read it null-safely at the boundary.
       return {
         stable: info.latestVersion ?? null,
         beta: info.latestBeta ?? null,

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -260,6 +260,6 @@ export function renderAutoResolveNoStableVersion(
     logger
       .warn`Extension ${extension} has no stable version and cannot be auto-resolved.`;
     logger
-      .warn`Install manually with: swamp extension pull ${extension} --channel rc`;
+      .warn`Install manually with: swamp extension pull ${extension} --channel <rc|beta>`;
   }
 }

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -238,3 +238,28 @@ export function renderAutoResolveNetworkError(
     logger.error`Install manually with: swamp extension pull <extension-name>`;
   }
 }
+
+/**
+ * Renders an error message when auto-resolution finds an extension that
+ * has no stable version (only prerelease channels).
+ */
+export function renderAutoResolveNoStableVersion(
+  extension: string,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(
+      JSON.stringify({
+        event: "auto_resolve",
+        status: "failed",
+        extension,
+        reason: "no_stable_version",
+      }),
+    );
+  } else {
+    logger
+      .warn`Extension ${extension} has no stable version and cannot be auto-resolved.`;
+    logger
+      .warn`Install manually with: swamp extension pull ${extension} --channel rc`;
+  }
+}

--- a/src/presentation/renderers/extension_info.ts
+++ b/src/presentation/renderers/extension_info.ts
@@ -158,7 +158,11 @@ class LogExtensionInfoRenderer implements Renderer<ExtensionInfoEvent> {
       completed: (e) => {
         const d = e.data;
 
-        logger.info`${d.name} (${d.latestVersion})`;
+        const versionLabel = d.latestVersion ??
+          (d.latestRc ? `rc: ${d.latestRc}` : null) ??
+          (d.latestBeta ? `beta: ${d.latestBeta}` : null) ??
+          "prerelease only";
+        logger.info`${d.name} (${versionLabel})`;
         logger.info`${d.description}`;
         logger.info``;
 

--- a/src/presentation/renderers/extension_info_test.ts
+++ b/src/presentation/renderers/extension_info_test.ts
@@ -311,6 +311,38 @@ Deno.test("LogExtensionInfoRenderer: not_found throws UserError", () => {
   );
 });
 
+Deno.test("LogExtensionInfoRenderer: null latestVersion shows prerelease channel", async () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({
+        latestVersion: null,
+        latestRc: "2026.07.19.1",
+        latestBeta: "2026.07.18.3",
+      }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("LogExtensionInfoRenderer: null latestVersion with only beta", async () => {
+  const renderer = createExtensionInfoRenderer("log");
+  const events: ExtensionInfoEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: makeInfoData({
+        latestVersion: null,
+        latestRc: null,
+        latestBeta: "2026.07.18.3",
+      }),
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
 Deno.test("LogExtensionInfoRenderer: error event throws UserError", () => {
   const renderer = createExtensionInfoRenderer("log");
   const handlers = renderer.handlers();

--- a/src/presentation/renderers/extension_search.tsx
+++ b/src/presentation/renderers/extension_search.tsx
@@ -142,7 +142,9 @@ function renderExtensionResultLine(
   return (
     <Text>
       {`${item.name} `}
-      <Text dimColor>{`v${item.latestVersion}`}</Text>
+      <Text dimColor>
+        {item.latestVersion ? `v${item.latestVersion}` : "prerelease"}
+      </Text>
       {deprecated && <Text color="yellow">[deprecated]</Text>}
       {truncatedDesc && <Text dimColor>{` ${EM_DASH} ${truncatedDesc}`}</Text>}
       {labelsStr && <Text color="blue">{labelsStr}</Text>}
@@ -160,7 +162,9 @@ function renderExtensionPreview(
   const lines: React.ReactElement[] = [
     <Text key="name" wrap="truncate-end">
       <Text color="cyan" bold>{item.name}</Text>{" "}
-      <Text dimColor>v{item.latestVersion}</Text>
+      <Text dimColor>
+        {item.latestVersion ? `v${item.latestVersion}` : "prerelease"}
+      </Text>
     </Text>,
   ];
 
@@ -254,7 +258,9 @@ function renderExtensionScrollback(
   _detail: ExtensionSearchItem | undefined,
 ): string {
   const lines: string[] = [
-    `${item.name} v${item.latestVersion}`,
+    `${item.name} ${
+      item.latestVersion ? `v${item.latestVersion}` : "prerelease"
+    }`,
   ];
 
   if (item.description) {


### PR DESCRIPTION
## Summary

- Changes `latestVersion` from `string` to `string | null` in 7 interface definitions (`ExtensionInfo`, `ExtensionInfoData`, `ExtensionRegistryInfo`, `ExtensionLookupInfo`, `ExtensionSearchItem`, `ExtensionSearchEntry`, and inline search response type)
- Pull path: replaces misleading "has no published versions" error with actionable message suggesting the available `--channel` flag
- Auto-resolver: emits a `noStableVersion` warning via the output port instead of silently returning false
- Info renderer: shows best prerelease channel version (e.g. `rc: 2026.07.19.1`) instead of `(null)`
- Removes redundant workaround comment in `version.ts` (added by #1902)

## Test Plan

- New unit tests: pull with null latestVersion (rc-only and beta-only variants), auto-resolver noStableVersion emission, info renderer with null latestVersion
- All 9163 existing tests pass
- Full `deno check` passes with no type errors
- Live verification against `@shrug/mercury` (prerelease-only extension):
  - `swamp extension info @shrug/mercury` → now shows `"@shrug/mercury" ("rc: 2026.07.19.1")`
  - `swamp extension pull @shrug/mercury` → now shows `"has no stable version. Use --channel rc to pull the latest rc."`
- UAT tests verified safe: all pull commands use explicit version pins, no assertions on the old error message

Closes swamp-club#1276