### PR TITLE
docs(skills): add version-drift check to troubleshooting guide

### DIFF
--- a/.claude/skills/swamp/references/troubleshooting/guide.md
+++ b/.claude/skills/swamp/references/troubleshooting/guide.md
@@ -9,6 +9,26 @@ current tier doesn't resolve the issue.
 both `log` (default, human-readable) and `--json` (structured) output, and
 returns non-zero on user-facing failure.
 
+## Before you start: version-drift check
+
+Before entering the diagnostic tiers, check whether the swamp binary or any
+installed extensions are out of date. A stale version is a common root cause —
+the fix may already exist in a newer release, and the check takes seconds.
+
+```bash
+swamp update --check          # is the swamp binary up to date?
+swamp extension outdated      # are any extensions behind their latest version?
+```
+
+- If either reports an update is available, run `swamp update` and/or
+  `swamp extension pull <name>` to get the latest, then retry the failing
+  operation before continuing.
+- If both report up to date (or the commands fail), proceed to the diagnostic
+  tiers below.
+
+For the full procedure (JSON output interpretation, what to do when updates are
+found), see [references/version-check.md](references/version-check.md).
+
 ## Diagnostic mindset
 
 - **Start cheap, escalate.** Don't fetch source when a doctor command would name
@@ -31,15 +51,17 @@ returns non-zero on user-facing failure.
 
 ## Symptom → tier index
 
-| Symptom                                           | Start at                              |
-| ------------------------------------------------- | ------------------------------------- |
-| Extension not loaded / `swamp-warning:` on stderr | Tier 1 → `swamp doctor extensions`    |
-| Run stuck in "running" / orphaned after crash     | Tier 1 → `swamp run doctor --fix`     |
-| "Is anything running right now?"                  | Tier 1 → `swamp run history --active` |
-| Command errored — message is clear                | Tier 2 → read it, fix the named issue |
-| Command errored — message is vague                | Tier 2 → re-run with `--json`         |
-| Model method or workflow run failed               | Tier 2 → inspect generated reports    |
-| Workflow / method / sync is slow                  | Tier 3 → enable tracing               |
-| Need to understand internal behavior              | Tier 4 → fetch source                 |
+| Symptom                                           | Start at                               |
+| ------------------------------------------------- | -------------------------------------- |
+| Extension or binary misbehaves unexpectedly       | Before you start → version-drift check |
+| "This used to work" / suspected regression        | Before you start → version-drift check |
+| Extension not loaded / `swamp-warning:` on stderr | Tier 1 → `swamp doctor extensions`     |
+| Run stuck in "running" / orphaned after crash     | Tier 1 → `swamp run doctor --fix`      |
+| "Is anything running right now?"                  | Tier 1 → `swamp run history --active`  |
+| Command errored — message is clear                | Tier 2 → read it, fix the named issue  |
+| Command errored — message is vague                | Tier 2 → re-run with `--json`          |
+| Model method or workflow run failed               | Tier 2 → inspect generated reports     |
+| Workflow / method / sync is slow                  | Tier 3 → enable tracing                |
+| Need to understand internal behavior              | Tier 4 → fetch source                  |
 
 For detailed walkthroughs of each tier, see [reference.md](reference.md).

--- a/.claude/skills/swamp/references/troubleshooting/reference.md
+++ b/.claude/skills/swamp/references/troubleshooting/reference.md
@@ -1,5 +1,13 @@
 ## The diagnostic loop
 
+### Before you start — Version-drift check
+
+Before entering the tiers, check whether the swamp binary or any installed
+extensions are out of date. A stale version is the most common "invisible" root
+cause — the fix may already ship in a newer release.
+
+→ See [references/version-check.md](references/version-check.md).
+
 ### Tier 1 — Health checks
 
 For symptoms tied to a known integration (audit pipeline, extension loading).
@@ -37,6 +45,8 @@ reach for it last.
 
 | Symptom                                                  | Start at                                                  |
 | -------------------------------------------------------- | --------------------------------------------------------- |
+| Extension or binary misbehaves unexpectedly              | Before you start → version-drift check                    |
+| "This used to work" / suspected regression               | Before you start → version-drift check                    |
 | Audit log empty / hooks not firing                       | Tier 1 → `swamp doctor audit`                             |
 | Extension model/vault/driver/datastore/report not loaded | Tier 1 → `swamp doctor extensions`                        |
 | `swamp-warning:` line on stderr                          | Tier 1 → `swamp doctor extensions`                        |
