### PR TITLE
fix(log): escape curly braces in process output before LogTape rendering (swamp-club#1301)

### DIFF
--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -224,6 +224,12 @@ export function getRunLogger(modelName: string, methodName: string) {
   ]);
 }
 
+// LogTape interprets {…} in message templates as property placeholders.
+// Raw process output containing JSON objects would render as "undefined".
+export function escapeLogTemplate(text: string): string {
+  return text.replaceAll("{", "{{").replaceAll("}", "}}");
+}
+
 export function getWorkflowRunLogger(
   workflowName: string,
   jobName?: string,

--- a/src/infrastructure/logging/logger_test.ts
+++ b/src/infrastructure/logging/logger_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import {
+  escapeLogTemplate,
   getRunLogger,
   getSwampLogger,
   getWorkflowRunLogger,
@@ -107,6 +108,42 @@ Deno.test("initializeLogging accepts logLevel option", async () => {
   // logLevel should be accepted without error (idempotent, first call wins)
   await initializeLogging({ logLevel: "warning" });
   assertEquals(true, true);
+});
+
+Deno.test("escapeLogTemplate: escapes curly braces for LogTape", async (t) => {
+  await t.step("escapes JSON object", () => {
+    assertEquals(escapeLogTemplate('{"a":1}'), '{{"a":1}}');
+  });
+
+  await t.step("escapes empty object", () => {
+    assertEquals(escapeLogTemplate("{}"), "{{}}");
+  });
+
+  await t.step("escapes nested braces", () => {
+    assertEquals(
+      escapeLogTemplate('{"outer":{"inner":true}}'),
+      '{{"outer":{{"inner":true}}}}',
+    );
+  });
+
+  await t.step("leaves arrays unchanged", () => {
+    assertEquals(escapeLogTemplate("[1,2]"), "[1,2]");
+  });
+
+  await t.step("leaves plain strings unchanged", () => {
+    assertEquals(escapeLogTemplate("plain line"), "plain line");
+  });
+
+  await t.step("leaves empty string unchanged", () => {
+    assertEquals(escapeLogTemplate(""), "");
+  });
+
+  await t.step("handles mixed content", () => {
+    assertEquals(
+      escapeLogTemplate('tags: {} inputs: {"key":"val"}'),
+      'tags: {{}} inputs: {{"key":"val"}}',
+    );
+  });
 });
 
 Deno.test("getWorkflowRunLogger", async (t) => {

--- a/src/infrastructure/process/process_executor.ts
+++ b/src/infrastructure/process/process_executor.ts
@@ -19,6 +19,7 @@
 
 import type { Logger } from "@logtape/logtape";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
+import { escapeLogTemplate } from "../logging/logger.ts";
 
 /**
  * Options for executing a process.
@@ -187,18 +188,18 @@ export async function executeProcess(
         const redacted = redact(line);
         if (onOutput) {
           onOutput(redacted, "stdout");
-          logger.debug(redacted);
+          logger.debug(escapeLogTemplate(redacted));
         } else {
-          logger.info(redacted);
+          logger.info(escapeLogTemplate(redacted));
         }
       };
       stderrOnLine = (line: string) => {
         const redacted = redact(line);
         if (onOutput) {
           onOutput(redacted, "stderr");
-          logger.debug(redacted);
+          logger.debug(escapeLogTemplate(redacted));
         } else {
-          logger.warn(redacted);
+          logger.warn(escapeLogTemplate(redacted));
         }
       };
     }
@@ -328,18 +329,18 @@ export async function executeProcess(
           const redacted = redact(line);
           if (onOutput) {
             onOutput(redacted, "stdout");
-            logger.debug(redacted);
+            logger.debug(escapeLogTemplate(redacted));
           } else {
-            logger.info(redacted);
+            logger.info(escapeLogTemplate(redacted));
           }
         }),
         streamLines(process.stderr, (line) => {
           const redacted = redact(line);
           if (onOutput) {
             onOutput(redacted, "stderr");
-            logger.debug(redacted);
+            logger.debug(escapeLogTemplate(redacted));
           } else {
-            logger.warn(redacted);
+            logger.warn(escapeLogTemplate(redacted));
           }
         }),
         process.status,

--- a/src/presentation/renderers/issue_create.ts
+++ b/src/presentation/renderers/issue_create.ts
@@ -24,7 +24,10 @@ import type {
 } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  escapeLogTemplate,
+  getSwampLogger,
+} from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import type {
   RefusalReason,
@@ -302,7 +305,7 @@ export function renderExtensionRefusal(
   // log line — readable on terminals that wrap long single-line logs.
   const logger = getSwampLogger(["issue", "create"]);
   for (const line of data.guidance.split("\n")) {
-    logger.info(line);
+    logger.info(escapeLogTemplate(line));
   }
 }
 

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -21,6 +21,7 @@ import type { EventHandlers, ModelMethodRunEvent } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import {
+  escapeLogTemplate,
   getRunLogger,
   writeOutput,
 } from "../../infrastructure/logging/logger.ts";
@@ -109,10 +110,11 @@ class LogModelMethodRunRenderer implements ModelMethodRunRenderer {
       },
       method_output: (e) => {
         const logger = getRunLogger(e.modelName, e.methodName);
+        const escaped = escapeLogTemplate(e.line);
         if (e.stream === "stderr") {
-          logger.warn(e.line);
+          logger.warn(escaped);
         } else {
-          logger.info(e.line);
+          logger.info(escaped);
         }
       },
       method_event: (e) => {

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -26,6 +26,7 @@ import {
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import {
+  escapeLogTemplate,
   getRunLogger,
   getWorkflowRunLogger,
   writeOutput,
@@ -159,10 +160,11 @@ class LogWorkflowRunRenderer implements WorkflowRunRenderer {
       },
       method_output: (e) => {
         const logger = getRunLogger(e.modelName, e.methodName);
+        const escaped = escapeLogTemplate(e.line);
         if (e.stream === "stderr") {
-          logger.warn(e.line);
+          logger.warn(escaped);
         } else {
-          logger.info(e.line);
+          logger.info(escaped);
         }
       },
       method_event: (e) => {


### PR DESCRIPTION
## Summary

- Adds `escapeLogTemplate()` utility that escapes `{` → `{{` and `}` → `}}` to prevent LogTape from interpreting raw process output as property placeholders
- Fixes all 13 call sites across 4 files where process stdout/stderr lines are passed directly to LogTape logger methods
- JSON objects in stdout (e.g. `{"a":1}`, `{}`) were silently rendered as `undefined` — actively misleading output that caused real misdiagnosis

### Files changed

| File | Change |
|------|--------|
| `src/infrastructure/logging/logger.ts` | Added `escapeLogTemplate()` utility |
| `src/infrastructure/logging/logger_test.ts` | 7 test cases for the utility |
| `src/presentation/renderers/model_method_run.ts` | Escape in `method_output` handler |
| `src/presentation/renderers/workflow_run.ts` | Escape in `method_output` handler |
| `src/infrastructure/process/process_executor.ts` | Escape at all 8 logger call sites |
| `src/presentation/renderers/issue_create.ts` | Escape guidance lines in `renderExtensionRefusal` |

## Test Plan

- [x] Unit tests for `escapeLogTemplate`: JSON objects, empty objects, nested braces, arrays (passthrough), plain strings, empty strings, mixed content
- [x] Verified end-to-end against the reproduction from the issue: `printf "%s\n" "plain line" '{"a":1}' '{}' '[1,2]' "trailing"` — all 5 lines render verbatim
- [x] Verified no double-escaping: `onOutput` sends raw text to renderers, and each logger call site escapes independently
- [x] Verified `runFileSink` and OTel sink both consume `record.message` (resolved by `parseMessageTemplate`), not `rawMessage` — `{{`/`}}` are correctly unescaped to `{`/`}` before reaching any sink
- [x] Verified Ink workflow renderer (`InkWorkflowRunRenderer`) does not use LogTape — `e.line` flows through React state into `<Text>` components, unaffected
- [x] All existing tests pass (`deno run test` — 9194 passed, pre-existing flaky failures in unrelated `shutdown_handlers_test.ts` and `workflow_test.ts`)

Closes swamp-club#1301