### PR TITLE
fix(auth): improve scope error message to mention personal login

### DIFF
--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -70,8 +70,10 @@ export function requireScope(scope: string): void {
   if (authScopes !== undefined && authScopes.includes(scope)) return;
 
   throw new UserError(
-    `Your token lacks the ${scope} scope.\n\n` +
-      `Create a new collective token at swamp-club.com/collectives that\n` +
+    `Your collective token lacks the ${scope} scope.\n\n` +
+      `Either sign in with your personal account:\n\n` +
+      `  swamp auth login\n\n` +
+      `Or create a collective token at swamp-club.com/collectives that\n` +
       `includes the ${scope} scope and set SWAMP_API_KEY.\n`,
     "missing_scope",
   );


### PR DESCRIPTION
## Summary

- The missing-scope error (fired when a collective token lacks e.g. `datastore:*`) previously only suggested creating a new collective token
- Users can also sign in with a personal account (`swamp auth login`) which has full access — the error now mentions both options

### Before
```
Error: Your token lacks the datastore:* scope.

Create a new collective token at swamp-club.com/collectives that
includes the datastore:* scope and set SWAMP_API_KEY.
```

### After
```
Error: Your collective token lacks the datastore:* scope.

Either sign in with your personal account:

  swamp auth login

Or create a collective token at swamp-club.com/collectives that
includes the datastore:* scope and set SWAMP_API_KEY.
```

## Test plan
- [x] 10 auth_context tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)