### PR TITLE
fix(datastore): stop stripping namespace from --config in setup extension (swamp-club#1302)

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -274,7 +274,7 @@ const datastoreSetupExtensionCommand = new Command()
       );
     }
 
-    const { namespace: configNamespace, ...providerConfig } = config;
+    const configNamespace = config.namespace;
 
     const { repoDir, marker } = await resolveDatastoreForRepo(
       resolveRepoDir(options.repoDir),
@@ -313,7 +313,7 @@ const datastoreSetupExtensionCommand = new Command()
     await consumeStream(
       datastoreSetupExtension(ctx, deps, {
         type: resolvedType,
-        config: providerConfig,
+        config,
         repoDir,
         repoId: marker?.repoId,
         skipMigration: !!options.skipMigration,

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -17,7 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { join } from "@std/path";
 import { z } from "zod";
 import { collect } from "../testing.ts";
@@ -442,6 +446,31 @@ Deno.test("datastoreSetupExtension: errors on invalid config schema", async () =
   assertEquals(error.kind, "error");
   assertEquals(error.error.code, "validation_failed");
   assertStringIncludes(error.error.message, "Invalid config");
+});
+
+Deno.test("datastoreSetupExtension: passes config with namespace to extension schema that requires it", async () => {
+  const schema = z.object({
+    uri: z.string(),
+    namespace: z.string(),
+  });
+  ensureTestExtensionType("test-ext-ns-required", { configSchema: schema });
+  const deps = makeDeps();
+  const input = makeExtensionInput({
+    type: "test-ext-ns-required",
+    config: { uri: "mongodb://localhost:27017", namespace: "my-ns" },
+    namespace: "my-ns",
+  });
+
+  const events = await collect<DatastoreSetupEvent>(
+    datastoreSetupExtension(createLibSwampContext(), deps, input),
+  );
+
+  const error = events.find((e) => e.kind === "error") as
+    | Extract<DatastoreSetupEvent, { kind: "error" }>
+    | undefined;
+  assertEquals(error, undefined, "expected no validation error");
+  const completed = events.find((e) => e.kind === "completed");
+  assertNotEquals(completed, undefined, "expected setup to complete");
 });
 
 Deno.test("datastoreSetupExtension: errors on unhealthy backend", async () => {


### PR DESCRIPTION
## Summary

- `swamp datastore setup extension` destructured `namespace` out of the
  `--config` JSON before passing it to the extension's schema validation,
  breaking any extension that declares `namespace` as a required config field
  (e.g. `@keeb/mongodb-datastore`).
- Read `config.namespace` directly instead of stripping it via rest-spread.
  Pass the full config object downstream — Zod's default strip mode ensures
  extensions that don't declare `namespace` silently ignore the extra key.
- Adds a unit test with a schema that requires `namespace` to prevent
  regression.

Closes swamp-club#1302

## Test Plan

- Reproduced the bug in a scratch repo with `@keeb/mongodb-datastore` —
  confirmed the `"Invalid config... namespace undefined"` error
- Verified the fix: MongoDB extension now passes validation (fails at
  credentials, not schema)
- Verified `@swamp/s3-datastore` with `--namespace` flag — still works
- Verified `@swamp/s3-datastore` with `namespace` in `--config` JSON — still
  works (Zod strips the extra key)
- Verified `@swamp/gcs-datastore` with `--namespace` flag — still works
- 9311 tests pass, `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)