### PR TITLE
fix(models): prevent globalArgs from leaking into z.record() method args

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -231,6 +231,12 @@ the definition combined with per-method arguments) as its first parameter, and a
 `definition` metadata (id, name, version, tags), `methodName`, and an optional
 `redactor` (`SecretRedactor`) for stripping vault secrets from output.
 
+When the method's `arguments` schema is a `z.record()` (rather than
+`z.object()`), global arguments are **not** merged into the method args — the
+method receives only the per-method arguments. This prevents global argument
+fields from leaking into the open-ended record. Global arguments remain
+accessible via `context.globalArgs`.
+
 Methods can write data, which is tracked by the method invocation and the
 definition required to re-instantiate the object.
 

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -35,7 +35,11 @@ import { ModelOutput } from "./model_output.ts";
 import { DataOutputValidationService } from "./data_output_validation_service.ts";
 import { DefinitionUpgradeService } from "./definition_upgrade_service.ts";
 import { modelRequiresVault } from "./data_writer.ts";
-import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
+import {
+  coerceMethodArgs,
+  getObjectShape,
+  isRecordSchema,
+} from "./zod_type_coercion.ts";
 import {
   extractExpressions,
   valueContainsExpression,
@@ -211,7 +215,9 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       filteredRawGlobalArgs[key] = value;
     }
 
-    const mergedArgs = { ...filteredGlobalArgs, ...resolvedMethodArgs };
+    const mergedArgs = isRecordSchema(method.arguments)
+      ? resolvedMethodArgs
+      : { ...filteredGlobalArgs, ...resolvedMethodArgs };
     const methodArgs = coerceMethodArgs(mergedArgs, method.arguments);
     const argsResult = method.arguments.safeParse(methodArgs);
 

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -3457,3 +3457,58 @@ Deno.test(
     assertEquals(lastSave.output.error?.message, "intentional failure");
   },
 );
+
+Deno.test(
+  "execute: z.record() method args do not include globalArguments",
+  async () => {
+    const service = new DefaultMethodExecutionService();
+
+    let capturedArgs: Record<string, unknown> = {};
+    const recordModel: ModelDefinition = {
+      type: ModelType.create("test/record-args"),
+      version: "2026.07.24.1",
+      globalArguments: z.object({
+        baseUrl: z.string(),
+        apiKey: z.string(),
+      }),
+      methods: {
+        send: {
+          description: "Send key-value pairs",
+          arguments: z.record(z.string(), z.string()),
+          execute: (
+            args: Record<string, unknown>,
+          ): Promise<MethodResult> => {
+            capturedArgs = { ...args };
+            return Promise.resolve({ dataHandles: [] });
+          },
+        },
+      },
+    };
+
+    const definition = Definition.create({
+      name: "record-test",
+      globalArguments: {
+        baseUrl: "https://api.example.com",
+        apiKey: "secret-key",
+      },
+      methods: { send: { arguments: { someKey: "someValue" } } },
+    });
+
+    const { context } = createTestContext({
+      modelType: recordModel.type,
+      methodName: "send",
+      globalArgs: {
+        baseUrl: "https://api.example.com",
+        apiKey: "secret-key",
+      },
+    });
+
+    await service.execute(
+      definition,
+      recordModel.methods.send,
+      context,
+    );
+
+    assertEquals(capturedArgs, { someKey: "someValue" });
+  },
+);

--- a/src/domain/models/model_invocation_service.ts
+++ b/src/domain/models/model_invocation_service.ts
@@ -38,7 +38,7 @@ import { resolveModelType } from "../extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../extensions/auto_resolver_context.ts";
 import { buildMethodContext } from "./method_context.ts";
 import type { CommonMethodContextDeps } from "./method_context.ts";
-import { getObjectShape } from "./zod_type_coercion.ts";
+import { getObjectShape, isRecordSchema } from "./zod_type_coercion.ts";
 
 const MAX_INVOCATION_DEPTH = 10;
 const MAX_INVOCATION_BREADTH = 100;
