### PR TITLE
fix(reports): skip persistence of empty report results (swamp-club#1443)

### DIFF
--- a/design/reports.md
+++ b/design/reports.md
@@ -356,6 +356,12 @@ Both artifacts are written with:
 - **Garbage collection**: `5` (keep latest 5 versions)
 - **Tags**: `{ type: "report", reportName, reportScope }`
 
+**Empty results are not persisted.** When a report's `execute()` returns empty
+markdown (trimmed), persistence is skipped entirely — no version is created and
+the previous version stays `latest`. This prevents method-scoped reports that
+return empty for inapplicable methods from masking real content with 0-byte
+versions.
+
 Data handles are returned in the `ReportExecutionResult` and included in the
 final view.
 

--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -460,7 +460,20 @@ export async function executeReports(
     try {
       const result = await report.execute(context);
 
-      // Persist results
+      // Empty markdown means the report is not applicable to this method.
+      // Skip persistence so the previous real version stays latest.
+      if (result.markdown.trim() === "") {
+        results.push({
+          name,
+          scope: report.scope,
+          success: true,
+          markdown: result.markdown,
+          json: result.json,
+          dataHandles: [],
+        });
+        continue;
+      }
+
       const dataHandles = await persistReportData(
         context.dataRepository,
         modelType,

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -26,7 +26,10 @@ import {
 import type { ReportDefinition } from "./report.ts";
 import type { ReportContext } from "./report_context.ts";
 import type { ReportSelection } from "./report_selection.ts";
-import type { ReportFilterOptions } from "./report_execution_service.ts";
+import type {
+  ReportEventCallback,
+  ReportFilterOptions,
+} from "./report_execution_service.ts";
 import { ReportRegistry } from "./report_registry.ts";
 import type { MethodReportContext } from "./report_context.ts";
 import { ModelType } from "../models/model_type.ts";
@@ -1675,4 +1678,174 @@ Deno.test("executeReports: unresolvable require failure survives artifact persis
   assertEquals(summary.failures, 1);
   assertEquals(summary.results[0].success, false);
   assertEquals(summary.results[0].dataHandles, undefined);
+});
+
+// --- Empty report skip tests (issue #1443) ---
+
+function makeEmptyReport(
+  scope: "method" | "model" | "workflow" = "method",
+): ReportDefinition {
+  return {
+    description: `Empty ${scope} report`,
+    scope,
+    execute(_context: ReportContext) {
+      return Promise.resolve({ markdown: "", json: {} });
+    },
+  };
+}
+
+function makeWhitespaceReport(
+  scope: "method" | "model" | "workflow" = "method",
+): ReportDefinition {
+  return {
+    description: `Whitespace ${scope} report`,
+    scope,
+    execute(_context: ReportContext) {
+      return Promise.resolve({ markdown: "   \n\t  \n  ", json: {} });
+    },
+  };
+}
+
+Deno.test("executeReports: empty markdown report skips persistence", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-empty", makeEmptyReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["test-empty"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 1);
+  assertEquals(summary.results[0].success, true);
+  assertEquals(summary.results[0].dataHandles, []);
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("executeReports: whitespace-only markdown report skips persistence", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-whitespace", makeWhitespaceReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["test-whitespace"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 1);
+  assertEquals(summary.results[0].success, true);
+  assertEquals(summary.results[0].dataHandles, []);
+  assertEquals(saved.length, 0);
+});
+
+Deno.test("executeReports: non-empty markdown report persists normally", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-content", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["test-content"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 1);
+  assertEquals(summary.results[0].success, true);
+  assertEquals(summary.results[0].dataHandles?.length, 2);
+  assertEquals(saved.length, 2);
+});
+
+Deno.test("executeReports: empty markdown report does not fire onReportCompleted", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-empty", makeEmptyReport("method"));
+
+  const { repo } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  let completedCalled = false;
+  const events: ReportEventCallback = {
+    onReportStarted: () => {},
+    onReportCompleted: () => {
+      completedCalled = true;
+    },
+    onReportFailed: () => {},
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["test-empty"] },
+    {},
+    events,
+    "run",
+    undefined,
+  );
+
+  assertEquals(completedCalled, false);
+});
+
+Deno.test("executeReports: mixed empty and non-empty reports persist only non-empty", async () => {
+  const registry = new ReportRegistry();
+  registry.register("test-empty", makeEmptyReport("method"));
+  registry.register("test-content", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+  const context = makeMethodContext(repo, modelType);
+
+  const summary = await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["test-empty", "test-content"] },
+    {},
+    undefined,
+    "run",
+    undefined,
+  );
+
+  assertEquals(summary.failures, 0);
+  assertEquals(summary.results.length, 2);
+
+  const emptyResult = summary.results.find((r) => r.name === "test-empty");
+  const contentResult = summary.results.find((r) => r.name === "test-content");
+  assertEquals(emptyResult?.dataHandles, []);
+  assertEquals(contentResult?.dataHandles?.length, 2);
+  assertEquals(saved.length, 2);
 });


### PR DESCRIPTION
## Summary

- When a report's `execute()` returns empty markdown (trimmed), skip persistence entirely — no version bump, no 0-byte artifact
- The previous real version stays `latest`, preventing method-scoped reports from masking real content
- GC no longer permanently discards real reports in favor of empty placeholders

Fixes swamp-club#1443

## What changed

**`src/domain/reports/report_execution_service.ts`** — Added an empty-result guard in the `executeReports` loop. When `result.markdown.trim() === ""`, the report is treated as "not applicable": persistence and the `onReportCompleted` event are skipped, but the result is still pushed (with empty `dataHandles`) so callers see the report ran.

**`src/domain/reports/report_execution_service_test.ts`** — 5 new tests: empty markdown skips persistence, whitespace-only skips persistence, non-empty persists normally, empty does not fire `onReportCompleted`, mixed empty/non-empty persists only non-empty.

**`design/reports.md`** — Documented the empty-result skip behavior in the Data Persistence section.

## Test plan

- [x] Unit tests: 5 new tests covering empty, whitespace-only, non-empty, event suppression, and mixed scenarios (51/51 pass)
- [x] End-to-end reproduction: created a model type with a selective report, ran `produce` (real content at v1), then 6x `noop` — report stayed at v1 with 63 bytes, no 0-byte versions created
- [x] GC verification: ran `swamp data gc` after the reproduction — real report survived, no data loss
- [x] `deno check`, `deno lint`, `deno fmt` all pass