### PR TITLE
feat(workers): add workers.connected() CEL helper for fleet fan-out

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -100,6 +100,40 @@ name.
 For workflows, you should be able to reference other workflows by name or id, in
 addition to any model.
 
+## Workers Namespace
+
+The `workers` namespace provides helpers for querying workers eligible for
+dispatch. It is available in the same contexts as `data.*` (model
+globalArguments, workflow step inputs, forEach.in expressions).
+
+### `workers.connected()`
+
+Returns an array of worker data records whose status is not `disconnected`.
+This is the canonical query for building fleet fan-out workflows:
+
+```yaml
+steps:
+  - name: scan-${{ self.worker.attributes.name }}
+    forEach:
+      item: worker
+      in: "${{ workers.connected() }}"
+    target: "${{ self.worker.attributes.name }}"
+    task:
+      model: fleet-scanner
+      method: scan
+```
+
+Internally equivalent to:
+
+```
+data.query('modelType == "swamp/worker" && name == "state-main" && attributes.status != "disconnected"')
+```
+
+The `workers.connected()` helper exists because the unfiltered
+`data.query('modelType == "swamp/worker"')` includes disconnected workers,
+which causes fleet fan-out workflows to create steps for unavailable workers
+that queue until `queueTimeout` expires.
+
 ## Input Access
 
 Both model definitions and workflow definitions can specify inputs

--- a/design/remote-execution.md
+++ b/design/remote-execution.md
@@ -856,6 +856,18 @@ Dispatch matches a ready step against the pool:
 4. **Tiebreak** — least-loaded (or round-robin) among matching workers; queue
    when all matching workers are busy.
 
