### PR TITLE
fix(data): address review feedback from autoGc gating PR (#1921)

### DIFF
--- a/packages/client/protocol.ts
+++ b/packages/client/protocol.ts
@@ -673,6 +673,7 @@ export type ModelMethodRunEvent =
   | { kind: "report_failed"; reportName: string; scope: string; error: string }
   | { kind: "completed"; run: ModelMethodRunView }
   | { kind: "cancelled"; run: ModelMethodRunView; reason?: string }
+  | { kind: "auto_gc_started" }
   | {
     kind: "auto_gc_completed";
     versionsDeleted: number;

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -807,6 +807,7 @@ export async function requireInitializedRepoUnlocked(
       )
       : undefined,
     namespace: datastoreConfig.namespace,
+    autoGc: marker?.autoGc === true,
     ...factoryConfig,
   });
 

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1714,7 +1714,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         toRemove,
       );
       logger
-        .warn`Pruned ${toRemove.length} excess version(s) of ${dataName} (cap: ${cap}, prior: ${priorVersions.length})`;
+        .info`Pruned ${toRemove.length} excess version(s) of ${dataName} (cap: ${cap}, prior: ${priorVersions.length})`;
     }
   }
 

--- a/src/infrastructure/persistence/unified_data_repository_test.ts
+++ b/src/infrastructure/persistence/unified_data_repository_test.ts
@@ -1369,3 +1369,50 @@ Deno.test("save: prunes versions at write time with enableWriteGc", async () => 
     }
   }
 });
+
+Deno.test("save: write-time pruning emits markDirty for each pruned version", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const catalogStore = new CatalogStore(join(tmpDir, "_catalog.db"));
+    const calls: Array<string | undefined> = [];
+    const markDirty = (relPath?: string) => {
+      calls.push(relPath);
+      return Promise.resolve();
+    };
+    const repo = new FileSystemUnifiedDataRepository(
+      tmpDir,
+      undefined,
+      catalogStore,
+      markDirty,
+      undefined,
+      SOLO_NAMESPACE,
+      true,
+    );
+
+    const data = Data.create({
+      name: "dirty-prune",
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 2,
+      streaming: false,
+      tags: { type: "resource" },
+      ownerDefinition: { ownerType: "manual", ownerRef: "test" },
+    });
+
+    await repo.save(testType, "m", data, new TextEncoder().encode("a"));
+    await repo.save(testType, "m", data, new TextEncoder().encode("b"));
+    calls.length = 0;
+
+    await repo.save(testType, "m", data, new TextEncoder().encode("c"));
+
+    const v1Dir = repo.getPath(testType, "m", "dirty-prune", 1);
+    const pruneMarkDirty = calls.filter((c) => c === v1Dir);
+    assertEquals(pruneMarkDirty.length, 1);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  }
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -1142,7 +1142,7 @@ export async function* modelMethodRun(
           yield { kind: "completed", run: view };
 
           if (input.autoGc) {
-            yield { kind: "auto_gc_started" as const };
+            yield { kind: "auto_gc_started" };
             let lifecycleDeps: AutoGcLifecycleDeps | undefined;
             if (deps.workflowRunRepo) {
               const lifecycleService = new DefaultDataLifecycleService(


### PR DESCRIPTION
## Summary

Follow-up to #1921, addressing all review feedback:

- **Add `auto_gc_started` to client protocol** — `packages/client/protocol.ts` was missing the new event kind, so TypeScript consumers couldn't handle it type-safely.
- **Wire `autoGc` in `requireInitializedRepoUnlocked`** — the unlocked repo context path wasn't passing `autoGc` to the factory, making write-time pruning inconsistent across init paths.
- **`warn` → `info` for write-time pruning log** — `warn` is reserved for unexpected conditions in this file; opt-in pruning is expected behavior.
- **Remove `as const` on `auto_gc_started` yield** — style consistency with the rest of the generator.
- **Restore `markDirty` test** — write-time pruning's `markDirty` integration was untested after the original PR deleted the test.

## Test Plan

- [x] All 85 affected tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)