### PR TITLE
fix(cel): allow indexing into JSON content via .content.<key> (swamp-club#1445)

### DIFF
--- a/design/expressions.md
+++ b/design/expressions.md
@@ -253,6 +253,19 @@ attributes:
   result: ${{ data.latest('my-model', 'output').attributes.value }}
 ```
 
+For `application/json` resources, `.content` is the same parsed object as
+`.attributes`, so both access patterns work:
+
+```yaml
+inputs:
+  # These are equivalent for JSON resources:
+  via_attributes: ${{ data.latest('shell-runner', 'result').attributes.stdout }}
+  via_content: ${{ data.latest('shell-runner', 'result').content.stdout }}
+```
+
+For non-JSON content types (e.g. `text/plain`), `.content` remains the raw text
+string.
+
 ### data.version(modelName, dataName, version)
 
 Returns a specific version of a data artifact:

--- a/src/domain/data/data_record.ts
+++ b/src/domain/data/data_record.ts
@@ -47,7 +47,7 @@ export interface DataRecord {
   ownerType: string;
   streaming: boolean;
   size: number;
-  content: string;
+  content: unknown;
 
   // Provenance fields — promoted from tags/ownerDefinition to first-class.
   // Empty string when the data was not produced inside a workflow.

--- a/src/domain/data/data_record_mapper.ts
+++ b/src/domain/data/data_record_mapper.ts
@@ -42,9 +42,9 @@ function parseContent(
   contentType: string,
   loadAttributes: boolean,
   loadContent: boolean,
-): { attributes: Record<string, unknown>; textContent: string } {
+): { attributes: Record<string, unknown>; textContent: unknown } {
   let attributes: Record<string, unknown> = {};
-  let textContent = "";
+  let textContent: unknown = "";
 
   if (!rawBytes) return { attributes, textContent };
 
@@ -56,6 +56,7 @@ function parseContent(
   if (loadAttributes && contentType === "application/json") {
     try {
       attributes = JSON.parse(decoded) as Record<string, unknown>;
+      textContent = attributes;
     } catch {
       // Not valid JSON, use empty attributes
     }
@@ -248,8 +249,7 @@ export async function fromData(
  *   only — other content types yield empty attributes. Downstream
  *   CEL access patterns reference `attributes.<field>`; raw text
  *   content is intentionally not eagerly loaded into the record.
- * - `content` is always "" (parsing into attributes is sufficient
- *   for downstream CEL).
+ * - `content` is the parsed attributes object for JSON, otherwise "".
  * - `dataType` defaults to "resource" rather than "" because the
  *   caller already knows the handle is a resource.
  *
@@ -309,7 +309,9 @@ export async function fromResourceHandle(
     ownerType: handle.metadata.ownerDefinition.ownerType,
     streaming: handle.metadata.streaming,
     size: handle.size,
-    content: "",
+    content: handle.metadata.contentType === "application/json"
+      ? attributes
+      : "",
     ownerRef: handle.metadata.ownerDefinition.ownerRef,
     workflowRunId: handle.metadata.ownerDefinition.workflowRunId ?? "",
     workflowName: handle.metadata.ownerDefinition.workflowName ?? "",

--- a/src/domain/data/data_record_mapper_test.ts
+++ b/src/domain/data/data_record_mapper_test.ts
@@ -79,7 +79,7 @@ Deno.test("fromRow: parses JSON attributes when loadAttributes is true", () => {
   const record = fromRow(createRow(), repo, true, false);
 
   assertEquals(record.attributes, json);
-  assertEquals(record.content, "");
+  assertEquals(record.content, json);
 });
 
 Deno.test("fromRow: loads text content when loadContent is true", () => {
@@ -99,7 +99,7 @@ Deno.test("fromRow: loads both attributes and content together", () => {
   const record = fromRow(createRow(), repo, true, true);
 
   assertEquals(record.attributes, json);
-  assertEquals(record.content, JSON.stringify(json));
+  assertEquals(record.content, json);
 });
 
 Deno.test("fromRow: skips content loading when both flags are false", () => {
@@ -250,7 +250,7 @@ Deno.test("fromData: parses JSON content and resolves attributes", async () => {
   );
 
   assertEquals(record!.attributes, json);
-  assertEquals(record!.content, JSON.stringify(json));
+  assertEquals(record!.content, json);
   assertEquals(record!.name, "my-data");
   assertEquals(record!.modelType, "test/model");
   assertEquals(record!.specName, "my-spec");
@@ -460,4 +460,108 @@ Deno.test("fromResourceHandle: returns raw vault refs when vaultService is omitt
 
   assertEquals(record.attributes.apiKey, vaultRef);
   assertEquals(record.attributes.label, "test");
+});
+
+// ============================================================================
+// content — JSON content is parsed object, not raw string
+// ============================================================================
+
+Deno.test("fromRow: content is parsed object for JSON, enabling dot access", () => {
+  const json = { exitCode: 0, stdout: "12929", stderr: "" };
+  const repo = stubRepo(encoder.encode(JSON.stringify(json)));
+  const record = fromRow(createRow(), repo, true, true);
+
+  const content = record.content as Record<string, unknown>;
+  assertEquals(content.exitCode, 0);
+  assertEquals(content.stdout, "12929");
+  assertEquals(content.stderr, "");
+});
+
+Deno.test("fromRow: content remains raw string for text/plain", () => {
+  const text = "hello world";
+  const repo = stubRepo(encoder.encode(text));
+  const record = fromRow(
+    createRow({ content_type: "text/plain" }),
+    repo,
+    false,
+    true,
+  );
+
+  assertEquals(record.content, text);
+});
+
+Deno.test("fromRow: content is same reference as attributes for JSON", () => {
+  const json = { key: "value" };
+  const repo = stubRepo(encoder.encode(JSON.stringify(json)));
+  const record = fromRow(createRow(), repo, true, true);
+
+  assertEquals(record.content === record.attributes, true);
+});
+
+Deno.test("fromResourceHandle: content is parsed attributes for JSON", async () => {
+  const data = { exitCode: 0, stdout: "output" };
+  const repo = stubRepo(null, encoder.encode(JSON.stringify(data)));
+
+  const handle: DataHandle = {
+    name: "result",
+    specName: "result",
+    kind: "resource",
+    dataId: "data-id-1" as DataId,
+    version: 1,
+    size: 100,
+    tags: { type: "resource", modelName: "test-model" },
+    metadata: {
+      contentType: "application/json",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: {},
+      ownerDefinition: { ownerType: "model-method", ownerRef: "ref-1" },
+    },
+  };
+
+  const record = await fromResourceHandle(
+    handle,
+    ModelType.create("test/model"),
+    "model-123",
+    "test-model",
+    repo,
+  );
+
+  const content = record.content as Record<string, unknown>;
+  assertEquals(content.exitCode, 0);
+  assertEquals(content.stdout, "output");
+  assertEquals(record.content === record.attributes, true);
+});
+
+Deno.test("fromResourceHandle: content is empty string for non-JSON", async () => {
+  const repo = stubRepo(null, encoder.encode("plain text"));
+
+  const handle: DataHandle = {
+    name: "result",
+    specName: "result",
+    kind: "resource",
+    dataId: "data-id-1" as DataId,
+    version: 1,
+    size: 100,
+    tags: { type: "resource", modelName: "test-model" },
+    metadata: {
+      contentType: "text/plain",
+      lifetime: "infinite",
+      garbageCollection: 10,
+      streaming: false,
+      tags: {},
+      ownerDefinition: { ownerType: "model-method", ownerRef: "ref-1" },
+    },
+  };
+
+  const record = await fromResourceHandle(
+    handle,
+    ModelType.create("test/model"),
+    "model-123",
+    "test-model",
+    repo,
+  );
+
+  assertEquals(record.content, "");
 });

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -1013,7 +1013,7 @@ export class ModelResolver {
 
     const resolvedVersion = version ?? data.version;
     let attributes: Record<string, unknown> = {};
-    let textContent = "";
+    let textContent: unknown = "";
 
     if (isTextContentType(data.contentType)) {
       const rawBytes = this.dataRepo.getContentSync(
@@ -1028,6 +1028,7 @@ export class ModelResolver {
         if (data.contentType === "application/json") {
           try {
             attributes = JSON.parse(decoded) as Record<string, unknown>;
+            textContent = attributes;
           } catch {
             // Not valid JSON, use empty attributes
           }

--- a/src/infrastructure/cel/cel_evaluator_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_test.ts
@@ -1293,3 +1293,105 @@ Deno.test("evaluateAsync: mixed-type map literals with dyn and string values", a
   );
   assertEquals(result, { name: "host1", address: "10.0.0.1", user: "ansible" });
 });
+
+// --- .content.<key> access for JSON resources (swamp-club#1445) ---
+
+Deno.test("CelEvaluator: data.latest().content.<key> works for JSON resources", () => {
+  const evaluator = new CelEvaluator();
+  const parsed = { exitCode: 0, stdout: "12929", stderr: "" };
+  const context = {
+    data: {
+      latest: (modelName: string, dataName: string) => {
+        if (modelName === "shell-runner" && dataName === "result") {
+          return {
+            id: "data-1",
+            name: "result",
+            version: 1,
+            contentType: "application/json",
+            attributes: parsed,
+            content: parsed,
+          };
+        }
+        return null;
+      },
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      'data.latest("shell-runner", "result").content.stdout',
+      context,
+    ),
+    "12929",
+  );
+  assertEquals(
+    evaluator.evaluate(
+      'data.latest("shell-runner", "result").content.exitCode',
+      context,
+    ),
+    0,
+  );
+});
+
+Deno.test("CelEvaluator: content and attributes are interchangeable for JSON resources", () => {
+  const evaluator = new CelEvaluator();
+  const parsed = { exitCode: 0, stdout: "output" };
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => ({
+        attributes: parsed,
+        content: parsed,
+      }),
+    },
+  };
+
+  assertEquals(
+    evaluator.evaluate(
+      'data.latest("m", "r").content.stdout',
+      context,
+    ),
+    "output",
+  );
+  assertEquals(
+    evaluator.evaluate(
+      'data.latest("m", "r").attributes.stdout',
+      context,
+    ),
+    "output",
+  );
+});
+
+Deno.test("CelEvaluator: .?content.?key optional select works for JSON resources", async () => {
+  const evaluator = new CelEvaluator();
+  const parsed = { stdout: "hello" };
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) =>
+        Promise.resolve({
+          attributes: parsed,
+          content: parsed,
+        }),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    'data.latest("m", "r").?content.?stdout',
+    context,
+  );
+  assertEquals(result, "hello");
+});
+
+Deno.test("CelEvaluator: .?content.?key returns null when data doesn't exist", async () => {
+  const evaluator = new CelEvaluator();
+  const context = {
+    data: {
+      latest: (_m: string, _d: string) => Promise.resolve(null),
+    },
+  };
+
+  const result = await evaluator.evaluateAsync(
+    'data.latest("m", "r").?content.?stdout',
+    context,
+  );
+  assertEquals(result, null);
+});


### PR DESCRIPTION
## Summary

- For `application/json` resources, `DataRecord.content` is now the parsed JSON
  object (same reference as `attributes`) instead of the raw string
- CEL expressions like `data.latest('model', 'name').content.stdout` now work
  alongside `.attributes.stdout`
- Aligns CEL behavior with what `swamp data get --json` shows to users

Fixes swamp-club#1445

## Test plan

- [x] Updated 3 existing mapper tests to expect parsed object
- [x] Added 5 new mapper tests (content dot access, text/plain unchanged, same reference, fromResourceHandle JSON/non-JSON)
- [x] Added 4 CEL evaluator tests (.content.<key>, content/attributes interchangeable, .?content.?key, null data)
- [x] Full test suite passes (9509 tests, 0 failures)
- [x] Reproduced the issue in scratch repo, verified fix with compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBRyrE9UwsXkTjicaWdRA