### PR TITLE
perf(serve): SQL pushdown for data.query, summary projections for workflow ops

### DIFF
--- a/design/data-query.md
+++ b/design/data-query.md
@@ -359,23 +359,47 @@ the sync implementation internally.
 
 ## Query Execution
 
-Queries iterate over catalog rows and evaluate the full CEL predicate against
-each row. There is no SQL pushdown — SQLite serves as a fast metadata store,
-and CEL handles all filtering semantics.
+Queries use a two-phase evaluation: SQL pre-filtering narrows the candidate
+set, then the full CEL predicate evaluates on every row returned by SQL. The
+CEL evaluation is always the correctness authority — SQL pushdown is a
+performance optimization only.
+
+### SQL Pushdown
+
+Before iterating, the query service extracts trivially correct predicates from
+the CEL AST and pushes them down to SQL WHERE clauses:
+
+| CEL pattern                     | SQL pushdown                  | Notes                                              |
+| ------------------------------- | ----------------------------- | -------------------------------------------------- |
+| implicit `isLatest == true`     | `WHERE is_latest = 1`         | Applied when predicate doesn't reference `version` or `isLatest` |
+| `modelName == "<literal>"`      | `WHERE model_name = ?`        | Extracted from top-level AND conjuncts only         |
+
+All other predicates (OR expressions, comparisons, tag filters, `attributes`
+references, complex expressions) remain CEL-only and are evaluated per-row on
+the narrowed result set. Future versions may push down additional patterns
+(tag equality via `json_extract`, comparisons on indexed columns).
+
+The pushdown invariant: SQL must produce a **superset** of matching rows. CEL
+can only narrow, never widen. If a pushdown translation is uncertain, the
+conjunct stays in CEL.
+
+### Execution Flow
 
 ```
 1. Parse predicate into AST
 2. Validate field references
-3. Detect whether predicate references `attributes`
-4. SELECT metadata columns from catalog (via paged LIMIT/OFFSET queries using stmt.all())
-5. For each row:
+3. Extract SQL pushdown clauses (isLatest, modelName equality)
+4. Detect whether predicate references `attributes`
+5. SELECT metadata columns from catalog with WHERE pushdown
+   (via paged LIMIT/OFFSET queries using stmt.all())
+6. For each row:
    a. Project row into query record
    b. If predicate references `attributes`:
       load JSON content from disk for this row
-   c. Evaluate CEL predicate against query record
+   c. Evaluate full CEL predicate against query record
    d. If true: add to results
    e. If results.length >= limit: stop
-6. Return results
+7. Return results
 ```
 
 Iteration uses paged `stmt.all()` with `LIMIT/OFFSET` so that rows are fetched

