### PR TITLE
fix(data): normalize query and get to use consistent content key

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -365,14 +365,18 @@ export class DataQueryService {
       ) => unknown;
     }
 
-    // Detect attributes and content usage — union filter and select expression
-    let needsAttributes = options?.loadAttributes ??
-      referencesAttributes(filterAst);
+    // Detect attributes and content usage — union filter and select expression.
+    // content is aliased to attributes for JSON records in the CEL context,
+    // so referencing content also requires loading attributes.
     let needsContent = referencesContent(filterAst);
+    let needsAttributes = options?.loadAttributes ??
+      (referencesAttributes(filterAst) || needsContent);
     if (options?.select) {
       const selectAst = (selectParsed as unknown as { ast: ASTNode }).ast;
-      if (!needsAttributes) needsAttributes = referencesAttributes(selectAst);
       if (!needsContent) needsContent = referencesContent(selectAst);
+      if (!needsAttributes) {
+        needsAttributes = referencesAttributes(selectAst) || needsContent;
+      }
     }
 
     // SQL pushdown: pre-filter rows in SQLite before CEL evaluation.
@@ -411,6 +415,9 @@ export class DataQueryService {
         record as unknown as Record<string, unknown>,
       ) as Record<string, unknown>;
       ctx["ns"] = record.namespace;
