### PR TITLE
fix(datastores): namespace per-model lock keys to match data layout (swamp-club#1323)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -1079,23 +1079,13 @@ When a `namespace` is configured, the **global** lock key moves to
 repos writing to different namespaces of a shared datastore never contend on
 structural commands. `FileLock` lazily creates the `.locks/` directory on first
 acquire. This is a lock-**path** change only — the lifecycle protocol below is
-unchanged. Per-model lock keys (`data/{type}/{modelId}/.lock`) are **not**
-namespaced: model ids are UUIDs, so they are already globally unique across
-namespaces.
-
-Known cosmetic consequence of leaving per-model lock keys un-namespaced: in a
-namespaced repo the lock lives at `{datastore}/data/{type}/{modelId}/.lock`
-(un-namespaced tier) while the data it guards lives at
-`{datastore}/{namespace}/data/{type}/{modelId}/...`. Because `FileLock.acquire`
-runs `ensureDir(dirname(lockPath))`, acquiring the lock leaves an **empty**
-`{datastore}/data/{type}/{modelId}/` directory behind in the un-namespaced
-tier after release. This is harmless — no data, no catalog rows, and `data
-list`/`data query` (which read the repo-local catalog) are unaffected; the
-empty dirs are never confused with data because they contain no `raw`/metadata.
-Co-locating the lock with the namespaced data would require namespace-scoping
-`parseModelLockKey`/`scanModelLocks`/`waitForPerModelLocks` (which anchor on
-`data` as the first path segment), so it is deferred to the per-model lock
-namespacing work rather than expanding this phase's scope for a cosmetic issue.
+unchanged. Per-model lock keys are namespaced:
+`{namespace}/data/{type}/{modelId}/.lock` when a namespace is set,
+`data/{type}/{modelId}/.lock` otherwise. The `modelLockKey()` helper in
+`lock.ts` constructs the key; `createModelLock` and `acquireModelLocks` read
+`config.namespace` to thread it through. `parseModelLockKey` is unchanged —
+callers use `stripNamespacePrefix()` to strip the namespace from
+filesystem-relative paths before parsing.
 
 ### Lock Timeout and Retry Behavior
 
@@ -1163,14 +1153,11 @@ same model are unsafe). The coordinator uses unique keys per lock
 acquisition (suffixed with a random ID) so parallel steps on the same
 model get separate entries and do not overwrite each other.
 
-Because per-model lock keys are not namespaced, `waitForPerModelLocks`
-(which walks the datastore root) drains in-flight per-model writers across
-**all** namespaces, not just the structural command's own. This is a
-conservative over-wait, not a correctness issue: data dirs are
-namespace-partitioned, catalogs are repo-local, and global locks are
-namespaced, so there is no shared mutable state for a cross-namespace writer
-to corrupt. Structural commands are infrequent; namespacing per-model locks
-can be revisited if real contention appears.
+Per-model lock keys are namespace-scoped, so `waitForPerModelLocks` uses
+`stripNamespacePrefix` to match locks under the repo's namespace. The walk
+still starts from the datastore root, so locks from other namespaces are
+visible but filtered out by the prefix check — only the current namespace's
+per-model locks are drained.
 
 #### Symmetric Drain (structural commands)
 

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -46,7 +46,9 @@ import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 import {
   enumeratePulledExtensionDirs,
+  modelLockKey,
   parseModelLockKey,
+  stripNamespacePrefix,
 } from "../libswamp/mod.ts";
 import { resolveDatastoreConfig } from "./resolve_datastore.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
