### PR TITLE
fix(serve): force HTTP/1.1 ALPN on WebSocket client for reverse proxy compatibility

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -325,14 +325,22 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
     ) as T;
 }
 
+// Force HTTP/1.1 ALPN for wss:// connections so WebSocket upgrades succeed
+// through HTTP/2-capable reverse proxies (Caddy, Traefik, nginx). Without
+// this, Deno's default client advertises h2 ALPN, the proxy selects h2, and
+// the HTTP/1.1 WebSocket Upgrade is invalid over HTTP/2.
+// See: https://github.com/denoland/deno/issues/16923
+const wsHttpClient = Deno.createHttpClient({ http2: false });
+
 function defaultCreateSocket(
   url: string,
   headers?: Record<string, string>,
 ): WebSocket {
+  const opts: Record<string, unknown> = { client: wsHttpClient };
   if (headers && Object.keys(headers).length > 0) {
-    return new WebSocket(url, { headers });
+    opts.headers = headers;
   }
-  return new WebSocket(url);
+  return new WebSocket(url, opts);
 }
 
 interface OutboundRequest {

--- a/src/worker/connect.ts
+++ b/src/worker/connect.ts
@@ -48,6 +48,10 @@ import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
 const logger = getSwampLogger(["worker", "connect"]);
 
+// Force HTTP/1.1 ALPN for wss:// so WebSocket upgrades succeed through
+// HTTP/2-capable reverse proxies. See: https://github.com/denoland/deno/issues/16923
+const wsHttpClient = Deno.createHttpClient({ http2: false });
+
 /** Refresh the session credential when 2/3 of its lifetime has elapsed. */
 const REFRESH_FRACTION = 2 / 3;
 
@@ -332,10 +336,13 @@ interface ConnectOnceArgs {
 function connectOnce(args: ConnectOnceArgs): Promise<string> {
   const { options, instanceUuid, machineId, session } = args;
   return new Promise<string>((resolve, reject) => {
-    const defaultCreate = (url: string, headers?: Record<string, string>) =>
-      headers && Object.keys(headers).length > 0
-        ? new WebSocket(url, { headers })
-        : new WebSocket(url);
+    const defaultCreate = (url: string, headers?: Record<string, string>) => {
+      const opts: Record<string, unknown> = { client: wsHttpClient };
+      if (headers && Object.keys(headers).length > 0) {
+        opts.headers = headers;
+      }
+      return new WebSocket(url, opts);
+    };
     const socket = (options.createSocket ?? defaultCreate)(
       options.url,
       options.headers,


### PR DESCRIPTION
## Summary

Fixes swamp-club#1345 and swamp-club#1363 — `--server wss://` connections fail through HTTP/2-capable reverse proxies (Caddy, Traefik, nginx) because Deno's default WebSocket client advertises `h2` in TLS ALPN, the proxy selects h2, and the HTTP/1.1 WebSocket Upgrade is invalid over HTTP/2.

The fix passes `Deno.createHttpClient({ http2: false })` to the WebSocket constructor via Deno's `client` option, forcing the TLS ALPN to advertise only `http/1.1`. This is the same mechanism Deno's own fix for [denoland/deno#16923](https://github.com/denoland/deno/issues/16923) uses (merged in [denoland/deno#19303](https://github.com/denoland/deno/pull/19303)).

Changes:
- `src/cli/remote_run.ts` — `defaultCreateSocket` passes a shared `http2: false` HTTP client
- `src/worker/connect.ts` — `connectOnce` default socket factory does the same

## Test Plan

- `deno run test src/cli/remote_run_test.ts` — 24 passed
- `deno run test src/worker/connect_test.ts` — 4 passed
- Verified via local Caddy proxy test that `Deno.createHttpClient({ http2: false })` forces ALPN to `"http/1.1"` even when the server offers `[h2, http/1.1]`
- Needs confirmation from reporter on Linux/Traefik setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)