--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -29,6 +29,7 @@ import type { DataRecord } from "./data_record.ts";
 import {
   type ASTNode,
   collectRootIdentifiers,
+  extractModelNameEquality,
   HISTORY_OPT_IN_FIELDS,
   referencesAttributes,
   referencesContent,
@@ -374,13 +375,37 @@ export class DataQueryService {
       if (!needsContent) needsContent = referencesContent(selectAst);
     }
 
+    // SQL pushdown: pre-filter rows in SQLite before CEL evaluation.
+    // Only trivially correct translations are pushed down; the full CEL
+    // predicate still evaluates on every row returned by SQL.
+    const whereClauses: string[] = [];
+    const whereParams: (string | number)[] = [];
+
+    if (!opensHistory) {
+      whereClauses.push("is_latest = ?");
+      whereParams.push(1);
+    }
+
+    const modelNameLiteral = extractModelNameEquality(userAst);
+    if (modelNameLiteral !== null) {
+      whereClauses.push("model_name = ?");
+      whereParams.push(modelNameLiteral);
+    }
+
+    const rows = whereClauses.length > 0
+      ? this.catalogStore.iterateFiltered(
+        whereClauses.join(" AND "),
+        whereParams,
+      )
+      : this.catalogStore.iterate();
+
     // Iterate catalog rows and evaluate predicate.
     // CEL reserves "namespace" as an identifier, so we expose an "ns" alias
     // via a prototype-chain overlay — the record itself is not mutated.
     const results: DataRecord[] = [];
     const needsHydration = !needsAttributes && !selectParsed;
     const matchedRows: CatalogRow[] = [];
-    for (const row of this.catalogStore.iterate()) {
+    for (const row of rows) {
       const record = this.rowToRecord(row, needsAttributes, needsContent);
       const ctx = Object.create(
         record as unknown as Record<string, unknown>,

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1187,3 +1187,143 @@ Deno.test("getLatestRecord: namespace filtering works in scoped path", async () 
   catalog.close();
   Deno.removeSync(dir, { recursive: true });
 });
+
+// ---------------------------------------------------------------------------
+// SQL pushdown tests — verify that pushdown produces identical results to
+// full CEL evaluation for all predicate shapes.
+// ---------------------------------------------------------------------------
+
+Deno.test("DataQueryService pushdown: isLatest pushdown returns same results as CEL-only", () => {
+  const { catalog, service } = setupTest();
+  catalog.upsert(makeRow({ model_name: "a", is_latest: 1 }));
+  catalog.upsert(
+    makeRow({
+      data_name: "old",
+      model_name: "a",
+      is_latest: 0,
+      version: 1,
+      id: "uuid-old",
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      data_name: "other",
+      model_name: "b",
+      is_latest: 1,
+      id: "uuid-b",
+    }),
+  );
+
+  const results = service.querySync('modelName == "a"') as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].modelName, "a");
+  assertEquals(results[0].isLatest, true);
+  catalog.close();
+});
+
+Deno.test("DataQueryService pushdown: modelName equality narrows scan", () => {
+  const { catalog, service } = setupTest();
+  for (let i = 0; i < 50; i++) {
+    catalog.upsert(
+      makeRow({
+        data_name: `data-${i}`,
+        model_name: i < 5 ? "target" : "other",
+        id: `uuid-${i}`,
+      }),
+    );
+  }
+
+  const results = service.querySync(
+    'modelName == "target"',
+  ) as DataRecord[];
+  assertEquals(results.length, 5);
+  for (const r of results) {
+    assertEquals(r.modelName, "target");
+  }
+  catalog.close();
+});
+
+Deno.test("DataQueryService pushdown: compound modelName + specName", () => {
+  const { catalog, service } = setupTest();
+  catalog.upsert(makeRow({ model_name: "m1", spec_name: "result" }));
+  catalog.upsert(
+    makeRow({
+      data_name: "d2",
+      model_name: "m1",
+      spec_name: "log",
+      id: "uuid-2",
+    }),
+  );
+  catalog.upsert(
+    makeRow({
+      data_name: "d3",
+      model_name: "m2",
+      spec_name: "result",
+      id: "uuid-3",
+    }),
+  );
+
+  const results = service.querySync(
+    'modelName == "m1" && specName == "result"',
+  ) as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].modelName, "m1");
+  assertEquals(results[0].specName, "result");
+  catalog.close();
+});
+
+Deno.test("DataQueryService pushdown: version opt-in skips isLatest pushdown", () => {
+  const { catalog, service } = setupTest();
+  catalog.upsert(
+    makeRow({ model_name: "a", version: 1, is_latest: 0, id: "uuid-v1" }),
+  );
+  catalog.upsert(
+    makeRow({ model_name: "a", version: 2, is_latest: 1, id: "uuid-v2" }),
+  );
+
+  const all = service.querySync("version >= 0") as DataRecord[];
+  assertEquals(all.length, 2);
+
+  const latest = service.querySync("version == 2") as DataRecord[];
+  assertEquals(latest.length, 1);
+  assertEquals(latest[0].version, 2);
+  catalog.close();
+});
+
+Deno.test("DataQueryService pushdown: OR predicate falls back to full scan", () => {
+  const { catalog, service } = setupTest();
+  catalog.upsert(makeRow({ model_name: "a", id: "uuid-a" }));
+  catalog.upsert(
+    makeRow({ data_name: "d2", model_name: "b", id: "uuid-b" }),
+  );
+  catalog.upsert(
+    makeRow({ data_name: "d3", model_name: "c", id: "uuid-c" }),
+  );
+
+  const results = service.querySync(
+    'modelName == "a" || modelName == "b"',
+  ) as DataRecord[];
+  assertEquals(results.length, 2);
+  const names = results.map((r) => r.modelName).sort();
+  assertEquals(names, ["a", "b"]);
+  catalog.close();
+});
+
+Deno.test("DataQueryService pushdown: limit interacts correctly with pushdown", () => {
+  const { catalog, service } = setupTest();
+  for (let i = 0; i < 10; i++) {
+    catalog.upsert(
+      makeRow({
+        data_name: `data-${i}`,
+        model_name: "target",
+        id: `uuid-${i}`,
+      }),
+    );
+  }
+
+  const results = service.querySync('modelName == "target"', {
+    limit: 3,
+  }) as DataRecord[];
+  assertEquals(results.length, 3);
+  catalog.close();
+});