@@ -577,7 +579,10 @@ export function requireInitializedRepo(
       // to be released. A writer that has *already* acquired a per-model
       // lock and passed its TOCTOU recheck (acquireModelLocks, this file)
       // is committed to writing data; we must let it finish.
-      await waitForPerModelLocks(datastoreConfig.path);
+      await waitForPerModelLocks(
+        datastoreConfig.path,
+        datastoreConfig.namespace,
+      );
 
       // Acquire the global lock. From here on, any writer that inspects
       // the global lock will back off — but a writer that slipped past the
@@ -601,7 +606,10 @@ export function requireInitializedRepo(
       // closes the symmetric TOCTOU window — do not remove without
       // updating the lock-lifecycle contract documented in
       // design/datastores.md.
-      await waitForPerModelLocks(datastoreConfig.path);
+      await waitForPerModelLocks(
+        datastoreConfig.path,
+        datastoreConfig.namespace,
+      );
 
       if (datastoreConfig.namespace) {
         needsCatalogInvalidation = true;
@@ -830,7 +838,7 @@ export async function createModelLock(
   modelType: string,
   modelId: string,
 ): Promise<DistributedLock> {
-  const lockKey = `data/${modelType}/${modelId}/.lock`;
+  const lockKey = modelLockKey(config.namespace, modelType, modelId);
   const maxWaitMs = resolveLockTimeoutMs();
   if (isCustomDatastoreConfig(config)) {
     const provider = await resolveCustomProvider(config);
@@ -858,6 +866,7 @@ export const SWAMP_LOCK_HOLDER_PID = "SWAMP_LOCK_HOLDER_PID";
 
 export async function waitForPerModelLocks(
   datastorePath: string,
+  namespace?: string,
   findModelLocksOverride?: () => Promise<number>,
 ): Promise<void> {
   const logger = getSwampLogger(["datastore", "lock"]);
@@ -875,7 +884,9 @@ export async function waitForPerModelLocks(
           })
         ) {
           const rel = relative(datastorePath, entry.path);
-          if (!parseModelLockKey(rel)) continue;
+          if (!parseModelLockKey(stripNamespacePrefix(namespace, rel))) {
+            continue;
+          }
           try {
             const content = await Deno.readTextFile(entry.path);
             const info = JSON.parse(content) as {
@@ -1100,7 +1111,7 @@ export async function acquireModelLocks(
   }
 
   for (const { modelType, modelId } of unique) {
-    const lockFileKey = `data/${modelType}/${modelId}/.lock`;
+    const lockFileKey = modelLockKey(config.namespace, modelType, modelId);
     // Use cached provider for custom types to avoid repeated registry lookups
     const lock = customProvider && isCustomDatastoreConfig(config)
       ? customProvider.createLock(config.datastorePath, {

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -1031,7 +1031,7 @@ Deno.test(
     };
 
     const start = Date.now();
-    await waitForPerModelLocks("/unused/datastore/path", scanner);
+    await waitForPerModelLocks("/unused/datastore/path", undefined, scanner);
     const elapsed = Date.now() - start;
 
     // No polling loop entered — single scan call, no setTimeout delay.
@@ -1060,7 +1060,7 @@ Deno.test(
     };
 
     const start = Date.now();
-    await waitForPerModelLocks("/unused/datastore/path", scanner);
+    await waitForPerModelLocks("/unused/datastore/path", undefined, scanner);
     const elapsed = Date.now() - start;
 
     // 3 calls: initial check + 2 polls (the second poll observes 0 and
@@ -1086,7 +1086,11 @@ Deno.test(
         const prev = Deno.env.get("SWAMP_LOCK_TIMEOUT_MS");
         Deno.env.set("SWAMP_LOCK_TIMEOUT_MS", "2000");
         try {
-          await waitForPerModelLocks("/unused/datastore/path", scanner);
+          await waitForPerModelLocks(
+            "/unused/datastore/path",
+            undefined,
+            scanner,
+          );
         } finally {
           if (prev !== undefined) {
             Deno.env.set("SWAMP_LOCK_TIMEOUT_MS", prev);

--- a/src/libswamp/datastores/lock.ts
+++ b/src/libswamp/datastores/lock.ts
@@ -31,6 +31,38 @@ import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 export type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 
+// ── Lock-key construction ─────────────────────────────────────────────
+
+/**
+ * Constructs the canonical per-model lock key, optionally scoped under a
+ * namespace. Uses `/` (not SEPARATOR) since lock keys are passed as opaque
+ * strings to custom providers (e.g. S3 object keys).
+ */
+export function modelLockKey(
+  namespace: string | undefined,
+  modelType: string,
+  modelId: string,
+): string {
+  const base = `data/${modelType}/${modelId}/.lock`;
+  return namespace ? `${namespace}/${base}` : base;
+}
+
+/**
+ * Strips a leading `{namespace}{SEPARATOR}` from a filesystem-relative path
+ * so that `parseModelLockKey` can parse it. Uses SEPARATOR because this
+ * operates on paths produced by `relative()` from `@std/path`.
+ * Returns the input unchanged when namespace is empty or the prefix doesn't
+ * match.
+ */
+export function stripNamespacePrefix(
+  namespace: string | undefined,
+  rel: string,
+): string {
+  if (!namespace) return rel;
+  const prefix = `${namespace}${SEPARATOR}`;
+  return rel.startsWith(prefix) ? rel.slice(prefix.length) : rel;
+}
+
 // ── Lock-key parsing ───────────────────────────────────────────────────
 
 /**
@@ -246,6 +278,7 @@ export async function* datastoreLockRelease(
  */
 async function scanModelLocks(
   datastorePath: string,
+  namespace?: string,
 ): Promise<
   Array<{
     lockKey: string;
@@ -269,14 +302,13 @@ async function scanModelLocks(
       })
     ) {
       const rel = relative(datastorePath, entry.path);
-      const parsed = parseModelLockKey(rel);
+      const parsed = parseModelLockKey(stripNamespacePrefix(namespace, rel));
       if (!parsed) continue;
       try {
         const content = await Deno.readTextFile(entry.path);
         const info = JSON.parse(content) as LockInfo;
         results.push({
-          // Canonical key form uses `/` regardless of platform separator
-          lockKey: `data/${parsed.modelType}/${parsed.modelId}/.lock`,
+          lockKey: modelLockKey(namespace, parsed.modelType, parsed.modelId),
           modelType: parsed.modelType,
           modelId: parsed.modelId,
           info,
@@ -303,7 +335,7 @@ export function createDatastoreLockStatusDeps(
 
   return {
     inspectGlobalLock: () => globalLock.inspect(),
-    scanModelLocks: () => scanModelLocks(datastorePath),
+    scanModelLocks: () => scanModelLocks(datastorePath, config.namespace),
   };
 }
 

--- a/src/libswamp/datastores/lock_test.ts
+++ b/src/libswamp/datastores/lock_test.ts
@@ -30,8 +30,10 @@ import {
   type DatastoreLockStatusDeps,
   type DatastoreLockStatusEvent,
   type LockInfo,
+  modelLockKey,
   parseModelLockKey,
   parseModelSpec,
+  stripNamespacePrefix,
 } from "./lock.ts";
 
 const sampleLockInfo: LockInfo = {
@@ -333,6 +335,59 @@ Deno.test("parseModelSpec: empty string returns null", () => {
   assertEquals(parseModelSpec(""), null);
 });
 
+// ── modelLockKey ──────────────────────────────────────────────────────
+
+Deno.test("modelLockKey: without namespace", () => {
+  assertEquals(
+    modelLockKey(undefined, "aws-ec2", "server-1"),
+    "data/aws-ec2/server-1/.lock",
+  );
+});
+
+Deno.test("modelLockKey: with empty namespace", () => {
+  assertEquals(
+    modelLockKey("", "aws-ec2", "server-1"),
+    "data/aws-ec2/server-1/.lock",
+  );
+});
+
+Deno.test("modelLockKey: with namespace", () => {
+  assertEquals(
+    modelLockKey("infra", "aws-ec2", "server-1"),
+    "infra/data/aws-ec2/server-1/.lock",
+  );
+});
+
+Deno.test("modelLockKey: with namespace and scoped extension type", () => {
+  assertEquals(
+    modelLockKey("asdlc", "@hivemq/harvester-host-kernel", "abc-123"),
+    "asdlc/data/@hivemq/harvester-host-kernel/abc-123/.lock",
+  );
+});
+
+// ── stripNamespacePrefix ──────────────────────────────────────────────
+
+Deno.test("stripNamespacePrefix: no namespace returns input unchanged", () => {
+  const rel = ["data", "aws-ec2", "server-1", ".lock"].join(SEPARATOR);
+  assertEquals(stripNamespacePrefix(undefined, rel), rel);
+});
+
+Deno.test("stripNamespacePrefix: empty namespace returns input unchanged", () => {
+  const rel = ["data", "aws-ec2", "server-1", ".lock"].join(SEPARATOR);
+  assertEquals(stripNamespacePrefix("", rel), rel);
+});
+
+Deno.test("stripNamespacePrefix: strips matching namespace prefix", () => {
+  const rel = ["infra", "data", "aws-ec2", "server-1", ".lock"].join(SEPARATOR);
+  const stripped = ["data", "aws-ec2", "server-1", ".lock"].join(SEPARATOR);
+  assertEquals(stripNamespacePrefix("infra", rel), stripped);
+});
+
+Deno.test("stripNamespacePrefix: non-matching prefix returns input unchanged", () => {
+  const rel = ["other", "data", "aws-ec2", "server-1", ".lock"].join(SEPARATOR);
+  assertEquals(stripNamespacePrefix("infra", rel), rel);
+});
+
 // ── Functional: scanModelLocks against real filesystem ────────────────
 
 Deno.test("scanModelLocks: finds both simple and scoped extension type locks", async () => {
@@ -381,6 +436,48 @@ Deno.test("scanModelLocks: finds both simple and scoped extension type locks", a
       "data/@hivemq/harvester-host-kernel/abc/.lock",
       "data/aws-ec2/server-1/.lock",
     ]);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+});
+
+Deno.test("scanModelLocks: finds locks under namespace-scoped directory", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-lock-ns-scan-" });
+  try {
+    const now = new Date().toISOString();
+    const lock = JSON.stringify({
+      holder: "h@h",
+      hostname: "h",
+      pid: 1,
+      acquiredAt: now,
+      ttlMs: 600000,
+      nonce: "n",
+    });
+    await Deno.mkdir(`${dir}/myns/data/aws-ec2/server-1`, { recursive: true });
+    await Deno.writeTextFile(
+      `${dir}/myns/data/aws-ec2/server-1/.lock`,
+      lock,
+    );
+
+    const deps = createDatastoreLockStatusDeps(
+      {
+        // deno-lint-ignore require-await
+        async inspect() {
+          return null;
+        },
+      } as unknown as Parameters<typeof createDatastoreLockStatusDeps>[0],
+      { type: "filesystem", path: dir, namespace: "myns" },
+    );
+
+    const locks = await deps.scanModelLocks();
+    assertEquals(locks.length, 1);
+    assertEquals(locks[0].modelType, "aws-ec2");
+    assertEquals(locks[0].modelId, "server-1");
+    assertEquals(locks[0].lockKey, "myns/data/aws-ec2/server-1/.lock");
   } finally {
     if (Deno.build.os === "windows") {
       await Deno.remove(dir, { recursive: true }).catch(() => {});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1475,8 +1475,10 @@ export {
   type DatastoreLockStatusEvent,
   type DatastoreLockStatusInput,
   type LockInfo,
+  modelLockKey,
   parseModelLockKey,
   parseModelSpec,
+  stripNamespacePrefix,
 } from "./datastores/lock.ts";
 export {
   datastoreCompact,


### PR DESCRIPTION
## Summary

- Per-model lock keys (`data/{type}/{id}/.lock`) were constructed without the repo's namespace prefix, causing `.lock` files to land at the datastore root instead of under the namespace directory. On shared multi-tenant datastores (S3) this polluted the root that namespacing exists to keep clean.
- Added `modelLockKey()` and `stripNamespacePrefix()` helpers in `lock.ts`, updated `createModelLock`, `acquireModelLocks`, `waitForPerModelLocks`, and `scanModelLocks` to be namespace-aware.
- Updated `design/datastores.md` to remove the "deferred" language and document the new behavior.

Fixes swamp-club#1323

## Test Plan

- [x] Reproduced the bug: created a namespaced filesystem repo, ran a model method, observed `.lock` at the un-namespaced root
- [x] Verified the fix: lock now lands under `{namespace}/data/{type}/{id}/.lock`
- [x] 9 new unit tests for `modelLockKey`, `stripNamespacePrefix`, and namespaced `scanModelLocks`
- [x] All 80 existing tests pass (31 lock + 49 repo_context)
- [x] Type check, lint, and format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)