@@ -78,6 +88,9 @@ For a typical investigation:
 
 ## References
 
+- [references/version-check.md](references/version-check.md) — Before you start:
+  `swamp update --check`, `swamp extension outdated`, deciding whether to update
+  before diagnosing.
 - [references/health-checks.md](references/health-checks.md) — Tier 1: doctor
   commands (`swamp doctor audit`, `swamp doctor extensions`), exit codes, CI
   usage.

--- a/.claude/skills/swamp/references/troubleshooting/references/version-check.md
+++ b/.claude/skills/swamp/references/troubleshooting/references/version-check.md
@@ -1,0 +1,58 @@
+# Version-Drift Check
+
+Run before entering the diagnostic tiers. A stale swamp binary or extension is a
+common root cause for unexpected behavior — the check is cheap and can
+short-circuit hours of investigation.
+
+## Step 1: Check the swamp binary
+
+```bash
+swamp update --check --json
+```
+
+Parse the JSON output:
+
+- `{"status": "up_to_date", ...}` → the binary is current. Proceed to step 2.
+- `{"status": "update_available", "currentVersion": "...", "latestVersion": "..."}`
+  → a newer binary exists. Run `swamp update` to install it, then retry the
+  failing operation. If the problem is resolved, stop — no further diagnosis
+  needed.
+
+If the command fails, note it and proceed to step 2.
+
+## Step 2: Check installed extensions
+
+```bash
+swamp extension outdated
+```
+
+This lists every installed extension that has a newer version available. It
+exits 1 if any update is available (suitable for CI gates).
+
+- **No output / exit 0** → all extensions are current. Proceed to the diagnostic
+  tiers.
+- **Updates listed / exit 1** → one or more extensions are behind. Pull the
+  updated extensions:
+
+  ```bash
+  swamp extension pull <name>    # pull a specific extension
+  ```
+
+  Then retry the failing operation. If the problem is resolved, stop.
+
+If the command fails, note it and proceed to the diagnostic tiers.
+
+## Step 3: Decide
+
+| Binary   | Extensions | Action                                  |
+| -------- | ---------- | --------------------------------------- |
+| Current  | Current    | Proceed to Tier 1 (health checks)       |
+| Updated  | —          | Retry the operation; if fixed, stop     |
+| —        | Updated    | Retry the operation; if fixed, stop     |
+| Updated  | Updated    | Retry the operation; if fixed, stop     |
+| Failures | Failures   | Note the failures and proceed to Tier 1 |
+
+The version-drift check is a quick gate, not a deep analysis. If updating
+resolves the issue, no further diagnosis is needed. If the problem persists
+after updating (or if the checks themselves fail), move on to the diagnostic
+tiers — the issue is not caused by staleness.

--- a/src/infrastructure/assets/skill_assets.ts
+++ b/src/infrastructure/assets/skill_assets.ts
@@ -370,6 +370,11 @@ const BUNDLED_SKILLS: SkillInfo[] = [
     relativePath: "swamp/references/troubleshooting/references/tracing.md",
     name: "swamp",
   },
+  {
+    relativePath:
+      "swamp/references/troubleshooting/references/version-check.md",
+    name: "swamp",
+  },
   // serve
   { relativePath: "swamp/references/serve/guide.md", name: "swamp" },
   // swamp share guide area


### PR DESCRIPTION
## Summary

- Adds a "Before you start: version-drift check" section to the troubleshooting guide, before the existing 4 diagnostic tiers
- Creates a new `references/version-check.md` with the detailed procedure (`swamp update --check`, `swamp extension outdated`, decision table)
- Adds version-drift symptom entries to both symptom index tables and the references list

Fixes swamp-club#1331 — the troubleshooting guide previously had no version-staleness check, so debugging sessions could spend hours source-diving when `swamp extension outdated` would have caught a stale extension in seconds.

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] All cross-references between guide.md, reference.md, and version-check.md are correct
- [x] Symptom tables in both files have matching version-drift entries
- [x] Existing issue-filing version_check.md is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)