### PR TITLE
docs(skills): add guard field documentation to workflow skill

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -19,8 +19,8 @@ description: >
   destroy, sync).
 - **Data** — versioned state snapshots produced by method runs; referenced via
   CEL expressions.
-- **Workflows** — declarative DAGs chaining model methods with assert steps for
-  validation.
+- **Workflows** — declarative DAGs chaining model methods with guard expressions
+  for idempotent execution and assert steps for validation.
 - **Vaults** — secret storage referenced by models at runtime.
 - **Extensions** — TypeScript packages adding model types, vault backends,
   datastores, and reports.
@@ -65,9 +65,12 @@ swamp data get <name>                          # get latest data snapshot
 
 # Workflows
 swamp workflow create <name>                   # create a new workflow
-swamp workflow run <name>                      # execute a workflow
 swamp workflow validate <name>                 # validate DAG before running
-swamp workflow history <name>                  # view past workflow runs
+swamp workflow run <name>                      # execute a workflow
+swamp workflow run <name> --input key=value    # execute with inputs
+swamp workflow resume <name>                   # resume a suspended workflow
+swamp workflow resume <name> --from <step>     # re-enter failed run at step
+swamp workflow history search --json           # search run history
 
 # Run tracking
 swamp run history                              # recent runs (last 24h)
@@ -83,16 +86,13 @@ swamp extension init <name>                    # scaffold a new extension
 
 ## Workflow
 
-Follow this procedure for every swamp task:
-
-1. **Route** — match the user's intent to a guide in the routing table above.
-2. **Load** — read that guide. If it doesn't answer the question, load its
-   companion `reference.md`. Load deeper `references/` files only when the guide
-   tells you to.
+1. **Route** — match intent to a guide in the routing table.
+2. **Load** — read the guide; load its `reference.md` if needed, deeper
+   `references/` only when the guide says to.
 3. **Validate** — before running any workflow: `swamp workflow validate <name>`.
    Before destructive methods (delete, stop, destroy):
-   `swamp model get <name> --json` to confirm the target. Proceed only when
-   validation passes.
+   `swamp model get <name> --json` to confirm the target exists and is in the
+   expected state. Proceed only when validation passes.
 4. **Execute** — run the command.
 5. **On failure** — load
    [references/troubleshooting/guide.md](references/troubleshooting/guide.md)

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -470,6 +470,88 @@ steps:
 - Downstream `dependsOn: succeeded` steps will skip; `dependsOn: completed`
   steps will run
 
+## Guard (Idempotent Step Execution)
+
+A step can declare a `guard` — a CEL expression evaluated before execution. When
+the guard evaluates truthy, the step is skipped (already done). When falsy or
+absent, the step executes normally.
+
+Guard is the workflow-level primitive for idempotent step execution, enabling
+safe workflow resume, re-run, and cron scheduling without re-executing completed
+steps.
+
+**Evaluation order:**
+
+1. Dependency conditions are checked (`dependsOn`)
+2. Expression context is built (including `self.*` for forEach steps)
+3. Guard expression is evaluated
+4. If truthy → step is skipped with reason `"guarded"`
+5. If falsy → step proceeds to execution
+
+**Guard patterns:**
+
+```yaml
+steps:
+  # Data truthiness — truthy scalar means done, null means not done
+  - name: read-plate
+    guard: ${{ data.latest("plate-reader", "scan-complete").attributes.id }}
+    task:
+      type: model_method
+      modelIdOrName: plate-reader
+      methodName: read-all
+
+  # Value comparison — same batch means skip, different batch means re-run
+  - name: dispense-reagent
+    guard: >-
+      ${{ data.latest("liquid-handler", "dispense-log").attributes.batchId
+          == inputs.batchId }}
+    task:
+      type: model_method
+      modelIdOrName: liquid-handler
+      methodName: dispense
+
+  # Method call — invoke a model method to check external state
+  - name: create-instance
+    guard: >-
+      ${{ model.method("infra", "check-exists",
+          {"name": inputs.instanceName}).stdout }}
+    task:
+      type: model_method
+      modelIdOrName: infra
+      methodName: create
+```
+
+**`model.method()` in guards:**
+
+`model.method(modelName, methodName)` or
+`model.method(modelName, methodName, inputs)` invokes a model method and returns
+the content of its first resource data output (parsed as JSON if possible). This
+lets guards check external state by running a lightweight probe method. For
+command/shell models the return value is `{exitCode, stdout, stderr, ...}`, so
+guard expressions typically access a specific field like `.stdout`.
+
+**forEach compatibility:** Guard expressions can reference `self.*`, so each
+expanded iteration evaluates its own guard independently:
+
+```yaml
+- name: read-plate
+  forEach:
+    item: well
+    in: ${{ range(1, 97) }}
+  guard: ${{ data.latest("plate-reader", self.well) }}
+  task:
+    type: model_method
+    modelIdOrName: plate-reader
+    methodName: read-single-well
+```
+
+**Error handling:** A CEL parse error or runtime error in a guard expression
+fails the step with a `step_failed` event containing the error message.
+
+**Events and rendering:** Guard-skipped steps emit a `step_skipped` event with
+`reason: "guarded"` (vs `"dependency"` for dependency skips). The console
+renderer shows `skipped (guarded)` to distinguish from dependency skips.
+
 ## Step Task Types
 
 Steps support four task types:
