### PR TITLE
fix(vaults): vault selection followup — options bag, serve wiring, cleanup

### DIFF
--- a/integration/vault_selection_test.ts
+++ b/integration/vault_selection_test.ts
@@ -17,18 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-/**
- * Integration tests for vault selection across the full resolution chain.
- *
- * Tests every tier of the vault resolution order:
- *   1. Field-level vaultName from .meta() metadata
- *   2. Spec-level vaultName from ResourceOutputSpec (or definition YAML override)
- *   3. Repo-level defaultVault from .swamp.yaml (via VaultService)
- *   4. First available vault from VaultService (backwards-compat fallback)
- *
- * Also tests createResourceWriter with definition-level vaultName overrides
- * and VaultService.getDefaultVaultName() for the serve/device_auth path.
- */
+// Integration tests for the vault selection resolution chain (field → spec → definition → defaultVault → first-available).
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { ensureDir } from "@std/fs";
@@ -462,9 +451,7 @@ Deno.test("vault selection: fromRepository with defaultVaultName routes put to t
   await withTwoVaultRepo(async (repoDir) => {
     const vaultService = await VaultService.fromRepository(
       repoDir,
-      undefined,
-      undefined,
-      "beta-vault",
+      { defaultVaultName: "beta-vault" },
     );
 
     assertEquals(vaultService.getDefaultVaultName(), "beta-vault");
@@ -500,9 +487,7 @@ Deno.test("vault selection: fromRepository + processSensitiveResourceData end-to
   await withTwoVaultRepo(async (repoDir) => {
     const vaultService = await VaultService.fromRepository(
       repoDir,
-      undefined,
-      undefined,
-      "beta-vault",
+      { defaultVaultName: "beta-vault" },
     );
 
     const spec = createSensitiveSpec();

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -327,12 +327,9 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
             repoContext.evaluatedDefinitionRepo.save(type, definition),
           createExecutionService: () => new DefaultMethodExecutionService(),
           createVaultService: () =>
-            VaultService.fromRepository(
-              repoDir,
-              undefined,
-              undefined,
-              marker?.defaultVault,
-            ),
+            VaultService.fromRepository(repoDir, {
+              defaultVaultName: marker?.defaultVault,
+            }),
           dataRepo: repoContext.unifiedDataRepo,
           definitionRepo: repoContext.definitionRepo,
           outputRepo: repoContext.outputRepo,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1122,14 +1122,12 @@ export const serveCommand = new Command()
     if (authConfig.mode === "oauth") {
       const vaultService = await VaultService.fromRepository(
         resolvedRepoDir,
-        undefined,
-        undefined,
-        repoMarker?.defaultVault,
+        { defaultVaultName: repoMarker?.defaultVault },
       );
       const vaultNames = vaultService.getVaultNames();
       if (vaultNames.length === 0) {
         throw new UserError(
-          "oauth mode requires a vault — run 'swamp vault create local default' first",
+          "oauth mode requires a vault — run 'swamp vault create local_encryption default' first",
         );
       }
       const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
@@ -1499,6 +1497,7 @@ export const serveCommand = new Command()
         cancelRegistry,
         runTracker,
         dispatchService,
+        defaultVault: repoMarker?.defaultVault,
       };
 
     const ac = new AbortController();
@@ -1601,14 +1600,12 @@ export const serveCommand = new Command()
     ) {
       const vaultService = await VaultService.fromRepository(
         resolvedRepoDir,
-        undefined,
-        undefined,
-        repoMarker?.defaultVault,
+        { defaultVaultName: repoMarker?.defaultVault },
       );
       const vaultNames = vaultService.getVaultNames();
       if (vaultNames.length === 0) {
         throw new UserError(
-          "group refresh requires a vault — run 'swamp vault create local default' first",
+          "group refresh requires a vault — run 'swamp vault create local_encryption default' first",
         );
       }
       const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];

--- a/src/domain/definitions/definition.ts
+++ b/src/domain/definitions/definition.ts
@@ -145,7 +145,7 @@ export type CheckSelection = {
 const ResourceOverrideSchema = z.object({
   lifetime: LifetimeSchema.optional(),
   garbageCollection: GarbageCollectionSchema.optional(),
-  vaultName: z.string().optional(),
+  vaultName: z.string().min(1).optional(),
 });
 
 export type ResourceOverride = z.infer<typeof ResourceOverrideSchema>;

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -486,8 +486,7 @@ export class ModelResolver {
     if (this.repoDir) {
       this.vaultService = await VaultService.fromRepository(
         this.repoDir,
-        undefined,
-        refreshOpts,
+        { refreshOptions: refreshOpts },
       );
     } else {
       // No repoDir, create an empty vault service with defaults

--- a/src/domain/models/data_output_override.ts
+++ b/src/domain/models/data_output_override.ts
@@ -55,5 +55,5 @@ export const DataOutputOverrideSchema = z.object({
   garbageCollection: GarbageCollectionSchema.optional(),
   tags: z.record(z.string(), z.string()).optional(),
   vary: z.array(z.string().min(1)).optional(),
-  vaultName: z.string().optional(),
+  vaultName: z.string().min(1).optional(),
 });

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -560,6 +560,7 @@ export function createResourceWriter(
       spec.garbageCollection;
 
     // Apply data output overrides for this spec name
+    let effectiveSpec = spec;
     if (dataOutputOverrides) {
       const override = dataOutputOverrides.find(
         (o) => o.specName === specName,
@@ -570,21 +571,12 @@ export function createResourceWriter(
         if (override.tags) {
           Object.assign(resolvedTags, override.tags);
         }
-        // Apply vary suffix to produce composite instance names
         if (override.resolvedVarySuffix) {
           instanceName = `${instanceName}-${override.resolvedVarySuffix}`;
         }
-      }
-    }
-
-    // Resolve definition-level vaultName override for this spec
-    let effectiveSpec = spec;
-    if (dataOutputOverrides) {
-      const override = dataOutputOverrides.find(
-        (o) => o.specName === specName,
-      );
-      if (override?.vaultName) {
-        effectiveSpec = { ...spec, vaultName: override.vaultName };
+        if (override.vaultName) {
+          effectiveSpec = { ...spec, vaultName: override.vaultName };
+        }
       }
     }
 

--- a/src/domain/vaults/vault_service.ts
+++ b/src/domain/vaults/vault_service.ts
@@ -62,14 +62,14 @@ export class VaultService {
   private readonly auditFlags = new Map<string, boolean>();
   private readonly refreshOptions?: VaultRefreshOptions;
   private auditRepository?: VaultAuditRepository;
-  private readonly defaultVaultName_?: string;
+  private readonly configuredDefaultVault?: string;
 
   constructor(
     refreshOptions?: VaultRefreshOptions,
     defaultVaultName?: string,
   ) {
     this.refreshOptions = refreshOptions;
-    this.defaultVaultName_ = defaultVaultName;
+    this.configuredDefaultVault = defaultVaultName;
   }
 
   setAuditRepository(repo: VaultAuditRepository): void {
@@ -89,17 +89,22 @@ export class VaultService {
    */
   static async fromRepository(
     repoDir: string,
-    vaultsDir?: string,
-    refreshOptions?: VaultRefreshOptions,
-    defaultVaultName?: string,
+    options?: {
+      vaultsDir?: string;
+      refreshOptions?: VaultRefreshOptions;
+      defaultVaultName?: string;
+    },
   ): Promise<VaultService> {
     await vaultTypeRegistry.ensureLoaded();
-    const vaultService = new VaultService(refreshOptions, defaultVaultName);
+    const vaultService = new VaultService(
+      options?.refreshOptions,
+      options?.defaultVaultName,
+    );
     let vaultConfigs: Awaited<
       ReturnType<YamlVaultConfigRepository["findAll"]>
     >;
     try {
-      const effectiveVaultsDir = vaultsDir ?? join(repoDir, "vaults");
+      const effectiveVaultsDir = options?.vaultsDir ?? join(repoDir, "vaults");
       const vaultRepo = new YamlVaultConfigRepository(
         repoDir,
         undefined,
@@ -467,10 +472,10 @@ export class VaultService {
    */
   getDefaultVaultName(): string | undefined {
     if (
-      this.defaultVaultName_ !== undefined &&
-      this.providers.has(this.defaultVaultName_)
+      this.configuredDefaultVault !== undefined &&
+      this.providers.has(this.configuredDefaultVault)
     ) {
-      return this.defaultVaultName_;
+      return this.configuredDefaultVault;
     }
     return undefined;
   }

--- a/src/libswamp/vaults/read_secret.ts
+++ b/src/libswamp/vaults/read_secret.ts
@@ -73,8 +73,7 @@ export function createVaultReadSecretDeps(
     if (!vaultServicePromise) {
       vaultServicePromise = VaultService.fromRepository(
         repoDir,
-        undefined,
-        createVaultRefreshOptions(),
+        { refreshOptions: createVaultRefreshOptions() },
       );
     }
     return vaultServicePromise;

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -222,12 +222,9 @@ export async function createModelMethodRunDeps(
       repoContext.evaluatedDefinitionRepo.save(type, definition),
     createExecutionService: () => new DefaultMethodExecutionService(),
     createVaultService: () =>
-      VaultService.fromRepository(
-        repoDir,
-        undefined,
-        undefined,
-        options?.defaultVault,
-      ),
+      VaultService.fromRepository(repoDir, {
+        defaultVaultName: options?.defaultVault,
+      }),
     dataRepo: repoContext.unifiedDataRepo,
     definitionRepo: repoContext.definitionRepo,
     outputRepo: repoContext.outputRepo,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -299,7 +299,7 @@ async function mintServerTokenImpl(
   const vaultNames = vaultService.getVaultNames();
   if (vaultNames.length === 0) {
     throw new Error(
-      "No vaults configured — create one with: swamp vault create local default",
+      "No vaults configured — create one with: swamp vault create local_encryption default",
     );
   }
   const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -294,9 +294,7 @@ async function mintServerTokenImpl(
 
   const vaultService = await VaultService.fromRepository(
     repoDir,
-    undefined,
-    undefined,
-    defaultVault,
+    { defaultVaultName: defaultVault },
   );
   const vaultNames = vaultService.getVaultNames();
   if (vaultNames.length === 0) {
@@ -397,9 +395,7 @@ export function createDeviceAuthDeps(
     storeAccessToken: async (tokenName: string, accessToken: string) => {
       const vaultService = await VaultService.fromRepository(
         repoDir,
-        undefined,
-        undefined,
-        defaultVault,
+        { defaultVaultName: defaultVault },
       );
       const vaultNames = vaultService.getVaultNames();
       if (vaultNames.length === 0) return;

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -172,7 +172,11 @@ export async function handleModelMethodRun(
     const deps = await createModelMethodRunDeps(
       ctx.repoDir,
       ctx.repoContext,
-      { directExecution: isDirectExecution, runTracker: ctx.runTracker },
+      {
+        directExecution: isDirectExecution,
+        runTracker: ctx.runTracker,
+        defaultVault: ctx.defaultVault,
+      },
     );
     const libCtx = createLibSwampContext({ signal: controller.signal });
 

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -95,6 +95,7 @@ export interface ConnectionContext {
   cancelRegistry?: RunCancelRegistry;
   runTracker?: RunTrackerRepository;
   dispatchService?: import("../dispatch_service.ts").DispatchService;
+  defaultVault?: string;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,


### PR DESCRIPTION
## Summary

Follow-up to #1984 addressing review feedback and gaps:

- **Options bag for `fromRepository()`** — Replace `(repoDir, undefined, undefined, defaultVaultName)` positional pattern with `(repoDir, { defaultVaultName })`. Cleaner call sites, easier to extend.
- **Wire `defaultVault` through serve model execution** — Add `defaultVault` to `ConnectionContext`, pass it to `createModelMethodRunDeps` in `model_handlers.ts`. Fixes silent misrouting where serve model runs ignored `.swamp.yaml` `defaultVault`.
- **Merge duplicate `find()`** — `data_writer.ts` scanned `dataOutputOverrides` twice for the same spec name. Combined into one lookup.
- **Rename `defaultVaultName_`** → `configuredDefaultVault` for consistency with other private fields.
- **Add `.min(1)` to `vaultName` schema fields** — Consistent with `specName: z.string().min(1)` in the same schemas.
- **Fix vault create error messages** — `swamp vault create local default` → `swamp vault create local_encryption default`.
- **Condense multi-line JSDoc** — Single-line comment per CLAUDE.md convention.

## Test Plan

- 9434 tests pass, 0 failures
- Recompiled binary, re-ran all 3 E2E scenarios (no default → first vault, defaultVault → routes correctly, definition override → beats default)
- Type checking passes on all 13 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)