### PR TITLE
fix(auth): scope cache tests, delete cleanup, and dedup prefix check

### DIFF
--- a/src/cli/auth_context_test.ts
+++ b/src/cli/auth_context_test.ts
@@ -90,6 +90,7 @@ Deno.test("requireScope: throws when collective token lacks scope", () => {
   );
   assertEquals(err.code, "missing_scope");
   assertStringIncludes(err.message, "serve:*");
+  assertStringIncludes(err.message, "swamp auth login");
   assertStringIncludes(err.message, "swamp-club.com");
   setCollectiveToken("");
   setAuthScopes(undefined);

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -107,6 +107,7 @@ import type { ClientIdentity } from "../infrastructure/http/client_identity.ts";
 import { loadIdentity, USER_AGENT } from "./load_identity.ts";
 import {
   isAuthenticated,
+  isCollectiveToken,
   setAuthenticated,
   setAuthScopes,
   setCollectiveToken,
@@ -1339,9 +1340,8 @@ export async function runCli(args: string[]): Promise<void> {
       const creds = await authRepo.load();
       if (creds) {
         if (creds.apiKey) setCollectiveToken(creds.apiKey);
-        const isCollective = creds.apiKey.startsWith("swamp_org_");
         const fingerprint = apiKeyFingerprint(creds.apiKey);
-        if (isCollective) {
+        if (isCollectiveToken()) {
           const cachedScopes = await authRepo.loadScopeCache(fingerprint);
           if (cachedScopes) {
             setAuthScopes(cachedScopes);

--- a/src/infrastructure/persistence/auth_repository.ts
+++ b/src/infrastructure/persistence/auth_repository.ts
@@ -213,13 +213,15 @@ export class AuthRepository {
     return undefined;
   }
 
-  /** Delete stored auth credentials. */
+  /** Delete stored auth credentials and scope cache. */
   async delete(): Promise<void> {
-    try {
-      await Deno.remove(this.getAuthPath());
-    } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        throw error;
+    for (const path of [this.getAuthPath(), this.getScopeCachePath()]) {
+      try {
+        await Deno.remove(path);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
       }
     }
   }

--- a/src/infrastructure/persistence/auth_repository_test.ts
+++ b/src/infrastructure/persistence/auth_repository_test.ts
@@ -427,3 +427,101 @@ Deno.test("AuthRepository - load leaves custom server URLs untouched", async () 
     await Deno.remove(tmpDir, { recursive: true });
   }
 });
+
+// ── Scope cache tests ───────────────────────────────────────────────────
+
+Deno.test("AuthRepository - saveScopeCache and loadScopeCache round trip", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new AuthRepository({ configDir: join(tmpDir, "swamp") });
+    const fingerprint = "swamp_org_te";
+    const scopes = ["extensions:*", "serve:*", "datastore:*", "vault:*"];
+
+    await repo.saveScopeCache(fingerprint, scopes);
+    const loaded = await repo.loadScopeCache(fingerprint);
+
+    assertEquals(loaded, scopes);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - loadScopeCache returns undefined on fingerprint mismatch", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new AuthRepository({ configDir: join(tmpDir, "swamp") });
+
+    await repo.saveScopeCache("swamp_org_aa", ["serve:*"]);
+    const loaded = await repo.loadScopeCache("swamp_org_bb");
+
+    assertEquals(loaded, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - loadScopeCache returns undefined when no cache file exists", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const repo = new AuthRepository({ configDir: join(tmpDir, "swamp") });
+    const loaded = await repo.loadScopeCache("swamp_org_te");
+
+    assertEquals(loaded, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - loadScopeCache returns undefined on corrupted JSON", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    await Deno.mkdir(configDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(configDir, "scope_cache.json"),
+      "not json{{{",
+    );
+
+    const repo = new AuthRepository({ configDir });
+    const loaded = await repo.loadScopeCache("swamp_org_te");
+
+    assertEquals(loaded, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - saveScopeCache sets restrictive file permissions", async () => {
+  if (Deno.build.os === "windows") return;
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const repo = new AuthRepository({ configDir });
+
+    await repo.saveScopeCache("swamp_org_te", ["serve:*"]);
+
+    const stat = await Deno.stat(join(configDir, "scope_cache.json"));
+    assertEquals(stat.mode !== null && (stat.mode & 0o777) === 0o600, true);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("AuthRepository - delete also removes scope_cache.json", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const configDir = join(tmpDir, "swamp");
+    const repo = new AuthRepository({ configDir });
+
+    await repo.save(TEST_CREDENTIALS);
+    await repo.saveScopeCache("swamp_org_te", ["serve:*"]);
+    await repo.delete();
+
+    const loaded = await repo.load();
+    assertEquals(loaded, null);
+    const scopes = await repo.loadScopeCache("swamp_org_te");
+    assertEquals(scopes, undefined);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up cleanup from the auth scope PRs (#1934, #1936, #1937):

- **Add unit tests for `saveScopeCache`/`loadScopeCache`** — round-trip, fingerprint mismatch returns undefined, missing file returns undefined, corrupted JSON returns undefined, and file permissions (0o600)
- **`delete()` cleans up `scope_cache.json`** — `swamp auth logout` now removes the scope cache alongside `auth.json`
- **Dedup prefix check in `mod.ts`** — replaced `creds.apiKey.startsWith("swamp_org_")` with `isCollectiveToken()` which already encapsulates the `COLLECTIVE_TOKEN_PREFIX` constant
- **Test assertion parity** — added `assertStringIncludes(err.message, "swamp auth login")` to the `requireScope` throw test, matching the `requireAuthenticated` test

## Not addressed (noted for future)

- **Scope cache TTL**: `loadScopeCache` matches on fingerprint only with no expiry. If scopes are narrowed server-side without rotating the key, the CLI serves stale cached scopes. Since all gated operations make server API calls that enforce scopes independently, this is a UX issue (confusing server-side 403 vs clear local error), not an authorization bypass. A TTL or `--force-refresh` flag would close this gap.

## Test plan
- [x] 34 tests pass (10 auth_context + 24 auth_repository including 6 new scope cache tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)