### PR TITLE
fix(datastore): make namespace set idempotent for extension datastores (swamp-club#1265)

### DIFF
--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -115,6 +115,18 @@ export const datastoreNamespaceSetCommand = new Command()
           const slugs = await resolvedProvider.listNamespaces(
             (datastoreConfig as CustomDatastoreConfig).datastorePath,
           );
+          const cachePath =
+            (datastoreConfig as CustomDatastoreConfig).cachePath;
+          if (cachePath) {
+            const manifests = await listNamespaceManifests(cachePath);
+            const bySlug = new Map(
+              manifests.map((m) => [m.namespace, m.repoId]),
+            );
+            return slugs.map((ns) => ({
+              namespace: ns,
+              repoId: bySlug.get(ns) ?? "",
+            }));
+          }
           return slugs.map((ns) => ({ namespace: ns, repoId: "" }));
         }
         const manifests = await listNamespaceManifests(dsBasePath);

--- a/src/libswamp/datastores/namespace_set.ts
+++ b/src/libswamp/datastores/namespace_set.ts
@@ -101,7 +101,7 @@ export async function* datastoreNamespaceSet(
       if (deps.supportsRegistration) {
         const existing = await deps.listNamespaces();
         const conflict = existing.find((r) => r.namespace === slug);
-        if (conflict && conflict.repoId !== repoId) {
+        if (conflict && conflict.repoId !== "" && conflict.repoId !== repoId) {
           yield {
             kind: "error",
             error: validationFailed(

--- a/src/libswamp/datastores/namespace_set_test.ts
+++ b/src/libswamp/datastores/namespace_set_test.ts
@@ -119,6 +119,17 @@ Deno.test("datastoreNamespaceSet: re-registration with same repoId succeeds", as
   assertEquals(last.kind, "completed");
 });
 
+Deno.test("datastoreNamespaceSet: re-registration with empty repoId succeeds", async () => {
+  const deps = makeDeps({
+    listNamespaces: () => Promise.resolve([{ namespace: "infra", repoId: "" }]),
+  });
+  const events = await collect<NamespaceSetEvent>(
+    datastoreNamespaceSet(createLibSwampContext(), deps, { slug: "infra" }),
+  );
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+});
+
 Deno.test("datastoreNamespaceSet: registration skipped when unsupported", async () => {
   let registerCalled = false;
   const deps = makeDeps({


### PR DESCRIPTION
## Summary

- Enrich provider `listNamespaces` slugs with `repoId` from cache manifests, fixing `namespace set` idempotency on extension datastores
- Treat empty `repoId` as unknown ownership (no conflict) as a fallback when cache manifests don't exist
- The remaining bugs in swamp-club#1265 (sync guard skipping bound namespace, migrate-index empty shards) are tracked as extension issue swamp-club#1280

**Root cause:** `DatastoreProvider.listNamespaces` returns `string[]` (slugs only). The CLI adapter mapped these to `repoId: ""`, so the conflict check at `namespace_set.ts:104` always saw a mismatch against the real repo UUID — making `namespace set` fail on re-run with "already registered by repo ."

**Fix:** Read cache manifests (written by the #834 orphan-detection fix) to get the real `repoId`. When no manifest exists, treat unknown ownership as no-conflict since the provider can't determine the owner.

## Test plan

- [x] Unit test: `re-registration with empty repoId succeeds` in `namespace_set_test.ts`
- [x] Inline reproduction: `datastoreNamespaceSet` with `repoId: ""` now succeeds
- [x] All 9155 tests pass
- [x] Type check, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)