### PR TITLE
fix(security): redact vault secrets in remote worker output (swamp-club#1239)

### DIFF
--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -958,6 +958,25 @@ provisioning credentials and extensions onto workers:
   the step that needs them (consistent with the out-of-process resolution pattern
   in [execution-drivers.md](./execution-drivers.md#vault-secret-resolution)).
 
+  **Secret redaction.** Vault-derived values must be scrubbed from all persisted
+  output — log resources, result resources, and workflow-run records — before
+  they reach durable storage or the WS event stream. Two complementary layers
+  enforce this:
+
+  1. **Worker-side (source redaction):** The orchestrator extracts resolved
+     secret values from sensitive argument fields and ships them in the dispatch
+     params (`secretValues`). The worker registers these with its
+     `SecretRedactor` before method execution, so `stdout`/`stderr` and any
+     `writeResource` data are redacted at the point of origin.
+  2. **Data plane (defense in depth):** The orchestrator stores a per-dispatch
+     `SecretRedactor` on the `ActiveDispatch` registration. When the data plane
+     persists a worker's `writeResource` call, it passes this redactor to
+     `createResourceWriter`, catching any value the worker-side redactor missed.
+
+  Both layers use the same `SecretRedactor` class and the same
+  `extractSensitiveFieldValues` utility that local execution has always used;
+  the invariant is identical, just extended across the dispatch boundary.
+
 - The **enrollment token** is named, time-boxed, and enrolls up to
   `maxEnrollments` machines, each binding to the worker's durable `machineId`. The
   `{token, machineId}` pair is a *bearer* reconnection secret rather than

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -59,6 +59,7 @@ import {
 import type { RpcStreamEvent } from "../remote/protocol.ts";
 import { hasPlacement } from "../remote/scheduler.ts";
 import { createDataId } from "../data/data_id.ts";
+import { extractSensitiveFieldValues } from "./sensitive_field_extractor.ts";
 
 /**
  * Maximum depth for recursive follow-up action processing.
@@ -371,6 +372,22 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       ) as Record<string, unknown>
       : executionRequest.globalArgs;
 
+    const secretValues: string[] = [];
+    if (secretBag && !secretBag.isEmpty) {
+      secretValues.push(...secretBag.rawValues);
+    }
+    if (modelDef.globalArguments) {
+      secretValues.push(
+        ...extractSensitiveFieldValues(modelDef.globalArguments, globalArgs),
+      );
+    }
+    const methodArgSchema = modelDef.methods[methodName]?.arguments;
+    if (methodArgSchema) {
+      secretValues.push(
+        ...extractSensitiveFieldValues(methodArgSchema, methodArgs),
+      );
+    }
+
     return await withSpan("swamp.remote.dispatch", {
       "model.type": context.modelType.normalized,
       "method.name": methodName,
@@ -395,6 +412,7 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
         stepName: context.tagOverrides?.step,
         signal: context.signal,
         dataRepo: context.dataRepository,
+        secretValues: secretValues.length > 0 ? secretValues : undefined,
         onEvent: context.onEvent
           ? (event: RpcStreamEvent) => {
             if (event.kind === "method_event" && "event" in event) {

--- a/src/domain/remote/protocol.ts
+++ b/src/domain/remote/protocol.ts
@@ -266,6 +266,14 @@ export const DispatchParamsSchema = z.object({
    * rather than the environment snapshot (which denylists SWAMP_* vars).
    */
   probeMarker: z.string().optional(),
+  /**
+   * Resolved vault secret values the worker must register with its
+   * SecretRedactor before executing the method body. The orchestrator
+   * extracts these from sensitive argument fields; the worker adds them
+   * so stdout/stderr redaction catches secrets injected through args.
+   * Optional for backward compatibility with older workers.
+   */
+  secretValues: z.array(z.string()).optional(),
 });
 
 export type DispatchParams = z.infer<typeof DispatchParamsSchema>;

--- a/src/domain/remote/remote_dispatch.ts
+++ b/src/domain/remote/remote_dispatch.ts
@@ -63,6 +63,11 @@ export interface RemoteStepRequest {
   /** Dispatch-level probe marker for fleet verification. */
   probeMarker?: string;
   /**
+   * Resolved vault secret values for the worker's SecretRedactor.
+   * Extracted from sensitive argument fields on the orchestrator side.
+   */
+  secretValues?: string[];
+  /**
    * Bypass the scheduler and dispatch directly to the targeted worker.
    * Only used by the fleet verification probe, which must reach workers
    * in "unverified" status that the scheduler would otherwise exclude.

--- a/src/domain/vaults/vault_secret_bag.ts
+++ b/src/domain/vaults/vault_secret_bag.ts
@@ -80,6 +80,11 @@ export class VaultSecretBag {
     return this.secrets.size === 0;
   }
 
+  /** Returns all raw secret values (for registering with a SecretRedactor). */
+  get rawValues(): string[] {
+    return [...this.secrets.values()];
+  }
+
   /**
    * Returns sentinel tokens that appear inside single quotes in the given
    * command string. Single quotes prevent shell variable expansion, so an

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -378,7 +378,7 @@ export class DataPlane {
       await this.#vault(),
       dispatch.methodName,
       undefined, // onEvent
-      undefined, // redactor
+      dispatch.redactor,
     );
     // Mark the lease BEFORE persisting: a lease may over-report writes
     // (safe, conservative) but must never under-report them.

--- a/src/serve/data_plane_test.ts
+++ b/src/serve/data_plane_test.ts
@@ -597,3 +597,33 @@ Deno.test("DataPlane: /bundle/{fp}/files caps total file count", async () => {
     }
   });
 });
+
+Deno.test("DataPlane: per-dispatch redactor scrubs secrets from written resources", async () => {
+  await withHarness(async (h) => {
+    const { SecretRedactor } = await import(
+      "../domain/secrets/secret_redactor.ts"
+    );
+    const redactor = new SecretRedactor();
+    redactor.addSecret("top-secret-value");
+    const d = activeDispatch();
+    d.redactor = redactor;
+    h.dispatches.register(d);
+
+    const resp = await h.plane.handle(
+      request("/data/resource", {
+        method: "POST",
+        body: JSON.stringify({
+          specName: "result",
+          name: "result",
+          data: { value: "output: top-secret-value" },
+        }),
+      }),
+    );
+    assertEquals(resp?.status, 200);
+
+    const key = `${MODEL_TYPE.normalized}/m-1/result`;
+    const entry = h.stored.get(key);
+    const content = JSON.parse(new TextDecoder().decode(entry!.content!));
+    assertEquals(content.value, "output: ***");
+  });
+});

--- a/src/serve/dispatch_registry.ts
+++ b/src/serve/dispatch_registry.ts
@@ -30,6 +30,7 @@ import type { ModelType } from "../domain/models/model_type.ts";
 import type {
   VaultExtractionResult,
 } from "../domain/expressions/vault_reference_extractor.ts";
+import type { SecretRedactor } from "../domain/secrets/secret_redactor.ts";
 
 export interface ActiveDispatch {
   workerName: string;
@@ -45,6 +46,8 @@ export interface ActiveDispatch {
   runtimeTags?: Record<string, string>;
   dataRepo?: UnifiedDataRepository;
   allowedSecrets?: VaultExtractionResult;
+  /** Per-dispatch redactor populated with vault-derived secret values. */
+  redactor?: SecretRedactor;
 }
 
 export class DispatchRegistry {

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -72,6 +72,7 @@ import type { ActiveDispatch, DispatchRegistry } from "./dispatch_registry.ts";
 import type { BundleRegistry } from "./bundle_registry.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import { extractVaultReferences } from "../domain/expressions/vault_reference_extractor.ts";
+import { SecretRedactor } from "../domain/secrets/secret_redactor.ts";
 
 export { hasPlacement };
 
@@ -152,6 +153,17 @@ export class DispatchService {
       ((input) => this.#defaultRunModelMethod(input));
     this.#captureEnvironment = options.captureEnvironment ??
       (() => captureEnvironmentSnapshot(Deno.env.toObject()));
+  }
+
+  #buildDispatchRedactor(
+    secretValues: string[] | undefined,
+  ): SecretRedactor | undefined {
+    if (!secretValues || secretValues.length === 0) return undefined;
+    const redactor = new SecretRedactor();
+    for (const value of secretValues) {
+      redactor.addSecret(value);
+    }
+    return redactor;
   }
 
   bindGateway(gateway: DispatchGateway): void {
@@ -375,6 +387,7 @@ export class DispatchService {
         request.globalArgs,
         request.methodArgs,
       ),
+      redactor: this.#buildDispatchRedactor(request.secretValues),
     });
 
     const params: DispatchParams = {
@@ -401,6 +414,7 @@ export class DispatchService {
         stepName: request.stepName,
       },
       probeMarker: request.probeMarker,
+      secretValues: request.secretValues,
     };
 
     try {

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -508,6 +508,11 @@ export function createRemoteMethodContext(
   } as unknown as DataQueryService;
 
   const redactor = new SecretRedactor();
+  if (dispatch.secretValues) {
+    for (const value of dispatch.secretValues) {
+      redactor.addSecret(value);
+    }
+  }
 
   const readResource = async (
     instanceName: string,

--- a/src/worker/remote_method_context_test.ts
+++ b/src/worker/remote_method_context_test.ts
@@ -72,6 +72,7 @@ function harness(
   scratchDir: string,
   extensionFilesDir?: string,
   artifactContent?: Record<string, unknown>,
+  overrideDispatch?: DispatchParams,
 ) {
   const calls: StubCall[] = [];
   // The orchestrator side of the control socket, with stub verb handlers.
@@ -196,7 +197,7 @@ function harness(
   const { context, getHandles } = createRemoteMethodContext({
     channel: worker,
     client,
-    dispatch: dispatch(),
+    dispatch: overrideDispatch ?? dispatch(),
     scratchDir,
     extensionFilesDir,
     signal: new AbortController().signal,
@@ -378,5 +379,27 @@ Deno.test("remote context: deleteResource calls client.deleteResource", async ()
       h.calls.filter((c) => c.method === "deleteResource"),
       [{ method: "deleteResource", params: { name: "stale-data" } }],
     );
+  });
+});
+
+Deno.test("remote context: secretValues populate the redactor", async () => {
+  await withScratch((dir) => {
+    const d = dispatch();
+    d.secretValues = ["super-secret-value"];
+    const h = harness(dir, undefined, undefined, d);
+    assertEquals(h.context.redactor!.hasSecrets, true);
+    assertEquals(
+      h.context.redactor!.redact("output: super-secret-value here"),
+      "output: *** here",
+    );
+    return Promise.resolve();
+  });
+});
+
+Deno.test("remote context: empty secretValues leaves redactor without secrets", async () => {
+  await withScratch((dir) => {
+    const h = harness(dir);
+    assertEquals(h.context.redactor!.hasSecrets, false);
+    return Promise.resolve();
   });
 });


### PR DESCRIPTION
## Summary

Vault-injected secrets were persisted **unredacted** when steps ran on remote workers. The `SecretRedactor` was correctly wired for local execution but bypassed entirely on the remote path:

1. The worker-side `SecretRedactor` was created empty — vault secrets resolved from args on the orchestrator were never registered with it
2. The orchestrator data plane passed `undefined` as the redactor to `createResourceWriter()`
3. Dispatch results were returned unredacted

Secrets landed in plaintext in all three persistence locations: the `result` resource, the `log` file, and the workflow-run record YAML — all reachable over the WS event stream.

### Fix

Two complementary redaction layers, matching the existing local execution pattern:

1. **Worker-side (source redaction):** The orchestrator extracts resolved vault values from the `VaultSecretBag` and sensitive argument fields (`extractSensitiveFieldValues`), ships them as `secretValues` in the dispatch params. The worker registers them with its `SecretRedactor` before method execution, so stdout/stderr and `writeResource` data are redacted at the point of origin.

2. **Data plane (defense in depth):** The orchestrator stores a per-dispatch `SecretRedactor` on the `ActiveDispatch` registration. When the data plane persists a worker's `writeResource` call, it passes this redactor to `createResourceWriter()`.

### Files changed

| File | What |
|---|---|
| `src/domain/vaults/vault_secret_bag.ts` | Added `rawValues` getter to expose resolved secret values |
| `src/domain/remote/protocol.ts` | Added optional `secretValues` field to `DispatchParamsSchema` |
| `src/domain/remote/remote_dispatch.ts` | Added `secretValues` to `RemoteStepRequest` interface |
| `src/domain/models/method_execution_service.ts` | Extracts vault bag raw values + sensitive field values, passes in dispatch |
| `src/serve/dispatch_service.ts` | Builds per-dispatch `SecretRedactor`, passes `secretValues` to wire protocol |
| `src/serve/dispatch_registry.ts` | Added `redactor` field to `ActiveDispatch` |
| `src/serve/data_plane.ts` | Passes `dispatch.redactor` to `createResourceWriter()` instead of `undefined` |
| `src/worker/remote_method_context.ts` | Populates worker-side `SecretRedactor` from `dispatch.secretValues` |
| `design/remote-execution.md` | Added "Secret redaction" subsection documenting the two-layer contract |

### Rolling upgrade note

Both orchestrator **and** worker must run the new binary for redaction to take effect on remote steps. The `secretValues` field is optional in the Zod schema, so mixed versions degrade gracefully to the prior (unredacted) behavior — no regression, but no fix for the old side.

### Latent data

Data already persisted unredacted from past runs remains on disk. This fix is forward-only.

### Follow-up

- swamp-club/swamp-uat#328 — adversarial UAT test for remote worker secret redaction

## Test Plan

- **Unit tests:** 2 new tests in `remote_method_context_test.ts` (redactor populated / empty), 1 new test in `data_plane_test.ts` (per-dispatch redactor scrubs written resources)
- **Reproduction verified:** Ran the exact scenario from the issue report — `command/shell` step with `vault.get()` in `env`, one local and one on a labelled remote worker via `swamp serve`. Before fix: local step `***`, worker step plaintext. After fix: both steps `***` in all three persistence locations (result resource, log file, workflow-run record)
- **Existing tests:** All 9327 tests pass, no regressions

Closes swamp-club#1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)