@@ -838,6 +920,11 @@ End-to-end workflow creation:
   [references/data-chaining.md](references/data-chaining.md) for `model.*` vs
   `data.latest()` expression guidance, delete/update workflow ordering, and
   command/shell chaining examples
+- **Idempotent execution with guards**: See
+  [references/scenarios.md](references/scenarios.md#scenario-6-idempotent-provisioning-with-guards)
+  for end-to-end examples of guard patterns — data truthiness, value comparison,
+  `model.method()` probes, forEach + guard for partial re-execution, and
+  scheduled workflow guards
 - **Remote execution**: See
   [references/remote-execution.md](references/remote-execution.md) for worker
   provisioning and step placement (target/labels/platform)

--- a/.claude/skills/swamp/references/workflow/references/data-chaining.md
+++ b/.claude/skills/swamp/references/workflow/references/data-chaining.md
@@ -284,6 +284,74 @@ The `vary` field lists input key names (matching keys in `task.inputs`). Their
 resolved values are appended to the data instance name with hyphens, producing
 names like `result-prod` or `result-dev-us-east-1`.
 
+## Guard Expressions for Idempotent Data Chaining
+
+Guards use the same data accessors as step inputs. A step can check whether its
+output data already exists before executing, making the workflow safe to re-run
+or resume without duplicating work.
+
+### Skip if data exists
+
+```yaml
+steps:
+  - name: lookup-ami
+    guard: ${{ data.latest("ami-lookup", "result") }}
+    task:
+      type: model_method
+      modelIdOrName: ami-lookup
+      methodName: execute
+  - name: create-instance
+    guard: ${{ data.latest("my-instance", "resource") }}
+    dependsOn:
+      - step: lookup-ami
+        condition:
+          type: completed
+    task:
+      type: model_method
+      modelIdOrName: my-instance
+      methodName: create
+```
+
+First run: both steps execute. Second run: both guards are truthy (data exists),
+both steps skip. If `lookup-ami` succeeded but `create-instance` failed, re-run
+skips the lookup and retries only the create.
+
+### Skip based on value comparison
+
+```yaml
+steps:
+  - name: deploy
+    guard: >-
+      ${{ data.latest("deploy-service", "result").attributes.version
+          == inputs.version }}
+    task:
+      type: model_method
+      modelIdOrName: deploy-service
+      methodName: deploy
+      inputs:
+        version: ${{ inputs.version }}
+```
+
+Skips if the deployed version matches the requested version. A new version
+triggers re-execution.
+
+### Probe external state with model.method()
+
+```yaml
+steps:
+  - name: create-vpc
+    guard: >-
+      ${{ model.method("vpc-lookup", "execute",
+          {"vpcName": inputs.vpcName}).stdout }}
+    task:
+      type: model_method
+      modelIdOrName: networking-vpc
+      methodName: create
+```
+
+Runs a lightweight probe method to check external state (e.g., does the VPC
+already exist in AWS?) before deciding whether to create it.
+
 ## Delete Workflow Ordering
 
 Delete workflows require **explicit `dependsOn`** in reverse dependency order.

--- a/.claude/skills/swamp/references/workflow/references/execution-semantics.md
+++ b/.claude/skills/swamp/references/workflow/references/execution-semantics.md
@@ -48,6 +48,25 @@ guards always execute on resume. Only works on failed runs — use the
 gate-approval path for suspended runs. If multiple failed runs exist, add
 `--run <run-id>` to disambiguate.
 
+## Step Evaluation Order
+
+When a step is ready to execute (all dependency conditions met), the executor
+follows this sequence:
+
+1. **Dependency conditions** — `dependsOn` conditions are checked. If not met,
+   the step is skipped with reason `"dependency"`.
+2. **Expression context** — the step's expression context is built, including
+   `self.*` for forEach steps, `inputs.*`, `data.*`, and `run.*`.
+3. **Guard evaluation** — if the step declares a `guard` expression, it is
+   evaluated. A truthy result skips the step with reason `"guarded"` (already
+   done). A falsy result proceeds to execution. A CEL error fails the step.
+4. **Task execution** — the step's task runs (model method, nested workflow,
+   manual approval, or assert).
+
+Guard evaluation happens after dependency checks but before task execution. This
+means a guarded step still respects its dependency graph — it won't evaluate the
+guard at all if its dependencies haven't been met.
+
 ## Concurrency Limits
 
 The `concurrency` field caps parallel execution at three levels:

