### PR TITLE
fix(serve): harden cancel auth, token auth, gate wiring, and scope errors

### DIFF
--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -27,6 +27,7 @@ interface AuthState {
   authenticated: boolean;
   collectiveToken: boolean;
   authScopes: string[] | undefined;
+  scopeResolutionFailed: boolean;
 }
 
 const STATE_KEY = "__swamp_auth_state__";
@@ -37,6 +38,7 @@ function state(): AuthState {
       authenticated: false,
       collectiveToken: false,
       authScopes: undefined,
+      scopeResolutionFailed: false,
     };
   }
   return g[STATE_KEY];
@@ -64,6 +66,10 @@ export function setAuthScopes(scopes: string[] | undefined): void {
 
 export function getAuthScopes(): string[] | undefined {
   return state().authScopes;
+}
+
+export function setScopeResolutionFailed(value: boolean): void {
+  state().scopeResolutionFailed = value;
 }
 
 export function requireAuthenticated(
@@ -105,6 +111,17 @@ export function requireScope(scope: string): void {
     s.authScopes !== undefined &&
     s.authScopes.some((held) => scopeMatches(held, scope))
   ) return;
+
+  if (s.authScopes === undefined && s.scopeResolutionFailed) {
+    throw new UserError(
+      `Could not verify your collective token's scopes (the startup\n` +
+        `connectivity check to swamp-club.com failed). Retry, or check\n` +
+        `your network connectivity.\n\n` +
+        `If the problem persists, sign in with your personal account:\n\n` +
+        `  swamp auth login\n`,
+      "scope_unverified",
+    );
+  }
 
   throw new UserError(
     `Your collective token lacks the ${scope} scope.\n\n` +

--- a/src/cli/auth_context_test.ts
+++ b/src/cli/auth_context_test.ts
@@ -26,6 +26,7 @@ import {
   setAuthenticated,
   setAuthScopes,
   setCollectiveToken,
+  setScopeResolutionFailed,
 } from "./auth_context.ts";
 import { UserError } from "../domain/errors.ts";
 
@@ -108,14 +109,31 @@ Deno.test("requireScope: throws when collective token has empty scopes", () => {
   setAuthScopes(undefined);
 });
 
-Deno.test("requireScope: throws when collective token has undefined scopes (whoami failed)", () => {
+Deno.test("requireScope: throws missing_scope when collective token has undefined scopes", () => {
   setCollectiveToken("swamp_org_abc");
   setAuthScopes(undefined);
-  assertThrows(
+  setScopeResolutionFailed(false);
+  const err = assertThrows(
     () => requireScope("serve:*"),
     UserError,
   );
+  assertEquals(err.code, "missing_scope");
   setCollectiveToken("");
+});
+
+Deno.test("requireScope: throws scope_unverified when scope resolution failed", () => {
+  setCollectiveToken("swamp_org_abc");
+  setAuthScopes(undefined);
+  setScopeResolutionFailed(true);
+  const err = assertThrows(
+    () => requireScope("serve:*"),
+    UserError,
+  );
+  assertEquals(err.code, "scope_unverified");
+  assertStringIncludes(err.message, "Could not verify");
+  assertStringIncludes(err.message, "swamp-club.com");
+  setCollectiveToken("");
+  setScopeResolutionFailed(false);
 });
 
 Deno.test("scopeMatches: exact match", () => {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1926,7 +1926,7 @@ export const serveCommand = new Command()
           if (webhookResponse) return webhookResponse;
         }
 
-        // Cancel endpoint (authenticated — same auth as WebSocket)
+        // Cancel endpoint (authenticated + authorized)
         if (req.method === "POST") {
           const url = new URL(req.url);
           const cancelMatch = url.pathname.match(
@@ -1935,6 +1935,14 @@ export const serveCommand = new Command()
           const isBulkCancel = url.pathname === "/api/v1/cancel";
           if (cancelMatch || isBulkCancel) {
             if (authConfig.mode !== "none") {
+              const cancelRemoteAddr = trustProxy
+                ? (req.headers.get("x-forwarded-for")
+                  ?.split(",")[0]?.trim() ??
+                  info.remoteAddr.hostname)
+                : info.remoteAddr.hostname;
+              if (!checkRateLimit(cancelRemoteAddr)) {
+                return new Response("Too Many Requests", { status: 429 });
+              }
               const authHeader = req.headers.get("authorization");
               const token = authHeader?.startsWith("Bearer ")
                 ? authHeader.slice(7)
@@ -1951,6 +1959,27 @@ export const serveCommand = new Command()
               );
               if (!authResult.ok) {
                 return new Response("Unauthorized", { status: 401 });
+              }
+              clearRateLimit(cancelRemoteAddr);
+
+              const cancelPrincipal = parsePrincipal(authResult.principalId);
+              if (policySnapshotLoader) {
+                const service = policySnapshotLoader.decisionService;
+                const decision = service.decide(
+                  {
+                    principal: cancelPrincipal,
+                    collectives: [...authResult.collectives],
+                    groups: [...authResult.groups],
+                  },
+                  "admin",
+                  { kind: "access", name: "*", fields: {} },
+                );
+                if (!decision || decision.effect !== "allow") {
+                  return Response.json({
+                    status: "error",
+                    message: "Access denied: cancel requires admin permission",
+                  }, { status: 403 });
+                }
               }
             }
           }

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -111,6 +111,7 @@ import {
   setAuthenticated,
   setAuthScopes,
   setCollectiveToken,
+  setScopeResolutionFailed,
 } from "./auth_context.ts";
 import {
   apiKeyFingerprint,
@@ -1378,8 +1379,11 @@ export async function runCli(args: string[]): Promise<void> {
           }
         }
       }
-    } catch {
-      // Best-effort — don't block CLI startup
+    } catch (err) {
+      setScopeResolutionFailed(true);
+      logger.warn`Scope resolution failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
     }
   }
 

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -677,23 +677,9 @@ export async function* modelMethodRun(
               });
           }
 
-          if (
-            "workflowGateService" in executionService &&
-            !executionService.workflowGateService &&
-            deps.workflowRepo &&
-            deps.workflowRunRepo
-          ) {
-            const { createWorkflowGateService } = await import(
-              "./workflow_gate.ts"
-            );
-            (executionService as {
-              workflowGateService?:
-                import("../../domain/models/workflow_gate_service.ts").WorkflowGateService;
-            }).workflowGateService = createWorkflowGateService(
-              deps.workflowRepo,
-              deps.workflowRunRepo,
-            );
-          }
+          // Gate service intentionally not wired here — approving/rejecting
+          // workflow gates from model code bypasses authorization. Use the
+          // CLI (swamp workflow approve/reject) or WebSocket API instead.
 
           // Start heartbeat inside the try so it's always cleaned up on error.
           if (deps.runTracker) {

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -562,15 +562,9 @@ export async function* workflowRun(
           ephemeral.catalog,
         );
 
-        if (!service.workflowGateService) {
-          const { createWorkflowGateService } = await import(
-            "../models/workflow_gate.ts"
-          );
-          service.workflowGateService = createWorkflowGateService(
-            deps.workflowRepo,
-            deps.runRepo,
-          );
-        }
+        // Gate service intentionally not wired here — approving/rejecting
+        // workflow gates from model code bypasses authorization. Use the
+        // CLI (swamp workflow approve/reject) or WebSocket API instead.
 
         // Per-method-invocation telemetry bridge. Constructed once per
         // stream consumption and finalized in the outer try/finally so

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -19,7 +19,6 @@
 
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { createLibSwampContext, modelMethodRun } from "../libswamp/mod.ts";
-import { SERVER_TOKEN_MODEL_TYPE } from "../domain/models/access/server_token_model.ts";
 import { createModelMethodRunDeps } from "./deps.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
@@ -121,9 +120,7 @@ export async function authenticateServerToken(
     };
   }
 
-  const deps = await createModelMethodRunDeps(repoDir, repoContext, {
-    directExecution: true,
-  });
+  const deps = await createModelMethodRunDeps(repoDir, repoContext);
   const libCtx = createLibSwampContext({});
 
   let principalId: string | undefined;
@@ -135,8 +132,6 @@ export async function authenticateServerToken(
       methodName: "redeem",
       inputs: { presentedToken: presented },
       lastEvaluated: false,
-      typeArg: SERVER_TOKEN_MODEL_TYPE.normalized,
-      definitionName: split.name,
       skipAllReports: true,
     })
   ) {


### PR DESCRIPTION
## Summary

Fixes four user-reported `swamp serve` issues:

- **#1397 — approveWorkflowGate no authorization.** Removes automatic wiring of the workflow gate service onto model execution contexts in both `models/run.ts` and `workflows/run.ts`. Models can no longer call `context.approveWorkflowGate()` / `rejectWorkflowGate()` — gate operations must go through the CLI (`swamp workflow approve/reject`) or WebSocket API, both of which have proper authorization. The `InProcessExecutor` still supports the service if explicitly provided; only the unconditional injection is removed.

- **#1394 — failed auth writes attacker-named YAML definitions.** Token authentication now uses the standard definition lookup path instead of `directExecution: true`. When a presented token name doesn't match an existing definition, `modelMethodRun` yields a `modelNotFound` error — no YAML is ever auto-created. Legitimate tokens (whose definitions were created at mint time) continue to authenticate normally.

- **#1383 — cancel endpoint authenticates but never authorizes.** The cancel endpoint (`POST /api/v1/cancel`) now applies rate limiting (`checkRateLimit`/`clearRateLimit`) matching the WebSocket upgrade path, and requires admin permission via `policySnapshotLoader.decisionService.decide()` after successful authentication. Non-admin principals receive 403.

- **#1381 — misleading "lacks scope" on network failure.** `requireScope` now distinguishes between "scopes resolved but missing" (`missing_scope`) and "scope resolution failed" (`scope_unverified`). The bare `catch {}` in `mod.ts` sets a `scopeResolutionFailed` flag and logs the error at `warn` level instead of silently discarding it.

## Test Plan

- `deno check`, `deno lint`, `deno fmt` — all pass
- `deno run test` — 9343 passed, 0 failed
- New unit test for `scope_unverified` error path in `auth_context_test.ts`
- Compiled binary verification against each original issue reproduction:
  - **#1394**: 12 bogus token auth requests → 0 new YAML files (was 12), plus edge-case token names (dashed, special chars) all authenticate successfully
  - **#1383**: Bob (zero grants) → 403 "cancel requires admin permission"; Alice (admin) → 200; rate limiter → 429 after 5 bad attempts
  - **#1381**: `SWAMP_CLUB_URL=https://192.0.2.1:9` → "Could not verify your collective token's scopes" (was "lacks the serve:* scope")
  - **#1397**: Pulled extension model reports `approveWorkflowGate=false, rejectWorkflowGate=false`; CLI `swamp workflow approve` still works end-to-end (workflow suspends → approve → approvals clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)