--- a/src/domain/data/query_predicate.ts
+++ b/src/domain/data/query_predicate.ts
@@ -188,6 +188,39 @@ export function referencesContent(node: ASTNode): boolean {
 }
 
 /**
+ * Extracts a string literal from a top-level `modelName == "literal"`
+ * equality in the AST. Walks through AND conjuncts but does not descend
+ * into OR branches. Returns null if no pushdown-eligible modelName
+ * equality is found.
+ */
+export function extractModelNameEquality(ast: ASTNode): string | null {
+  if (ast.op === "==") {
+    const [left, right] = ast.args as [ASTNode, ASTNode];
+    if (
+      left.op === "id" && left.args === "modelName" &&
+      right.op === "value" && typeof right.args === "string"
+    ) {
+      return right.args;
+    }
+    if (
+      right.op === "id" && right.args === "modelName" &&
+      left.op === "value" && typeof left.args === "string"
+    ) {
+      return left.args;
+    }
+    return null;
+  }
+
+  if (ast.op === "&&") {
+    const [left, right] = ast.args as [ASTNode, ASTNode];
+    return extractModelNameEquality(left) ??
+      extractModelNameEquality(right);
+  }
+
+  return null;
+}
+
+/**
  * Validates that all root identifiers in the AST are known query fields
  * or CEL built-ins. Throws UserError on unknown fields.
  */

--- a/src/domain/data/query_predicate_test.ts
+++ b/src/domain/data/query_predicate_test.ts
@@ -1,0 +1,84 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { Environment } from "cel-js";
+import { type ASTNode, extractModelNameEquality } from "./query_predicate.ts";
+
+const env = new Environment({
+  unlistedVariablesAreDyn: true,
+  homogeneousAggregateLiterals: false,
+});
+
+function ast(expr: string): ASTNode {
+  return env.parse(expr).ast as ASTNode;
+}
+
+Deno.test("extractModelNameEquality: simple equality", () => {
+  assertEquals(extractModelNameEquality(ast('modelName == "foo"')), "foo");
+});
+
+Deno.test("extractModelNameEquality: reversed operand order", () => {
+  assertEquals(extractModelNameEquality(ast('"bar" == modelName')), "bar");
+});
+
+Deno.test("extractModelNameEquality: nested in AND", () => {
+  assertEquals(
+    extractModelNameEquality(ast('modelName == "m1" && specName == "s1"')),
+    "m1",
+  );
+});
+
+Deno.test("extractModelNameEquality: deeply nested AND", () => {
+  assertEquals(
+    extractModelNameEquality(
+      ast('size > 100 && modelName == "deep" && specName == "s"'),
+    ),
+    "deep",
+  );
+});
+
+Deno.test("extractModelNameEquality: OR returns null", () => {
+  assertEquals(
+    extractModelNameEquality(ast('modelName == "a" || modelName == "b"')),
+    null,
+  );
+});
+
+Deno.test("extractModelNameEquality: no modelName returns null", () => {
+  assertEquals(
+    extractModelNameEquality(ast('specName == "result"')),
+    null,
+  );
+});
+
+Deno.test("extractModelNameEquality: modelName compared to non-literal returns null", () => {
+  assertEquals(
+    extractModelNameEquality(ast("modelName == specName")),
+    null,
+  );
+});
+
+Deno.test("extractModelNameEquality: true literal returns null", () => {
+  assertEquals(extractModelNameEquality(ast("true")), null);
+});
+
+Deno.test("extractModelNameEquality: false literal returns null", () => {
+  assertEquals(extractModelNameEquality(ast("false")), null);
+});

--- a/src/infrastructure/persistence/catalog_store.ts
+++ b/src/infrastructure/persistence/catalog_store.ts
@@ -544,6 +544,27 @@ export class CatalogStore {
     }
   }
 
