### PR TITLE
feat(auth): add `swamp auth token create` for collective tokens

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -19,10 +19,19 @@
 
 import { Command } from "@cliffy/command";
 import { groupCommandAction } from "../group_action.ts";
+import { unknownCommandErrorHandler } from "../unknown_command_handler.ts";
 import { authLoginCommand } from "./auth_login.ts";
 import { authLogoutCommand } from "./auth_logout.ts";
 import { authWhoamiCommand } from "./auth_whoami.ts";
 import { authServerLoginCommand } from "./auth_server_login.ts";
+import { authTokenCreateCommand } from "./auth_token_create.ts";
+
+export const authTokenCommand = new Command()
+  .name("token")
+  .description("Manage collective API tokens")
+  .error(unknownCommandErrorHandler)
+  .action(groupCommandAction)
+  .command("create", authTokenCreateCommand);
 
 export const authCommand = new Command()
   .name("auth")
@@ -31,4 +40,5 @@ export const authCommand = new Command()
   .command("login", authLoginCommand)
   .command("logout", authLogoutCommand)
   .command("whoami", authWhoamiCommand)
-  .command("server-login", authServerLoginCommand);
+  .command("server-login", authServerLoginCommand)
+  .command("token", authTokenCommand);

--- a/src/cli/commands/auth_token_create.ts
+++ b/src/cli/commands/auth_token_create.ts
@@ -1,0 +1,115 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { requireAuthenticated } from "../auth_context.ts";
+import { isCollectiveToken } from "../auth_context.ts";
+import { loadIdentity } from "../load_identity.ts";
+import {
+  authTokenCreate,
+  type AuthTokenCreateData,
+  type AuthTokenCreateEvent,
+  consumeStream,
+  createAuthTokenCreateDeps,
+  createLibSwampContext,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { renderAuthTokenCreate } from "../../presentation/output/auth_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const authTokenCreateCommand = new Command()
+  .name("create")
+  .description("Create a scoped API token for a collective")
+  .option(
+    "--collective <collective:string>",
+    "Collective slug to create the token for",
+    { required: true },
+  )
+  .option(
+    "--scopes <scopes:string>",
+    "Comma-separated scopes to grant (e.g. extensions:push,serve:*)",
+    { required: true },
+  )
+  .option(
+    "--name <name:string>",
+    "Token label (default: cli-<hostname>-<timestamp>)",
+  )
+  .example(
+    "Create a token with extension push scope",
+    "swamp auth token create --collective myorg --scopes extensions:push",
+  )
+  .example(
+    "Create a named token with multiple scopes",
+    'swamp auth token create --collective myorg --scopes "extensions:push,serve:*" --name ci-deploy',
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "auth",
+      "token",
+      "create",
+    ]);
+
+    requireAuthenticated(
+      "Creating collective tokens is a feature",
+      "collective:write",
+    );
+
+    const scopes = (options.scopes as string)
+      .split(",")
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
+
+    if (scopes.length === 0) {
+      throw new UserError("At least one scope is required (--scopes).");
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const identity = await loadIdentity();
+    const deps = createAuthTokenCreateDeps({
+      serverUrlOverride: Deno.env.get("SWAMP_CLUB_URL"),
+      identity,
+      isCollectiveToken,
+    });
+
+    let data: AuthTokenCreateData | undefined;
+
+    await consumeStream(
+      authTokenCreate(ctx, deps, {
+        collective: options.collective as string,
+        scopes,
+        name: options.name as string | undefined,
+      }),
+      withDefaults<AuthTokenCreateEvent>({
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+
+    if (data) {
+      renderAuthTokenCreate(data, cliCtx.outputMode);
+    }
+  });

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -27,6 +27,21 @@ import type { GenesisPass } from "../../domain/quest/genesis_pass.ts";
 
 export type { ClientIdentity };
 
+/** Response from creating a collective API token. */
+export interface CreateCollectiveTokenResponse {
+  token: {
+    id: string;
+    name: string;
+    keyPrefix: string;
+    enabled: boolean;
+    expiresAt: string | null;
+    createdAt: string;
+    lastUsedAt: string | null;
+    scopes: string[];
+  };
+  key: string;
+}
+
 /** Response from BetterAuth sign-in endpoint. */
 export interface SignInResponse {
   token: string;
@@ -605,6 +620,59 @@ export class SwampClubClient {
       const text = await res.text();
       throw new UserError(
         `Failed to fetch ghost quest pass (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    return await res.json();
+  }
+
+  /**
+   * Create a scoped API token for a collective.
+   * Requires a personal API key — collective tokens cannot create other tokens.
+   */
+  async createCollectiveToken(
+    apiKey: string,
+    collectiveSlug: string,
+    input: { name: string; scopes: string[] },
+    signal?: AbortSignal,
+  ): Promise<CreateCollectiveTokenResponse> {
+    const res = await this.fetch(
+      `/api/v1/collectives/${encodeURIComponent(collectiveSlug)}/api-tokens`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify({ name: input.name, scopes: input.scopes }),
+      },
+      signal,
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 401) {
+        throw new UserError(
+          "Not authenticated. Sign in with `swamp auth login`.",
+        );
+      }
+      if (res.status === 403) {
+        throw new UserError(
+          `You do not have permission to create tokens for collective "${collectiveSlug}". Only owners and admins can manage collective API tokens.`,
+        );
+      }
+      if (res.status === 404) {
+        throw new UserError(
+          `Collective "${collectiveSlug}" not found.`,
+        );
+      }
+      if (res.status === 422) {
+        throw new UserError(
+          `Invalid token request: ${text}`,
+        );
+      }
+      throw new UserError(
+        `Failed to create collective token (HTTP ${res.status}): ${text}`,
       );
     }
 

--- a/src/libswamp/auth/token_create.ts
+++ b/src/libswamp/auth/token_create.ts
@@ -1,0 +1,163 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import type { CreateCollectiveTokenResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
+import {
+  AuthRepository,
+  type AuthRepositoryOptions,
+} from "../../infrastructure/persistence/auth_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import {
+  cancelled,
+  notAuthenticated,
+  type SwampError,
+  validationFailed,
+} from "../errors.ts";
+
+export interface AuthTokenCreateData {
+  key: string;
+  id: string;
+  name: string;
+  collective: string;
+  scopes: string[];
+}
+
+export type AuthTokenCreateEvent =
+  | { kind: "creating"; collective: string; name: string }
+  | { kind: "completed"; data: AuthTokenCreateData }
+  | { kind: "error"; error: SwampError };
+
+export interface AuthTokenCreateInput {
+  collective: string;
+  scopes: string[];
+  name?: string;
+}
+
+export interface AuthTokenCreateDeps {
+  loadCredentials: () => Promise<AuthCredentials | null>;
+  createToken: (
+    serverUrl: string,
+    apiKey: string,
+    collective: string,
+    input: { name: string; scopes: string[] },
+    signal: AbortSignal,
+  ) => Promise<CreateCollectiveTokenResponse>;
+  getHostname: () => string;
+  getTimestamp: () => number;
+  isCollectiveToken: () => boolean;
+  serverUrlOverride?: string;
+}
+
+export interface CreateAuthTokenCreateDepsOptions {
+  serverUrlOverride?: string;
+  identity?: ClientIdentity;
+  repo?: AuthRepositoryOptions;
+  isCollectiveToken: () => boolean;
+}
+
+export function createAuthTokenCreateDeps(
+  options: CreateAuthTokenCreateDepsOptions,
+): AuthTokenCreateDeps {
+  const repo = new AuthRepository(options.repo);
+  return {
+    loadCredentials: () => repo.load(),
+    createToken: (serverUrl, apiKey, collective, input, signal) => {
+      const client = new SwampClubClient(serverUrl, options.identity);
+      return client.createCollectiveToken(apiKey, collective, input, signal);
+    },
+    getHostname: () => {
+      try {
+        return Deno.hostname?.() ?? "unknown";
+      } catch {
+        return "unknown";
+      }
+    },
+    getTimestamp: () => Date.now(),
+    isCollectiveToken: options.isCollectiveToken,
+    serverUrlOverride: options.serverUrlOverride,
+  };
+}
+
+export async function* authTokenCreate(
+  ctx: LibSwampContext,
+  deps: AuthTokenCreateDeps,
+  input: AuthTokenCreateInput,
+): AsyncIterable<AuthTokenCreateEvent> {
+  if (deps.isCollectiveToken()) {
+    yield {
+      kind: "error",
+      error: validationFailed(
+        "Collective tokens cannot create other collective tokens. Sign in with a personal account using `swamp auth login`.",
+      ),
+    };
+    return;
+  }
+
+  if (input.scopes.length === 0) {
+    yield {
+      kind: "error",
+      error: validationFailed("At least one scope is required."),
+    };
+    return;
+  }
+
+  const credentials = await deps.loadCredentials();
+  if (!credentials) {
+    yield { kind: "error", error: notAuthenticated() };
+    return;
+  }
+
+  const serverUrl = deps.serverUrlOverride ?? credentials.serverUrl ??
+    DEFAULT_SWAMP_CLUB_URL;
+  const host = deps.getHostname().slice(0, 14);
+  const tokenName = input.name ?? `cli-${host}-${deps.getTimestamp()}`;
+
+  yield { kind: "creating", collective: input.collective, name: tokenName };
+
+  try {
+    const response = await deps.createToken(
+      serverUrl,
+      credentials.apiKey,
+      input.collective,
+      { name: tokenName, scopes: input.scopes },
+      ctx.signal,
+    );
+
+    yield {
+      kind: "completed",
+      data: {
+        key: response.key,
+        id: response.token.id,
+        name: response.token.name,
+        collective: input.collective,
+        scopes: response.token.scopes,
+      },
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      yield { kind: "error", error: cancelled(error) };
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/libswamp/auth/token_create_test.ts
+++ b/src/libswamp/auth/token_create_test.ts
@@ -1,0 +1,254 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import type { CreateCollectiveTokenResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import { createLibSwampContext } from "../context.ts";
+import { collect } from "../testing.ts";
+import {
+  authTokenCreate,
+  type AuthTokenCreateDeps,
+  type AuthTokenCreateEvent,
+} from "./token_create.ts";
+
+const testCredentials: AuthCredentials = {
+  serverUrl: "https://swamp-club.com",
+  apiKey: "swamp_test_key",
+  apiKeyId: "key-1",
+  username: "adam",
+};
+
+const testTokenResponse: CreateCollectiveTokenResponse = {
+  token: {
+    id: "tok-1",
+    name: "cli-testhost-1700000000",
+    keyPrefix: "swamp_org_ab",
+    enabled: true,
+    expiresAt: null,
+    createdAt: "2026-07-23T00:00:00Z",
+    lastUsedAt: null,
+    scopes: ["extensions:push"],
+  },
+  key:
+    "swamp_org_abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+};
+
+function makeDeps(
+  overrides: Partial<AuthTokenCreateDeps> = {},
+): AuthTokenCreateDeps {
+  return {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    createToken: () => Promise.resolve(testTokenResponse),
+    getHostname: () => "testhost",
+    getTimestamp: () => 1700000000,
+    isCollectiveToken: () => false,
+    ...overrides,
+  };
+}
+
+Deno.test("authTokenCreate: yields creating -> completed on success", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  assertEquals(events, [
+    { kind: "creating", collective: "myorg", name: "cli-testhost-1700000000" },
+    {
+      kind: "completed",
+      data: {
+        key: testTokenResponse.key,
+        id: "tok-1",
+        name: "cli-testhost-1700000000",
+        collective: "myorg",
+        scopes: ["extensions:push"],
+      },
+    },
+  ]);
+});
+
+Deno.test("authTokenCreate: uses provided name instead of generating one", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+      name: "ci-deploy",
+    }),
+  );
+
+  assertEquals(events[0], {
+    kind: "creating",
+    collective: "myorg",
+    name: "ci-deploy",
+  });
+});
+
+Deno.test("authTokenCreate: rejects collective tokens", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ isCollectiveToken: () => true });
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenCreateEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "validation_failed");
+});
+
+Deno.test("authTokenCreate: rejects empty scopes", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: [],
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenCreateEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "validation_failed");
+});
+
+Deno.test("authTokenCreate: yields not_authenticated when no credentials", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ loadCredentials: () => Promise.resolve(null) });
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenCreateEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "not_authenticated");
+});
+
+Deno.test("authTokenCreate: uses serverUrlOverride when provided", async () => {
+  const ctx = createLibSwampContext();
+  const calledUrls: string[] = [];
+  const deps = makeDeps({
+    createToken: (serverUrl, _apiKey, _collective, _input, _signal) => {
+      calledUrls.push(serverUrl);
+      return Promise.resolve(testTokenResponse);
+    },
+    serverUrlOverride: "https://custom.server",
+  });
+
+  await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  assertEquals(calledUrls, ["https://custom.server"]);
+});
+
+Deno.test("authTokenCreate: truncates hostname to 14 chars", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({
+    getHostname: () => "a-very-long-hostname-that-exceeds-fourteen-chars",
+  });
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  const creating = events[0] as Extract<
+    AuthTokenCreateEvent,
+    { kind: "creating" }
+  >;
+  assertEquals(creating.name, "cli-a-very-long-ho-1700000000");
+});
+
+Deno.test("authTokenCreate: yields cancelled error on abort", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const ctx = createLibSwampContext({ signal: controller.signal });
+  const deps = makeDeps({
+    createToken: (_serverUrl, _apiKey, _collective, _input, signal) => {
+      signal.throwIfAborted();
+      return Promise.resolve(testTokenResponse);
+    },
+  });
+
+  const events = await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push"],
+    }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    AuthTokenCreateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "cancelled");
+});
+
+Deno.test("authTokenCreate: passes correct input to createToken", async () => {
+  const ctx = createLibSwampContext();
+  let capturedInput: { name: string; scopes: string[] } | undefined;
+  let capturedCollective: string | undefined;
+  const deps = makeDeps({
+    createToken: (_serverUrl, _apiKey, collective, input, _signal) => {
+      capturedCollective = collective;
+      capturedInput = input;
+      return Promise.resolve(testTokenResponse);
+    },
+  });
+
+  await collect<AuthTokenCreateEvent>(
+    authTokenCreate(ctx, deps, {
+      collective: "myorg",
+      scopes: ["extensions:push", "serve:*"],
+      name: "my-token",
+    }),
+  );
+
+  assertEquals(capturedCollective, "myorg");
+  assertEquals(capturedInput, {
+    name: "my-token",
+    scopes: ["extensions:push", "serve:*"],
+  });
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1247,6 +1247,17 @@ export {
   createAuthLoginDeps,
 } from "./auth/login.ts";
 
+// Auth token create operations
+export {
+  authTokenCreate,
+  type AuthTokenCreateData,
+  type AuthTokenCreateDeps,
+  type AuthTokenCreateEvent,
+  type AuthTokenCreateInput,
+  createAuthTokenCreateDeps,
+  type CreateAuthTokenCreateDepsOptions,
+} from "./auth/token_create.ts";
+
 // Auth logout operations
 export {
   authLogout,

--- a/src/presentation/output/auth_token_output.ts
+++ b/src/presentation/output/auth_token_output.ts
@@ -1,0 +1,45 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, cyan, yellow } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { AuthTokenCreateData } from "../../libswamp/mod.ts";
+import type { OutputMode } from "./output.ts";
+
+export function renderAuthTokenCreate(
+  data: AuthTokenCreateData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  const lines = [
+    `Token created for collective "${data.collective}"`,
+    `${bold(cyan("Scopes:"))} ${data.scopes.join(", ")}`,
+    "",
+    `  ${bold(data.key)}`,
+    "",
+    yellow(
+      "This token is shown once and will not be displayed again — save it now.",
+    ),
+  ];
+  writeOutput(lines.join("\n"));
+}


### PR DESCRIPTION
## Summary

Adds a CLI command to create scoped collective API tokens, completing phase 8 of #960. Users can now provision tokens from the CLI instead of requiring the web UI.

```
swamp auth token create --collective myorg --scopes extensions:push,serve:*
```

- Adds `createCollectiveToken` method to `SwampClubClient` with distinct error handling for 401/403/404/422
- Adds libswamp async generator (`authTokenCreate`) with dependency injection following the `workerTokenCreate` pattern
- Blocks collective tokens from creating other tokens (defense-in-depth — server also enforces this)
- Generates default token name using `cli-<hostname>-<timestamp>` pattern from `auth login`
- Supports both log and JSON output modes
- 9 unit tests covering success path, validation, auth checks, cancellation, and input passthrough

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes
- [x] `deno fmt --check` — formatting passes
- [x] `deno run test src/libswamp/auth/token_create_test.ts` — 9/9 tests pass
- [x] `deno run compile` — binary compiles
- [x] `swamp auth token create --help` — shows correct usage, flags, and examples
- [x] Manual e2e: ran `swamp auth token create --collective <slug> --scopes extensions:push` against live swamp-club — token created successfully with correct scopes

Closes swamp-club#1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)