### PR TITLE
feat(model): show auto-created indicator in model get output

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -15,22 +15,18 @@ description: >
 
 ## Core Concepts
 
-- **Models** — typed definitions of resources (an EC2 instance, a DNS record, a
-  GitHub repo). Each exposes **methods** (create, start, stop, destroy, sync)
-  that operate on the real resource.
-- **Data** — versioned state snapshots produced by method runs; other models
-  reference them via CEL expressions.
-- **Workflows** — declarative DAGs chaining model methods, wiring step outputs
-  into step inputs.
-- **Vaults** — secret storage (API keys, tokens) that models reference at
-  runtime.
+- **Models** — typed resource definitions exposing **methods** (create, stop,
+  destroy, sync). Auto-created models (via direct type execution) live in
+  `.swamp/auto-definitions/` for data ownership only — they are not visible in
+  `model search`/`list`.
+- **Data** — versioned state snapshots produced by method runs; referenced via
+  CEL expressions.
+- **Workflows** — declarative DAGs chaining model methods.
+- **Vaults** — secret storage referenced by models at runtime.
 - **Extensions** — TypeScript packages adding model types, vault backends,
-  datastores, and report generators; published to a registry.
-- **Reports** — summaries of data across models for observability.
-- **Grants** — authorization rules controlling who can do what on a swamp serve
-  instance. Authored via CLI commands or YAML files in the `grants/` directory.
-- **Serve** — exposes the repo over the network with TLS, authentication (token
-  or OAuth via swamp-club), and grant-based authorization.
+  datastores, and reports; published to a registry.
+- **Grants** — authorization rules for swamp serve access control.
+- **Serve** — exposes the repo over the network with TLS and authentication.
 
 ## Routing Table
 

--- a/.claude/skills/swamp/references/model/references/direct-execution.md
+++ b/.claude/skills/swamp/references/model/references/direct-execution.md
@@ -28,11 +28,14 @@ ambiguous keys, unknown keys are rejected.
 
 ## Storage
 
-Auto-created definitions live in `.swamp/auto-definitions/{type}/{id}.yaml`:
+Auto-created definitions live in `.swamp/auto-definitions/{type}/{id}.yaml`.
+They exist for data ownership boundaries — giving model data a home without
+requiring a hand-authored definition file.
 
 - Not git-tracked (local runtime state)
-- Not shown in `swamp model search`
+- Not visible in `swamp model search` or `swamp model list` (by design)
 - Findable by name for `model get`, `model method run`, workflows
+- `swamp model get` shows `Auto-created: yes` for these definitions
 - Synced via datastores when configured (shared across team)
 
 ## Input Routing

--- a/.claude/skills/swamp/references/workflow/references/direct-execution.md
+++ b/.claude/skills/swamp/references/workflow/references/direct-execution.md
@@ -21,7 +21,9 @@ task:
 - `modelIdOrName` and `modelType` are **mutually exclusive** — the schema
   rejects YAML with both.
 - `modelType` requires `modelName` to name the auto-created definition.
-- Auto-created definitions are stored in `.swamp/auto-definitions/`.
+- Auto-created definitions are stored in `.swamp/auto-definitions/` and exist
+  for data ownership boundaries. They are not visible in `swamp model search` or
+  `swamp model list` (by design). Use `swamp model get <name>` to inspect them.
 - Inputs are routed between global args and method args using the type's schemas
   (method args take precedence on ambiguous keys).
 - An optional `globalArgs` field passes global arguments explicitly, bypassing

