### PR TITLE
fix(extensions): send x-api-key on all registry read paths so private extensions are accessible (swamp-club#1338)

### DIFF
--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -272,12 +272,13 @@ export const extensionSearchCommand = withRemoteOptions(
     );
 
     const lockfileRepository = await LockfileRepository.create(lockfilePath);
+    const apiKey = identity.bearerToken;
     const pullCtx: PullContext = {
-      getExtension: (name) => client.getExtension(name),
+      getExtension: (name) => client.getExtension(name, apiKey),
       downloadArchive: (name, version, channel) =>
-        client.downloadArchive(name, version, undefined, channel),
+        client.downloadArchive(name, version, apiKey, channel),
       getChecksum: (name, version, channel) =>
-        client.getChecksum(name, version, channel),
+        client.getChecksum(name, version, apiKey, channel),
       logger: ctx.logger,
       lockfileRepository,
       skillsDirs,

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -73,16 +73,16 @@ export async function createExtensionInstallDeps(
   const serverUrl = resolveServerUrl();
   const identity = await loadIdentity();
   const client = new ExtensionApiClient(serverUrl, identity);
+  const apiKey = identity.bearerToken;
 
   return {
     lockfilePath,
     repoDir: absoluteRepoDir,
     skillsDirsRelative,
     createInstallContext: async (_name, _version) => ({
-      getExtension: (n) => client.getExtension(n),
-      downloadArchive: (n, v, ch) =>
-        client.downloadArchive(n, v, undefined, ch),
-      getChecksum: (n, v, ch) => client.getChecksum(n, v, ch),
+      getExtension: (n) => client.getExtension(n, apiKey),
+      downloadArchive: (n, v, ch) => client.downloadArchive(n, v, apiKey, ch),
+      getChecksum: (n, v, ch) => client.getChecksum(n, v, apiKey, ch),
       logger,
       lockfileRepository: await LockfileRepository.create(lockfilePath),
       skillsDirs: absoluteSkillsDirs,

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -473,18 +473,23 @@ export function configureExtensionAutoResolver(
   }
   const serverUrl = Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
   const extensionClient = new ExtensionApiClient(serverUrl, identity);
+  const apiKey = identity.bearerToken;
   const modelsDir = resolveModelsDir(marker);
   const denoRuntime = new EmbeddedDenoRuntime();
   setAutoResolver(
     new ExtensionAutoResolver({
       allowedCollectives: trustedCollectives,
-      extensionLookup: extensionClient,
+      extensionLookup: {
+        getExtension: (name) => extensionClient.getExtension(name, apiKey),
+        searchExtensions: (params) =>
+          extensionClient.searchExtensions(params, apiKey),
+      },
       extensionInstaller: createAutoResolveInstallerAdapter({
-        getExtension: (name) => extensionClient.getExtension(name),
+        getExtension: (name) => extensionClient.getExtension(name, apiKey),
         downloadArchive: (name, version, channel) =>
-          extensionClient.downloadArchive(name, version, undefined, channel),
+          extensionClient.downloadArchive(name, version, apiKey, channel),
         getChecksum: (name, version, channel) =>
-          extensionClient.getChecksum(name, version, channel),
+          extensionClient.getChecksum(name, version, apiKey, channel),
         lockfilePath: join(
           resolve(repoDir, modelsDir),
           "upstream_extensions.json",

--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -526,15 +526,18 @@ export class ExtensionApiClient {
   async getChecksum(
     name: string,
     version: string,
+    apiKey?: string,
     channel?: string,
   ): Promise<string | null> {
     const encodedName = encodeURIComponent(name);
     const encodedVersion = encodeURIComponent(version);
+    const headers = apiKey ? this.authHeaders(apiKey) : {};
     const qs = channel ? `?channel=${encodeURIComponent(channel)}` : "";
     const res = await this.fetch(
       `/api/v1/extensions/${encodedName}@${encodedVersion}/checksum${qs}`,
       {
         method: "GET",
+        headers,
       },
     );
 

--- a/src/infrastructure/http/extension_api_client_test.ts
+++ b/src/infrastructure/http/extension_api_client_test.ts
@@ -638,7 +638,7 @@ Deno.test("ExtensionApiClient version-scoped methods URL-encode version path seg
     assertEquals(downloadUrlCh.pathname, `${expectedBase}/download`);
     assertEquals(downloadUrlCh.searchParams.get("channel"), "beta");
 
-    await client.getChecksum("@test/ext", hostileVersion, "rc");
+    await client.getChecksum("@test/ext", hostileVersion, undefined, "rc");
     const checksumUrlCh = new URL(captured.checksum);
     assertEquals(checksumUrlCh.pathname, `${expectedBase}/checksum`);
     assertEquals(checksumUrlCh.searchParams.get("channel"), "rc");

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -1433,17 +1433,18 @@ export async function createExtensionPullDeps(
   },
 ): Promise<ExtensionPullDeps> {
   const client = new ExtensionApiClient(serverUrl, args?.identity);
+  const apiKey = args?.identity?.bearerToken;
   const lockfileRepository = await LockfileRepository.create(lockfilePath);
   return {
-    getExtension: (name) => client.getExtension(name),
+    getExtension: (name) => client.getExtension(name, apiKey),
     getLatestVersion: async (name, channel) => {
-      const info = await client.getLatestVersion(name, undefined, channel);
+      const info = await client.getLatestVersion(name, apiKey, channel);
       return info?.version ?? null;
     },
     downloadArchive: (name, version, channel) =>
-      client.downloadArchive(name, version, undefined, channel),
+      client.downloadArchive(name, version, apiKey, channel),
     getChecksum: (name, version, channel) =>
-      client.getChecksum(name, version, channel),
+      client.getChecksum(name, version, apiKey, channel),
     lockfileRepository,
     skillsDirs,
     repoDir,
@@ -1474,13 +1475,14 @@ export async function createInstallContext(
   },
 ): Promise<InstallContext> {
   const client = new ExtensionApiClient(serverUrl, opts.identity);
+  const apiKey = opts.identity?.bearerToken;
   const lockfileRepository = await LockfileRepository.create(opts.lockfilePath);
   return {
-    getExtension: (name) => client.getExtension(name),
+    getExtension: (name) => client.getExtension(name, apiKey),
     downloadArchive: (name, version, channel) =>
-      client.downloadArchive(name, version, undefined, channel),
+      client.downloadArchive(name, version, apiKey, channel),
     getChecksum: (name, version, channel) =>
-      client.getChecksum(name, version, channel),
+      client.getChecksum(name, version, apiKey, channel),
     logger: opts.logger,
     lockfileRepository,
     skillsDirs: opts.skillsDirs,

--- a/src/libswamp/extensions/update.ts
+++ b/src/libswamp/extensions/update.ts
@@ -114,6 +114,7 @@ export async function createExtensionUpdateDeps(options: {
     options.serverUrl ?? resolveServerUrl(),
     options.identity,
   );
+  const apiKey = options.identity?.bearerToken;
   return {
     lockfileRepository: await LockfileRepository.create(options.lockfilePath),
     getExtension: async (name, channel?) => {
@@ -121,11 +122,11 @@ export async function createExtensionUpdateDeps(options: {
         if (channel && channel !== "stable") {
           const versionInfo = await extensionClient.getLatestVersion(
             name,
-            undefined,
+            apiKey,
             channel,
           );
           if (!versionInfo) return null;
-          const info = await extensionClient.getExtension(name);
+          const info = await extensionClient.getExtension(name, apiKey);
           return {
             latestVersion: versionInfo.version,
             deprecatedAt: info?.deprecatedAt ?? null,
@@ -133,7 +134,7 @@ export async function createExtensionUpdateDeps(options: {
             supersededBy: info?.supersededBy ?? null,
           };
         }
-        const info = await extensionClient.getExtension(name);
+        const info = await extensionClient.getExtension(name, apiKey);
         if (!info) return null;
         return {
           latestVersion: info.latestVersion ?? null,

--- a/src/libswamp/extensions/version.ts
+++ b/src/libswamp/extensions/version.ts
@@ -86,9 +86,10 @@ export function createExtensionVersionDeps(
 ): ExtensionVersionDeps {
   const serverUrl = resolveServerUrl();
   const client = new ExtensionApiClient(serverUrl, identity);
+  const apiKey = identity?.bearerToken;
   return {
     getPublishedVersions: async (name: string) => {
-      const info = await client.getExtension(name);
+      const info = await client.getExtension(name, apiKey);
       if (!info) return null;
       return {
         stable: info.latestVersion ?? null,


### PR DESCRIPTION
## Summary

- Extension read paths (`pull`, `version`, `update`, auto-resolver, `search` inline-install) were only sending `Authorization: Bearer` on registry API calls — not `x-api-key`. Commands like `info` and `search` already sent both headers. This inconsistency meant private extensions were invisible to `pull`/`version`/`update` even for authenticated collective members.
- Threads `identity.bearerToken` as `apiKey` through every composition root that wires `ExtensionApiClient` calls: `createExtensionPullDeps`, `createInstallContext`, `createExtensionVersionDeps`, `createExtensionUpdateDeps`, `configureExtensionAutoResolver`, `createExtensionInstallDeps`, and the `extension_search` inline pull context.
- Adds the missing `apiKey` parameter to `ExtensionApiClient.getChecksum` (the only read method that lacked it).
- Domain interfaces are untouched — `apiKey` is baked into closures at the factory level. Unauthenticated users are unaffected (when `bearerToken` is `undefined`, behaviour is identical to before).

## Test Plan

- [x] All 39 API client tests pass (including updated `getChecksum` signature test)
- [x] All 31 pull, 21 push, 7 version, 15 update, 27 auto-resolver, 5 roundtrip unit tests pass
- [x] Integration tests pass: extension pull (7), push (13), doctor extensions (4), auto-resolver (2)
- [x] `deno fmt`, `deno lint` clean
- [x] Full test suite: 9239 passed, 6 pre-existing failures (unrelated: `extension_quality_test.ts`, `oauth_client_test.ts`)
- [x] Verified every `getChecksum` call site updated for new `(name, version, apiKey?, channel?)` signature
- [x] Verified serve handlers intentionally omit auth (server-to-server context)

Closes swamp-club#1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)