### PR TITLE
fix(datastores): guard against un-migrated namespace data (swamp-club#1314)

### DIFF
--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -47,7 +47,15 @@ import { FilesystemDatastoreVerifier } from "../../infrastructure/persistence/fi
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveDatastoreConfig } from "../resolve_datastore.ts";
+import {
+  datastoreBasePath,
+  resolveDatastoreConfig,
+} from "../resolve_datastore.ts";
+import {
+  createFilesystemDetectDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+} from "../../libswamp/datastores/namespace_migration_check.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -56,12 +64,20 @@ async function createDoctorDatastoresDeps(
   repoDir: string,
 ): Promise<DoctorDatastoresDeps> {
   await datastoreTypeRegistry.ensureLoaded();
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(RepoPath.create(repoDir));
+  const datastoreConfig = await resolveDatastoreConfig(
+    marker,
+    undefined,
+    repoDir,
+  );
+  const dsBasePath = isCustomDatastoreConfig(datastoreConfig) &&
+      datastoreConfig.cachePath
+    ? datastoreConfig.cachePath
+    : datastoreBasePath(datastoreConfig);
+
   return {
-    getDatastoreConfig: async () => {
-      const markerRepo = new RepoMarkerRepository();
-      const marker = await markerRepo.read(RepoPath.create(repoDir));
-      return await resolveDatastoreConfig(marker, undefined, repoDir);
-    },
+    getDatastoreConfig: () => Promise.resolve(datastoreConfig),
     checkHealth: async (config) => {
       if (isCustomDatastoreConfig(config)) {
         await datastoreTypeRegistry.ensureTypeLoaded(config.type);
@@ -89,6 +105,20 @@ async function createDoctorDatastoresDeps(
       } catch {
         return [];
       }
+    },
+    checkMigrationStatus: async () => {
+      const unmigrated = await detectUnmigratedNamespaceData(
+        dsBasePath,
+        datastoreConfig.namespace,
+        createFilesystemDetectDeps(),
+      );
+      if (unmigrated.length > 0) {
+        return {
+          migrated: false,
+          message: formatUnmigratedWarning(unmigrated),
+        };
+      }
+      return { migrated: true };
     },
   };
 }

--- a/src/cli/commands/workflow_approvals.ts
+++ b/src/cli/commands/workflow_approvals.ts
@@ -34,6 +34,12 @@ import {
 import type { CommandContext } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import {
+  createFilesystemDetectDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+} from "../../libswamp/datastores/namespace_migration_check.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
@@ -119,10 +125,11 @@ export const workflowApprovalsCommand = withRemoteOptions(
     return;
   }
 
-  const { repoContext } = await requireInitializedRepoUnlocked({
-    repoDir: resolveRepoDir(options.repoDir),
-    outputMode: cliCtx.outputMode,
-  });
+  const { repoContext, datastoreResolver } =
+    await requireInitializedRepoUnlocked({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: cliCtx.outputMode,
+    });
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });
   const runRepo = repoContext.workflowRunRepo;
@@ -156,4 +163,21 @@ export const workflowApprovalsCommand = withRemoteOptions(
   );
 
   renderApprovals(cliCtx, pending);
+
+  if (pending.length === 0) {
+    const dsConfig = datastoreResolver.config();
+    if (dsConfig.namespace) {
+      const dsBasePath = isCustomDatastoreConfig(dsConfig)
+        ? (dsConfig.cachePath ?? dsConfig.datastorePath)
+        : dsConfig.path;
+      const unmigrated = await detectUnmigratedNamespaceData(
+        dsBasePath,
+        dsConfig.namespace,
+        createFilesystemDetectDeps(),
+      );
+      if (unmigrated.length > 0) {
+        cliCtx.logger.warn(formatUnmigratedWarning(unmigrated));
+      }
+    }
+  }
 });

--- a/src/cli/commands/workflow_run_search.ts
+++ b/src/cli/commands/workflow_run_search.ts
@@ -40,6 +40,12 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
+import {
+  createFilesystemDetectDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+} from "../../libswamp/datastores/namespace_migration_check.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import {
   createWorkflowId,
