### PR TITLE
fix(worker): validate --cache-dir exists before writing service definition

### DIFF
--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Command } from "@cliffy/command";
+import { isAbsolute, resolve } from "@std/path";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { groupCommandAction } from "../group_action.ts";
 import { UserError } from "../../domain/errors.ts";
@@ -42,6 +43,30 @@ export function collectWorkerExtraArgs(options: AnyOptions): string[] {
     args.push("--no-reconnect");
   }
   return args;
+}
+
+export async function validateCacheDir(
+  rawPath: string,
+): Promise<string> {
+  const resolved = isAbsolute(rawPath) ? rawPath : resolve(rawPath);
+  try {
+    const stat = await Deno.stat(resolved);
+    if (!stat.isDirectory) {
+      throw new UserError(
+        `--cache-dir is not a directory: ${resolved}\n\n` +
+          `  Create it with: mkdir -p ${resolved}`,
+      );
+    }
+  } catch (err: unknown) {
+    if (err instanceof Deno.errors.NotFound) {
+      throw new UserError(
+        `--cache-dir does not exist: ${resolved}\n\n` +
+          `  Create it with: mkdir -p ${resolved}`,
+      );
+    }
+    throw err;
+  }
+  return resolved;
 }
 
 export function collectWorkerEnv(options: AnyOptions): Record<string, string> {
@@ -155,7 +180,12 @@ const daemonEnableCommand = new Command()
       );
     }
 
-    const resolvedOptions = { ...options, url: urlArg };
+    let cacheDir: string | undefined;
+    if (options.cacheDir) {
+      cacheDir = await validateCacheDir(options.cacheDir as string);
+    }
+
+    const resolvedOptions = { ...options, url: urlArg, cacheDir };
     const mode = await resolveServiceMode({
       user: options.user as boolean | undefined,
     });
@@ -167,7 +197,7 @@ const daemonEnableCommand = new Command()
       binaryPath: Deno.execPath(),
       extraArgs: extraArgs.length > 0 ? extraArgs : undefined,
       env: Object.keys(env).length > 0 ? env : undefined,
-      cacheDir: options.cacheDir as string | undefined,
+      cacheDir,
     });
 
     renderWorkerDaemonEnabled(ctx.outputMode, toServiceMode(mode));

--- a/src/cli/commands/worker_daemon_test.ts
+++ b/src/cli/commands/worker_daemon_test.ts
@@ -17,8 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { collectWorkerEnv, collectWorkerExtraArgs } from "./worker_daemon.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { resolve } from "@std/path";
+import {
+  collectWorkerEnv,
+  collectWorkerExtraArgs,
+  validateCacheDir,
+} from "./worker_daemon.ts";
+import { UserError } from "../../domain/errors.ts";
 
 Deno.test("collectWorkerExtraArgs: includes data-plane-url when provided", () => {
   const args = collectWorkerExtraArgs({
@@ -72,4 +78,47 @@ Deno.test("collectWorkerEnv: omits SWAMP_SERVER_TOKEN when not provided", () => 
 Deno.test("collectWorkerEnv: returns empty when no options", () => {
   const env = collectWorkerEnv({});
   assertEquals(Object.keys(env).length, 0);
+});
+
+Deno.test("validateCacheDir: rejects non-existent absolute path", async () => {
+  const err = await assertRejects(
+    () => validateCacheDir("/tmp/swamp-nonexistent-dir-abc123"),
+    UserError,
+  );
+  assertStringIncludes(err.message, "--cache-dir does not exist");
+  assertStringIncludes(err.message, "mkdir -p");
+});
+
+Deno.test("validateCacheDir: resolves relative path and rejects if missing", async () => {
+  const err = await assertRejects(
+    () => validateCacheDir("./nonexistent-relative-dir-abc123"),
+    UserError,
+  );
+  assertStringIncludes(err.message, "--cache-dir does not exist");
+  const expected = resolve("./nonexistent-relative-dir-abc123");
+  assertStringIncludes(err.message, expected);
+});
+
+Deno.test("validateCacheDir: accepts existing directory and returns absolute path", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "swamp-test-cache-" });
+  try {
+    const result = await validateCacheDir(tmpDir);
+    assertEquals(result, tmpDir);
+  } finally {
+    await Deno.remove(tmpDir).catch(() => {});
+  }
+});
+
+Deno.test("validateCacheDir: rejects path that is a file, not a directory", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-test-cache-" });
+  try {
+    const err = await assertRejects(
+      () => validateCacheDir(tmpFile),
+      UserError,
+    );
+    assertStringIncludes(err.message, "--cache-dir is not a directory");
+    assertStringIncludes(err.message, "mkdir -p");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
 });


### PR DESCRIPTION
Fixes #1414

## Summary

- `worker daemon enable` wrote `--cache-dir` verbatim into the service definition's `WorkingDirectory`. A relative path or non-existent directory caused launchd/systemd to reject the job with `EX_CONFIG` (exit code 78), while `daemon status` still reported "running".
- Added `validateCacheDir()` in the enable action handler that resolves relative paths to absolute and verifies the directory exists before writing the service definition. Throws a `UserError` with an actionable `mkdir -p` hint if the directory is missing or not a directory.

## Test plan

- Added 4 unit tests: non-existent absolute path, relative path resolution, valid directory, file-not-directory rejection
- Compiled binary and manually verified both error paths produce actionable messages:
  - `swamp worker daemon enable ... --cache-dir ./nonexistent` → resolves to absolute path, errors with `mkdir -p` hint
  - `swamp worker daemon enable ... --cache-dir /tmp/nonexistent` → errors with `mkdir -p` hint
- `deno check`, `deno lint`, `deno fmt`, `deno run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)