+  *iterateFiltered(
+    whereClause: string,
+    params: readonly (string | number)[],
+  ): IterableIterator<CatalogRow> {
+    let offset = 0;
+    while (true) {
+      const stmt = this.db.prepare(
+        `SELECT * FROM catalog WHERE ${whereClause} ORDER BY rowid LIMIT ? OFFSET ?`,
+      );
+      const rows = stmt.all(
+        ...params,
+        ITERATE_PAGE_SIZE,
+        offset,
+      ) as unknown as CatalogRow[];
+      if (rows.length === 0) break;
+      yield* rows;
+      if (rows.length < ITERATE_PAGE_SIZE) break;
+      offset += ITERATE_PAGE_SIZE;
+    }
+  }
+
   *iterateNamespace(namespace: string): IterableIterator<CatalogRow> {
     const stmt = this.db.prepare(
       "SELECT * FROM catalog WHERE namespace = ? ORDER BY rowid LIMIT ? OFFSET ?",

--- a/src/libswamp/workflows/approvals.ts
+++ b/src/libswamp/workflows/approvals.ts
@@ -21,6 +21,8 @@ import type {
   WorkflowRepository,
   WorkflowRunRepository,
 } from "../../domain/workflows/repositories.ts";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import { evaluateApprovalTimeout } from "../../domain/workflows/approval_timeout.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -47,13 +49,19 @@ export type WorkflowApprovalsEvent =
 export interface WorkflowApprovalsDeps {
   workflowRepo: WorkflowRepository;
   runRepo: WorkflowRunRepository;
+  findSuspendedRuns?: (
+    workflowId: WorkflowId,
+  ) => Promise<WorkflowRun[]>;
 }
 
 export function createWorkflowApprovalsDeps(
   workflowRepo: WorkflowRepository,
   runRepo: WorkflowRunRepository,
+  findSuspendedRuns?: (
+    workflowId: WorkflowId,
+  ) => Promise<WorkflowRun[]>,
 ): WorkflowApprovalsDeps {
-  return { workflowRepo, runRepo };
+  return { workflowRepo, runRepo, findSuspendedRuns };
 }
 
 export async function* workflowApprovals(
@@ -70,7 +78,9 @@ export async function* workflowApprovals(
       const pending: PendingApproval[] = [];
 
       for (const workflow of workflows) {
-        const runs = await deps.runRepo.findAllByWorkflowId(workflow.id);
+        const runs = deps.findSuspendedRuns
+          ? await deps.findSuspendedRuns(workflow.id)
+          : await deps.runRepo.findAllByWorkflowId(workflow.id);
         for (const run of runs) {
           if (run.status !== "suspended") continue;
           const waiting = run.findWaitingApprovalStep();

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -64,7 +64,11 @@ import type {
 } from "../protocol.ts";
 import { acquireModelLocks } from "../../cli/repo_context.ts";
 import { resolveSuspendedRun } from "../../domain/workflows/suspended_run_resolver.ts";
-import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
+import {
+  createWorkflowId,
+  type WorkflowRunId,
+} from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
   type StepLockHook,
   WorkflowExecutionService,
@@ -233,9 +237,21 @@ export async function handleWorkflowApprovals(
 
   try {
     const libCtx = createLibSwampContext();
+    const runRepo = ctx.repoContext.workflowRunRepo;
     const deps = createWorkflowApprovalsDeps(
       ctx.repoContext.workflowRepo,
-      ctx.repoContext.workflowRunRepo,
+      runRepo,
+      async (workflowId) => {
+        const summaries = await runRepo
+          .findAllSummariesByWorkflowId(workflowId);
+        const suspended = summaries.filter((s) => s.status === "suspended");
+        const runs = await Promise.all(
+          suspended.map((s) =>
+            runRepo.findById(workflowId, s.id as WorkflowRunId)
+          ),
+        );
+        return runs.filter((r): r is WorkflowRun => r !== null);
+      },
     );
 
     let result: Record<string, unknown> | undefined;
@@ -540,9 +556,8 @@ export async function handleWorkflowRunSearch(
     const deps: WorkflowRunSearchDeps = {
       findAllWorkflows: () => ctx.repoContext.workflowRepo.findAll(),
       findAllRunsByWorkflowId: (id) =>
-        ctx.repoContext.workflowRunRepo.findAllByWorkflowId(
-          createWorkflowId(id),
-        ),
+        ctx.repoContext.workflowRunRepo
+          .findAllSummariesByWorkflowId(createWorkflowId(id)),
     };
 
     let result: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- Add SQL pre-filtering to `DataQueryService.executeQuery()` — pushes `is_latest = 1` and `model_name = ?` to SQLite WHERE clauses using existing indexes, keeping full CEL evaluation as the correctness authority
- Optimize `workflow.approvals` serve handler to load summary projections first, then full aggregates only for suspended runs
- Switch `workflow.run.search` serve handler to use `findAllSummariesByWorkflowId` instead of constructing full `WorkflowRun` aggregates

Fixes swamp-club#1284

## Benchmark Results (1588 records, WebSocket)

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| `data.query 'false'` (0 match) | 12ms | 2ms | 6x faster |
| `data.query modelName=="bench-001"` | 12ms | 1ms | 12x faster |
| `data.query modelName + limit=5` | 12ms | <1ms | instant |
| `data.query 'true'` (all latest) | 19ms | 10ms | ~2x faster |
| `data.query specName=="result"` | 16ms | 5ms | ~3x faster |

## Safety

The SQL pushdown is strictly a pre-filter — the full CEL predicate still evaluates on every row returned by SQL. Only two trivially correct translations are pushed down (isLatest and modelName equality). If zero pushdown clauses are extracted (OR predicates, complex expressions), the fallback is today's full-scan behavior.

## Test Plan

- 9 new unit tests for `extractModelNameEquality` AST extraction
- 6 new unit tests for `DataQueryService` pushdown correctness (isLatest, modelName, compound predicates, version opt-in, OR fallback, limit interaction)
- All 9180 existing tests pass
- Manual WebSocket benchmark with 1588-record scratch repo confirming improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)