### PR TITLE
fix(models): serialize concurrent auto-definition creation with file lock (swamp-club#1431)

### DIFF
--- a/integration/auto_definition_race_test.ts
+++ b/integration/auto_definition_race_test.ts
@@ -1,0 +1,130 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { resolveOrCreateDefinition } from "../src/libswamp/models/direct_execution.ts";
+import type { ModelDefinition } from "../src/domain/models/model.ts";
+import type { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import { join } from "@std/path";
+import { ensureDir } from "@std/fs";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-race-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+function createTestModelDef(): ModelDefinition {
+  return {
+    type: "test/race",
+    version: "2026.01.01.1",
+    globalArguments: undefined,
+    methods: {
+      run: {
+        description: "Test method",
+        arguments: z.object({}),
+        execute: () => Promise.resolve({ dataHandles: [] }),
+      },
+    },
+  } as unknown as ModelDefinition;
+}
+
+Deno.test("integration: concurrent auto-creation converges on a single definition", async () => {
+  await withTempDir(async (tmpDir) => {
+    const lockDir = join(tmpDir, "locks");
+    const defsDir = join(tmpDir, "auto-definitions", "test", "race");
+    await ensureDir(lockDir);
+    await ensureDir(defsDir);
+
+    const modelDef = createTestModelDef();
+    const resolvedType = ModelType.create("test/race");
+    const savedDefinitions: Definition[] = [];
+    let lookupCount = 0;
+
+    const deps = {
+      lookupDefinition: () => {
+        lookupCount++;
+        // Simulate filesystem scan: return the first saved definition
+        // (mimics what YamlDefinitionRepository.findByNameGlobal does)
+        if (savedDefinitions.length > 0) {
+          return Promise.resolve({
+            definition: savedDefinitions[0],
+            type: resolvedType,
+          });
+        }
+        return Promise.resolve(null);
+      },
+      getModelDef: () => modelDef,
+      saveDefinition: (_type: ModelType, def: Definition) => {
+        savedDefinitions.push(def);
+        return Promise.resolve();
+      },
+      getDefinitionPath: (_type: ModelType, id: string) =>
+        join(defsDir, `${id}.yaml`),
+    };
+
+    const N = 8;
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        resolveOrCreateDefinition(
+          deps,
+          "test/race",
+          "racy",
+          "run",
+          {},
+          resolvedType,
+          modelDef,
+          undefined,
+          lockDir,
+        )),
+    );
+
+    // All N calls succeed
+    for (const result of results) {
+      assertEquals(result.ok, true);
+    }
+
+    // Exactly one definition was created; the rest adopted it
+    assertEquals(savedDefinitions.length, 1, "expected exactly one save");
+    const createdCount = results.filter((r) => r.ok && r.created).length;
+    assertEquals(createdCount, 1, "expected exactly one created=true");
+
+    // All results reference the same definition ID
+    const ids = new Set(
+      results.filter((r) => r.ok).map((r) => r.ok ? r.definition.id : ""),
+    );
+    assertEquals(
+      ids.size,
+      1,
+      "all results should share the same definition ID",
+    );
+
+    // The lookup was called more than N times (fast path + re-checks under lock)
+    assertEquals(
+      lookupCount > N,
+      true,
+      `expected more than ${N} lookups (got ${lookupCount})`,
+    );
+  });
+});

--- a/integration/auto_definition_race_test.ts
+++ b/integration/auto_definition_race_test.ts
@@ -19,7 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import { z } from "zod";
-import { resolveOrCreateDefinition } from "../src/libswamp/models/direct_execution.ts";
+import { resolveOrCreateDefinition } from "../src/libswamp/mod.ts";
 import type { ModelDefinition } from "../src/domain/models/model.ts";
 import type { Definition } from "../src/domain/definitions/definition.ts";
 import { ModelType } from "../src/domain/models/model_type.ts";

--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -210,6 +210,9 @@ export function buildModelMethodRunDeps(
         );
       }
       : undefined,
+    autoDefinitionsDir: isDirectExecution
+      ? repoContext.autoDefinitionsDir
+      : undefined,
     workflowRepo: repoContext.workflowRepo,
     workflowRunRepo: repoContext.workflowRunRepo,
   };

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -378,6 +378,9 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
               );
             }
             : undefined,