@@ -175,10 +181,11 @@ export async function workflowRunSearchAction(
   const libCtx = createLibSwampContext();
   ctx.logger.debug`Searching workflow runs with query: ${query ?? "(none)"}`;
 
-  const { repoContext } = await requireInitializedRepoReadOnly({
-    repoDir: resolveRepoDir(options.repoDir),
-    outputMode: effectiveMode,
-  });
+  const { repoContext, datastoreResolver } =
+    await requireInitializedRepoReadOnly({
+      repoDir: resolveRepoDir(options.repoDir),
+      outputMode: effectiveMode,
+    });
   const workflowRepo = repoContext.workflowRepo;
   const runRepo = repoContext.workflowRunRepo;
 
@@ -221,6 +228,24 @@ export async function workflowRunSearchAction(
   );
 
   const selected = renderer.selectedItem();
+
+  if (!selected) {
+    const dsConfig = datastoreResolver.config();
+    if (dsConfig.namespace) {
+      const dsBasePath = isCustomDatastoreConfig(dsConfig)
+        ? (dsConfig.cachePath ?? dsConfig.datastorePath)
+        : dsConfig.path;
+      const unmigrated = await detectUnmigratedNamespaceData(
+        dsBasePath,
+        dsConfig.namespace,
+        createFilesystemDetectDeps(),
+      );
+      if (unmigrated.length > 0) {
+        ctx.logger.warn(formatUnmigratedWarning(unmigrated));
+      }
+    }
+  }
+
   if (selected) {
     ctx.logger.debug`Selected run: ${selected.runId}`;
     // In JSON mode, still display the full run details after auto-select

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -60,6 +60,10 @@ export interface DoctorDatastoresDeps {
     config: DatastoreConfig,
   ) => Promise<{ healthy: boolean; message: string; latencyMs: number }>;
   getVaultConfigs: () => Promise<Array<{ name: string; type: string }>>;
+  checkMigrationStatus?: () => Promise<{
+    migrated: boolean;
+    message?: string;
+  }>;
 }
 
 /**
@@ -92,6 +96,19 @@ export async function* doctorDatastores(
         passed: healthy,
         message,
       });
+
+      // Namespace migration check
+      if (config.namespace && deps.checkMigrationStatus) {
+        const migration = await deps.checkMigrationStatus();
+        healthFindings.push({
+          check: "namespace-migration",
+          passed: migration.migrated,
+          message: migration.migrated
+            ? "Namespace data has been migrated"
+            : migration.message ??
+              "Un-migrated data detected. Run 'swamp datastore namespace migrate --confirm'.",
+        });
+      }
 
       // Vault mismatch check — only relevant for custom (remote) datastores
       if (isCustom) {

--- a/src/libswamp/datastores/namespace_migration_check.ts
+++ b/src/libswamp/datastores/namespace_migration_check.ts
@@ -1,0 +1,99 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import { DEFAULT_DATASTORE_SUBDIRS } from "../../domain/datastore/datastore_config.ts";
+import { INFRASTRUCTURE_FILES } from "./namespace_migrate.ts";
+
+export interface UnmigratedSubdir {
+  subdir: string;
+  source: string;
+  destination: string;
+}
+
+export interface DetectUnmigratedDeps {
+  dirExists: (path: string) => Promise<boolean>;
+  dirHasDataFiles: (path: string) => Promise<boolean>;
+}
+
+/**
+ * Checks whether un-namespaced data directories contain files that should
+ * be at namespaced paths. Returns a list of subdirs with un-migrated data.
+ *
+ * Returns an empty array when no namespace is set or when all data has
+ * already been migrated.
+ */
+export async function detectUnmigratedNamespaceData(
+  datastorePath: string,
+  namespace: string | undefined,
+  deps: DetectUnmigratedDeps,
+): Promise<UnmigratedSubdir[]> {
+  if (!namespace) return [];
+
+  const unmigrated: UnmigratedSubdir[] = [];
+  for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
+    const source = join(datastorePath, subdir);
+    const destination = join(datastorePath, namespace, subdir);
+
+    if (!(await deps.dirExists(source))) continue;
+    if (!(await deps.dirHasDataFiles(source))) continue;
+    if (
+      await deps.dirExists(destination) &&
+      await deps.dirHasDataFiles(destination)
+    ) continue;
+
+    unmigrated.push({ subdir, source, destination });
+  }
+
+  return unmigrated;
+}
+
+export function createFilesystemDetectDeps(): DetectUnmigratedDeps {
+  return {
+    dirExists: async (path: string) => {
+      try {
+        const stat = await Deno.stat(path);
+        return stat.isDirectory;
+      } catch {
+        return false;
+      }
+    },
+    dirHasDataFiles: async (path: string) => {
+      try {
+        for await (const entry of Deno.readDir(path)) {
+          if (!INFRASTRUCTURE_FILES.has(entry.name)) return true;
+        }
+      } catch {
+        return false;
+      }
+      return false;
+    },
+  };
+}
+
+export function formatUnmigratedWarning(
+  unmigrated: UnmigratedSubdir[],
+): string {
+  const dirs = unmigrated.map((u) => u.subdir).join(", ");
+  return `Data in ${unmigrated.length} director${
+    unmigrated.length === 1 ? "y" : "ies"
+  } (${dirs}) ` +
+    `has not been migrated to the namespaced layout. Run ` +
+    `'swamp datastore namespace migrate --confirm' to move it.`;
+}