@@ -95,6 +95,7 @@ function routeArguments(
   }
 
   const methodShape = getObjectShape(method.arguments);
+  const methodIsRecord = isRecordSchema(method.arguments);
   const globalShape = modelDef.globalArguments
     ? getObjectShape(modelDef.globalArguments)
     : null;
@@ -115,6 +116,8 @@ function routeArguments(
       methodArgs[key] = value;
     } else if (globalKeys.has(key)) {
       globalArgs[key] = value;
+    } else if (methodIsRecord) {
+      methodArgs[key] = value;
     } else {
       unknownKeys.push(key);
     }

--- a/src/domain/models/model_invocation_service_test.ts
+++ b/src/domain/models/model_invocation_service_test.ts
@@ -627,3 +627,104 @@ Deno.test("ModelInvocationService: routes method args for by-type auto-creation"
   assertEquals(capturedDef!.getMethodArguments("greet"), { name: "World" });
   assertEquals(capturedCtx!.globalArgs, { region: "us-west-2" });
 });
+
+// ── z.record() argument routing tests ──
+
+const RECORD_ROUTING_TYPE = ModelType.create("test/record-routing-target");
+if (!modelRegistry.get(RECORD_ROUTING_TYPE)) {
+  const recordModel: ModelDefinition = {
+    type: RECORD_ROUTING_TYPE,
+    version: "2026.07.24.1",
+    globalArguments: z.object({
+      baseUrl: z.string(),
+      apiKey: z.string(),
+    }),
+    methods: {
+      send: {
+        description: "test method with z.record() args",
+        arguments: z.record(z.string(), z.string()),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  };
+  defineModel(recordModel);
+}
+
+function makeRecordArgRoutingSvc(options: {
+  captureDefinition: (def: Definition) => void;
+  captureContext: (ctx: MethodContext) => void;
+  targetDefName: string;
+  targetDef: Definition;
+}) {
+  const mockExecutionService: MethodExecutionService = {
+    execute: () => Promise.resolve({ dataHandles: [] }),
+    executeWorkflow: (def, _modelDef, _method, ctx) => {
+      options.captureDefinition(def);
+      options.captureContext(ctx);
+      return Promise.resolve({ dataHandles: [] });
+    },
+  };
+
+  const stubDataRepo = {
+    findAllForModel: () => Promise.resolve([]),
+    getContent: () => Promise.resolve(null),
+  };
+
+  return new ModelInvocationService({
+    executionService: mockExecutionService,
+    commonDeps: {
+      dataRepository: stubDataRepo,
+      definitionRepository: {
+        findByNameGlobal: (name: string) => {
+          if (name === options.targetDefName) {
+            return Promise.resolve({
+              definition: options.targetDef,
+              type: RECORD_ROUTING_TYPE,
+            });
+          }
+          return Promise.resolve(null);
+        },
+        findById: () => Promise.resolve(null),
+        save: () => Promise.resolve(),
+      },
+      createCelEnvironment: () =>
+        ({}) as ReturnType<MethodContext["createCelEnvironment"]>,
+    } as unknown as CommonMethodContextDeps,
+    repoDir: "/tmp/test-repo",
+  });
+}
+
+Deno.test("ModelInvocationService: z.record() method routes non-global keys to method args", async () => {
+  let capturedDef: Definition | undefined;
+
+  const targetDef = Definition.create({
+    name: "record-def",
+    type: "test/record-routing-target",
+    globalArguments: { baseUrl: "https://example.com", apiKey: "key123" },
+  });
+
+  const svc = makeRecordArgRoutingSvc({
+    captureDefinition: (def) => {
+      capturedDef = def;
+    },
+    captureContext: () => {},
+    targetDefName: "record-def",
+    targetDef,
+  });
+
+  const callerCtx = makeStubContext();
+  const result = await svc.invoke(
+    {
+      definition: "record-def",
+      method: "send",
+      arguments: { someKey: "someValue", other: "data" },
+    },
+    callerCtx,
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(capturedDef!.getMethodArguments("send"), {
+    someKey: "someValue",
+    other: "data",
+  });
+});

--- a/src/domain/models/zod_type_coercion.ts
+++ b/src/domain/models/zod_type_coercion.ts
@@ -181,3 +181,13 @@ export function getObjectShape(
   }
   return readShape(getSchemaDef(unwrapped));
 }
+
+/**
+ * Returns true when the schema (after unwrapping optional/nullable/default/
+ * effects wrappers) resolves to a ZodRecord. Record schemas accept arbitrary
+ * string keys, so key-based routing and unknown-key checks don't apply.
+ */
+export function isRecordSchema(schema: z.ZodTypeAny): boolean {
+  const unwrapped = unwrapSchema(schema);
+  return getSchemaType(unwrapped) === "record";
+}

--- a/src/domain/models/zod_type_coercion_test.ts
+++ b/src/domain/models/zod_type_coercion_test.ts
@@ -19,7 +19,11 @@
 
 import { assertEquals } from "@std/assert";
 import { z } from "zod";
-import { coerceMethodArgs, getObjectShape } from "./zod_type_coercion.ts";
+import {
+  coerceMethodArgs,
+  getObjectShape,
+  isRecordSchema,
+} from "./zod_type_coercion.ts";
 
 Deno.test("coerces string 'true' to boolean true", () => {
   const schema = z.object({ enabled: z.boolean() });
@@ -244,4 +248,46 @@ Deno.test("getObjectShape handles Zod v3 ZodEffects (typeName + .schema)", () =>
   } as unknown as z.ZodTypeAny;
   const shape = getObjectShape(v3LikeRefined);
   assertEquals(Object.keys(shape ?? {}), ["name"]);
+});
+
+// ---------- isRecordSchema ----------
+
+Deno.test("isRecordSchema: returns true for plain z.record()", () => {
+  const schema = z.record(z.string(), z.string());
+  assertEquals(isRecordSchema(schema), true);
+});
+
+Deno.test("isRecordSchema: returns true for z.record() wrapped in .optional()", () => {
+  const schema = z.record(z.string(), z.string()).optional();
+  assertEquals(isRecordSchema(schema), true);
+});
+
+Deno.test("isRecordSchema: returns true for z.record() wrapped in .nullable()", () => {
+  const schema = z.record(z.string(), z.string()).nullable();
+  assertEquals(isRecordSchema(schema), true);
+});
+
+Deno.test("isRecordSchema: returns true for z.record() wrapped in .default()", () => {
+  const schema = z.record(z.string(), z.string()).default({});
+  assertEquals(isRecordSchema(schema), true);
+});
+
+Deno.test("isRecordSchema: returns true for z.record() wrapped in .refine()", () => {
+  const schema = z.record(z.string(), z.string()).refine(
+    (v) => Object.keys(v).length > 0,
+  );
+  assertEquals(isRecordSchema(schema), true);
+});
+
+Deno.test("isRecordSchema: returns false for z.object()", () => {
+  const schema = z.object({ name: z.string() });
+  assertEquals(isRecordSchema(schema), false);
+});
+
+Deno.test("isRecordSchema: returns false for z.string()", () => {
+  assertEquals(isRecordSchema(z.string()), false);
+});
+
+Deno.test("isRecordSchema: returns false for z.array()", () => {
+  assertEquals(isRecordSchema(z.array(z.string())), false);
 });

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -24,6 +24,7 @@ import type { ModelDefinition } from "../../domain/models/model.ts";
 import {
   coerceMethodArgs,
   getObjectShape,
+  isRecordSchema,
 } from "../../domain/models/zod_type_coercion.ts";
 import { stripExpressionFields } from "../../domain/expressions/expression_parser.ts";
 import {
@@ -84,6 +85,7 @@ export function routeInputsBySchema(
   }
 
   const methodShape = getObjectShape(method.arguments);
+  const methodIsRecord = isRecordSchema(method.arguments);
   const globalShape = modelDef.globalArguments
     ? getObjectShape(modelDef.globalArguments)
     : null;
@@ -104,6 +106,8 @@ export function routeInputsBySchema(
       methodArguments[key] = value;
     } else if (globalKeys.has(key)) {
       globalArguments[key] = value;
+    } else if (methodIsRecord) {
+      methodArguments[key] = value;
     } else {
       unknownKeys.push(key);
     }

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -158,6 +158,47 @@ Deno.test("routeInputsBySchema: handles empty inputs", () => {
   }
 });
 
+Deno.test("routeInputsBySchema: z.record() method routes non-global keys to method args", () => {
+  const modelDef = createTestModelDef(
+    z.object({ baseUrl: z.string(), apiKey: z.string() }),
+    { send: z.record(z.string(), z.string()) },
+  );
+
+  const result = routeInputsBySchema(
+    { baseUrl: "https://example.com", someKey: "someValue", other: "data" },
+    "send",
+    modelDef,
+  );
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.globalArguments, { baseUrl: "https://example.com" });
+    assertEquals(result.methodArguments, {
+      someKey: "someValue",
+      other: "data",
+    });
+  }
+});
+
+Deno.test("routeInputsBySchema: z.record() method with no global args routes all to method", () => {
+  const modelDef = createTestModelDef(
+    undefined,
+    { send: z.record(z.string(), z.string()) },
+  );
+
+  const result = routeInputsBySchema(
+    { foo: "bar", baz: "qux" },
+    "send",
+    modelDef,
+  );
+
+  assertEquals("error" in result, false);
+  if (!("error" in result)) {
+    assertEquals(result.methodArguments, { foo: "bar", baz: "qux" });
+    assertEquals(result.globalArguments, {});
+  }
+});
+
 Deno.test("resolveOrCreateDefinition: auto-creates definition with routed globalArgs", async () => {
   const modelDef = createTestModelDef(
     z.object({ region: z.string(), account: z.string() }),


### PR DESCRIPTION
## Summary

Fixes swamp-club#1364. When a method's arguments schema is a bare `z.record()`, globalArguments fields leak into the method's `args` object alongside the intended `--input` values.

**Root cause:** The execution merge at `method_execution_service.ts:214` spreads `{...filteredGlobalArgs, ...resolvedMethodArgs}` unconditionally. For `z.object()` methods, Zod's strip mode removes undeclared keys after the merge. For `z.record()`, every key passes validation — so globalArgs leak through.

**Design stance:** GlobalArgs merge into method args so that `z.object()` methods can declare overlapping keys and receive globalArgs values as defaults — Zod's strip mode naturally limits what survives. For `z.record()`, that filtering can't happen, so we skip the merge. The method receives only its per-method args; globalArgs remain accessible through `context.globalArgs`.

**What changed:**
- Added `isRecordSchema()` helper in `zod_type_coercion.ts` — detects `z.record()` schemas including wrapped variants (optional, nullable, default, refine)
- `method_execution_service.ts`: skip globalArgs spread when method schema is `z.record()`
- `direct_execution.ts` (`routeInputsBySchema`): route non-globalArg `--input` keys to method args for `z.record()` methods instead of rejecting them as unknown
- `model_invocation_service.ts` (`routeArguments`): same fix for nested `context.runModel()` calls
- Updated `design/models.md` to document the `z.record()` behavior

## Test Plan

- 12 new unit tests across 4 test files covering `isRecordSchema()`, execution merge, and input routing
- Reproduced the exact issue scenario in a scratch repo, verified the fix: method args now contain only `--input` values, globalArgs accessible via `context.globalArgs`
- Full test suite passes (9322 tests)