### PR TITLE
fix(data): prevent autoGc from retroactively enforcing numeric garbageCollection caps (swamp-club#1304)

### DIFF
--- a/design/repo.md
+++ b/design/repo.md
@@ -106,12 +106,13 @@ attributes to control the behaviour of the swamp operations.
   `trustedCollectives` list. Toggleable via
   `swamp extension trust auto-trust <on|off>`.
 - `autoGc`: Enable automatic garbage collection after model method runs.
-  Default: `false`. When `true`, `collectGarbage` runs for the model that just
-  executed after reports complete and the method result is shown. Reuses each
-  data item's declared `garbageCollection` policy (version-count caps and
-  duration-based retention). Errors are logged but never fail the method run.
-  The sync push includes GC deletions so the current push benefits immediately.
-  `swamp data gc` remains available for repo-wide manual GC.
+  Default: `false`. When `true`, runs for the model that just executed after
+  reports complete and the method result is shown. Enforces duration-based
+  `garbageCollection` policies (e.g. `"7d"`) and lifetime expiration, but skips
+  numeric version-count caps — those are enforced incrementally at write time
+  (via `pruneExcessVersions`) and on-demand via `swamp data gc` (with
+  preview/confirmation). Errors are logged but never fail the method run. The
+  sync push includes GC deletions so the current push benefits immediately.
 
 ### Run Garbage Collection
 

--- a/src/domain/data/composite_data_repository.ts
+++ b/src/domain/data/composite_data_repository.ts
@@ -115,7 +115,7 @@ export class CompositeUnifiedDataRepository implements UnifiedDataRepository {
   collectGarbage(
     type: ModelType,
     modelId: string,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; skipNumericCap?: boolean },
   ): Promise<GarbageCollectionResult> {
     return this.persistent.collectGarbage(type, modelId, options);
   }

