### PR TITLE
fix(serve): check process liveness before reaping workflow runs at startup (swamp-club#1297)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -128,7 +128,12 @@ import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { sweepStaleRecords } from "../../serve/boot_reconciliation.ts";
 import { installUnhandledRejectionGuard } from "../../serve/unhandled_rejection_guard.ts";
-import { checkOpenFileLimit } from "../../infrastructure/runtime/process.ts";
+import {
+  checkOpenFileLimit,
+  isProcessDead,
+} from "../../infrastructure/runtime/process.ts";
+import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -313,6 +318,74 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
     args.push("--trusted-hosts", options.trustedHosts as string);
   }
   return args;
+}
+
+export interface ReapResult {
+  readonly reaped: number;
+  readonly skipped: number;
+}
+
+export async function reapOrphanedWorkflowRuns(
+  runs: { run: WorkflowRun; workflowId: WorkflowId }[],
+  save: (workflowId: WorkflowId, run: WorkflowRun) => Promise<void>,
+  trackerLookup: (runId: string) => { status: string } | null,
+  isDeadFn: (pid: number) => boolean = isProcessDead,
+): Promise<ReapResult> {
+  let reaped = 0;
+  let skipped = 0;
+
+  for (const { run, workflowId } of runs) {
+    if (run.status !== "running") continue;
+
+    const tracked = trackerLookup(run.id);
+    if (tracked) {
+      if (tracked.status === "running") {
+        logger.info(
+          "Skipping workflow run {runId} (workflow: {workflowName}) — tracker reports still running",
+          { runId: run.id, workflowName: run.workflowName },
+        );
+        skipped++;
+        continue;
+      }
+      // Tracker already reaped this run (heartbeat stale + PID dead)
+      logger.warn(
+        "Reaping orphaned workflow run {runId} (workflow: {workflowName}, reason: {reason})",
+        {
+          runId: run.id,
+          workflowName: run.workflowName,
+          reason: "tracker confirmed stale",
+        },
+      );
+      run.cancel("daemon restarted (tracker confirmed stale)");
+      await save(workflowId, run);
+      reaped++;
+      continue;
+    }
+
+    // Not in tracker (legacy run) — fall back to PID check
+    const pid = run.pid;
+    if (pid !== undefined && !isDeadFn(pid)) {
+      logger.info(
+        "Skipping workflow run {runId} (workflow: {workflowName}) — owning process {pid} is still alive (no tracker record)",
+        { runId: run.id, workflowName: run.workflowName, pid },
+      );
+      skipped++;
+      continue;
+    }
+
+    const reason = pid === undefined
+      ? "daemon restarted (no PID recorded, no tracker record)"
+      : "daemon restarted (owning process dead, no tracker record)";
+    logger.warn(
+      "Reaping orphaned workflow run {runId} (workflow: {workflowName}, reason: {reason})",
+      { runId: run.id, workflowName: run.workflowName, reason },
+    );
+    run.cancel(reason);
+    await save(workflowId, run);
+    reaped++;
+  }
+
+  return { reaped, skipped };
 }
 
 const daemonEnableCommand = new Command()
@@ -1345,33 +1418,33 @@ export const serveCommand = new Command()
 
     const cancelRegistry = new RunCancelRegistry();
 