--- a/src/libswamp/datastores/namespace_migration_check_test.ts
+++ b/src/libswamp/datastores/namespace_migration_check_test.ts
@@ -1,0 +1,133 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  type DetectUnmigratedDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+} from "./namespace_migration_check.ts";
+
+const DS_PATH = "/tmp/ds";
+
+function makeDeps(
+  overrides: Partial<DetectUnmigratedDeps> = {},
+): DetectUnmigratedDeps {
+  return {
+    dirExists: () => Promise.resolve(false),
+    dirHasDataFiles: () => Promise.resolve(false),
+    ...overrides,
+  };
+}
+
+Deno.test("detectUnmigratedNamespaceData: returns empty when no namespace", async () => {
+  const result = await detectUnmigratedNamespaceData(
+    DS_PATH,
+    undefined,
+    makeDeps(),
+  );
+  assertEquals(result, []);
+});
+
+Deno.test("detectUnmigratedNamespaceData: returns empty when no source dirs exist", async () => {
+  const result = await detectUnmigratedNamespaceData(
+    DS_PATH,
+    "infra",
+    makeDeps({ dirExists: () => Promise.resolve(false) }),
+  );
+  assertEquals(result, []);
+});
+
+Deno.test("detectUnmigratedNamespaceData: returns empty when source has no data files", async () => {
+  const result = await detectUnmigratedNamespaceData(
+    DS_PATH,
+    "infra",
+    makeDeps({
+      dirExists: () => Promise.resolve(true),
+      dirHasDataFiles: () => Promise.resolve(false),
+    }),
+  );
+  assertEquals(result, []);
+});
+
+Deno.test("detectUnmigratedNamespaceData: detects un-migrated dirs", async () => {
+  const existingDirs = new Set([
+    "/tmp/ds/workflow-runs",
+    "/tmp/ds/data",
+    "/tmp/ds/outputs",
+  ]);
+  const dirsWithData = new Set([
+    "/tmp/ds/workflow-runs",
+    "/tmp/ds/data",
+  ]);
+
+  const result = await detectUnmigratedNamespaceData(
+    DS_PATH,
+    "infra",
+    makeDeps({
+      dirExists: (p) => Promise.resolve(existingDirs.has(p)),
+      dirHasDataFiles: (p) => Promise.resolve(dirsWithData.has(p)),
+    }),
+  );
+
+  assertEquals(result.length, 2);
+  const subdirs = result.map((r) => r.subdir);
+  assertEquals(subdirs.includes("workflow-runs"), true);
+  assertEquals(subdirs.includes("data"), true);
+});
+
+Deno.test("detectUnmigratedNamespaceData: skips dirs already migrated", async () => {
+  const existingDirs = new Set([
+    "/tmp/ds/workflow-runs",
+    "/tmp/ds/infra/workflow-runs",
+  ]);
+  const dirsWithData = new Set([
+    "/tmp/ds/workflow-runs",
+    "/tmp/ds/infra/workflow-runs",
+  ]);
+
+  const result = await detectUnmigratedNamespaceData(
+    DS_PATH,
+    "infra",
+    makeDeps({
+      dirExists: (p) => Promise.resolve(existingDirs.has(p)),
+      dirHasDataFiles: (p) => Promise.resolve(dirsWithData.has(p)),
+    }),
+  );
+
+  assertEquals(result, []);
+});
+
+Deno.test("formatUnmigratedWarning: singular directory", () => {
+  const warning = formatUnmigratedWarning([
+    { subdir: "workflow-runs", source: "/a", destination: "/b" },
+  ]);
+  assertStringIncludes(warning, "1 directory");
+  assertStringIncludes(warning, "workflow-runs");
+  assertStringIncludes(warning, "namespace migrate --confirm");
+});
+
+Deno.test("formatUnmigratedWarning: multiple directories", () => {
+  const warning = formatUnmigratedWarning([
+    { subdir: "workflow-runs", source: "/a", destination: "/b" },
+    { subdir: "data", source: "/c", destination: "/d" },
+  ]);
+  assertStringIncludes(warning, "2 directories");
+  assertStringIncludes(warning, "workflow-runs, data");
+});

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -26,6 +26,11 @@ import type { DatastorePathResolver } from "../../domain/datastore/datastore_pat
 import { runBoundedSync } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
