### PR TITLE
feat(extensions): show channel and visibility in push output (swamp-club#1338)

### DIFF
--- a/src/infrastructure/http/extension_api_client.ts
+++ b/src/infrastructure/http/extension_api_client.ts
@@ -118,6 +118,7 @@ export interface ExtensionInfo {
   latestRc: string | null;
   latestBeta: string | null;
   dependencies?: string[];
+  isPrivate?: boolean;
 }
 
 /** Parameters for the extension search endpoint. */

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -132,6 +132,8 @@ export interface ExtensionPushSuccessData {
   datastoreCount: number;
   reportCount: number;
   skillCount: number;
+  channel: string;
+  visibility: "public" | "private";
 }
 
 /** Data for compilation error output. */
@@ -325,6 +327,11 @@ export interface ExtensionPushExecuteDeps {
     metadata: ExtensionPushMetadata,
     apiKey: string,
   ) => Promise<{ name: string; version: string; extensionId: string }>;
+  getExtensionVisibility: (
+    serverUrl: string,
+    name: string,
+    apiKey: string,
+  ) => Promise<{ isPrivate: boolean } | null>;
 }
 
 // ── Deps factory ──────────────────────────────────────────────────────
@@ -421,6 +428,12 @@ export function createExtensionPushExecuteDeps(
     confirmPush: async (serverUrl, metadata, apiKey) => {
       const client = new ExtensionApiClient(serverUrl, identity);
       return await client.confirmPush(metadata, apiKey);
+    },
+    getExtensionVisibility: async (serverUrl, name, apiKey) => {
+      const client = new ExtensionApiClient(serverUrl, identity);
+      const info = await client.getExtension(name, apiKey);
+      if (!info) return null;
+      return { isPrivate: info.isPrivate ?? false };
     },
   };
 }
@@ -933,6 +946,18 @@ export async function* extensionPush(
         return;
       }
 
+      let visibility: "public" | "private" = "public";
+      try {
+        const info = await deps.getExtensionVisibility(
+          credentials.serverUrl,
+          confirmResult.name,
+          credentials.apiKey,
+        );
+        if (info?.isPrivate) visibility = "private";
+      } catch {
+        // Best-effort — don't fail the push over a visibility check.
+      }
+
       yield {
         kind: "completed" as const,
         data: {
@@ -948,6 +973,8 @@ export async function* extensionPush(
           datastoreCount: input.counts.datastores,
           reportCount: input.counts.reports,
           skillCount: input.counts.skills,
+          channel: input.channel ?? "stable",
+          visibility,
         },
       };
     })(),

--- a/src/libswamp/extensions/push_test.ts
+++ b/src/libswamp/extensions/push_test.ts
@@ -150,6 +150,7 @@ function makeExecuteDeps(
         version: "2026.03.22.1",
         extensionId: "ext-123",
       }),
+    getExtensionVisibility: () => Promise.resolve({ isPrivate: false }),
     ...overrides,
   };
 }
@@ -502,6 +503,61 @@ Deno.test("extensionPush: yields pushing events for each phase", async () => {
     assertEquals(pushingEvents[0].phase, "initiate");
     assertEquals(pushingEvents[1].phase, "upload");
     assertEquals(pushingEvents[2].phase, "confirm");
+  }
+});
+
+Deno.test("extensionPush: completed includes visibility=private when extension is private", async () => {
+  const deps = makeExecuteDeps({
+    getExtensionVisibility: () => Promise.resolve({ isPrivate: true }),
+  });
+  const input = makeExecuteInput();
+
+  const events = await collect(extensionPush(ctx, deps, input));
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.visibility, "private");
+    assertEquals(last.data.channel, "stable");
+  }
+});
+
+Deno.test("extensionPush: completed includes visibility=public when extension is public", async () => {
+  const deps = makeExecuteDeps({
+    getExtensionVisibility: () => Promise.resolve({ isPrivate: false }),
+  });
+  const input = makeExecuteInput();
+
+  const events = await collect(extensionPush(ctx, deps, input));
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.visibility, "public");
+  }
+});
+
+Deno.test("extensionPush: completed includes channel from input", async () => {
+  const deps = makeExecuteDeps();
+  const input = makeExecuteInput({ channel: "beta" });
+
+  const events = await collect(extensionPush(ctx, deps, input));
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.channel, "beta");
+  }
+});
+
+Deno.test("extensionPush: visibility check failure defaults to public", async () => {
+  const deps = makeExecuteDeps({
+    getExtensionVisibility: () => Promise.reject(new Error("Network error")),
+  });
+  const input = makeExecuteInput();
+
+  const events = await collect(extensionPush(ctx, deps, input));
+  const last = events[events.length - 1];
+  assertEquals(last.kind, "completed");
+  if (last.kind === "completed") {
+    assertEquals(last.data.visibility, "public");
   }
 });
 

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -273,6 +273,12 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
       completed: (e) => {
         this.logger
           .info`Pushed ${e.data.name}@${e.data.version}`;
+        this.logger.info`Channel: ${e.data.channel}`;
+        this.logger.info`Visibility: ${e.data.visibility}`;
+        if (e.data.visibility === "private") {
+          this.logger
+            .warn`This extension is private — only collective members can pull it`;
+        }
         this.logger.info`Extension ID: ${e.data.extensionId}`;
         this.logger.info`Archive size: ${formatBytes(e.data.archiveSize)}`;
         const parts = [


### PR DESCRIPTION
## Summary

- After a successful `swamp extension push`, the output now always shows the target **channel** (stable/beta/rc) and the extension's **visibility** (public/private).
- When the extension is private, an additional warning line tells the publisher that only collective members can pull it.
- Adds `isPrivate?: boolean` to `ExtensionInfo` (the server already returns it).
- Adds `getExtensionVisibility` dep to the push execute phase — a best-effort call after confirm that never blocks the push on failure.
- JSON output includes `channel` and `visibility` fields for CI pipelines.

Example log output (public):
```
Pushed @hivemq/session/handoff@2026.07.22.1
Channel: beta
Visibility: public
Extension ID: 516b7493-...
```

Example log output (private):
```
Pushed @hivemq/session/handoff@2026.07.22.1
Channel: beta
Visibility: private
⚠ This extension is private — only collective members can pull it
Extension ID: 516b7493-...
```

## Test Plan

- [x] 4 new unit tests: private visibility, public visibility, channel passthrough, visibility check failure defaults to public
- [x] All 25 push tests pass
- [x] `deno fmt`, `deno lint` clean

Closes swamp-club#1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)