### PR TITLE
fix(extensions): enforce label cap (max 20) in local manifest validation (swamp-club#1393)

### DIFF
--- a/src/domain/extensions/extension_manifest.ts
+++ b/src/domain/extensions/extension_manifest.ts
@@ -25,6 +25,8 @@ import { UserError } from "../errors.ts";
 /** Scoped name pattern: @collective/name or @collective/name/subname/... */
 const SCOPED_NAME_PATTERN = /^@[a-z0-9_-]+\/[a-z0-9_-]+(\/[a-z0-9_-]+)*$/;
 
+export const MAX_LABELS = 20;
+
 /**
  * Checks whether a relative path is safe for use in an extension manifest.
  * Rejects absolute paths and paths containing '..' components, which would
@@ -100,7 +102,9 @@ const ExtensionManifestSchemaV1 = z.object({
   additionalFiles: z.array(safePathString).optional(),
   binaries: z.array(safePathString).optional(),
   platforms: z.array(z.string().min(1)).optional(),
-  labels: z.array(z.string().min(1)).optional(),
+  labels: z.array(z.string().min(1)).max(MAX_LABELS, {
+    message: `Too many labels (max ${MAX_LABELS})`,
+  }).optional(),
   releaseNotes: z.string().max(5000).optional(),
   dependencies: z.array(
     z.string().refine((dep) => dep.includes("/"), {

--- a/src/domain/extensions/extension_manifest_test.ts
+++ b/src/domain/extensions/extension_manifest_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { assertStringIncludes } from "@std/assert/string-includes";
 import {
   isSafeRelativePath,
+  MAX_LABELS,
   parseExtensionManifest,
 } from "./extension_manifest.ts";
 
@@ -289,6 +290,36 @@ labels:
 `;
   const manifest = parseExtensionManifest(yaml);
   assertEquals(manifest.labels, ["aws", "kubernetes", "security"]);
+});
+
+Deno.test("parseExtensionManifest accepts manifest with exactly MAX_LABELS labels", () => {
+  const labels = Array.from({ length: MAX_LABELS }, (_, i) => `label-${i}`);
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - foo.ts
+labels:
+${labels.map((l) => `  - ${l}`).join("\n")}
+`;
+  const manifest = parseExtensionManifest(yaml);
+  assertEquals(manifest.labels.length, MAX_LABELS);
+});
+
+Deno.test("parseExtensionManifest rejects manifest with more than MAX_LABELS labels", () => {
+  const labels = Array.from({ length: MAX_LABELS + 1 }, (_, i) => `label-${i}`);
+  const yaml = `
+manifestVersion: 1
+name: "@myuser/myext"
+version: "2026.02.26.1"
+models:
+  - foo.ts
+labels:
+${labels.map((l) => `  - ${l}`).join("\n")}
+`;
+  const error = assertThrows(() => parseExtensionManifest(yaml));
+  assertStringIncludes(String(error), "Too many labels");
 });
 
 Deno.test("parseExtensionManifest parses valid manifest with repository", () => {


### PR DESCRIPTION
## Summary

- Adds `MAX_LABELS = 20` constant and `.max(MAX_LABELS)` constraint to the `labels` Zod array in the extension manifest schema
- `extension push --dry-run` (and real push) now fail at manifest parse time when labels exceed 20, instead of passing locally and being rejected server-side
- Adds boundary and rejection unit tests for the new constraint

Closes swamp-club#1393

## Test Plan

- [x] `parseExtensionManifest` accepts a manifest with exactly 20 labels
- [x] `parseExtensionManifest` rejects a manifest with 21 labels with "Too many labels" error
- [x] All 43 existing manifest tests continue to pass
- [x] `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)