### PR TITLE
fix(workflows): resolve self.* in placement fields during forEach expansion (swamp-club#1334)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -555,17 +555,28 @@ export class DefaultStepExecutor implements StepExecutor {
     }
 
     // Resolve every available expression (self.* from the forEach variable,
-    // run.*, etc.) anywhere in the task before model lookup. The expression
-    // context has self populated with the forEach variable by runStep().
-    // resolveAvailableExpressions defers vault/env and step-output kinds to their
-    // dedicated stages — see available_expression_resolver.ts.
+    // run.*, etc.) anywhere in the task and placement fields before model
+    // lookup. The expression context has self populated with the forEach
+    // variable by runStep(). resolveAvailableExpressions defers vault/env and
+    // step-output kinds to their dedicated stages — see
+    // available_expression_resolver.ts.
+    let resolvedPlacement = ctx.step?.placement;
     if (ctx.expressionContext) {
       const celEvaluator = new CelEvaluator();
+      const evaluate = (expr: string, context: Record<string, unknown>) =>
+        celEvaluator.evaluate(expr, context);
       task = resolveAvailableExpressions(
         task,
         ctx.expressionContext,
-        (expr, context) => celEvaluator.evaluate(expr, context),
+        evaluate,
       ) as typeof task;
+      if (resolvedPlacement) {
+        resolvedPlacement = resolveAvailableExpressions(
+          resolvedPlacement,
+          ctx.expressionContext,
+          evaluate,
+        ) as typeof resolvedPlacement;
+      }
     }
 
     // Resolve whole-field expression strings for inputs/globalArgs that survived
@@ -880,6 +891,7 @@ export class DefaultStepExecutor implements StepExecutor {
           evaluatedDefinition,
           runLogger,
           secretBag,
+          resolvedPlacement,
         });
 
         if (heartbeatInterval) clearInterval(heartbeatInterval);
