### PR TITLE
fix(data): propagate workflowId so workflow/job-lifetime data is collected

### DIFF
--- a/src/domain/data/data_lifecycle_service_test.ts
+++ b/src/domain/data/data_lifecycle_service_test.ts
@@ -929,3 +929,103 @@ Deno.test("deleteOrphanedData - no orphans when all models live", async () => {
   assertEquals(result.modelsReclaimed, 0);
   assertEquals(result.reclaimedModels.length, 0);
 });
+
+// --- isExpired: workflow/job lifetime ---
+
+function createWorkflowData(overrides: {
+  name: string;
+  lifetime: string;
+  workflowId?: string;
+  workflowRunId?: string;
+}): Data {
+  return Data.create({
+    name: overrides.name,
+    contentType: "application/json",
+    lifetime: overrides.lifetime,
+    garbageCollection: 5,
+    tags: { type: "test" },
+    ownerDefinition: {
+      ownerType: "model-method",
+      ownerRef: "test-ref",
+      ...(overrides.workflowId ? { workflowId: overrides.workflowId } : {}),
+      ...(overrides.workflowRunId
+        ? { workflowRunId: overrides.workflowRunId }
+        : {}),
+    },
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+  });
+}
+
+Deno.test("isExpired: workflow lifetime — expired when workflow run is deleted", async () => {
+  const mockRunRepo = new MockWorkflowRunRepository();
+  mockRunRepo.findById = () => Promise.resolve(null);
+
+  const service = new DefaultDataLifecycleService(
+    new MockDataRepository() as never,
+    mockRunRepo as never,
+  );
+
+  const data = createWorkflowData({
+    name: "wf-data",
+    lifetime: "workflow",
+    workflowId: "5e646ae3-17a6-4ada-9a5b-6355a657b088",
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  });
+
+  assertEquals(await service.isExpired(data), true);
+});
+
+Deno.test("isExpired: workflow lifetime — not expired when workflow run exists", async () => {
+  const mockRunRepo = new MockWorkflowRunRepository();
+  mockRunRepo.findById = () => Promise.resolve({} as never);
+
+  const service = new DefaultDataLifecycleService(
+    new MockDataRepository() as never,
+    mockRunRepo as never,
+  );
+
+  const data = createWorkflowData({
+    name: "wf-data",
+    lifetime: "workflow",
+    workflowId: "5e646ae3-17a6-4ada-9a5b-6355a657b088",
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  });
+
+  assertEquals(await service.isExpired(data), false);
+});
+
+Deno.test("isExpired: job lifetime — expired when workflow run is deleted", async () => {
+  const mockRunRepo = new MockWorkflowRunRepository();
+  mockRunRepo.findById = () => Promise.resolve(null);
+
+  const service = new DefaultDataLifecycleService(
+    new MockDataRepository() as never,
+    mockRunRepo as never,
+  );
+
+  const data = createWorkflowData({
+    name: "job-data",
+    lifetime: "job",
+    workflowId: "5e646ae3-17a6-4ada-9a5b-6355a657b088",
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  });
+
+  assertEquals(await service.isExpired(data), true);
+});
+
+Deno.test("isExpired: workflow lifetime — not expired when workflowId missing", async () => {
+  const mockRunRepo = new MockWorkflowRunRepository();
+
+  const service = new DefaultDataLifecycleService(
+    new MockDataRepository() as never,
+    mockRunRepo as never,
+  );
+
+  const data = createWorkflowData({
+    name: "legacy-data",
+    lifetime: "workflow",
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  });
+
+  assertEquals(await service.isExpired(data), false);
+});

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -614,6 +614,9 @@ export function createResourceWriter(
       ownerDefinition: {
         ownerType: "model-method",
         ownerRef: modelId,
+        ...(tagOverrides?.["workflowId"]
+          ? { workflowId: tagOverrides["workflowId"] }
+          : {}),
         ...(tagOverrides?.["workflowRunId"]
           ? { workflowRunId: tagOverrides["workflowRunId"] }
           : {}),
@@ -926,6 +929,9 @@ export function createFileWriterFactory(
       ownerDefinition: {
         ownerType: "model-method",
         ownerRef: modelId,
+        ...(tagOverrides?.["workflowId"]
+          ? { workflowId: tagOverrides["workflowId"] }
+          : {}),
         ...(tagOverrides?.["workflowRunId"]
           ? { workflowRunId: tagOverrides["workflowRunId"] }
           : {}),

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -345,6 +345,67 @@ Deno.test("createResourceWriter: omits ownerDefinition.jobName when not in tagOv
   assertEquals(handle.metadata.ownerDefinition.jobName, undefined);
 });
 
+Deno.test("createResourceWriter: populates ownerDefinition.workflowId from tagOverrides", async () => {
+  const repo = createMockRepo();
+  const workflowId = "5e646ae3-17a6-4ada-9a5b-6355a657b088";
+  const tagOverrides = {
+    source: "step-output",
+    workflow: "my-wf",
+    workflowId,
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  };
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+    tagOverrides,
+  );
+
+  const handle = await writeResource("item", "test-item", { value: "hello" });
+  assertEquals(handle.metadata.ownerDefinition.workflowId, workflowId);
+});
+
+Deno.test("createResourceWriter: omits ownerDefinition.workflowId when not in tagOverrides", async () => {
+  const repo = createMockRepo();
+  const tagOverrides = { source: "step-output", workflow: "my-wf" };
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+    tagOverrides,
+  );
+
+  const handle = await writeResource("item", "test-item", { value: "hello" });
+  assertEquals(handle.metadata.ownerDefinition.workflowId, undefined);
+});
+
+Deno.test("createFileWriterFactory: populates ownerDefinition.workflowId from tagOverrides", async () => {
+  const repo = createMockRepo();
+  const workflowId = "5e646ae3-17a6-4ada-9a5b-6355a657b088";
+  const tagOverrides = {
+    source: "step-output",
+    workflow: "my-wf",
+    workflowId,
+    workflowRunId: "7e820a5f-518e-4d35-8f9e-60b55bbb15df",
+  };
+
+  const { createFileWriter } = createFileWriterFactory(
+    repo,
+    modelType,
+    modelId,
+    testFiles,
+    tagOverrides,
+  );
+
+  const writer = createFileWriter("log", "test-log");
+  const handle = await writer.writeText("log content");
+  assertEquals(handle.metadata.ownerDefinition.workflowId, workflowId);
+});
+
 Deno.test("createFileWriterFactory: populates ownerDefinition.workflowRunId from tagOverrides", async () => {
   const repo = createMockRepo();
   const workflowRunId = "6be8c3b8-ff3f-4e23-b998-fd9456d84d0a";

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1007,6 +1007,7 @@ export class DefaultStepExecutor implements StepExecutor {
       ...(ctx.workflowTags ?? {}),
       source: "step-output",
       workflow: ctx.workflowName,
+      workflowId: ctx.workflowId,
       workflowRunId: ctx.workflowRunId,
       job: ctx.jobName,
       step: ctx.stepName,


### PR DESCRIPTION
## Summary

- Propagate `workflowId` from `StepExecutionContext` into `workflowTagOverrides` in `execution_service.ts`, and extract it into the `ownerDefinition` at both write sites in `data_writer.ts`
- This unblocks the `isExpired` check in `data_lifecycle_service.ts` which requires `workflowId` to look up whether the owning workflow run still exists — without it, `workflow` and `job` lifetime data was silently never garbage-collected
- Add unit tests for `isExpired` with workflow/job lifetimes and for `workflowId` propagation through tag overrides

Fixes swamp-club#1398

## Test plan

- [x] `deno check` on all modified files passes
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `data_lifecycle_service_test.ts` — 41 tests pass (4 new: workflow expired, workflow not expired, job expired, missing workflowId)
- [x] `data_writer_test.ts` — 79 tests pass (3 new: resource writer workflowId, resource writer omit, file writer workflowId)
- [x] End-to-end verification: workflow-lifetime data with the fixed binary is collected by `data gc` after the owning run is deleted (`reason: "workflow-deleted"`); the same scenario with the installed binary leaves the data orphaned with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)