+          autoDefinitionsDir: isDirectExecution
+            ? repoContext.autoDefinitionsDir
+            : undefined,
           runTracker,
           workflowRepo: repoContext.workflowRepo,
           workflowRunRepo: repoContext.workflowRunRepo,

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -356,6 +356,8 @@ export const workflowResumeCommand = withRemoteOptions(
         inputs,
         resolvedType,
         modelDef,
+        undefined,
+        repoContext.autoDefinitionsDir,
       );
       if (!result.ok) throw new Error(result.error.message);
       return {

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -398,6 +398,7 @@ export const workflowRunCommand = new Command()
               resolvedType,
               modelDef,
               globalArgs,
+              repoContext.autoDefinitionsDir,
             );
             if (!result.ok) throw new Error(result.error.message);
             return {

--- a/src/libswamp/access/run_deps.ts
+++ b/src/libswamp/access/run_deps.ts
@@ -121,6 +121,7 @@ export async function createServerTokenRunDeps(
         `${id}.yaml`,
       );
     },
+    autoDefinitionsDir: repoContext.autoDefinitionsDir,
     workflowRepo: repoContext.workflowRepo,
     workflowRunRepo: repoContext.workflowRunRepo,
   };

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -155,6 +155,7 @@ export {
   unknownModelType,
 } from "./models/run.ts";
 export {
+  autoDefinitionLockKey,
   type DirectExecutionDeps,
   type DirectExecutionResult,
   resolveOrCreateDefinition,

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -33,6 +33,7 @@ import {
 } from "../../domain/models/sensitive_field_extractor.ts";
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
+import { FileLock } from "../../infrastructure/persistence/file_lock.ts";
 
 export interface DirectExecutionDeps {
   lookupDefinition: (
@@ -135,8 +136,23 @@ export function routeInputsBySchema(
 }
 
 /**
+ * Lock key for serializing concurrent auto-creation of the same definition name.
+ * Flattens '/' from scoped names (e.g. @collective/name) to avoid creating
+ * intermediate directories in the lock path.
+ */
+export function autoDefinitionLockKey(name: string): string {
+  const sanitized = name.replace(/\//g, "--");
+  return `.auto-definition-create/${sanitized}.lock`;
+}
+
+/**
  * Resolves an existing definition by name or auto-creates one.
  * When the definition exists, verifies the type matches.
+ *
+ * When `lockDir` is provided, concurrent auto-creation of the same name is
+ * serialized with a file lock (double-check locking): the fast-path lookup
+ * runs without a lock; only when the definition is missing does the lock
+ * acquire, re-check, and create.
  */
 export async function resolveOrCreateDefinition(
   deps: DirectExecutionDeps,
@@ -147,6 +163,7 @@ export async function resolveOrCreateDefinition(
   resolvedType: ModelType,
   modelDef: ModelDefinition,
   explicitGlobalArgs?: Record<string, unknown>,
+  lockDir?: string,
 ): Promise<DirectExecutionResult> {
   // When explicit globalArgs are provided, skip routing — treat inputs as
   // method args only and use the explicit values as global args.
@@ -290,25 +307,62 @@ export async function resolveOrCreateDefinition(
     };
   }
 
-  // Auto-create the definition
-  const definition = Definition.create({
-    name: definitionName,
-    type: resolvedType.normalized,
-    typeVersion: modelDef.version,
-    globalArguments: routed.globalArguments,
-  });
-
-  await deps.saveDefinition(resolvedType, definition);
-
-  const definitionPath = deps.getDefinitionPath(resolvedType, definition.id);
-
-  return {
-    ok: true,
-    definition,
-    modelType: resolvedType,
-    modelDef,
-    created: true,
-    definitionPath,
-    routedInputs: routed,
+  const createResult = async (): Promise<DirectExecutionResult> => {
+    const definition = Definition.create({
+      name: definitionName,
+      type: resolvedType.normalized,
+      typeVersion: modelDef.version,
+      globalArguments: routed.globalArguments,
+    });
+    await deps.saveDefinition(resolvedType, definition);
+    return {
+      ok: true,
+      definition,
+      modelType: resolvedType,
+      modelDef,
+      created: true,
+      definitionPath: deps.getDefinitionPath(resolvedType, definition.id),
+      routedInputs: routed,
+    };
   };
+
+  // Serialize auto-creation with a name-based file lock so concurrent
+  // processes converge on a single definition instead of creating duplicates.
+  if (lockDir) {
+    const lock = new FileLock(lockDir, {
+      lockKey: autoDefinitionLockKey(definitionName),
+      ttlMs: 5_000,
+      maxWaitMs: 10_000,
+    });
+    return await lock.withLock(async () => {
+      const raceWinner = await deps.lookupDefinition(definitionName);
+      if (raceWinner) {
+        if (raceWinner.type.normalized !== resolvedType.normalized) {
+          return {
+            ok: false,
+            error: validationFailed(
+              `Definition '${definitionName}' exists with type '${raceWinner.type.normalized}' ` +
+                `but '${typeArg}' resolves to '${resolvedType.normalized}'. ` +
+                `Type mismatch — delete the existing definition or use a different name.`,
+            ),
+          };
+        }
+        return {
+          ok: true,
+          definition: raceWinner.definition,
+          modelType: raceWinner.type,
+          modelDef,
+          created: false,
+          definitionPath: deps.getDefinitionPath(
+            raceWinner.type,
+            raceWinner.definition.id,
+          ),
+          routedInputs: routed,
+        };
+      }
+      return await createResult();
+    });
+  }
+
+  return await createResult();
 }

--- a/src/libswamp/models/direct_execution.ts
+++ b/src/libswamp/models/direct_execution.ts
@@ -34,6 +34,7 @@ import {
 import type { SwampError } from "../errors.ts";
 import { validationFailed } from "../errors.ts";
 import { FileLock } from "../../infrastructure/persistence/file_lock.ts";
+import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 
 export interface DirectExecutionDeps {
   lookupDefinition: (
@@ -334,34 +335,52 @@ export async function resolveOrCreateDefinition(
       ttlMs: 5_000,
       maxWaitMs: 10_000,
     });
-    return await lock.withLock(async () => {
-      const raceWinner = await deps.lookupDefinition(definitionName);
-      if (raceWinner) {
-        if (raceWinner.type.normalized !== resolvedType.normalized) {
+    try {
+      return await lock.withLock(async () => {
+        // Re-check under lock — race losers adopt the winner's definition.
+        // Global-args reconciliation is skipped here: concurrent auto-creators
+        // share the same input line, so args are identical.
+        const raceWinner = await deps.lookupDefinition(definitionName);
+        if (raceWinner) {
+          if (raceWinner.type.normalized !== resolvedType.normalized) {
+            return {
+              ok: false,
+              error: validationFailed(
+                `Definition '${definitionName}' exists with type '${raceWinner.type.normalized}' ` +
+                  `but '${typeArg}' resolves to '${resolvedType.normalized}'. ` +
+                  `Type mismatch — delete the existing definition or use a different name.`,
+              ),
+            };
+          }
           return {
-            ok: false,
-            error: validationFailed(
-              `Definition '${definitionName}' exists with type '${raceWinner.type.normalized}' ` +
-                `but '${typeArg}' resolves to '${resolvedType.normalized}'. ` +
-                `Type mismatch — delete the existing definition or use a different name.`,
+            ok: true,
+            definition: raceWinner.definition,
+            modelType: raceWinner.type,
+            modelDef,
+            created: false,
+            definitionPath: deps.getDefinitionPath(
+              raceWinner.type,
+              raceWinner.definition.id,
             ),
+            routedInputs: routed,
           };
         }
+        return await createResult();
+      });
+    } catch (e) {
+      if (e instanceof LockTimeoutError) {
         return {
-          ok: true,
-          definition: raceWinner.definition,
-          modelType: raceWinner.type,
-          modelDef,
-          created: false,
-          definitionPath: deps.getDefinitionPath(
-            raceWinner.type,
-            raceWinner.definition.id,
-          ),
-          routedInputs: routed,
+          ok: false,
+          error: {
+            code: "lock_timeout",
+            message:
+              `Timed out waiting for auto-definition lock on '${definitionName}'. ` +
+              `Another process may be creating this definition.`,
+          },
         };
       }
-      return await createResult();
-    });
+      throw e;
+    }
   }
 
   return await createResult();

--- a/src/libswamp/models/direct_execution_test.ts
+++ b/src/libswamp/models/direct_execution_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
+  autoDefinitionLockKey,
   resolveOrCreateDefinition,
   routeInputsBySchema,
 } from "./direct_execution.ts";
@@ -711,4 +712,168 @@ Deno.test("resolveOrCreateDefinition: explicit globalArgs object is not mutated 
     "42",
     "caller's explicitGlobalArgs must not be mutated by coercion",
   );
+});
+
+// ── autoDefinitionLockKey ──────────────────────────────────────────────
+
+Deno.test("autoDefinitionLockKey: simple name", () => {
+  assertEquals(
+    autoDefinitionLockKey("my-model"),
+    ".auto-definition-create/my-model.lock",
+  );
+});
+
+Deno.test("autoDefinitionLockKey: scoped name flattens slashes", () => {
+  assertEquals(
+    autoDefinitionLockKey("@collective/model-name"),
+    ".auto-definition-create/@collective--model-name.lock",
+  );
+});
+
+Deno.test("autoDefinitionLockKey: deeply scoped name flattens all slashes", () => {
+  assertEquals(
+    autoDefinitionLockKey("@org/nested/deep"),
+    ".auto-definition-create/@org--nested--deep.lock",
+  );
+});
+
+// ── resolveOrCreateDefinition with lockDir ──────────────────────────────
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-direct-exec-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("resolveOrCreateDefinition: with lockDir creates definition under lock", async () => {
+  await withTempDir(async (lockDir) => {
+    const modelDef = createTestModelDef(
+      undefined,
+      { run: z.object({}) },
+    );
+    const resolvedType = ModelType.create("test/model");
+    let saveCount = 0;
+
+    const result = await resolveOrCreateDefinition(
+      {
+        lookupDefinition: () => Promise.resolve(null),
+        getModelDef: () => modelDef,
+        saveDefinition: () => {
+          saveCount++;
+          return Promise.resolve();
+        },
+        getDefinitionPath: (_type, id) => `/tmp/${id}.yaml`,
+      },
+      "test/model",
+      "locked-model",
+      "run",
+      {},
+      resolvedType,
+      modelDef,
+      undefined,
+      lockDir,
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.created, true);
+      assertEquals(result.definition.name, "locked-model");
+    }
+    assertEquals(saveCount, 1);
+  });
+});
+
+Deno.test("resolveOrCreateDefinition: with lockDir skips lock when definition exists (fast path)", async () => {
+  await withTempDir(async (lockDir) => {
+    const modelDef = createTestModelDef(
+      z.object({ region: z.string() }),
+      { run: z.object({}) },
+    );
+    const resolvedType = ModelType.create("test/model");
+    const existingDef = Definition.create({
+      name: "existing",
+      type: "test/model",
+      typeVersion: "2026.01.01.1",
+      globalArguments: { region: "us-east-1" },
+    });
+
+    const result = await resolveOrCreateDefinition(
+      {
+        lookupDefinition: () =>
+          Promise.resolve({ definition: existingDef, type: resolvedType }),
+        getModelDef: () => modelDef,
+        saveDefinition: () => Promise.resolve(),
+        getDefinitionPath: (_type, id) => `/tmp/${id}.yaml`,
+      },
+      "test/model",
+      "existing",
+      "run",
+      { region: "us-east-1" },
+      resolvedType,
+      modelDef,
+      undefined,
+      lockDir,
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.created, false);
+      assertEquals(result.definition.id, existingDef.id);
+    }
+  });
+});
+
+Deno.test("resolveOrCreateDefinition: with lockDir adopts race winner's definition", async () => {
+  await withTempDir(async (lockDir) => {
+    const modelDef = createTestModelDef(
+      undefined,
+      { run: z.object({}) },
+    );
+    const resolvedType = ModelType.create("test/model");
+    const winnerDef = Definition.create({
+      name: "racy",
+      type: "test/model",
+      typeVersion: "2026.01.01.1",
+    });
+    let lookupCount = 0;
+
+    const result = await resolveOrCreateDefinition(
+      {
+        lookupDefinition: () => {
+          lookupCount++;
+          // First call (fast path): not found. Second call (under lock): found.
+          if (lookupCount === 1) return Promise.resolve(null);
+          return Promise.resolve({
+            definition: winnerDef,
+            type: resolvedType,
+          });
+        },
+        getModelDef: () => modelDef,
+        saveDefinition: () => {
+          throw new Error("should not save — race winner exists");
+        },
+        getDefinitionPath: (_type, id) => `/tmp/${id}.yaml`,
+      },
+      "test/model",
+      "racy",
+      "run",
+      {},
+      resolvedType,
+      modelDef,
+      undefined,
+      lockDir,
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.created, false);
+      assertEquals(result.definition.id, winnerDef.id);
+    }
+    assertEquals(lookupCount, 2);
+  });
 });

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -79,10 +79,6 @@ import {
   withGeneratorTraceContext,
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
-import {
-  SWAMP_SUBDIRS,
-  swampPath,
-} from "../../infrastructure/persistence/paths.ts";
 import { autoGc, type AutoGcLifecycleDeps } from "../data/gc.ts";
 import { DefaultDataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
 import { ActiveRun } from "../../domain/models/active_run.ts";
@@ -215,6 +211,7 @@ export interface ModelMethodRunDeps {
     definition: Definition,
   ) => Promise<void>;
   getDefinitionPath?: (type: ModelType, id: string) => string;
+  autoDefinitionsDir?: string;
   runTracker?: RunTrackerRepository;
   eventBus?: EventBus;
   workflowRepo?:
@@ -346,7 +343,7 @@ export async function* modelMethodRun(
             resolvedType,
             resolvedModelDef,
             undefined,
-            swampPath(deps.repoDir, SWAMP_SUBDIRS.autoDefinitions),
+            deps.autoDefinitionsDir,
           );
 
           if (!result.ok) {

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -79,6 +79,10 @@ import {
   withGeneratorTraceContext,
 } from "../../infrastructure/tracing/mod.ts";
 import { resolveOrCreateDefinition } from "./direct_execution.ts";
+import {
+  SWAMP_SUBDIRS,
+  swampPath,
+} from "../../infrastructure/persistence/paths.ts";
 import { autoGc, type AutoGcLifecycleDeps } from "../data/gc.ts";
 import { DefaultDataLifecycleService } from "../../domain/data/data_lifecycle_service.ts";
 import { ActiveRun } from "../../domain/models/active_run.ts";
@@ -341,6 +345,8 @@ export async function* modelMethodRun(
             input.inputs,
             resolvedType,
             resolvedModelDef,
+            undefined,
+            swampPath(deps.repoDir, SWAMP_SUBDIRS.autoDefinitions),
           );
 
           if (!result.ok) {

--- a/src/libswamp/worker/run_deps.ts
+++ b/src/libswamp/worker/run_deps.ts
@@ -130,6 +130,7 @@ export async function createWorkerModelRunDeps(
         `${id}.yaml`,
       );
     },
+    autoDefinitionsDir: repoContext.autoDefinitionsDir,
     workflowRepo: repoContext.workflowRepo,
     workflowRunRepo: repoContext.workflowRunRepo,
   };

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -148,6 +148,7 @@ export async function createWorkflowRunDeps(
           resolvedType,
           modelDef,
           globalArgs,
+          repoContext.autoDefinitionsDir,
         );
         if (!result.ok) throw new Error(result.error.message);
         return {


### PR DESCRIPTION
## Summary

- Fixes a TOCTOU race in `resolveOrCreateDefinition` where N concurrent `@type` direct execution runs against the same non-existent name would create N separate definitions sharing one name — only one reachable, the rest orphaned with invisible data
- Adds an optional `lockDir` parameter to `resolveOrCreateDefinition` with double-check locking: fast-path lookup without lock (existing definitions skip locking), then acquire a name-based `FileLock`, re-lookup under lock, create only if still missing
- Wired at all 4 direct call sites (`run.ts`, `workflow_run.ts`, `workflow_resume.ts`, `serve/deps.ts`); callers through `run.ts` (including `access_helpers`, `worker/run_deps`, `access/run_deps`) get protection automatically

Closes swamp-club#1431

## Test Plan

- Unit tests for `autoDefinitionLockKey` name sanitization (3 tests) and `resolveOrCreateDefinition` locking behavior (3 tests: creation under lock, fast-path skip, race winner adoption)
- Integration test: 8 concurrent `resolveOrCreateDefinition` calls against the same name — asserts exactly 1 definition created, all 8 succeed
- Manual reproduction: `for i in 1 2 3 4; do swamp model @command/shell method run execute racy --input run="echo $i" & done; wait` — before: 4 definition files; after: 1 definition file, all runs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)