--- a/design/models.md
+++ b/design/models.md
@@ -172,9 +172,11 @@ automatically — this ensures parameterized workflows that vary inputs per run
 always use the current values.
 
 **Storage:** Auto-created definitions live in `.swamp/auto-definitions/` (not
-`models/`). They are local runtime state, not git-tracked, and do not appear in
-`swamp model search` results. They are findable by name for `model get`,
-`model method run`, and workflow references.
+`models/`). They exist for data ownership boundaries — giving model data a home
+without requiring a hand-authored definition file. They are local runtime state,
+not git-tracked, and do not appear in `swamp model search` results (by design).
+They are findable by name for `model get`, `model method run`, and workflow
+references. `model get` shows `Auto-created: yes` for these definitions.
 
 ### Choosing Between the Two
 

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -44,6 +44,7 @@ export interface ModelGetData {
   version: number;
   tags: Record<string, string>;
   globalArguments: Record<string, unknown>;
+  autoCreated?: boolean;
   typeVersion?: string;
   globalArgumentsSchema?: object;
   methods?: MethodDescribeData[];
@@ -58,7 +59,9 @@ export type ModelGetEvent =
 export interface ModelGetDeps {
   lookupDefinition: (
     idOrName: string,
-  ) => Promise<{ definition: Definition; type: ModelType } | null>;
+  ) => Promise<
+    { definition: Definition; type: ModelType; autoCreated?: boolean } | null
+  >;
   getModelDef: (
     type: ModelType,
   ) => ModelDefinition | undefined | Promise<ModelDefinition | undefined>;
@@ -71,8 +74,21 @@ export async function createModelGetDeps(
   await modelRegistry.ensureLoaded();
   const definitionRepo = new YamlDefinitionRepository(repoDir);
   return {
-    lookupDefinition: (idOrName) =>
-      findDefinitionByIdOrName(definitionRepo, idOrName),
+    lookupDefinition: async (idOrName) => {
+      const result = await findDefinitionByIdOrName(definitionRepo, idOrName);
+      if (!result) return null;
+      const primaryPath = definitionRepo.getPath(
+        result.type,
+        result.definition.id,
+      );
+      let autoCreated = false;
+      try {
+        await Deno.stat(primaryPath);
+      } catch {
+        autoCreated = true;
+      }
+      return { ...result, autoCreated };
+    },
     getModelDef: async (type) => {
       await modelRegistry.ensureTypeLoaded(type);
       return modelRegistry.get(type);
@@ -98,7 +114,7 @@ export async function* modelGet(
         return;
       }
 
-      const { definition, type: modelType } = result;
+      const { definition, type: modelType, autoCreated } = result;
       const modelDef = await deps.getModelDef(modelType);
 
       // Redact global arguments marked `{ sensitive: true }` before they enter
@@ -120,6 +136,7 @@ export async function* modelGet(
         version: definition.version,
         tags: definition.tags,
         globalArguments,
+        autoCreated: autoCreated || undefined,
         typeVersion: modelDef?.version,
         globalArgumentsSchema: modelDef?.globalArguments
           ? zodToJsonSchema(modelDef.globalArguments)

--- a/src/libswamp/models/get_test.ts
+++ b/src/libswamp/models/get_test.ts
@@ -32,7 +32,9 @@ function completedData(events: ModelGetEvent[]) {
 }
 
 function makeDeps(overrides: {
-  lookupResult?: { definition: object; type: object } | null;
+  lookupResult?:
+    | { definition: object; type: object; autoCreated?: boolean }
+    | null;
   modelDef?: object | undefined;
 }): ModelGetDeps {
   return {
@@ -80,12 +82,30 @@ Deno.test("modelGet yields resolving -> completed with model data on success", a
         version: 3,
         tags: { env: "prod" },
         globalArguments: { region: "us-east-1" },
+        autoCreated: undefined,
         typeVersion: undefined,
         globalArgumentsSchema: undefined,
         methods: undefined,
       },
     },
   ]);
+});
+
+Deno.test("modelGet: surfaces autoCreated flag when lookup returns it", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: testDefinition,
+      type: testModelType,
+      autoCreated: true,
+    },
+    modelDef: undefined,
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "my-model"),
+  );
+
+  assertEquals(completedData(events).autoCreated, true);
 });
 
 Deno.test("modelGet redacts sensitive global arguments when the schema is known", async () => {

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -124,6 +124,10 @@ class LogModelGetRenderer implements Renderer<ModelGetEvent> {
           `${bold(cyan("Version:"))} ${data.version}`,
         ];
 
+        if (data.autoCreated) {
+          lines.push(`${bold(cyan("Auto-created:"))} ${dim("yes")}`);
+        }
+
         const tagEntries = Object.entries(data.tags);
         if (tagEntries.length > 0) {
           lines.push("");

--- a/src/presentation/renderers/model_get_test.ts
+++ b/src/presentation/renderers/model_get_test.ts
@@ -107,6 +107,61 @@ Deno.test("createModelGetRenderer - factory returns correct type per mode", () =
   assertEquals(typeof jsonRenderer.handlers, "function");
 });
 
+Deno.test("LogModelGetRenderer - auto-created model runs without error", async () => {
+  const renderer = createModelGetRenderer("log");
+  const events: ModelGetEvent[] = [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: { ...testData, autoCreated: true },
+    },
+  ];
+  await consumeStream(toStream(events), renderer.handlers());
+});
+
+Deno.test("JsonModelGetRenderer - auto-created flag appears in JSON output", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createModelGetRenderer("json");
+    const events: ModelGetEvent[] = [
+      { kind: "resolving" },
+      {
+        kind: "completed",
+        data: { ...testData, autoCreated: true },
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.autoCreated, true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonModelGetRenderer - autoCreated absent when not set", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createModelGetRenderer("json");
+    const events: ModelGetEvent[] = [
+      { kind: "resolving" },
+      { kind: "completed", data: testData },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.autoCreated, undefined);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("formatSchemaType: returns undefined for undefined input", () => {
   assertEquals(formatSchemaType(undefined), undefined);
 });


### PR DESCRIPTION
## Summary

- `swamp model get` now shows `Auto-created: yes` (log mode) / `"autoCreated": true` (JSON mode) when a definition lives in `.swamp/auto-definitions/` rather than `models/`
- Updated skill docs and `design/models.md` to explain that auto-created definitions exist for data ownership boundaries and are intentionally not visible in `model search`/`list`

Closes swamp-club#1370

Co-authored-by: Simon Helson <shelson@users.noreply.github.com>

## Test Plan

- [x] Unit tests for `autoCreated` flag threading through `ModelGetData` (true and undefined cases)
- [x] Renderer tests for log-mode output and JSON presence/absence of the flag
- [x] Verified with compiled binary: auto-created model shows indicator, regular model does not
- [x] `deno fmt`, `deno lint`, `deno check` all pass
- [x] All 19 affected tests pass