### PR TITLE
fix(output): downgrade model-name-vs-UUID warnings to debug level

### DIFF
--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -526,7 +526,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   ): Promise<Data[]> {
     if (!isUuid(modelId)) {
       logger
-        .warn`findAllForModel called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
+        .debug`findAllForModel called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
     }
     type = coerceModelType(type);
     const dataDir = this.getModelDataDir(type, modelId);
@@ -743,7 +743,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
   ): Promise<Uint8Array | null> {
     if (!isUuid(modelId)) {
       logger
-        .warn`getContent called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
+        .debug`getContent called with model name ${modelId} instead of a UUID — use context.readModelData(${modelId}) for cross-model access by name`;
     }
     type = coerceModelType(type);
     const versionToRead = version ??


### PR DESCRIPTION
## Summary

- Downgraded two LogTape warnings in `unified_data_repository.ts` from
  `.warn` to `.debug` — the "called with model name instead of a UUID"
  messages in `findAllForModel` and `getContent`
- These developer diagnostics were the last remaining LogTape warnings
  leaking raw timestamped output into workflow runs (following the
  pipe-prefixed conversion in 44f7d5f3)
- At `.debug` level they remain available for development but no longer
  pollute user-facing workflow output

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] All 39 `unified_data_repository_test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)