### PR TITLE
fix(repo): use double quotes in .swamp.yaml to prevent quote style flip (swamp-club#1439)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,7 @@
     "jsr:@std/tar@~0.1.10": "0.1.10",
     "jsr:@std/text@^1.0.17": "1.0.18",
     "jsr:@std/yaml@*": "1.1.0",
+    "jsr:@std/yaml@1.1.0": "1.1.0",
     "jsr:@std/yaml@^1.1.0": "1.1.0",
     "npm:@aws-sdk/client-cloudcontrol@^3.1042.0": "3.1042.0",
     "npm:@marcbachmann/cel-js@7.6.1": "7.6.1",

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+import { parse as parseYaml } from "@std/yaml";
+import { stringify as stringifyYaml } from "@std/yaml/unstable-stringify";
 import { atomicWriteTextFile } from "./atomic_write.ts";
 import type { SwampVersion } from "../../domain/repo/swamp_version.ts";
 import type { RepoPath } from "../../domain/repo/repo_path.ts";
@@ -156,7 +157,9 @@ export class RepoMarkerRepository {
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
     delete cleanData.tool;
-    const content = stringifyYaml(cleanData as Record<string, unknown>);
+    const content = stringifyYaml(cleanData as Record<string, unknown>, {
+      quoteStyle: '"',
+    });
     await atomicWriteTextFile(path, content);
   }
 

--- a/src/infrastructure/persistence/repo_marker_repository_test.ts
+++ b/src/infrastructure/persistence/repo_marker_repository_test.ts
@@ -464,6 +464,26 @@ Deno.test("RepoMarkerRepository.write and read roundtrip with defaultVault", asy
   });
 });
 
+Deno.test("RepoMarkerRepository.write: uses double quotes for string values", async () => {
+  await withTempDir(async (dir) => {
+    const repo = new RepoMarkerRepository();
+    const repoPath = RepoPath.create(dir);
+
+    const data = {
+      swampVersion: "1.0.0",
+      initializedAt: "2024-01-15T10:30:00.000Z",
+      upgradedAt: "2024-02-20T14:00:00.000Z",
+    };
+
+    await repo.write(repoPath, data);
+
+    const markerPath = join(dir, ".swamp.yaml");
+    const content = await Deno.readTextFile(markerPath);
+    assertStringIncludes(content, 'initializedAt: "2024-01-15T10:30:00.000Z"');
+    assertStringIncludes(content, 'upgradedAt: "2024-02-20T14:00:00.000Z"');
+  });
+});
+
 Deno.test("RepoMarkerRepository.read: missing defaultVault returns undefined", async () => {
   await withTempDir(async (dir) => {
     const repo = new RepoMarkerRepository();


### PR DESCRIPTION
## Summary

- Switch `RepoMarkerRepository.write()` to use `@std/yaml/unstable-stringify` with `quoteStyle: '"'` so `.swamp.yaml` is serialized with double quotes, matching the format written by older swamp versions
- Prevents gratuitous quote style diffs (`"` → `'`) when the marker file is rewritten during CLI startup (e.g. the skill migration warning cooldown)
- Reported by @webframp — running `swamp extension quality --json` across 137 extensions caused 56 `.swamp.yaml` files to show as modified in `git status` due to the quote flip

Closes swamp-club#1439

## Test Plan

- [x] New unit test verifying `write()` produces double-quoted timestamp strings
- [x] All 9479 existing tests pass
- [x] Manual reproduction: created a scratch repo with double-quoted `.swamp.yaml` and local bundled skill copy, ran `swamp model list`, confirmed no quote style change in the output