### PR TITLE
feat(vaults): add vault selection for sensitive fields (swamp-club#1420)

### DIFF
--- a/design/vaults.md
+++ b/design/vaults.md
@@ -490,8 +490,48 @@ single quotes.
 The vault used for storing a sensitive field is resolved in this order:
 
 1. Field-level `vaultName` from `.meta()` metadata
-2. Spec-level `vaultName` from `ResourceOutputSpec`
-3. First available vault from `VaultService`
+2. Spec-level `vaultName` from `ResourceOutputSpec` (set by extension author or
+   overridden via definition YAML `resources.<specName>.vaultName`)
+3. Repo-level `defaultVault` from `.swamp.yaml`
+4. First available vault from `VaultService`
+
+### Definition-Level Vault Override
+
+Model definition YAML can override which vault a resource's sensitive fields are
+stored in, using the existing `resources` block:
+
+```yaml
+resources:
+  credentials:
+    vaultName: high-trust-vault
+  runtime-tokens:
+    vaultName: runtime-vault
+```
+
+The `vaultName` here maps to the extension's `ResourceOutputSpec` names. It
+slots into the resolution order at tier 2, overriding the extension author's
+default but still below any field-level `.meta()` override.
+
+### Repo-Level Default Vault
+
+Set a repo-wide default vault in `.swamp.yaml`:
+
+```yaml
+defaultVault: my-vault
+```
+
+This applies when no field-level or spec-level `vaultName` is set. It also
+applies to `swamp serve` vault operations (OAuth credentials, device auth
+tokens). If not set, the system falls back to the first available vault —
+identical to the behaviour before this feature.
+
+### Sensitive Method Arguments
+
+Sensitive method arguments are the user's responsibility to vault. The runtime
+enforces that `sensitive: true` global arguments must not be literal values (they
+must be `${{ vault.get(...) }}` expressions), but it does not automatically
+route argument values into a vault. Use `swamp vault put` to store argument
+values before referencing them in definitions.
 
 ### Processing Behavior
 

--- a/integration/vault_selection_test.ts
+++ b/integration/vault_selection_test.ts
@@ -1,0 +1,532 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Integration tests for vault selection across the full resolution chain.
+ *
+ * Tests every tier of the vault resolution order:
+ *   1. Field-level vaultName from .meta() metadata
+ *   2. Spec-level vaultName from ResourceOutputSpec (or definition YAML override)
+ *   3. Repo-level defaultVault from .swamp.yaml (via VaultService)
+ *   4. First available vault from VaultService (backwards-compat fallback)
+ *
+ * Also tests createResourceWriter with definition-level vaultName overrides
+ * and VaultService.getDefaultVaultName() for the serve/device_auth path.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+import { stringify as stringifyYaml } from "@std/yaml";
+import { z } from "zod";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import type { ResourceOutputSpec } from "../src/domain/models/model.ts";
+import { VaultService } from "../src/domain/vaults/vault_service.ts";
+import {
+  createResourceWriter,
+  processSensitiveResourceData,
+} from "../src/domain/models/data_writer.ts";
+import type { UnifiedDataRepository } from "../src/domain/data/repositories.ts";
+import { SOLO_NAMESPACE } from "../src/domain/data/namespace.ts";
+import { generateDataId } from "../src/domain/data/data_id.ts";
+
+function createMockRepo(): UnifiedDataRepository {
+  return {
+    namespace: SOLO_NAMESPACE,
+    findAllGlobal: () => Promise.resolve([]),
+    findAllForType: () => Promise.resolve([]),
+    findByName: () => Promise.resolve(null),
+    findById: () => Promise.resolve(null),
+    listVersions: () => Promise.resolve([]),
+    findAllForModel: () => Promise.resolve([]),
+    save: () => Promise.resolve({ version: 1 }),
+    append: () => Promise.resolve(),
+    stream: async function* () {},
+    getContent: () => Promise.resolve(null),
+    delete: () => Promise.resolve(),
+    removeLatestMarker: () => Promise.resolve(),
+    nextId: () => generateDataId(),
+    getPath: () => "",
+    getContentPath: () => "",
+    collectGarbage: () =>
+      Promise.resolve({ versionsRemoved: 0, bytesReclaimed: 0 }),
+    allocateVersion: () =>
+      Promise.resolve({
+        version: 1,
+        contentPath: "/tmp/mock",
+        priorVersions: [],
+      }),
+    finalizeVersion: () =>
+      Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    getLatestVersionSync: () => null,
+    findByNameSync: () => null,
+    listVersionsSync: () => [],
+    getContentSync: () => null,
+    findAllForModelSync: () => [],
+    findAllGlobalSync: () => [],
+    findByTaggedName: () => Promise.resolve([]),
+    rename: () => {
+      throw new Error("not implemented");
+    },
+  };
+}
+
+const modelType = ModelType.create("test/vault-selection");
+const modelId = "vault-selection-test-id";
+
+function createSensitiveSpec(
+  overrides?: Partial<ResourceOutputSpec>,
+): ResourceOutputSpec {
+  return {
+    schema: z.object({
+      secret: z.string().meta({ sensitive: true }),
+      name: z.string(),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+    ...overrides,
+  };
+}
+
+// --- Scenario 1: Single vault, no overrides — backwards compatible ---
+
+Deno.test("vault selection: single vault with no overrides uses that vault", async () => {
+  const spec = createSensitiveSpec();
+  const data: Record<string, unknown> = { secret: "my-secret", name: "test" };
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "only-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'only-vault'");
+  assertEquals(data.name, "test");
+});
+
+// --- Scenario 2: Two vaults, no overrides — falls back to vaultNames[0] ---
+
+Deno.test("vault selection: two vaults with no overrides uses first registered", async () => {
+  const spec = createSensitiveSpec();
+  const data: Record<string, unknown> = { secret: "my-secret", name: "test" };
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "alpha-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "beta-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'alpha-vault'");
+});
+
+// --- Scenario 3: defaultVault overrides first-registered fallback ---
+
+Deno.test("vault selection: defaultVault overrides first-registered fallback", async () => {
+  const spec = createSensitiveSpec();
+  const data: Record<string, unknown> = { secret: "my-secret", name: "test" };
+  const vaultService = new VaultService(undefined, "beta-vault");
+  vaultService.registerVault({
+    name: "alpha-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "beta-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'beta-vault'");
+});
+
+// --- Scenario 4: spec-level vaultName overrides defaultVault ---
+
+Deno.test("vault selection: spec-level vaultName overrides defaultVault", async () => {
+  const spec = createSensitiveSpec({ vaultName: "spec-vault" });
+  const data: Record<string, unknown> = { secret: "my-secret", name: "test" };
+  const vaultService = new VaultService(undefined, "default-vault");
+  vaultService.registerVault({
+    name: "default-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "spec-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'spec-vault'");
+});
+
+// --- Scenario 5: field-level vaultName overrides everything ---
+
+Deno.test("vault selection: field-level vaultName overrides spec and default", async () => {
+  const spec: ResourceOutputSpec = {
+    schema: z.object({
+      secret: z.string().meta({ sensitive: true, vaultName: "field-vault" }),
+      name: z.string(),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+    vaultName: "spec-vault",
+  };
+  const data: Record<string, unknown> = { secret: "my-secret", name: "test" };
+  const vaultService = new VaultService(undefined, "default-vault");
+  vaultService.registerVault({
+    name: "default-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "spec-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "field-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'field-vault'");
+});
+
+// --- Scenario 6: Definition-level vaultName override via createResourceWriter ---
+
+Deno.test("vault selection: definition-level vaultName override via createResourceWriter", async () => {
+  const repo = createMockRepo();
+  const resources: Record<string, ResourceOutputSpec> = {
+    creds: createSensitiveSpec(),
+  };
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "first-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "definition-vault",
+    type: "mock",
+    config: {},
+  });
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    resources,
+    undefined,
+    [{ specName: "creds", vaultName: "definition-vault" }],
+    undefined,
+    undefined,
+    undefined,
+    vaultService,
+    "create",
+  );
+
+  const data = { secret: "my-secret-value", name: "test" };
+  await writeResource("creds", "main", data);
+
+  assertStringIncludes(data.secret as string, "'definition-vault'");
+  assertEquals(data.name, "test");
+});
+
+// --- Scenario 7: Definition vaultName beats defaultVault but loses to field ---
+
+Deno.test("vault selection: definition override beats defaultVault", async () => {
+  const repo = createMockRepo();
+  const resources: Record<string, ResourceOutputSpec> = {
+    creds: createSensitiveSpec(),
+  };
+
+  const vaultService = new VaultService(undefined, "default-vault");
+  vaultService.registerVault({
+    name: "default-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "definition-vault",
+    type: "mock",
+    config: {},
+  });
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    resources,
+    undefined,
+    [{ specName: "creds", vaultName: "definition-vault" }],
+    undefined,
+    undefined,
+    undefined,
+    vaultService,
+    "create",
+  );
+
+  const data = { secret: "my-secret", name: "test" };
+  await writeResource("creds", "main", data);
+
+  assertStringIncludes(data.secret as string, "'definition-vault'");
+});
+
+// --- Scenario 8: No overrides, no default — backwards-compat fallback ---
+
+Deno.test("vault selection: no overrides and no default preserves backwards-compat", async () => {
+  const repo = createMockRepo();
+  const resources: Record<string, ResourceOutputSpec> = {
+    creds: createSensitiveSpec(),
+  };
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "vault-a",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "vault-b",
+    type: "mock",
+    config: {},
+  });
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    resources,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    vaultService,
+    "create",
+  );
+
+  const data = { secret: "my-secret", name: "test" };
+  await writeResource("creds", "main", data);
+
+  assertStringIncludes(data.secret as string, "'vault-a'");
+});
+
+// --- Scenario 9: VaultService.getDefaultVaultName for serve path ---
+
+Deno.test("vault selection: VaultService.getDefaultVaultName for serve path", () => {
+  const service = new VaultService(undefined, "oauth-vault");
+  service.registerVault({ name: "first-vault", type: "mock", config: {} });
+  service.registerVault({ name: "oauth-vault", type: "mock", config: {} });
+
+  const vaultName = service.getDefaultVaultName() ??
+    service.getVaultNames()[0];
+
+  assertEquals(vaultName, "oauth-vault");
+});
+
+Deno.test("vault selection: VaultService.getDefaultVaultName falls back when no default", () => {
+  const service = new VaultService();
+  service.registerVault({ name: "first-vault", type: "mock", config: {} });
+  service.registerVault({ name: "second-vault", type: "mock", config: {} });
+
+  const vaultName = service.getDefaultVaultName() ??
+    service.getVaultNames()[0];
+
+  assertEquals(vaultName, "first-vault");
+});
+
+Deno.test("vault selection: VaultService.getDefaultVaultName ignores unregistered default", () => {
+  const service = new VaultService(undefined, "nonexistent-vault");
+  service.registerVault({ name: "first-vault", type: "mock", config: {} });
+
+  const vaultName = service.getDefaultVaultName() ??
+    service.getVaultNames()[0];
+
+  assertEquals(vaultName, "first-vault");
+});
+
+// --- Scenario 12-14: VaultService.fromRepository with real vault configs on disk ---
+
+async function withTwoVaultRepo(
+  fn: (repoDir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const vaultADir = join(tempDir, "vaults", "mock");
+    await ensureDir(vaultADir);
+    await Deno.writeTextFile(
+      join(vaultADir, "alpha-id.yaml"),
+      stringifyYaml({
+        id: "alpha-id",
+        name: "alpha-vault",
+        type: "mock",
+        config: {},
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    await Deno.writeTextFile(
+      join(vaultADir, "beta-id.yaml"),
+      stringifyYaml({
+        id: "beta-id",
+        name: "beta-vault",
+        type: "mock",
+        config: {},
+        createdAt: "2026-01-02T00:00:00.000Z",
+      }),
+    );
+    await fn(tempDir);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("vault selection: fromRepository with defaultVaultName routes put to the correct vault", async () => {
+  await withTwoVaultRepo(async (repoDir) => {
+    const vaultService = await VaultService.fromRepository(
+      repoDir,
+      undefined,
+      undefined,
+      "beta-vault",
+    );
+
+    assertEquals(vaultService.getDefaultVaultName(), "beta-vault");
+
+    const targetVault = vaultService.getDefaultVaultName() ??
+      vaultService.getVaultNames()[0];
+    await vaultService.put(targetVault, "test-key", "test-secret");
+
+    const stored = await vaultService.get("beta-vault", "test-key");
+    assertEquals(stored, "test-secret");
+  });
+});
+
+Deno.test("vault selection: fromRepository without defaultVaultName falls back to first vault", async () => {
+  await withTwoVaultRepo(async (repoDir) => {
+    const vaultService = await VaultService.fromRepository(repoDir);
+
+    assertEquals(vaultService.getDefaultVaultName(), undefined);
+
+    const targetVault = vaultService.getDefaultVaultName() ??
+      vaultService.getVaultNames()[0];
+    await vaultService.put(targetVault, "test-key", "test-secret");
+
+    const stored = await vaultService.get(
+      vaultService.getVaultNames()[0],
+      "test-key",
+    );
+    assertEquals(stored, "test-secret");
+  });
+});
+
+Deno.test("vault selection: fromRepository + processSensitiveResourceData end-to-end", async () => {
+  await withTwoVaultRepo(async (repoDir) => {
+    const vaultService = await VaultService.fromRepository(
+      repoDir,
+      undefined,
+      undefined,
+      "beta-vault",
+    );
+
+    const spec = createSensitiveSpec();
+    const data: Record<string, unknown> = {
+      secret: "serve-oauth-secret",
+      name: "test",
+    };
+
+    await processSensitiveResourceData(
+      data,
+      spec,
+      vaultService,
+      modelType,
+      modelId,
+      "create",
+      "creds",
+      "main",
+    );
+
+    assertStringIncludes(data.secret as string, "'beta-vault'");
+    assertEquals(data.name, "test");
+
+    const vaultKey = `test-vault-selection-${modelId}-create-creds-main-secret`;
+    const storedSecret = await vaultService.get("beta-vault", vaultKey);
+    assertEquals(storedSecret, "serve-oauth-secret");
+  });
+});

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -326,7 +326,13 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
           saveEvaluatedDefinition: (type, definition) =>
             repoContext.evaluatedDefinitionRepo.save(type, definition),
           createExecutionService: () => new DefaultMethodExecutionService(),
-          createVaultService: () => VaultService.fromRepository(repoDir),
+          createVaultService: () =>
+            VaultService.fromRepository(
+              repoDir,
+              undefined,
+              undefined,
+              marker?.defaultVault,
+            ),
           dataRepo: repoContext.unifiedDataRepo,
           definitionRepo: repoContext.definitionRepo,
           outputRepo: repoContext.outputRepo,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1120,14 +1120,19 @@ export const serveCommand = new Command()
 
     let oauthClientSecret = "";
     if (authConfig.mode === "oauth") {
-      const vaultService = await VaultService.fromRepository(resolvedRepoDir);
+      const vaultService = await VaultService.fromRepository(
+        resolvedRepoDir,
+        undefined,
+        undefined,
+        repoMarker?.defaultVault,
+      );
       const vaultNames = vaultService.getVaultNames();
       if (vaultNames.length === 0) {
         throw new UserError(
           "oauth mode requires a vault — run 'swamp vault create local default' first",
         );
       }
-      const vaultName = vaultNames[0];
+      const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
       const credentials = await resolveOAuthClientCredentials(
         {
           getVaultSecret: async (v, k) => {
@@ -1594,9 +1599,19 @@ export const serveCommand = new Command()
       groupRefreshMs > 0 && authConfig.mode === "oauth" &&
       oauthClientSecret
     ) {
-      const vaultService = await VaultService.fromRepository(resolvedRepoDir);
+      const vaultService = await VaultService.fromRepository(
+        resolvedRepoDir,
+        undefined,
+        undefined,
+        repoMarker?.defaultVault,
+      );
       const vaultNames = vaultService.getVaultNames();
-      const vaultName = vaultNames[0];
+      if (vaultNames.length === 0) {
+        throw new UserError(
+          "group refresh requires a vault — run 'swamp vault create local default' first",
+        );
+      }
+      const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
 
       const {
         CollectiveRefreshService,
@@ -2062,6 +2077,7 @@ export const serveCommand = new Command()
             oauthClientSecret,
             resolvedRepoDir,
             repoContext,
+            repoMarker?.defaultVault,
           );
           const deviceAuthResponse = await handleDeviceAuth(
             req,

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -145,6 +145,7 @@ export type CheckSelection = {
 const ResourceOverrideSchema = z.object({
   lifetime: LifetimeSchema.optional(),
   garbageCollection: GarbageCollectionSchema.optional(),
+  vaultName: z.string().optional(),
 });
 
 export type ResourceOverride = z.infer<typeof ResourceOverrideSchema>;

--- a/src/domain/definitions/definition_test.ts
+++ b/src/domain/definitions/definition_test.ts
@@ -571,3 +571,40 @@ Deno.test("Legacy numeric typeVersion coerced to undefined", () => {
 
   assertEquals(definition.typeVersion, undefined);
 });
+
+Deno.test("Definition.parse: accepts resources with vaultName override", () => {
+  const data: DefinitionData = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {},
+    inputs: undefined,
+    resources: {
+      creds: { vaultName: "secure-vault" },
+    },
+  };
+
+  const definition = Definition.fromData(data);
+  assertEquals(definition.resources?.creds?.vaultName, "secure-vault");
+});
+
+Deno.test("Definition.parse: resources without vaultName remain backwards compatible", () => {
+  const data: DefinitionData = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    name: "test-definition",
+    version: 1,
+    tags: {},
+    globalArguments: {},
+    methods: {},
+    inputs: undefined,
+    resources: {
+      result: { lifetime: "infinite", garbageCollection: 5 },
+    },
+  };
+
+  const definition = Definition.fromData(data);
+  assertEquals(definition.resources?.result?.vaultName, undefined);
+  assertEquals(definition.resources?.result?.lifetime, "infinite");
+});

--- a/src/domain/models/data_output_override.ts
+++ b/src/domain/models/data_output_override.ts
@@ -44,6 +44,9 @@ export interface DataOutputOverride {
 
   /** Input key names to vary by — produces composite data names per dimension */
   vary?: string[];
+
+  /** Override vault name for sensitive field storage */
+  vaultName?: string;
 }
 
 export const DataOutputOverrideSchema = z.object({
@@ -52,4 +55,5 @@ export const DataOutputOverrideSchema = z.object({
   garbageCollection: GarbageCollectionSchema.optional(),
   tags: z.record(z.string(), z.string()).optional(),
   vary: z.array(z.string().min(1)).optional(),
+  vaultName: z.string().optional(),
 });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -385,7 +385,8 @@ export async function processSensitiveResourceData(
   }
 
   for (const { field, originalValue } of fieldsWithValues) {
-    const targetVault = field.vaultName ?? spec.vaultName ?? vaultNames[0];
+    const targetVault = field.vaultName ?? spec.vaultName ??
+      vaultService.getDefaultVaultName() ?? vaultNames[0];
     const vaultKey = field.vaultKey ??
       sanitizeVaultKey(
         `${modelType.normalized}/${modelId}/${methodName}/${specName}/${instanceName}/${field.path}`,
@@ -446,6 +447,7 @@ export function createResourceWriter(
     garbageCollection?: GarbageCollectionPolicy;
     tags?: Record<string, string>;
     resolvedVarySuffix?: string;
+    vaultName?: string;
   }>,
   definitionTags?: Record<string, string>,
   runtimeTags?: Record<string, string>,
@@ -575,13 +577,24 @@ export function createResourceWriter(
       }
     }
 
+    // Resolve definition-level vaultName override for this spec
+    let effectiveSpec = spec;
+    if (dataOutputOverrides) {
+      const override = dataOutputOverrides.find(
+        (o) => o.specName === specName,
+      );
+      if (override?.vaultName) {
+        effectiveSpec = { ...spec, vaultName: override.vaultName };
+      }
+    }
+
     // Process sensitive fields before serialization
-    const hasSensitiveFields = spec.sensitiveOutput ||
-      extractSensitiveFields(spec.schema).length > 0;
+    const hasSensitiveFields = effectiveSpec.sensitiveOutput ||
+      extractSensitiveFields(effectiveSpec.schema).length > 0;
     if (hasSensitiveFields && !vaultService) {
-      const fields = extractSensitiveFields(spec.schema)
+      const fields = extractSensitiveFields(effectiveSpec.schema)
         .map((f) => `'${f.path}'`).join(", ");
-      const detail = spec.sensitiveOutput
+      const detail = effectiveSpec.sensitiveOutput
         ? `resource '${specName}' is marked sensitiveOutput`
         : `fields ${fields} in resource '${specName}' are marked as sensitive`;
       throw new Error(
@@ -592,7 +605,7 @@ export function createResourceWriter(
     if (vaultService && methodName && hasSensitiveFields) {
       await processSensitiveResourceData(
         data,
-        spec,
+        effectiveSpec,
         vaultService,
         modelType,
         modelId,

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1788,3 +1788,119 @@ Deno.test("createResourceDeleter: propagates repository errors", async () => {
     "delete failed",
   );
 });
+
+Deno.test("processSensitiveResourceData: uses defaultVaultName when no field or spec vaultName", async () => {
+  const spec: ResourceOutputSpec = {
+    schema: z.object({
+      secret: z.string().meta({ sensitive: true }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+
+  const data: Record<string, unknown> = { secret: "my-secret" };
+  const vaultService = new VaultService(undefined, "repo-default");
+  vaultService.registerVault({
+    name: "first-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "repo-default",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'repo-default'");
+});
+
+Deno.test("createResourceWriter: definition-level vaultName override routes sensitive fields to specified vault", async () => {
+  const repo = createMockRepo();
+  const sensitiveResources: Record<string, ResourceOutputSpec> = {
+    creds: {
+      schema: z.object({
+        secret: z.string().meta({ sensitive: true }),
+      }),
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  };
+
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "default-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "override-vault",
+    type: "mock",
+    config: {},
+  });
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    sensitiveResources,
+    undefined, // tagOverrides
+    [{ specName: "creds", vaultName: "override-vault" }], // dataOutputOverrides
+    undefined, // definitionTags
+    undefined, // runtimeTags
+    undefined, // definitionName
+    vaultService,
+    "create", // methodName
+  );
+
+  const data = { secret: "my-secret-value" };
+  await writeResource("creds", "main", data);
+
+  assertStringIncludes(data.secret as string, "'override-vault'");
+});
+
+Deno.test("processSensitiveResourceData: falls back to vaultNames[0] when no default configured", async () => {
+  const spec: ResourceOutputSpec = {
+    schema: z.object({
+      secret: z.string().meta({ sensitive: true }),
+    }),
+    lifetime: "infinite",
+    garbageCollection: 10,
+  };
+
+  const data: Record<string, unknown> = { secret: "my-secret" };
+  const vaultService = new VaultService();
+  vaultService.registerVault({
+    name: "alpha-vault",
+    type: "mock",
+    config: {},
+  });
+  vaultService.registerVault({
+    name: "beta-vault",
+    type: "mock",
+    config: {},
+  });
+
+  await processSensitiveResourceData(
+    data,
+    spec,
+    vaultService,
+    modelType,
+    modelId,
+    "create",
+    "creds",
+    "main",
+  );
+
+  assertStringIncludes(data.secret as string, "'alpha-vault'");
+});

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -62,9 +62,14 @@ export class VaultService {
   private readonly auditFlags = new Map<string, boolean>();
   private readonly refreshOptions?: VaultRefreshOptions;
   private auditRepository?: VaultAuditRepository;
+  private readonly defaultVaultName_?: string;
 
-  constructor(refreshOptions?: VaultRefreshOptions) {
+  constructor(
+    refreshOptions?: VaultRefreshOptions,
+    defaultVaultName?: string,
+  ) {
     this.refreshOptions = refreshOptions;
+    this.defaultVaultName_ = defaultVaultName;
   }
 
   setAuditRepository(repo: VaultAuditRepository): void {
@@ -86,9 +91,10 @@ export class VaultService {
     repoDir: string,
     vaultsDir?: string,
     refreshOptions?: VaultRefreshOptions,
+    defaultVaultName?: string,
   ): Promise<VaultService> {
     await vaultTypeRegistry.ensureLoaded();
-    const vaultService = new VaultService(refreshOptions);
+    const vaultService = new VaultService(refreshOptions, defaultVaultName);
     let vaultConfigs: Awaited<
       ReturnType<YamlVaultConfigRepository["findAll"]>
     >;
@@ -453,6 +459,20 @@ export class VaultService {
    */
   getVaultNames(): string[] {
     return Array.from(this.providers.keys());
+  }
+
+  /**
+   * Returns the repo-level default vault name if configured and the vault
+   * is registered, otherwise undefined.
+   */
+  getDefaultVaultName(): string | undefined {
+    if (
+      this.defaultVaultName_ !== undefined &&
+      this.providers.has(this.defaultVaultName_)
+    ) {
+      return this.defaultVaultName_;
+    }
+    return undefined;
   }
 
   /**

--- a/src/domain/vaults/vault_service_test.ts
+++ b/src/domain/vaults/vault_service_test.ts
@@ -784,3 +784,30 @@ Deno.test("VaultService - audit trail", async (t) => {
     },
   );
 });
+
+Deno.test("VaultService - getDefaultVaultName", async (t) => {
+  await t.step("returns undefined when no defaultVaultName is set", () => {
+    const service = new VaultService();
+    service.registerVault({ name: "vault-a", type: "mock", config: {} });
+    assertEquals(service.getDefaultVaultName(), undefined);
+  });
+
+  await t.step(
+    "returns the default vault name when it is registered",
+    () => {
+      const service = new VaultService(undefined, "vault-b");
+      service.registerVault({ name: "vault-a", type: "mock", config: {} });
+      service.registerVault({ name: "vault-b", type: "mock", config: {} });
+      assertEquals(service.getDefaultVaultName(), "vault-b");
+    },
+  );
+
+  await t.step(
+    "returns undefined when default vault name is not registered",
+    () => {
+      const service = new VaultService(undefined, "nonexistent");
+      service.registerVault({ name: "vault-a", type: "mock", config: {} });
+      assertEquals(service.getDefaultVaultName(), undefined);
+    },
+  );
+});

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -208,6 +208,7 @@ function mergeDataOutputOverrides(
       specName,
       lifetime: override.lifetime,
       garbageCollection: override.garbageCollection,
+      vaultName: override.vaultName,
     }))
     : [];
 

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -62,6 +62,7 @@ export interface RepoMarkerData {
   lastSkillMigrationWarning?: string;
   skillMigrationDismissed?: boolean;
   autoGc?: boolean;
+  defaultVault?: string;
 }
 
 /**

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -445,3 +445,38 @@ Deno.test("RepoMarkerRepository.createUpgradeMarker always sets upgradedAt", () 
   // The new upgradedAt should be different from the old one
   assertEquals(marker.upgradedAt !== existing.upgradedAt, true);
 });
+
+Deno.test("RepoMarkerRepository.write and read roundtrip with defaultVault", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(dir);
+
+    const original = {
+      swampVersion: "1.2.3",
+      initializedAt: "2024-01-15T10:30:00.000Z",
+      defaultVault: "my-secure-vault",
+    };
+
+    await repo.write(repoPath, original);
+    const result = await repo.read(repoPath);
+
+    assertEquals(result?.defaultVault, "my-secure-vault");
+  });
+});
+
+Deno.test("RepoMarkerRepository.read: missing defaultVault returns undefined", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(dir);
+
+    const original = {
+      swampVersion: "1.2.3",
+      initializedAt: "2024-01-15T10:30:00.000Z",
+    };
+
+    await repo.write(repoPath, original);
+    const result = await repo.read(repoPath);
+
+    assertEquals(result?.defaultVault, undefined);
+  });
+});

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -747,6 +747,7 @@ export async function* modelMethodRun(
                           specName,
                           lifetime: override.lifetime,
                           garbageCollection: override.garbageCollection,
+                          vaultName: override.vaultName,
                         }))
                         : undefined,
                       vaultSecrets: secretBag,

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -186,6 +186,7 @@ export async function createModelMethodRunDeps(
   options?: {
     directExecution?: boolean;
     runTracker?: ModelMethodRunDeps["runTracker"];
+    defaultVault?: string;
   },
 ): Promise<ModelMethodRunDeps> {
   await Promise.all([
@@ -220,7 +221,13 @@ export async function createModelMethodRunDeps(
     saveEvaluatedDefinition: (type, definition) =>
       repoContext.evaluatedDefinitionRepo.save(type, definition),
     createExecutionService: () => new DefaultMethodExecutionService(),
-    createVaultService: () => VaultService.fromRepository(repoDir),
+    createVaultService: () =>
+      VaultService.fromRepository(
+        repoDir,
+        undefined,
+        undefined,
+        options?.defaultVault,
+      ),
     dataRepo: repoContext.unifiedDataRepo,
     definitionRepo: repoContext.definitionRepo,
     outputRepo: repoContext.outputRepo,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -286,19 +286,25 @@ async function mintServerTokenImpl(
   groups: string[],
   repoDir: string,
   repoContext: RepositoryContext,
+  defaultVault?: string,
 ): Promise<string> {
   const tokenName = `oauth-${crypto.randomUUID().slice(0, 8)}`;
   const secretKey = serverTokenSecretKey(tokenName);
   const plaintext = generateOpaqueToken();
 
-  const vaultService = await VaultService.fromRepository(repoDir);
+  const vaultService = await VaultService.fromRepository(
+    repoDir,
+    undefined,
+    undefined,
+    defaultVault,
+  );
   const vaultNames = vaultService.getVaultNames();
   if (vaultNames.length === 0) {
     throw new Error(
       "No vaults configured — create one with: swamp vault create local default",
     );
   }
-  const vaultName = vaultNames[0];
+  const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
 
   await vaultService.put(vaultName, secretKey, plaintext);
 
@@ -360,6 +366,7 @@ export function createDeviceAuthDeps(
   clientSecret: string,
   repoDir: string,
   repoContext: RepositoryContext,
+  defaultVault?: string,
 ): DeviceAuthDeps {
   return {
     authConfig,
@@ -370,13 +377,34 @@ export function createDeviceAuthDeps(
     pollForToken: oauthPollForToken,
     getUserInfo: oauthGetUserInfo,
     checkAdmission,
-    mintServerToken: mintServerTokenImpl,
+    mintServerToken: (
+      principalId: string,
+      principalEmail: string,
+      collectives: string[],
+      groups: string[],
+      rd: string,
+      rc: RepositoryContext,
+    ) =>
+      mintServerTokenImpl(
+        principalId,
+        principalEmail,
+        collectives,
+        groups,
+        rd,
+        rc,
+        defaultVault,
+      ),
     storeAccessToken: async (tokenName: string, accessToken: string) => {
-      const vaultService = await VaultService.fromRepository(repoDir);
+      const vaultService = await VaultService.fromRepository(
+        repoDir,
+        undefined,
+        undefined,
+        defaultVault,
+      );
       const vaultNames = vaultService.getVaultNames();
       if (vaultNames.length === 0) return;
       await vaultService.put(
-        vaultNames[0],
+        vaultService.getDefaultVaultName() ?? vaultNames[0],
         oauthAccessTokenKey(tokenName),
         accessToken,
       );


### PR DESCRIPTION
## Summary

- Add per-resource `vaultName` override in definition YAML — routes sensitive fields to a named vault via the existing `resources` block
- Add repo-level `defaultVault` in `.swamp.yaml` — applies to model execution and serve/device-auth vault selection
- Both are optional: no config = identical behaviour to today (`vaultNames[0]` fallback)

Resolution chain: `field.vaultName` → `spec.vaultName` (populated from definition override) → `defaultVault` → `vaultNames[0]`

### Definition-level override

```yaml
resources:
  credentials:
    vaultName: high-trust-vault
```

### Repo-level default

```yaml
# .swamp.yaml
defaultVault: my-vault
```

## Changes

| Area | Files | What |
|------|-------|------|
| Schema | `definition.ts`, `data_output_override.ts` | Added optional `vaultName` field |
| Threading | `execution_service.ts`, `run.ts` | Carry `vaultName` through DataOutputOverride |
| VaultService | `vault_service.ts`, `repo_marker_repository.ts` | `defaultVaultName` + `getDefaultVaultName()`, `defaultVault` on RepoMarkerData |
| Data writer | `data_writer.ts` | Definition override into effective spec + defaultVault fallback |
| Serve | `serve.ts`, `device_auth_handler.ts`, `deps.ts` | Pass `defaultVault` through to VaultService |
| CLI | `model_method_run.ts` | Pass `marker?.defaultVault` to VaultService |
| Tests | 4 unit test files + 1 integration test (14 scenarios) | Full resolution chain coverage |
| Docs | `design/vaults.md` | Updated resolution chain, new features, sensitive args clarification |

## Test Plan

- 9425 tests pass (0 failures), including 14 new vault selection scenarios
- Integration tests cover every resolution tier: field → spec → definition override → defaultVault → first-available
- `fromRepository` tests verify real vault configs on disk with `defaultVaultName`
- E2E verified with compiled binary: created a real repo with two `local_encryption` vaults and a locally-authored extension with sensitive fields. Confirmed:
  - No `defaultVault` → secret routes to first available vault
  - `defaultVault: alpha-vault` → secret routes to `alpha-vault`
  - `defaultVault: alpha-vault` + definition `vaultName: beta-vault` → secret routes to `beta-vault` (definition wins)

Closes swamp-club#1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)