--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -335,7 +335,7 @@ export interface UnifiedDataRepository {
   collectGarbage(
     type: ModelType,
     modelId: string,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; skipNumericCap?: boolean },
   ): Promise<GarbageCollectionResult>;
 
   /**

--- a/src/infrastructure/persistence/in_memory_data_repository.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository.ts
@@ -570,9 +570,12 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
   collectGarbage(
     type: ModelType,
     modelId: string,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; skipNumericCap?: boolean },
   ): Promise<GarbageCollectionResult> {
     this.ensureNotDisposed();
+    if (options?.skipNumericCap) {
+      return Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 });
+    }
     let versionsRemoved = 0;
     let bytesReclaimed = 0;
 

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1493,9 +1493,10 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   async collectGarbage(
     type: ModelType,
     modelId: string,
-    options?: { dryRun?: boolean },
+    options?: { dryRun?: boolean; skipNumericCap?: boolean },
   ): Promise<GarbageCollectionResult> {
     const dryRun = options?.dryRun ?? false;
+    const skipNumericCap = options?.skipNumericCap ?? false;
     let versionsRemoved = 0;
     let bytesReclaimed = 0;
 
@@ -1509,7 +1510,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
       let versionsToRemove: number[] = [];
 
       if (typeof gc === "number") {
-        // Keep N most recent versions
+        if (skipNumericCap) continue;
         const toKeep = gc;
         if (versions.length > toKeep) {
           versionsToRemove = versions.slice(0, versions.length - toKeep);

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -958,6 +958,77 @@ Deno.test("collectGarbage: emits per-path markDirty for each removed version", a
   }
 });
 
+Deno.test("collectGarbage: skipNumericCap skips numeric policies", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+    );
+
+    const gcHighCap = Data.create({
+      name: "gc-skip",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 100,
+      streaming: false,
+      tags: { type: "resource" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await repo.save(
+        testType,
+        "gc-skip-model",
+        gcHighCap,
+        new TextEncoder().encode(`v${i}`),
+      );
+    }
+
+    const gcLowCap = Data.create({
+      name: "gc-skip",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 2,
+      streaming: false,
+      tags: { type: "resource" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+    await repo.save(
+      testType,
+      "gc-skip-model",
+      gcLowCap,
+      new TextEncoder().encode("v5"),
+    );
+
+    const versions = await repo.listVersions(
+      testType,
+      "gc-skip-model",
+      "gc-skip",
+    );
+
+    const result = await repo.collectGarbage(testType, "gc-skip-model", {
+      skipNumericCap: true,
+    });
+    assertEquals(result.versionsRemoved, 0);
+
+    const versionsAfter = await repo.listVersions(
+      testType,
+      "gc-skip-model",
+      "gc-skip",
+    );
+    assertEquals(versionsAfter.length, versions.length);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});
+
 Deno.test("markDirty is not called on read paths", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/libswamp/data/gc.ts
+++ b/src/libswamp/data/gc.ts
@@ -219,6 +219,7 @@ export async function autoGc(
     collectGarbage: (
       type: ModelType,
       modelId: string,
+      options?: { skipNumericCap?: boolean },
     ) => Promise<GarbageCollectionResult>;
   },
   type: ModelType,
@@ -227,7 +228,9 @@ export async function autoGc(
 ): Promise<AutoGcResult | null> {
   const logger = getLogger(["swamp", "auto-gc"]);
   try {
-    const result = await dataRepo.collectGarbage(type, modelId);
+    const result = await dataRepo.collectGarbage(type, modelId, {
+      skipNumericCap: true,
+    });
 
     let dataEntriesExpired = 0;
     if (lifecycleDeps) {

--- a/src/libswamp/data/gc_test.ts
+++ b/src/libswamp/data/gc_test.ts
@@ -216,13 +216,31 @@ Deno.test("dataGc: passes dryRun flag through", async () => {
 function makeFakeDataRepo(
   result: GarbageCollectionResult = { versionsRemoved: 0, bytesReclaimed: 0 },
 ) {
+  const calls: Array<{
+    type: ModelType;
+    modelId: string;
+    options?: { skipNumericCap?: boolean };
+  }> = [];
   return {
+    calls,
     collectGarbage: (
-      _type: ModelType,
-      _modelId: string,
-    ): Promise<GarbageCollectionResult> => Promise.resolve(result),
+      type: ModelType,
+      modelId: string,
+      options?: { skipNumericCap?: boolean },
+    ): Promise<GarbageCollectionResult> => {
+      calls.push({ type, modelId, options });
+      return Promise.resolve(result);
+    },
   };
 }
+
+Deno.test("autoGc: passes skipNumericCap to collectGarbage", async () => {
+  const repo = makeFakeDataRepo({ versionsRemoved: 0, bytesReclaimed: 0 });
+  await autoGc(repo, ModelType.create("test/type"), "model-1");
+
+  assertEquals(repo.calls.length, 1);
+  assertEquals(repo.calls[0].options, { skipNumericCap: true });
+});
 
 Deno.test("autoGc: returns result when versions are removed", async () => {
   const repo = makeFakeDataRepo({ versionsRemoved: 10, bytesReclaimed: 4096 });

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -70,6 +70,7 @@ export type NamespaceMigrateEvent =
   | { kind: "preview"; data: NamespaceMigratePreviewData }
   | { kind: "progress"; data: NamespaceMigrateProgressData }
   | { kind: "warning"; data: NamespaceMigrateWarningData }
+  | { kind: "catalog_invalidated_warning" }
   | { kind: "completed"; data: NamespaceMigrateCompletedData }
   | {
     kind: "error";
@@ -332,6 +333,7 @@ export async function* datastoreNamespaceMigrate(
 
       deps.invalidateCatalog();
       ctx.logger.info("Catalog invalidated — will rebuild on next access");
+      yield { kind: "catalog_invalidated_warning" } as const;
 
       if (deps.isExtensionDatastore) {
         await deps.markDirtyBulk();

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -160,6 +160,11 @@ Deno.test("datastoreNamespaceMigrate: confirm executes forward migration", async
   assertEquals(renamed[0].source, join(DS_PATH, "data"));
   assertEquals(renamed[0].destination, join(DS_PATH, NAMESPACE, "data"));
   assertEquals(catalogInvalidated, true);
+
+  const warningEvent = events.find((e) =>
+    e.kind === "catalog_invalidated_warning"
+  );
+  assertEquals(warningEvent?.kind, "catalog_invalidated_warning");
 });
 
 Deno.test("datastoreNamespaceMigrate: confirm executes reverse migration with manifest cleanup", async () => {

--- a/src/presentation/renderers/datastore_namespace_migrate.ts
+++ b/src/presentation/renderers/datastore_namespace_migrate.ts
@@ -82,6 +82,14 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
         ];
         writeOutput(lines.join("\n"));
       },
+      catalog_invalidated_warning: () => {
+        writeOutput(
+          yellow(
+            "  ⚠ Catalog invalidated. If your data specs declare garbageCollection limits,\n" +
+              "    run 'swamp data gc --dry-run' to preview what would be cleaned up.",
+          ),
+        );
+      },
       completed: (e) => {
         if (e.data.migratedDirectories.length === 0) return;
 
@@ -130,6 +138,7 @@ class LogNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
 class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
   #previewData: NamespaceMigratePreviewData | null = null;
   #warnings: NamespaceMigrateWarningData[] = [];
+  #catalogInvalidated = false;
 
   handlers(): EventHandlers<NamespaceMigrateEvent> {
     return {
@@ -140,11 +149,17 @@ class JsonNamespaceMigrateRenderer implements Renderer<NamespaceMigrateEvent> {
       warning: (e) => {
         this.#warnings.push(e.data);
       },
+      catalog_invalidated_warning: () => {
+        this.#catalogInvalidated = true;
+      },
       completed: (e) => {
         if (e.data.migratedDirectories.length > 0) {
-          const output = this.#warnings.length > 0
+          const base = this.#warnings.length > 0
             ? { ...e.data, warnings: this.#warnings }
-            : e.data;
+            : { ...e.data };
+          const output = this.#catalogInvalidated
+            ? { ...base, catalogInvalidated: true }
+            : base;
           writeOutput(JSON.stringify(output, null, 2));
         } else {
           writeOutput(JSON.stringify(this.#previewData, null, 2));


### PR DESCRIPTION
## Summary

- **Stop autoGc from doing batch numeric cap enforcement.** `autoGc()` now passes `skipNumericCap: true` to `collectGarbage()`, so it only enforces duration-based GC policies and lifetime expiration. Numeric cap enforcement is handled incrementally at write time (`pruneExcessVersions`) and on-demand by `swamp data gc` (with preview/confirmation).
- **Add catalog invalidation warning to namespace migration.** After `namespace migrate` or `namespace unset --migrate` invalidates the catalog, the output now warns users to run `swamp data gc --dry-run` to preview cleanup.
- **Update `design/repo.md`** to document the changed `autoGc` behavior.

Closes swamp-club#1304

## Root Cause

`namespace unset --migrate` invalidates the data catalog after moving directories. The next `autoGc` call (on model method run) invoked `collectGarbage()` which retroactively enforced `garbageCollection: N` on all accumulated versions — silently deleting everything beyond the retention cap. In the reporter's case this destroyed ~484k files / ~6 GB.

## Test Plan

- [x] `autoGc: passes skipNumericCap to collectGarbage` — verifies the option is threaded through
- [x] `collectGarbage: skipNumericCap skips numeric policies` — verifies versions are preserved when option is set
- [x] `catalog_invalidated_warning` event emitted after namespace migration
- [x] Reproduced the original bug in a scratch repo, verified the fix prevents silent bulk deletion
- [x] All pre-existing tests pass (9190 passed, 6 pre-existing failures unrelated to this change)
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)