### PR TITLE
fix(workflows): three assert-step fixes — validation, renderer, JUnit

### DIFF
--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -136,10 +136,6 @@ async function executeCommand(
       signal: context.signal,
       logger: context.logger,
       redactor: context.redactor,
-      onOutput: context.onEvent
-        ? (line: string, stream: "stdout" | "stderr") =>
-          context.onEvent!({ type: "output", line, stream })
-        : undefined,
     });
 
     stdout = redact(result.stdout);

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -183,6 +183,7 @@ export type WorkflowExecutionEvent =
     message: string;
     severity: AssertSeverity;
     expr: string;
+    error?: string;
   }
   | { kind: "completed"; run: WorkflowRun }
   | { kind: "cancelled"; run: WorkflowRun; reason?: string }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2576,6 +2576,7 @@ export class WorkflowExecutionService {
           message: stepRun.assertResult.message,
           severity: stepRun.assertResult.severity,
           expr: stepRun.assertResult.expr,
+          error: stepRun.assertResult.error,
         };
       }
       stepSpan.end();
@@ -2758,11 +2759,30 @@ export class WorkflowExecutionService {
           const errorMessage = error instanceof Error
             ? error.message
             : String(error);
+
+          const assertResult = {
+            passed: false,
+            expr: task.expr,
+            message: errorMessage,
+            severity: task.severity,
+            error: errorMessage,
+          };
+          stepRun.recordAssertResult(assertResult);
           stepRun.fail(errorMessage);
           stepSpan.setStatus({
             code: SpanStatusCode.ERROR,
             message: errorMessage,
           });
+          yield {
+            kind: "assert_result" as const,
+            jobId: job.name,
+            stepId: stepName,
+            passed: false,
+            message: errorMessage,
+            severity: task.severity,
+            expr: task.expr,
+            error: errorMessage,
+          };
           yield {
             kind: "step_failed",
             jobId: job.name,

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -171,6 +171,9 @@ export class DefaultWorkflowValidationService
     // 10. queueTimeout without placement is a no-op
     results.push(...this.validateQueueTimeoutPlacement(workflow));
 
+    // 11. Assert expr must not be wrapped in ${{ }}
+    results.push(...this.validateAssertExprNotInterpolated(workflow));
+
     return results;
   }
 
@@ -186,6 +189,31 @@ export class DefaultWorkflowValidationService
               `queueTimeout without placement in job '${job.name}' step '${step.name}'`,
               `Step '${step.name}' sets queueTimeout but has no target, labels, or platform — ` +
                 `queueTimeout only applies to remote-execution steps with placement requirements`,
+            ),
+          );
+        }
+      }
+    }
+    return results;
+  }
+
+  private validateAssertExprNotInterpolated(
+    workflow: Workflow,
+  ): WorkflowValidationResult[] {
+    const results: WorkflowValidationResult[] = [];
+    const exprPattern = /^\$\{\{.*\}\}\s*$/s;
+    for (const job of workflow.jobs) {
+      for (const step of job.steps) {
+        if (!step.task) continue;
+        const taskData = step.task.data;
+        if (taskData.type !== "assert") continue;
+        if (exprPattern.test(taskData.expr)) {
+          results.push(
+            WorkflowValidationResult.fail(
+              `Assert expr in job '${job.name}' step '${step.name}'`,
+              `assert expr must be a raw CEL expression — remove the ` +
+                `\${{ }} wrapper. Interpolation converts the expression ` +
+                `before runtime evaluation, which causes a type error`,
             ),
           );
         }

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1628,3 +1628,76 @@ Deno.test("validate: no warning when queueTimeout is set with placement", async 
   );
   assertEquals(warning, undefined);
 });
+
+// --- Assert expr interpolation validation tests ---
+
+Deno.test("validate: fails when assert expr is wrapped in interpolation syntax", async () => {
+  const workflow = Workflow.create({
+    name: "test-assert-wrapped",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "verify",
+            task: StepTask.assert("${{ true }}", "should pass", "high"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const assertResult = results.find((r) => r.name.includes("Assert expr"));
+  assertEquals(assertResult?.passed, false);
+  assertEquals(
+    assertResult?.error?.includes("raw CEL expression"),
+    true,
+  );
+});
+
+Deno.test("validate: passes when assert expr is raw CEL", async () => {
+  const workflow = Workflow.create({
+    name: "test-assert-raw",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "verify",
+            task: StepTask.assert("1 == 1", "should pass", "high"),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const assertResult = results.find((r) => r.name.includes("Assert expr"));
+  assertEquals(assertResult, undefined);
+});
+
+Deno.test("validate: fails when assert expr uses multiline interpolation", async () => {
+  const workflow = Workflow.create({
+    name: "test-assert-multiline",
+    jobs: [
+      Job.create({
+        name: "main",
+        steps: [
+          Step.create({
+            name: "verify",
+            task: StepTask.assert(
+              '${{ data.latest("m", "s").attributes.x == 1 }}',
+              "check data",
+              "high",
+            ),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await service.validate(workflow);
+  const assertResult = results.find((r) => r.name.includes("Assert expr"));
+  assertEquals(assertResult?.passed, false);
+});

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -45,6 +45,7 @@ export const AssertResultSchema = z.object({
   expr: z.string(),
   message: z.string(),
   severity: AssertSeveritySchema,
+  error: z.string().optional(),
 });
 
 export type AssertResultData = z.infer<typeof AssertResultSchema>;

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -187,6 +187,7 @@ export type WorkflowRunEvent =
     message: string;
     severity: AssertSeverity;
     expr: string;
+    error?: string;
   }
   | {
     kind: "report_started";

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -52,6 +52,7 @@ export interface AssertResultView {
   expr: string;
   message: string;
   severity: AssertSeverity;
+  error?: string;
 }
 
 export interface StepRunView {

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -87,6 +87,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
     passed: boolean;
     message: string;
     severity: AssertSeverity;
+    error?: string;
   }> = [];
   private assertStepIds = new Set<string>();
 
@@ -458,6 +459,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
           passed: e.passed,
           message: e.message,
           severity: e.severity,
+          error: e.error,
         });
         const displayName = this.forEachDisplayNames.get(key) ?? e.jobId;
         const startTime = this.stepStartTimes.get(key);
@@ -527,7 +529,9 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
         // Render assert summary if any assert steps ran
         if (this.assertResults.length > 0) {
           const passed = this.assertResults.filter((r) => r.passed).length;
-          const failed = this.assertResults.filter((r) => !r.passed).length;
+          const failed = this.assertResults.filter((r) => !r.passed && !r.error)
+            .length;
+          const errors = this.assertResults.filter((r) => !!r.error).length;
           const failedAboveThreshold = this.assertResults.filter(
             (r) =>
               !r.passed &&
@@ -535,11 +539,14 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
           ).length;
 
           writeBlankLine();
-          const summary = failed > 0
-            ? `${passed} passed, ${failed} failed`
-            : `${passed} passed`;
+          const parts = [`${passed} passed`];
+          if (failed > 0) parts.push(`${failed} failed`);
+          if (errors > 0) parts.push(`${errors} errored`);
           writeOutput(
-            this.pipe.line("system", dim(`Assertions: ${summary}`)),
+            this.pipe.line(
+              "system",
+              dim(`Assertions: ${parts.join(", ")}`),
+            ),
           );
 
           if (failedAboveThreshold > 0) {

--- a/src/presentation/renderers/workflow_run_junit.ts
+++ b/src/presentation/renderers/workflow_run_junit.ts
@@ -33,6 +33,7 @@ interface AssertRecord {
   message: string;
   severity: AssertSeverity;
   expr: string;
+  error?: string;
   duration?: number;
 }
 
@@ -107,6 +108,7 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
           message: e.message,
           severity: e.severity,
           expr: e.expr,
+          error: e.error,
           duration,
         });
       },
@@ -157,7 +159,9 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
 
   private buildXml(): string {
     const totalTests = this.asserts.length;
-    const totalFailures = this.asserts.filter((a) => !a.passed).length;
+    const totalFailures = this.asserts.filter((a) => !a.passed && !a.error)
+      .length;
+    const totalErrors = this.asserts.filter((a) => !!a.error).length;
 
     // Group by job
     const byJob = new Map<string, AssertRecord[]>();
@@ -174,18 +178,20 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
       `<?xml version="1.0" encoding="UTF-8"?>`,
       `<testsuites name="${
         escapeXml(this.workflowName)
-      }" tests="${totalTests}" failures="${totalFailures}" time="${
+      }" tests="${totalTests}" failures="${totalFailures}" errors="${totalErrors}" time="${
         this.totalDuration.toFixed(1)
       }">`,
     ];
 
     for (const [jobId, records] of byJob) {
-      const suiteFailures = records.filter((r) => !r.passed).length;
+      const suiteFailures = records.filter((r) => !r.passed && !r.error)
+        .length;
+      const suiteErrors = records.filter((r) => !!r.error).length;
       const suiteTime = records.reduce((s, r) => s + (r.duration ?? 0), 0);
       lines.push(
         `  <testsuite name="${
           escapeXml(jobId)
-        }" tests="${records.length}" failures="${suiteFailures}" time="${
+        }" tests="${records.length}" failures="${suiteFailures}" errors="${suiteErrors}" time="${
           suiteTime.toFixed(1)
         }">`,
       );
@@ -200,6 +206,24 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
               (r.duration ?? 0).toFixed(1)
             }"/>`,
           );
+        } else if (r.error) {
+          lines.push(
+            `    <testcase name="${
+              escapeXml(r.stepId)
+            }" classname="${classname}" time="${
+              (r.duration ?? 0).toFixed(1)
+            }">`,
+          );
+          lines.push(
+            `      <error message="${
+              escapeXml(r.error)
+            }" type="ExpressionEvaluationError">`,
+          );
+          lines.push(
+            `severity: ${r.severity}\nexpr: ${escapeXml(r.expr)}`,
+          );
+          lines.push(`      </error>`);
+          lines.push(`    </testcase>`);
         } else {
           lines.push(
             `    <testcase name="${

--- a/src/presentation/renderers/workflow_run_junit_test.ts
+++ b/src/presentation/renderers/workflow_run_junit_test.ts
@@ -17,8 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
-import { escapeXml } from "./workflow_run_junit.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { escapeXml, JUnitWorkflowRunRenderer } from "./workflow_run_junit.ts";
+import type { WorkflowRunView } from "../../libswamp/mod.ts";
 
 Deno.test("escapeXml: escapes ampersand", () => {
   assertEquals(escapeXml("a & b"), "a &amp; b");
@@ -51,4 +52,126 @@ Deno.test("escapeXml: preserves legal whitespace", () => {
   assertEquals(escapeXml("line\nbreak"), "line\nbreak");
   assertEquals(escapeXml("tab\there"), "tab\there");
   assertEquals(escapeXml("cr\rhere"), "cr\rhere");
+});
+
+function makeRunView(
+  status: "succeeded" | "failed" = "succeeded",
+): WorkflowRunView {
+  return {
+    id: "run-1",
+    workflowId: "wf-1",
+    workflowName: "test-workflow",
+    status,
+    jobs: [{
+      name: "job1",
+      status: "succeeded" as const,
+      steps: [],
+    }],
+    duration: 100,
+  };
+}
+
+Deno.test("JUnitWorkflowRunRenderer: eval error appears as <error> element", async () => {
+  const outFile = await Deno.makeTempFile({ suffix: ".xml" });
+  try {
+    const renderer = new JUnitWorkflowRunRenderer({ outFile });
+    const h = renderer.handlers();
+
+    h.started({
+      kind: "started",
+      runId: "run-1",
+      workflowName: "test-workflow",
+      jobs: [{ id: "verify", stepCount: 2, dependsOn: [] }],
+    });
+    h.step_started({
+      kind: "step_started",
+      jobId: "verify",
+      stepId: "assert-true",
+    });
+    h.assert_result({
+      kind: "assert_result",
+      jobId: "verify",
+      stepId: "assert-true",
+      passed: true,
+      message: "trivially true",
+      severity: "high",
+      expr: "1 == 1",
+    });
+    h.step_started({
+      kind: "step_started",
+      jobId: "verify",
+      stepId: "assert-error",
+    });
+    h.assert_result({
+      kind: "assert_result",
+      jobId: "verify",
+      stepId: "assert-error",
+      passed: false,
+      message: "No such key: attributes",
+      severity: "high",
+      expr: 'data.latest("m", "s").attributes.x',
+      error: "No such key: attributes",
+    });
+
+    await h.completed({
+      kind: "completed",
+      run: makeRunView("failed"),
+    });
+
+    const xml = await Deno.readTextFile(outFile);
+
+    assertStringIncludes(xml, 'tests="2"');
+    assertStringIncludes(xml, 'errors="1"');
+    assertStringIncludes(xml, 'failures="0"');
+    assertStringIncludes(xml, "<error message=");
+    assertStringIncludes(xml, 'type="ExpressionEvaluationError"');
+    assertStringIncludes(xml, 'name="assert-error"');
+    assertStringIncludes(xml, 'name="assert-true"');
+  } finally {
+    await Deno.remove(outFile);
+  }
+});
+
+Deno.test("JUnitWorkflowRunRenderer: clean failure uses <failure> element", async () => {
+  const outFile = await Deno.makeTempFile({ suffix: ".xml" });
+  try {
+    const renderer = new JUnitWorkflowRunRenderer({ outFile });
+    const h = renderer.handlers();
+
+    h.started({
+      kind: "started",
+      runId: "run-1",
+      workflowName: "test-workflow",
+      jobs: [{ id: "verify", stepCount: 1, dependsOn: [] }],
+    });
+    h.step_started({
+      kind: "step_started",
+      jobId: "verify",
+      stepId: "assert-false",
+    });
+    h.assert_result({
+      kind: "assert_result",
+      jobId: "verify",
+      stepId: "assert-false",
+      passed: false,
+      message: "expected true",
+      severity: "high",
+      expr: "1 == 2",
+    });
+
+    await h.completed({
+      kind: "completed",
+      run: makeRunView("failed"),
+    });
+
+    const xml = await Deno.readTextFile(outFile);
+
+    assertStringIncludes(xml, 'tests="1"');
+    assertStringIncludes(xml, 'failures="1"');
+    assertStringIncludes(xml, 'errors="0"');
+    assertStringIncludes(xml, "<failure message=");
+    assertStringIncludes(xml, 'type="AssertionFailure"');
+  } finally {
+    await Deno.remove(outFile);
+  }
 });


### PR DESCRIPTION
## Summary

Fixes three issues reported against the new assert step type:

- **swamp-club#1425** — `workflow validate` now rejects `${{ }}`-wrapped assert `expr` fields with a clear message ("assert expr must be a raw CEL expression — remove the ${{ }} wrapper"), instead of passing validation and failing at runtime with a Zod type error.

- **swamp-club#1426** — Command/shell steps no longer print each stdout line twice. The shell model was passing both an `onOutput` callback and a logger wrapped by `wrapLoggerWithOutput` to `executeProcess`, and both emitted `method_output` events for the same line. Removed the redundant `onOutput` callback.

- **swamp-club#1427** — Assert steps whose CEL expression fails to *evaluate* (e.g. `data.latest("missing", "model").attributes.x`) now appear in `--junit` XML as `<error>` elements (distinct from `<failure>` for cleanly-false assertions), and are counted as "errored" in the console summary. Previously they were silently omitted from the XML — `tests="1" failures="0"` when there should have been two test cases — causing artifact-gated CI to report green.

## Test Plan

- Reproduced all three issues against the installed binary before fixing
- Verified all three fixes against the compiled binary after fixing
- Added 3 unit tests for assert expr interpolation validation
- Added 2 unit tests for JUnit renderer `<error>` vs `<failure>` element generation
- Full test suite passes (9,417 passed, 0 failed)
- `deno fmt`, `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)