### PR TITLE
feat(cli): resolve repo root from subdirectories (swamp-club#1286)

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -18,7 +18,8 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Logger } from "@logtape/logtape";
-import { resolve } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
+import { SWAMP_MARKER_FILE } from "../infrastructure/persistence/paths.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { OutputMode } from "../presentation/output/output.ts";
 
@@ -107,13 +108,81 @@ export function isQuietFromArgs(args: string[]): boolean {
   return args.includes("--quiet") || args.includes("-q");
 }
 
+const MAX_ANCESTOR_DEPTH = 10;
+
+function getGitRootSync(startDir: string): string | null {
+  try {
+    const result = new Deno.Command("git", {
+      args: ["rev-parse", "--show-toplevel"],
+      cwd: startDir,
+      stdout: "piped",
+      stderr: "null",
+    }).outputSync();
+    if (result.success) {
+      const raw = new TextDecoder().decode(result.stdout).trim();
+      try {
+        return Deno.realPathSync(raw);
+      } catch {
+        return resolve(raw);
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walks up the directory tree from `startDir` looking for a `.swamp.yaml`
+ * marker file.
+ *
+ * Stops at the git repository root (when inside a git repo) or after
+ * MAX_ANCESTOR_DEPTH levels (when not in a git repo).
+ *
+ * @returns The ancestor directory containing `.swamp.yaml`, or `null`.
+ */
+export function findAncestorRepoDir(startDir: string): string | null {
+  const gitRoot = getGitRootSync(startDir);
+
+  let dir: string;
+  try {
+    dir = Deno.realPathSync(startDir);
+  } catch {
+    dir = resolve(startDir);
+  }
+
+  for (let depth = 0; depth < MAX_ANCESTOR_DEPTH; depth++) {
+    try {
+      const stat = Deno.statSync(join(dir, SWAMP_MARKER_FILE));
+      if (stat.isFile) {
+        return dir;
+      }
+    } catch {
+      // .swamp.yaml not found at this level — continue up
+    }
+
+    if (gitRoot !== null && dir === gitRoot) {
+      break;
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+
+  return null;
+}
+
 /**
  * Pre-parses --repo-dir from raw CLI arguments before Cliffy option parsing.
  *
  * Supports both `--repo-dir <value>` and `--repo-dir=<value>` forms.
  * Returns the resolved absolute path.
  *
- * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > cwd.
+ * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > cwd (with ancestor
+ * traversal).
  */
 export function getRepoDirFromArgs(args: string[]): string {
   for (let i = 0; i < args.length; i++) {
@@ -129,14 +198,16 @@ export function getRepoDirFromArgs(args: string[]): string {
   if (envDir && envDir.length > 0) {
     return resolve(envDir);
   }
-  return Deno.cwd();
+  const cwd = Deno.cwd();
+  return findAncestorRepoDir(cwd) ?? cwd;
 }
 
 /**
  * Resolves the repository directory for a command action, given the Cliffy
  * parsed `--repo-dir` option value.
  *
- * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > "." (cwd).
+ * Priority: --repo-dir flag > SWAMP_REPO_DIR env var > cwd (with ancestor
+ * traversal).
  *
  * Command option definitions must NOT set a Cliffy `default` for `--repo-dir`
  * — otherwise Cliffy always populates the value and the env var is ignored.
@@ -149,7 +220,8 @@ export function resolveRepoDir(cliValue: string | undefined): string {
   if (envDir && envDir.length > 0) {
     return resolve(envDir);
   }
-  return Deno.cwd();
+  const cwd = Deno.cwd();
+  return findAncestorRepoDir(cwd) ?? cwd;
 }
 
 /**

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -19,8 +19,10 @@
 
 import { assertEquals } from "@std/assert";
 import { isAbsolute, resolve } from "@std/path";
+import { join } from "@std/path";
 import {
   createContext,
+  findAncestorRepoDir,
   getExtensionsDirFromArgs,
   getOutputModeFromArgs,
   getRepoDirFromArgs,
@@ -32,6 +34,7 @@ import {
 } from "./context.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { assertPathEquals } from "../infrastructure/persistence/path_test_helpers.ts";
+import { SWAMP_MARKER_FILE } from "../infrastructure/persistence/paths.ts";
 
 // Initialize logging once before tests run
 await initializeLogging({});
@@ -260,6 +263,114 @@ Deno.test("resolveRepoDir treats empty SWAMP_REPO_DIR as unset", () => {
     if (original !== undefined) Deno.env.set("SWAMP_REPO_DIR", original);
     else Deno.env.delete("SWAMP_REPO_DIR");
   }
+});
+
+// ============================================================================
+// findAncestorRepoDir Tests
+// ============================================================================
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-context-" });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+Deno.test("findAncestorRepoDir: returns dir when marker exists at startDir", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = Deno.realPathSync(dir);
+    await Deno.writeTextFile(join(dir, SWAMP_MARKER_FILE), "swampVersion: 1");
+    const result = findAncestorRepoDir(dir);
+    assertPathEquals(result!, realDir);
+  });
+});
+
+Deno.test("findAncestorRepoDir: finds marker in parent directory", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = Deno.realPathSync(dir);
+    await Deno.writeTextFile(join(dir, SWAMP_MARKER_FILE), "swampVersion: 1");
+    const subdir = join(dir, "models");
+    await Deno.mkdir(subdir);
+    const result = findAncestorRepoDir(subdir);
+    assertPathEquals(result!, realDir);
+  });
+});
+
+Deno.test("findAncestorRepoDir: finds marker in grandparent directory", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = Deno.realPathSync(dir);
+    await Deno.writeTextFile(join(dir, SWAMP_MARKER_FILE), "swampVersion: 1");
+    const nested = join(dir, "models", "my-type");
+    await Deno.mkdir(nested, { recursive: true });
+    const result = findAncestorRepoDir(nested);
+    assertPathEquals(result!, realDir);
+  });
+});
+
+Deno.test("findAncestorRepoDir: returns null when no marker in any ancestor", async () => {
+  await withTempDir(async (dir) => {
+    const subdir = join(dir, "some", "path");
+    await Deno.mkdir(subdir, { recursive: true });
+    const result = findAncestorRepoDir(subdir);
+    assertEquals(result, null);
+  });
+});
+
+Deno.test("findAncestorRepoDir: stops at git root and does not traverse above it", async () => {
+  await withTempDir(async (dir) => {
+    // Create a .swamp.yaml ABOVE the git root — should not be found
+    await Deno.writeTextFile(join(dir, SWAMP_MARKER_FILE), "swampVersion: 1");
+
+    // Create a git repo in a subdirectory
+    const gitRepo = join(dir, "git-project");
+    await Deno.mkdir(gitRepo);
+    const gitInit = new Deno.Command("git", {
+      args: ["init"],
+      cwd: gitRepo,
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await gitInit.output();
+    if (!result.success) {
+      // git not available — skip this test
+      return;
+    }
+
+    const subdir = join(gitRepo, "src");
+    await Deno.mkdir(subdir);
+
+    const found = findAncestorRepoDir(subdir);
+    assertEquals(found, null);
+  });
+});
+
+Deno.test("findAncestorRepoDir: finds marker inside git root", async () => {
+  await withTempDir(async (dir) => {
+    const realDir = Deno.realPathSync(dir);
+    const gitInit = new Deno.Command("git", {
+      args: ["init"],
+      cwd: dir,
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await gitInit.output();
+    if (!result.success) {
+      return;
+    }
+
+    await Deno.writeTextFile(join(dir, SWAMP_MARKER_FILE), "swampVersion: 1");
+    const subdir = join(dir, "models", "my-type");
+    await Deno.mkdir(subdir, { recursive: true });
+
+    const found = findAncestorRepoDir(subdir);
+    assertPathEquals(found!, realDir);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add git-like parent directory traversal to repo resolution so swamp commands work from subdirectories of a swamp repo
- Walk up from cwd looking for `.swamp.yaml`, bounded by the git root (when in a git repo) or a 10-level depth cap (when not)
- Priority chain preserved: `--repo-dir` flag > `SWAMP_REPO_DIR` env var > cwd with ancestor traversal

Closes swamp-club#1286

## Test Plan

- [x] Unit tests for `findAncestorRepoDir`: finds marker at startDir, parent, grandparent; returns null when no marker; stops at git root boundary; finds marker inside git root
- [x] All 9172 existing tests pass
- [x] Type checking, linting, formatting all pass
- [x] `repo init` is unaffected (uses raw path, not `resolveRepoDir`)