### PR TITLE
fix(help): include global options in subtree schema output

### DIFF
--- a/src/cli/cli_schema.ts
+++ b/src/cli/cli_schema.ts
@@ -38,6 +38,7 @@ export interface CliCommandSchema {
   description: string;
   arguments: CliArgumentSchema[];
   options: CliOptionSchema[];
+  globalOptions?: CliOptionSchema[];
   subcommands: CliCommandSchema[];
 }
 
@@ -70,10 +71,26 @@ export function buildCliSchema(
   options?: BuildCliSchemaOptions,
 ): CliSchema {
   const stripGlobals = options?.stripGlobalOptions ?? false;
-  return {
-    version,
-    root: walkCommand(rootCommand, !stripGlobals, stripGlobals),
-  };
+  const root = walkCommand(rootCommand, !stripGlobals, stripGlobals);
+  if (stripGlobals) {
+    root.globalOptions = rootCommand.getOptions()
+      .filter((opt: { name: string }) => !BUILTIN_OPTION_NAMES.has(opt.name))
+      .filter((opt: { global?: boolean }) => opt.global === true)
+      // deno-lint-ignore no-explicit-any
+      .map((opt: any) => {
+        const schema: CliOptionSchema = {
+          flags: (opt.flags as string[]).join(", "),
+          description: opt.description as string,
+          required: opt.required === true,
+          collect: opt.collect === true,
+        };
+        if (opt.default !== undefined) {
+          schema.default = opt.default;
+        }
+        return schema;
+      });
+  }
+  return { version, root };
 }
 
 function walkCommand(

--- a/src/cli/cli_schema_test.ts
+++ b/src/cli/cli_schema_test.ts
@@ -152,7 +152,7 @@ Deno.test("buildCliSchema filters global options from subcommands", () => {
   assertEquals(subLocal !== undefined, true);
 });
 
-Deno.test("buildCliSchema stripGlobalOptions removes globals from root too", () => {
+Deno.test("buildCliSchema stripGlobalOptions removes globals from options and populates globalOptions", () => {
   const sub = new Command().description("subcommand").option(
     "--local",
     "Local option",
@@ -166,13 +166,45 @@ Deno.test("buildCliSchema stripGlobalOptions removes globals from root too", () 
   // Build schema for the subcommand with stripGlobalOptions
   const schema = buildCliSchema(sub, "1.0.0", { stripGlobalOptions: true });
 
-  // Global option should NOT appear even though sub is the root of this schema
+  // Global option should NOT appear in options
   const jsonOpt = schema.root.options.find((o) => o.flags.includes("--json"));
   assertEquals(jsonOpt, undefined);
 
-  // Local option should still appear
+  // Local option should still appear in options
   const localOpt = schema.root.options.find((o) => o.flags.includes("--local"));
   assertEquals(localOpt !== undefined, true);
+
+  // Global option should appear in globalOptions
+  assertEquals(schema.root.globalOptions !== undefined, true);
+  const globalJson = schema.root.globalOptions!.find((o) =>
+    o.flags.includes("--json")
+  );
+  assertEquals(globalJson !== undefined, true);
+  assertEquals(globalJson!.description, "JSON output");
+
+  // Local option should NOT appear in globalOptions
+  const globalLocal = schema.root.globalOptions!.find((o) =>
+    o.flags.includes("--local")
+  );
+  assertEquals(globalLocal, undefined);
+});
+
+Deno.test("buildCliSchema without stripGlobalOptions does not set globalOptions", () => {
+  const root = new Command()
+    .name("cli")
+    .description("root")
+    .globalOption("--json", "JSON output")
+    .command(
+      "sub",
+      new Command().description("subcommand").option(
+        "--local",
+        "Local option",
+      ),
+    );
+
+  const schema = buildCliSchema(root, "1.0.0");
+
+  assertEquals(schema.root.globalOptions, undefined);
 });
 
 Deno.test("buildCliSchema filters builtin --help and --version flags", () => {


### PR DESCRIPTION
## Summary

Fixes swamp-club#1409

- `swamp help workflow run` (and all subtree views) stripped global options like `--json` from the schema output, making them undiscoverable even though they work at runtime via Cliffy's `.globalOption()` propagation
- Added an optional `globalOptions` array to `CliCommandSchema` that is populated when `stripGlobalOptions` is true, surfacing inherited options (e.g. `--json`, `--log`, `--quiet`, `--verbose`) in a dedicated section
- Updated and expanded tests to verify `globalOptions` is populated in subtree schemas and absent in full schemas

## Test Plan

- [x] `deno check` passes on changed files
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] All 9 `cli_schema_test.ts` tests pass (including 2 new/updated tests)
- [x] Full test suite passes (9365 passed, 1 pre-existing flaky failure in `shutdown_handlers_test.ts`)
- [x] Compiled binary: `./swamp help workflow run` now includes `--json` in `globalOptions` section
- [x] Verified `--json` still works at runtime: `swamp workflow run nonexistent --json` returns structured JSON error

🤖 Generated with [Claude Code](https://claude.com/claude-code)