--- a/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
+++ b/.claude/skills/swamp/references/workflow/references/expressions-and-foreach.md
@@ -151,6 +151,35 @@ through `task.inputs`. See
 [nested-workflows.md § When to Use Nested Workflows](nested-workflows.md#when-to-use-nested-workflows)
 for the full pattern.
 
+### forEach with Guards
+
+Guard expressions can reference `self.*`, so each forEach iteration evaluates
+its own guard independently. This enables partial re-execution — on resume or
+re-run, completed iterations are skipped while failed or unstarted iterations
+execute:
+
+```yaml
+steps:
+  - name: deploy-${{ self.env }}
+    forEach:
+      item: env
+      in: ${{ inputs.environments }}
+    guard: ${{ data.latest("deploy-service", "result", [self.env]) }}
+    task:
+      type: model_method
+      modelIdOrName: deploy-service
+      methodName: deploy
+      inputs:
+        environment: ${{ self.env }}
+    dataOutputOverrides:
+      - specName: result
+        vary:
+          - environment
+```
+
+If `dev` and `staging` succeed but `prod` fails, re-running the workflow skips
+`dev` and `staging` (their guards are truthy) and retries only `prod`.
+
 ### forEach with Concurrency Limits
 
 By default, all forEach iterations run in parallel. Add `concurrency` to cap

--- a/.claude/skills/swamp/references/workflow/references/scenarios.md
+++ b/.claude/skills/swamp/references/workflow/references/scenarios.md
@@ -9,6 +9,7 @@ End-to-end scenarios showing how to build workflows for common use cases.
 - [Scenario 3: forEach Iteration](#scenario-3-foreach-iteration)
 - [Scenario 4: Conditional Cleanup](#scenario-4-conditional-cleanup)
 - [Scenario 5: Nested Workflows](#scenario-5-nested-workflows)
+- [Scenario 6: Idempotent Provisioning with Guards](#scenario-6-idempotent-provisioning-with-guards)
 
 ---
 
@@ -561,6 +562,167 @@ swamp workflow run deploy-and-notify --input environment=production
 | deploy-and-notify | `inputs.environment` | Parent workflow input |
 | notify-team       | `inputs.message`     | Passed from parent    |
 | notify-team       | `inputs.channel`     | Passed from parent    |
+
+---
+
+## Scenario 6: Idempotent Provisioning with Guards
+
+### User Request
+
+> "I need a provisioning workflow I can safely re-run. If a step already
+> completed, it should skip instead of re-creating the resource."
+
+### What You'll Build
+
+- 1 workflow with guard expressions on each step
+- Guards that check whether output data already exists
+- Safe re-run: only incomplete steps execute
+
+### Decision Tree
+
+```
+Need to re-run safely → Guard expressions
+Check if step already done → data.latest() truthiness
+Check external state → model.method() in guard
+Per-iteration resume → forEach + guard with self.*
+```
+
+### Step-by-Step
+
+**1. Create the models**
+
+```bash
+swamp model create @user/vpc networking-vpc --json
+swamp model create @user/subnet public-subnet --json
+swamp model create @user/security-group app-sg --json
+```
+
+**2. Create the workflow with guards**
+
+```bash
+swamp workflow create provision-networking --json
+```
+
+```yaml
+id: a9b0c1d2-e3f4-4a5b-6c7d-8e9f0a1b2c3d
+name: provision-networking
+description: Idempotent networking provisioning — safe to re-run
+version: 1
+jobs:
+  - name: create-vpc
+    steps:
+      - name: vpc
+        guard: ${{ data.latest("networking-vpc", "resource") }}
+        task:
+          type: model_method
+          modelIdOrName: networking-vpc
+          methodName: create
+
+  - name: create-subnets
+    dependsOn:
+      - job: create-vpc
+        condition:
+          type: succeeded
+    steps:
+      - name: subnet
+        guard: ${{ data.latest("public-subnet", "resource") }}
+        task:
+          type: model_method
+          modelIdOrName: public-subnet
+          methodName: create
+
+  - name: create-sg
+    dependsOn:
+      - job: create-subnets
+        condition:
+          type: succeeded
+    steps:
+      - name: security-group
+        guard: ${{ data.latest("app-sg", "resource") }}
+        task:
+          type: model_method
+          modelIdOrName: app-sg
+          methodName: create
+```
+
+**3. First run — everything executes**
+
+```bash
+swamp workflow run provision-networking
+# vpc ✓, subnet ✓, security-group ✓
+```
+
+**4. Second run — everything skips**
+
+```bash
+swamp workflow run provision-networking
+# vpc skipped (guarded), subnet skipped (guarded), security-group skipped (guarded)
+```
+
+**5. Partial failure recovery**
+
+If subnet succeeded but security-group failed, re-running skips vpc and subnet,
+retries only security-group.
+
+### Guard Patterns Used
+
+| Guard expression                                | Meaning                      |
+| ----------------------------------------------- | ---------------------------- |
+| `data.latest("model", "spec")`                  | Truthy if data exists        |
+| `data.latest("model", "spec").attributes.field` | Truthy if field has a value  |
+| `model.method("model", "check", {}).stdout`     | Truthy if probe returns data |
+| `data.latest(...).attributes.v == inputs.v`     | Truthy if values match       |
+
+### Combining Guards with forEach
+
+For multi-environment provisioning, guards make each iteration independently
+resumable:
+
+```yaml
+jobs:
+  - name: deploy-all
+    steps:
+      - name: deploy-${{ self.env }}
+        forEach:
+          item: env
+          in: ${{ inputs.environments }}
+        guard: ${{ data.latest("deploy-service", "result", [self.env]) }}
+        task:
+          type: model_method
+          modelIdOrName: deploy-service
+          methodName: deploy
+          inputs:
+            environment: ${{ self.env }}
+        dataOutputOverrides:
+          - specName: result
+            vary:
+              - environment
+```
+
+If `dev` and `staging` succeed but `prod` fails, re-running skips `dev` and
+`staging` (their guards find existing data) and retries only `prod`.
+
+### Combining Guards with Scheduled Workflows
+
+Guards are essential for cron-scheduled workflows. Without guards, a scheduled
+workflow re-executes every step on every tick. With guards, completed steps are
+skipped and only pending work executes:
+
+```yaml
+trigger:
+  schedule: "*/30 * * * *"
+jobs:
+  - name: sync
+    steps:
+      - name: fetch-data
+        guard: >-
+          ${{ model.method("api-client", "check-freshness",
+              {"maxAge": 1800}).stdout }}
+        task:
+          type: model_method
+          modelIdOrName: api-client
+          methodName: fetch
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Add guard field documentation across all workflow skill reference files
  so it reads as a first-class concept, not an afterthought
- Full "Guard (Idempotent Step Execution)" section in `reference.md` with
  evaluation order, three guard patterns (data truthiness, value comparison,
  `model.method()` probe), forEach compatibility, error handling, and rendering
- New "Step Evaluation Order" section in `execution-semantics.md` showing where
  guard sits in the execution pipeline
- New "forEach with Guards" section in `expressions-and-foreach.md` for partial
  re-execution patterns
- New "Guard Expressions for Idempotent Data Chaining" section in
  `data-chaining.md` with skip-if-exists, value comparison, and external probe
  patterns
- New "Scenario 6: Idempotent Provisioning with Guards" in `scenarios.md` with
  end-to-end walkthrough, forEach + guard, and scheduled workflow guard patterns
- Updated `SKILL.md` core concepts, common commands (added resume, `--from`,
  validate ordering), and tightened workflow procedure

Follows up on #1993 (guard implementation) and #1998 (`--from` resume).

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `npx tessl skill review .claude/skills/swamp` — 92% (description 100%, content 85%)
- [x] Conflict with #1998's `execution-semantics.md` additions resolved — both
  the `--from` resume section and guard evaluation order section are preserved
- [x] All `--from` additions to `reference.md` and `guide.md` verified intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)