### PR TITLE
fix(models): persist invocation tracking so breadth limit is enforced (swamp-club#1399)

### DIFF
--- a/src/domain/models/model_invocation_service.ts
+++ b/src/domain/models/model_invocation_service.ts
@@ -154,11 +154,12 @@ export class ModelInvocationService {
     options: RunModelOptions,
     callerContext: MethodContext,
   ): Promise<RunModelResult> {
-    const tracking = callerContext._invocationTracking ?? {
+    callerContext._invocationTracking ??= {
       depth: 0,
       ancestors: new Set<string>(),
       breadthCounter: { count: 0 },
     };
+    const tracking = callerContext._invocationTracking;
 
     if (tracking.depth >= MAX_INVOCATION_DEPTH) {
       return {

--- a/src/domain/models/model_invocation_service_test.ts
+++ b/src/domain/models/model_invocation_service_test.ts
@@ -191,6 +191,40 @@ Deno.test("ModelInvocationService: initializes tracking when not present on cont
     (result as RunModelResult & { ok: false }).error.message,
     "not found",
   );
+
+  // Tracking must be persisted on the caller context so subsequent calls
+  // share the same breadth counter
+  assertEquals(ctx._invocationTracking !== undefined, true);
+  assertEquals(ctx._invocationTracking!.breadthCounter.count, 1);
+});
+
+Deno.test("ModelInvocationService: breadth limit enforced from fresh context without pre-seeded tracking", async () => {
+  const svc = makeSvc();
+  const ctx = makeStubContext();
+
+  for (let i = 0; i < 100; i++) {
+    const result = await svc.invoke(
+      { definition: `def-${i}`, method: "read" },
+      ctx,
+    );
+    // Each call increments the counter and fails on definition lookup
+    assertEquals(result.ok, false);
+    assertStringIncludes(
+      (result as RunModelResult & { ok: false }).error.message,
+      "not found",
+    );
+  }
+
+  // Call 101 must be refused by the breadth guard
+  const result = await svc.invoke(
+    { definition: "one-too-many", method: "read" },
+    ctx,
+  );
+  assertEquals(result.ok, false);
+  assertStringIncludes(
+    (result as RunModelResult & { ok: false }).error.message,
+    "Maximum cross-model invocation count",
+  );
 });
 
 Deno.test("ModelInvocationService: depth 0 with no tracking allows first call", async () => {


### PR DESCRIPTION
## Summary

- Persist the invocation tracking object back to `callerContext._invocationTracking` so `MAX_INVOCATION_BREADTH` (100) is enforced for top-level `runModel()` calls
- Fix existing test that asserted the buggy behavior (tracking left `undefined` on caller context)
- Add new test exercising 101 sequential calls from a fresh context to verify the breadth guard fires

Closes swamp-club#1399

## Test Plan

- [x] `deno check` passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 17 `model_invocation_service_test.ts` tests pass
- [x] New test `"breadth limit enforced from fresh context without pre-seeded tracking"` verifies the exact scenario from the issue report (101 calls, no pre-seeded tracking)
- [x] Binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)