### PR TITLE
fix(telemetry): surface flush failure reason in CLI warning (swamp-club#1408)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1559,7 +1559,7 @@ export async function runCli(args: string[]): Promise<void> {
               telemetryCtx.telemetryEndpoint,
               USER_AGENT,
             );
-            const flushed = await telemetryCtx.service.flushTelemetry({
+            const flushResult = await telemetryCtx.service.flushTelemetry({
               sender,
               distinctId,
               repoId: telemetryCtx.repoId,
@@ -1567,9 +1567,13 @@ export async function runCli(args: string[]): Promise<void> {
               keepFlushed: telemetryCtx.keepFlushed,
               signal: AbortSignal.timeout(2000),
             });
-            if (!flushed) {
-              logger
-                .warn`Telemetry flush failed — entries are queued locally and will retry on the next invocation`;
+            if (!flushResult.ok) {
+              const detail = flushResult.reason
+                ? ` (${flushResult.reason})`
+                : "";
+              logger.warn(
+                `Telemetry flush failed${detail} — entries are queued locally and will retry on the next invocation`,
+              );
             }
           }
 

--- a/src/domain/telemetry/mod.ts
+++ b/src/domain/telemetry/mod.ts
@@ -71,7 +71,10 @@ export {
 
 export type { TelemetryRepository } from "./repositories.ts";
 
-export type { TelemetrySender } from "./telemetry_sender.ts";
+export type {
+  TelemetryFlushResult,
+  TelemetrySender,
+} from "./telemetry_sender.ts";
 
 export {
   type TelemetryFlushConfig,

--- a/src/domain/telemetry/telemetry_sender.ts
+++ b/src/domain/telemetry/telemetry_sender.ts
@@ -19,26 +19,21 @@
 
 import type { TelemetryEntry } from "./telemetry_entry.ts";
 
+export interface TelemetryFlushResult {
+  ok: boolean;
+  reason?: string;
+}
+
 /**
  * Port for sending telemetry events to a remote endpoint.
  * Implemented by infrastructure adapters (e.g. HttpTelemetrySender).
  */
 export interface TelemetrySender {
-  /**
-   * Sends a batch of telemetry entries to the remote endpoint.
-   *
-   * @param entries - The entries to send
-   * @param distinctId - The user or repo UUID used as distinct_id
-   * @param repoId - Optional repo UUID included as a property
-   * @param authToken - Optional API key sent via x-api-key header to authenticate the flush request
-   * @param signal - Optional AbortSignal for cancellation
-   * @returns true if the batch was accepted, false otherwise
-   */
   sendBatch(
     entries: TelemetryEntry[],
     distinctId: string,
     repoId?: string,
     authToken?: string,
     signal?: AbortSignal,
-  ): Promise<boolean>;
+  ): Promise<TelemetryFlushResult>;
 }

--- a/src/domain/telemetry/telemetry_service.ts
+++ b/src/domain/telemetry/telemetry_service.ts
@@ -18,7 +18,10 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { TelemetryRepository } from "./repositories.ts";
-import type { TelemetrySender } from "./telemetry_sender.ts";
+import type {
+  TelemetryFlushResult,
+  TelemetrySender,
+} from "./telemetry_sender.ts";
 import { TelemetryEntry } from "./telemetry_entry.ts";
 import type { CommandInvocationData } from "./command_invocation.ts";
 import type { InvocationContextData } from "./invocation_context.ts";
@@ -249,12 +252,14 @@ export class TelemetryService {
 
   /**
    * Flushes unflushed telemetry entries to a remote endpoint.
-   * Returns true if the flush succeeded (or there was nothing to flush),
-   * false if the send failed. Never throws.
+   * Returns a result indicating whether the flush succeeded and, on failure,
+   * the reason. Never throws.
    *
    * @param config - Flush configuration with sender and distinctId
    */
-  async flushTelemetry(config: TelemetryFlushConfig): Promise<boolean> {
+  async flushTelemetry(
+    config: TelemetryFlushConfig,
+  ): Promise<TelemetryFlushResult> {
     const batchSize = config.batchSize ?? DEFAULT_FLUSH_BATCH_SIZE;
     const keepFlushed = config.keepFlushed ?? false;
 
@@ -269,7 +274,7 @@ export class TelemetryService {
         config.signal,
       );
     } catch {
-      return false;
+      return { ok: false, reason: "unexpected error" };
     }
   }
 
@@ -281,23 +286,23 @@ export class TelemetryService {
     repoId?: string,
     authToken?: string,
     signal?: AbortSignal,
-  ): Promise<boolean> {
+  ): Promise<TelemetryFlushResult> {
     const entries = await this.repository.findUnflushed(batchSize);
-    if (entries.length === 0) return true;
+    if (entries.length === 0) return { ok: true };
 
-    const success = await sender.sendBatch(
+    const result = await sender.sendBatch(
       entries,
       distinctId,
       repoId,
       authToken,
       signal,
     );
-    if (success) {
+    if (result.ok) {
       for (const entry of entries) {
         await this.repository.markFlushed(entry, keepFlushed);
       }
     }
-    return success;
+    return result;
   }
 
   /**

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -20,7 +20,10 @@
 import { assertEquals } from "@std/assert";
 import { TelemetryService } from "./telemetry_service.ts";
 import type { TelemetryRepository } from "./repositories.ts";
-import type { TelemetrySender } from "./telemetry_sender.ts";
+import type {
+  TelemetryFlushResult,
+  TelemetrySender,
+} from "./telemetry_sender.ts";
 import { TelemetryEntry, type TelemetryEntryData } from "./telemetry_entry.ts";
 
 /** Mock repository for testing */
@@ -76,7 +79,7 @@ class MockTelemetrySender implements TelemetrySender {
     repoId?: string;
     authToken?: string;
   }> = [];
-  shouldSucceed = true;
+  result: TelemetryFlushResult = { ok: true };
 
   sendBatch(
     entries: TelemetryEntry[],
@@ -84,9 +87,9 @@ class MockTelemetrySender implements TelemetrySender {
     repoId?: string,
     authToken?: string,
     _signal?: AbortSignal,
-  ): Promise<boolean> {
+  ): Promise<TelemetryFlushResult> {
     this.sentBatches.push({ entries, distinctId, repoId, authToken });
-    return Promise.resolve(this.shouldSucceed);
+    return Promise.resolve(this.result);
   }
 }
 
@@ -283,17 +286,17 @@ Deno.test("TelemetryService.flushTelemetry sends unflushed entries and marks the
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(sender.sentBatches[0].entries.length, 2);
   assertEquals(sender.sentBatches[0].distinctId, "repo-uuid");
   assertEquals(repo.flushedEntries.length, 2);
 });
 
-Deno.test("TelemetryService.flushTelemetry returns false on send failure", async () => {
+Deno.test("TelemetryService.flushTelemetry propagates failure reason from sender", async () => {
   const repo = new MockTelemetryRepository();
   const sender = new MockTelemetrySender();
-  sender.shouldSucceed = false;
+  sender.result = { ok: false, reason: "HTTP 401" };
   const service = new TelemetryService(repo, "1.0.0");
 
   const entry = createFlushTestEntry(
@@ -307,12 +310,13 @@ Deno.test("TelemetryService.flushTelemetry returns false on send failure", async
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result, false);
+  assertEquals(result.ok, false);
+  assertEquals(result.reason, "HTTP 401");
   assertEquals(sender.sentBatches.length, 1);
   assertEquals(repo.flushedEntries.length, 0);
 });
 
-Deno.test("TelemetryService.flushTelemetry returns true when no unflushed entries", async () => {
+Deno.test("TelemetryService.flushTelemetry returns ok when no unflushed entries", async () => {
   const repo = new MockTelemetryRepository();
   const sender = new MockTelemetrySender();
   const service = new TelemetryService(repo, "1.0.0");
@@ -324,7 +328,7 @@ Deno.test("TelemetryService.flushTelemetry returns true when no unflushed entrie
     distinctId: "repo-uuid",
   });
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(sender.sentBatches.length, 0);
   assertEquals(repo.flushedEntries.length, 0);
 });

--- a/src/infrastructure/telemetry/http_telemetry_sender.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender.ts
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import type { TelemetrySender } from "../../domain/telemetry/telemetry_sender.ts";
+import type {
+  TelemetryFlushResult,
+  TelemetrySender,
+} from "../../domain/telemetry/telemetry_sender.ts";
 import type { TelemetryEntry } from "../../domain/telemetry/telemetry_entry.ts";
 
 /**
@@ -41,7 +44,7 @@ export class HttpTelemetrySender implements TelemetrySender {
     repoId?: string,
     authToken?: string,
     signal?: AbortSignal,
-  ): Promise<boolean> {
+  ): Promise<TelemetryFlushResult> {
     const events = entries.map((entry) => ({
       event: "cli_invocation",
       distinct_id: distinctId,
@@ -75,9 +78,18 @@ export class HttpTelemetrySender implements TelemetrySender {
       });
       // Consume the response body to prevent resource leaks
       await response.body?.cancel();
-      return response.status === 202;
-    } catch {
-      return false;
+      if (response.status === 202) {
+        return { ok: true };
+      }
+      return { ok: false, reason: `HTTP ${response.status}` };
+    } catch (error: unknown) {
+      if (
+        error instanceof DOMException &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        return { ok: false, reason: "timeout" };
+      }
+      return { ok: false, reason: "network error" };
     }
   }
 }

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -59,7 +59,7 @@ Deno.test("HttpTelemetrySender.sendBatch sends single event format for one entry
 
   const result = await sender.sendBatch([entry], "repo-uuid-123");
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(capturedUrl, `http://localhost:${port}/ingest`);
 
   const parsed = JSON.parse(capturedBody!);
@@ -85,7 +85,7 @@ Deno.test("HttpTelemetrySender.sendBatch sends batch format for multiple entries
 
   const result = await sender.sendBatch([entry1, entry2], "repo-uuid");
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals(parsed.events.length, 2);
@@ -96,7 +96,7 @@ Deno.test("HttpTelemetrySender.sendBatch sends batch format for multiple entries
   await server.shutdown();
 });
 
-Deno.test("HttpTelemetrySender.sendBatch returns false on non-202 status", async () => {
+Deno.test("HttpTelemetrySender.sendBatch returns reason on non-202 status", async () => {
   const server = Deno.serve({ port: 0 }, () => {
     return new Response(JSON.stringify({ error: "bad request" }), {
       status: 400,
@@ -108,18 +108,20 @@ Deno.test("HttpTelemetrySender.sendBatch returns false on non-202 status", async
   const entry = createTestEntry("uuid-1", new Date("2024-03-10T10:00:00Z"));
 
   const result = await sender.sendBatch([entry], "repo-uuid");
-  assertEquals(result, false);
+  assertEquals(result.ok, false);
+  assertEquals(result.reason, "HTTP 400");
 
   await server.shutdown();
 });
 
-Deno.test("HttpTelemetrySender.sendBatch returns false on network error", async () => {
+Deno.test("HttpTelemetrySender.sendBatch returns network error reason on connection failure", async () => {
   // Use a port that nothing is listening on
   const sender = new HttpTelemetrySender("http://localhost:1");
   const entry = createTestEntry("uuid-1", new Date("2024-03-10T10:00:00Z"));
 
   const result = await sender.sendBatch([entry], "repo-uuid");
-  assertEquals(result, false);
+  assertEquals(result.ok, false);
+  assertEquals(result.reason, "network error");
 });
 
 Deno.test("HttpTelemetrySender.sendBatch includes $repo_id when provided", async () => {
@@ -143,7 +145,7 @@ Deno.test("HttpTelemetrySender.sendBatch includes $repo_id when provided", async
     "repo-uuid-456",
   );
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals(parsed.distinct_id, "user-uuid-123");
@@ -169,7 +171,7 @@ Deno.test("HttpTelemetrySender.sendBatch omits $repo_id when not provided", asyn
 
   const result = await sender.sendBatch([entry], "user-uuid-123");
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals(parsed.distinct_id, "user-uuid-123");
@@ -201,7 +203,7 @@ Deno.test("HttpTelemetrySender.sendBatch includes x-api-key header when authToke
     "test-api-key-abc",
   );
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(capturedApiKey, "test-api-key-abc");
 
   await server.shutdown();
@@ -225,7 +227,7 @@ Deno.test("HttpTelemetrySender.sendBatch omits x-api-key header when authToken n
 
   const result = await sender.sendBatch([entry], "user-uuid-123");
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(capturedApiKey, null);
 
   await server.shutdown();
@@ -252,7 +254,7 @@ Deno.test("HttpTelemetrySender.sendBatch includes User-Agent header when provide
 
   const result = await sender.sendBatch([entry], "user-uuid-123");
 
-  assertEquals(result, true);
+  assertEquals(result.ok, true);
   assertEquals(capturedUserAgent, "swamp-cli/1.2.3");
 
   await server.shutdown();
@@ -297,7 +299,7 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
   });
 
   const ok = await sender.sendBatch([entry], "user-uuid");
-  assertEquals(ok, true);
+  assertEquals(ok.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals(parsed.properties.invocationContext.configuredAiTools, [
@@ -354,7 +356,7 @@ Deno.test("HttpTelemetrySender.sendBatch lands parentInvocationId and workflowCo
   });
 
   const ok = await sender.sendBatch([entry], "user-uuid");
-  assertEquals(ok, true);
+  assertEquals(ok.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals(parsed.properties.parentInvocationId, "parent-wire");
@@ -386,7 +388,7 @@ Deno.test("HttpTelemetrySender.sendBatch omits parentInvocationId / workflowCont
   );
 
   const ok = await sender.sendBatch([entry], "user-uuid");
-  assertEquals(ok, true);
+  assertEquals(ok.ok, true);
 
   const parsed = JSON.parse(capturedBody!);
   assertEquals("parentInvocationId" in parsed.properties, false);


### PR DESCRIPTION
## Summary

- Replace the bare `boolean` return from `TelemetrySender.sendBatch` and `TelemetryService.flushTelemetry` with a `TelemetryFlushResult` that carries the failure reason
- `HttpTelemetrySender` now classifies failures: `HTTP <status>` for non-202 responses, `timeout` for `AbortSignal` cancellation, `network error` for connection/DNS failures
- CLI warning includes the reason: e.g. `Telemetry flush failed (HTTP 401) — entries are queued locally and will retry on the next invocation`

**Investigation:** Compiled and compared the pre-20260726 binary against the current binary — both produce identical telemetry requests and identical warnings. This is not a client-side regression; the flush failure is external (server-side, auth, or network). The fix makes the warning actionable so users can diagnose the cause.

## Test Plan

- [x] `deno check` — type checking passes (pre-existing `TS2741` in `deno_runtime.ts` unrelated to this change)
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 9,361 passed, 0 failed
- [x] Updated `HttpTelemetrySender` tests to verify failure reasons (`HTTP 400`, `network error`)
- [x] Updated `MockTelemetrySender` and `TelemetryService` flush tests for new return type
- [x] End-to-end verified with compiled binary against mock servers:
  - HTTP 401 → `Telemetry flush failed (HTTP 401)`
  - HTTP 500 → `Telemetry flush failed (HTTP 500)`
  - Connection refused → `Telemetry flush failed (network error)`
  - 10s slow server with 2s timeout → `Telemetry flush failed (timeout)`
  - Successful flush → no warning
  - `--json` mode → warning suppressed (unchanged behavior)

Closes swamp-club#1408