### PR TITLE
fix(expressions): add dotAll flag to expression regexes so multi-line YAML scalars evaluate (swamp-club#1316)

### DIFF
--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -156,10 +156,10 @@ function replaceExpressionsRecursive(
 ): unknown {
   if (typeof data === "string") {
     // Check if the entire string is a single expression
-    const singleMatch = data.match(/^\$\{\{\s*(.+?)\s*\}\}\s*$/s);
+    const singleMatch = data.match(/^(\$\{\{\s*.+?\s*\}\})\s*$/s);
     if (singleMatch) {
       // Return the evaluated value directly (preserves type)
-      const evaluated = values.get(data);
+      const evaluated = values.get(singleMatch[1]);
       return evaluated !== undefined ? evaluated : data;
     }
 

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -23,7 +23,7 @@ import type { ExpressionLocation } from "./expression.ts";
  * Pattern to match ${{ ... }} expressions.
  * Captures the inner CEL expression.
  */
-const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/g;
+const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/gs;
 
 /**
  * Transforms model references with hyphenated names to bracket notation.
@@ -49,7 +49,7 @@ export function transformHyphenatedModelRefs(expression: string): string {
  * Checks if a string contains any expressions.
  */
 export function containsExpression(value: string): boolean {
-  return /\$\{\{.+?\}\}/.test(value);
+  return /\$\{\{.+?\}\}/s.test(value);
 }
 
 /**
@@ -156,7 +156,7 @@ function replaceExpressionsRecursive(
 ): unknown {
   if (typeof data === "string") {
     // Check if the entire string is a single expression
-    const singleMatch = data.match(/^\$\{\{\s*(.+?)\s*\}\}$/);
+    const singleMatch = data.match(/^\$\{\{\s*(.+?)\s*\}\}\s*$/s);
     if (singleMatch) {
       // Return the evaluated value directly (preserves type)
       const evaluated = values.get(data);
@@ -205,7 +205,7 @@ function replaceExpressionsRecursive(
  * @returns The CEL expression (e.g., "model.foo.input") or null if not valid
  */
 export function extractCelExpression(raw: string): string | null {
-  const match = raw.match(/^\$\{\{\s*(.+?)\s*\}\}$/);
+  const match = raw.match(/^\$\{\{\s*(.+?)\s*\}\}\s*$/s);
   return match ? match[1].trim() : null;
 }
 

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -476,6 +476,14 @@ Deno.test("replaceExpressions: replaces whole-value expression spanning newlines
   assertEquals(result.deliveryId, "gh-abc-123");
 });
 
+Deno.test("replaceExpressions: preserves type for whole-value expression with trailing newline", () => {
+  const raw = "${{ model.foo.resource.id }}";
+  const data = { value: raw + "\n" };
+  const values = new Map<string, unknown>([[raw, 42]]);
+  const result = replaceExpressions(data, values) as { value: unknown };
+  assertEquals(result.value, 42);
+});
+
 Deno.test("extractCelExpression: extracts expression spanning newlines", () => {
   assertEquals(
     extractCelExpression(

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -441,3 +441,46 @@ Deno.test("extractInputReferencesFromCel: returns all branch inputs in ternary r
     new Set(["transport", "lan_host", "tailnet_host"]),
   );
 });
+
+// Multi-line expression tests (swamp-club#1316)
+
+Deno.test("containsExpression: detects expression spanning newlines", () => {
+  assertEquals(
+    containsExpression(
+      '${{ webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: webhook.headers["linear-delivery"] }}',
+    ),
+    true,
+  );
+});
+
+Deno.test("extractExpressions: extracts expression spanning newlines", () => {
+  const data = {
+    deliveryId:
+      '${{ webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: webhook.headers["linear-delivery"] }}',
+  };
+  const expressions = extractExpressions(data);
+  assertEquals(expressions.length, 1);
+  assertEquals(expressions[0].path, "deliveryId");
+  assertEquals(
+    expressions[0].celExpression,
+    'webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: webhook.headers["linear-delivery"]',
+  );
+});
+
+Deno.test("replaceExpressions: replaces whole-value expression spanning newlines", () => {
+  const raw =
+    '${{ webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: webhook.headers["linear-delivery"] }}';
+  const data = { deliveryId: raw };
+  const values = new Map<string, unknown>([[raw, "gh-abc-123"]]);
+  const result = replaceExpressions(data, values) as { deliveryId: unknown };
+  assertEquals(result.deliveryId, "gh-abc-123");
+});
+
+Deno.test("extractCelExpression: extracts expression spanning newlines", () => {
+  assertEquals(
+    extractCelExpression(
+      '${{ webhook.route == "/hooks/github"\n? webhook.headers["x"] }}',
+    ),
+    'webhook.route == "/hooks/github"\n? webhook.headers["x"]',
+  );
+});

--- a/src/domain/expressions/vault_reference_extractor.ts
+++ b/src/domain/expressions/vault_reference_extractor.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/g;
+const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/gs;
 
 const VAULT_GET_PATTERN =
   /vault\.get\(\s*(?:(['"`])(.+?)\1|([^\s,)]+))\s*,\s*(?:(['"`])(.+?)\4|([^\s,)]+))\s*\)/g;

--- a/src/domain/models/env_var_detector.ts
+++ b/src/domain/models/env_var_detector.ts
@@ -59,7 +59,7 @@ function collectEnvVarUsages(
   usages: EnvVarUsageDetail[],
 ): void {
   if (typeof data === "string") {
-    const exprPattern = /\$\{\{\s*(.+?)\s*\}\}/g;
+    const exprPattern = /\$\{\{\s*(.+?)\s*\}\}/gs;
     for (const match of data.matchAll(exprPattern)) {
       const celExpr = match[1];
       const envPattern = /\benv\.([a-zA-Z_][a-zA-Z0-9_]*)/g;

--- a/src/domain/models/sensitive_field_extractor.ts
+++ b/src/domain/models/sensitive_field_extractor.ts
@@ -193,7 +193,7 @@ function isExpressionOnly(value: string): boolean {
   if (!containsExpression(value)) {
     return false;
   }
-  return value.replace(/\$\{\{.+?\}\}/g, "").trim() === "";
+  return value.replace(/\$\{\{.+?\}\}/gs, "").trim() === "";
 }
 
 /**

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -78,7 +78,7 @@ export class WorkflowExpressionEvaluator {
     for (const job of workflow.jobs) {
       for (const step of job.steps) {
         if (step.forEach) {
-          const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+          const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/s);
           if (match) {
             forEachInExpressions.add(step.forEach.in);
           }

--- a/src/domain/workflows/for_each_expansion_service.ts
+++ b/src/domain/workflows/for_each_expansion_service.ts
@@ -64,7 +64,7 @@ export function resolveForEachStepName(
   if (hasExpression) {
     let hadEvalFailure = false;
     const resolved = template.replace(
-      /\$\{\{\s*(.+?)\s*\}\}/g,
+      /\$\{\{\s*(.+?)\s*\}\}/gs,
       (_match, expr) => {
         try {
           return String(

--- a/src/domain/workflows/for_each_expansion_service.ts
+++ b/src/domain/workflows/for_each_expansion_service.ts
@@ -115,7 +115,7 @@ export class ForEachExpansionService {
       const inExpression = step.forEach.in;
       const itemName = step.forEach.item;
 
-      const match = inExpression.match(/\$\{\{\s*(.+?)\s*\}\}/);
+      const match = inExpression.match(/\$\{\{\s*(.+?)\s*\}\}/s);
       if (!match) {
         throw new UserError(
           `Invalid forEach.in expression: ${inExpression}. Must be in $\{{ }} format.`,
@@ -126,7 +126,7 @@ export class ForEachExpansionService {
       // query) that return Promises resolve here before we iterate.
       const items = await this.celEvaluator.evaluateAsync(match[1], context);
 
-      const nameHasExpression = /\$\{\{.+?\}\}/.test(step.name);
+      const nameHasExpression = /\$\{\{.+?\}\}/s.test(step.name);
       const expandedSteps: ExpandedStep[] = [];
 
       if (Array.isArray(items)) {

--- a/src/domain/workflows/step_task.ts
+++ b/src/domain/workflows/step_task.ts
@@ -19,7 +19,7 @@
 
 import { z } from "zod";
 
-const EXPRESSION_PATTERN = /^\$\{\{\s*.+?\s*\}\}$/;
+const EXPRESSION_PATTERN = /^\$\{\{\s*.+?\s*\}\}\s*$/s;
 
 const recordOrExpression = z.union([
   z.record(z.string(), z.unknown()),

--- a/src/domain/workflows/trigger_input_resolver.ts
+++ b/src/domain/workflows/trigger_input_resolver.ts
@@ -20,8 +20,8 @@
 import type { ExpressionContext } from "../expressions/model_resolver.ts";
 import type { CelExpressionEvaluator } from "../expressions/cel_runtime.ts";
 
-const WHOLE_EXPRESSION = /^\$\{\{\s*(.+?)\s*\}\}$/;
-const EMBEDDED_EXPRESSION = /\$\{\{\s*(.+?)\s*\}\}/g;
+const WHOLE_EXPRESSION = /^\$\{\{\s*(.+?)\s*\}\}\s*$/s;
+const EMBEDDED_EXPRESSION = /\$\{\{\s*(.+?)\s*\}\}/gs;
 
 /**
  * Resolves a trigger's `inputs` value map by evaluating its CEL expressions

--- a/src/domain/workflows/trigger_input_resolver_test.ts
+++ b/src/domain/workflows/trigger_input_resolver_test.ts
@@ -117,6 +117,57 @@ Deno.test("TriggerInputResolver: supports has()/ternary fallback for a missing f
   assertEquals(result, { identifier: "FALLBACK-1" });
 });
 
+Deno.test("TriggerInputResolver: resolves a multi-line whole-value expression", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const ctx = contextWith({
+    body: {},
+    headers: {
+      "x-github-delivery": "gh-abc",
+      "linear-delivery": "lin-xyz",
+    },
+    route: "/hooks/github",
+  });
+  const result = await resolver.resolve(
+    {
+      deliveryId:
+        '${{ webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: webhook.headers["linear-delivery"] }}',
+    },
+    ctx,
+  );
+  assertEquals(result, { deliveryId: "gh-abc" });
+});
+
+Deno.test("TriggerInputResolver: resolves a whole-value expression with trailing newline", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const ctx = contextWith({
+    body: { id: 42 },
+    headers: {},
+    route: "/hooks/x",
+  });
+  const result = await resolver.resolve(
+    { count: "${{ webhook.body.id }}\n" },
+    ctx,
+  );
+  assertEquals(result, { count: 42 });
+});
+
+Deno.test("TriggerInputResolver: resolves a multi-line embedded expression", async () => {
+  const resolver = new TriggerInputResolver(new CelEvaluator());
+  const ctx = contextWith({
+    body: {},
+    headers: { "x-github-delivery": "gh-abc" },
+    route: "/hooks/github",
+  });
+  const result = await resolver.resolve(
+    {
+      ref:
+        'delivery-${{ webhook.route == "/hooks/github"\n? webhook.headers["x-github-delivery"]\n: "unknown" }}-end',
+    },
+    ctx,
+  );
+  assertEquals(result, { ref: "delivery-gh-abc-end" });
+});
+
 Deno.test("TriggerInputResolver: propagates a hard reference error", async () => {
   const resolver = new TriggerInputResolver(new CelEvaluator());
   await assertRejects(() =>

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -190,7 +190,7 @@ async function evaluateWorkflowInternal(
   for (const job of workflow.jobs) {
     for (const step of job.steps) {
       if (step.forEach) {
-        const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+        const match = step.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/s);
         if (match) {
           forEachInExpressions.add(step.forEach.in);
         }
@@ -251,7 +251,7 @@ async function evaluateWorkflowInternal(
       }
 
       // Evaluate the forEach.in expression
-      const inMatch = stepData.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/);
+      const inMatch = stepData.forEach.in.match(/\$\{\{\s*(.+?)\s*\}\}/s);
       if (!inMatch) {
         expandedSteps.push(stepData);
         continue;
@@ -262,7 +262,7 @@ async function evaluateWorkflowInternal(
       // propagates Promises through its evaluator natively.
       const items = await deps.evaluateCelAsync(inMatch[1], context);
       const itemName = stepData.forEach.item;
-      const nameHasExpression = /\$\{\{.+?\}\}/.test(stepData.name);
+      const nameHasExpression = /\$\{\{.+?\}\}/s.test(stepData.name);
 
       // Build one expanded step for a single forEach item: resolve every
       // available expression (self.* etc.) across the step name AND task in one
@@ -284,7 +284,7 @@ async function evaluateWorkflowInternal(
           // If any expression in the name could not be resolved, the raw name
           // would repeat across iterations — append a suffix to keep names
           // unique (matches ForEachExpansionService.resolveForEachStepName).
-          if (/\$\{\{.+?\}\}/.test(expandedName)) {
+          if (/\$\{\{.+?\}\}/s.test(expandedName)) {
             expandedName = `${expandedName}-${fallbackSuffix}`;
           }
         } else {


### PR DESCRIPTION
## Summary

- Adds the `s` (dotAll) flag to all `${{ }}` expression-matching regex
  patterns across 7 production files so `.` matches `\n` — multi-line
  YAML block scalars (`|`, `|-`) now evaluate instead of silently passing
  through as literal text
- Adds `\s*` before `$` anchors in whole-expression regexes to tolerate
  trailing newlines from YAML block scalars without the strip indicator
  (`>`, `|`)
- Adds 7 new test cases covering multi-line and trailing-newline
  expression matching in `trigger_input_resolver_test.ts` and
  `expression_parser_test.ts`

Fixes swamp-club#1316

## Test Plan

- [x] Reproduced the bug: `TriggerInputResolver` passes multi-line
  `${{ }}` expressions through as literal text; single-line expressions
  resolve correctly
- [x] Verified fix covers all 5 YAML block scalar styles (`>-`, `>`,
  `|-`, `|`, quoted flow)
- [x] Verified bad CEL syntax in multi-line expressions produces
  actionable error messages (not silent pass-through)
- [x] 9216 tests pass; all failures pre-existing (oauth_client,
  shutdown_handlers, extension_quality)
- [x] `deno fmt --check` and `deno lint` clean
- [x] Binary compiles

Co-authored-by: Blake Irvin <blakeirvin@me.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)