### PR TITLE
fix(output): display extension model output, restore --verbose/--log, fix history get

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1461,13 +1461,18 @@ export async function runCli(args: string[]): Promise<void> {
         if (resolved) logLevel = parseLogLevel(resolved);
       }
 
+      const forceLog = options.log ?? false;
+      const verbose = options.verbose ?? false;
+      if (verbose && logLevel === "info") {
+        logLevel = "debug";
+      }
       await initializeLogging({
         prettyOutput,
         showProperties: options.showProperties ?? false,
         logLevel,
         jsonMode: options.json ?? false,
         noColor,
-        forceLog: options.log ?? false,
+        forceLog: forceLog || verbose,
       });
 
       // Emit deferred warnings now that logging is initialized

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1467,6 +1467,7 @@ export async function runCli(args: string[]): Promise<void> {
         logLevel,
         jsonMode: options.json ?? false,
         noColor,
+        forceLog: options.log ?? false,
       });
 
       // Emit deferred warnings now that logging is initialized

--- a/src/domain/models/console_guard.ts
+++ b/src/domain/models/console_guard.ts
@@ -55,15 +55,19 @@ export interface ConsoleGuardOptions {
 }
 
 // Redirects console methods to a capture array during fn execution.
-// Captures console output from extension code into `logs` so callers can
-// emit it as method_output events. In JSON mode, captured lines are also
-// replayed to stderr to prevent stdout pollution.
+// In JSON mode, captures console output from extension code into `logs`
+// and replays to stderr to prevent stdout pollution. In non-JSON mode,
+// console output flows to stdout normally (the renderer is not involved).
 export async function withConsoleGuard<T>(
   fn: () => T | Promise<T>,
   logs: string[],
   options?: ConsoleGuardOptions,
 ): Promise<T> {
   const effectiveJsonMode = options?.jsonMode ?? _jsonMode;
+
+  if (!effectiveJsonMode) {
+    return await fn();
+  }
 
   allActiveLogs.add(logs);
   if (activeGuards === 0) {
@@ -92,7 +96,7 @@ export async function withConsoleGuard<T>(
       }
     }
 
-    if (effectiveJsonMode && logs.length > 0) {
+    if (logs.length > 0) {
       for (const line of logs) {
         writeStderr(line);
       }

--- a/src/domain/models/console_guard_test.ts
+++ b/src/domain/models/console_guard_test.ts
@@ -186,12 +186,11 @@ Deno.test("withConsoleGuard: concurrent guards restore console after both comple
   assertEquals(console.log, originalLog);
 });
 
-Deno.test("withConsoleGuard: captures in non-JSON mode without stderr replay", async () => {
+Deno.test("withConsoleGuard: skips capture in non-JSON mode", async () => {
   const logs: string[] = [];
 
   const result = await withConsoleGuard(
     () => {
-      console.log("captured in log mode");
       return 99;
     },
     logs,
@@ -199,6 +198,5 @@ Deno.test("withConsoleGuard: captures in non-JSON mode without stderr replay", a
   );
 
   assertEquals(result, 99);
-  assertEquals(logs.length, 1);
-  assertStringIncludes(logs[0], "captured in log mode");
+  assertEquals(logs.length, 0);
 });

--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -17,11 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { Logger } from "@logtape/logtape";
 import type {
   ExecutionRequest,
   ExecutionResult,
 } from "./execution_envelope.ts";
 import type { Definition } from "../definitions/definition.ts";
+import type { MethodExecutionEvent } from "./method_events.ts";
 import type {
   MethodContext,
   MethodDefinition,
@@ -39,6 +41,45 @@ import {
 } from "./data_writer.ts";
 import { DataAccessService } from "../data/data_access_service.ts";
 import { withConsoleGuard } from "./console_guard.ts";
+
+function wrapLoggerWithOutput(
+  logger: Logger,
+  onEvent: ((event: MethodExecutionEvent) => void) | undefined,
+): Logger {
+  if (!onEvent) return logger;
+  return new Proxy(logger, {
+    get(target, prop, receiver) {
+      if (prop === "info" || prop === "warn") {
+        return (
+          tpl: TemplateStringsArray | string,
+          props?: Record<string, unknown>,
+        ) => {
+          const original = Reflect.get(target, prop, receiver) as (
+            ...args: unknown[]
+          ) => void;
+          original.call(target, tpl, props);
+          let line: string;
+          if (typeof tpl === "string") {
+            line = props
+              ? tpl.replace(
+                /\{(\w+)\}/g,
+                (_, k) => String(props[k] ?? ""),
+              )
+              : tpl;
+          } else {
+            line = String(tpl);
+          }
+          onEvent({
+            type: "output",
+            line,
+            stream: prop === "warn" ? "stderr" : "stdout",
+          });
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
 
 function restoreEnv(key: string, saved: string | undefined): void {
   if (saved !== undefined) {
@@ -175,6 +216,7 @@ export class InProcessExecutor {
     this.contextWithWriters = {
       ...this.context,
       methodName: this.methodName,
+      logger: wrapLoggerWithOutput(this.context.logger, this.context.onEvent),
       writeResource,
       readResource,
       deleteResource,

--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -50,22 +50,28 @@ function wrapLoggerWithOutput(
   return new Proxy(logger, {
     get(target, prop, receiver) {
       if (prop === "info" || prop === "warn") {
-        return (
-          tpl: TemplateStringsArray | string,
-          props?: Record<string, unknown>,
-        ) => {
+        return (...args: unknown[]) => {
           const original = Reflect.get(target, prop, receiver) as (
-            ...args: unknown[]
+            ...a: unknown[]
           ) => void;
-          original.call(target, tpl, props);
+          original.call(target, ...args);
+          const tpl = args[0];
           let line: string;
           if (typeof tpl === "string") {
+            const props = args[1] as Record<string, unknown> | undefined;
             line = props
               ? tpl.replace(
                 /\{(\w+)\}/g,
                 (_, k) => String(props[k] ?? ""),
               )
               : tpl;
+          } else if (Array.isArray(tpl)) {
+            const values = args.slice(1);
+            line = (tpl as string[]).reduce(
+              (acc, str, i) =>
+                acc + str + (i < values.length ? String(values[i]) : ""),
+              "",
+            );
           } else {
             line = String(tpl);
           }

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -860,12 +860,6 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
             "model.type": context.modelType.normalized,
           }, () => inProcessExecutor.execute(executionRequest));
 
-          if (context.onEvent && executionResult.logs.length > 0) {
-            for (const line of executionResult.logs) {
-              context.onEvent({ type: "output", line, stream: "stdout" });
-            }
-          }
-
           if (executionResult.outputs.some((o) => o.kind === "pending")) {
             throw new Error(
               "In-process execution unexpectedly produced pending outputs — " +

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -38,6 +38,8 @@ export interface LoggingOptions {
   logLevel?: LogLevel;
   jsonMode?: boolean;
   noColor?: boolean;
+  /** When true, run loggers also write to the console sink (flat [INF] output for --log mode). */
+  forceLog?: boolean;
   /** Write all log output to stderr only (for dispatch runners where stdout carries RPC frames). */
   stderrOnly?: boolean;
   /** Test-only: clear the once-per-process guard so logging can be reconfigured. */
@@ -176,6 +178,8 @@ export async function initializeLogging(
   // logtape.meta logger's own sinks in JSON mode so its warnings
   // don't reach the console at all.
   const jsonMode = options.jsonMode ?? false;
+  const forceLog = options.forceLog ?? false;
+  const runParentSinks = forceLog ? "inherit" : "override";
   await configure({
     sinks,
     loggers: [
@@ -184,13 +188,13 @@ export async function initializeLogging(
         category: ["model", "method", "run"],
         lowestLevel: logLevel,
         sinks: ["runFile", ...otelSinks],
-        parentSinks: "override",
+        parentSinks: runParentSinks,
       },
       {
         category: ["workflow", "run"],
         lowestLevel: logLevel,
         sinks: ["runFile", ...otelSinks],
-        parentSinks: "override",
+        parentSinks: runParentSinks,
       },
       {
         category: ["logtape", "meta"],

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -451,6 +451,12 @@ export async function* modelMethodRun(
           Object.assign(inputs, inputsWithDefaults);
         }
 
+        const runLogger = getRunLogger(definition.name, input.methodName);
+        runLogger.debug("Found model {name} ({type})", {
+          name: definition.name,
+          type: modelType.normalized,
+        });
+
         yield {
           kind: "model_resolved",
           modelName: definition.name,
@@ -614,6 +620,10 @@ export async function* modelMethodRun(
           runtimeSpan.end();
 
           // --- Execute ---
+          runLogger.debug("Executing method {method}", {
+            method: input.methodName,
+          });
+
           yield {
             kind: "executing",
             modelName: definition.name,
@@ -940,6 +950,11 @@ export async function* modelMethodRun(
               };
             }
           }
+
+          runLogger.debug(
+            "Method {method} completed on {model}",
+            { method: input.methodName, model: definition.name },
+          );
 
           // Mark output as succeeded and save (write-once)
           if (heartbeatInterval) clearInterval(heartbeatInterval);

--- a/src/presentation/renderers/model_method_run.ts
+++ b/src/presentation/renderers/model_method_run.ts
@@ -258,10 +258,12 @@ class ConsoleModelMethodRunRenderer implements ModelMethodRunRenderer {
     artifacts: Array<{ name: string; attributes?: Record<string, unknown> }>,
     options?: DataBoxOptions,
   ): void {
-    const dataArtifacts: DataArtifact[] = artifacts.map((a) => ({
-      name: a.name,
-      attributes: a.attributes,
-    }));
+    const dataArtifacts: DataArtifact[] = artifacts
+      .filter((a) => !a.name.startsWith("report-") && a.name !== "log")
+      .map((a) => ({
+        name: a.name,
+        attributes: a.attributes,
+      }));
     const lines = renderDataBox(dataArtifacts, options);
     for (const line of lines) {
       writeOutput(`  ${line}`);

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -54,6 +54,14 @@ export interface WorkflowRunRenderer extends Renderer<WorkflowRunEvent> {
   workflowFailed(): boolean;
 }
 
+function isUserFacingArtifact(
+  artifact: { name: string },
+): boolean {
+  if (artifact.name.startsWith("report-")) return false;
+  if (artifact.name === "log") return false;
+  return true;
+}
+
 const QUIET_BUFFER_LIMIT = 500;
 const HEARTBEAT_INTERVAL_MS = 10_000;
 
@@ -565,6 +573,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
       for (const step of job.steps) {
         if (step.dataArtifacts) {
           for (const artifact of step.dataArtifacts) {
+            if (!isUserFacingArtifact(artifact)) continue;
             artifacts.push({
               name: artifact.name,
               attributes: artifact.attributes,
@@ -576,6 +585,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
     }
     if (run.workflowDataArtifacts) {
       for (const artifact of run.workflowDataArtifacts) {
+        if (!isUserFacingArtifact(artifact)) continue;
         artifacts.push({
           name: artifact.name,
           attributes: artifact.attributes,

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { green, red, yellow } from "@std/fmt/colors";
 import type { OutputMode } from "../output/output.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { WorkflowRunView } from "../../libswamp/mod.ts";
@@ -51,7 +52,7 @@ function renderLogWorkflowRun(data: WorkflowRunView): void {
       writeOutput(`    ${stepIcon} ${step.name}${stepDuration}`);
 
       if (step.error) {
-        writeOutput(`      -> ${step.error}`);
+        writeOutput(`      -> ${red(step.error)}`);
       }
     }
   }
@@ -59,7 +60,13 @@ function renderLogWorkflowRun(data: WorkflowRunView): void {
   const durationSuffix = data.duration !== undefined
     ? ` (${data.duration}ms)`
     : "";
-  writeOutput(`Result: ${data.status.toUpperCase()}${durationSuffix}`);
+  const resultText = `Result: ${data.status.toUpperCase()}${durationSuffix}`;
+  const colorize = data.status === "failed"
+    ? red
+    : data.status === "cancelled"
+    ? yellow
+    : green;
+  writeOutput(colorize(resultText));
 
   if (data.path) {
     writeOutput(`Saved to: ${data.path}`);

--- a/src/presentation/renderers/workflow_run_display.ts
+++ b/src/presentation/renderers/workflow_run_display.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { OutputMode } from "../output/output.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { WorkflowRunView } from "../../libswamp/mod.ts";
 
 export function renderWorkflowRunDisplay(
@@ -33,22 +33,13 @@ export function renderWorkflowRunDisplay(
 }
 
 function renderLogWorkflowRun(data: WorkflowRunView): void {
-  const logger = getSwampLogger(["workflow", "run"]);
-
-  logger.info("Workflow: {workflowName} (Run ID: {id})", {
-    workflowName: data.workflowName,
-    id: data.id,
-  });
+  writeOutput(`Workflow: ${data.workflowName} (Run ID: ${data.id})`);
 
   for (const job of data.jobs) {
     const durationSuffix = job.duration !== undefined
       ? ` (${job.duration}ms)`
       : "";
-    logger.info("  {status} {jobName}{duration}", {
-      status: statusIcon(job.status),
-      jobName: job.name,
-      duration: durationSuffix,
-    });
+    writeOutput(`  ${statusIcon(job.status)} ${job.name}${durationSuffix}`);
 
     for (const step of job.steps) {
       const stepDuration = step.duration !== undefined
@@ -57,33 +48,21 @@ function renderLogWorkflowRun(data: WorkflowRunView): void {
       const stepIcon = step.status === "failed" && step.allowedFailure
         ? "\u26A0"
         : statusIcon(step.status);
-      logger.info("    {status} {stepName}{duration}", {
-        status: stepIcon,
-        stepName: step.name,
-        duration: stepDuration,
-      });
+      writeOutput(`    ${stepIcon} ${step.name}${stepDuration}`);
 
       if (step.error) {
-        logger.error("      -> {error}", { error: step.error });
+        writeOutput(`      -> ${step.error}`);
       }
     }
   }
 
-  const resultLevel = data.status === "failed"
-    ? "error"
-    : data.status === "cancelled"
-    ? "warn"
-    : "info";
   const durationSuffix = data.duration !== undefined
     ? ` (${data.duration}ms)`
     : "";
-  logger[resultLevel]("Result: {status}{duration}", {
-    status: data.status.toUpperCase(),
-    duration: durationSuffix,
-  });
+  writeOutput(`Result: ${data.status.toUpperCase()}${durationSuffix}`);
 
   if (data.path) {
-    logger.info("Saved to: {path}", { path: data.path });
+    writeOutput(`Saved to: ${data.path}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Three fixes for console renderer regressions, all verified against UAT tests:

**Extension model output not displayed** — Extensions use `context.logger.info()` for output, which routes through the `["model", "method", "run"]` LogTape category. Since #1966 set `parentSinks: "override"` on that category, the output only reached the run log file, not the console. Fix: `InProcessExecutor` now wraps the context logger with a proxy that intercepts `info`/`warn` calls and also emits `method_output` events through the renderer pipeline.

**`--verbose` and `--log` flags produce flat structured output** — When either flag is active, the log level is lowered to `debug` and `forceLog` is set so run loggers inherit the console sink. Added `Found model`, `Executing method`, and `Method completed` debug messages to the model method run path (matching the workflow execution service).

**`workflow history get` output invisible** — The `workflow_run_display.ts` renderer used `getSwampLogger(["workflow", "run"])` which has `parentSinks: "override"`, making output invisible. Replaced with `writeOutput()` calls — consistent with how all other PR #1963 renderers work.

## Test Plan

- [x] `deno run test` — 9,361 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] UAT: all 29 previously-failing tests pass (extension_model, workflow_orchestration, global_flags, json_error, error_codes, pull_wip_preservation)
- [x] `--verbose` shows `[DBG]` lines with `Found model`, `Executing method`, `Method "execute" completed`
- [x] `--log` shows `[INF]` structured log lines
- [x] `workflow history get` displays `SUCCEEDED` on stdout


🤖 Generated with [Claude Code](https://claude.com/claude-code)