### PR TITLE
fix(output): fix log file audit trail, auto-resolve severity, and suspended handler

### DIFF
--- a/integration/serve_run_test.ts
+++ b/integration/serve_run_test.ts
@@ -147,7 +147,6 @@ Deno.test({
       const kinds: string[] = [];
       const renderer = createWorkflowRunRenderer("log", {
         workflowName: "serve-run-demo",
-        forceLog: true,
       });
       const handlers = renderer.handlers();
 
@@ -184,7 +183,6 @@ Deno.test({
       // the renderer's error handler throws — identical to local behavior.
       const renderer = createWorkflowRunRenderer("log", {
         workflowName: "no-such-workflow",
-        forceLog: true,
       });
       const handlers = renderer.handlers() as Record<
         string,

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -414,7 +414,7 @@ export const workflowRunCommand = new Command()
 
         const renderer = createWorkflowRunRenderer(ctx.outputMode, {
           workflowName: workflowIdOrName,
-          forceLog: ctx.forceLog,
+
           isAuthenticated: isAuthenticated(),
           quiet: ctx.verbosity === "quiet",
         });
@@ -569,7 +569,6 @@ async function runWorkflowViaServer(
       }
       const renderer = createWorkflowRunRenderer(ctx.outputMode, {
         workflowName: workflowIdOrName,
-        forceLog: ctx.forceLog,
         isAuthenticated: isAuthenticated(),
         quiet: ctx.verbosity === "quiet",
       });

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1424,7 +1424,7 @@ export async function runCli(args: string[]): Promise<void> {
     .globalType("model_type", new ModelTypeType())
     .globalType("workflow_name", new WorkflowNameType())
     .globalOption("--json", "Output in JSON format (non-interactive)")
-    .globalOption("--log", "Force flat log output (no interactive tree)")
+    .globalOption("--log", "Force non-interactive log output")
     .globalOption(
       "--log-level <level:string>",
       "Set log level (trace, debug, info, warning, error, fatal)",

--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -19,8 +19,6 @@
 
 import { dirname, join, resolve, SEPARATOR, toFileUrl } from "@std/path";
 import { getLogger } from "@logtape/logtape";
-import { dim } from "@std/fmt/colors";
-import { getSystemPipeWidth } from "../../infrastructure/logging/logger.ts";
 import {
   bundleExtension,
   fixCjsEsmInterop,
@@ -378,14 +376,8 @@ export class ExtensionLoader {
       expectedSourceDirsFingerprint: currentSourceFingerprint,
     });
     if (guard.shouldInvalidate && guard.reason !== "not-populated") {
-      const syspad = "system".padStart(getSystemPipeWidth() + 1);
-      console.error(
-        `${dim(`${syspad} │`)} ${
-          dim(
-            `Catalog invalidated for ${this.adapter.kind} rescan: ${guard.reason}`,
-          )
-        }`,
-      );
+      this.logger
+        .info`Catalog invalidated for ${this.adapter.kind} rescan: ${guard.reason}`;
       catalog.invalidate(this.adapter.kind);
 
       if (guard.reason === "layout-version-mismatch") {

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -183,18 +183,14 @@ export async function initializeLogging(
       {
         category: ["model", "method", "run"],
         lowestLevel: logLevel,
-        // In JSON mode these loggers override parent sinks, so the otel sink
-        // must be listed here explicitly or per-run logs would never reach it.
-        // In non-JSON mode they inherit the root's otel sink, so adding it here
-        // too would double-export — hence the jsonMode guard.
-        sinks: jsonMode ? ["runFile", ...otelSinks] : ["runFile"],
-        parentSinks: jsonMode ? "override" : "inherit",
+        sinks: ["runFile", ...otelSinks],
+        parentSinks: "override",
       },
       {
         category: ["workflow", "run"],
         lowestLevel: logLevel,
-        sinks: jsonMode ? ["runFile", ...otelSinks] : ["runFile"],
-        parentSinks: jsonMode ? "override" : "inherit",
+        sinks: ["runFile", ...otelSinks],
+        parentSinks: "override",
       },
       {
         category: ["logtape", "meta"],

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -34,8 +34,7 @@ import type {
   LockOptions,
 } from "../../domain/datastore/distributed_lock.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
-import { getSwampLogger, getSystemPipeWidth } from "../logging/logger.ts";
-import { dim, yellow } from "@std/fmt/colors";
+import { getSwampLogger } from "../logging/logger.ts";
 import { isProcessDead } from "../runtime/process.ts";
 
 const DEFAULT_TTL_MS = 30_000;
@@ -127,12 +126,9 @@ export class FileLock implements DistributedLock {
 
         if (retryCount > 0) {
           const waitMs = Date.now() - startTime;
-          const syspad = "system".padStart(getSystemPipeWidth() + 1);
-          console.error(
-            `${dim(`${syspad} │`)} ${
-              dim(`Acquired lock after ${retryCount} retries (${waitMs}ms)`)
-            }`,
-          );
+          const logger = getSwampLogger(["datastore", "lock"]);
+          logger
+            .info`Acquired lock ${this.lockPath} after ${retryCount} retries (${waitMs}ms)`;
         }
         return;
       } catch (error) {
@@ -161,14 +157,9 @@ export class FileLock implements DistributedLock {
 
         if (!contentionLogged) {
           const ageMs = Date.now() - new Date(existing.acquiredAt).getTime();
-          const syspad2 = "system".padStart(getSystemPipeWidth() + 1);
-          console.error(
-            `${dim(`${syspad2} │`)} ${
-              yellow(
-                `Waiting for lock held by ${existing.holder} (pid ${existing.pid}, acquired ${ageMs}ms ago)`,
-              )
-            }`,
-          );
+          const logger = getSwampLogger(["datastore", "lock"]);
+          logger
+            .warn`Waiting for lock ${this.lockPath} held by ${existing.holder} (pid ${existing.pid}, acquired ${ageMs}ms ago)`;
           contentionLogged = true;
         }
       }

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -456,7 +456,7 @@ Deno.test("FileLock - contention message includes lock file path", async () => {
 
     await assertRejects(() => waiter.acquire(), LockTimeoutError);
 
-    const lockPath = join(dir, ".datastore.lock");
+    const lockPath = `${dir}/.datastore.lock`;
     const messages = capturedLogRecords.map((r) =>
       r.message.map((p) => String(p)).join("")
     );

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -17,12 +17,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { join } from "@std/path";
+import { configure, type LogRecord } from "@logtape/logtape";
 import { FileLock } from "./file_lock.ts";
 import type { LockInfo } from "../../domain/datastore/distributed_lock.ts";
 import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import { initializeLogging } from "../logging/logger.ts";
+
+const capturedLogRecords: LogRecord[] = [];
 
 await initializeLogging({});
 
@@ -414,5 +422,51 @@ Deno.test("FileLock - maxWaitMs override is respected", async () => {
     );
 
     await holder.release();
+  });
+});
+
+Deno.test("FileLock - contention message includes lock file path", async () => {
+  await withTempDir(async (dir) => {
+    // Set up a LogTape capture sink for the datastore.lock category
+    capturedLogRecords.length = 0;
+    await configure({
+      sinks: {
+        capture: (record: LogRecord) => {
+          capturedLogRecords.push(record);
+        },
+      },
+      loggers: [
+        {
+          category: ["datastore", "lock"],
+          lowestLevel: "info",
+          sinks: ["capture"],
+        },
+      ],
+      reset: true,
+    });
+
+    const holder = new FileLock(dir, { ttlMs: 60_000 });
+    await holder.acquire();
+
+    const waiter = new FileLock(dir, {
+      ttlMs: 60_000,
+      retryIntervalMs: 50,
+      maxWaitMs: 300,
+    });
+
+    await assertRejects(() => waiter.acquire(), LockTimeoutError);
+
+    const lockPath = join(dir, ".datastore.lock");
+    const messages = capturedLogRecords.map((r) =>
+      r.message.map((p) => String(p)).join("")
+    );
+    const output = messages.join("\n");
+    assertStringIncludes(output, lockPath);
+    assertStringIncludes(output, "Waiting for lock");
+
+    await holder.release();
+
+    // Restore normal logging
+    await initializeLogging({ _reset: true });
   });
 });

--- a/src/infrastructure/process/process_executor.ts
+++ b/src/infrastructure/process/process_executor.ts
@@ -186,21 +186,13 @@ export async function executeProcess(
       const onOutput = options.onOutput;
       stdoutOnLine = (line: string) => {
         const redacted = redact(line);
-        if (onOutput) {
-          onOutput(redacted, "stdout");
-          logger.debug(escapeLogTemplate(redacted));
-        } else {
-          logger.info(escapeLogTemplate(redacted));
-        }
+        if (onOutput) onOutput(redacted, "stdout");
+        logger.info(escapeLogTemplate(redacted));
       };
       stderrOnLine = (line: string) => {
         const redacted = redact(line);
-        if (onOutput) {
-          onOutput(redacted, "stderr");
-          logger.debug(escapeLogTemplate(redacted));
-        } else {
-          logger.warn(escapeLogTemplate(redacted));
-        }
+        if (onOutput) onOutput(redacted, "stderr");
+        logger.warn(escapeLogTemplate(redacted));
       };
     }
 
@@ -327,21 +319,13 @@ export async function executeProcess(
       const [stdoutResult, stderrResult, status] = await Promise.all([
         streamLines(process.stdout, (line) => {
           const redacted = redact(line);
-          if (onOutput) {
-            onOutput(redacted, "stdout");
-            logger.debug(escapeLogTemplate(redacted));
-          } else {
-            logger.info(escapeLogTemplate(redacted));
-          }
+          if (onOutput) onOutput(redacted, "stdout");
+          logger.info(escapeLogTemplate(redacted));
         }),
         streamLines(process.stderr, (line) => {
           const redacted = redact(line);
-          if (onOutput) {
-            onOutput(redacted, "stderr");
-            logger.debug(escapeLogTemplate(redacted));
-          } else {
-            logger.warn(escapeLogTemplate(redacted));
-          }
+          if (onOutput) onOutput(redacted, "stderr");
+          logger.warn(escapeLogTemplate(redacted));
         }),
         process.status,
       ]);

--- a/src/presentation/renderers/components/picker_layout.ts
+++ b/src/presentation/renderers/components/picker_layout.ts
@@ -107,8 +107,7 @@ const STACKED_RESULTS_FRACTION = 0.45;
  * Computes the appropriate layout tier and dimensions given terminal size.
  * Pure function — no side effects, fully deterministic.
  *
- * Follows the same pattern as workflow_run_tree/budget.ts: check from
- * richest tier to most compact, returning the first that fits.
+ * Checks from richest tier to most compact, returning the first that fits.
  */
 export function computePickerLayout(
   width: number,

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -113,8 +113,8 @@ export function renderAutoResolveNotFound(
   } else {
     writeOutput(
       gutterLine(
-        "Warning",
-        STATUS_COLORS.warn,
+        "Error",
+        STATUS_COLORS.error,
         `auto-resolution failed for type ${type}: no extension publishes this type`,
       ),
     );
@@ -142,8 +142,8 @@ export function renderAutoResolveAlreadyInstalled(
   } else {
     writeOutput(
       gutterLine(
-        "Warning",
-        STATUS_COLORS.warn,
+        "Error",
+        STATUS_COLORS.error,
         `${extension} is installed at ${path} but failed to load`,
       ),
     );
@@ -179,8 +179,8 @@ export function renderAutoResolveTruncated(
       : missing.join(", ");
     writeOutput(
       gutterLine(
-        "Warning",
-        STATUS_COLORS.warn,
+        "Error",
+        STATUS_COLORS.error,
         `${extension} at ${path} is incomplete — missing ${missing.length} file(s): ${list}`,
       ),
     );
@@ -237,8 +237,8 @@ export function renderAutoResolveNetworkError(
   } else {
     writeOutput(
       gutterLine(
-        "Warning",
-        STATUS_COLORS.warn,
+        "Error",
+        STATUS_COLORS.error,
         `auto-resolution failed for type ${type}: ${error}`,
       ),
     );

--- a/src/presentation/renderers/extension_auto_resolve_test.ts
+++ b/src/presentation/renderers/extension_auto_resolve_test.ts
@@ -1,0 +1,216 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { setColorEnabled } from "@std/fmt/colors";
+import {
+  renderAutoResolveAlreadyInstalled,
+  renderAutoResolveCollectiveNotTrusted,
+  renderAutoResolveInstalled,
+  renderAutoResolveInstalling,
+  renderAutoResolveNetworkError,
+  renderAutoResolveNoStableVersion,
+  renderAutoResolveNotFound,
+  renderAutoResolveSearching,
+  renderAutoResolveTruncated,
+} from "./extension_auto_resolve.ts";
+
+function captureOutput(fn: () => void): string[] {
+  const lines: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(
+      args.map((a) => typeof a === "string" ? a : String(a)).join(" "),
+    );
+  };
+  setColorEnabled(false);
+  try {
+    fn();
+  } finally {
+    console.log = origLog;
+    setColorEnabled(true);
+  }
+  return lines;
+}
+
+// --- log mode: info-level (non-failure) renderers ---
+
+Deno.test("renderAutoResolveSearching: log mode shows Resolving", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveSearching("@acme/widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Resolving");
+  assertStringIncludes(output, "@acme/widget");
+});
+
+Deno.test("renderAutoResolveInstalling: log mode shows Installing", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveInstalling("@acme/widget", "1.2.0", "A widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Installing");
+  assertStringIncludes(output, "@acme/widget@1.2.0");
+});
+
+Deno.test("renderAutoResolveInstalled: log mode shows Installed", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveInstalled("@acme/widget", "1.2.0", 3, "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Installed");
+  assertStringIncludes(output, "3 models registered");
+});
+
+// --- log mode: hard-failure renderers must show "Error" ---
+
+Deno.test("renderAutoResolveNotFound: log mode shows Error not Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveNotFound("@acme/widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Error");
+  assertEquals(output.includes("Warning"), false);
+  assertStringIncludes(output, "no extension publishes this type");
+  assertStringIncludes(output, "swamp extension pull");
+});
+
+Deno.test("renderAutoResolveAlreadyInstalled: log mode shows Error not Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveAlreadyInstalled(
+      "@acme/widget",
+      "/path/to/widget",
+      "log",
+    );
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Error");
+  assertEquals(output.includes("Warning"), false);
+  assertStringIncludes(output, "failed to load");
+  assertStringIncludes(output, "swamp extension pull @acme/widget --force");
+});
+
+Deno.test("renderAutoResolveTruncated: log mode shows Error not Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveTruncated(
+      "@acme/widget",
+      "/path/to/widget",
+      ["file1.ts", "file2.ts"],
+      "log",
+    );
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Error");
+  assertEquals(output.includes("Warning"), false);
+  assertStringIncludes(output, "incomplete");
+  assertStringIncludes(output, "2 file(s)");
+});
+
+Deno.test("renderAutoResolveNetworkError: log mode shows Error not Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveNetworkError("@acme/widget", "connection refused", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Error");
+  assertEquals(output.includes("Warning"), false);
+  assertStringIncludes(output, "connection refused");
+});
+
+// --- log mode: soft-failure renderers remain Warning ---
+
+Deno.test("renderAutoResolveCollectiveNotTrusted: log mode shows Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveCollectiveNotTrusted("acme", "@acme/widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Warning");
+  assertStringIncludes(output, "not trusted");
+  assertStringIncludes(output, "swamp extension trust add");
+});
+
+Deno.test("renderAutoResolveNoStableVersion: log mode shows Warning", () => {
+  const lines = captureOutput(() => {
+    renderAutoResolveNoStableVersion("@acme/widget", "log");
+  });
+  const output = lines.join("\n");
+  assertStringIncludes(output, "Warning");
+  assertStringIncludes(output, "no stable version");
+});
+
+// --- JSON mode: all failure renderers emit status: "failed" ---
+
+Deno.test("renderAutoResolveNotFound: json mode emits failed status", () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    renderAutoResolveNotFound("@acme/widget", "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "failed");
+    assertEquals(parsed.reason, "not_found");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("renderAutoResolveNetworkError: json mode emits failed status", () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    renderAutoResolveNetworkError("@acme/widget", "timeout", "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "failed");
+    assertEquals(parsed.reason, "network_error");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("renderAutoResolveAlreadyInstalled: json mode emits failed status", () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    renderAutoResolveAlreadyInstalled("@acme/widget", "/path", "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "failed");
+    assertEquals(parsed.reason, "already_installed");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+Deno.test("renderAutoResolveTruncated: json mode emits failed status", () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    renderAutoResolveTruncated("@acme/widget", "/path", ["a.ts"], "json");
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.status, "failed");
+    assertEquals(parsed.reason, "truncated");
+  } finally {
+    console.log = origLog;
+  }
+});

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -46,7 +46,6 @@ import {
 
 export interface WorkflowRunRenderOpts {
   workflowName: string;
-  forceLog?: boolean;
   isAuthenticated?: boolean;
   quiet?: boolean;
 }
@@ -518,7 +517,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
           ),
         );
       },
-      suspended: () => {
+      suspended: (e) => {
         this.clearAllHeartbeats();
         if (!this.pipe) return;
         writeBlankLine();
@@ -527,11 +526,19 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
             "system",
             "Suspended",
             STATUS_COLORS.warn,
-            `workflow ${this.workflowName}`,
+            `workflow ${this.workflowName} — awaiting approval on step ${e.stepId}`,
             formatTimestamp(),
           ),
         );
         writeBlankLine();
+        writeOutput(
+          this.pipe.line(
+            "system",
+            `${
+              yellow("To approve:")
+            }  swamp workflow approve ${this.workflowName} ${e.stepId}`,
+          ),
+        );
         writeOutput(
           this.pipe.line(
             "system",

--- a/src/presentation/renderers/workflow_run_test.ts
+++ b/src/presentation/renderers/workflow_run_test.ts
@@ -343,7 +343,7 @@ Deno.test("ConsoleWorkflowRunRenderer: quiet mode replays buffer on step failure
   assertStringIncludes(output, "Failed");
 });
 
-Deno.test("ConsoleWorkflowRunRenderer: suspended workflow shows approval instructions", async () => {
+Deno.test("ConsoleWorkflowRunRenderer: suspended workflow shows step ID and approval instructions", async () => {
   const renderer = createWorkflowRunRenderer("log", {
     workflowName: "test-pipeline",
   });
@@ -377,8 +377,9 @@ Deno.test("ConsoleWorkflowRunRenderer: suspended workflow shows approval instruc
   });
   const output = lines.join("\n");
   assertStringIncludes(output, "Suspended");
-  assertStringIncludes(output, "swamp workflow approve");
-  assertStringIncludes(output, "swamp workflow resume");
+  assertStringIncludes(output, "awaiting approval on step apply");
+  assertStringIncludes(output, "swamp workflow approve test-pipeline apply");
+  assertStringIncludes(output, "swamp workflow resume test-pipeline");
 });
 
 Deno.test("ConsoleWorkflowRunRenderer: cancelled run sets workflowFailed()", async () => {
@@ -566,6 +567,43 @@ Deno.test("JsonWorkflowRunRenderer: never shows auth nudge", async () => {
   }
 });
 
+Deno.test("JsonWorkflowRunRenderer: suspended includes stepId and prompt", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createWorkflowRunRenderer("json", {
+      workflowName: "test-pipeline",
+    });
+    const events: WorkflowRunEvent[] = [
+      { kind: "validating_inputs" },
+      { kind: "evaluating_workflow" },
+      {
+        kind: "started",
+        runId: "run-1",
+        workflowName: "test-pipeline",
+        jobs: [{ id: "deploy", stepCount: 1, dependsOn: [] }],
+      },
+      {
+        kind: "suspended",
+        run: makeRunView("succeeded"),
+        jobId: "deploy",
+        stepId: "apply",
+        prompt: "Review the plan",
+      },
+    ];
+    await consumeStream(toStream(events), renderer.handlers());
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.approvalRequired.stepId, "apply");
+    assertEquals(parsed.approvalRequired.jobId, "deploy");
+    assertEquals(parsed.approvalRequired.prompt, "Review the plan");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("createWorkflowRunRenderer: factory returns correct type per mode", () => {
   const logRenderer = createWorkflowRunRenderer("log", {
     workflowName: "w",
@@ -578,12 +616,4 @@ Deno.test("createWorkflowRunRenderer: factory returns correct type per mode", ()
   assertEquals(typeof logRenderer.workflowFailed, "function");
   assertEquals(typeof jsonRenderer.handlers, "function");
   assertEquals(typeof jsonRenderer.workflowFailed, "function");
-});
-
-Deno.test("createWorkflowRunRenderer: forceLog flag accepted but irrelevant", () => {
-  const renderer = createWorkflowRunRenderer("log", {
-    workflowName: "w",
-    forceLog: true,
-  });
-  assertEquals(typeof renderer.handlers, "function");
 });


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #1963 (console renderer replacement), addressing PR review suggestions and two regressions:

**Log file audit trail regression** — Run log files (`.swamp/outputs/**/*.log`, `.swamp/workflow-runs/**/*.log`) were created but empty. The `ProcessExecutor` dropped output to `debug` level when `onOutput` was provided, which fell below the `RunFileSink`'s threshold. Fixed by always logging at `info`/`warn` regardless of `onOutput`, and setting `parentSinks: "override"` on run loggers to prevent duplicate lines on the console.

**Auto-resolve error severity** — Four hard-failure auto-resolve functions (`NotFound`, `AlreadyInstalled`, `Truncated`, `NetworkError`) now show red "Error" instead of yellow "Warning". Soft failures (`CollectiveNotTrusted`, `NoStableVersion`) remain "Warning".

**Suspended handler drops step ID** — The console renderer's `suspended` handler now includes the step ID and a "To approve:" line, so users who scrolled past `approval_requested` still know which step to approve.

**Infrastructure ANSI leak to stderr in --json mode** — `file_lock.ts` and `extension_loader.ts` were writing ANSI-decorated `console.error` lines that could pollute stderr during `--json` runs under lock contention. Replaced with structured LogTape logger calls.

**Dead `forceLog` plumbing removed** — The Ink interactive tree was deleted in #1963, making `--log` naturally satisfied by the console renderer. Removed the unused `forceLog` field from `WorkflowRunRenderOpts` and updated the flag description.

**Stale comment** — Removed reference to deleted `workflow_run_tree/budget.ts` in `picker_layout.ts`.

## Test Plan

- [x] `deno fmt` — 1,926 files checked
- [x] `deno lint` — 1,793 files checked
- [x] `deno run test` — 9,361 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Real model method run — verified Cargo-style gutter output, log file populated with process output
- [x] Real workflow run — verified pipe-style output, workflow log file populated
- [x] `--json` stderr — verified clean JSON error envelopes with no ANSI leaking
- [x] New tests: 13 auto-resolve renderer tests (4 hard-failure Error, 2 soft-failure Warning, 4 JSON status, 3 info-level)
- [x] Updated tests: suspended handler asserts on step ID and approve command, JSON suspended includes stepId/prompt, file lock contention asserts lock path via LogTape capture sink


🤖 Generated with [Claude Code](https://claude.com/claude-code)