### PR TITLE
fix(output): display extension model output, suppress catalog log, fix auto-resolve wording

### DIFF
--- a/src/domain/extensions/extension_loader.ts
+++ b/src/domain/extensions/extension_loader.ts
@@ -377,7 +377,7 @@ export class ExtensionLoader {
     });
     if (guard.shouldInvalidate && guard.reason !== "not-populated") {
       this.logger
-        .info`Catalog invalidated for ${this.adapter.kind} rescan: ${guard.reason}`;
+        .debug`Catalog invalidated for ${this.adapter.kind} rescan: ${guard.reason}`;
       catalog.invalidate(this.adapter.kind);
 
       if (guard.reason === "layout-version-mismatch") {

--- a/src/domain/models/console_guard.ts
+++ b/src/domain/models/console_guard.ts
@@ -55,18 +55,15 @@ export interface ConsoleGuardOptions {
 }
 
 // Redirects console methods to a capture array during fn execution.
-// In JSON mode, captured output is replayed to stderr to prevent stdout
-// pollution. In non-JSON mode, console output flows to stdout normally.
+// Captures console output from extension code into `logs` so callers can
+// emit it as method_output events. In JSON mode, captured lines are also
+// replayed to stderr to prevent stdout pollution.
 export async function withConsoleGuard<T>(
   fn: () => T | Promise<T>,
   logs: string[],
   options?: ConsoleGuardOptions,
 ): Promise<T> {
   const effectiveJsonMode = options?.jsonMode ?? _jsonMode;
-
-  if (!effectiveJsonMode) {
-    return await fn();
-  }
 
   allActiveLogs.add(logs);
   if (activeGuards === 0) {
@@ -75,7 +72,7 @@ export async function withConsoleGuard<T>(
       (console as any)[method] = (...args: unknown[]) => {
         const line = args.map(formatArg).join(" ");
         for (const logArray of allActiveLogs) {
-          logArray.push(`[${method}] ${line}`);
+          logArray.push(line);
         }
       };
     }
@@ -95,7 +92,7 @@ export async function withConsoleGuard<T>(
       }
     }
 
-    if (logs.length > 0) {
+    if (effectiveJsonMode && logs.length > 0) {
       for (const line of logs) {
         writeStderr(line);
       }

--- a/src/domain/models/console_guard_test.ts
+++ b/src/domain/models/console_guard_test.ts
@@ -33,7 +33,6 @@ Deno.test("withConsoleGuard: captures console.log into logs array", async () => 
 
   assertEquals(logs.length, 1);
   assertStringIncludes(logs[0], "hello from extension");
-  assertStringIncludes(logs[0], "[log]");
 });
 
 Deno.test("withConsoleGuard: captures all console methods", async () => {
@@ -52,11 +51,11 @@ Deno.test("withConsoleGuard: captures all console methods", async () => {
   );
 
   assertEquals(logs.length, 5);
-  assertStringIncludes(logs[0], "[log] log msg");
-  assertStringIncludes(logs[1], "[info] info msg");
-  assertStringIncludes(logs[2], "[debug] debug msg");
-  assertStringIncludes(logs[3], "[warn] warn msg");
-  assertStringIncludes(logs[4], "[error] error msg");
+  assertStringIncludes(logs[0], "log msg");
+  assertStringIncludes(logs[1], "info msg");
+  assertStringIncludes(logs[2], "debug msg");
+  assertStringIncludes(logs[3], "warn msg");
+  assertStringIncludes(logs[4], "error msg");
 });
 
 Deno.test("withConsoleGuard: restores console after normal completion", async () => {
@@ -142,7 +141,7 @@ Deno.test("withConsoleGuard: handles circular objects without throwing", async (
   );
 
   assertEquals(logs.length, 1);
-  assertStringIncludes(logs[0], "[log] circular:");
+  assertStringIncludes(logs[0], "circular:");
   assertStringIncludes(logs[0], "name");
 });
 
@@ -187,11 +186,12 @@ Deno.test("withConsoleGuard: concurrent guards restore console after both comple
   assertEquals(console.log, originalLog);
 });
 
-Deno.test("withConsoleGuard: skips capture in non-JSON mode", async () => {
+Deno.test("withConsoleGuard: captures in non-JSON mode without stderr replay", async () => {
   const logs: string[] = [];
 
   const result = await withConsoleGuard(
     () => {
+      console.log("captured in log mode");
       return 99;
     },
     logs,
@@ -199,5 +199,6 @@ Deno.test("withConsoleGuard: skips capture in non-JSON mode", async () => {
   );
 
   assertEquals(result, 99);
-  assertEquals(logs.length, 0);
+  assertEquals(logs.length, 1);
+  assertStringIncludes(logs[0], "captured in log mode");
 });

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -860,6 +860,12 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             "model.type": context.modelType.normalized,
           }, () => inProcessExecutor.execute(executionRequest));
 
+          if (context.onEvent && executionResult.logs.length > 0) {
+            for (const line of executionResult.logs) {
+              context.onEvent({ type: "output", line, stream: "stdout" });
+            }
+          }
+
           if (executionResult.outputs.some((o) => o.kind === "pending")) {
             throw new Error(
               "In-process execution unexpectedly produced pending outputs — " +

--- a/src/presentation/renderers/extension_auto_resolve.ts
+++ b/src/presentation/renderers/extension_auto_resolve.ts
@@ -144,14 +144,14 @@ export function renderAutoResolveAlreadyInstalled(
       gutterLine(
         "Error",
         STATUS_COLORS.error,
-        `${extension} is installed at ${path} but failed to load`,
+        `${extension} already installed at ${path} but failed to load`,
       ),
     );
     writeContentLine(
       "Local edits may be preventing it from registering — inspect the source and fix errors.",
     );
     writeContentLine(
-      `To reset: swamp extension pull ${extension} --force`,
+      `To reset: swamp extension pull "${extension}" --force`,
     );
   }
 }

--- a/src/presentation/renderers/extension_auto_resolve_test.ts
+++ b/src/presentation/renderers/extension_auto_resolve_test.ts
@@ -102,8 +102,9 @@ Deno.test("renderAutoResolveAlreadyInstalled: log mode shows Error not Warning",
   const output = lines.join("\n");
   assertStringIncludes(output, "Error");
   assertEquals(output.includes("Warning"), false);
+  assertStringIncludes(output, "already installed at");
   assertStringIncludes(output, "failed to load");
-  assertStringIncludes(output, "swamp extension pull @acme/widget --force");
+  assertStringIncludes(output, 'swamp extension pull "@acme/widget" --force');
 });
 
 Deno.test("renderAutoResolveTruncated: log mode shows Error not Warning", () => {


### PR DESCRIPTION
## Summary

Three follow-up fixes for the console renderer (#1963, #1966):

**Extension model output not displayed** — Extension-type models run inline TypeScript via `InProcessExecutor`, not as a subprocess. Their `console.log` output was captured by `withConsoleGuard` into a `logs[]` array but nobody consumed it. Fix: `withConsoleGuard` now always captures (previously no-oped in non-JSON mode), and `method_execution_service.ts` emits the captured logs as `method_output` events after in-process execution — feeding the same renderer pipeline as shell commands.

**LogTape catalog line leaking to stdout** — PR #1966 changed `extension_loader.ts` from `console.error` to `this.logger.info`, but `info` level routes to stdout via the console sink. Downgraded to `debug` so it's filtered out by the default log threshold and stdout stays clean for failing commands.

**Auto-resolve AlreadyInstalled wording** — Updated to say "already installed at" (was "is installed at") and added quotes around the extension name in the `--force` hint to match the documented recovery message contract.

## Test Plan

- [x] `deno fmt` — formatted
- [x] `deno lint` — clean
- [x] `deno run test` — 9,361 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] Verified stdout is empty on `swamp model get nonexistent` (no catalog log line)
- [x] Verified log files still populated with process output
- [x] Updated console_guard tests: removed `[method]` prefix assertions, added non-JSON capture test
- [x] Updated auto-resolve test: asserts "already installed at" and quoted extension name in --force hint


🤖 Generated with [Claude Code](https://claude.com/claude-code)