### PR TITLE
fix(persistence): write .runs-index.json to local path, not synced cache

### DIFF
--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -468,6 +468,13 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     return join(this.baseDir, workflowId);
   }
 
+  private getLocalIndexDir(workflowId: WorkflowId): string {
+    return join(
+      swampPath(this.repoDir, SWAMP_SUBDIRS.workflowRuns),
+      workflowId,
+    );
+  }
+
   async deleteAllByWorkflowId(workflowId: WorkflowId): Promise<number> {
     const dir = this.getRunsDir(workflowId);
 
@@ -585,6 +592,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
     for (const dir of affectedDirs) {
       await deleteRunIndex(dir);
+      const workflowId = dir.split("/").pop() as WorkflowId;
+      if (workflowId) {
+        await deleteRunIndex(this.getLocalIndexDir(workflowId));
+      }
     }
 
     return { deleted, bytesReclaimed };
@@ -593,8 +604,9 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   async findAllSummariesFromIndex(
     workflowId: WorkflowId,
   ): Promise<WorkflowRunSummary[]> {
-    const dir = this.getRunsDir(workflowId);
-    const index = await this.getValidatedIndex(dir);
+    const runsDir = this.getRunsDir(workflowId);
+    const indexDir = this.getLocalIndexDir(workflowId);
+    const index = await this.getValidatedIndex(runsDir, indexDir);
     if (!index) {
       return this.findAllSummariesByWorkflowId(workflowId);
     }
@@ -605,8 +617,9 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     workflowId: WorkflowId,
     status: string,
   ): Promise<WorkflowRunSummary[]> {
-    const dir = this.getRunsDir(workflowId);
-    const index = await this.getValidatedIndex(dir);
+    const runsDir = this.getRunsDir(workflowId);
+    const indexDir = this.getLocalIndexDir(workflowId);
+    const index = await this.getValidatedIndex(runsDir, indexDir);
     if (!index) {
       const all = await this.findAllSummariesByWorkflowId(workflowId);
       return all.filter((s) => s.status === status);
@@ -615,33 +628,35 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
   }
 
   private async getValidatedIndex(
-    dir: string,
+    runsDir: string,
+    indexDir: string,
   ): Promise<WorkflowRunIndex | null> {
-    const entries = await listDirEntries(dir);
+    const entries = await listDirEntries(runsDir);
     const yamlCount = countYamlRunFiles(entries);
     if (yamlCount === 0) return null;
 
-    const index = await readRunIndex(dir);
+    const index = await readRunIndex(indexDir);
     if (!index || isIndexStale(index, yamlCount)) {
-      return await this.rebuildIndex(dir);
+      return await this.rebuildIndex(runsDir, indexDir);
     }
 
     return index;
   }
 
   private async rebuildIndex(
-    dir: string,
+    runsDir: string,
+    indexDir: string,
   ): Promise<WorkflowRunIndex | null> {
     const index: WorkflowRunIndex = {};
     try {
-      for await (const entry of Deno.readDir(dir)) {
+      for await (const entry of Deno.readDir(runsDir)) {
         if (
           !entry.isFile || !entry.name.startsWith("workflow-run-") ||
           !entry.name.endsWith(".yaml")
         ) {
           continue;
         }
-        const path = join(dir, entry.name);
+        const path = join(runsDir, entry.name);
         try {
           const content = await Deno.readTextFile(path);
           const summary = parseWorkflowRunSummary(parseYaml(content));
@@ -657,7 +672,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     }
 
     try {
-      await writeRunIndex(dir, index);
+      await ensureDir(indexDir);
+      await writeRunIndex(indexDir, index);
     } catch (error) {
       logger
         .warn`Failed to write rebuilt index, will retry next read: ${error}`;
@@ -670,9 +686,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
     workflowId: WorkflowId,
     run: WorkflowRun,
   ): Promise<void> {
-    const dir = this.getRunsDir(workflowId);
+    const indexDir = this.getLocalIndexDir(workflowId);
     try {
-      const existing = await readRunIndex(dir) ?? {};
+      await ensureDir(indexDir);
+      const existing = await readRunIndex(indexDir) ?? {};
       existing[run.id] = {
         status: run.status,
         workflowId: run.workflowId,
@@ -682,10 +699,10 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
         tags: run.tags ?? {},
         inputs: run.inputs ?? {},
       };
-      await writeRunIndex(dir, existing);
+      await writeRunIndex(indexDir, existing);
     } catch (error) {
       logger.warn`Failed to update run index, deleting for rebuild: ${error}`;
-      await deleteRunIndex(dir);
+      await deleteRunIndex(indexDir);
     }
   }
 }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { basename, join } from "@std/path";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import { cleanupEmptyParentDirs } from "./directory_cleanup.ts";
@@ -496,6 +496,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
       }
     }
 
+    await deleteRunIndex(this.getLocalIndexDir(workflowId));
+
     return count;
   }
 
@@ -592,7 +594,7 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
     for (const dir of affectedDirs) {
       await deleteRunIndex(dir);
-      const workflowId = dir.split("/").pop() as WorkflowId;
+      const workflowId = basename(dir) as WorkflowId;
       if (workflowId) {
         await deleteRunIndex(this.getLocalIndexDir(workflowId));
       }

--- a/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository_test.ts
@@ -943,3 +943,28 @@ Deno.test("index: corrupt JSON triggers rebuild on read", async () => {
     assertEquals(summaries[0].status, "running");
   });
 });
+
+Deno.test("save: index is written to local path, not cache baseDir", async () => {
+  await withTempDir(async (dir) => {
+    const cacheDir = await Deno.makeTempDir();
+    try {
+      const repo = new YamlWorkflowRunRepository(dir, undefined, cacheDir);
+      const workflow = createTestWorkflow();
+      const run = WorkflowRun.create(workflow);
+      run.start();
+      await repo.save(workflow.id, run);
+
+      // Index must be under the repo-local .swamp/ path
+      const localIndexDir = join(dir, ".swamp", "workflow-runs", workflow.id);
+      const localIndex = await readRunIndex(localIndexDir);
+      assertNotEquals(localIndex, null, "index must exist under local .swamp/");
+      assertEquals(localIndex![run.id]?.status, "running");
+
+      // Index must NOT be in the cache baseDir (would pollute sync)
+      const cacheIndex = await readRunIndex(join(cacheDir, workflow.id));
+      assertEquals(cacheIndex, null, "index must not exist in cache baseDir");
+    } finally {
+      await Deno.remove(cacheDir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The `.runs-index.json` (per-workflow performance index introduced in #1918) is a local read-model, analogous to `_catalog.db` — it can be rebuilt from the YAML files on disk and should not be synced between repos
- Currently it's written to the datastore cache directory (`baseDir`), which means the sync walker discovers and uploads it
- This moves the index to the repo-local `.swamp/workflow-runs/` path (via `repoDir`), keeping it out of the sync tree entirely without requiring extension-side changes

## Test plan

- [x] All 36 `yaml_workflow_run_repository_test.ts` tests pass (including 7 index-backed tests from #1918)
- [x] All 10 `workflow_run_index_test.ts` tests pass
- [x] New test: `save: index is written to local path, not cache baseDir` — verifies the index exists under `.swamp/` and does NOT exist in the cache baseDir when a custom datastore is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)