+      if (record.contentType === "application/json") {
+        ctx["content"] = record.attributes;
+      }
       try {
         const match = parsed(ctx);
         if (match === true) {
@@ -446,6 +453,9 @@ export class DataQueryService {
             r as unknown as Record<string, unknown>,
           ) as Record<string, unknown>;
           selectCtx["ns"] = r.namespace;
+          if (r.contentType === "application/json") {
+            selectCtx["content"] = r.attributes;
+          }
           return coerceBigInts(selectParsed(selectCtx));
         } catch {
           return null;

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1327,3 +1327,168 @@ Deno.test("DataQueryService pushdown: limit interacts correctly with pushdown", 
   assertEquals(results.length, 3);
   catalog.close();
 });
+
+Deno.test("DataQueryService: content.field works as alias for attributes.field in predicate", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-content-alias-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "my-data",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(
+    join(dataDir, "raw"),
+    JSON.stringify({ status: "ok", count: 7 }),
+  );
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "my-data",
+      id: "00000000-0000-1000-8000-000000000001",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "my-data", "latest"),
+    "1",
+  );
+
+  catalog.upsert(makeRow());
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  const results = service.querySync(
+    'content.status == "ok"',
+  ) as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].attributes["status"], "ok");
+  assertEquals(results[0].attributes["count"], 7);
+  catalog.close();
+});
+
+Deno.test("DataQueryService: content.field works in --select projection", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-content-select-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "my-data",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(
+    join(dataDir, "raw"),
+    JSON.stringify({ kernel: "6.1", arch: "x86_64" }),
+  );
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "my-data",
+      id: "00000000-0000-1000-8000-000000000001",
+      version: 1,
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "resource", specName: "result", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "my-data", "latest"),
+    "1",
+  );
+
+  catalog.upsert(makeRow());
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  const projected = service.querySync(
+    'modelName == "ingest"',
+    { select: '{"k": content.kernel}' },
+  ) as Record<string, unknown>[];
+  assertEquals(projected.length, 1);
+  assertEquals(projected[0], { k: "6.1" });
+  catalog.close();
+});
+
+Deno.test("DataQueryService: content stays raw string for non-JSON records", () => {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-query-content-text-" });
+  const dbPath = join(dir, ".swamp", "data", "_catalog.db");
+  const catalog = new CatalogStore(dbPath);
+  catalog.markPopulated();
+
+  const dataDir = join(
+    dir,
+    ".swamp",
+    "data",
+    "test-model",
+    "model-001",
+    "my-log",
+    "1",
+  );
+  ensureDirSync(dataDir);
+  Deno.writeTextFileSync(join(dataDir, "raw"), "hello world");
+  Deno.writeTextFileSync(
+    join(dataDir, "metadata.yaml"),
+    stringifyYaml({
+      name: "my-log",
+      id: "00000000-0000-1000-8000-000000000002",
+      version: 1,
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: { type: "file", specName: "log", modelName: "ingest" },
+      ownerDefinition: { ownerType: "model-method", ownerRef: "test" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  Deno.writeTextFileSync(
+    join(dir, ".swamp", "data", "test-model", "model-001", "my-log", "latest"),
+    "1",
+  );
+
+  catalog.upsert(makeRow({
+    data_name: "my-log",
+    id: "00000000-0000-1000-8000-000000000002",
+    content_type: "text/plain",
+    spec_name: "log",
+    data_type: "file",
+    streaming: 1,
+  }));
+
+  const dataRepo = new FileSystemUnifiedDataRepository(dir, undefined, catalog);
+  const service = new DataQueryService(catalog, dataRepo);
+
+  const results = service.querySync(
+    'content == "hello world"',
+  ) as DataRecord[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].content, "hello world");
+  catalog.close();
+});

--- a/src/presentation/renderers/data_query.ts
+++ b/src/presentation/renderers/data_query.ts
@@ -20,6 +20,7 @@
 import type {
   DataQueryData,
   DataQueryEvent,
+  DataRecord,
   EventHandlers,
   ProjectedData,
 } from "../../libswamp/mod.ts";
@@ -200,6 +201,21 @@ function renderProjected(data: DataQueryData): string {
 }
 
 /**
+ * Transforms a DataRecord for JSON output: moves the payload from
+ * `attributes` to `content` (matching `data get --json`) and strips
+ * the internal `attributes` key.
+ */
+function recordToJsonOutput(
+  record: DataRecord,
+): Record<string, unknown> {
+  const { attributes, content: _rawContent, ...rest } = record;
+  return {
+    ...rest,
+    content: record.contentType === "application/json" ? attributes : "",
+  };
+}
+
+/**
  * Renders JSON output for the completed event.
  */
 function renderJson(data: DataQueryData): void {
@@ -217,7 +233,16 @@ function renderJson(data: DataQueryData): void {
       2,
     ));
   } else {
-    writeOutput(JSON.stringify(data, null, 2));
+    writeOutput(JSON.stringify(
+      {
+        predicate: data.predicate,
+        results: data.results.map(recordToJsonOutput),
+        total: data.total,
+        limited: data.limited,
+      },
+      null,
+      2,
+    ));
   }
 }
 

--- a/src/presentation/renderers/data_query_test.ts
+++ b/src/presentation/renderers/data_query_test.ts
@@ -1,0 +1,181 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { DataRecord } from "../../libswamp/mod.ts";
+import { createDataQueryRenderer } from "./data_query.ts";
+
+function makeRecord(
+  overrides: Partial<DataRecord> = {},
+): DataRecord {
+  return {
+    id: "record-1",
+    name: "result",
+    version: 1,
+    isLatest: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    namespace: "",
+    attributes: {},
+    tags: { type: "resource", specName: "result", modelName: "test" },
+    modelName: "test",
+    modelId: "model-1",
+    modelType: "test-model",
+    specName: "result",
+    dataType: "resource",
+    contentType: "application/json",
+    lifetime: "infinite",
+    ownerType: "model-method",
+    streaming: false,
+    size: 100,
+    content: "",
+    ownerRef: "model-1",
+    workflowRunId: "",
+    workflowName: "",
+    jobName: "",
+    stepName: "",
+    source: "",
+    ...overrides,
+  };
+}
+
+function captureJsonOutput(
+  fn: () => void,
+): Record<string, unknown> {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return JSON.parse(logs[0]);
+}
+
+Deno.test("renderJson: JSON record maps attributes to content", () => {
+  const renderer = createDataQueryRenderer("json");
+  const handlers = renderer.handlers();
+
+  const record = makeRecord({
+    attributes: { hostname: "worker-01", os: "linux" },
+    contentType: "application/json",
+    content: "",
+  });
+
+  const output = captureJsonOutput(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        predicate: 'modelName == "test"',
+        results: [record],
+        total: 1,
+        limited: false,
+      },
+    });
+  });
+
+  assertEquals(output.predicate, 'modelName == "test"');
+  assertEquals(output.total, 1);
+  assertEquals(output.limited, false);
+
+  const results = output.results as Record<string, unknown>[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0].content, { hostname: "worker-01", os: "linux" });
+  assertEquals(results[0].attributes, undefined);
+});
+
+Deno.test("renderJson: non-JSON record gets empty content", () => {
+  const renderer = createDataQueryRenderer("json");
+  const handlers = renderer.handlers();
+
+  const record = makeRecord({
+    contentType: "text/plain",
+    attributes: {},
+    content: "",
+  });
+
+  const output = captureJsonOutput(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        predicate: 'modelName == "test"',
+        results: [record],
+        total: 1,
+        limited: false,
+      },
+    });
+  });
+
+  const results = output.results as Record<string, unknown>[];
+  assertEquals(results[0].content, "");
+  assertEquals(results[0].attributes, undefined);
+});
+
+Deno.test("renderJson: projected query is unaffected", () => {
+  const renderer = createDataQueryRenderer("json");
+  const handlers = renderer.handlers();
+
+  const output = captureJsonOutput(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        predicate: 'modelName == "test"',
+        results: [],
+        projected: {
+          shape: "map",
+          columns: ["name", "status"],
+          rows: [{ name: "result", status: "ok" }],
+        },
+        total: 1,
+        limited: false,
+      },
+    });
+  });
+
+  const results = output.results as Record<string, unknown>[];
+  assertEquals(results.length, 1);
+  assertEquals(results[0], { name: "result", status: "ok" });
+});
+
+Deno.test("renderJson: empty attributes produce empty content object", () => {
+  const renderer = createDataQueryRenderer("json");
+  const handlers = renderer.handlers();
+
+  const record = makeRecord({
+    contentType: "application/json",
+    attributes: {},
+    content: "",
+  });
+
+  const output = captureJsonOutput(() => {
+    handlers.completed({
+      kind: "completed",
+      data: {
+        predicate: "true",
+        results: [record],
+        total: 1,
+        limited: false,
+      },
+    });
+  });
+
+  const results = output.results as Record<string, unknown>[];
+  assertEquals(results[0].content, {});
+  assertEquals(results[0].attributes, undefined);
+});


### PR DESCRIPTION
## Summary

- `data query --json` now exposes the resource payload under `content` (matching `data get --json`) instead of the internal `attributes` key
- `content.fieldName` works in CEL predicates and `--select` expressions alongside the existing `attributes.fieldName` accessor
- Removes the misleading empty `content: ""` from query JSON output for JSON resources

Fixes swamp-club#1335, swamp-club#620

## Test Plan

- Added 3 unit tests to `data_query_service_test.ts`: content.field in predicate, content.field in --select, non-JSON content stays raw string
- Added 4 unit tests in new `data_query_test.ts`: JSON record maps attributes→content, non-JSON gets empty content, projected query unaffected, empty attributes
- Verified with scratch repo reproduction: both `data get --json` and `data query --json` show payload under `content`, `attributes` absent from query output, `content.fieldName` and `attributes.fieldName` both work in `--select`