### PR TITLE
fix(update): skip global skill sync when running as root (swamp-club#1260)

### DIFF
--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -79,6 +79,12 @@ async function dirExists(path: string): Promise<boolean> {
 async function syncGlobalSkills(
   logger: ReturnType<typeof getSwampLogger>,
 ): Promise<void> {
+  if (isRunningAsRoot()) {
+    logger
+      .warn`Skipping global skill sync: running as root. Run ${"swamp update"} without sudo or ${"swamp repo upgrade"} in a repository to sync skills.`;
+    return;
+  }
+
   let home: string | null = null;
   try {
     home = homeDirectory();


### PR DESCRIPTION
## Summary

- Skip global skill sync in `syncGlobalSkills()` when `Deno.uid() === 0` (running as root via sudo), preventing root-owned files from being written to `~/.claude/skills/`
- Log a warning directing the user to re-run `swamp update` without sudo or run `swamp repo upgrade` as their normal user to sync skills
- Fixes swamp-club#1260 — `sudo swamp update` previously left root-owned files that broke subsequent non-root commands like `swamp repo upgrade`

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — all 9160 tests pass
- [ ] Manual verification requires running as root, which is environment-specific. The fix is a 5-line guard clause using the existing `isRunningAsRoot()` utility — verifiable by code inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)