### PR TITLE
feat(cli): standardize --yes/-y as universal confirmation-skip flag (swamp-club#1251)

### DIFF
--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -110,7 +110,8 @@ export const dataDeleteCommand = withRemoteOptions(
     )
     .option("--all", "Delete all data for the model")
     .option("--dry-run", "Show what would be deleted without deleting")
-    .option("-f, --force", "Skip confirmation prompt"),
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
 ).action(
   async function (
     options: AnyOptions,
@@ -249,7 +250,10 @@ export const dataDeleteCommand = withRemoteOptions(
           : { kind: "prefix", value: prefix! };
 
         // Phase 1: Preview + Prompt (unless --force or --dry-run).
-        if (cliCtx.outputMode === "log" && !options.force && !dryRun) {
+        if (
+          cliCtx.outputMode === "log" && !options.yes && !options.force &&
+          !dryRun
+        ) {
           let preview;
           try {
             preview = await dataBatchDeletePreview(ctx, deps, {
@@ -288,7 +292,7 @@ export const dataDeleteCommand = withRemoteOptions(
         const renderer = createDataDeleteRenderer(cliCtx.outputMode);
 
         // Phase 1: Preview + Prompt (only in interactive log mode without --force).
-        if (cliCtx.outputMode === "log" && !options.force) {
+        if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
           let preview;
           try {
             preview = await dataDeletePreview(ctx, deps, {

--- a/src/cli/commands/data_gc.ts
+++ b/src/cli/commands/data_gc.ts
@@ -58,7 +58,8 @@ export const dataGcCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--dry-run", "Show what would be deleted without deleting")
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["data", "gc"]);
 
@@ -78,7 +79,10 @@ export const dataGcCommand = new Command()
     );
 
     // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
-    if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {
+    if (
+      cliCtx.outputMode === "log" && !options.yes && !options.force &&
+      !options.dryRun
+    ) {
       const preview = await dataGcPreview(ctx, deps);
       if (
         preview.items.length === 0 && preview.versionGcItems.length === 0

--- a/src/cli/commands/data_prune.ts
+++ b/src/cli/commands/data_prune.ts
@@ -66,7 +66,8 @@ export const dataPruneCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--dry-run", "Show what would be reclaimed without deleting")
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, ["data", "prune"]);
 
@@ -82,7 +83,10 @@ export const dataPruneCommand = new Command()
     const deps = createDataPruneDeps(repoDir, datastoreResolver);
 
     // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
-    if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {
+    if (
+      cliCtx.outputMode === "log" && !options.yes && !options.force &&
+      !options.dryRun
+    ) {
       const preview = await dataPrunePreview(ctx, deps);
       if (preview.items.length === 0) {
         console.log("No orphaned data to reclaim.");

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -192,8 +192,12 @@ export const datastoreNamespaceUnsetCommand = new Command()
     "Also reverse-migrate data back to un-namespaced layout",
   )
   .option(
-    "--confirm",
+    "-y, --yes",
     "Execute the migration (required with --migrate, ignored otherwise)",
+  )
+  .option(
+    "--confirm",
+    "Execute the migration (alias for --yes)",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -257,13 +261,13 @@ export const datastoreNamespaceUnsetCommand = new Command()
       );
       await consumeStream(
         datastoreNamespaceMigrate(ctx, migrateDeps, {
-          confirm: !!options.confirm,
+          confirm: !!options.yes || !!options.confirm,
           reverse: true,
         }),
         migrateRenderer.handlers(),
       );
 
-      if (options.confirm) {
+      if (options.yes || options.confirm) {
         const current = await markerRepo.read(repoPath);
         if (current?.datastore) {
           delete current.datastore.namespace;
@@ -413,8 +417,12 @@ export const datastoreNamespaceMigrateCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option(
-    "--confirm",
+    "-y, --yes",
     "Execute the migration (without this flag, only a preview is shown)",
+  )
+  .option(
+    "--confirm",
+    "Execute the migration (alias for --yes)",
   )
   .option(
     "--reverse",
@@ -462,7 +470,7 @@ export const datastoreNamespaceMigrateCommand = new Command()
     const renderer = createNamespaceMigrateRenderer(cliCtx.outputMode);
     await consumeStream(
       datastoreNamespaceMigrate(ctx, deps, {
-        confirm: !!options.confirm,
+        confirm: !!options.yes || !!options.confirm,
         reverse: !!options.reverse,
       }),
       renderer.handlers(),

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -128,7 +128,11 @@ export const doctorExtensionsCommand = withRemoteOptions(
       "--dry-run",
       "Preview repair operations without executing (use with --repair)",
     )
-    .option("-f, --force", "Skip confirmation prompt (use with --repair)"),
+    .option("-y, --yes", "Skip confirmation prompt (use with --repair)")
+    .option(
+      "-f, --force",
+      "Skip confirmation prompt (alias for --yes, use with --repair)",
+    ),
 ).action(async function (options: AnyOptions) {
   const cliCtx = createContext(options as GlobalOptions, [
     "doctor",
@@ -174,8 +178,8 @@ export const doctorExtensionsCommand = withRemoteOptions(
   const verbose = options.verbose === true;
   const repair = options.repair === true;
   const dryRun = options.dryRun === true;
-  const force = options.force === true;
-  const needsPrompt = repair && !dryRun && !force &&
+  const skipConfirm = options.yes === true || options.force === true;
+  const needsPrompt = repair && !dryRun && !skipConfirm &&
     cliCtx.outputMode === "log";
 
   const repoDir = resolveRepoDir(options.repoDir);

--- a/src/cli/commands/extension_deprecate.ts
+++ b/src/cli/commands/extension_deprecate.ts
@@ -59,6 +59,7 @@ export const extensionDeprecateCommand = new Command()
     "Extension that supersedes this one",
   )
   .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -89,7 +90,7 @@ export const extensionDeprecateCommand = new Command()
       throw error;
     }
 
-    if (cliCtx.outputMode === "log" && !options.yes) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       let prompt =
         `Deprecate ${preview.extensionName}? Users will see a deprecation notice.`;
       if (preview.supersededBy) {

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -196,7 +196,11 @@ export const extensionPullCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .option("--force", "Overwrite existing files without prompting")
+  .option("-y, --yes", "Overwrite existing files without prompting")
+  .option(
+    "--force",
+    "Overwrite existing files without prompting (alias for --yes)",
+  )
   .option(
     "--channel <channel:string>",
     "Release channel: 'beta', 'rc', or 'stable' (default: stable)",
@@ -275,7 +279,7 @@ export const extensionPullCommand = new Command()
         lockfileRepository: deps.lockfileRepository,
         skillsDirs,
         repoDir,
-        force: options.force ?? false,
+        force: options.yes ?? options.force ?? false,
         outputMode: ctx.outputMode,
         alreadyPulled: new Set(),
         depth: 0,

--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -65,6 +65,7 @@ interface ExtensionPushOptions extends GlobalOptions {
   repoDir?: string;
   extensionsDir?: string;
   yes?: boolean;
+  force?: boolean;
   dryRun?: boolean;
   releaseNotes?: string;
   channel?: string;
@@ -183,6 +184,7 @@ export const extensionPushCommand = new Command()
     "Extensions source directory (env: SWAMP_EXTENSIONS_DIR)",
   )
   .option("-y, --yes", "Skip confirmation prompts")
+  .option("-f, --force", "Skip confirmation prompts (alias for --yes)")
   .option("--dry-run", "Build archive locally without pushing to registry")
   .option(
     "--release-notes <text:string>",
@@ -407,7 +409,7 @@ export const extensionPushCommand = new Command()
         } else if (details?.existingVersion) {
           // Version already exists — handle interactive bump
           const existingVersion = details.existingVersion as string;
-          if (cliCtx.outputMode === "log" && !options.yes) {
+          if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
             const bumped = CalVer.bump(CalVer.create(existingVersion));
             const confirmed = await promptConfirmation(
               `Version ${existingVersion} already exists. Bump to ${bumped.value}?`,
@@ -520,6 +522,7 @@ export const extensionPushCommand = new Command()
       prepared.reviewRulesResult.warnings.length > 0;
     if (
       hasBlockableWarnings && !prepared.isDryRun && !options.yes &&
+      !options.force &&
       cliCtx.outputMode === "log"
     ) {
       const confirmed = await promptConfirmation(
@@ -551,7 +554,7 @@ export const extensionPushCommand = new Command()
     }
 
     // 8. Confirmation prompt
-    if (!options.yes && cliCtx.outputMode === "log") {
+    if (!options.yes && !options.force && cliCtx.outputMode === "log") {
       const confirmed = await promptConfirmation(
         `Push ${prepared.manifest.name}@${prepared.manifest.version} to registry?`,
       );

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -67,7 +67,8 @@ export const extensionRemoveCommand = withRemoteOptions(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
-    .option("-f, --force", "Skip confirmation prompt"),
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)"),
 ).action(async function (options: AnyOptions, extension: string) {
   const ctx = createContext(options as GlobalOptions, ["extension", "rm"]);
   ctx.logger.debug`Starting extension remove`;
@@ -140,7 +141,7 @@ export const extensionRemoveCommand = withRemoteOptions(
     }
 
     // Confirmation prompt (log mode only, unless --force)
-    if (ctx.outputMode === "log" && !options.force) {
+    if (ctx.outputMode === "log" && !options.yes && !options.force) {
       const confirmed = await promptConfirmation(
         `Remove ${preview.name} (v${preview.version})? This will delete ${preview.fileCount} file(s).`,
       );

--- a/src/cli/commands/extension_undeprecate.ts
+++ b/src/cli/commands/extension_undeprecate.ts
@@ -48,6 +48,7 @@ export const extensionUndeprecateCommand = new Command()
   )
   .arguments("<extension:string>")
   .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -76,7 +77,7 @@ export const extensionUndeprecateCommand = new Command()
       throw error;
     }
 
-    if (cliCtx.outputMode === "log" && !options.yes) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const confirmed = await promptConfirmation(
         `Remove deprecation from ${preview.extensionName}?`,
       );

--- a/src/cli/commands/extension_unyank.ts
+++ b/src/cli/commands/extension_unyank.ts
@@ -63,6 +63,7 @@ export const extensionUnyankCommand = new Command()
     "Release channel to unyank: 'stable', 'beta', or 'rc' (default: all channels)",
   )
   .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -108,7 +109,7 @@ export const extensionUnyankCommand = new Command()
       throw error;
     }
 
-    if (cliCtx.outputMode === "log" && !options.yes) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const prompt = preview.version
         ? `Unyank ${preview.extensionName}@${preview.version}? This will restore availability.`
         : preview.channel

--- a/src/cli/commands/extension_yank.ts
+++ b/src/cli/commands/extension_yank.ts
@@ -63,6 +63,7 @@ export const extensionYankCommand = new Command()
     "Release channel to yank: 'stable', 'beta', or 'rc' (default: all channels)",
   )
   .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (
     options: AnyOptions,
     extension: string,
@@ -111,7 +112,7 @@ export const extensionYankCommand = new Command()
     }
 
     // Phase 2: Confirmation prompt (log mode only, unless --yes)
-    if (cliCtx.outputMode === "log" && !options.yes) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const prompt = preview.version
         ? `Yank ${preview.extensionName}@${preview.version}? This will mark it yanked.`
         : preview.channel

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -64,6 +64,7 @@ export const modelDeleteCommand = withRemoteOptions(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
+    .option("-y, --yes", "Skip confirmation prompt")
     .option(
       "-f, --force",
       "Skip confirmation and allow deletion when data artifacts exist",
@@ -173,7 +174,7 @@ export const modelDeleteCommand = withRemoteOptions(
       }
 
       // Phase 2: Prompt (CLI concern)
-      if (cliCtx.outputMode === "log" && !force) {
+      if (cliCtx.outputMode === "log" && !force && !options.yes) {
         let deleteDetails = "";
         if (preview.outputCount > 0) {
           deleteDetails += ` ${preview.outputCount} output(s),`;

--- a/src/cli/commands/run_gc.ts
+++ b/src/cli/commands/run_gc.ts
@@ -63,7 +63,8 @@ export const runGcCommand = new Command()
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
   .option("--dry-run", "Show what would be deleted without deleting")
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .option(
     "--older-than <duration:string>",
     `Retention period. Units: m=minutes, h=hours, d=days, w=weeks, mo=months, y=years (e.g. 7d, 2w, 1mo). Default: ${DEFAULT_WORKFLOW_RUN_RETENTION_DAYS}d`,
@@ -98,7 +99,10 @@ export const runGcCommand = new Command()
       outputRetentionDays: retentionDays,
     };
 
-    if (cliCtx.outputMode === "log" && !options.force && !options.dryRun) {
+    if (
+      cliCtx.outputMode === "log" && !options.yes && !options.force &&
+      !options.dryRun
+    ) {
       const preview = await runGcPreview(ctx, deps, gcInput);
       if (
         preview.workflowRunsToDelete === 0 && preview.outputsToDelete === 0

--- a/src/cli/commands/vault_delete.ts
+++ b/src/cli/commands/vault_delete.ts
@@ -77,6 +77,7 @@ When using --server, the confirmation prompt is not available — use --force to
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
+    .option("-y, --yes", "Skip confirmation prompt")
     .option("-f, --force", "Skip confirmation prompt and ignore missing keys"),
 ).action(async function (
   options: AnyOptions,
@@ -173,7 +174,7 @@ When using --server, the confirmation prompt is not available — use --force to
       );
     }
 
-    if (cliCtx.outputMode === "log" && !options.force) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const confirmed = await promptConfirmation(
         `Delete secret '${key}' from vault '${vaultName}'?`,
       );

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -63,7 +63,8 @@ Both the source and target vaults must be different types.`,
     "--config <config:string>",
     'Provider-specific config as JSON (e.g. \'{"region":"us-east-1"}\')',
   )
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .option("--dry-run", "Preview migration without making changes")
   .option(
     "--repo-dir <dir:string>",
@@ -287,7 +288,7 @@ Both the source and target vaults must be different types.`,
       return;
     }
 
-    if (cliCtx.outputMode === "log" && !options.force) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const confirmed = await promptConfirmation(
         `Migrate vault backend from ${preview.currentType} to ${preview.targetType}?`,
       );

--- a/src/cli/commands/vault_put.ts
+++ b/src/cli/commands/vault_put.ts
@@ -170,7 +170,11 @@ When using --server, the value must be passed as a positional argument or KEY=VA
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
     )
-    .option("-f, --force", "Skip confirmation prompt when overwriting")
+    .option("-y, --yes", "Skip confirmation prompt when overwriting")
+    .option(
+      "-f, --force",
+      "Skip confirmation prompt when overwriting (alias for --yes)",
+    )
     .option(
       "--refresh-from <command:string>",
       "Command to run to refresh the secret value when the TTL expires",
@@ -359,12 +363,13 @@ When using --server, the value must be passed as a positional argument or KEY=VA
 
     // Phase 2: Prompt on overwrite
     if (
-      preview.secretExists && cliCtx.outputMode === "log" && !options.force
+      preview.secretExists && cliCtx.outputMode === "log" && !options.yes &&
+      !options.force
     ) {
       if (stdinContent !== null) {
         throw new UserError(
           `Secret '${key}' already exists in vault '${vaultName}'.\n` +
-            `Use --force (-f) to overwrite when piping from stdin.`,
+            `Use --yes (-y) to overwrite when piping from stdin.`,
         );
       }
       const confirmed = await promptConfirmation(

--- a/src/cli/commands/vault_read_secret.ts
+++ b/src/cli/commands/vault_read_secret.ts
@@ -57,7 +57,8 @@ unless --force is set. In --json mode, outputs the value directly.`,
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   .action(async function (
     options: AnyOptions,
     vaultName: string,
@@ -81,7 +82,7 @@ unless --force is set. In --json mode, outputs the value directly.`,
     );
 
     try {
-      if (cliCtx.outputMode === "log" && !options.force) {
+      if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
         const confirmed = await promptConfirmation(
           `This will reveal the secret '${key}' from vault '${vaultName}'. Continue?`,
         );

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -51,7 +51,8 @@ export const workflowDeleteCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
-  .option("-f, --force", "Skip confirmation prompt")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
   .action(async function (options: AnyOptions, workflowIdOrName: string) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -82,7 +83,7 @@ export const workflowDeleteCommand = new Command()
     }
 
     // Phase 2: Prompt
-    if (cliCtx.outputMode === "log" && !options.force) {
+    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
       const runWarning = preview.runCount > 0
         ? ` This will also delete ${preview.runCount} run${
           preview.runCount === 1 ? "" : "s"

--- a/src/cli/prompt_helpers.ts
+++ b/src/cli/prompt_helpers.ts
@@ -34,13 +34,13 @@ function assertInteractiveStdin(): void {
   try {
     if (!Deno.stdin.isTerminal()) {
       throw new UserError(
-        "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+        "stdin is not a terminal — use --yes (-y) to skip confirmation prompts non-interactively",
       );
     }
   } catch (error) {
     if (error instanceof UserError) throw error;
     throw new UserError(
-      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+      "stdin is not a terminal — use --yes (-y) to skip confirmation prompts non-interactively",
     );
   }
 }

--- a/src/cli/prompt_helpers_test.ts
+++ b/src/cli/prompt_helpers_test.ts
@@ -185,7 +185,7 @@ Deno.test("promptConfirmation: throws UserError on non-interactive stdin", async
     );
     assertEquals(
       error.message,
-      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+      "stdin is not a terminal — use --yes (-y) to skip confirmation prompts non-interactively",
     );
   } finally {
     io.restore();
@@ -221,7 +221,7 @@ Deno.test("promptChoice: throws UserError on non-interactive stdin", async () =>
     );
     assertEquals(
       error.message,
-      "stdin is not a terminal — use the confirmation-skip flag (e.g. --force or --yes) to run non-interactively",
+      "stdin is not a terminal — use --yes (-y) to skip confirmation prompts non-interactively",
     );
   } finally {
     io.restore();


### PR DESCRIPTION
## Summary

- Adds `--yes`/`-y` as the universal confirmation-skip flag across all 19 destructive CLI commands
- Commands previously using only `--force` now accept `--yes`/`-y` as the primary flag, with `--force` kept as an alias (retaining additional semantics where applicable, e.g. `model delete --force` still allows deletion when data artifacts exist)
- Extension commands previously using only `--yes` now also accept `--force`/`-f`
- `datastore namespace migrate/unset` accept `--yes`/`-y` as an alias for `--confirm`
- Non-interactive stdin error message updated to reference `--yes (-y)` as the standard flag
- All existing flags continue to work identically — fully backward-compatible

Closes swamp-club#1251

Follow-up documentation issue filed: swamp-club#1290

## Test Plan

- [x] `deno fmt --check` — passes
- [x] `deno lint` — passes
- [x] `deno run test` — 9165 passed (1 pre-existing flaky failure unrelated to changes)
- [x] Compiled binary and tested all 19 commands' `--help` output shows both `--yes` and `--force`/`--confirm`
- [x] Verified `--yes`, `-y`, and `--force` all skip confirmation prompts at runtime
- [x] Verified non-interactive stdin error message shows `--yes (-y)`
- [x] Verified `--force` retains extra semantics on `model delete` and `vault delete` (not just prompt-skip)
- [x] Verified `--yes` as alias for `--confirm` on `datastore namespace migrate`
- [x] Verified no UAT test breakage in `swamp-club/swamp-uat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)