### PR TITLE
fix(auth): fix scope checking for collective tokens

### DIFF
--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -21,39 +21,56 @@ import { UserError } from "../domain/errors.ts";
 
 const COLLECTIVE_TOKEN_PREFIX = "swamp_org_";
 
-let authenticated = false;
-let collectiveToken = false;
-let authScopes: string[] | undefined;
+// State lives on globalThis so that all module copies produced by
+// --unstable-bundle share the same values at runtime.
+interface AuthState {
+  authenticated: boolean;
+  collectiveToken: boolean;
+  authScopes: string[] | undefined;
+}
+
+const STATE_KEY = "__swamp_auth_state__";
+function state(): AuthState {
+  const g = globalThis as unknown as Record<string, AuthState>;
+  if (!g[STATE_KEY]) {
+    g[STATE_KEY] = {
+      authenticated: false,
+      collectiveToken: false,
+      authScopes: undefined,
+    };
+  }
+  return g[STATE_KEY];
+}
 
 export function setAuthenticated(value: boolean): void {
-  authenticated = value;
+  state().authenticated = value;
 }
 
 export function isAuthenticated(): boolean {
-  return authenticated;
+  return state().authenticated;
 }
 
 export function setCollectiveToken(apiKey: string): void {
-  collectiveToken = apiKey.startsWith(COLLECTIVE_TOKEN_PREFIX);
+  state().collectiveToken = apiKey.startsWith(COLLECTIVE_TOKEN_PREFIX);
 }
 
 export function isCollectiveToken(): boolean {
-  return collectiveToken;
+  return state().collectiveToken;
 }
 
 export function setAuthScopes(scopes: string[] | undefined): void {
-  authScopes = scopes;
+  state().authScopes = scopes;
 }
 
 export function getAuthScopes(): string[] | undefined {
-  return authScopes;
+  return state().authScopes;
 }
 
 export function requireAuthenticated(
   featureSentence: string,
   scope: string,
 ): void {
-  if (!authenticated) {
+  if (!state().authenticated) {
     throw new UserError(
       `${featureSentence} that requires a free swamp-club.com account.\n\n` +
         `Sign in:\n\n` +
@@ -66,8 +83,9 @@ export function requireAuthenticated(
 }
 
 export function requireScope(scope: string): void {
-  if (!collectiveToken) return;
-  if (authScopes !== undefined && authScopes.includes(scope)) return;
+  const s = state();
+  if (!s.collectiveToken) return;
+  if (s.authScopes !== undefined && s.authScopes.includes(scope)) return;
 
   throw new UserError(
     `Your token lacks the ${scope} scope.\n\n` +

--- a/src/cli/auth_context_test.ts
+++ b/src/cli/auth_context_test.ts
@@ -106,7 +106,7 @@ Deno.test("requireScope: throws when collective token has empty scopes", () => {
   setAuthScopes(undefined);
 });
 
-Deno.test("requireScope: throws when collective token has undefined scopes (cache miss)", () => {
+Deno.test("requireScope: throws when collective token has undefined scopes (whoami failed)", () => {
   setCollectiveToken("swamp_org_abc");
   setAuthScopes(undefined);
   assertThrows(
@@ -114,5 +114,4 @@ Deno.test("requireScope: throws when collective token has undefined scopes (cach
     UserError,
   );
   setCollectiveToken("");
-  setAuthScopes(undefined);
 });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1327,27 +1327,51 @@ export async function runCli(args: string[]): Promise<void> {
     loaderSpan.end();
   }
 
-  // Resolve identity for SWAMP_API_KEY users on first use (or key rotation).
+  // Resolve identity and scopes for SWAMP_API_KEY users. Calls whoami only
+  // when the cache is stale (first use, key rotation, or missing scopes for
+  // a collective token). Scopes are set directly from the response to avoid
+  // cache round-trip issues with --unstable-bundle module duplication.
   // Must run before the authCollectives read so the first invocation gets
   // cached collectives for extension trust.
   if (!hookMode && Deno.env.get("SWAMP_API_KEY")) {
     try {
       const authRepo = new AuthRepository();
       const creds = await authRepo.load();
-      if (creds && !creds.username) {
-        const identity = await loadIdentity();
-        const client = new SwampClubClient(creds.serverUrl, identity);
-        const signal = AbortSignal.timeout(10_000);
-        const response = await client.whoami(creds.apiKey, signal);
-        if (response.authenticated && response.username) {
-          const collectives = getCollectives(response) ?? [];
-          await authRepo.saveIdentityCache(
-            creds.serverUrl,
-            response.username,
-            collectives,
-            apiKeyFingerprint(creds.apiKey),
-            response.scopes,
-          );
+      if (creds) {
+        if (creds.apiKey) setCollectiveToken(creds.apiKey);
+        const isCollective = creds.apiKey.startsWith("swamp_org_");
+        const fingerprint = apiKeyFingerprint(creds.apiKey);
+        if (isCollective) {
+          const cachedScopes = await authRepo.loadScopeCache(fingerprint);
+          if (cachedScopes) {
+            setAuthScopes(cachedScopes);
+          } else {
+            const identity = await loadIdentity();
+            const client = new SwampClubClient(creds.serverUrl, identity);
+            const signal = AbortSignal.timeout(10_000);
+            const response = await client.whoami(creds.apiKey, signal);
+            if (response.authenticated) {
+              setAuthScopes(response.scopes);
+              if (response.scopes) {
+                await authRepo.saveScopeCache(fingerprint, response.scopes);
+              }
+            }
+          }
+        } else if (!creds.username) {
+          const identity = await loadIdentity();
+          const client = new SwampClubClient(creds.serverUrl, identity);
+          const signal = AbortSignal.timeout(10_000);
+          const response = await client.whoami(creds.apiKey, signal);
+          if (response.authenticated && response.username) {
+            const collectives = getCollectives(response) ?? [];
+            await authRepo.saveIdentityCache(
+              creds.serverUrl,
+              response.username,
+              collectives,
+              fingerprint,
+              response.scopes,
+            );
+          }
         }
       }
     } catch {
@@ -1362,8 +1386,10 @@ export async function runCli(args: string[]): Promise<void> {
       const authRepo = new AuthRepository();
       const creds = await authRepo.load();
       authCollectives = creds?.collectives;
-      if (creds?.apiKey) setCollectiveToken(creds.apiKey);
-      setAuthScopes(creds?.scopes);
+      if (!Deno.env.get("SWAMP_API_KEY")) {
+        if (creds?.apiKey) setCollectiveToken(creds.apiKey);
+        setAuthScopes(creds?.scopes);
+      }
     } catch {
       // Auth file unreadable — continue without membership collectives
     }

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -179,6 +179,40 @@ export class AuthRepository {
     await this.save(merged);
   }
 
+  private getScopeCachePath(): string {
+    return join(this.getConfigDir(), "scope_cache.json");
+  }
+
+  async saveScopeCache(
+    fingerprint: string,
+    scopes: string[],
+  ): Promise<void> {
+    await Deno.mkdir(this.getConfigDir(), { recursive: true });
+    await atomicWriteTextFile(
+      this.getScopeCachePath(),
+      JSON.stringify({ fingerprint, scopes }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  }
+
+  async loadScopeCache(
+    fingerprint: string,
+  ): Promise<string[] | undefined> {
+    try {
+      const content = await Deno.readTextFile(this.getScopeCachePath());
+      const cached = JSON.parse(content) as {
+        fingerprint?: string;
+        scopes?: string[];
+      };
+      if (cached.fingerprint === fingerprint) {
+        return cached.scopes;
+      }
+    } catch {
+      // No cache file
+    }
+    return undefined;
+  }
+
   /** Delete stored auth credentials. */
   async delete(): Promise<void> {
     try {


### PR DESCRIPTION
## Summary

Fixes three bugs in the scope checking shipped in #1934 that made collective tokens (`swamp_org_` prefix) unable to pass `requireScope` checks.

### Bug 1: whoami response has no `username` for collective tokens

Collective tokens represent a collective, not a user — `response.username` is `undefined`. The whoami block guarded `setAuthScopes` behind `if (response.authenticated && response.username)`, so scopes were never set.

**Fix**: set scopes when `response.authenticated` is true, regardless of `username`.

### Bug 2: `--unstable-bundle` duplicates module state

The `--unstable-bundle` compiler created separate copies of `auth_context.ts` module-level variables. `setAuthScopes` in `mod.ts` and `requireScope` in command files operated on different `authScopes` variables — confirmed by debug tracing showing `setAuthScopes` called with the correct array but `requireScope` seeing `undefined`.

**Fix**: move state to `globalThis` via a `__swamp_auth_state__` key so all module copies share it.

### Bug 3: collective tokens clobbered personal login

`saveIdentityCache` for collective tokens overwrote the user's `auth.json` — replacing their personal key's fingerprint and username with the collective token's values. Running `SWAMP_API_KEY=... swamp datastore setup ...` would break subsequent unauthenticated commands.

**Fix**: collective token scopes are cached in a separate `~/.config/swamp/scope_cache.json` keyed by API key fingerprint. Personal `auth.json` is never touched by collective token operations — matching the principle already established in `whoami.ts` which skips `saveCredentials` for collective tokens.

### Performance

- **First run** with a collective token: one whoami call (~200ms), scopes cached to `scope_cache.json`
- **Subsequent runs**: scopes read from cache file, zero network cost
- **Key rotation**: fingerprint mismatch → fresh whoami → update cache
- **Personal tokens**: unchanged, `requireScope` returns immediately

## Debug session walkthrough

The root cause was found through iterative debug tracing:
1. Added `[TRACE]` to the catch block — no output → whoami wasn't throwing
2. Added `[TRACE]` after whoami — confirmed scopes returned correctly from server
3. Added `[TRACE]` inside `requireScope` — showed `authScopes: undefined` despite being set → found the `--unstable-bundle` module duplication
4. Moved to `globalThis` — still `undefined` → found `setAuthScopes` trace never fired
5. Added `[TRACE]` after whoami response — showed `username: undefined` → found the `response.username` guard

## Test plan
- [x] `SWAMP_API_KEY=swamp_org_... swamp datastore setup extension ...` — passes with correct scope
- [x] `SWAMP_API_KEY=swamp_org_... swamp auth whoami` — shows scopes correctly
- [x] Personal `auth.json` not clobbered after collective token use
- [x] Second run with same collective token reads from cache (no whoami call)
- [x] 55 unit tests pass (auth_context, auth_repository, error_output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)