### PR TITLE
fix(datastore): restore init validation and fix cleanup ordering in filesystem setup

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -83,24 +83,26 @@ async function resolveOutgoingCachePath(
     // Extension may be uninstalled — fall back to reading the marker
     // directly to get repoId and compute the default cache path.
     const repoPath = RepoPath.create(repoDir);
-    try {
-      const markerRepo = new RepoMarkerRepository();
-      const marker = await markerRepo.read(repoPath);
-      if (marker?.repoId && marker?.datastore?.type !== "filesystem") {
-        const cachePath = join(
-          getSwampDataDir(),
-          "repos",
-          marker.repoId,
-        );
-        return {
-          resolvedRepoDir: repoPath.value,
-          outgoingCachePath: cachePath,
-        };
-      }
-      return { resolvedRepoDir: repoPath.value };
-    } catch {
-      return { resolvedRepoDir: repoPath.value };
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(repoPath);
+    if (!marker) {
+      throw new UserError(
+        `Not a swamp repository: ${repoPath.value}. ` +
+          "To initialize a new repository, run 'swamp repo init'.",
+      );
     }
+    if (marker.repoId && marker.datastore?.type !== "filesystem") {
+      const cachePath = join(
+        getSwampDataDir(),
+        "repos",
+        marker.repoId,
+      );
+      return {
+        resolvedRepoDir: repoPath.value,
+        outgoingCachePath: cachePath,
+      };
+    }
+    return { resolvedRepoDir: repoPath.value };
   }
 }
 

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -179,6 +179,7 @@ export async function* datastoreSetupFilesystem(
       let bytesCopied = 0;
       let directoriesMigrated: string[] = [];
       const errors: string[] = [];
+      let sourceDir = `${input.repoDir}/.swamp`;
 
       if (!input.skipMigration) {
         yield { kind: "migrating" };
@@ -186,7 +187,6 @@ export async function* datastoreSetupFilesystem(
         // When switching from a remote/sync-based datastore, content lives
         // in the local cache, not under .swamp/. Use the cache path when
         // it was provided and actually exists on disk.
-        let sourceDir = `${input.repoDir}/.swamp`;
         if (input.outgoingCachePath) {
           try {
             const stat = await Deno.stat(input.outgoingCachePath);
@@ -227,16 +227,12 @@ export async function* datastoreSetupFilesystem(
             `Migration verification: source has ${verification.sourceCount} files, destination has ${verification.destCount}`,
           );
         }
-
-        // Clean up migrated directories from source on success
-        if (errors.length === 0 && directoriesMigrated.length > 0) {
-          await deps.cleanupSourceDirs(sourceDir, directoriesMigrated);
-        }
       }
 
       // Update .swamp.yaml only when migration succeeded (or was skipped).
-      // Mirrors the extension path guard — avoids pointing the config at
-      // a destination with incomplete data.
+      // Persists BEFORE source cleanup so a crash leaves orphaned source
+      // data (harmless) rather than a repo still pointing at the old
+      // datastore with its cache already cleaned up.
       if (errors.length === 0) {
         const collapsedPath = deps.collapseEnvVars(input.datastorePath);
         await deps.updateRepoConfig(input.repoDir, {
@@ -244,6 +240,14 @@ export async function* datastoreSetupFilesystem(
           path: collapsedPath,
           directories: input.directories ?? undefined,
         });
+      }
+
+      // Clean up migrated directories from source after config is persisted
+      if (
+        !input.skipMigration && errors.length === 0 &&
+        directoriesMigrated.length > 0
+      ) {
+        await deps.cleanupSourceDirs(sourceDir, directoriesMigrated);
       }
 
       yield {


### PR DESCRIPTION
## Summary

Follow-up to #1943 (swamp-club#1271). Addresses two findings from the adversarial code review:

- **Restore repo initialization validation**: `resolveOutgoingCachePath`'s fallback path (extension uninstalled) now throws `UserError` when the marker is missing, instead of silently proceeding on an uninitialized directory
- **Fix cleanup ordering**: `.swamp.yaml` is persisted BEFORE cleaning up source directories, so a crash leaves orphaned source data (harmless) rather than a repo pointing at the old datastore with its cache already deleted

## Test Plan

- [x] All 46 existing tests pass — no behavior change for the happy path
- [x] `deno fmt`, `deno lint`, `deno check` all pass
- [x] Cleanup ordering change verified by reading the code flow: config update at line 237 now precedes cleanup at line 248

🤖 Generated with [Claude Code](https://claude.com/claude-code)