### PR TITLE
fix(extensions): validate upgrade chain consistency at push and pull time (swamp-club#1410)

### DIFF
--- a/src/cli/commands/extension_push.ts
+++ b/src/cli/commands/extension_push.ts
@@ -393,6 +393,10 @@ export const extensionPushCommand = new Command()
           renderer.renderSafetyErrors(
             details.safetyErrors as SafetyIssue[],
           );
+        } else if (details?.upgradeChainErrors) {
+          renderer.renderUpgradeChainErrors(
+            details.upgradeChainErrors as QualityIssue[],
+          );
         } else if (details?.qualityErrors) {
           renderer.renderQualityErrors(
             details.qualityErrors as QualityIssue[],

--- a/src/domain/extensions/extension_content_extractor.ts
+++ b/src/domain/extensions/extension_content_extractor.ts
@@ -328,6 +328,35 @@ export function extractModelVersion(content: string): string | null {
 }
 
 /**
+ * Extracts the last upgrade `toVersion` from the `export const model` body.
+ * Returns null when no upgrades array is present or no toVersion is found.
+ */
+export function extractLastUpgradeToVersion(
+  content: string,
+): string | null {
+  const modelExportMatch = content.match(/export\s+const\s+model\s*=\s*\{/);
+  if (!modelExportMatch || modelExportMatch.index === undefined) return null;
+
+  const bodyStart = modelExportMatch.index + modelExportMatch[0].length;
+  const body = extractBalancedBraces(content, bodyStart);
+  if (!body) return null;
+
+  const upgradesMatch = body.match(/upgrades:\s*\[/);
+  if (!upgradesMatch || upgradesMatch.index === undefined) return null;
+
+  const arrayStart = upgradesMatch.index + upgradesMatch[0].length;
+  const arrayBody = extractBalancedBrackets(body, arrayStart);
+  if (!arrayBody) return null;
+
+  const toVersionMatches = [
+    ...arrayBody.matchAll(/toVersion:\s*["']([^"']+)["']/g),
+  ];
+  if (toVersionMatches.length === 0) return null;
+
+  return toVersionMatches[toVersionMatches.length - 1][1];
+}
+
+/**
  * Extracts global arguments from the model source.
  * Looks for top-level `globalArguments: z.object({...})` or a named schema reference.
  */

--- a/src/domain/extensions/extension_quality_checker.ts
+++ b/src/domain/extensions/extension_quality_checker.ts
@@ -18,11 +18,14 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { basename } from "@std/path";
-import { extractModelVersion } from "./extension_content_extractor.ts";
+import {
+  extractLastUpgradeToVersion,
+  extractModelVersion,
+} from "./extension_content_extractor.ts";
 
 /** A quality issue found during checking. */
 export interface QualityIssue {
-  check: "fmt" | "lint" | "dynamic-import" | "version-drift";
+  check: "fmt" | "lint" | "dynamic-import" | "version-drift" | "upgrade-chain";
   output: string;
 }
 
@@ -36,6 +39,8 @@ export function qualityCheckLabel(check: QualityIssue["check"]): string {
       return "Dynamic import";
     case "version-drift":
       return "Version drift";
+    case "upgrade-chain":
+      return "Upgrade chain";
   }
 }
 
@@ -346,6 +351,54 @@ export async function checkVersionConsistency(
           `${basename(file)}: model version "${modelVersion}" differs from ` +
           `manifest version "${manifestVersion}" ` +
           `(update the model's version field to align)`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Validates that each model file's upgrade chain terminates at its
+ * declared version. Blocks push when upgrades are present but the last
+ * toVersion does not match the model version. Files without upgrades
+ * (new models) pass cleanly.
+ */
+export async function checkUpgradeChainConsistency(
+  modelFiles: string[],
+): Promise<QualityIssue[]> {
+  const issues: QualityIssue[] = [];
+
+  for (const file of modelFiles) {
+    let content: string;
+    try {
+      content = await Deno.readTextFile(file);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        issues.push({
+          check: "upgrade-chain",
+          output: `${basename(file)}: could not read file: ${e}`,
+        });
+      }
+      continue;
+    }
+
+    const modelVersion = extractModelVersion(content);
+    if (!modelVersion) continue;
+
+    const lastToVersion = extractLastUpgradeToVersion(content);
+    if (!lastToVersion) continue;
+
+    if (lastToVersion !== modelVersion) {
+      issues.push({
+        check: "upgrade-chain",
+        output:
+          `${
+            basename(file)
+          }: last upgrade toVersion "${lastToVersion}" does not match ` +
+          `model version "${modelVersion}". The upgrade chain must terminate ` +
+          `at the current version — add an upgrade entry for "${modelVersion}" ` +
+          `or update the model version to match.`,
       });
     }
   }

--- a/src/domain/extensions/extension_quality_checker_test.ts
+++ b/src/domain/extensions/extension_quality_checker_test.ts
@@ -21,6 +21,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import {
   checkExtensionQuality,
+  checkUpgradeChainConsistency,
   checkVersionConsistency,
   stripCommentsAndStrings,
 } from "./extension_quality_checker.ts";
@@ -491,4 +492,106 @@ Deno.test("checkVersionConsistency: nonexistent files are skipped", async () => 
     "/tmp/does-not-exist-12345.ts",
   ]);
   assertEquals(issues, []);
+});
+
+// ── checkUpgradeChainConsistency tests ─────────────────────────────
+
+Deno.test("checkUpgradeChainConsistency: model without upgrades produces no issues", async () => {
+  await withTempFiles(
+    {
+      "model.ts": `export const model = {
+  type: "@test/greeter",
+  version: "2026.05.22.1",
+  methods: {},
+};
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkUpgradeChainConsistency(paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkUpgradeChainConsistency: matching last toVersion produces no issues", async () => {
+  await withTempFiles(
+    {
+      "model.ts": `export const model = {
+  type: "@test/greeter",
+  version: "2026.05.22.1",
+  methods: {},
+  upgrades: [
+    {
+      toVersion: "2026.03.01.1",
+      description: "First upgrade",
+      upgradeAttributes: (old) => old,
+    },
+    {
+      toVersion: "2026.05.22.1",
+      description: "Latest upgrade",
+      upgradeAttributes: (old) => old,
+    },
+  ],
+};
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkUpgradeChainConsistency(paths);
+      assertEquals(issues, []);
+    },
+  );
+});
+
+Deno.test("checkUpgradeChainConsistency: mismatching last toVersion reports error", async () => {
+  await withTempFiles(
+    {
+      "model.ts": `export const model = {
+  type: "@test/greeter",
+  version: "2026.07.16.2",
+  methods: {},
+  upgrades: [
+    {
+      toVersion: "2026.03.28.2",
+      description: "Old upgrade",
+      upgradeAttributes: (old) => old,
+    },
+  ],
+};
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkUpgradeChainConsistency(paths);
+      assertEquals(issues.length, 1);
+      assertEquals(issues[0].check, "upgrade-chain");
+      assertStringIncludes(issues[0].output, "2026.03.28.2");
+      assertStringIncludes(issues[0].output, "2026.07.16.2");
+    },
+  );
+});
+
+Deno.test("checkUpgradeChainConsistency: empty file list produces no issues", async () => {
+  const issues = await checkUpgradeChainConsistency([]);
+  assertEquals(issues, []);
+});
+
+Deno.test("checkUpgradeChainConsistency: nonexistent files are skipped", async () => {
+  const issues = await checkUpgradeChainConsistency([
+    "/tmp/does-not-exist-12345.ts",
+  ]);
+  assertEquals(issues, []);
+});
+
+Deno.test("checkUpgradeChainConsistency: file without model export is skipped", async () => {
+  await withTempFiles(
+    {
+      "helper.ts": `export function add(a: number, b: number): number {
+  return a + b;
+}
+`,
+    },
+    async (_dir, paths) => {
+      const issues = await checkUpgradeChainConsistency(paths);
+      assertEquals(issues, []);
+    },
+  );
 });

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -248,8 +248,8 @@ function formatUserModelError(error: z.ZodError): string {
 
   return issues
     .map((i) => {
-      const path = i.path.join(".");
-      return `${path}: ${i.message}`;
+      if (i.path.length === 0) return i.message;
+      return `${i.path.join(".")}: ${i.message}`;
     })
     .join("; ");
 }

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -149,6 +149,18 @@ const UserModelSchema = z.object({
   checks: z.record(z.string(), UserCheckSchema).optional(),
   upgrades: z.array(UserUpgradeSchema).optional(),
   reports: z.array(z.string()).optional(),
+}).superRefine((model, ctx) => {
+  if (!model.upgrades || model.upgrades.length === 0) return;
+  const last = model.upgrades[model.upgrades.length - 1];
+  if (last.toVersion !== model.version) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        `Last upgrade toVersion "${last.toVersion}" does not match model ` +
+        `version "${model.version}". ` +
+        `The upgrade chain must terminate at the current version.`,
+    });
+  }
 });
 
 const UserExtensionSchema = z.object({

--- a/src/domain/extensions/model_kind_adapter_test.ts
+++ b/src/domain/extensions/model_kind_adapter_test.ts
@@ -188,3 +188,75 @@ Deno.test("importAndExtendBundle: throws for bundle with neither model nor exten
     "Bundle has no extension export",
   );
 });
+
+// ── validatePrimaryExport: upgrade chain consistency ─────────────────
+
+const fakeZodSchema = {
+  _def: {},
+  parse: () => ({}),
+  safeParse: () => ({ success: true, data: {} }),
+};
+
+function makeValidModel(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "@test/greeter",
+    version: "2026.01.01.1",
+    methods: {
+      greet: {
+        description: "Say hello",
+        arguments: fakeZodSchema,
+        execute: () => Promise.resolve({ message: "hi" }),
+      },
+    },
+    ...overrides,
+  };
+}
+
+Deno.test("validatePrimaryExport: model without upgrades passes", () => {
+  const result = modelKindAdapter.validatePrimaryExport(makeValidModel());
+  assertEquals(result.success, true);
+});
+
+Deno.test("validatePrimaryExport: model with empty upgrades passes", () => {
+  const result = modelKindAdapter.validatePrimaryExport(
+    makeValidModel({ upgrades: [] }),
+  );
+  assertEquals(result.success, true);
+});
+
+Deno.test("validatePrimaryExport: model with matching last toVersion passes", () => {
+  const result = modelKindAdapter.validatePrimaryExport(
+    makeValidModel({
+      version: "2026.03.28.2",
+      upgrades: [
+        {
+          toVersion: "2026.01.01.1",
+          description: "Initial",
+          upgradeAttributes: (old: Record<string, unknown>) => old,
+        },
+        {
+          toVersion: "2026.03.28.2",
+          description: "Latest",
+          upgradeAttributes: (old: Record<string, unknown>) => old,
+        },
+      ],
+    }),
+  );
+  assertEquals(result.success, true);
+});
+
+Deno.test("validatePrimaryExport: model with mismatching last toVersion fails", () => {
+  const result = modelKindAdapter.validatePrimaryExport(
+    makeValidModel({
+      version: "2026.07.16.2",
+      upgrades: [
+        {
+          toVersion: "2026.03.28.2",
+          description: "Old upgrade",
+          upgradeAttributes: (old: Record<string, unknown>) => old,
+        },
+      ],
+    }),
+  );
+  assertEquals(result.success, false);
+});

--- a/src/libswamp/extensions/push.ts
+++ b/src/libswamp/extensions/push.ts
@@ -344,7 +344,10 @@ import {
 import { ExtensionApiClient } from "../../infrastructure/http/extension_api_client.ts";
 import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
 import { analyzeExtensionSafety } from "../../domain/extensions/extension_safety_analyzer.ts";
-import { checkExtensionQuality } from "../../domain/extensions/extension_quality_checker.ts";
+import {
+  checkExtensionQuality,
+  checkUpgradeChainConsistency,
+} from "../../domain/extensions/extension_quality_checker.ts";
 import { extractDependencySpecifiers } from "../../domain/extensions/extension_dependency_extractor.ts";
 import { checkDependencyTrust } from "../../domain/extensions/extension_dependency_trust_checker.ts";
 import { checkReviewRules as checkReviewRulesImpl } from "../../domain/extensions/extension_review_rules.ts";
@@ -729,6 +732,19 @@ export async function extensionPushPrepare(
         { qualityErrors: qualityResult.issues },
       );
     }
+  }
+
+  // 10a. Upgrade chain consistency — validate that each model's upgrade
+  // chain terminates at its declared version. Always runs (not gated on
+  // cache hit) since it's a fast file read.
+  const upgradeChainIssues = await checkUpgradeChainConsistency(
+    input.allModelFiles,
+  );
+  if (upgradeChainIssues.length > 0) {
+    throw validationFailed(
+      "Extension has model upgrade chain errors that must be resolved before pushing.",
+      { upgradeChainErrors: upgradeChainIssues },
+    );
   }
 
   // 10b. Review — runs after the mechanical gates (safety/deps/fmt) so those

--- a/src/presentation/renderers/extension_push.ts
+++ b/src/presentation/renderers/extension_push.ts
@@ -50,6 +50,7 @@ export interface ExtensionPushRenderer extends Renderer<ExtensionPushEvent> {
     mismatches: CollectiveMismatch[],
   ): void;
   renderQualityErrors(issues: QualityIssue[]): void;
+  renderUpgradeChainErrors(issues: QualityIssue[]): void;
   renderVersionDriftWarnings(warnings: QualityIssue[]): void;
   renderCompilationErrors(errors: CompilationError[]): void;
   renderDryRun(data: {
@@ -243,6 +244,13 @@ class LogExtensionPushRenderer implements ExtensionPushRenderer {
       .error`Run 'swamp extension fmt <manifest-path>' to fix these issues.`;
   }
 
+  renderUpgradeChainErrors(issues: QualityIssue[]): void {
+    this.logger.error`Upgrade chain validation failed (push blocked):`;
+    for (const issue of issues) {
+      this.logger.error`  ${issue.output}`;
+    }
+  }
+
   renderVersionDriftWarnings(warnings: QualityIssue[]): void {
     this.logger.warn`Version drift warnings (non-blocking):`;
     for (const w of warnings) {
@@ -356,6 +364,10 @@ class JsonExtensionPushRenderer implements ExtensionPushRenderer {
 
   renderQualityErrors(issues: QualityIssue[]): void {
     console.log(JSON.stringify({ qualityErrors: issues }, null, 2));
+  }
+
+  renderUpgradeChainErrors(issues: QualityIssue[]): void {
+    console.log(JSON.stringify({ upgradeChainErrors: issues }, null, 2));
   }
 
   renderVersionDriftWarnings(warnings: QualityIssue[]): void {


### PR DESCRIPTION
## Summary

- Add upgrade chain consistency validation to `swamp extension push` — blocks publishing models where `upgrades[-1].toVersion` doesn't match the model's `version` field
- Add the same validation to `UserModelSchema` via `.superRefine()` so it fires at pull/reconcile time during `validatePrimaryExport`, catching bad extensions before lazy registration
- Models without upgrades (new extensions) pass both checks cleanly

Previously this invariant was only enforced during `ModelRegistry.register()` which fires lazily after catalog invalidation — e.g. after a CLI upgrade that bumps `BUNDLE_LAYOUT_VERSION`. Extension authors could publish models with inconsistent upgrade chains that worked until the next cache eviction, then surfaced as cryptic registration errors for users.

Closes swamp-club#1410

## Test Plan

- 4 new unit tests for `UserModelSchema` `.superRefine()`: no upgrades, empty upgrades, matching toVersion, mismatching toVersion
- 6 new unit tests for `checkUpgradeChainConsistency`: matching chain, mismatching chain, empty file list, nonexistent files, missing model export, no upgrades
- Verified existing `ModelRegistry.register()` tests pass unchanged (62 tests)
- Full test suite passes (9417 tests)
- Verified against reproduction at `/tmp/swamp-repro-issue-1410/` — the check catches the exact mismatch from the issue with a clear, actionable error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)