+import {
+  createFilesystemDetectDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+} from "./namespace_migration_check.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -53,6 +58,10 @@ export interface DatastoreSyncDeps {
     supported: boolean;
     type: string;
     errorMessage?: string;
+  }>;
+  checkMigrationStatus?: () => Promise<{
+    migrated: boolean;
+    message?: string;
   }>;
   pushSync: () => Promise<{ filesPushed: number }>;
   pullSync: () => Promise<{ filesPulled: number }>;
@@ -116,6 +125,20 @@ export async function createDatastoreSyncDeps(
     return {
       validateSyncSupport: () =>
         Promise.resolve({ supported: true, type: config.type }),
+      checkMigrationStatus: async () => {
+        const unmigrated = await detectUnmigratedNamespaceData(
+          config.cachePath!,
+          ns,
+          createFilesystemDetectDeps(),
+        );
+        if (unmigrated.length > 0) {
+          return {
+            migrated: false,
+            message: formatUnmigratedWarning(unmigrated),
+          };
+        }
+        return { migrated: true };
+      },
       pushSync: async () => {
         const count = await runBoundedSync(
           label,
@@ -223,6 +246,25 @@ export async function* datastoreSync(
           },
         };
         return;
+      }
+
+      if (
+        (input.mode === "push" || input.mode === "sync") &&
+        deps.checkMigrationStatus
+      ) {
+        const migration = await deps.checkMigrationStatus();
+        if (!migration.migrated) {
+          yield {
+            kind: "error",
+            error: {
+              code: "unmigrated_namespace_data",
+              message: migration.message ??
+                "Un-migrated namespace data detected. " +
+                  "Run 'swamp datastore namespace migrate --confirm' before pushing.",
+            },
+          };
+          return;
+        }
       }
 
       yield { kind: "syncing", mode: input.mode };

--- a/src/libswamp/datastores/sync_test.ts
+++ b/src/libswamp/datastores/sync_test.ts
@@ -222,6 +222,69 @@ Deno.test("createDatastoreSyncDeps: omits namespace when config has none", async
   assertEquals(push?.options?.namespace, undefined);
 });
 
+Deno.test("datastoreSync: push blocked when un-migrated namespace data exists", async () => {
+  const deps = makeDeps({
+    checkMigrationStatus: () =>
+      Promise.resolve({
+        migrated: false,
+        message:
+          "Data in 2 directories (workflow-runs, data) has not been migrated.",
+      }),
+  });
+
+  const error = await assertErrors<DatastoreSyncEvent>(
+    datastoreSync(createLibSwampContext(), deps, { mode: "push" }),
+    "unmigrated_namespace_data",
+  );
+  assertEquals(
+    error.message,
+    "Data in 2 directories (workflow-runs, data) has not been migrated.",
+  );
+});
+
+Deno.test("datastoreSync: full sync blocked when un-migrated namespace data exists", async () => {
+  const deps = makeDeps({
+    checkMigrationStatus: () =>
+      Promise.resolve({
+        migrated: false,
+        message: "Un-migrated data detected.",
+      }),
+  });
+
+  const error = await assertErrors<DatastoreSyncEvent>(
+    datastoreSync(createLibSwampContext(), deps, { mode: "sync" }),
+    "unmigrated_namespace_data",
+  );
+  assertEquals(error.message, "Un-migrated data detected.");
+});
+
+Deno.test("datastoreSync: pull allowed when un-migrated namespace data exists", async () => {
+  const deps = makeDeps({
+    checkMigrationStatus: () =>
+      Promise.resolve({ migrated: false, message: "Un-migrated data." }),
+  });
+
+  const events = await collect<DatastoreSyncEvent>(
+    datastoreSync(createLibSwampContext(), deps, { mode: "pull" }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "syncing", mode: "pull" });
+});
+
+Deno.test("datastoreSync: push succeeds when migration is complete", async () => {
+  const deps = makeDeps({
+    checkMigrationStatus: () => Promise.resolve({ migrated: true }),
+  });
+
+  const events = await collect<DatastoreSyncEvent>(
+    datastoreSync(createLibSwampContext(), deps, { mode: "push" }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "syncing", mode: "push" });
+});
+
 Deno.test("datastoreSync: unsupported datastore type yields error", async () => {
   const deps = makeDeps({
     validateSyncSupport: () =>

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1521,6 +1521,13 @@ export {
   type SubdirPreview,
 } from "./datastores/namespace_migrate.ts";
 export {
+  createFilesystemDetectDeps,
+  type DetectUnmigratedDeps,
+  detectUnmigratedNamespaceData,
+  formatUnmigratedWarning,
+  type UnmigratedSubdir,
+} from "./datastores/namespace_migration_check.ts";
+export {
   questPass,
   type QuestPassData,
   type QuestPassDeps,


### PR DESCRIPTION
## Summary

Fixes swamp-club#1314: after `datastore namespace set`, workflow run search and
approvals return empty results because the path resolver points to namespaced
paths while existing files remain at the old un-namespaced layout.

**Root cause:** `namespace set` changes the `DatastorePathResolver` to resolve
`workflow-runs` (and all datastore-tier dirs) to `{dsPath}/{namespace}/workflow-runs/`,
but the actual YAML files stay at `{dsPath}/workflow-runs/`. The existing warning
message is insufficient — `sync --push` succeeds silently, `doctor` passes, and
suspended `manual_approval` runs become permanently unreachable.

**Fix:** Add un-migrated namespace data detection at three layers:
- **`sync --push`** — refuses to push when un-migrated data is detected, with the
  exact remediation command in the error message
- **`doctor datastores`** — new health check flags un-migrated directories as a
  failure (previously passed all checks in this scenario)
- **`workflow run search` / `workflow approvals`** — warn when results are empty
  and un-migrated namespace data exists

**Immediate remediation for affected users:**
```
swamp datastore namespace migrate --confirm
```

## Test Plan

- 11 new unit tests (7 for detection function, 4 for sync guard)
- All 127 existing datastore tests pass
- End-to-end verification with compiled binary:
  1. Created scratch repo with 6 workflow run YAMLs at non-namespaced paths
  2. Ran `namespace set asdlc` without `namespace migrate`
  3. Verified `doctor datastores` exits non-zero with migration failure message
  4. Verified `workflow run search` logs migration warning
  5. Ran `namespace migrate --confirm`
  6. Verified doctor passes and warnings disappear