### PR TITLE
fix(workflow): propagate cycle detection error from nested workflows

### DIFF
--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3018,7 +3018,11 @@ export class WorkflowExecutionService {
     }
 
     if (!childRun || childRun.status === "failed") {
-      const errorMessage = `Nested workflow "${task.workflowIdOrName}" failed.`;
+      const childStepError = childRun?.jobs
+        .flatMap((j) => j.steps)
+        .find((s) => s.status === "failed" && !s.allowedFailure)?.error;
+      const errorMessage = childStepError ??
+        `Nested workflow "${task.workflowIdOrName}" failed.`;
       stepRun.fail(errorMessage);
       if (allowFailure) {
         stepRun.markAllowedFailure();

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -17,7 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { join } from "@std/path";
 import {
   DefaultStepExecutor,
@@ -1428,6 +1434,71 @@ Deno.test("workflow step fails on direct cycle detection", async () => {
     assertEquals(
       events[0].error?.includes("Workflow cycle detected"),
       true,
+    );
+  });
+});
+
+Deno.test("workflow step propagates cycle error from mutually recursive workflows", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    const cycleA = Workflow.create({
+      name: "cycle-a",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "call-b",
+              task: StepTask.workflow("cycle-b"),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const cycleB = Workflow.create({
+      name: "cycle-b",
+      jobs: [
+        Job.create({
+          name: "main",
+          steps: [
+            Step.create({
+              name: "call-a",
+              task: StepTask.workflow("cycle-a"),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await workflowRepo.save(cycleA);
+    await workflowRepo.save(cycleB);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      undefined,
+      undefined,
+      catalogStore,
+    );
+
+    let completedRun: import("./workflow_run.ts").WorkflowRun | undefined;
+    for await (const event of service.run("cycle-a")) {
+      if (event.kind === "completed") {
+        completedRun = event.run;
+      }
+    }
+
+    assert(completedRun, "expected a completed run");
+    assertEquals(completedRun.status, "failed");
+    const stepError = completedRun.jobs[0].steps[0].error ?? "";
+    assertStringIncludes(
+      stepError.toLowerCase(),
+      "workflow cycle detected",
     );
   });
 });


### PR DESCRIPTION
## Summary

- When mutually recursive workflows triggered cycle detection, the parent
  discarded the specific "Workflow cycle detected" error and replaced it with a
  generic "Nested workflow X failed." message. Now the parent extracts the first
  non-allowed step error from the child's `WorkflowRun`, so the cycle detection
  message (and other meaningful child errors) propagate to the user.

## Test Plan

- Added unit test for mutually recursive workflows (`cycle-a` → `cycle-b` →
  `cycle-a`) asserting the parent step's error contains "workflow cycle
  detected"
- Verified the test fails on unfixed code with `"nested workflow "cycle-b"
  failed."`
- Compiled binary and ran end-to-end reproduction per the issue's repro steps —
  output now shows `Workflow cycle detected: ...`
- All existing tests pass (61/61 in `execution_service_test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)