### PR TITLE
fix(logging): preserve run log file output under --quiet mode (swamp-club#1402)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1473,6 +1473,7 @@ export async function runCli(args: string[]): Promise<void> {
         jsonMode: options.json ?? false,
         noColor,
         forceLog: forceLog || verbose,
+        quiet: options.quiet ?? false,
       });
 
       // Emit deferred warnings now that logging is initialized

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -40,6 +40,8 @@ export interface LoggingOptions {
   noColor?: boolean;
   /** When true, run loggers also write to the console sink (flat [INF] output for --log mode). */
   forceLog?: boolean;
+  /** Suppress console output while keeping the run file sink at info level. */
+  quiet?: boolean;
   /** Write all log output to stderr only (for dispatch runners where stdout carries RPC frames). */
   stderrOnly?: boolean;
   /** Test-only: clear the once-per-process guard so logging can be reconfigured. */
@@ -179,20 +181,22 @@ export async function initializeLogging(
   // don't reach the console at all.
   const jsonMode = options.jsonMode ?? false;
   const forceLog = options.forceLog ?? false;
-  const runParentSinks = forceLog ? "inherit" : "override";
+  const quiet = options.quiet ?? false;
+  const runParentSinks = forceLog && !quiet ? "inherit" : "override";
+  const runLogLevel: LogLevel = quiet ? "info" : logLevel;
   await configure({
     sinks,
     loggers: [
       ...loggers,
       {
         category: ["model", "method", "run"],
-        lowestLevel: logLevel,
+        lowestLevel: runLogLevel,
         sinks: ["runFile", ...otelSinks],
         parentSinks: runParentSinks,
       },
       {
         category: ["workflow", "run"],
-        lowestLevel: logLevel,
+        lowestLevel: runLogLevel,
         sinks: ["runFile", ...otelSinks],
         parentSinks: runParentSinks,
       },

--- a/src/infrastructure/logging/logger_test.ts
+++ b/src/infrastructure/logging/logger_test.ts
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import {
   escapeLogTemplate,
   getRunLogger,
@@ -25,6 +26,7 @@ import {
   getWorkflowRunLogger,
   initializeLogging,
 } from "./logger.ts";
+import { runFileSink } from "./run_file_sink.ts";
 
 // Note: LogTape can only be configured once per process.
 // These tests are structured to work within that limitation.
@@ -176,4 +178,36 @@ Deno.test("getWorkflowRunLogger", async (t) => {
     assertEquals(typeof logger1.info, "function");
     assertEquals(typeof logger2.info, "function");
   });
+});
+
+Deno.test("initializeLogging: quiet mode keeps run file sink at info level", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "logger-quiet-test-" });
+  try {
+    const logPath = join(dir, "run.log");
+    const handle = await runFileSink.register(
+      ["model", "method", "run", "quiet-test"],
+      logPath,
+    );
+    try {
+      await initializeLogging({
+        logLevel: "error",
+        quiet: true,
+        _reset: true,
+      });
+
+      const logger = getRunLogger("quiet-test", "greet");
+      logger.info`Extension says hello`;
+
+      const content = await Deno.readTextFile(logPath);
+      assertStringIncludes(content, "Extension says hello");
+    } finally {
+      runFileSink.unregister(handle);
+    }
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- `--quiet` sets `logLevel` to `"error"` globally, which suppresses `info`/`warn` records from the `runFile` sink — emptying the per-run log file and losing the audit trail
- Adds a `quiet` flag to `LoggingOptions` that decouples the run category log level from the root logger: root stays at `"error"` (console suppressed), run categories keep `"info"` (log file preserved)
- Ensures `parentSinks` stays `"override"` under quiet even when `forceLog` is set, preventing sink inheritance from leaking logger output to the console

## Test Plan

- [x] New unit test: `initializeLogging: quiet mode keeps run file sink at info level` — configures logging with `logLevel: "error"` + `quiet: true`, verifies a run-category `info` record reaches the `runFile` sink
- [x] Reproduced before/after: ran `swamp model @swamp/issue-lifecycle method run review` with `--quiet` — log file was empty before the fix, populated after
- [x] Full test suite passes (9465 tests, 0 failures)
- [x] Terminal output remains suppressed under `--quiet` (unchanged behavior)

Closes swamp-club/lab#1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)