### PR TITLE
fix(workflows): assert step followups — multi-input guard, resume replay, polish

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -226,6 +226,12 @@ Non-assert steps are omitted from the JUnit output.
 **forEach compatibility:** Assert steps support `forEach` expansion. Each
 expanded iteration produces its own assert result and JUnit `<testcase>`.
 
+**Known limitation — message interpolation:** The `${{ }}` pattern in `message`
+uses non-greedy matching. A CEL expression containing a literal `}}` (e.g.
+map/struct literals) will be split prematurely. The error is silently caught and
+the expression left as-is, so it degrades gracefully. Keep `message`
+interpolation to simple value lookups; use the `expr` field for complex CEL.
+
 ## Concurrency Limits
 
 By default, all jobs in a topological level and all steps in a topological level

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -450,6 +450,13 @@ export const workflowRunCommand = new Command()
         )
         : [cliInputs];
 
+      if (options.junit && inputSets.length > 1) {
+        throw new UserError(
+          "--junit cannot be combined with multiple input sets (--stdin with NDJSON). " +
+            "Each input set would produce a separate XML document, resulting in malformed output.",
+        );
+      }
+
       for (let i = 0; i < inputSets.length; i++) {
         if (inputSets.length > 1) {
           ctx.logger

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2565,6 +2565,19 @@ export class WorkflowExecutionService {
       (stepRun.status === "succeeded" || stepRun.status === "failed" ||
         stepRun.status === "skipped")
     ) {
+      // Replay assert_result for completed assert steps so renderers
+      // (JUnit, console summary) include prior-run results.
+      if (stepRun.assertResult) {
+        yield {
+          kind: "assert_result" as const,
+          jobId: job.name,
+          stepId: stepName,
+          passed: stepRun.assertResult.passed,
+          message: stepRun.assertResult.message,
+          severity: stepRun.assertResult.severity,
+          expr: stepRun.assertResult.expr,
+        };
+      }
       stepSpan.end();
       return;
     }

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -575,7 +575,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
               "system",
               "Failed",
               STATUS_COLORS.error,
-              `workflow ${this.workflowName} — assertion failures above threshold (${this.failOnSeverity})${duration}`,
+              `workflow ${this.workflowName} — assertion failures at severity ≥ ${this.failOnSeverity}${duration}`,
               formatTimestamp(),
             ),
           );

--- a/src/presentation/renderers/workflow_run_junit.ts
+++ b/src/presentation/renderers/workflow_run_junit.ts
@@ -74,6 +74,11 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
       evaluating_workflow: () => {},
       started: (e) => {
         this.workflowName = e.workflowName;
+        if (!this.outFile) {
+          console.error(
+            `JUnit XML will be written to stdout on completion.`,
+          );
+        }
       },
       job_started: () => {},
       job_completed: () => {},
@@ -110,6 +115,11 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
       report_failed: () => {},
       completed: async (e) => {
         this.totalDuration = (e.run.duration ?? 0) / 1000;
+        if (this.asserts.length === 0) {
+          console.error(
+            "Warning: --junit produced 0 testcases. The workflow has no assert steps.",
+          );
+        }
         const failedAboveThreshold = this.asserts.filter(
           (a) =>
             !a.passed && severityAtOrAbove(a.severity, this.failOnSeverity),
@@ -199,11 +209,13 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
             }">`,
           );
           lines.push(
-            `      <failure message="${escapeXml(r.message)}" type="${
-              escapeXml(r.severity)
-            }">`,
+            `      <failure message="${
+              escapeXml(r.message)
+            }" type="AssertionFailure">`,
           );
-          lines.push(`expr: ${escapeXml(r.expr)}`);
+          lines.push(
+            `severity: ${r.severity}\nexpr: ${escapeXml(r.expr)}`,
+          );
           lines.push(`      </failure>`);
           lines.push(`    </testcase>`);
         }


### PR DESCRIPTION
## Summary

Followup fixes for the assert step feature (#1970):

- **Bug fix**: Error when `--junit` combined with multiple input sets (`--stdin` NDJSON) — previously produced malformed XML (concatenated documents) or silently overwrote `--out` file per iteration
- **Bug fix**: Replay `assert_result` events for already-completed assert steps on workflow resume, so JUnit XML and console summaries include results from before the suspension point
- **Polish**: Clarify threshold failure message (`severity ≥ low` instead of ambiguous `above threshold (low)`)
- **Polish**: Stderr note when `--junit` without `--out` so interactive users know output arrives on completion
- **Polish**: JUnit `<failure type="">` uses `AssertionFailure` instead of severity level, severity encoded in body
- **Polish**: Warning when `--junit` produces 0 testcases
- **Docs**: Document message interpolation `}}` limitation in design/workflow.md

## Test plan

- [ ] All existing assert integration tests pass (6/6)
- [ ] All workflow domain tests pass (473+)
- [ ] Verify `--junit` with `--stdin` NDJSON errors with clear message
- [ ] Verify resume path replays prior assert results

🤖 Generated with [Claude Code](https://claude.com/claude-code)