### PR TITLE
fix(data): propagate delete/rename/prune to remote datastores (swamp-club#1440)

### DIFF
--- a/src/cli/commands/data_delete.ts
+++ b/src/cli/commands/data_delete.ts
@@ -242,7 +242,11 @@ export const dataDeleteCommand = withRemoteOptions(
 
     try {
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataDeleteDeps(repoDir, datastoreResolver);
+      const deps = createDataDeleteDeps(
+        repoDir,
+        datastoreResolver,
+        repoContext.unifiedDataRepo,
+      );
 
       if (isBatchMode) {
         const filter: BatchDeleteFilter = all

--- a/src/cli/commands/data_prune.ts
+++ b/src/cli/commands/data_prune.ts
@@ -75,12 +75,16 @@ export const dataPruneCommand = new Command()
       repoDir: resolveRepoDir(options.repoDir),
       outputMode: cliCtx.outputMode,
     };
-    const { repoDir, datastoreResolver } = options.dryRun
+    const { repoDir, repoContext, datastoreResolver } = options.dryRun
       ? await requireInitializedRepoReadOnly(repoOpts)
       : await requireInitializedRepo(repoOpts);
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDataPruneDeps(repoDir, datastoreResolver);
+    const deps = createDataPruneDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.unifiedDataRepo,
+    );
 
     // Phase 1: Preview + Prompt (only in interactive mode without --force and not dry-run)
     if (

--- a/src/cli/commands/data_rename.ts
+++ b/src/cli/commands/data_rename.ts
@@ -163,7 +163,11 @@ export const dataRenameCommand = withRemoteOptions(
 
     try {
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createDataRenameDeps(repoDir, datastoreResolver);
+      const deps = createDataRenameDeps(
+        repoDir,
+        datastoreResolver,
+        repoContext.unifiedDataRepo,
+      );
       const renderer = createDataRenameRenderer(cliCtx.outputMode);
       await consumeStream(
         dataRename(ctx, deps, { modelIdOrName, oldName, newName }),

--- a/src/libswamp/data/prune.ts
+++ b/src/libswamp/data/prune.ts
@@ -98,18 +98,20 @@ export interface DataPruneDeps {
 export function createDataPruneDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDataRepo?: FileSystemUnifiedDataRepository,
 ): DataPruneDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
   const catalogStore = createCatalogStore(repoDir, datastoreResolver);
-  const unifiedDataRepo = new FileSystemUnifiedDataRepository(
-    repoDir,
-    dsPath(SWAMP_SUBDIRS.data),
-    catalogStore,
-    undefined,
-    undefined,
-    namespaceFromResolver(datastoreResolver),
-  );
+  const unifiedDataRepo = injectedDataRepo ??
+    new FileSystemUnifiedDataRepository(
+      repoDir,
+      dsPath(SWAMP_SUBDIRS.data),
+      catalogStore,
+      undefined,
+      undefined,
+      namespaceFromResolver(datastoreResolver),
+    );
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,

--- a/src/libswamp/data/prune_test.ts
+++ b/src/libswamp/data/prune_test.ts
@@ -21,12 +21,15 @@ import { assertEquals } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
+  createDataPruneDeps,
   dataPrune,
   type DataPruneDeps,
   type DataPruneEvent,
   dataPrunePreview,
 } from "./prune.ts";
 import type { OrphanReclamationResult } from "../../domain/data/data_lifecycle_service.ts";
+import { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
+import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 
 function emptyResult(
   overrides: Partial<OrphanReclamationResult> = {},
@@ -163,3 +166,26 @@ Deno.test("dataPrune: passes dryRun flag through to deleteOrphanedData", async (
 
   assertEquals(receivedDryRun, true);
 });
+
+Deno.test(
+  "createDataPruneDeps: accepts an injected data repo",
+  async () => {
+    const dir = await Deno.makeTempDir({ prefix: "swamp-test-" });
+    try {
+      const injected = new FileSystemUnifiedDataRepository(
+        dir,
+        undefined,
+        new CatalogStore(":memory:"),
+      );
+      const deps = createDataPruneDeps(dir, undefined, injected);
+      assertEquals(typeof deps.findOrphanedData, "function");
+      assertEquals(typeof deps.deleteOrphanedData, "function");
+    } finally {
+      if (Deno.build.os === "windows") {
+        await Deno.remove(dir, { recursive: true }).catch(() => {});
+      } else {
+        await Deno.remove(dir, { recursive: true });
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Pass `repoContext.unifiedDataRepo` to `createDataDeleteDeps`, `createDataRenameDeps`, and `createDataPruneDeps` in the CLI commands so the shared data repository with its `markDirty` hook is reused instead of creating standalone instances without sync notification
- Add `injectedDataRepo` parameter to `createDataPruneDeps` (delete and rename already had it)
- Add unit test for the new `createDataPruneDeps` injection path

The CLI commands for `data delete`, `data rename`, and `data prune` each constructed a standalone `FileSystemUnifiedDataRepository` without the `markDirty` hook. The sync service never learned about dirty paths so `pushChanged()` fast-pathed to "no changes" — the next pull silently restored everything from the remote. The serve handlers already used the correct pattern; the CLI paths were missed when the `injectedDataRepo` escape hatch was added in 185c1922.

Closes swamp-club#1440

## Test Plan

- [x] Unit tests pass (9479 passed, 0 failed)
- [x] Reproduced with MinIO S3-compatible datastore: before fix, `data delete --all` reports "Commit complete, no index changes" and data reappears on next sync; after fix, reports "Committed 12 file(s) to datastore index" and data stays deleted
- [x] Existing UAT coverage in `swamp-uat/tests/cli/data/delete_test.ts`
- [x] `deno fmt`, `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)