### PR TITLE
fix(workflows): treat empty workflow set as valid in validate (swamp-club#1411)

### DIFF
--- a/integration/workflow_test.ts
+++ b/integration/workflow_test.ts
@@ -341,7 +341,7 @@ Deno.test("CLI: workflow validate with no args validates all workflows", async (
   });
 });
 
-Deno.test("CLI: workflow validate errors when no workflows found", async () => {
+Deno.test("CLI: workflow validate succeeds with empty result when no workflows found", async () => {
   await withTempDir(async (repoDir) => {
     await initializeTestRepo(repoDir);
     const result = await runCliCommand(
@@ -355,8 +355,10 @@ Deno.test("CLI: workflow validate errors when no workflows found", async () => {
       Deno.cwd(),
     );
 
-    assertEquals(result.code !== 0, true, "Command should fail");
-    assertStringIncludes(result.stderr + result.stdout, "No workflows found");
+    assertEquals(result.code, 0, "Command should succeed");
+    const output = JSON.parse(result.stdout);
+    assertEquals(output.passed, true);
+    assertEquals(output.workflows.length, 0);
   });
 });
 

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -27,7 +27,7 @@ import {
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { createWorkflowId } from "../../domain/workflows/workflow_id.ts";
 import type { LibSwampContext } from "../context.ts";
-import { notFound, type SwampError, validationFailed } from "../errors.ts";
+import { notFound, type SwampError } from "../errors.ts";
 import type { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
@@ -276,8 +276,14 @@ async function* validateAll(
 
   if (allWorkflows.length === 0 && brokenWorkflows.length === 0) {
     yield {
-      kind: "error",
-      error: validationFailed("No workflows found"),
+      kind: "completed",
+      data: {
+        workflows: [],
+        totalPassed: 0,
+        totalFailed: 0,
+        totalWarnings: 0,
+        passed: true,
+      },
     };
     return;
   }

--- a/src/libswamp/workflows/validate_test.ts
+++ b/src/libswamp/workflows/validate_test.ts
@@ -264,3 +264,28 @@ Deno.test("workflowValidate all: broken files alone still yield results, not no-
   }
   assertEquals(completed.data.totalFailed, 1);
 });
+
+Deno.test("workflowValidate all: empty repository yields passed=true with no workflows", async () => {
+  const deps = makeDeps({
+    findAllWorkflows: () => Promise.resolve([]),
+    listBrokenWorkflows: () => Promise.resolve([]),
+  });
+  const events = await collect<WorkflowValidateEvent>(
+    workflowValidate(createLibSwampContext(), deps, {}),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "resolving" });
+  const completed = events[1] as Extract<
+    WorkflowValidateEvent,
+    { kind: "completed" }
+  >;
+  if (!isWorkflowValidateAllData(completed.data)) {
+    throw new Error("expected aggregate data");
+  }
+  assertEquals(completed.data.passed, true);
+  assertEquals(completed.data.workflows.length, 0);
+  assertEquals(completed.data.totalPassed, 0);
+  assertEquals(completed.data.totalFailed, 0);
+  assertEquals(completed.data.totalWarnings, 0);
+});

--- a/src/presentation/renderers/workflow_validate.ts
+++ b/src/presentation/renderers/workflow_validate.ts
@@ -127,6 +127,12 @@ class LogWorkflowValidateRenderer implements WorkflowValidateRenderer {
 
   private renderAll(data: WorkflowValidateAllData): void {
     this._passed = data.passed;
+
+    if (data.workflows.length === 0) {
+      writeOutput(`${bold(cyan("No workflows to validate"))}`);
+      return;
+    }
+
     const lines: string[] = [];
     lines.push(bold(cyan("Validating all workflows...")));
 

--- a/src/presentation/renderers/workflow_validate_test.ts
+++ b/src/presentation/renderers/workflow_validate_test.ts
@@ -74,3 +74,57 @@ Deno.test("WorkflowValidateRenderer - error throws UserError", () => {
     "boom",
   );
 });
+
+Deno.test("LogWorkflowValidateRenderer - empty workflows prints informational message", async () => {
+  const renderer = createWorkflowValidateRenderer("log");
+  await consumeStream(
+    toStream([
+      { kind: "resolving" },
+      {
+        kind: "completed",
+        data: {
+          workflows: [],
+          totalPassed: 0,
+          totalFailed: 0,
+          totalWarnings: 0,
+          passed: true,
+        },
+      },
+    ]),
+    renderer.handlers(),
+  );
+  assertEquals(renderer.passed(), true);
+});
+
+Deno.test("JsonWorkflowValidateRenderer - empty workflows outputs valid JSON with passed=true", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createWorkflowValidateRenderer("json");
+    await consumeStream(
+      toStream([
+        { kind: "resolving" },
+        {
+          kind: "completed",
+          data: {
+            workflows: [],
+            totalPassed: 0,
+            totalFailed: 0,
+            totalWarnings: 0,
+            passed: true,
+          },
+        },
+      ]),
+      renderer.handlers(),
+    );
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.passed, true);
+    assertEquals(parsed.workflows.length, 0);
+    assertEquals(renderer.passed(), true);
+  } finally {
+    console.log = originalLog;
+  }
+});


### PR DESCRIPTION
## Summary

- `swamp workflow validate` in a repository with no workflow definitions now exits 0 with "No workflows to validate" instead of exiting 1 with "Error: No workflows found"
- JSON mode emits the standard `WorkflowValidateAllData` shape with an empty workflows array and `passed: true`, preserving schema compatibility for CI consumers
- Fixes swamp-club#1411

## Test Plan

- [x] Unit test: `validateAll` with zero workflows yields `completed` event with `passed: true`
- [x] Renderer test (log mode): prints informational message, `renderer.passed()` returns true
- [x] Renderer test (json mode): outputs valid JSON with `passed: true` and empty workflows array
- [x] Reproduced bug in scratch repo (`/tmp/swamp-repro-issue-1411`) — confirmed exit 0 after fix
- [x] `deno check`, `deno lint`, `deno fmt` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)