### PR TITLE
fix(validation): resolve vault expressions in globalArgs before pre-flight checks (swamp-club#1362)

### DIFF
--- a/src/domain/models/validation_service.ts
+++ b/src/domain/models/validation_service.ts
@@ -243,6 +243,12 @@ export interface CheckValidationContext {
    * (libswamp / CLI) supplies the implementation.
    */
   createCelEnvironment: MethodContext["createCelEnvironment"];
+  /**
+   * Resolves runtime expressions (vault.get, env.*) in arbitrary data.
+   * When provided, globalArguments are resolved before passing to checks
+   * so they see real secret values instead of raw expression text.
+   */
+  resolveRuntimeExpressions?: (data: unknown) => Promise<unknown>;
   labels?: string[];
   method?: string;
 }
@@ -359,6 +365,20 @@ export class DefaultModelValidationService implements ModelValidationService {
     const defChecks = definition.checkSelection;
     const skippedCheckNames = new Set(defChecks?.skip ?? []);
 
+    // Resolve vault/env expressions in globalArguments so checks see real
+    // values instead of raw ${{ vault.get(...) }} text. Falls back to the
+    // raw definition values if resolution is unavailable or fails.
+    let resolvedGlobalArgs = definition.globalArguments;
+    if (checkContext.resolveRuntimeExpressions) {
+      try {
+        resolvedGlobalArgs = await checkContext.resolveRuntimeExpressions(
+          definition.globalArguments,
+        ) as Record<string, unknown>;
+      } catch {
+        // Vault may not be configured; degrade to unresolved values
+      }
+    }
+
     for (const [name, check] of Object.entries(checks)) {
       // Definition-level skip always wins
       if (skippedCheckNames.has(name)) {
@@ -389,9 +409,7 @@ export class DefaultModelValidationService implements ModelValidationService {
           ? definition.getMethodArguments(methodName)
           : {};
         const filteredGlobalArgs: Record<string, unknown> = {};
-        for (
-          const [key, value] of Object.entries(definition.globalArguments)
-        ) {
+        for (const [key, value] of Object.entries(resolvedGlobalArgs)) {
           if (valueContainsExpression(value)) {
             continue;
           }
@@ -410,7 +428,7 @@ export class DefaultModelValidationService implements ModelValidationService {
             repoDir: checkContext.repoDir,
             modelType: modelDef.type,
             modelId: definition.id,
-            globalArgs: definition.globalArguments,
+            globalArgs: resolvedGlobalArgs,
             definition: {
               id: definition.id,
               name: definition.name,

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1333,6 +1333,202 @@ Deno.test("validateModel no checkContext provided skips checks", async () => {
   assertEquals(checkResults.length, 0);
 });
 
+// ---------- Vault Expression Resolution in Checks ----------
+
+Deno.test("validateModel: checks receive resolved globalArgs when resolveRuntimeExpressions provided", async () => {
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      password: '${{ vault.get("my-vault", "MY_SECRET") }}',
+    },
+  });
+
+  let capturedGlobalArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/vault-check"),
+    version: "2026.02.09.1",
+    globalArguments: z.object({ password: z.string() }),
+    methods: {
+      create: {
+        description: "Create",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures globalArgs for assertion",
+        execute: (ctx) => {
+          capturedGlobalArgs = ctx.globalArgs as Record<string, unknown>;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  await service.validateModel(
+    definition,
+    model,
+    undefined,
+    createCheckContext({
+      resolveRuntimeExpressions: (data) =>
+        Promise.resolve(
+          JSON.parse(
+            JSON.stringify(data).replace(
+              /\$\{\{[^}]+\}\}/g,
+              "resolved-secret",
+            ),
+          ),
+        ),
+    }),
+  );
+
+  assertEquals(capturedGlobalArgs?.password, "resolved-secret");
+});
+
+Deno.test("validateModel: checks receive raw globalArgs when resolveRuntimeExpressions not provided", async () => {
+  const service = new DefaultModelValidationService();
+  const vaultExpr = '${{ vault.get("my-vault", "MY_SECRET") }}';
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { password: vaultExpr },
+  });
+
+  let capturedGlobalArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/vault-check"),
+    version: "2026.02.09.1",
+    globalArguments: z.object({ password: z.string() }),
+    methods: {
+      create: {
+        description: "Create",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures globalArgs for assertion",
+        execute: (ctx) => {
+          capturedGlobalArgs = ctx.globalArgs as Record<string, unknown>;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  await service.validateModel(
+    definition,
+    model,
+    undefined,
+    createCheckContext(),
+  );
+
+  // Without resolver, checks see the raw expression (existing behavior)
+  assertEquals(capturedGlobalArgs?.password, vaultExpr);
+});
+
+Deno.test("validateModel: vault resolution failure degrades gracefully to raw globalArgs", async () => {
+  const service = new DefaultModelValidationService();
+  const vaultExpr = '${{ vault.get("my-vault", "MY_SECRET") }}';
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: { password: vaultExpr },
+  });
+
+  let capturedGlobalArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/vault-check"),
+    version: "2026.02.09.1",
+    globalArguments: z.object({ password: z.string() }),
+    methods: {
+      create: {
+        description: "Create",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures globalArgs for assertion",
+        execute: (ctx) => {
+          capturedGlobalArgs = ctx.globalArgs as Record<string, unknown>;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  await service.validateModel(
+    definition,
+    model,
+    undefined,
+    createCheckContext({
+      resolveRuntimeExpressions: () => {
+        throw new Error("Vault not configured");
+      },
+    }),
+  );
+
+  // Resolution failed — checks fall back to raw expression
+  assertEquals(capturedGlobalArgs?.password, vaultExpr);
+});
+
+Deno.test("validateModel: resolved globalArgs also appear in unresolvedMethodArgs", async () => {
+  const service = new DefaultModelValidationService();
+  const definition = Definition.create({
+    name: "test-definition",
+    globalArguments: {
+      password: '${{ vault.get("my-vault", "MY_SECRET") }}',
+    },
+  });
+
+  let capturedUnresolvedMethodArgs: Record<string, unknown> | undefined;
+  const model: ModelDefinition = {
+    type: ModelType.create("test/vault-check"),
+    version: "2026.02.09.1",
+    globalArguments: z.object({ password: z.string() }),
+    methods: {
+      create: {
+        description: "Create",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({}),
+      },
+    },
+    checks: {
+      "capture-args": {
+        description: "Captures unresolvedMethodArgs for assertion",
+        execute: (ctx) => {
+          capturedUnresolvedMethodArgs = ctx
+            .unresolvedMethodArgs as Record<string, unknown>;
+          return Promise.resolve({ pass: true });
+        },
+      },
+    },
+  };
+
+  await service.validateModel(
+    definition,
+    model,
+    undefined,
+    createCheckContext({
+      resolveRuntimeExpressions: (data) =>
+        Promise.resolve(
+          JSON.parse(
+            JSON.stringify(data).replace(
+              /\$\{\{[^}]+\}\}/g,
+              "resolved-secret",
+            ),
+          ),
+        ),
+    }),
+  );
+
+  // Resolved value should pass through filteredGlobalArgs into unresolvedMethodArgs
+  assertEquals(capturedUnresolvedMethodArgs?.password, "resolved-secret");
+});
+
 // ---------- Check Selection Validation Tests ----------
 
 Deno.test("validateModel check selection passes when no selection set", async () => {

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -41,6 +41,7 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError, validationFailed } from "../errors.ts";
 
+import { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /** Validation result for a single check. */
 export interface ValidationItemData {
@@ -146,6 +147,11 @@ export function createModelValidateDeps(
   );
   const dataQueryService = new DataQueryService(catalogStore, dataRepo);
   const validationService = new DefaultModelValidationService();
+  const expressionService = new ExpressionEvaluationService(
+    definitionRepo,
+    repoDir,
+    { dataRepo, dataQueryService },
+  );
 
   const checkContext: CheckValidationContext = {
     repoDir,
@@ -153,6 +159,8 @@ export function createModelValidateDeps(
     definitionRepository: definitionRepo,
     dataQueryService,
     createCelEnvironment: createExtensionCelEnvironment,
+    resolveRuntimeExpressions: (data) =>
+      expressionService.resolveRuntimeExpressionsInData(data),
     labels: options?.labels,
     method: options?.method,
   };


### PR DESCRIPTION
## Summary

- Resolve vault/env expressions in `globalArguments` before passing to pre-flight checks during `model validate`
- Checks now see real secret values instead of raw `${{ vault.get(...) }}` expression text, matching the behavior of `model method run`
- Graceful degradation: if vault resolution fails, checks fall back to unresolved values

Fixes swamp-club#1362

## Root Cause

`validation_service.ts` `runCheckValidations()` passed raw `definition.globalArguments` to checks without vault resolution. The `model method run` path (`method_execution_service.ts`) already handled this correctly via Phase D sentinel resolution, but the validation path was never wired into the vault resolution pipeline.

## Changes

- **`src/domain/models/validation_service.ts`**: Add optional `resolveRuntimeExpressions` to `CheckValidationContext`; resolve globalArgs before the check loop and feed resolved values to both `globalArgs` and `unresolvedMethodArgs`
- **`src/libswamp/models/validate.ts`**: Wire `ExpressionEvaluationService` into the check context via `resolveRuntimeExpressionsInData`
- **`src/domain/models/validation_service_test.ts`**: 4 new tests — resolved values with resolver, raw values without resolver, graceful degradation on failure, resolved values in unresolvedMethodArgs

## Test Plan

- [x] Unit tests: 4 new tests covering vault resolution, backward compatibility, graceful degradation, and unresolvedMethodArgs consistency
- [x] Reproduction: created scratch repo with vault-backed `globalArguments` and a check that inspects them; `model validate` now passes (previously failed with raw expression text)
- [x] Full test suite: 9265 passed, 5 pre-existing failures (unrelated)
- [x] Type check, lint, format all pass