### PR TITLE
docs(skills): recommend setup extension --namespace for new shared datastores

### DIFF
--- a/.claude/skills/swamp/references/repo/reference.md
+++ b/.claude/skills/swamp/references/repo/reference.md
@@ -304,12 +304,12 @@ swamp datastore namespace unset --json                 # Remove namespace
 swamp datastore catalog pull --namespaces <list> --json # Pull foreign catalogs
 ```
 
-Standard multi-repo flow:
+Standard multi-repo flow (new shared setups):
 
 ```bash
-swamp datastore namespace set infra
-swamp datastore namespace migrate --confirm
-swamp datastore sync --push
+swamp datastore setup extension @swamp/s3-datastore \
+  --namespace infra \
+  --config '{"bucket":"shared-bucket","prefix":"swamp","region":"us-east-1"}'
 ```
 
 For the full command reference, output shapes, and cross-namespace data access,

--- a/.claude/skills/swamp/references/repo/references/namespaces.md
+++ b/.claude/skills/swamp/references/repo/references/namespaces.md
@@ -79,18 +79,22 @@ The standard flow when two repos share a remote datastore (e.g. S3 or GCS):
 
 ```bash
 # Repo 1 (infra):
-swamp datastore namespace set infra
-swamp datastore namespace migrate --confirm
-swamp datastore sync --push
+swamp datastore setup extension @swamp/s3-datastore \
+  --namespace infra \
+  --config '{"bucket":"shared-bucket","prefix":"swamp","region":"us-east-1"}'
 
 # Repo 2 (platform):
-swamp datastore namespace set platform
-swamp datastore namespace migrate --confirm
-swamp datastore sync --push
+swamp datastore setup extension @swamp/s3-datastore \
+  --namespace platform \
+  --config '{"bucket":"shared-bucket","prefix":"swamp","region":"us-east-1"}'
 ```
 
-After this, each repo's data lives under its own namespace prefix. Locks are
+This assigns the namespace and configures the datastore in one step. After
+setup, each repo's data lives under its own namespace prefix. Locks are
 per-namespace (`{prefix}/.locks/{namespace}.lock`), so the repos don't contend.
+
+> **Note:** `namespace set` + `namespace migrate` is only needed when converting
+> an existing solo repo to a namespaced layout — not for new shared setups.
 
 ## Cross-Namespace Data Access
 

--- a/.claude/skills/swamp/references/share/guide.md
+++ b/.claude/skills/swamp/references/share/guide.md
@@ -84,10 +84,16 @@ and config details, build a single `swamp datastore setup` command and run it.
 Save the exact command string — if it fails, you will re-run it verbatim after
 the user fixes the issue.
 
+Before building the command, ask: **"Will other repos share this datastore?"**
+If yes, ask for a namespace slug (lowercase alphanumeric + hyphens, e.g.
+`infra`) and add `--namespace <slug>` to the `setup extension` command. This
+assigns the namespace during setup in one step — no separate `namespace set` +
+`namespace migrate` needed.
+
 | Choice                      | Command                                                                                                             |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| AWS S3                      | `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"…","region":"…"}'`                        |
-| Google Cloud Storage        | `swamp datastore setup extension @swamp/gcs-datastore --config '{"bucket":"…"}'`                                    |
+| AWS S3                      | `swamp datastore setup extension @swamp/s3-datastore [--namespace <slug>] --config '{"bucket":"…","region":"…"}'`   |
+| Google Cloud Storage        | `swamp datastore setup extension @swamp/gcs-datastore [--namespace <slug>] --config '{"bucket":"…"}'`               |
 | S3-compatible (MinIO, etc.) | Same as S3 but add `"endpoint":"http://…","forcePathStyle":true` to config                                          |
 | Shared filesystem           | `swamp datastore setup filesystem --path <path>`                                                                    |
 | Other                       | `swamp extension search <keyword> --label datastore` → then `swamp datastore setup extension <type> --config '{…}'` |

--- a/.claude/skills/swamp/references/share/reference.md
+++ b/.claude/skills/swamp/references/share/reference.md
@@ -184,10 +184,10 @@ For multi-repo shared datastores, a namespace prevents data collisions. This is
 optional for simple two-person sharing but required when multiple repos share
 one S3 bucket.
 
-```bash
-swamp datastore namespace set <slug> --json
-swamp datastore namespace migrate --confirm --json
-```
+For new shared setups, include `--namespace <slug>` in the
+`swamp datastore setup extension` command — it assigns the namespace during
+setup in one step. Use `namespace set` + `namespace migrate` only when
+converting an existing solo repo.
 
 See [../repo/references/namespaces.md](../repo/references/namespaces.md) for
 full namespace documentation.


### PR DESCRIPTION
## Summary

Closes swamp-club#1356.

- Updated four skill files to recommend `swamp datastore setup extension --namespace` instead of the old `namespace set` + `namespace migrate` flow for new shared datastore setups
- Added a namespace question to the share skill's State 2 datastore flow
- Preserved existing `namespace set`/`migrate`/`unset` command documentation — those commands still work for converting existing solo repos

### Files changed

| File | Change |
|------|--------|
| `references/repo/references/namespaces.md` | Multi-Repo Workflow section now uses `setup extension --namespace` |
| `references/share/guide.md` | State 2 asks "Will other repos share this datastore?" and shows `[--namespace <slug>]` in the table |
| `references/repo/reference.md` | "Standard multi-repo flow" snippet updated |
| `references/share/reference.md` | Namespace section recommends `--namespace` for new setups |

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] Verified `--namespace` flag exists in `src/cli/commands/datastore_setup.ts`
- [x] Confirmed manual docs (`giga-swamp/add-namespace.md`) already reference the new flag
- [x] Old `namespace set`/`migrate`/`unset` command docs untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)