### PR TITLE
fix(auth): polish auth token create output and error handling

### DIFF
--- a/src/cli/commands/auth_token_create.ts
+++ b/src/cli/commands/auth_token_create.ts
@@ -19,8 +19,7 @@
 
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
-import { requireAuthenticated } from "../auth_context.ts";
-import { isCollectiveToken } from "../auth_context.ts";
+import { isCollectiveToken, requireAuthenticated } from "../auth_context.ts";
 import { loadIdentity } from "../load_identity.ts";
 import {
   authTokenCreate,
@@ -32,6 +31,7 @@ import {
   withDefaults,
 } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import { renderAuthTokenCreate } from "../../presentation/output/auth_token_output.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -70,7 +70,7 @@ export const authTokenCreateCommand = new Command()
     ]);
 
     requireAuthenticated(
-      "Creating collective tokens is a feature",
+      "Collective tokens are a team feature",
       "collective:write",
     );
 
@@ -100,6 +100,13 @@ export const authTokenCreateCommand = new Command()
         name: options.name as string | undefined,
       }),
       withDefaults<AuthTokenCreateEvent>({
+        creating: (event) => {
+          if (cliCtx.outputMode === "log") {
+            writeOutput(
+              `Creating token "${event.name}" for collective "${event.collective}"...`,
+            );
+          }
+        },
         completed: (event) => {
           data = event.data;
         },

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -667,9 +667,16 @@ export class SwampClubClient {
         );
       }
       if (res.status === 422) {
-        throw new UserError(
-          `Invalid token request: ${text}`,
-        );
+        let message = text;
+        try {
+          const parsed = JSON.parse(text);
+          if (typeof parsed?.error === "string") {
+            message = parsed.error;
+          }
+        } catch {
+          // use raw text
+        }
+        throw new UserError(`Invalid token request: ${message}`);
       }
       throw new UserError(
         `Failed to create collective token (HTTP ${res.status}): ${text}`,

--- a/src/presentation/output/auth_token_output.ts
+++ b/src/presentation/output/auth_token_output.ts
@@ -32,13 +32,14 @@ export function renderAuthTokenCreate(
   }
 
   const lines = [
-    `Token created for collective "${data.collective}"`,
+    `${bold(cyan("Token:"))} ${bold(data.name)}`,
+    `${bold(cyan("Collective:"))} ${data.collective}`,
     `${bold(cyan("Scopes:"))} ${data.scopes.join(", ")}`,
     "",
     `  ${bold(data.key)}`,
     "",
     yellow(
-      "This token is shown once and will not be displayed again — save it now.",
+      "This token is shown once and will not be displayed again — store it now.",
     ),
   ];
   writeOutput(lines.join("\n"));


### PR DESCRIPTION
## Summary

Addresses review feedback from #1944 on `swamp auth token create`:

- **Show token name in log output** — adds `Token: <name>` and `Collective: <slug>` lines, matching the worker token pattern so users can identify tokens for later management
- **Fix `requireAuthenticated` wording** — changes "Creating collective tokens is a feature" to "Collective tokens are a team feature" to match the convention used by all other commands
- **Handle `creating` event** — shows "Creating token ... for collective ..." progress during the network call instead of silent waiting
- **Parse 422 error JSON** — extracts the `error` field from JSON responses instead of dumping raw response text
- **Consistent warning wording** — "store it now" matches the worker token warning (was "save it now")
- **Merge duplicate imports** — combines two `auth_context.ts` imports into one

## Test Plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — linting passes  
- [x] `deno fmt --check` — formatting passes
- [x] `deno run test src/libswamp/auth/token_create_test.ts` — 9/9 tests pass (no logic changes in the generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)