### PR TITLE
fix(workflows): defer assert message interpolation past step-output dependencies (swamp-club#1424)

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -440,11 +440,12 @@ inputs:
 
 All `data.*` functions (`data.latest`, `data.version`, `data.listVersions`,
 `data.findBySpec`, `data.query`, `data.findByTag`) are classified as
-step-output dependencies. In workflow step `task.inputs`, they are **deferred**
-past workflow evaluation and resolved at step execution time — after upstream
-steps have run and their data is available. This enables patterns where step 1
-produces ephemeral data and step 2 consumes it via `data.findBySpec()` or
-`data.query()`.
+step-output dependencies. In workflow step `task.inputs` and assert step
+`task.message`, they are **deferred** past workflow evaluation and resolved at
+step execution time — after upstream steps have run and their data is available.
+This enables patterns where step 1 produces ephemeral data and step 2 consumes
+it via `data.findBySpec()` or `data.query()`, and assert steps that interpolate
+prior-step data in their failure messages.
 
 The `--last-evaluated` flag preserves this behavior: deferred expressions saved
 as raw `${{ }}` in the evaluated workflow are resolved at step execution time

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -233,6 +233,20 @@ export function isTaskGlobalArgsPath(path: string): boolean {
 }
 
 /**
+ * Checks if an expression path is a step's assert task.message field.
+ *
+ * Assert message expressions with step-output dependencies must be deferred
+ * past workflow evaluation — the message is interpolated at step execution
+ * time when upstream step outputs are available.
+ *
+ * @param path - The expression path (e.g., "jobs[0].steps[1].task.message")
+ * @returns True if the path is a step's task.message
+ */
+export function isAssertMessagePath(path: string): boolean {
+  return path.endsWith(".task.message");
+}
+
+/**
  * Checks if an expression path is within a workflow's `trigger.inputs`.
  *
  * These values are resolved at fire time by the trigger machinery — webhook

--- a/src/domain/expressions/expression_parser_test.ts
+++ b/src/domain/expressions/expression_parser_test.ts
@@ -24,6 +24,7 @@ import {
   extractExpressions,
   extractInputReferences,
   extractInputReferencesFromCel,
+  isAssertMessagePath,
   isTaskGlobalArgsPath,
   isTaskInputsPath,
   isTriggerInputsPath,
@@ -336,6 +337,36 @@ Deno.test("isTaskGlobalArgsPath returns true for globalArgs field itself", () =>
 Deno.test("isTaskGlobalArgsPath returns false for task.inputs", () => {
   assertEquals(
     isTaskGlobalArgsPath("jobs[0].steps[0].task.inputs.foo"),
+    false,
+  );
+});
+
+// Tests for isAssertMessagePath
+
+Deno.test("isAssertMessagePath: returns true for task.message", () => {
+  assertEquals(
+    isAssertMessagePath("jobs[0].steps[1].task.message"),
+    true,
+  );
+});
+
+Deno.test("isAssertMessagePath: returns false for task.inputs", () => {
+  assertEquals(
+    isAssertMessagePath("jobs[0].steps[0].task.inputs.foo"),
+    false,
+  );
+});
+
+Deno.test("isAssertMessagePath: returns false for task.expr", () => {
+  assertEquals(
+    isAssertMessagePath("jobs[0].steps[0].task.expr"),
+    false,
+  );
+});
+
+Deno.test("isAssertMessagePath: returns false for step name", () => {
+  assertEquals(
+    isAssertMessagePath("jobs[0].steps[0].name"),
     false,
   );
 });

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -22,6 +22,7 @@ import type { Workflow, WorkflowInput } from "./workflow.ts";
 import { Workflow as WorkflowClass } from "./workflow.ts";
 import {
   extractExpressions,
+  isAssertMessagePath,
   isTaskInputsPath,
   isTriggerInputsPath,
   replaceExpressions,
@@ -114,10 +115,11 @@ export class WorkflowExpressionEvaluator {
       if (isTriggerInputsPath(expr.path)) {
         continue;
       }
-      // task.inputs that depend on step outputs are evaluated at step
-      // execution time when upstream step outputs are available.
+      // task.inputs and assert task.message that depend on step outputs
+      // are evaluated at step execution time when upstream step outputs
+      // are available.
       if (
-        isTaskInputsPath(expr.path) &&
+        (isTaskInputsPath(expr.path) || isAssertMessagePath(expr.path)) &&
         hasStepOutputDependency(expr.celExpression)
       ) {
         continue;

--- a/src/domain/workflows/expression_evaluators_test.ts
+++ b/src/domain/workflows/expression_evaluators_test.ts
@@ -225,6 +225,36 @@ Deno.test("WorkflowExpressionEvaluator: skips task.inputs that depend on step ou
   assertEquals(result.expressionsEvaluated, 0);
 });
 
+Deno.test("WorkflowExpressionEvaluator: skips assert task.message that depends on step outputs", async () => {
+  const evaluator = new WorkflowExpressionEvaluator(new CelEvaluator());
+  const workflow = Workflow.create({
+    name: "assert-msg-deferred",
+    jobs: [
+      Job.create({
+        name: "j",
+        steps: [
+          Step.create({
+            name: "collect",
+            task: StepTask.model("server", "run"),
+          }),
+          Step.create({
+            name: "verify",
+            task: StepTask.assert(
+              'data.latest("server", "result").attributes.exitCode == 0',
+              'Exit code was ${{ data.latest("server", "result").attributes.exitCode }}',
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+  const result = await evaluator.evaluate(workflow, emptyContext());
+  assertEquals(result.expressionsEvaluated, 0);
+  const assertStep = result.workflow.jobs[0].steps[1];
+  const task = assertStep.task.data as { message: string };
+  assertStringIncludes(task.message, "${{ data.latest");
+});
+
 Deno.test("WorkflowExpressionEvaluator: STRICT — per-expression eval error propagates", async () => {
   const evaluator = new WorkflowExpressionEvaluator(new ThrowingEvaluator());
   const workflow = Workflow.create({

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -28,6 +28,7 @@ import {
 } from "../../domain/workflows/workflow_id.ts";
 import {
   extractExpressions,
+  isAssertMessagePath,
   isTaskGlobalArgsPath,
   isTaskInputsPath,
   replaceExpressions,
@@ -212,10 +213,11 @@ async function evaluateWorkflowInternal(
     if (forEachInExpressions.has(expr.raw)) {
       continue;
     }
-    // Skip task.inputs/globalArgs expressions that depend on step outputs (resource, file, execution, data, file.contents).
+    // Skip task.inputs/globalArgs/message expressions that depend on step outputs (resource, file, execution, data, file.contents).
     // These are evaluated at step execution time when upstream step outputs are available.
     if (
-      (isTaskInputsPath(expr.path) || isTaskGlobalArgsPath(expr.path)) &&
+      (isTaskInputsPath(expr.path) || isTaskGlobalArgsPath(expr.path) ||
+        isAssertMessagePath(expr.path)) &&
       hasStepOutputDependency(expr.celExpression)
     ) {
       continue;


### PR DESCRIPTION
## Summary

- Assert step `message` fields with `${{ data.latest(...) }}` were eagerly
  evaluated during the workflow-level expression pass, before upstream
  data-producing steps ran — crashing the workflow with
  `No such key: attributes`
- Added `isAssertMessagePath()` to the expression path classifiers and
  included it in the deferral guard for both the runtime evaluator
  (`expression_evaluators.ts`) and the CLI evaluate path (`evaluate.ts`)
- Updated `design/expressions.md` to document that step-output deferral
  applies to `task.message` in addition to `task.inputs`

Closes swamp-club#1424

## Test Plan

- Added unit tests for `isAssertMessagePath()` in `expression_parser_test.ts`
- Added unit test in `expression_evaluators_test.ts` verifying assert message
  with `data.latest()` is deferred (`expressionsEvaluated` = 0, raw expression
  preserved)
- Compiled binary and verified with the reproduction workflow from the issue:
  workflow now completes successfully with the assert message interpolated
  after the data-producing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)