### PR TITLE
feat(install): show license and registry terms during install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -326,6 +326,13 @@ function Main {
     Write-Header "Installation of '$BinName' release '$Version' complete"
     Write-Info ""
 
+    Write-Info "By using Swamp you agree to its software license and extension"
+    Write-Info "registry terms."
+    Write-Info ""
+    Write-Info "  Software License:     https://swamp-club.com/software-license-agreement"
+    Write-Info "  Extension Registry:   https://swamp-club.com/extension-registry-terms"
+    Write-Host ""
+
     # Prompt to connect to SWAMP CLUB when running interactively
     if ([Environment]::UserInteractive -and [Console]::KeyAvailable -ne $null) {
         Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,6 +95,13 @@ main() {
   indent "$dest/$bin" --version
   echo
 
+  info "By using Swamp you agree to its software license and extension"
+  info "registry terms."
+  info ""
+  info "  Software License:     https://swamp-club.com/software-license-agreement"
+  info "  Extension Registry:   https://swamp-club.com/extension-registry-terms"
+  echo
+
   # Prompt to connect to SWAMP CLUB when running interactively
   if [ -e /dev/tty ] && [ -t 1 ]; then
     echo


### PR DESCRIPTION
## Summary

- Adds a notice to both `install.sh` (macOS/Linux) and `install.ps1` (Windows) informing users that by using Swamp they agree to the software license and extension registry terms
- Links to https://swamp-club.com/software-license-agreement and https://swamp-club.com/extension-registry-terms
- The notice appears after installation completes but before the SWAMP CLUB account prompt — informational only, no opt-in required

## Test Plan

- Run `sh scripts/install.sh -d /tmp/swamp-test` and verify the license notice appears after the version output and before the SWAMP CLUB prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)