### PR TITLE
fix(testing): align DataRecord.content type with canonical definition

### DIFF
--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -160,7 +160,7 @@ export interface DataRecord {
   ownerType: string;
   streaming: boolean;
   size: number;
-  content: string;
+  content: unknown;
   ownerRef: string;
   workflowRunId: string;
   workflowName: string;


### PR DESCRIPTION
## Summary

- Updates `packages/testing/types.ts` `DataRecord.content` from `string` to `unknown` to match the canonical type changed in #2000
- Prevents extension authors from writing tests that assume `content` is always a string when it's now a parsed JSON object for `application/json` resources

Follow-up to #2000 (swamp-club#1445), flagged by the adversarial code review.

## Test plan

- [x] `deno check` passes (only pre-existing bench file error)
- [x] One-line type change, no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmBRyrE9UwsXkTjicaWdRA