### PR TITLE
fix(workflows): populate run context in CEL after suspend+resume (swamp-club#1347)

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2043,6 +2043,15 @@ export class WorkflowExecutionService {
       resumeInputs,
     );
 
+    expressionContext.workflowRunId = existingRun.id;
+    expressionContext.run = {
+      id: existingRun.id,
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      startedAt: existingRun.startedAt!.toISOString(),
+      tags: { ...existingRun.tags },
+    };
+
     const evaluator = new WorkflowExpressionEvaluator(
       new CelEvaluator(),
     );

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3603,6 +3603,167 @@ Deno.test("run.id expression in step inputs resolves to the workflow run UUID", 
   });
 });
 
+Deno.test("resume: run.id expression in step inputs resolves after suspend+resume", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    const capturedContexts: StepExecutionContext[] = [];
+    const capturingExecutor: StepExecutor = {
+      execute(
+        _step: Step,
+        ctx: StepExecutionContext,
+      ): Promise<unknown> {
+        capturedContexts.push(ctx);
+        return Promise.resolve({ executed: true });
+      },
+    };
+
+    const workflow = Workflow.create({
+      name: "run-id-resume-test",
+      jobs: [
+        Job.create({
+          name: "j",
+          steps: [
+            Step.create({
+              name: "gate",
+              task: StepTask.manualApproval("Approve"),
+            }),
+            Step.create({
+              name: "s",
+              task: StepTask.model("test-model", "run", {
+                scopedKey: "result-${{ run.id }}",
+                wfName: "${{ run.workflowName }}",
+              }),
+              dependsOn: [
+                { step: "gate", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      capturingExecutor,
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+    assertEquals(suspended.status, "suspended");
+    assertEquals(capturedContexts.length, 0);
+
+    const toApprove = await runRepo.findById(workflow.id, suspended.id);
+    const waiting = toApprove!.findWaitingApprovalStep()!;
+    toApprove!.getJob(waiting.jobName)!.getStep(waiting.stepName)!.succeed();
+    await runRepo.save(workflow.id, toApprove!);
+
+    let resumedRun: WorkflowRun | undefined;
+    for await (
+      const event of service.resume(workflow.name, suspended.id)
+    ) {
+      if (event.kind === "completed") resumedRun = event.run;
+    }
+
+    assertEquals(resumedRun?.status, "succeeded");
+    assertEquals(capturedContexts.length, 1);
+
+    const ctx = capturedContexts[0];
+    assertNotEquals(ctx.expressionContext?.run, undefined);
+    assertEquals(ctx.expressionContext?.run?.id, suspended.id);
+    assertEquals(
+      ctx.expressionContext?.run?.workflowName,
+      "run-id-resume-test",
+    );
+    assertNotEquals(ctx.expressionContext?.run?.startedAt, undefined);
+  });
+});
+
+Deno.test("resume: workflowRunId expression resolves after suspend+resume", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    const capturedContexts: StepExecutionContext[] = [];
+    const capturingExecutor: StepExecutor = {
+      execute(
+        _step: Step,
+        ctx: StepExecutionContext,
+      ): Promise<unknown> {
+        capturedContexts.push(ctx);
+        return Promise.resolve({ executed: true });
+      },
+    };
+
+    const workflow = Workflow.create({
+      name: "wfrunid-resume-test",
+      jobs: [
+        Job.create({
+          name: "j",
+          steps: [
+            Step.create({
+              name: "gate",
+              task: StepTask.manualApproval("Approve"),
+            }),
+            Step.create({
+              name: "s",
+              task: StepTask.model("test-model", "run", {
+                runRef: "${{ workflowRunId }}",
+              }),
+              dependsOn: [
+                { step: "gate", condition: TriggerCondition.succeeded() },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      capturingExecutor,
+      undefined,
+      catalogStore,
+    );
+
+    const suspended = await service.execute(workflow.name);
+    assertEquals(suspended.status, "suspended");
+
+    const toApprove = await runRepo.findById(workflow.id, suspended.id);
+    const waiting = toApprove!.findWaitingApprovalStep()!;
+    toApprove!.getJob(waiting.jobName)!.getStep(waiting.stepName)!.succeed();
+    await runRepo.save(workflow.id, toApprove!);
+
+    let resumedRun: WorkflowRun | undefined;
+    for await (
+      const event of service.resume(workflow.name, suspended.id)
+    ) {
+      if (event.kind === "completed") resumedRun = event.run;
+    }
+
+    assertEquals(resumedRun?.status, "succeeded");
+    assertEquals(capturedContexts.length, 1);
+
+    const ctx = capturedContexts[0];
+    assertEquals(
+      ctx.expressionContext?.workflowRunId,
+      suspended.id,
+    );
+  });
+});
+
 Deno.test(
   "stepNameFromCompositeKey: preserves colons in the step name segment",
   () => {


### PR DESCRIPTION
## Summary

- Fixes `run.id`, `run.workflowName`, `run.startedAt`, `run.tags`, and
  `workflowRunId` being undefined in step-input CEL expressions after a
  workflow suspends at a `manual_approval` gate and resumes
- Root cause: the `resume()` method in `execution_service.ts` built a fresh
  `expressionContext` but never populated `run` or `workflowRunId` — these
  assignments existed only in `run()`
- Adds two unit tests exercising the full suspend→approve→resume cycle to
  verify both `run.*` and `workflowRunId` resolve after resume

## Test Plan

- [x] New unit test: `resume: run.id expression in step inputs resolves after suspend+resume`
- [x] New unit test: `resume: workflowRunId expression resolves after suspend+resume`
- [x] Existing `execution_service_test.ts` suite: 60 passed, 0 failed
- [x] Reproduced the bug in a scratch repo with the installed binary (failed before fix)
- [x] Verified the fix in the same scratch repo (succeeds after fix — both `RUNID` and `WFRUNID` resolve)
- [x] `deno check`, `deno lint`, `deno fmt` all pass

Closes swamp-club#1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)