### PR TITLE
fix(telemetry): prevent ~40s post-command hang from spool scan (swamp-club#1412)

### DIFF
--- a/integration/telemetry_global_spool_test.ts
+++ b/integration/telemetry_global_spool_test.ts
@@ -173,9 +173,12 @@ Deno.test("repo-less telemetry spools to the user-global directory", async () =>
 
 async function seedRepoLocalEntry(repoDir: string): Promise<string> {
   // Simulate a legacy repo-local spool holding one unflushed entry.
+  // Use today's date so the hard-retention cleanup (7-day cap) doesn't
+  // delete it before the test can verify it was migrated.
   const spool = join(repoDir, ".swamp", "telemetry");
   await Deno.mkdir(spool, { recursive: true });
-  const name = `telemetry-2026-07-13-${crypto.randomUUID()}.json`;
+  const today = new Date().toISOString().split("T")[0];
+  const name = `telemetry-${today}-${crypto.randomUUID()}.json`;
   await Deno.writeTextFile(join(spool, name), '{"id":"legacy"}');
   return name;
 }

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1573,8 +1573,11 @@ export async function runCli(args: string[]): Promise<void> {
             }
           }
 
-          // Trigger cleanup asynchronously (fire-and-forget)
-          telemetryCtx.service.cleanupOldTelemetry();
+          // Cleanup with bounded timeout so Deno.exit() doesn't kill it
+          await Promise.race([
+            telemetryCtx.service.cleanupOldTelemetry(),
+            new Promise<void>((r) => setTimeout(r, 3000)),
+          ]);
         } catch {
           // Best effort — never break the CLI for telemetry failures
         }

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -225,26 +225,27 @@ export class TelemetryService {
    * Unflushed entries survive until the hard cap (`HARD_RETENTION_DAYS`,
    * 7 days) to allow retry, then are deleted to prevent unbounded growth.
    *
-   * This method is fire-and-forget and does not block.
-   *
    * @param retentionDays - Number of days to retain flushed entries (default: 2)
    */
-  cleanupOldTelemetry(retentionDays: number = DEFAULT_RETENTION_DAYS): void {
+  async cleanupOldTelemetry(
+    retentionDays: number = DEFAULT_RETENTION_DAYS,
+  ): Promise<void> {
     const flushedCutoff = new Date();
     flushedCutoff.setDate(flushedCutoff.getDate() - retentionDays);
 
     const hardCutoff = new Date();
     hardCutoff.setDate(hardCutoff.getDate() - HARD_RETENTION_DAYS);
 
-    // Fire-and-forget: don't await, don't let errors propagate
-    Promise.all([
-      this.repository.deleteOlderThan(flushedCutoff),
-      this.repository.deleteAllOlderThan(hardCutoff),
-    ]).catch((error) => {
+    try {
+      await Promise.all([
+        this.repository.deleteOlderThan(flushedCutoff),
+        this.repository.deleteAllOlderThan(hardCutoff),
+      ]);
+    } catch (error) {
       if (Deno.env.get("SWAMP_DEBUG")) {
         console.error("[Telemetry] Cleanup failed:", error);
       }
-    });
+    }
   }
 
   /**

--- a/src/infrastructure/persistence/json_telemetry_repository.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository.ts
@@ -198,9 +198,13 @@ export class JsonTelemetryRepository implements TelemetryRepository {
 
   /**
    * Finds unflushed telemetry entries, sorted oldest first.
+   *
+   * Uses filename-based sorting (date prefix is chronologically sortable)
+   * and only reads/parses the first `limit` files. This avoids O(n) file
+   * reads when the spool contains thousands of accumulated entries.
    */
   async findUnflushed(limit: number): Promise<TelemetryEntry[]> {
-    const entries: Array<{ entry: TelemetryEntry; startedAt: Date }> = [];
+    const filenames: string[] = [];
 
     try {
       const telemetryDir = this.getTelemetryDir();
@@ -212,15 +216,7 @@ export class JsonTelemetryRepository implements TelemetryRepository {
           dirEntry.name.endsWith(".json") &&
           !dirEntry.name.endsWith(".flushed.json")
         ) {
-          try {
-            const path = join(telemetryDir, dirEntry.name);
-            const content = await Deno.readTextFile(path);
-            const data = JSON.parse(content) as TelemetryEntryData;
-            const entry = TelemetryEntry.fromData(data);
-            entries.push({ entry, startedAt: entry.startedAt });
-          } catch {
-            // Skip files that can't be parsed
-          }
+          filenames.push(dirEntry.name);
         }
       }
     } catch (error) {
@@ -230,10 +226,25 @@ export class JsonTelemetryRepository implements TelemetryRepository {
       throw error;
     }
 
-    // Sort oldest first by startedAt
-    entries.sort((a, b) => a.startedAt.getTime() - b.startedAt.getTime());
+    // Sort by filename — the `telemetry-YYYY-MM-DD-` prefix gives
+    // chronological ordering. Within the same day, order is arbitrary
+    // but acceptable for batch priority.
+    filenames.sort();
 
-    return entries.slice(0, limit).map((e) => e.entry);
+    const telemetryDir = this.getTelemetryDir();
+    const entries: TelemetryEntry[] = [];
+    for (const filename of filenames.slice(0, limit)) {
+      try {
+        const path = join(telemetryDir, filename);
+        const content = await Deno.readTextFile(path);
+        const data = JSON.parse(content) as TelemetryEntryData;
+        entries.push(TelemetryEntry.fromData(data));
+      } catch {
+        // Skip files that can't be parsed
+      }
+    }
+
+    return entries;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Optimize `findUnflushed()`** to sort by filename (date prefix is chronologically sortable) and only read/parse the first `limit` (25) files, instead of reading all files in the spool directory
- **Await `cleanupOldTelemetry()`** with a 3-second timeout so it actually completes before `Deno.exit()` kills it, preventing unbounded file accumulation

## Root Cause

`findUnflushed()` reads and JSON-parses every file in `~/.config/swamp/telemetry/` before filtering to a 25-entry batch. Files accumulate without bound because `cleanupOldTelemetry()` is fire-and-forget and gets killed by the explicit `Deno.exit()` in `main.ts`. With thousands of accumulated entries (common when the telemetry endpoint is unreachable per #1408), the scan takes tens of seconds — all happening after the command already printed its output.

## Test plan

- [x] `deno check` — type checking passes
- [x] `deno lint` — no lint issues
- [x] `deno fmt` — formatting clean
- [x] All 144 related tests pass (telemetry repository, service, CLI mod)
- [x] Verified with 5000 accumulated files: fixed binary 1.25s vs installed 2.13s
- [x] Verified cleanup correctly deletes entries older than 7-day hard cap

Fixes swamp-club#1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)