### PR TITLE
fix(serve): persist OAuth bootstrap access token to survive failed admin resolution

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -803,7 +803,7 @@ export const serveCommand = new Command()
   )
   .option(
     "--admins <principals:string>",
-    "Comma-separated principal IDs for admin access (e.g. user:oauth|user-123)",
+    "Comma-separated admin principals: plain usernames for OAuth mode (e.g. dmc), user:<subject-id> for token mode",
   )
   .option(
     "--allowed-collectives <list:string>",
@@ -866,7 +866,11 @@ export const serveCommand = new Command()
   )
   .example(
     "Token auth",
-    "swamp serve --auth-mode token --admins 'user:oauth|user-123'",
+    "swamp serve --auth-mode token --admins 'user:abc-123'",
+  )
+  .example(
+    "OAuth auth",
+    "swamp serve --auth-mode oauth --admins dmc --allowed-collectives my-org",
   )
   .example(
     "Webhook (secret from env var)",

--- a/src/serve/oauth_registration.ts
+++ b/src/serve/oauth_registration.ts
@@ -24,6 +24,7 @@ const logger = getSwampLogger(["serve", "oauth-registration"]);
 export const OAUTH_CLIENT_ID_KEY = "oauth-client-id";
 export const OAUTH_CLIENT_SECRET_KEY = "oauth-client-secret";
 export const OAUTH_RESOLVED_ADMINS_KEY = "oauth-resolved-admins";
+export const OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY = "oauth-bootstrap-access-token";
 
 // Well-known bootstrap client ID for first-time OAuth registration.
 // This is a public client ID baked into the binary — the same pattern
@@ -86,20 +87,26 @@ export async function resolveOAuthClientCredentials(
 
   if (explicitClientId && storedClientSecret) {
     logger.info("Using explicit --oauth-client-id with stored client secret");
+    const storedAccessToken = resolvedAdmins
+      ? null
+      : await deps.getVaultSecret(vaultName, OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY);
     return {
       clientId: explicitClientId,
       clientSecret: storedClientSecret,
-      accessToken: null,
+      accessToken: storedAccessToken,
       resolvedAdmins,
     };
   }
 
   if (storedClientId && storedClientSecret) {
     logger.info("Using stored OAuth client credentials from vault");
+    const storedAccessToken = resolvedAdmins
+      ? null
+      : await deps.getVaultSecret(vaultName, OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY);
     return {
       clientId: storedClientId,
       clientSecret: storedClientSecret,
-      accessToken: null,
+      accessToken: storedAccessToken,
       resolvedAdmins,
     };
   }
@@ -115,6 +122,11 @@ export async function resolveOAuthClientCredentials(
     vaultName,
     OAUTH_CLIENT_SECRET_KEY,
     result.clientSecret,
+  );
+  await deps.putVaultSecret(
+    vaultName,
+    OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
+    result.accessToken,
   );
 
   logger.info(

--- a/src/serve/oauth_registration_test.ts
+++ b/src/serve/oauth_registration_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import {
+  OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY,
   OAUTH_CLIENT_ID_KEY,
   OAUTH_CLIENT_SECRET_KEY,
   OAUTH_RESOLVED_ADMINS_KEY,
@@ -110,7 +111,62 @@ Deno.test("resolveOAuthClientCredentials: bootstrap registers and returns access
     storedSecrets.get(OAUTH_CLIENT_SECRET_KEY),
     "new-client-secret",
   );
-  assertEquals(storedSecrets.has("oauth-access-token"), false);
+  assertEquals(
+    storedSecrets.get(OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY),
+    "new-access-token",
+  );
+});
+
+Deno.test("resolveOAuthClientCredentials: returns stored access token when no cached resolutions exist", async () => {
+  const deps = createMockDeps({
+    getVaultSecret: (_, key) => {
+      if (key === OAUTH_CLIENT_ID_KEY) return Promise.resolve("stored-id");
+      if (key === OAUTH_CLIENT_SECRET_KEY) {
+        return Promise.resolve("stored-secret");
+      }
+      if (key === OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY) {
+        return Promise.resolve("stored-bootstrap-token");
+      }
+      return Promise.resolve(null);
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.clientId, "stored-id");
+  assertEquals(result.clientSecret, "stored-secret");
+  assertEquals(result.accessToken, "stored-bootstrap-token");
+  assertEquals(result.resolvedAdmins, null);
+});
+
+Deno.test("resolveOAuthClientCredentials: prefers cached resolutions over stored access token", async () => {
+  const adminsJson = JSON.stringify({ swampadmin: "6a4d-sub-id" });
+  const deps = createMockDeps({
+    getVaultSecret: (_, key) => {
+      if (key === OAUTH_CLIENT_ID_KEY) return Promise.resolve("stored-id");
+      if (key === OAUTH_CLIENT_SECRET_KEY) {
+        return Promise.resolve("stored-secret");
+      }
+      if (key === OAUTH_RESOLVED_ADMINS_KEY) return Promise.resolve(adminsJson);
+      if (key === OAUTH_BOOTSTRAP_ACCESS_TOKEN_KEY) {
+        return Promise.resolve("stored-bootstrap-token");
+      }
+      return Promise.resolve(null);
+    },
+  });
+  const result = await resolveOAuthClientCredentials(
+    deps,
+    "https://swamp-club.com",
+    "default",
+    undefined,
+    AbortSignal.timeout(5000),
+  );
+  assertEquals(result.accessToken, null);
+  assertEquals(result.resolvedAdmins, { swampadmin: "6a4d-sub-id" });
 });
 
 Deno.test("storeResolvedAdmins: stores admin mapping in vault", async () => {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1379.

- **Persist the OAuth bootstrap access token** in the vault immediately after device-flow registration, so a failed admin/collective resolution doesn't discard valid credentials and force a full device-flow re-registration.
- **Fix `--admins` help text** — the example showed token-mode format (`user:oauth|user-123`) for all auth modes; OAuth mode expects plain usernames (e.g. `dmc`). Added a separate OAuth auth example.
- On subsequent boots with no cached admin resolutions, the stored token is used for retry. When cached resolutions already exist, they take priority over the stored token (avoids breaking a working flow if the token has expired).

## Test Plan

- Unit tests: 6 passing in `oauth_registration_test.ts` — covers bootstrap persistence, stored token fallback, and cached-resolutions-take-priority behavior
- Manual end-to-end verification against swamp-club.com:
  1. Cleared OAuth state, ran `swamp serve --auth-mode oauth --admins baduser` — device flow completed, admin resolution failed as expected
  2. Confirmed `oauth-bootstrap-access-token` was persisted in vault
  3. Retried with correct `--admins dmc` — server started without a new device flow, reusing the stored token

Co-authored-by: Kenichi Fukunaga <dmc.system.service@gmail.com>