@@ -962,6 +974,12 @@ export class DefaultStepExecutor implements StepExecutor {
       ExpressionEvaluationService["resolveRuntimeExpressionsInDefinition"]
     > extends Promise<infer R> ? R extends { secretBag: infer S } ? S : never
       : never;
+    resolvedPlacement?: {
+      target?: string;
+      labels?: Record<string, string>;
+      platform?: string;
+      queueTimeoutMs?: number;
+    };
   }): Promise<MethodResult> {
     const {
       task,
@@ -977,6 +995,7 @@ export class DefaultStepExecutor implements StepExecutor {
       evaluatedDefinition,
       runLogger,
       secretBag,
+      resolvedPlacement,
     } = args;
 
     runLogger.debug("Executing method {method}", { method: task.methodName });
@@ -1093,7 +1112,7 @@ export class DefaultStepExecutor implements StepExecutor {
             stepDataOutputOverrides,
           ),
           vaultSecrets: secretBag,
-          placement: ctx.step?.placement,
+          placement: resolvedPlacement,
           skipCheckNames: ctx.skipCheckNames,
           skipCheckLabels: ctx.skipCheckLabels,
           skipAllChecks: ctx.skipAllChecks,

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -265,18 +265,31 @@ async function evaluateWorkflowInternal(
       const nameHasExpression = /\$\{\{.+?\}\}/s.test(stepData.name);
 
       // Build one expanded step for a single forEach item: resolve every
-      // available expression (self.* etc.) across the step name AND task in one
-      // pass via the shared resolver, then apply the unique-name suffix policy.
+      // available expression (self.* etc.) across the step name, task, AND
+      // placement fields in one pass via the shared resolver, then apply the
+      // unique-name suffix policy.
       const buildExpandedStep = (
         // deno-lint-ignore no-explicit-any
         stepContext: any,
         fallbackSuffix: string,
       ) => {
         const resolved = resolveAvailableExpressions(
-          { name: stepData.name, task: stepData.task },
+          {
+            name: stepData.name,
+            task: stepData.task,
+            target: stepData.target,
+            labels: stepData.labels,
+            platform: stepData.platform,
+          },
           stepContext,
           deps.evaluateCel,
-        ) as { name: string; task: typeof stepData.task };
+        ) as {
+          name: string;
+          task: typeof stepData.task;
+          target: typeof stepData.target;
+          labels: typeof stepData.labels;
+          platform: typeof stepData.platform;
+        };
 
         let expandedName: string;
         if (nameHasExpression) {
@@ -295,6 +308,9 @@ async function evaluateWorkflowInternal(
           ...stepData,
           name: expandedName,
           task: resolved.task,
+          target: resolved.target,
+          labels: resolved.labels,
+          platform: resolved.platform,
           forEach: undefined,
         };
       };

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -565,6 +565,120 @@ Deno.test("forEach: resolves self.* in modelName (model task parity)", async () 
   assertEquals((steps[1].task as any).modelName, "scanner-eu-west-1");
 });
 
+// --- forEach self.* in placement fields (target, labels, platform) ---
+
+Deno.test("forEach: resolves self.* in target", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000010",
+    name: "foreach-target",
+    inputs: {},
+    jobs: [{
+      name: "collect",
+      steps: [{
+        name: "collect-${{ self.worker }}",
+        forEach: { item: "worker", in: "${{ items }}" },
+        target: "${{ self.worker }}",
+        task: {
+          type: "model_method",
+          modelIdOrName: "inventory",
+          methodName: "sync",
+        },
+      }],
+    }],
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["worker-01", "worker-02"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  assertEquals(data.forEachExpanded, true);
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(steps[0].name, "collect-worker-01");
+  assertEquals(steps[0].target, "worker-01");
+  assertEquals(steps[1].name, "collect-worker-02");
+  assertEquals(steps[1].target, "worker-02");
+});
+
+Deno.test("forEach: resolves self.* in labels", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000011",
+    name: "foreach-labels",
+    inputs: {},
+    jobs: [{
+      name: "deploy",
+      steps: [{
+        name: "deploy-${{ self.env }}",
+        forEach: { item: "env", in: "${{ items }}" },
+        labels: { environment: "${{ self.env }}" },
+        task: {
+          type: "model_method",
+          modelIdOrName: "app",
+          methodName: "deploy",
+        },
+      }],
+    }],
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        { model: {}, env: {}, self: {}, items: ["staging", "production"] } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  assertEquals(data.forEachExpanded, true);
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(steps[0].labels, { environment: "staging" });
+  assertEquals(steps[1].labels, { environment: "production" });
+});
+
+Deno.test("forEach: resolves self.* in platform", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000012",
+    name: "foreach-platform",
+    inputs: {},
+    jobs: [{
+      name: "build",
+      steps: [{
+        name: "build-${{ self.arch }}",
+        forEach: { item: "arch", in: "${{ items }}" },
+        platform: "${{ self.arch }}",
+        task: {
+          type: "model_method",
+          modelIdOrName: "builder",
+          methodName: "compile",
+        },
+      }],
+    }],
+  });
+
+  const data = await evaluateForEachWorkflow(workflow, {
+    buildExpressionContext: () =>
+      Promise.resolve(
+        {
+          model: {},
+          env: {},
+          self: {},
+          items: ["linux/amd64", "linux/arm64"],
+        } as // deno-lint-ignore no-explicit-any
+        any,
+      ),
+  });
+
+  assertEquals(data.forEachExpanded, true);
+  const steps = data.jobs![0].steps;
+  assertEquals(steps.length, 2);
+  assertEquals(steps[0].platform, "linux/amd64");
+  assertEquals(steps[1].platform, "linux/arm64");
+});
+
 Deno.test("isWorkflowEvaluateAllData: returns true for AllData, false for ItemData", () => {
   const allData: WorkflowEvaluateAllData = {
     items: [],


### PR DESCRIPTION
## Summary

- forEach expansion resolved `self.*` expressions in step `name` and `task` fields but skipped placement fields (`target`, `labels`, `platform`), causing expressions like `${{ self.worker.attributes.name }}` to survive as literal text in the `target` field
- Include placement fields in `resolveAvailableExpressions` during evaluate-time expansion (`evaluate.ts`) and runtime execution (`execution_service.ts`)
- Verified against the exact scenario from the issue: nested `self.worker.attributes.name` in `target` now resolves correctly per expanded step

Closes swamp-club/lab#1334

## Test Plan

- [x] Unit tests for `target`, `labels`, and `platform` resolution in `evaluate_test.ts`
- [x] Type checking passes (`deno check`)
- [x] Lint and format pass
- [x] Full test suite passes (6 pre-existing failures unrelated to this change)
- [x] Reproduction scenario verified with compiled binary — each expanded step gets its own resolved `target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)