### PR TITLE
feat(auth): require swamp-club account and scopes for team features

### DIFF
--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -17,7 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { UserError } from "../domain/errors.ts";
+
+const COLLECTIVE_TOKEN_PREFIX = "swamp_org_";
+
 let authenticated = false;
+let collectiveToken = false;
+let authScopes: string[] | undefined;
 
 export function setAuthenticated(value: boolean): void {
   authenticated = value;
@@ -25,4 +31,48 @@ export function setAuthenticated(value: boolean): void {
 
 export function isAuthenticated(): boolean {
   return authenticated;
+}
+
+export function setCollectiveToken(apiKey: string): void {
+  collectiveToken = apiKey.startsWith(COLLECTIVE_TOKEN_PREFIX);
+}
+
+export function isCollectiveToken(): boolean {
+  return collectiveToken;
+}
+
+export function setAuthScopes(scopes: string[] | undefined): void {
+  authScopes = scopes;
+}
+
+export function getAuthScopes(): string[] | undefined {
+  return authScopes;
+}
+
+export function requireAuthenticated(
+  featureSentence: string,
+  scope: string,
+): void {
+  if (!authenticated) {
+    throw new UserError(
+      `${featureSentence} that requires a free swamp-club.com account.\n\n` +
+        `Sign in:\n\n` +
+        `  swamp auth login\n\n` +
+        `Or create a collective token at swamp-club.com/collectives and set\n` +
+        `SWAMP_API_KEY. Your token should include the ${scope} scope.\n`,
+      "auth_required",
+    );
+  }
+}
+
+export function requireScope(scope: string): void {
+  if (!collectiveToken) return;
+  if (authScopes !== undefined && authScopes.includes(scope)) return;
+
+  throw new UserError(
+    `Your token lacks the ${scope} scope.\n\n` +
+      `Create a new collective token at swamp-club.com/collectives that\n` +
+      `includes the ${scope} scope and set SWAMP_API_KEY.\n`,
+    "missing_scope",
+  );
 }

--- a/src/cli/auth_context_test.ts
+++ b/src/cli/auth_context_test.ts
@@ -17,8 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { isAuthenticated, setAuthenticated } from "./auth_context.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  isAuthenticated,
+  requireAuthenticated,
+  requireScope,
+  setAuthenticated,
+  setAuthScopes,
+  setCollectiveToken,
+} from "./auth_context.ts";
+import { UserError } from "../domain/errors.ts";
 
 Deno.test("auth_context: defaults to not authenticated", () => {
   setAuthenticated(false);
@@ -35,4 +43,76 @@ Deno.test("auth_context: setAuthenticated false makes isAuthenticated return fal
   setAuthenticated(true);
   setAuthenticated(false);
   assertEquals(isAuthenticated(), false);
+});
+
+Deno.test("requireAuthenticated: throws UserError when not authenticated", () => {
+  setAuthenticated(false);
+  const err = assertThrows(
+    () => requireAuthenticated("swamp serve is a team feature", "serve:*"),
+    UserError,
+  );
+  assertEquals(err.code, "auth_required");
+  assertStringIncludes(
+    err.message,
+    "swamp serve is a team feature that requires a free swamp-club.com account",
+  );
+  assertStringIncludes(err.message, "swamp auth login");
+  assertStringIncludes(err.message, "SWAMP_API_KEY");
+  assertStringIncludes(err.message, "serve:*");
+});
+
+Deno.test("requireAuthenticated: does not throw when authenticated", () => {
+  setAuthenticated(true);
+  requireAuthenticated("swamp serve is a team feature", "serve:*");
+  setAuthenticated(false);
+});
+
+Deno.test("requireScope: passes for personal token (not collective)", () => {
+  setCollectiveToken("swamp_personal_abc");
+  setAuthScopes(undefined);
+  requireScope("serve:*");
+});
+
+Deno.test("requireScope: passes when collective token has required scope", () => {
+  setCollectiveToken("swamp_org_abc");
+  setAuthScopes(["serve:*", "datastore:*"]);
+  requireScope("serve:*");
+  setCollectiveToken("");
+  setAuthScopes(undefined);
+});
+
+Deno.test("requireScope: throws when collective token lacks scope", () => {
+  setCollectiveToken("swamp_org_abc");
+  setAuthScopes(["datastore:*"]);
+  const err = assertThrows(
+    () => requireScope("serve:*"),
+    UserError,
+  );
+  assertEquals(err.code, "missing_scope");
+  assertStringIncludes(err.message, "serve:*");
+  assertStringIncludes(err.message, "swamp-club.com");
+  setCollectiveToken("");
+  setAuthScopes(undefined);
+});
+
+Deno.test("requireScope: throws when collective token has empty scopes", () => {
+  setCollectiveToken("swamp_org_abc");
+  setAuthScopes([]);
+  assertThrows(
+    () => requireScope("vault:*"),
+    UserError,
+  );
+  setCollectiveToken("");
+  setAuthScopes(undefined);
+});
+
+Deno.test("requireScope: throws when collective token has undefined scopes (cache miss)", () => {
+  setCollectiveToken("swamp_org_abc");
+  setAuthScopes(undefined);
+  assertThrows(
+    () => requireScope("serve:*"),
+    UserError,
+  );
+  setCollectiveToken("");
+  setAuthScopes(undefined);
 });

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -48,6 +48,7 @@ import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.t
 import { RENAMED_DATASTORE_TYPES } from "../resolve_datastore.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseTimeoutFlag } from "./datastore_sync.ts";
+import { requireAuthenticated, requireScope } from "../auth_context.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { dim, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
@@ -185,6 +186,12 @@ const datastoreSetupExtensionCommand = new Command()
       "Preferred escape hatch for large first-time setups.",
   )
   .action(async function (options: AnyOptions, type: string) {
+    requireAuthenticated(
+      "External datastores are a team feature",
+      "datastore:*",
+    );
+    requireScope("datastore:*");
+
     const cliCtx = createContext(options as GlobalOptions, [
       "datastore",
       "setup",
@@ -506,6 +513,11 @@ export const datastoreSetupCommand = new Command()
         renderer.handlers(),
       );
     } else if (extensionType) {
+      requireAuthenticated(
+        "External datastores are a team feature",
+        "datastore:*",
+      );
+      requireScope("datastore:*");
       await datastoreTypeRegistry.ensureLoaded();
       try {
         await resolveDatastoreType(extensionType, getAutoResolver());

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -134,6 +134,7 @@ import {
 } from "../../infrastructure/runtime/process.ts";
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import { requireAuthenticated, requireScope } from "../auth_context.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -950,6 +951,11 @@ export const serveCommand = new Command()
         "--admins is set but --auth-mode is {mode} — admins will have no effect",
         { mode: authConfig.mode },
       );
+    }
+
+    if (authConfig.mode === "oauth" || authConfig.mode === "token") {
+      requireAuthenticated("swamp serve is a team feature", "serve:*");
+      requireScope("serve:*");
     }
 
     if (authConfig.mode === "none") {

--- a/src/cli/commands/vault_create.ts
+++ b/src/cli/commands/vault_create.ts
@@ -32,6 +32,7 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { requireAuthenticated, requireScope } from "../auth_context.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -81,6 +82,11 @@ export const vaultCreateCommand = new Command()
       vaultType: string,
       vaultNameArg?: string,
     ) {
+      if (vaultType !== "local_encryption") {
+        requireAuthenticated("Non-local vaults are a team feature", "vault:*");
+        requireScope("vault:*");
+      }
+
       const cliCtx = createContext(options as GlobalOptions, [
         "vault",
         "create",

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -105,7 +105,12 @@ import { ExtensionAutoResolver } from "../domain/extensions/extension_auto_resol
 import { ExtensionApiClient } from "../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
 import { loadIdentity, USER_AGENT } from "./load_identity.ts";
-import { isAuthenticated, setAuthenticated } from "./auth_context.ts";
+import {
+  isAuthenticated,
+  setAuthenticated,
+  setAuthScopes,
+  setCollectiveToken,
+} from "./auth_context.ts";
 import {
   apiKeyFingerprint,
   DEFAULT_SWAMP_CLUB_URL,
@@ -1341,6 +1346,7 @@ export async function runCli(args: string[]): Promise<void> {
             response.username,
             collectives,
             apiKeyFingerprint(creds.apiKey),
+            response.scopes,
           );
         }
       }
@@ -1349,13 +1355,15 @@ export async function runCli(args: string[]): Promise<void> {
     }
   }
 
-  // Load cached auth collectives for membership-based trust
+  // Load cached auth collectives and scopes for membership-based trust
   let authCollectives: string[] | undefined;
   if (!hookMode) {
     try {
       const authRepo = new AuthRepository();
       const creds = await authRepo.load();
       authCollectives = creds?.collectives;
+      if (creds?.apiKey) setCollectiveToken(creds.apiKey);
+      setAuthScopes(creds?.scopes);
     } catch {
       // Auth file unreadable — continue without membership collectives
     }

--- a/src/domain/auth/auth_credentials.ts
+++ b/src/domain/auth/auth_credentials.ts
@@ -41,6 +41,8 @@ export interface AuthCredentials {
   username: string;
   /** Cached collective memberships (slugs) from the last login/whoami */
   collectives?: string[];
+  /** Cached token scopes from the last login/whoami (collective tokens only) */
+  scopes?: string[];
   /** Prefix of the API key that was active when identity was cached.
    *  Used to detect key rotation for SWAMP_API_KEY users. */
   apiKeyFingerprint?: string;

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -92,6 +92,7 @@ export class AuthRepository {
 
       let username = "";
       let collectives: string[] | undefined;
+      let scopes: string[] | undefined;
       try {
         const content = await Deno.readTextFile(this.getAuthPath());
         const cached = JSON.parse(content) as AuthCredentials;
@@ -101,6 +102,7 @@ export class AuthRepository {
         ) {
           username = cached.username ?? "";
           collectives = cached.collectives;
+          scopes = cached.scopes;
         }
       } catch {
         // No cached identity — will be populated on first whoami
@@ -112,6 +114,7 @@ export class AuthRepository {
         apiKeyId: "",
         username,
         collectives,
+        ...(scopes ? { scopes } : {}),
       };
     }
 
@@ -154,6 +157,7 @@ export class AuthRepository {
     username: string,
     collectives: string[],
     fingerprint: string,
+    scopes?: string[],
   ): Promise<void> {
     let existing: AuthCredentials | undefined;
     try {
@@ -169,6 +173,7 @@ export class AuthRepository {
       apiKeyId: existing?.apiKeyId ?? "",
       username,
       collectives,
+      ...(scopes ? { scopes } : {}),
       apiKeyFingerprint: fingerprint,
     };
     await this.save(merged);

--- a/src/presentation/output/error_output.ts
+++ b/src/presentation/output/error_output.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { ValidationError } from "@cliffy/command";
+import { bold, red } from "@std/fmt/colors";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_user_error.ts";
@@ -111,7 +112,9 @@ export function renderError(error: unknown, outputMode?: OutputMode): void {
     return;
   }
 
-  if (err instanceof UserError || err instanceof ValidationError) {
+  if (err instanceof UserError) {
+    console.error(`\n${red(bold("Error:"))} ${err.message}`);
+  } else if (err instanceof ValidationError) {
     logger.fatal("Error: {message}", { message: err.message });
   } else {
     logger.fatal("{error}", { error: err });

--- a/src/presentation/output/error_output_test.ts
+++ b/src/presentation/output/error_output_test.ts
@@ -31,7 +31,7 @@ import { DuplicateTypeUserError } from "../../domain/extensions/duplicate_type_u
 
 await initializeLogging({});
 
-Deno.test("renderError logs UserError message without stack trace", () => {
+Deno.test("renderError logs UserError message directly to stderr without LogTape formatting", () => {
   const logs: string[] = [];
   const originalError = console.error;
   console.error = (...args: unknown[]) => logs.push(args.join(" "));
@@ -41,9 +41,12 @@ Deno.test("renderError logs UserError message without stack trace", () => {
     renderError(error);
 
     assertEquals(logs.length, 1);
+    assertStringIncludes(logs[0], "Error:");
     assertStringIncludes(logs[0], "Model not found");
     // Should not contain stack trace lines
     assertEquals(logs[0].includes("    at "), false);
+    // Should not contain LogTape formatting (level prefix, category)
+    assertEquals(logs[0].includes("FTL"), false);
   } finally {
     console.error = originalError;
   }
@@ -167,18 +170,20 @@ Deno.test("renderError: json mode emits clean JSON for ValidationError (issue #1
   }
 });
 
-Deno.test("renderError uses fatal level for all errors", () => {
+Deno.test("renderError: UserError goes to console.error directly, system errors go through LogTape", () => {
   const logs: string[] = [];
   const originalError = console.error;
-  // LogTape's console sink uses console.error for fatal level
   console.error = (...args: unknown[]) => logs.push(args.join(" "));
 
   try {
     renderError(new UserError("user error"));
     renderError(new Error("system error"));
 
-    // Both should have logged (fatal goes to console.error)
+    // Both should have logged (UserError direct, system via LogTape fatal)
     assertEquals(logs.length, 2);
+    // UserError: direct console.error, no LogTape formatting
+    assertStringIncludes(logs[0], "user error");
+    assertEquals(logs[0].includes("FTL"), false);
   } finally {
     console.error = originalError;
   }


### PR DESCRIPTION
## Summary

- Gate external datastores, non-local vaults, and `swamp serve` (token/oauth modes) behind a swamp-club.com account
- Collective tokens (`swamp_org_` prefix) must carry the appropriate scope (`datastore:*`, `vault:*`, `serve:*`); personal tokens get full access
- Collective tokens with unknown scopes (cache miss / failed whoami) fail closed rather than granting access
- Persist token scopes in `auth.json` via `saveIdentityCache()` so scope checks work without an extra API call
- Render `UserError` directly to stderr instead of through LogTape for cleaner multi-line error output
- Error messages are prescriptive: they name the required scope and point to `swamp-club.com/collectives` for token creation

### What's NOT gated
- `local_encryption` vaults — the "hello world" for secrets, no account needed
- `swamp serve --auth-mode none` — deprecated mode, if you're brave enough to run it unsecured we let you
- `swamp worker token create` / `swamp worker connect` — workers are downstream of serve, already authenticated via the serve → swamp-club chain

## Test plan
- [x] No auth + external datastore → blocks with auth_required error naming `datastore:*` scope
- [x] No auth + non-local vault → blocks with auth_required error naming `vault:*` scope
- [x] No auth + local_encryption vault → passes (no gate)
- [x] No auth + serve token mode → blocks with auth_required error naming `serve:*` scope
- [x] No auth + serve none mode → passes (no gate, deprecated warning shown)
- [x] Personal token + serve token mode → passes both auth and scope checks
- [x] Collective token with `serve:*` scope → passes both checks
- [x] Collective token without `serve:*` scope → blocks with missing_scope error
- [x] Collective token with no cached scopes (cache miss) → blocks (fail closed)
- [x] 55 unit tests pass (auth_context, error_output, auth_repository)

🤖 Generated with [Claude Code](https://claude.com/claude-code)