### PR TITLE
feat(workflows): include inputs, tags, and reports in workflow get/search JSON (swamp-club#1415)

### DIFF
--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { InputsSchema } from "../../domain/definitions/definition.ts";
+import type { ReportSelection } from "../../domain/reports/report_selection.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import {
   createWorkflowId,
@@ -36,6 +38,9 @@ export interface WorkflowGetData {
   name: string;
   description?: string;
   version: number;
+  inputs?: InputsSchema;
+  tags: Record<string, string>;
+  reports?: ReportSelection;
   jobs: {
     name: string;
     description?: string;
@@ -107,6 +112,9 @@ export async function* workflowGet(
         name: workflow.name,
         description: workflow.description,
         version: workflow.version,
+        inputs: workflow.inputs,
+        tags: workflow.tags,
+        reports: workflow.reports,
         jobs: workflow.jobs.map((job) => ({
           name: job.name,
           description: job.description,

--- a/src/libswamp/workflows/get_test.ts
+++ b/src/libswamp/workflows/get_test.ts
@@ -32,6 +32,14 @@ const testWorkflow = {
   id: "550e8400-e29b-41d4-a716-446655440000" as unknown as WorkflowId,
   name: "my-workflow",
   version: 1,
+  inputs: {
+    properties: {
+      labelKey: { type: "string", default: "role", description: "Label key" },
+    },
+    required: [],
+  },
+  tags: { env: "staging" },
+  reports: { require: ["junit"] },
   jobs: [{
     name: "job1",
     steps: [{ name: "step1", task: { toData: () => ({ type: "model/run" }) } }],
@@ -73,6 +81,18 @@ Deno.test("workflowGet yields resolving -> completed with workflow data on succe
         name: "my-workflow",
         description: undefined,
         version: 1,
+        inputs: {
+          properties: {
+            labelKey: {
+              type: "string",
+              default: "role",
+              description: "Label key",
+            },
+          },
+          required: [],
+        },
+        tags: { env: "staging" },
+        reports: { require: ["junit"] },
         jobs: [{
           name: "job1",
           description: undefined,

--- a/src/libswamp/workflows/search.ts
+++ b/src/libswamp/workflows/search.ts
@@ -29,6 +29,7 @@ export interface WorkflowSearchItem {
   name: string;
   description?: string;
   jobCount: number;
+  hasInputs: boolean;
 }
 
 /**
@@ -54,6 +55,7 @@ export interface WorkflowSearchDeps {
       name: string;
       description?: string;
       jobs: readonly unknown[];
+      inputs?: { properties?: Record<string, unknown> };
     }>
   >;
 }
@@ -88,6 +90,7 @@ export async function* workflowSearch(
         name: w.name,
         description: w.description,
         jobCount: w.jobs.length,
+        hasInputs: Object.keys(w.inputs?.properties ?? {}).length > 0,
       }));
 
       yield {

--- a/src/libswamp/workflows/search_test.ts
+++ b/src/libswamp/workflows/search_test.ts
@@ -37,6 +37,11 @@ function makeDeps(
           name: "deploy",
           description: "Deploy to production",
           jobs: [{}, {}],
+          inputs: {
+            properties: {
+              target: { type: "string", default: "prod" },
+            },
+          },
         },
         {
           id: "wf-2",
@@ -67,10 +72,12 @@ Deno.test("workflowSearch: returns all workflows with no query", async () => {
   assertEquals(completed.data.results[0].name, "deploy");
   assertEquals(completed.data.results[0].description, "Deploy to production");
   assertEquals(completed.data.results[0].jobCount, 2);
+  assertEquals(completed.data.results[0].hasInputs, true);
   assertEquals(completed.data.results[1].id, "wf-2");
   assertEquals(completed.data.results[1].name, "test");
   assertEquals(completed.data.results[1].description, undefined);
   assertEquals(completed.data.results[1].jobCount, 1);
+  assertEquals(completed.data.results[1].hasInputs, false);
 });
 
 Deno.test("workflowSearch: passes query through in data", async () => {

--- a/src/presentation/renderers/workflow_get_test.ts
+++ b/src/presentation/renderers/workflow_get_test.ts
@@ -19,14 +19,22 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { consumeStream } from "../../libswamp/mod.ts";
-import type { WorkflowGetEvent } from "../../libswamp/mod.ts";
+import type { WorkflowGetData, WorkflowGetEvent } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { createWorkflowGetRenderer } from "./workflow_get.ts";
 
-const testData = {
+const testData: WorkflowGetData = {
   id: "wf-1",
   name: "my-workflow",
   version: 1,
+  inputs: {
+    properties: {
+      env: { type: "string", default: "dev" },
+    },
+    required: [],
+  },
+  tags: { team: "platform" },
+  reports: undefined,
   jobs: [],
   path: "/repo/workflows/my-workflow.yaml",
 };


### PR DESCRIPTION
## Summary

- Add `inputs` (full JSON Schema), `tags`, and `reports` to `workflow get --json` output — the workflow domain model already carried these fields, they just weren't mapped through to the `WorkflowGetData` DTO
- Add `hasInputs: boolean` hint to `workflow search --json` results so list views can flag which workflows take parameters without an N+1 round-trip
- Update unit tests for get, search, and the get renderer to cover the new fields

Closes swamp-club#1415

## Test Plan

- [x] `deno check` passes on all changed files and dependents
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] Unit tests pass: `get_test.ts`, `search_test.ts`, `workflow_get_test.ts` (12/12)
- [x] Tests cover both `hasInputs: true` (workflow with inputs) and `hasInputs: false` (workflow without)
- [x] JSON renderer test verifies `inputs` and `tags` serialize correctly, `reports: undefined` is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)