### PR TITLE
fix(extensions): handle inline type annotations in source scanner (swamp-club#1413)

### DIFF
--- a/src/domain/datastore/user_datastore_loader_test.ts
+++ b/src/domain/datastore/user_datastore_loader_test.ts
@@ -726,3 +726,17 @@ export const datastore = {
   assertNotEquals(result, null);
   assertEquals(result?.typeNormalized, "@org/correct-datastore");
 });
+
+Deno.test("datastoreKindAdapter.extractTypeFromSource: handles inline structural type annotation", () => {
+  const source = `
+export const datastore: {
+  type: string;
+  connect: () => Promise<unknown>;
+} = {
+  type: "@org/typed-datastore",
+  connect: async () => ({}),
+};`;
+  const result = datastoreKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/typed-datastore");
+});

--- a/src/domain/extensions/datastore_kind_adapter.ts
+++ b/src/domain/extensions/datastore_kind_adapter.ts
@@ -71,7 +71,7 @@ export const datastoreKindAdapter: KindAdapter = {
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+datastore\s*[=:]/.test(source)) return null;
     const typeMatch = source.match(
-      /export\s+const\s+datastore\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+      /export\s+const\s+datastore\b[\s\S]*?=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
     );
     if (!typeMatch) return null;
     return {

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -409,13 +409,13 @@ export const modelKindAdapter: KindAdapter = {
     if (!modelMatch && !extensionMatch) return null;
 
     const typeMatch = source.match(
-      /export\s+const\s+(?:model|extension)\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+      /export\s+const\s+(?:model|extension)\b[\s\S]*?=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
     );
     if (!typeMatch) return null;
 
     const typeNormalized = ModelType.create(typeMatch[1]).normalized;
     const versionMatch = source.match(
-      /export\s+const\s+(?:model|extension)\s*=\s*\{[\s\S]*?version\s*:\s*["']([^"']+)["']/,
+      /export\s+const\s+(?:model|extension)\b[\s\S]*?=\s*\{[\s\S]*?version\s*:\s*["']([^"']+)["']/,
     );
 
     return {

--- a/src/domain/extensions/model_kind_adapter_test.ts
+++ b/src/domain/extensions/model_kind_adapter_test.ts
@@ -87,6 +87,53 @@ export const model = {
   assertEquals(result?.extendsType, "");
 });
 
+Deno.test("extractTypeFromSource: model with inline structural type annotation extracts type and version", () => {
+  const source = `
+import { z } from "npm:zod";
+export const model: {
+  type: string;
+  version: string;
+  resources: Record<string, {
+    nested: { deep: true };
+  }>;
+} = {
+  type: "@test/greeter",
+  version: "2026.01.01.0",
+};`;
+  const result = modelKindAdapter.extractTypeFromSource(source);
+  assertEquals(result?.typeNormalized, "@test/greeter");
+  assertEquals(result?.version, "2026.01.01.0");
+  assertEquals(result?.kind, "model");
+  assertEquals(result?.extendsType, "");
+});
+
+Deno.test("extractTypeFromSource: extension with inline type annotation extracts type", () => {
+  const source = `
+import { z } from "npm:zod";
+export const extension: {
+  type: string;
+} = {
+  type: "@test/greeter",
+};`;
+  const result = modelKindAdapter.extractTypeFromSource(source);
+  assertEquals(result?.typeNormalized, "@test/greeter");
+  assertEquals(result?.kind, "extension");
+  assertEquals(result?.extendsType, "@test/greeter");
+});
+
+Deno.test("extractTypeFromSource: model with simple named type annotation extracts type", () => {
+  const source = `
+import { z } from "npm:zod";
+export const model: ModelDefinition = {
+  type: "@test/greeter",
+  version: "2026.01.01.0",
+};`;
+  const result = modelKindAdapter.extractTypeFromSource(source);
+  assertEquals(result?.typeNormalized, "@test/greeter");
+  assertEquals(result?.version, "2026.01.01.0");
+  assertEquals(result?.kind, "model");
+});
+
 Deno.test("importAndExtendBundle: skips standalone model bundle without throwing", async () => {
   const entry = {
     source_path: "/tmp/fake/model.ts",

--- a/src/domain/extensions/report_kind_adapter.ts
+++ b/src/domain/extensions/report_kind_adapter.ts
@@ -72,7 +72,7 @@ export const reportKindAdapter: KindAdapter = {
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+report\s*[=:]/.test(source)) return null;
     const nameMatch = source.match(
-      /export\s+const\s+report\s*=\s*\{[\s\S]*?name\s*:\s*["']([^"']+)["']/,
+      /export\s+const\s+report\b[\s\S]*?=\s*\{[\s\S]*?name\s*:\s*["']([^"']+)["']/,
     );
     if (!nameMatch) return null;
     return {

--- a/src/domain/extensions/vault_kind_adapter.ts
+++ b/src/domain/extensions/vault_kind_adapter.ts
@@ -71,7 +71,7 @@ export const vaultKindAdapter: KindAdapter = {
   extractTypeFromSource(source: string) {
     if (!/export\s+const\s+vault\s*[=:]/.test(source)) return null;
     const typeMatch = source.match(
-      /export\s+const\s+vault\s*=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
+      /export\s+const\s+vault\b[\s\S]*?=\s*\{[\s\S]*?type\s*:\s*["']([^"']+)["']/,
     );
     if (!typeMatch) return null;
     return {

--- a/src/domain/reports/user_report_loader_test.ts
+++ b/src/domain/reports/user_report_loader_test.ts
@@ -402,3 +402,17 @@ export const report = {
   assertNotEquals(result, null);
   assertEquals(result?.typeNormalized, "@org/correct-report");
 });
+
+Deno.test("reportKindAdapter.extractTypeFromSource: handles inline structural type annotation", () => {
+  const source = `
+export const report: {
+  name: string;
+  render: () => string;
+} = {
+  name: "@org/typed-report",
+  render: () => "",
+};`;
+  const result = reportKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/typed-report");
+});

--- a/src/domain/vaults/user_vault_loader_test.ts
+++ b/src/domain/vaults/user_vault_loader_test.ts
@@ -838,3 +838,17 @@ export const vault = {
   assertNotEquals(result, null);
   assertEquals(result?.typeNormalized, "@org/correct-vault");
 });
+
+Deno.test("vaultKindAdapter.extractTypeFromSource: handles inline structural type annotation", () => {
+  const source = `
+export const vault: {
+  type: string;
+  resolve: () => Promise<string>;
+} = {
+  type: "@org/typed-vault",
+  resolve: async () => "secret",
+};`;
+  const result = vaultKindAdapter.extractTypeFromSource(source);
+  assertNotEquals(result, null);
+  assertEquals(result?.typeNormalized, "@org/typed-vault");
+});


### PR DESCRIPTION
## Summary

- Fix `extractTypeFromSource` regex across all four kind adapters (model, datastore, vault, report) to handle inline TypeScript type annotations between the export name and the initializer
- The regex expected `export const model = {` immediately, but failed when authors wrote `export const model: { ... } = {` with a structural type annotation
- Change `\s*=` to `\b[\s\S]*?=` so the lazy match skips any annotation and finds the initializer's `= {`

Closes swamp-club#1413

## Test Plan

- Added 6 unit tests across all four kind adapter test files covering inline structural type annotations and named type annotations
- Verified against reproduction: `swamp doctor extensions` no longer emits `type field could not be extracted` warning for exports with inline type annotations
- All 9374 existing tests pass