### PR TITLE
feat(workflows): add guard field for idempotent step execution

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -560,6 +560,106 @@ steps:
       methodName: execute
 ```
 
+## Guard (Idempotent Step Execution)
+
+A step can declare a `guard` — a CEL expression evaluated before execution. When
+the guard evaluates truthy, the step is skipped (already done). When falsy or
+absent, the step executes normally.
+
+Guard is the workflow-level primitive for idempotent step execution, enabling safe
+workflow resume, re-run, and cron scheduling without re-executing completed
+steps.
+
+### Evaluation order
+
+1. Dependency conditions are checked (`dependsOn`)
+2. Expression context is built (including `self.*` for forEach steps)
+3. Guard expression is evaluated via `celEvaluator.evaluateAsync()`
+4. If truthy → step is skipped with reason `"guarded"`
+5. If falsy → step proceeds to execution
+
+### Expression context
+
+Guard expressions have access to the same context as other step expressions:
+
+- `inputs` — workflow inputs
+- `data` — data namespace (e.g., `data.latest()`)
+- `self` — for forEach steps, includes the iteration variable
+
+### Guard patterns
+
+```yaml
+steps:
+  # Data truthiness — truthy scalar means done, null means not done
+  - name: read-plate
+    guard: ${{ data.latest("plate-reader", "scan-complete").attributes.id }}
+    task:
+      modelName: plate-reader
+      method: read-all
+
+  # Value comparison — same batch means skip, different batch means re-run
+  - name: dispense-reagent
+    guard: >
+      ${{ data.latest("liquid-handler", "dispense-log").attributes.batchId
+          == inputs.batchId }}
+    task:
+      modelName: liquid-handler
+      method: dispense
+
+  # Method call — invoke a model method to check external state
+  - name: create-instance
+    guard: >
+      ${{ model.method("infra", "check-exists",
+          {"name": inputs.instanceName}).stdout }}
+    task:
+      modelName: infra
+      method: create
+```
+
+### model.method() in guards
+
+`model.method(modelName, methodName)` or
+`model.method(modelName, methodName, inputs)` invokes a model method and returns
+the content of its first resource data output (parsed as JSON if possible). This
+lets guards check external state by running a lightweight probe method.
+
+The method executes through the same step executor as regular workflow steps, so
+it has full access to vault secrets, expression context, and data storage. The
+return value is the parsed data output content — for command/shell models this is
+`{exitCode, stdout, stderr, ...}`, so guard expressions typically access a
+specific field like `.stdout`.
+
+### forEach compatibility
+
+Guard expressions can reference `self.*` (the forEach variable), so each
+expanded iteration evaluates its own guard independently:
+
+```yaml
+- name: read-plate
+  forEach:
+    item: well
+    in: ${{ range(1, 97) }}
+  guard: ${{ data.latest("plate-reader", self.well) }}
+  task:
+    modelName: plate-reader
+    method: read-single-well
+```
+
+On resume, each iteration's guard evaluates independently — completed wells are
+skipped, failed/unstarted wells execute.
+
+### Error handling
+
+A CEL parse error or runtime error in a guard expression fails the step. Guard
+errors are not silently swallowed — they produce a `step_failed` event with the
+error message.
+
+### Events and rendering
+
+Guard-skipped steps emit a `step_skipped` event with `reason: "guarded"` (vs
+`"dependency"` for dependency skips). The console renderer shows
+`skipped (guarded)` to distinguish from dependency skips.
+
 ## Data Output Overrides with Vary Dimensions
 
 Steps can declare `vary` on `dataOutputOverrides` to produce

--- a/src/domain/expressions/expression_parser.ts
+++ b/src/domain/expressions/expression_parser.ts
@@ -265,6 +265,17 @@ export function isTriggerInputsPath(path: string): boolean {
 }
 
 /**
+ * Checks if an expression path is a step's guard field.
+ *
+ * Guard expressions are evaluated at step execution time — they check runtime
+ * state (data outputs from upstream steps, forEach variables) to decide whether
+ * a step should be skipped, so workflow-body evaluation must leave them raw.
+ */
+export function isGuardPath(path: string): boolean {
+  return path.endsWith(".guard");
+}
+
+/**
  * Pattern to match `inputs.fieldName` (dot notation) in CEL expressions.
  * Uses negative lookbehind to exclude cross-model references like `model.foo.input.bar`.
  */

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -74,6 +74,7 @@ export type WorkflowExecutionEvent =
     kind: "step_skipped";
     jobId: string;
     stepId: string;
+    reason?: "guarded" | "dependency";
     forEachTemplate?: string;
     forEachIndex?: number;
   }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -19,7 +19,8 @@
 
 import type { Workflow } from "./workflow.ts";
 import type { Job } from "./job.ts";
-import type { Step } from "./step.ts";
+import { Step } from "./step.ts";
+import { StepTask } from "./step_task.ts";
 import type { AssertSeverity } from "./step_task.ts";
 import { severityAtOrAbove } from "./assert_severity.ts";
 import {
@@ -2608,6 +2609,136 @@ export class WorkflowExecutionService {
           kind: "step_skipped",
           jobId: job.name,
           stepId: stepName,
+          reason: "dependency",
+          forEachTemplate,
+          forEachIndex,
+        };
+        return;
+      }
+    }
+
+    // Build expression context before guard evaluation so self.* is available
+    // for forEach-expanded steps.
+    let stepExprContext = expressionContext
+      ? { ...expressionContext }
+      : expressionContext;
+    if (stepExprContext && forEachVar && forEachVar.name) {
+      const baseSelf = stepExprContext.self ?? {
+        id: "",
+        name: "",
+        version: 1,
+        tags: {},
+        globalArguments: {},
+      };
+      stepExprContext = {
+        ...stepExprContext,
+        self: {
+          ...baseSelf,
+          [forEachVar.name]: forEachVar.value,
+        },
+      };
+    }
+
+    // Evaluate guard expression — truthy means the step is already done
+    if (step.guard) {
+      const guardCel = extractCelExpression(step.guard);
+      if (!guardCel) {
+        stepSpan.end();
+        throw new UserError(
+          `Step "${stepName}" guard must be a $\{{ }} expression, got: ${step.guard}`,
+        );
+      }
+      try {
+        const celEvaluator = new CelEvaluator();
+        const guardContext: Record<string, unknown> = {
+          ...(stepExprContext ?? {}),
+        };
+        guardContext["modelMethod"] = {
+          method: async (
+            modelName: string,
+            methodName: string,
+            inputs?: Record<string, unknown>,
+          ) => {
+            const guardStep = Step.create({
+              name: `__guard_${stepName}`,
+              task: StepTask.model(modelName, methodName, inputs),
+            });
+            const result = await this.executor.execute(guardStep, {
+              workflowId: workflow.id,
+              workflowRunId: run.id,
+              workflowName: workflow.name,
+              jobName: job.name,
+              stepName: `__guard_${stepName}`,
+              repoDir: this.repoDir,
+              signal: options.signal ?? AbortSignal.timeout(30_000),
+              expressionContext: stepExprContext,
+              catalogStore: this.catalogStore,
+              dataBaseDir: this.dataBaseDir,
+              runtimeTags: options.runtimeTags,
+              secretRedactor: options.secretRedactor,
+            });
+            const methodResult = result as {
+              dataHandles?: Array<{
+                specName: string;
+                kind: string;
+              }>;
+            };
+            if (methodResult?.dataHandles?.length) {
+              const resourceHandle = methodResult.dataHandles.find(
+                (h) => h.kind === "resource",
+              );
+              if (resourceHandle) {
+                const def = await findDefinitionByIdOrName(
+                  this.definitionRepo,
+                  modelName,
+                );
+                if (def) {
+                  const raw = await this.dataRepo.getContent(
+                    def.type,
+                    def.definition.id,
+                    resourceHandle.specName,
+                  );
+                  if (raw) {
+                    try {
+                      return JSON.parse(new TextDecoder().decode(raw));
+                    } catch {
+                      return new TextDecoder().decode(raw);
+                    }
+                  }
+                }
+              }
+            }
+            return result;
+          },
+        };
+        const guardResult = await celEvaluator.evaluateAsync(
+          guardCel,
+          guardContext,
+        );
+        if (guardResult) {
+          stepRun.skip();
+          stepSpan.setAttribute("step.status", "skipped");
+          stepSpan.setAttribute("step.skip.reason", "guarded");
+          stepSpan.end();
+          yield {
+            kind: "step_skipped",
+            jobId: job.name,
+            stepId: stepName,
+            reason: "guarded",
+            forEachTemplate,
+            forEachIndex,
+          };
+          return;
+        }
+      } catch (error) {
+        stepRun.fail(String(error));
+        stepSpan.setAttribute("step.status", "failed");
+        stepSpan.end();
+        yield {
+          kind: "step_failed",
+          jobId: job.name,
+          stepId: stepName,
+          error: `Guard expression failed: ${error}`,
           forEachTemplate,
           forEachIndex,
         };
@@ -2626,28 +2757,6 @@ export class WorkflowExecutionService {
     };
 
     try {
-      // Shallow-copy the expression context so parallel steps don't race on
-      // the mutable .self and .inputs properties.
-      let stepExprContext = expressionContext
-        ? { ...expressionContext }
-        : expressionContext;
-      if (stepExprContext && forEachVar && forEachVar.name) {
-        const baseSelf = stepExprContext.self ?? {
-          id: "",
-          name: "",
-          version: 1,
-          tags: {},
-          globalArguments: {},
-        };
-        stepExprContext = {
-          ...stepExprContext,
-          self: {
-            ...baseSelf,
-            [forEachVar.name]: forEachVar.value,
-          },
-        };
-      }
-
       const task = step.task.data;
 
       // Handle manual approval tasks — suspend the workflow

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -4179,3 +4179,423 @@ Deno.test("manual_approval suspension does not mark job span as ERROR", async ()
     otelApi.trace.disable();
   }
 });
+
+// guard tests
+
+Deno.test("guard: step without guard executes normally", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "no-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "unguarded",
+              task: StepTask.model("test-model", "run"),
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps, ["job1/unguarded"]);
+  });
+});
+
+Deno.test("guard: step with falsy guard expression executes", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "falsy-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "guarded-falsy",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ false }}",
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps, ["job1/guarded-falsy"]);
+  });
+});
+
+Deno.test("guard: step with truthy guard expression is skipped", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "truthy-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "guarded-truthy",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ true }}",
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const events: Array<{ kind: string; reason?: string }> = [];
+    for await (const event of service.run(workflow.name)) {
+      if (event.kind === "step_skipped") {
+        events.push({ kind: event.kind, reason: event.reason });
+      }
+    }
+
+    assertEquals(executor.executedSteps, []);
+    assertEquals(events.length, 1);
+    assertEquals(events[0].reason, "guarded");
+  });
+});
+
+Deno.test("guard: guarded-skip triggers downstream with skipped condition", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "guard-downstream-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "guarded-step",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ true }}",
+            }),
+            Step.create({
+              name: "downstream-on-skip",
+              task: StepTask.model("test-model", "run"),
+              dependsOn: [
+                {
+                  step: "guarded-step",
+                  condition: TriggerCondition.skipped(),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps, ["job1/downstream-on-skip"]);
+  });
+});
+
+Deno.test("guard: invalid guard expression (not wrapped in ${{ }}) fails the step", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "invalid-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "bad-guard",
+              task: StepTask.model("test-model", "run"),
+              guard: "not a cel expression",
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    await assertRejects(
+      () => service.execute(workflow.name),
+      Error,
+      "guard must be a ${{ }} expression",
+    );
+  });
+});
+
+Deno.test("guard: CEL runtime error in guard fails the step", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "runtime-error-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "error-guard",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ undefined_var.field }}",
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const events: Array<{ kind: string; error?: string }> = [];
+    for await (const event of service.run(workflow.name)) {
+      if (event.kind === "step_failed") {
+        events.push({ kind: event.kind, error: event.error });
+      }
+    }
+
+    assertEquals(executor.executedSteps, []);
+    assertEquals(events.length, 1);
+    assertStringIncludes(events[0].error!, "Guard expression failed");
+  });
+});
+
+Deno.test("guard: value comparison guard expression", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+    const executor = new MockStepExecutor();
+
+    const workflow = Workflow.create({
+      name: "comparison-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "matching",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ 1 == 1 }}",
+            }),
+            Step.create({
+              name: "not-matching",
+              task: StepTask.model("test-model", "run"),
+              guard: "${{ 1 == 2 }}",
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+    assertEquals(executor.executedSteps, ["job1/not-matching"]);
+  });
+});
+
+Deno.test("guard: model.method() guard skips step when method returns truthy", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    class TruthyMethodExecutor implements StepExecutor {
+      executedSteps: string[] = [];
+
+      execute(_step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.executedSteps.push(`${ctx.jobName}/${ctx.stepName}`);
+        if (ctx.stepName.startsWith("__guard_")) {
+          return Promise.resolve({ exists: true });
+        }
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new TruthyMethodExecutor();
+
+    const workflow = Workflow.create({
+      name: "model-method-guard-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "check-infra",
+              task: StepTask.model("infra", "create"),
+              guard: '${{ model.method("infra", "exists") }}',
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const events: Array<{ kind: string; reason?: string }> = [];
+    for await (const event of service.run(workflow.name)) {
+      if (event.kind === "step_skipped") {
+        events.push({ kind: event.kind, reason: event.reason });
+      }
+    }
+
+    assertEquals(
+      executor.executedSteps,
+      ["job1/__guard_check-infra"],
+    );
+    assertEquals(events.length, 1);
+    assertEquals(events[0].reason, "guarded");
+  });
+});
+
+Deno.test("guard: model.method() guard executes step when method returns falsy", async () => {
+  await withTempDir(async (tempDir) => {
+    const workflowRepo = new InMemoryWorkflowRepository();
+    const runRepo = new InMemoryWorkflowRunRepository();
+
+    class FalsyMethodExecutor implements StepExecutor {
+      executedSteps: string[] = [];
+
+      execute(_step: Step, ctx: StepExecutionContext): Promise<unknown> {
+        this.executedSteps.push(`${ctx.jobName}/${ctx.stepName}`);
+        if (ctx.stepName.startsWith("__guard_")) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve({ executed: true });
+      }
+    }
+    const executor = new FalsyMethodExecutor();
+
+    const workflow = Workflow.create({
+      name: "model-method-guard-falsy-wf",
+      jobs: [
+        Job.create({
+          name: "job1",
+          steps: [
+            Step.create({
+              name: "create-infra",
+              task: StepTask.model("infra", "create"),
+              guard: '${{ model.method("infra", "exists") }}',
+            }),
+          ],
+        }),
+      ],
+    });
+    await workflowRepo.save(workflow);
+
+    const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+    const service = new WorkflowExecutionService(
+      workflowRepo,
+      runRepo,
+      tempDir,
+      executor,
+      undefined,
+      catalogStore,
+    );
+
+    const run = await service.execute(workflow.name);
+    assertEquals(run.status, "succeeded");
+    assertEquals(
+      executor.executedSteps,
+      ["job1/__guard_create-infra", "job1/create-infra"],
+    );
+  });
+});

--- a/src/domain/workflows/expression_evaluators.ts
+++ b/src/domain/workflows/expression_evaluators.ts
@@ -23,6 +23,7 @@ import { Workflow as WorkflowClass } from "./workflow.ts";
 import {
   extractExpressions,
   isAssertMessagePath,
+  isGuardPath,
   isTaskInputsPath,
   isTriggerInputsPath,
   replaceExpressions,
@@ -113,6 +114,12 @@ export class WorkflowExpressionEvaluator {
       // workflow-body evaluation — leave them raw so a `webhook.*` reference
       // doesn't evaluate against a context that lacks the payload.
       if (isTriggerInputsPath(expr.path)) {
+        continue;
+      }
+      // Guard expressions are evaluated at step execution time — they check
+      // runtime state (data outputs, forEach variables) to decide idempotent
+      // skips.
+      if (isGuardPath(expr.path)) {
         continue;
       }
       // task.inputs and assert task.message that depend on step outputs

--- a/src/domain/workflows/step.ts
+++ b/src/domain/workflows/step.ts
@@ -93,6 +93,7 @@ const StepObjectSchema = z.object({
   labels: z.record(z.string(), z.string()).optional(),
   platform: z.string().optional(),
   queueTimeout: z.number().nonnegative().optional(),
+  guard: z.string().optional(),
 });
 
 /**
@@ -153,6 +154,7 @@ export interface CreateStepProps {
   labels?: Record<string, string>;
   platform?: string;
   queueTimeout?: number;
+  guard?: string;
 }
 
 /**
@@ -181,6 +183,7 @@ export class Step {
     readonly labels: Record<string, string> | undefined,
     readonly platform: string | undefined,
     readonly queueTimeout: number | undefined,
+    readonly guard: string | undefined,
   ) {}
 
   /**
@@ -204,6 +207,7 @@ export class Step {
       labels: props.labels,
       platform: props.platform,
       queueTimeout: props.queueTimeout,
+      guard: props.guard,
     });
 
     return Step.fromData(data);
@@ -249,6 +253,7 @@ export class Step {
       validated.labels,
       validated.platform,
       validated.queueTimeout,
+      validated.guard,
     );
   }
 
@@ -311,6 +316,7 @@ export class Step {
       labels: this.labels,
       platform: this.platform,
       queueTimeout: this.queueTimeout,
+      guard: this.guard,
     };
   }
 

--- a/src/domain/workflows/step_test.ts
+++ b/src/domain/workflows/step_test.ts
@@ -478,3 +478,55 @@ Deno.test("Step placement: queueTimeout converts seconds to milliseconds", () =>
   assertEquals(restored.queueTimeout, 30);
   assertEquals(restored.placement?.queueTimeoutMs, 30_000);
 });
+
+Deno.test("Step: guard field is parsed when present", () => {
+  const step = Step.fromData({
+    name: "guarded-step",
+    task: {
+      type: "model_method",
+      modelIdOrName: "my-model",
+      methodName: "run",
+    },
+    guard: '${{ data.latest("plate-reader", "scan-complete").attributes.id }}',
+  });
+  assertEquals(
+    step.guard,
+    '${{ data.latest("plate-reader", "scan-complete").attributes.id }}',
+  );
+});
+
+Deno.test("Step: guard field is undefined when absent", () => {
+  const step = Step.fromData({
+    name: "no-guard",
+    task: {
+      type: "model_method",
+      modelIdOrName: "my-model",
+      methodName: "run",
+    },
+  });
+  assertEquals(step.guard, undefined);
+});
+
+Deno.test("Step: guard field roundtrips through toData", () => {
+  const guard = '${{ data.latest("plate-reader", "result") }}';
+  const step = Step.fromData({
+    name: "guarded",
+    task: {
+      type: "model_method",
+      modelIdOrName: "my-model",
+      methodName: "run",
+    },
+    guard,
+  });
+  const data = step.toData();
+  assertEquals(data.guard, guard);
+  const restored = Step.fromData(data);
+  assertEquals(restored.guard, guard);
+});
+
+Deno.test("Step.create: guard field is passed through", () => {
+  const task = StepTask.model("my-model", "run");
+  const guard = '${{ data.latest("sensor", "reading") }}';
+  const step = Step.create({ name: "guarded", task, guard });
+  assertEquals(step.guard, guard);
+});

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -205,6 +205,37 @@ export class CelDataNamespace {
 }
 
 /**
+ * Wrapper class for model namespace context objects.
+ * Provides model.method() for invoking model methods from CEL expressions
+ * (e.g., guard expressions).
+ */
+export class CelModelNamespace {
+  private readonly delegate: Record<string, unknown>;
+
+  constructor(delegate: Record<string, unknown>) {
+    this.delegate = delegate;
+  }
+
+  method(
+    modelName: string,
+    methodName: string,
+    inputs?: Record<string, unknown>,
+  ): unknown {
+    const fn = this.delegate["method"];
+    if (typeof fn === "function") {
+      return (
+        fn as (
+          m: string,
+          n: string,
+          i?: Record<string, unknown>,
+        ) => unknown
+      )(modelName, methodName, inputs);
+    }
+    return null;
+  }
+}
+
+/**
  * Builds a fresh, isolated cel-js `Environment` with swamp's baseline
  * registrations for extension use.
  *
@@ -292,6 +323,7 @@ export class CelEvaluator {
     this.env.registerType("CelFileNamespace", CelFileNamespace);
     this.env.registerType("CelDataNamespace", CelDataNamespace);
     this.env.registerType("CelWorkersNamespace", CelWorkersNamespace);
+    this.env.registerType("CelModelNamespace", CelModelNamespace);
 
     // Register receiver methods for file namespace
     this.env.registerFunction(
@@ -383,6 +415,31 @@ export class CelEvaluator {
     this.env.registerFunction(
       "CelWorkersNamespace.connected(): dyn",
       (receiver: CelWorkersNamespace) => receiver.connected(),
+    );
+
+    // Register receiver methods for model namespace
+    this.env.registerFunction(
+      "CelModelNamespace.method(string, string): dyn",
+      (
+        receiver: CelModelNamespace,
+        modelName: string,
+        methodName: string,
+      ) => receiver.method(modelName, methodName),
+    );
+
+    this.env.registerFunction(
+      "CelModelNamespace.method(string, string, dyn): dyn",
+      (
+        receiver: CelModelNamespace,
+        modelName: string,
+        methodName: string,
+        inputs: unknown,
+      ) =>
+        receiver.method(
+          modelName,
+          methodName,
+          inputs as Record<string, unknown>,
+        ),
     );
   }
 
@@ -512,7 +569,8 @@ export class CelEvaluator {
     const file = context["file"];
     const data = context["data"];
     const workers = context["workers"];
-    if (!file && !data && !workers) return context;
+    const modelMethod = context["modelMethod"];
+    if (!file && !data && !workers && !modelMethod) return context;
 
     const wrapped = { ...context };
     if (
@@ -532,6 +590,15 @@ export class CelEvaluator {
       wrapped["workers"] = new CelWorkersNamespace(
         workers as Record<string, unknown>,
       );
+    }
+    if (
+      modelMethod && typeof modelMethod === "object" &&
+      !(modelMethod instanceof CelModelNamespace)
+    ) {
+      wrapped["model"] = new CelModelNamespace(
+        modelMethod as Record<string, unknown>,
+      );
+      delete wrapped["modelMethod"];
     }
     return wrapped;
   }

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -105,6 +105,7 @@ export type WorkflowRunEvent =
     kind: "step_skipped";
     jobId: string;
     stepId: string;
+    reason?: "guarded" | "dependency";
     forEachTemplate?: string;
     forEachIndex?: number;
   }

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -301,7 +301,7 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
         if (!this.pipe) return;
         this.clearHeartbeat(e.jobId, e.stepId);
         const displayName = this.getDisplayName(e.jobId, e.stepId, e);
-        writeOutput(this.pipe.skippedLine(displayName));
+        writeOutput(this.pipe.skippedLine(displayName, e.reason));
       },
       step_queued: (e) => {
         if (!this.pipe) return;
@@ -731,7 +731,16 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
       job_skipped: () => {},
       step_started: () => {},
       step_completed: () => {},
-      step_skipped: () => {},
+      step_skipped: (e) => {
+        if (e.reason === "guarded") {
+          console.log(JSON.stringify({
+            step: e.stepId,
+            job: e.jobId,
+            status: "skipped",
+            reason: "guarded",
+          }));
+        }
+      },
       step_queued: () => {},
       step_target_disconnected: () => {},
       step_failed: () => {},


### PR DESCRIPTION
## Summary

Closes swamp-club#1437.

- Add optional `guard` field to workflow steps — a CEL expression evaluated before step execution. Truthy skips the step (already done), falsy executes normally.
- Three guard patterns: data truthiness (`data.latest()`), value comparison, and method call (`model.method()`)
- `CelModelNamespace` enables `model.method(modelName, methodName, inputs)` in guard expressions — invokes a model method and returns the parsed data output content
- Guard expressions are deferred from eager workflow expression evaluation (same pattern as `forEach.in` and `trigger.inputs`)
- `step_skipped` event gains optional `reason` field (`"guarded"` vs `"dependency"`)
- Console renderer shows `skipped (guarded)`, JSON renderer emits structured line for guarded skips

## Files changed

| File | Change |
|------|--------|
| `step.ts` | `guard` field on schema, interface, class |
| `execution_events.ts` | `reason` on `step_skipped` event |
| `execution_service.ts` | Guard evaluation in `runStep()`, `model.method()` delegate |
| `expression_parser.ts` | `isGuardPath()` helper |
| `expression_evaluators.ts` | Skip guard expressions during eager evaluation |
| `cel_evaluator.ts` | `CelModelNamespace` type + receiver methods |
| `run.ts` (libswamp) | `reason` on libswamp `step_skipped` type |
| `workflow_run.ts` | Thread reason to console/JSON renderers |
| `workflow.md` (design) | Guard documentation section |

## Follow-up issues

- swamp-club/swamp-uat#332 — UAT test coverage for guard evaluation
- Manual docs gap for `content/manual/reference/workflows.md` (swamp-club/swamp-club has issues disabled)

## Test plan

- [x] 4 step schema unit tests (guard field parsing, roundtrip, create)
- [x] 9 execution service tests (guard absent, falsy, truthy, downstream skip condition, invalid format, CEL error, value comparison, model.method() truthy, model.method() falsy)
- [x] Full test suite: 9477 passed, 0 failed
- [x] End-to-end verification with compiled binary against scratch swamp repo:
  - Data truthiness guard (first run executes, second run skips)
  - Value comparison guard (matching skips, non-matching executes)
  - `model.method()` guard (empty stdout executes, truthy stdout skips)
  - Invalid guard format → clear error
  - Nonexistent model in guard → clear error
  - Console output: `skipped (guarded)`
  - JSON output: `{"reason":"guarded"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)