### PR TITLE
fix(datastore): transfer content from cache when switching remote datastore to filesystem (swamp-club#1271)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -1316,6 +1316,17 @@ errors, so the user knows re-running is safe without consulting documentation.
 Run `swamp datastore setup` again with the new backend type. The setup command
 migrates data from the current location to the new one.
 
+When switching **from a remote/sync-based datastore to filesystem**, the CLI
+resolves the outgoing datastore's local cache path
+(`~/.swamp/repos/{repoId}/`) and passes it to `datastoreSetupFilesystem` as
+`outgoingCachePath`. The migration copies content from the cache — not from
+`{repoDir}/.swamp`, which is empty for remote datastores. If the cache path
+does not exist or cannot be resolved (e.g. the outgoing extension was
+uninstalled), the setup falls back to `{repoDir}/.swamp` and logs a warning.
+
+To ensure the cache is fully up to date before switching, run
+`swamp datastore sync --pull` first.
+
 ### Health Verification
 
 `requireInitializedRepo()` (write commands) and

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -18,16 +18,13 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
-import { isAbsolute, resolve } from "@std/path";
+import { isAbsolute, join, resolve } from "@std/path";
 import {
   createContext,
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import {
-  requireInitializedRepo,
-  resolveDatastoreForRepo,
-} from "../repo_context.ts";
+import { resolveDatastoreForRepo } from "../repo_context.ts";
 import {
   consumeStream,
   createDatastoreSetupDeps,
@@ -42,11 +39,14 @@ import {
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import { expandEnvVars } from "../../infrastructure/persistence/env_path.ts";
+import { getSwampDataDir } from "../../infrastructure/persistence/paths.ts";
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { resolveDatastoreType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { RENAMED_DATASTORE_TYPES } from "../resolve_datastore.ts";
 import { UserError } from "../../domain/errors.ts";
+import { RepoPath } from "../../domain/repo/repo_path.ts";
+import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { parseTimeoutFlag } from "./datastore_sync.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
@@ -62,6 +62,47 @@ import {
 type AnyOptions = any;
 
 const encoder = new TextEncoder();
+
+/**
+ * Resolves the outgoing datastore's cache path when switching to filesystem.
+ * Returns undefined when the current datastore is already filesystem-based.
+ */
+async function resolveOutgoingCachePath(
+  repoDir: string,
+): Promise<{ resolvedRepoDir: string; outgoingCachePath?: string }> {
+  try {
+    const { repoDir: resolvedRepoDir, datastoreConfig, marker } =
+      await resolveDatastoreForRepo(repoDir);
+    if (isCustomDatastoreConfig(datastoreConfig)) {
+      const cachePath = datastoreConfig.cachePath ??
+        join(getSwampDataDir(), "repos", marker?.repoId ?? "unknown");
+      return { resolvedRepoDir, outgoingCachePath: cachePath };
+    }
+    return { resolvedRepoDir };
+  } catch {
+    // Extension may be uninstalled — fall back to reading the marker
+    // directly to get repoId and compute the default cache path.
+    const repoPath = RepoPath.create(repoDir);
+    try {
+      const markerRepo = new RepoMarkerRepository();
+      const marker = await markerRepo.read(repoPath);
+      if (marker?.repoId && marker?.datastore?.type !== "filesystem") {
+        const cachePath = join(
+          getSwampDataDir(),
+          "repos",
+          marker.repoId,
+        );
+        return {
+          resolvedRepoDir: repoPath.value,
+          outgoingCachePath: cachePath,
+        };
+      }
+      return { resolvedRepoDir: repoPath.value };
+    } catch {
+      return { resolvedRepoDir: repoPath.value };
+    }
+  }
+}
 
 async function nudgeVaultMigration(repoDir: string): Promise<void> {
   try {
@@ -109,7 +150,7 @@ const datastoreSetupFilesystemCommand = new Command()
   )
   .option(
     "--skip-migration",
-    "Skip copying existing .swamp/ data into the target path",
+    "Skip copying existing data into the target path",
   )
   .action(async function (options: AnyOptions) {
     const cliCtx = createContext(options as GlobalOptions, [
@@ -118,10 +159,8 @@ const datastoreSetupFilesystemCommand = new Command()
       "filesystem",
     ]);
 
-    const { repoDir } = await requireInitializedRepo({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
+    const { resolvedRepoDir: repoDir, outgoingCachePath } =
+      await resolveOutgoingCachePath(resolveRepoDir(options.repoDir));
 
     // Expand env vars (e.g. ~/data or $HOME/data) then resolve path
     const expandedPath = expandEnvVars(options.path);
@@ -140,6 +179,7 @@ const datastoreSetupFilesystemCommand = new Command()
         directories: options.directories ??
           [...DEFAULT_DATASTORE_SUBDIRS],
         skipMigration: !!options.skipMigration,
+        outgoingCachePath,
       }),
       renderer.handlers(),
     );
@@ -336,13 +376,20 @@ export const datastoreSetupCommand = new Command()
 
     const repoDir = resolveRepoDir(options.repoDir);
 
-    // Show the current datastore configuration
+    // Resolve the current datastore configuration up front. The result is
+    // reused later by the filesystem branch to detect a remote-to-filesystem
+    // transition (ADV-6: avoids a redundant resolveDatastoreForRepo call).
+    let currentResolution:
+      | Awaited<
+        ReturnType<typeof resolveDatastoreForRepo>
+      >
+      | undefined;
     try {
-      const { datastoreConfig } = await resolveDatastoreForRepo(repoDir);
+      currentResolution = await resolveDatastoreForRepo(repoDir);
       await Deno.stdout.write(
         encoder.encode(
           `\nCurrent datastore: ${
-            describeCurrentDatastore(datastoreConfig)
+            describeCurrentDatastore(currentResolution.datastoreConfig)
           }\n\n`,
         ),
       );
@@ -489,10 +536,24 @@ export const datastoreSetupCommand = new Command()
 
     // Execute the chosen setup path
     if (filesystemPath) {
-      const { repoDir: resolvedRepoDir } = await requireInitializedRepo({
-        repoDir,
-        outputMode: cliCtx.outputMode,
-      });
+      let resolvedRepoDir: string;
+      let outgoingCachePath: string | undefined;
+
+      if (currentResolution) {
+        resolvedRepoDir = currentResolution.repoDir;
+        if (isCustomDatastoreConfig(currentResolution.datastoreConfig)) {
+          outgoingCachePath = currentResolution.datastoreConfig.cachePath ??
+            join(
+              getSwampDataDir(),
+              "repos",
+              currentResolution.marker?.repoId ?? "unknown",
+            );
+        }
+      } else {
+        const result = await resolveOutgoingCachePath(repoDir);
+        resolvedRepoDir = result.resolvedRepoDir;
+        outgoingCachePath = result.outgoingCachePath;
+      }
 
       const expandedPath = expandEnvVars(filesystemPath);
       const datastorePath = isAbsolute(expandedPath)
@@ -509,6 +570,7 @@ export const datastoreSetupCommand = new Command()
           repoDir: resolvedRepoDir,
           directories: [...DEFAULT_DATASTORE_SUBDIRS],
           skipMigration: false,
+          outgoingCachePath,
         }),
         renderer.handlers(),
       );

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -83,6 +83,13 @@ export interface DatastoreSetupFilesystemInput {
   repoDir: string;
   directories?: string[];
   skipMigration: boolean;
+  /**
+   * When switching from a remote/sync-based datastore, the absolute path
+   * to the outgoing datastore's local cache (e.g. ~/.swamp/repos/{repoId}).
+   * If provided and the directory exists, migration reads from this path
+   * instead of {repoDir}/.swamp.
+   */
+  outgoingCachePath?: string;
 }
 
 /** Dependencies for datastore setup operations. */
@@ -175,8 +182,26 @@ export async function* datastoreSetupFilesystem(
 
       if (!input.skipMigration) {
         yield { kind: "migrating" };
+
+        // When switching from a remote/sync-based datastore, content lives
+        // in the local cache, not under .swamp/. Use the cache path when
+        // it was provided and actually exists on disk.
+        let sourceDir = `${input.repoDir}/.swamp`;
+        if (input.outgoingCachePath) {
+          try {
+            const stat = await Deno.stat(input.outgoingCachePath);
+            if (stat.isDirectory) {
+              sourceDir = input.outgoingCachePath;
+              ctx.logger
+                .debug`Migrating from outgoing datastore cache at ${sourceDir}`;
+            }
+          } catch {
+            ctx.logger
+              .warn`Outgoing cache path ${input.outgoingCachePath} not found, falling back to ${sourceDir}`;
+          }
+        }
+
         ctx.logger.debug`Migrating data to ${input.datastorePath}...`;
-        const sourceDir = `${input.repoDir}/.swamp`;
         const config = {
           type: "filesystem" as const,
           path: input.datastorePath,
@@ -203,7 +228,7 @@ export async function* datastoreSetupFilesystem(
           );
         }
 
-        // Clean up migrated directories from .swamp/ on success
+        // Clean up migrated directories from source on success
         if (errors.length === 0 && directoriesMigrated.length > 0) {
           await deps.cleanupSourceDirs(sourceDir, directoriesMigrated);
         }

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -153,6 +153,111 @@ Deno.test("datastoreSetupFilesystem: errors on non-upgraded repo", async () => {
   assertEquals(error.error.code, "validation_failed");
 });
 
+Deno.test("datastoreSetupFilesystem: migrates from outgoing cache path when provided and exists", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    // Create a fake cache directory with content
+    await Deno.mkdir(join(tempDir, "data"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tempDir, "data", "test.json"),
+      '{"hello":"world"}',
+    );
+
+    let capturedSourceDir = "";
+    const deps = makeDeps({
+      migrateData: (sourceDir: string) => {
+        capturedSourceDir = sourceDir;
+        return Promise.resolve({
+          filesCopied: 1,
+          bytesCopied: 18,
+          directoriesMigrated: ["data"],
+          errors: [],
+        });
+      },
+    });
+    const input = makeFilesystemInput({ outgoingCachePath: tempDir });
+
+    const events = await collect<DatastoreSetupEvent>(
+      datastoreSetupFilesystem(createLibSwampContext(), deps, input),
+    );
+
+    assertEquals(
+      capturedSourceDir,
+      tempDir,
+      "migrateData should use the outgoing cache path as source",
+    );
+    const completed = events[events.length - 1] as Extract<
+      DatastoreSetupEvent,
+      { kind: "completed" }
+    >;
+    assertEquals(completed.kind, "completed");
+    assertEquals(completed.data.filesCopied, 1);
+    assertEquals(completed.data.errors, []);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("datastoreSetupFilesystem: falls back to .swamp/ when outgoing cache path does not exist", async () => {
+  let capturedSourceDir = "";
+  const deps = makeDeps({
+    migrateData: (sourceDir: string) => {
+      capturedSourceDir = sourceDir;
+      return Promise.resolve({
+        filesCopied: 5,
+        bytesCopied: 1024,
+        directoriesMigrated: ["data", "outputs"],
+        errors: [],
+      });
+    },
+  });
+  const input = makeFilesystemInput({
+    outgoingCachePath: "/nonexistent/cache/path",
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupFilesystem(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(
+    capturedSourceDir,
+    "/tmp/repo/.swamp",
+    "migrateData should fall back to .swamp/ when cache path does not exist",
+  );
+  const completed = events[events.length - 1] as Extract<
+    DatastoreSetupEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.filesCopied, 5);
+});
+
+Deno.test("datastoreSetupFilesystem: uses .swamp/ when no outgoing cache path provided", async () => {
+  let capturedSourceDir = "";
+  const deps = makeDeps({
+    migrateData: (sourceDir: string) => {
+      capturedSourceDir = sourceDir;
+      return Promise.resolve({
+        filesCopied: 5,
+        bytesCopied: 1024,
+        directoriesMigrated: ["data", "outputs"],
+        errors: [],
+      });
+    },
+  });
+  const input = makeFilesystemInput();
+
+  await collect<DatastoreSetupEvent>(
+    datastoreSetupFilesystem(createLibSwampContext(), deps, input),
+  );
+
+  assertEquals(
+    capturedSourceDir,
+    "/tmp/repo/.swamp",
+    "migrateData should use .swamp/ when no outgoing cache path is set",
+  );
+});
+
 // ============================================================================
 // Extension datastore setup tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- `datastoreSetupFilesystem` always migrated from `{repoDir}/.swamp`, which is empty when the repo uses a sync-based remote datastore — content lives in `~/.swamp/repos/{repoId}/`
- The CLI now resolves the outgoing datastore's cache path via `resolveDatastoreForRepo` and passes it as `outgoingCachePath` to the libswamp function
- When the cache directory exists, migration reads from it instead of `.swamp/`; falls back gracefully when the extension is uninstalled or the cache is missing
- Both CLI call sites updated: explicit `swamp datastore setup filesystem` subcommand and the interactive wizard

## Test Plan

- [x] 3 new unit tests in `setup_test.ts`: cache path happy path, missing cache fallback, no cache path (existing behavior)
- [x] All 46 tests pass (40 existing + 6 CLI)
- [x] End-to-end verification: set up repo on S3 (Minio), pushed 3 data files, switched to filesystem — all 3 files transferred correctly (previously only catalog DBs were copied)
- [x] `deno fmt`, `deno lint`, `deno check` all pass
- [x] Compiled binary and verified against reproduction scenario

Closes swamp-club#1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)