### PR TITLE
fix(datastore): show relocation messaging in setup output (swamp-club#1278)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -1287,6 +1287,25 @@ timeout, Ctrl-C, transient 5xx), the repo stays in a safe, resumable state:
   idempotent, so a subsequent push overwrites with identical content.
 
 **To retry:** re-run the exact same `swamp datastore setup extension` command.
+
+### Directory Relocation
+
+When a datastore is enabled on a repo that previously used the default
+filesystem layout, the runtime directories (`data`, `outputs`, `workflow-runs`,
+and others listed in `DEFAULT_DATASTORE_SUBDIRS`) are relocated from
+`{repoDir}/.swamp/` to the datastore path. For extension datastores this is the
+local cache (`~/.swamp/repos/{repoId}/`), not the remote. The setup command
+prints which directories moved and where:
+
+```
+Relocated: data, outputs, workflow-runs now resolve under /new/path
+  Moved from: /repo/.swamp
+```
+
+After setup, `DefaultDatastorePathResolver.resolvePath()` routes these
+subdirectories to the new location. Code that hardcodes `.swamp/workflow-runs/`
+or similar paths will silently break — use `swamp workflow run search --json`,
+`swamp data get`, or equivalent CLI commands instead of direct filesystem access.
 The migration copies files to the cache (overwriting any partial cache from the
 previous attempt), pushes to the remote (idempotent), pulls from the remote,
 and only then updates `.swamp.yaml` and cleans up `.swamp/`.

--- a/src/libswamp/datastores/setup.ts
+++ b/src/libswamp/datastores/setup.ts
@@ -62,6 +62,8 @@ export interface DatastoreSetupData {
   errors: string[];
   retryHint?: string;
   namespace?: string;
+  sourcePath?: string;
+  destinationPath?: string;
 }
 
 export interface DatastoreSetupWarningData {
@@ -266,6 +268,12 @@ export async function* datastoreSetupFilesystem(
                 "Re-run the same command to retry. Local data is preserved and the retry is safe.",
             }
             : {}),
+          ...(directoriesMigrated.length > 0
+            ? {
+              sourcePath: sourceDir,
+              destinationPath: input.datastorePath,
+            }
+            : {}),
         },
       };
     })(),
@@ -438,6 +446,7 @@ export async function* datastoreSetupExtension(
       let migrationResult:
         | {
           filesCopied: number;
+          bytesCopied: number;
           directoriesMigrated: string[];
         }
         | undefined;
@@ -594,20 +603,29 @@ export async function* datastoreSetupExtension(
         }
       }
 
+      const migratedDirs = migrationResult?.directoriesMigrated ?? [];
+      const migratedBytes = migrationResult?.bytesCopied ?? 0;
+
       yield {
         kind: "completed",
         data: {
           type: input.type,
           filesCopied,
           filesPulled,
-          bytesCopied: 0,
-          directoriesMigrated: [],
+          bytesCopied: migratedBytes,
+          directoriesMigrated: migratedDirs,
           errors,
           ...(ns ? { namespace: ns } : {}),
           ...(errors.length > 0
             ? {
               retryHint:
                 "Re-run the same command to retry. Local data is preserved and the retry is safe.",
+            }
+            : {}),
+          ...(migratedDirs.length > 0
+            ? {
+              sourcePath: `${input.repoDir}/.swamp`,
+              destinationPath: cachePath,
             }
             : {}),
         },

--- a/src/libswamp/datastores/setup_test.ts
+++ b/src/libswamp/datastores/setup_test.ts
@@ -99,6 +99,8 @@ Deno.test("datastoreSetupFilesystem: completes with migration", async () => {
   assertEquals(completed.data.bytesCopied, 1024);
   assertEquals(completed.data.directoriesMigrated, ["data", "outputs"]);
   assertEquals(completed.data.errors, []);
+  assertEquals(completed.data.sourcePath, "/tmp/repo/.swamp");
+  assertEquals(completed.data.destinationPath, "/tmp/datastore");
 });
 
 Deno.test("datastoreSetupFilesystem: completes with skip migration", async () => {
@@ -118,6 +120,8 @@ Deno.test("datastoreSetupFilesystem: completes with skip migration", async () =>
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data.filesCopied, 0);
   assertEquals(completed.data.directoriesMigrated, []);
+  assertEquals(completed.data.sourcePath, undefined);
+  assertEquals(completed.data.destinationPath, undefined);
 });
 
 Deno.test("datastoreSetupFilesystem: errors on unhealthy path", async () => {
@@ -383,6 +387,10 @@ Deno.test("datastoreSetupExtension: completes with valid config", async () => {
   >;
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data.type, "test-ext-setup");
+  assertEquals(completed.data.directoriesMigrated, ["data", "outputs"]);
+  assertEquals(completed.data.bytesCopied, 1024);
+  assertEquals(completed.data.sourcePath, "/tmp/repo/.swamp");
+  assertEquals(completed.data.destinationPath, "/tmp/repo/.custom-cache");
 });
 
 Deno.test("datastoreSetupExtension: completes with skip migration", async () => {
@@ -409,6 +417,8 @@ Deno.test("datastoreSetupExtension: completes with skip migration", async () => 
   >;
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data.filesCopied, 0);
+  assertEquals(completed.data.sourcePath, undefined);
+  assertEquals(completed.data.destinationPath, undefined);
 });
 
 Deno.test("datastoreSetupExtension: errors on unregistered type", async () => {

--- a/src/presentation/renderers/datastore_setup.ts
+++ b/src/presentation/renderers/datastore_setup.ts
@@ -79,6 +79,16 @@ class LogDatastoreSetupRenderer implements Renderer<DatastoreSetupEvent> {
         }
         lines.push(`  Dirs:     ${data.directoriesMigrated.join(", ")}`);
 
+        if (data.sourcePath && data.destinationPath) {
+          lines.push("");
+          lines.push(
+            yellow(bold("Relocated:")) + " " +
+              data.directoriesMigrated.join(", ") +
+              " now resolve under " + bold(data.destinationPath),
+          );
+          lines.push(`  Moved from: ${data.sourcePath}`);
+        }
+
         if (data.errors.length > 0) {
           lines.push("");
           lines.push(yellow("Warnings:"));


### PR DESCRIPTION
## Summary

- `swamp datastore setup` now prints a `Relocated:` block showing which directories moved and where (source → destination path)
- Fixed extension setup discarding `directoriesMigrated` (was always `[]`) and `bytesCopied` (was always `0`) from the migration result
- Updated `design/datastores.md` with a "Directory Relocation" section documenting the behavior
- Filed #1964 for manual documentation updates

Closes #1278

## Test Plan

- [x] Unit tests verify `sourcePath`/`destinationPath` fields are present when migration occurs and absent when skipped (both filesystem and extension paths)
- [x] Unit tests verify extension setup now threads `directoriesMigrated` and `bytesCopied` through to the completed event
- [x] Reproduced the issue with MinIO (`@swamp/s3-datastore`) — confirmed the fix shows relocation messaging and correct byte counts
- [x] Also verified filesystem datastore setup shows the same relocation messaging
- [x] All 41 setup tests pass
- [x] `deno fmt`, `deno lint`, `deno check` clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)