### PR TITLE
fix(docs): remove Driver extension type from skill documentation (swamp-club#1432)

### DIFF
--- a/.claude/skills/swamp/references/extension/guide.md
+++ b/.claude/skills/swamp/references/extension/guide.md
@@ -1,6 +1,6 @@
 # Swamp Extension
 
-Create TypeScript extensions that swamp loads at startup. Five extension types
+Create TypeScript extensions that swamp loads at startup. Four extension types
 share the same workflow: implement an interface, register in a manifest, publish
 via `swamp-extension-publish`.
 
@@ -10,7 +10,6 @@ via `swamp-extension-publish`.
 | ---------------------------------------------- | --------- | ------------------------ | -------------------------------- |
 | New data source, API integration, automation   | Model     | `export const model`     | `extensions/models/*.ts`         |
 | Custom secret backend (HashiCorp Vault, 1P, …) | Vault     | `export const vault`     | `extensions/vaults/*/mod.ts`     |
-| Control where/how model methods execute        | Driver    | `export const driver`    | `extensions/drivers/*/mod.ts`    |
 | Custom storage backend (GCS, DB, …)            | Datastore | `export const datastore` | `extensions/datastores/*/mod.ts` |
 | Repeatable analysis of model/workflow output   | Report    | `export const report`    | `extensions/reports/*.ts`        |
 
@@ -26,8 +25,8 @@ via `swamp-extension-publish`.
    ```
 
    Available filters: `--platform` (aws, gcp, azure, …), `--content-type`
-   (models, workflows, vaults, datastores, drivers, reports), `--label`,
-   `--collective`. Prefer `@swamp/*` official extensions first.
+   (models, workflows, vaults, datastores, reports), `--label`, `--collective`.
+   Prefer `@swamp/*` official extensions first.
 
 2. **Inspect before pulling.** Once you find a candidate, check its types and
    methods with `extension info` — don't pull until you confirm it has what you

--- a/.claude/skills/swamp/references/extension/reference.md
+++ b/.claude/skills/swamp/references/extension/reference.md
@@ -101,55 +101,6 @@ export const vault = {
 };
 ```
 
-### Driver
-
-```typescript
-/**
- * Custom execution driver for running methods on a remote host.
- *
- * @module
- */
-// extensions/drivers/my-driver/mod.ts
-import { z } from "npm:zod@4";
-
-const ConfigSchema = z.object({
-  host: z.string(),
-  port: z.number().default(22),
-});
-
-/** Execution driver definition. */
-export const driver = {
-  type: "@myorg/my-driver",
-  name: "My Custom Driver",
-  description: "Executes methods on a remote host",
-  configSchema: ConfigSchema,
-  createDriver: (config: Record<string, unknown>) => {
-    const parsed = ConfigSchema.parse(config);
-    return {
-      type: "@myorg/my-driver",
-      execute: async (request, callbacks?) => {
-        callbacks?.onLog?.(`Executing ${request.methodName} on ${parsed.host}`);
-        const output = new TextEncoder().encode(
-          JSON.stringify({ result: "ok" }),
-        );
-        return {
-          status: "success" as const,
-          outputs: [{
-            kind: "pending" as const,
-            specName: request.methodName,
-            name: request.methodName,
-            type: "resource" as const,
-            content: output,
-          }],
-          logs: [],
-          durationMs: 0,
-        };
-      },
-    };
-  },
-};
-```
-
 ### Datastore
 
 ```typescript
@@ -203,8 +154,8 @@ All extension types follow the same lifecycle:
 1. **Confirm nothing covers it** — search built-in and community first.
 2. **Author the extension file** — use the Quick Start above;
    `~/.swamp/deno/deno check`.
-3. **Verify registration** — `swamp model type search --json` (models/drivers)
-   or `swamp vault status --json` / `swamp datastore status --json`.
+3. **Verify registration** — `swamp model type search --json` (models) or
+   `swamp vault status --json` / `swamp datastore status --json`.
 4. **Adversarial review** — see
    [Adversarial Review Gate](#adversarial-review-gate) below.
 5. **Smoke test** (models) — see
@@ -261,7 +212,6 @@ All extension types follow the same lifecycle:
 | --------- | ------------------------------- | ------------------------ | --------------------------- |
 | Model     | `extensions/models/**/*.ts`     | `export const model`     | (bundled inline)            |
 | Vault     | `extensions/vaults/**/*.ts`     | `export const vault`     | `.swamp/vault-bundles/`     |
-| Driver    | `extensions/drivers/**/*.ts`    | `export const driver`    | `.swamp/driver-bundles/`    |
 | Datastore | `extensions/datastores/**/*.ts` | `export const datastore` | `.swamp/datastore-bundles/` |
 | Report    | `extensions/reports/*.ts`       | `export const report`    | (bundled inline)            |
 

--- a/.claude/skills/swamp/references/extension/references/adversarial-review.md
+++ b/.claude/skills/swamp/references/extension/references/adversarial-review.md
@@ -179,7 +179,7 @@ continue). Do not proceed to step 5 until the user has acknowledged the report.
 
 ## Universal Dimensions
 
-These apply to **all** extension types (models, drivers, vaults, datastores).
+These apply to **all** extension types (models, vaults, datastores).
 
 ### 1. Credentials & Secrets
 
@@ -228,8 +228,7 @@ These apply to **all** extension types (models, drivers, vaults, datastores).
 ### 4. Testing Completeness
 
 - Unit tests use the appropriate test context (`createModelTestContext`,
-  `createDriverTestContext`, `assertVaultExportConformance`,
-  `assertDatastoreExportConformance`).
+  `assertVaultExportConformance`, `assertDatastoreExportConformance`).
 - Cover both success and failure paths — test what happens when the API returns
   an error, when a resource already exists, when input is invalid.
 - Use the injectable client pattern or mock primitives (`withMockedFetch`,
@@ -300,15 +299,6 @@ These apply to **all** extension types (models, drivers, vaults, datastores).
   reading back stored state in update/delete/sync methods.
 - **Version upgrades**: When bumping the model `version`, always add an
   `upgrades` entry with migration logic.
-
-### Drivers
-
-- Return the correct output `kind` — `"pending"` for data that swamp should
-  persist, `"persisted"` for data already written by the driver.
-- Record `durationMs` accurately in execution results.
-- Forward logs to the host via `callbacks.onLog()`.
-- Handle the `initialize`/`shutdown` lifecycle correctly.
-- On error, set `status: "error"` with a useful error message.
 
 ### Vaults
 

--- a/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
+++ b/.claude/skills/swamp/references/extension/references/model/troubleshooting.md
@@ -238,7 +238,7 @@ Models directory priority:
 manifest.** A manifest with no `paths` field — or with the explicit
 `paths.base: typedDir` — uses this priority chain to find the configured models
 directory. Only manifests that explicitly opt in with `paths.base: manifest`
-skip the table entirely and resolve typed keys (`models`, `vaults`, `drivers`,
+skip the table entirely and resolve typed keys (`models`, `vaults`,
 `datastores`, `reports`, `include`) relative to the manifest's own directory.
 Default behavior is unchanged. See
 [extension-publish references/publishing.md](../../../extension-publish/references/publishing.md#path-resolution--pathsbase)

--- a/.claude/skills/swamp/references/extension/references/quality/templates.md
+++ b/.claude/skills/swamp/references/extension/references/quality/templates.md
@@ -22,8 +22,6 @@ additionalFiles:
 # Pick one — or multiple — and remove the rest.
 models:
   - my-model.ts
-# drivers:
-#   - my-driver.ts
 # vaults:
 #   - my-vault.ts
 # datastores:

--- a/.claude/skills/swamp/references/extension/references/report/api.md
+++ b/.claude/skills/swamp/references/extension/references/report/api.md
@@ -29,8 +29,7 @@ export const report = {
 ## Name Conventions
 
 Report names follow `@collective/name` (e.g. `@myorg/cost-report`,
-`@myorg/aws/cost-report`) — same convention as models, drivers, vaults, and
-datastores.
+`@myorg/aws/cost-report`) — same convention as models, vaults, and datastores.
 
 ## Report Scopes
 


### PR DESCRIPTION
## Summary

- Remove all Driver extension type references from 6 shipped skill documentation files — Driver was replaced by the orchestrator/worker fan-out in swamp-club#535 but the docs were never updated
- Following the current docs produces an extension that silently does nothing (drivers are no longer reconciled from disk) and a `driver:` field on a model definition is rejected by `rejectRemovedDriverFields`
- Files changed: `guide.md`, `reference.md`, `adversarial-review.md`, `templates.md`, `model/troubleshooting.md`, `report/api.md`

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` passes
- [x] `grep -rn -i "driver" .claude/skills/swamp/references/extension/` returns zero results
- [x] Manual docs in `swamp-club/swamp-club` checked — no driver references found

Closes swamp-club#1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)