### PR TITLE
fix(cli): error on non-interactive stdin instead of silent no-op (swamp-club#1279)

### DIFF
--- a/src/cli/prompt_helpers.ts
+++ b/src/cli/prompt_helpers.ts
@@ -25,8 +25,25 @@
  * free-text input.
  */
 
+import { UserError } from "../domain/errors.ts";
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+function assertInteractiveStdin(): void {
+  try {
+    if (!Deno.stdin.isTerminal()) {
+      throw new UserError(
+        "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+      );
+    }
+  } catch (error) {
+    if (error instanceof UserError) throw error;
+    throw new UserError(
+      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+    );
+  }
+}
 
 /**
  * Prompt for a single line of text input.
@@ -46,6 +63,7 @@ export async function promptLine(message: string): Promise<string> {
  * (case-insensitive), `false` otherwise (including EOF).
  */
 export async function promptConfirmation(message: string): Promise<boolean> {
+  assertInteractiveStdin();
   const response = await promptLine(`${message} [y/N] `);
   if (response === "") return false;
   return response.toLowerCase() === "y" ||
@@ -61,6 +79,7 @@ export async function promptChoice(
   message: string,
   choices: string[],
 ): Promise<string> {
+  assertInteractiveStdin();
   while (true) {
     await Deno.stdout.write(encoder.encode(`${message}\n`));
     for (let i = 0; i < choices.length; i++) {

--- a/src/cli/prompt_helpers_test.ts
+++ b/src/cli/prompt_helpers_test.ts
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
+import { UserError } from "../domain/errors.ts";
 import {
   promptChoice,
   promptConfirmation,
@@ -43,7 +44,10 @@ function fakeStdinRead(
 }
 
 /** Capture stdout writes into a string array and stub stdin to return `input`. */
-function stubIO(input: string | null): {
+function stubIO(
+  input: string | null,
+  options?: { isTerminal?: boolean },
+): {
   written: string[];
   restore: () => void;
 } {
@@ -51,18 +55,21 @@ function stubIO(input: string | null): {
   const decoder = new TextDecoder();
   const origStdoutWrite = Deno.stdout.write.bind(Deno.stdout);
   const origStdinRead = Deno.stdin.read.bind(Deno.stdin);
+  const origIsTerminal = Deno.stdin.isTerminal.bind(Deno.stdin);
 
   Deno.stdout.write = (data: Uint8Array) => {
     written.push(decoder.decode(data));
     return Promise.resolve(data.length);
   };
   Deno.stdin.read = fakeStdinRead(input);
+  Deno.stdin.isTerminal = () => options?.isTerminal ?? true;
 
   return {
     written,
     restore() {
       Deno.stdout.write = origStdoutWrite;
       Deno.stdin.read = origStdinRead;
+      Deno.stdin.isTerminal = origIsTerminal;
     },
   };
 }
@@ -169,6 +176,22 @@ Deno.test("promptConfirmation: rejects arbitrary text", async () => {
   }
 });
 
+Deno.test("promptConfirmation: throws UserError on non-interactive stdin", async () => {
+  const io = stubIO("y\n", { isTerminal: false });
+  try {
+    const error = await assertRejects(
+      () => promptConfirmation("Delete?"),
+      UserError,
+    );
+    assertEquals(
+      error.message,
+      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+    );
+  } finally {
+    io.restore();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // promptChoice
 // ---------------------------------------------------------------------------
@@ -184,6 +207,22 @@ Deno.test("promptChoice: selects a numbered choice", async () => {
     assertEquals(output.includes("2. beta"), true);
     assertEquals(output.includes("3. gamma"), true);
     assertEquals(output.includes("Other path"), false);
+  } finally {
+    io.restore();
+  }
+});
+
+Deno.test("promptChoice: throws UserError on non-interactive stdin", async () => {
+  const io = stubIO("2\n", { isTerminal: false });
+  try {
+    const error = await assertRejects(
+      () => promptChoice("Pick:", ["alpha", "beta"]),
+      UserError,
+    );
+    assertEquals(
+      error.message,
+      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+    );
   } finally {
     io.restore();
   }


### PR DESCRIPTION
## Summary

- `promptConfirmation` and `promptChoice` now check `Deno.stdin.isTerminal()` before reading input. When stdin is not a terminal, they throw a `UserError` with a message telling the caller to use `--force` or `--yes` instead of silently returning false and exiting 0.
- Extracted a shared `assertInteractiveStdin()` helper used by both functions.
- Also resolves swamp-club#1281 (`promptChoice` infinite loop on non-interactive stdin).

## Test Plan

- Added unit test: `promptConfirmation` throws `UserError` when `isTerminal` returns false
- Added unit test: `promptChoice` throws `UserError` when `isTerminal` returns false
- Updated test infrastructure (`stubIO`) to stub `Deno.stdin.isTerminal` (defaults to `true` for existing tests)
- All 17 prompt_helpers tests pass, full suite (9159 tests) passes
- Compiled binary verified: `swamp data delete ... < /dev/null` now exits 1 with clear error message; `--force` still bypasses correctly