+### Disconnected-worker early warning
+
+When a step explicitly targets a worker by name and that worker is in the live
+pool but disconnected (within the grace window), the dispatch service emits a
+`step_target_disconnected` warning event before entering the queue loop. This
+is defense-in-depth — the primary prevention mechanism is `workers.connected()`
+(see [expressions.md](./expressions.md#workers-namespace)), which filters out
+disconnected workers at query time so fleet fan-out workflows never create
+steps for unavailable workers. The early warning only fires for workers still
+in the in-memory grace window; workers already removed from the pool are not
+checked.
+
 Label + platform matching plus direct targeting is the whole affinity story for
 v1; data-locality affinity is explicitly not pursued yet. Because every capability
 proxies home, **compute location and state location are fully decoupled** — a

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -256,6 +256,13 @@ export interface FileNamespace {
 }
 
 /**
+ * Namespace for querying workers eligible for dispatch in CEL expressions.
+ */
+export interface WorkersNamespace {
+  connected(): Promise<DataRecord[]>;
+}
+
+/**
  * Workflow run metadata exposed as `run.*` in CEL expressions.
  * Populated by the workflow engine after the run starts; only available
  * inside workflow step inputs (not during workflow-level evaluation).
@@ -325,6 +332,8 @@ export interface ExpressionContext {
   env: Record<string, string>;
   /** Data namespace for versioned data access */
   data?: DataNamespace;
+  /** Workers namespace for querying dispatchable workers */
+  workers?: WorkersNamespace;
   /** File namespace for lazy-loading file contents */
   file?: FileNamespace;
   /**
@@ -683,6 +692,7 @@ export class ModelResolver {
 
     const ownNamespace = this.dataRepo?.namespace ?? ("" as Namespace);
     context.data = this.buildDataNamespace(ownNamespace, coordsMap);
+    context.workers = this.buildWorkersNamespace();
 
     // Create file namespace for lazy-loading file contents
     context.file = {
@@ -729,7 +739,22 @@ export class ModelResolver {
       env: buildEnvContext(),
     };
     context.data = this.buildDataNamespace(ownNamespace, new Map());
+    context.workers = this.buildWorkersNamespace();
     return context;
+  }
+
+  private buildWorkersNamespace(): WorkersNamespace {
+    return {
+      connected: async (): Promise<DataRecord[]> => {
+        if (!this.dataQueryService) return [];
+        const predicate =
+          `modelType == "swamp/worker" && name == "state-main" && ` +
+          `attributes.status != "disconnected"`;
+        return await this.dataQueryService.query(predicate, {
+          loadAttributes: true,
+        }) as DataRecord[];
+      },
+    };
   }
 
   private buildDataNamespace(

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1008,3 +1008,168 @@ Deno.test("findBySpec: returns all data when workflowRunId is not set", async ()
     catalog.close();
   });
 });
+
+// ============================================================================
+// workers.connected() returns only non-disconnected workers
+// ============================================================================
+
+Deno.test("workers.connected() returns only non-disconnected workers", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const workerType = ModelType.create("swamp/worker");
+
+    const worker1 = Definition.create({
+      name: "worker-01",
+      globalArguments: {},
+    });
+    await defRepo.save(workerType, worker1);
+
+    const worker2 = Definition.create({
+      name: "worker-02",
+      globalArguments: {},
+    });
+    await defRepo.save(workerType, worker2);
+
+    const worker3 = Definition.create({
+      name: "worker-03",
+      globalArguments: {},
+    });
+    await defRepo.save(workerType, worker3);
+
+    const workerState = (name: string, status: string) =>
+      JSON.stringify({
+        name,
+        instanceUuid: `uuid-${name}`,
+        tokenName: "tok",
+        status,
+        labels: {},
+        platform: "linux",
+        arch: "x86_64",
+        swampVersion: "1.0.0",
+        protocolVersion: 1,
+        enrolledAt: "2026-01-01T00:00:00Z",
+        lastSeenAt: "2026-01-01T00:00:00Z",
+        capacity: 1,
+        activeDispatchIds: [],
+      });
+
+    for (
+      const [def, status] of [
+        [worker1, "idle"],
+        [worker2, "disconnected"],
+        [worker3, "busy"],
+      ] as const
+    ) {
+      const data = Data.create({
+        name: "state-main",
+        contentType: "application/json",
+        lifetime: "infinite",
+        garbageCollection: 5,
+        tags: {
+          type: "resource",
+          specName: "state",
+          modelName: def.name,
+        },
+        ownerDefinition: owner,
+      });
+      await dataRepo.save(
+        workerType,
+        def.id,
+        data,
+        new TextEncoder().encode(workerState(def.name, status)),
+      );
+    }
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.workers);
+    const connected = await ctx.workers.connected();
+    assertEquals(connected.length, 2);
+    const names = connected.map((r) => r.attributes.name).sort();
+    assertEquals(names, ["worker-01", "worker-03"]);
+    catalog.close();
+  });
+});
+
+Deno.test("workers.connected() returns empty array when all workers disconnected", async () => {
+  await withTempDir(async (repoDir) => {
+    await setupRepoDir(repoDir);
+    const defRepo = new YamlDefinitionRepository(repoDir);
+    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalog,
+    );
+    const workerType = ModelType.create("swamp/worker");
+
+    const worker1 = Definition.create({
+      name: "stale-worker",
+      globalArguments: {},
+    });
+    await defRepo.save(workerType, worker1);
+
+    const data = Data.create({
+      name: "state-main",
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 5,
+      tags: {
+        type: "resource",
+        specName: "state",
+        modelName: "stale-worker",
+      },
+      ownerDefinition: owner,
+    });
+    await dataRepo.save(
+      workerType,
+      worker1.id,
+      data,
+      new TextEncoder().encode(JSON.stringify({
+        name: "stale-worker",
+        instanceUuid: "uuid-stale",
+        tokenName: "tok",
+        status: "disconnected",
+        labels: {},
+        platform: "linux",
+        arch: "x86_64",
+        swampVersion: "1.0.0",
+        protocolVersion: 1,
+        enrolledAt: "2026-01-01T00:00:00Z",
+        lastSeenAt: "2026-01-01T00:00:00Z",
+        capacity: 1,
+        activeDispatchIds: [],
+      })),
+    );
+
+    const dqs = new DataQueryService(catalog, dataRepo);
+    await dqs.query('name == ""');
+
+    const resolver = new ModelResolver(defRepo, {
+      repoDir,
+      dataRepo,
+      dataQueryService: dqs,
+    });
+    const ctx = await resolver.buildContext();
+
+    assertExists(ctx.workers);
+    const connected = await ctx.workers.connected();
+    assertEquals(connected.length, 0);
+    catalog.close();
+  });
+});

--- a/src/domain/models/method_events.ts
+++ b/src/domain/models/method_events.ts
@@ -51,6 +51,10 @@ export type MethodExecutionEvent =
     requirement: string;
   }
   | {
+    type: "step_target_disconnected";
+    target: string;
+  }
+  | {
     type: "nested_model_invocation";
     targetModelType: string;
     targetMethod: string;

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -430,6 +430,13 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
                 type: "step_queued",
                 requirement: event.requirement as string,
               });
+            } else if (
+              event.kind === "target_disconnected" && "target" in event
+            ) {
+              context.onEvent!({
+                type: "step_target_disconnected",
+                target: event.target as string,
+              });
             }
           }
           : undefined,

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -144,6 +144,12 @@ export type WorkflowExecutionEvent =
     requirement: string;
   }
   | {
+    kind: "step_target_disconnected";
+    jobId: string;
+    stepId: string;
+    target: string;
+  }
+  | {
     kind: "method_event";
     jobId: string;
     stepId: string;

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1140,6 +1140,13 @@ export class DefaultStepExecutor implements StepExecutor {
                   stepId: ctx.stepName,
                   requirement: event.requirement,
                 });
+              } else if (event.type === "step_target_disconnected") {
+                ctx.emitEvent!({
+                  kind: "step_target_disconnected",
+                  jobId: ctx.jobName,
+                  stepId: ctx.stepName,
+                  target: event.target,
+                });
               } else {
                 ctx.emitEvent!({
                   kind: "method_event",

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -86,6 +86,26 @@ export class CelFileNamespace {
 }
 
 /**
+ * Wrapper class for workers namespace context objects.
+ * Provides helpers for querying workers eligible for dispatch.
+ */
+export class CelWorkersNamespace {
+  private readonly delegate: Record<string, unknown>;
+
+  constructor(delegate: Record<string, unknown>) {
+    this.delegate = delegate;
+  }
+
+  connected(): unknown {
+    const fn = this.delegate["connected"];
+    if (typeof fn === "function") {
+      return (fn as () => unknown)();
+    }
+    return [];
+  }
+}
+
+/**
  * Wrapper class for data namespace context objects.
  */
 export class CelDataNamespace {
@@ -271,6 +291,7 @@ export class CelEvaluator {
     // matching instead of trying to infer them as maps.
     this.env.registerType("CelFileNamespace", CelFileNamespace);
     this.env.registerType("CelDataNamespace", CelDataNamespace);
+    this.env.registerType("CelWorkersNamespace", CelWorkersNamespace);
 
     // Register receiver methods for file namespace
     this.env.registerFunction(
@@ -356,6 +377,12 @@ export class CelEvaluator {
       "CelDataNamespace.query(string, string): dyn",
       (receiver: CelDataNamespace, predicate: string, select: string) =>
         receiver.query(predicate, select),
+    );
+
+    // Register receiver methods for workers namespace
+    this.env.registerFunction(
+      "CelWorkersNamespace.connected(): dyn",
+      (receiver: CelWorkersNamespace) => receiver.connected(),
     );
   }
 
@@ -484,7 +511,8 @@ export class CelEvaluator {
   ): Record<string, unknown> {
     const file = context["file"];
     const data = context["data"];
-    if (!file && !data) return context;
+    const workers = context["workers"];
+    if (!file && !data && !workers) return context;
 
     const wrapped = { ...context };
     if (
@@ -496,6 +524,14 @@ export class CelEvaluator {
       data && typeof data === "object" && !(data instanceof CelDataNamespace)
     ) {
       wrapped["data"] = new CelDataNamespace(data as Record<string, unknown>);
+    }
+    if (
+      workers && typeof workers === "object" &&
+      !(workers instanceof CelWorkersNamespace)
+    ) {
+      wrapped["workers"] = new CelWorkersNamespace(
+        workers as Record<string, unknown>,
+      );
     }
     return wrapped;
   }

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -1201,3 +1201,48 @@ Deno.test("evaluate: sync data functions that return arrays still work", () => {
   assertEquals(Array.isArray(result), true);
   assertEquals((result as unknown[]).length, 1);
 });
+
+Deno.test("evaluateAsync: workers.connected() returns filtered worker records", async () => {
+  const evaluator = new CelEvaluator();
+  const workers = [
+    { name: "worker-01", attributes: { status: "idle" } },
+    { name: "worker-02", attributes: { status: "busy" } },
+  ];
+  const context = {
+    workers: {
+      connected: () => Promise.resolve(workers),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    "workers.connected()",
+    context,
+  );
+  assertEquals(Array.isArray(result), true);
+  assertEquals((result as unknown[]).length, 2);
+});
+
+Deno.test("evaluateAsync: workers.connected() returns empty array when no workers", async () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    workers: {
+      connected: () => Promise.resolve([]),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    "workers.connected()",
+    context,
+  );
+  assertEquals(result, []);
+});
+
+Deno.test("evaluate: workers.connected() returns empty array when delegate missing", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    workers: {},
+  };
+
+  const result = evaluator.evaluate("workers.connected()", context);
+  assertEquals(result, []);
+});

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -172,6 +172,12 @@ export type WorkflowRunEvent =
     requirement: string;
   }
   | {
+    kind: "step_target_disconnected";
+    jobId: string;
+    stepId: string;
+    target: string;
+  }
+  | {
     kind: "method_event";
     jobId: string;
     stepId: string;
@@ -505,6 +511,7 @@ export function mapWorkflowExecutionEvent(
     case "step_skipped":
     case "approval_requested":
     case "step_queued":
+    case "step_target_disconnected":
     case "step_failed":
     case "model_resolved":
     case "env_var_warning":

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -315,6 +315,22 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
           ),
         );
       },
+      step_target_disconnected: (e) => {
+        if (!this.pipe) return;
+        const displayName = this.forEachDisplayNames.get(
+          this.stepKey(e.jobId, e.stepId),
+        ) ?? e.jobId;
+        writeOutput(
+          this.pipe.line(
+            displayName,
+            yellow(`warning`) +
+              dim(
+                `: target worker '${e.target}' is disconnected; ` +
+                  `use workers.connected() to filter dispatchable workers`,
+              ),
+          ),
+        );
+      },
       step_failed: (e) => {
         if (!this.pipe) return;
         const key = this.stepKey(e.jobId, e.stepId);
@@ -717,6 +733,7 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       step_completed: () => {},
       step_skipped: () => {},
       step_queued: () => {},
+      step_target_disconnected: () => {},
       step_failed: () => {},
       approval_requested: () => {},
       model_resolved: () => {},

--- a/src/presentation/renderers/workflow_run_junit.ts
+++ b/src/presentation/renderers/workflow_run_junit.ts
@@ -90,6 +90,7 @@ export class JUnitWorkflowRunRenderer implements WorkflowRunRenderer {
       step_completed: () => {},
       step_skipped: () => {},
       step_queued: () => {},
+      step_target_disconnected: () => {},
       step_failed: () => {},
       approval_requested: () => {},
       model_resolved: () => {},

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -265,6 +265,27 @@ export class DispatchService {
     request.signal?.addEventListener("abort", onAbort, { once: true });
 
     try {
+      if (request.placement.target) {
+        const pool = this.#poolSnapshot();
+        const targetWorker = pool.find(
+          (w) =>
+            w.name === request.placement.target ||
+            w.instanceUuid === request.placement.target,
+        );
+        if (targetWorker && !targetWorker.connected) {
+          request.onEvent?.({
+            kind: "target_disconnected",
+            target: request.placement.target,
+          });
+          logger.warn(
+            "Step targets worker {target} which is disconnected " +
+              "(within grace window); use workers.connected() to " +
+              "filter dispatchable workers",
+            { target: request.placement.target },
+          );
+        }
+      }
+
       while (true) {
         request.signal?.throwIfAborted();
         const workerName = request.skipScheduler && request.placement.target

--- a/src/serve/dispatch_service_test.ts
+++ b/src/serve/dispatch_service_test.ts
@@ -556,3 +556,57 @@ Deno.test("DispatchService: worker_draining re-queues instead of failing the run
   assertEquals(result.durationMs, 1);
   assertEquals(attempts, 2);
 });
+
+Deno.test("executeRemote: emits target_disconnected event for grace-window disconnected worker", async () => {
+  const h = createHarness({
+    workers: [
+      snapshot({ name: "w1", connected: false, status: "idle" }),
+    ],
+    queueTimeoutMs: 100,
+  });
+  const events: Array<{ kind: string; [key: string]: unknown }> = [];
+  await assertRejects(
+    () =>
+      h.service.executeRemote(stepRequest({
+        placement: { target: "w1" },
+        onEvent: (event) => events.push(event),
+      })),
+    Error,
+    "Timed out",
+  );
+  const disconnectedEvents = events.filter(
+    (e) => e.kind === "target_disconnected",
+  );
+  assertEquals(disconnectedEvents.length, 1);
+  assertEquals(disconnectedEvents[0].target, "w1");
+});
+
+Deno.test("executeRemote: no target_disconnected event for connected worker", async () => {
+  const h = createHarness({
+    workers: [snapshot({ name: "w1", connected: true, status: "idle" })],
+  });
+  const events: Array<{ kind: string; [key: string]: unknown }> = [];
+  await h.service.executeRemote(stepRequest({
+    placement: { target: "w1" },
+    onEvent: (event) => events.push(event),
+  }));
+  const disconnectedEvents = events.filter(
+    (e) => e.kind === "target_disconnected",
+  );
+  assertEquals(disconnectedEvents.length, 0);
+});
+
+Deno.test("executeRemote: no target_disconnected event without explicit target", async () => {
+  const h = createHarness({
+    workers: [snapshot({ name: "w1", connected: true, status: "idle" })],
+  });
+  const events: Array<{ kind: string; [key: string]: unknown }> = [];
+  await h.service.executeRemote(stepRequest({
+    placement: { labels: {}, platform: "linux" },
+    onEvent: (event) => events.push(event),
+  }));
+  const disconnectedEvents = events.filter(
+    (e) => e.kind === "target_disconnected",
+  );
+  assertEquals(disconnectedEvents.length, 0);
+});


### PR DESCRIPTION
## Summary

Closes swamp-club#1336

- Add `workers.connected()` CEL namespace function that returns only dispatchable workers (status != disconnected), providing a discoverable canonical query for fleet fan-out `forEach.in` expressions
- Add pool-only `step_target_disconnected` early-warning event when a step targets a worker that is disconnected within the grace window (defense-in-depth)
- Wire the new event through the full pipeline: `MethodExecutionEvent` -> `WorkflowExecutionEvent` -> `WorkflowRunEvent` -> renderers (log, JSON, JUnit)

## Design

The `workers` namespace follows the established `CelDataNamespace`/`CelFileNamespace` pattern:
- `CelWorkersNamespace` registered as a CEL type with a `connected()` receiver function
- `WorkersNamespace` interface on `ExpressionContext`, built by `ModelResolver.buildWorkersNamespace()`
- Internally equivalent to `data.query('modelType == "swamp/worker" && name == "state-main" && attributes.status != "disconnected"')`

The early-warning is intentionally pool-only (no data query dependency in `DispatchService`). It fires only for workers within the 60s grace window -- workers already evicted from the pool are not checked. `workers.connected()` is the primary prevention mechanism.

## Test Plan

- 3 unit tests for `CelWorkersNamespace` (mock delegates, empty pool, missing delegate)
- 2 integration tests for `workers.connected()` with real persisted worker data through `DataQueryService` (mixed statuses, all-disconnected)
- 3 dispatch service tests for early-warning (disconnected target, connected target, no-target)
- All 9444+ existing tests pass

## Documentation

- Updated `design/expressions.md` with workers namespace docs and usage example
- Updated `design/remote-execution.md` with early-warning behavior
- External manual docs (swamp-club/swamp-club) need a follow-up update for CEL reference and worker-fleets how-to (issues disabled on that repo)

Generated with [Claude Code](https://claude.com/claude-code)