### PR TITLE
fix(cel): allow mixed-type values in CEL map and list literals (swamp-club#1441)

### DIFF
--- a/packages/testing/_cel_environment.ts
+++ b/packages/testing/_cel_environment.ts
@@ -35,6 +35,7 @@ export function createExtensionCelEnvironment(): Environment {
   const env = new Environment({
     unlistedVariablesAreDyn: true,
     enableOptionalTypes: true,
+    homogeneousAggregateLiterals: false,
   });
 
   env.registerOperator(

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -311,6 +311,7 @@ Deno.test("cel env factory parity: both factories produce identical results", ()
     ["2 + a", { a: 1.5 }],
     ["a.?b", { a: { b: 42 } }],
     ["a.?b", { a: null }],
+    ['{"k": a, "lit": "v"}', { a: "dyn" }],
   ];
 
   const a = canonicalFactory();

--- a/src/infrastructure/cel/cel_evaluator.ts
+++ b/src/infrastructure/cel/cel_evaluator.ts
@@ -240,9 +240,9 @@ export class CelModelNamespace {
  * registrations for extension use.
  *
  * Options: `{ unlistedVariablesAreDyn: true }` so callers can pass arbitrary
- * context maps without pre-registering every variable. Extensions can
- * `.clone({ homogeneousAggregateLiterals: false })` if they want mixed-type
- * literals.
+ * context maps without pre-registering every variable.
+ * `{ homogeneousAggregateLiterals: false }` so map/list literals can contain
+ * mixed value types (e.g. dyn context lookups alongside string literals).
  *
  * Registrations: bigint/double arithmetic operator overloads only. The
  * returned Environment does NOT carry swamp's internal namespace types
@@ -299,6 +299,7 @@ export function createExtensionCelEnvironment(): Environment {
   const env = new Environment({
     unlistedVariablesAreDyn: true,
     enableOptionalTypes: true,
+    homogeneousAggregateLiterals: false,
   });
   registerArithmeticOverloads(env);
   return env;

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -42,6 +42,27 @@ Deno.test("createExtensionCelEnvironment: unlistedVariablesAreDyn allows ad-hoc 
   assertEquals(env.evaluate("foo + bar", { foo: 1.0, bar: 2.0 }), 3);
 });
 
+Deno.test("createExtensionCelEnvironment: mixed-type map literals evaluate correctly", () => {
+  const env = createExtensionCelEnvironment();
+  const ctx = { s: { name: "host1", address: "10.0.0.1" } };
+
+  assertEquals(
+    env.evaluate(
+      '{"name": s.name, "address": s.address, "user": "ansible"}',
+      ctx,
+    ),
+    { name: "host1", address: "10.0.0.1", user: "ansible" },
+  );
+});
+
+Deno.test("createExtensionCelEnvironment: mixed-type list literals evaluate correctly", () => {
+  const env = createExtensionCelEnvironment();
+  assertEquals(
+    env.evaluate('[1, "two", 3.0]', {}),
+    [1n, "two", 3.0],
+  );
+});
+
 Deno.test("createExtensionCelEnvironment: callers can register custom functions", () => {
   const env = createExtensionCelEnvironment();
   env.registerFunction(
@@ -1245,4 +1266,30 @@ Deno.test("evaluate: workers.connected() returns empty array when delegate missi
 
   const result = evaluator.evaluate("workers.connected()", context);
   assertEquals(result, []);
+});
+
+Deno.test("evaluate: mixed-type map literals with dyn and string values", () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    s: { name: "host1", address: "10.0.0.1" },
+  };
+
+  const result = evaluator.evaluate(
+    '{"name": s.name, "address": s.address, "user": "ansible"}',
+    context,
+  );
+  assertEquals(result, { name: "host1", address: "10.0.0.1", user: "ansible" });
+});
+
+Deno.test("evaluateAsync: mixed-type map literals with dyn and string values", async () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    s: { name: "host1", address: "10.0.0.1" },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    '{"name": s.name, "address": s.address, "user": "ansible"}',
+    context,
+  );
+  assertEquals(result, { name: "host1", address: "10.0.0.1", user: "ansible" });
 });


### PR DESCRIPTION
## Summary

- Set `homogeneousAggregateLiterals: false` on the shared CEL `Environment` in `createExtensionCelEnvironment()` so map/list literals can contain mixed value types
- Mirrors the same change in the testing package's factory copy
- Adds tests for mixed-type map and list literals at both the `Environment` and `CelEvaluator` levels, plus a parity check in the compat test

**Root cause:** `cel-js` defaults `homogeneousAggregateLiterals` to `true`, which rejects maps where values mix `dyn` (context lookups like `s.name`) with typed literals (like `"ansible"`). This surfaced as an "Unresolved expression" error in `globalArguments` because the expression evaluation service silently catches CEL errors and leaves the raw `${{ }}` expression in place.

The `data_query_service.ts` already uses `homogeneousAggregateLiterals: false` in its own separate Environment for the same reason. This change applies it to the shared environment used by all expression evaluation and extensions.

Closes swamp-club#1441

## Test Plan

- Added unit tests for mixed-type map literals (dyn + string values) at `createExtensionCelEnvironment`, `CelEvaluator.evaluate`, and `CelEvaluator.evaluateAsync` levels
- Added mixed-type list literal test
- Added mixed-type map expression to the testing package compat parity test
- Reproduced the bug in a scratch repo (`/tmp/swamp-repro-issue-1441`) — verified the compiled binary resolves 3-key mixed-type maps correctly
- Full test suite: 9482 passed, 0 failed