-    // Reap orphaned runs left in "running" state by a previous daemon.
-    // Workflow runs still use YAML-based reaping (tracker wiring deferred to #519).
-    const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const recentRuns = await repoContext.workflowRunRepo.findAllGlobalSince(
-      reapCutoff,
-    );
-    for (const { run, workflowId } of recentRuns) {
-      if (run.status === "running") {
-        logger.warn(
-          "Reaping orphaned workflow run {runId} (workflow: {workflowName})",
-          { runId: run.id, workflowName: run.workflowName },
-        );
-        run.cancel("daemon restarted");
-        await repoContext.workflowRunRepo.save(workflowId, run);
-      }
-    }
-
-    // Model method runs use the SQLite run tracker for stale detection.
+    // Reap stale runs via the SQLite tracker (heartbeat + PID liveness).
+    // This handles both model-method and workflow runs registered with the tracker.
     const runTracker = RunTrackerStore.fromSwampDir(
       swampPath(resolvedRepoDir),
     );
     const reapedRuns = runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
     for (const run of reapedRuns) {
-      logger.warn`Reaped stale model method run ${run.id} (method: ${
-        run.methodName ?? "unknown"
+      logger.warn`Reaped stale ${run.runKind} run ${run.id} (${
+        run.methodName ?? run.workflowName ?? "unknown"
       })`;
     }
+
+    // Reconcile YAML-persisted workflow run state with tracker verdicts.
+    // The tracker is the liveness authority; the YAML entity is the run record.
+    // Legacy runs (pre-tracker) fall back to PID liveness checking.
+    const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const recentRuns = await repoContext.workflowRunRepo.findAllGlobalSince(
+      reapCutoff,
+    );
+    await reapOrphanedWorkflowRuns(
+      recentRuns,
+      (wid, r) => repoContext.workflowRunRepo.save(wid, r),
+      (runId) => {
+        const tracked = runTracker.findById(runId);
+        return tracked ? { status: tracked.status } : null;
+      },
+    );
 
     const swept = await sweepStaleRecords({
       repoDir: resolvedRepoDir,

--- a/src/cli/commands/serve_test.ts
+++ b/src/cli/commands/serve_test.ts
@@ -22,9 +22,12 @@ import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import {
   assertOffLoopbackSecurity,
   collectServeExtraArgs,
+  reapOrphanedWorkflowRuns,
   validateWebSocketOrigin,
 } from "./serve.ts";
 import { UserError } from "../../domain/errors.ts";
+import { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
+import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 
 // Initialize logging for tests
 await initializeLogging({});
@@ -380,4 +383,198 @@ Deno.test("collectServeExtraArgs: forwards --trusted-hosts", () => {
 Deno.test("collectServeExtraArgs: omits --trusted-hosts when not set", () => {
   const args = collectServeExtraArgs({});
   assertEquals(args, []);
+});
+
+// --- reapOrphanedWorkflowRuns ---
+
+const WORKFLOW_ID = "96968218-50aa-4b91-8161-a6995ce96cae" as WorkflowId;
+
+type RunStatus =
+  | "pending"
+  | "running"
+  | "suspended"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+function makeRun(
+  overrides: {
+    status?: RunStatus;
+    pid?: number;
+    id?: string;
+  } = {},
+): WorkflowRun {
+  return WorkflowRun.fromData({
+    id: overrides.id ?? crypto.randomUUID(),
+    workflowId: WORKFLOW_ID,
+    workflowName: "test-workflow",
+    status: overrides.status ?? "running",
+    startedAt: "2026-07-20T20:00:00.000Z",
+    pid: overrides.pid,
+    jobs: [{
+      jobName: "main",
+      status: "running",
+      startedAt: "2026-07-20T20:00:00.000Z",
+      steps: [{
+        stepName: "step1",
+        status: "running",
+        startedAt: "2026-07-20T20:00:00.000Z",
+      }],
+    }],
+    tags: {},
+  });
+}
+
+// Helper: no tracker record for any run (legacy fallback path)
+const noTracker = () => null;
+
+// Helper: tracker says run is still running
+const trackerRunning = () => ({ status: "running" });
+
+// Helper: tracker says run was reaped (stale)
+const trackerReaped = () => ({ status: "failed" });
+
+Deno.test("reapOrphanedWorkflowRuns: skips run when tracker reports still running", async () => {
+  const run = makeRun({ pid: 42 });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    trackerRunning,
+  );
+  assertEquals(result.reaped, 0);
+  assertEquals(result.skipped, 1);
+  assertEquals(run.status, "running");
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: cancels run when tracker confirmed stale", async () => {
+  const run = makeRun({ pid: 99999 });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    trackerReaped,
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "cancelled");
+  assertEquals(saved.length, 1);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: legacy run with live PID is skipped", async () => {
+  const run = makeRun({ pid: 42 });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    (_pid) => false, // PID is alive
+  );
+  assertEquals(result.reaped, 0);
+  assertEquals(result.skipped, 1);
+  assertEquals(run.status, "running");
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: legacy run with dead PID is cancelled", async () => {
+  const run = makeRun({ pid: 99999 });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    (_pid) => true, // PID is dead
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "cancelled");
+  assertEquals(saved.length, 1);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: legacy run with no PID is cancelled", async () => {
+  const run = makeRun(); // no pid
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    () => {
+      throw new Error("should not be called for undefined pid");
+    },
+  );
+  assertEquals(result.reaped, 1);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "cancelled");
+});
+
+Deno.test("reapOrphanedWorkflowRuns: skips run in terminal state", async () => {
+  const run = makeRun({ status: "succeeded" });
+  const saved: string[] = [];
+  const result = await reapOrphanedWorkflowRuns(
+    [{ run, workflowId: WORKFLOW_ID }],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    noTracker,
+    () => true,
+  );
+  assertEquals(result.reaped, 0);
+  assertEquals(result.skipped, 0);
+  assertEquals(run.status, "succeeded");
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("reapOrphanedWorkflowRuns: mixed scenario with tracker and legacy runs", async () => {
+  const trackedLive = makeRun({ pid: 100 });
+  const trackedStale = makeRun({ pid: 200 });
+  const legacyDeadPid = makeRun({ pid: 300 });
+  const legacyNoPid = makeRun();
+  const succeededRun = makeRun({ status: "succeeded" });
+  const saved: string[] = [];
+
+  const trackerMap = new Map<string, { status: string }>([
+    [trackedLive.id, { status: "running" }],
+    [trackedStale.id, { status: "failed" }],
+  ]);
+
+  const result = await reapOrphanedWorkflowRuns(
+    [
+      { run: trackedLive, workflowId: WORKFLOW_ID },
+      { run: trackedStale, workflowId: WORKFLOW_ID },
+      { run: legacyDeadPid, workflowId: WORKFLOW_ID },
+      { run: legacyNoPid, workflowId: WORKFLOW_ID },
+      { run: succeededRun, workflowId: WORKFLOW_ID },
+    ],
+    (_wid, r) => {
+      saved.push(r.id);
+      return Promise.resolve();
+    },
+    (runId) => trackerMap.get(runId) ?? null,
+    (pid) => pid === 300, // only PID 300 is dead
+  );
+  assertEquals(result.reaped, 3); // tracker-stale + legacy dead PID + legacy no PID
+  assertEquals(result.skipped, 1); // tracker-live
+  assertEquals(trackedLive.status, "running");
+  assertEquals(trackedStale.status, "cancelled");
+  assertEquals(legacyDeadPid.status, "cancelled");
+  assertEquals(legacyNoPid.status, "cancelled");
+  assertEquals(succeededRun.status, "succeeded");
+  assertEquals(saved.length, 3);
 });


### PR DESCRIPTION
## Summary

- Wire the SQLite run tracker as the primary liveness authority for workflow run reaping at `swamp serve` startup. The tracker provides heartbeat + PID two-factor checking via `reapStaleRuns()`, which already handles both model-method and workflow runs.
- Reconcile YAML-persisted workflow run state with tracker verdicts: runs the tracker reports as still running are skipped; runs the tracker reaped are cancelled in the YAML entity. Legacy runs not in the tracker fall back to PID-only liveness checking via `isProcessDead`.
- Extract reaping logic into a standalone `reapOrphanedWorkflowRuns` function with injectable tracker lookup and liveness predicate for testability.
- Reorder serve startup so `reapStaleRuns()` runs before the YAML scan, ensuring tracker verdicts are current.

Closes swamp-club#1297

## Test Plan

- [x] 7 new unit tests covering tracker-present and tracker-absent (legacy) paths
- [x] Manual reproduction: created a workflow run with `status: running` and PID 1 (launchd, always alive); verified old binary cancels it, fixed binary skips it
- [x] Verified dead-PID path still reaps correctly
- [x] All 45 serve tests pass (38 existing + 7 new)
- [x] `deno check`, `deno lint`, `deno fmt` all clean