### PR TITLE
fix(serve): surface WebSocket close codes and error details in --server connections

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -224,23 +224,39 @@ export function requestServerResponse<T>(
 
     options.signal?.addEventListener("abort", onAbort, { once: true });
 
-    socket.onerror = () => {
-      if (!settled) {
-        settled = true;
-        cleanup();
-        reject(
-          new UserError(`Could not connect to ${baseUrl}`),
-        );
+    let connectErrorDetail = "";
+    socket.onerror = (event) => {
+      if (event instanceof ErrorEvent && event.message) {
+        connectErrorDetail = `: ${event.message}`;
       }
-    };
-
-    socket.onclose = () => {
       if (!settled) {
         settled = true;
         cleanup();
         reject(
           new UserError(
-            "Connection closed before a response was received",
+            `Could not connect to ${baseUrl}${connectErrorDetail}`,
+          ),
+        );
+      }
+    };
+
+    socket.onclose = (event) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        const parts: string[] = [];
+        if (event.code !== 1000 && event.code !== 1005) {
+          parts.push(`code ${event.code}`);
+        }
+        if (event.reason) {
+          parts.push(event.reason);
+        }
+        const detail = parts.length > 0 ? ` (${parts.join(": ")})` : "";
+        reject(
+          new UserError(
+            connectErrorDetail
+              ? `Could not connect to ${baseUrl}${connectErrorDetail}`
+              : `Connection closed before a response was received${detail}`,
           ),
         );
       }
@@ -370,8 +386,11 @@ async function* streamServerRun(
     socketClosed = true;
     notify();
   };
-  socket.onerror = () => {
-    connectError = `Could not connect to ${baseUrl}`;
+  socket.onerror = (event) => {
+    const detail = event instanceof ErrorEvent && event.message
+      ? `: ${event.message}`
+      : "";
+    connectError = `Could not connect to ${baseUrl}${detail}`;
     notify();
   };
 
@@ -387,18 +406,28 @@ async function* streamServerRun(
       clearTimeout(timer);
       resolve();
     };
-    const earlyFail = () => {
+    const earlyFail = (closeEvent?: CloseEvent) => {
       clearTimeout(timer);
-      reject(
-        new UserError(
-          connectError ?? `Connection to ${baseUrl} closed before it opened`,
-        ),
-      );
+      let message = connectError ??
+        `Connection to ${baseUrl} closed before it opened`;
+      if (closeEvent && !connectError) {
+        const parts: string[] = [];
+        if (closeEvent.code !== 1000 && closeEvent.code !== 1005) {
+          parts.push(`code ${closeEvent.code}`);
+        }
+        if (closeEvent.reason) {
+          parts.push(closeEvent.reason);
+        }
+        if (parts.length > 0) {
+          message += ` (${parts.join(": ")})`;
+        }
+      }
+      reject(new UserError(message));
     };
     const prevClose = socket.onclose;
     socket.onclose = (event) => {
       prevClose?.call(socket, event);
-      earlyFail();
+      earlyFail(event);
     };
   });
 

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -449,15 +449,29 @@ function connectOnce(args: ConnectOnceArgs): Promise<string> {
       }
     };
 
-    socket.onclose = () => {
+    let connectErrorDetail = "";
+    socket.onclose = (event: CloseEvent | Event | undefined) => {
+      const parts: string[] = [];
+      const closeEvent = event instanceof CloseEvent ? event : undefined;
+      if (closeEvent && closeEvent.code !== 1000 && closeEvent.code !== 1005) {
+        parts.push(`code ${closeEvent.code}`);
+      }
+      if (closeEvent?.reason) {
+        parts.push(closeEvent.reason);
+      }
+      const detail = connectErrorDetail ||
+        (parts.length > 0 ? ` (${parts.join(": ")})` : "");
       finish(
-        enrolled ? "control socket closed" : "socket closed before enrollment",
+        enrolled
+          ? `control socket closed${detail}`
+          : `socket closed before enrollment${detail}`,
       );
     };
 
-    socket.onerror = () => {
-      // onclose follows; nothing to do here, but keep the handler so the
-      // runtime does not surface it as an unhandled error event.
+    socket.onerror = (event: Event) => {
+      if (event instanceof ErrorEvent && event.message) {
+        connectErrorDetail = `: ${event.message}`;
+      }
     };
   });
 }


### PR DESCRIPTION
## Summary

Fixes the secondary diagnosability bug from swamp-club#1345: all three WebSocket client paths (`streamServerRun`, `requestServerResponse`, `connectOnce`) discarded close codes, close reasons, and `ErrorEvent` messages, replacing them with a generic `"Could not connect to <url>"` string. When a connection fails behind a reverse proxy, due to TLS misconfiguration, or ALPN mismatch, the user saw no actionable detail — even at `--log-level trace`.

- **`src/cli/remote_run.ts`**: `socket.onerror` now extracts the `ErrorEvent.message` when available; `earlyFail` and `requestServerResponse`'s `onclose` now surface the `CloseEvent.code` and `.reason` in the error string
- **`src/worker/connect.ts`**: `socket.onerror` captures `ErrorEvent.message`; `onclose` appends close code and reason to the finish string (tolerant of test fakes that call `onclose()` without a `CloseEvent`)

This is the first step toward resolving #1345 — better error messages will help the reporter (and us) diagnose whether the underlying connection failure is ALPN-related, a TLS cert issue, or something else entirely. The primary ALPN-pinning fix is deferred until we can confirm the root cause with the improved diagnostics.

## Test Plan

- `deno run test src/cli/remote_run_test.ts` — 24 passed
- `deno run test src/worker/connect_test.ts` — 4 passed
- Full test suite: 9239 passed, 6 failed (all pre-existing on main in `oauth_client_test.ts`, `connection_test.ts`, `extension_quality_test.ts`)
- `deno check`, `deno lint`, `deno fmt` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)