### PR TITLE
feat(models): expose resource attributes in DataHandle (swamp-club#1401)

### DIFF
--- a/.claude/skills/swamp/references/extension/references/model/api.md
+++ b/.claude/skills/swamp/references/extension/references/model/api.md
@@ -289,16 +289,17 @@ const handle = await streamWriter.finalize();
 
 Returned by `writeResource` and writer methods:
 
-| Field      | Description                                |
-| ---------- | ------------------------------------------ |
-| `name`     | Data artifact name                         |
-| `specName` | The declared spec name                     |
-| `kind`     | `"resource"` or `"file"`                   |
-| `dataId`   | Unique ID for this data                    |
-| `version`  | Version number of this write               |
-| `size`     | Size of the written content in bytes       |
-| `tags`     | Tags from the writer options               |
-| `metadata` | Metadata for the data artifact (see below) |
+| Field        | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| `name`       | Data artifact name                                           |
+| `specName`   | The declared spec name                                       |
+| `kind`       | `"resource"` or `"file"`                                     |
+| `dataId`     | Unique ID for this data                                      |
+| `version`    | Version number of this write                                 |
+| `size`       | Size of the written content in bytes                         |
+| `tags`       | Tags from the writer options                                 |
+| `metadata`   | Metadata for the data artifact (see below)                   |
+| `attributes` | Top-level resource attributes (resource kind only, optional) |
 
 **`metadata` sub-fields:**
 

--- a/design/models.md
+++ b/design/models.md
@@ -630,6 +630,7 @@ Lightweight reference to data already persisted:
 | `size`     | Size of the written content in bytes      |
 | `tags`     | Tags from the writer options              |
 | `metadata` | Full metadata for the data artifact       |
+| `attributes` | Top-level resource attributes (resource kind only, optional) |
 
 ## Output
 

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -86,6 +86,8 @@ export interface DataHandle {
   tags: Record<string, string>;
   /** Metadata excluding auto-generated fields. */
   metadata: DataHandleMetadata;
+  /** Top-level resource attributes (resource kind only). */
+  attributes?: Record<string, unknown>;
 }
 
 /** Writer for binary or text file data. */

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -645,6 +645,7 @@ export function createResourceWriter(
       ? redactor.redact(JSON.stringify(data))
       : JSON.stringify(data);
     const handle = await writer.writeText(serialized);
+    handle.attributes = { ...data };
     handles.push(handle);
     return handle;
   };

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -1904,3 +1904,37 @@ Deno.test("processSensitiveResourceData: falls back to vaultNames[0] when no def
 
   assertStringIncludes(data.secret as string, "'alpha-vault'");
 });
+
+// --- createResourceWriter attributes tests ---
+
+Deno.test("createResourceWriter: resource handle includes attributes from written data", async () => {
+  const repo = createMockRepo();
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+  );
+
+  const handle = await writeResource("item", "test-item", {
+    value: "hello",
+  });
+  assertEquals(handle.attributes, { value: "hello" });
+});
+
+Deno.test("createResourceWriter: attributes is a shallow copy of the data", async () => {
+  const repo = createMockRepo();
+
+  const { writeResource } = createResourceWriter(
+    repo,
+    modelType,
+    modelId,
+    testResources,
+  );
+
+  const data = { value: "hello" };
+  const handle = await writeResource("item", "test-item", data);
+  data.value = "mutated";
+  assertEquals(handle.attributes, { value: "hello" });
+});

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -549,6 +549,8 @@ export interface DataHandle {
     DataMetadata,
     "id" | "name" | "version" | "createdAt" | "size" | "checksum"
   >;
+  /** Top-level resource attributes (resource kind only). */
+  attributes?: Record<string, unknown>;
 }
 
 /**

--- a/src/domain/models/testing_package_compat_test.ts
+++ b/src/domain/models/testing_package_compat_test.ts
@@ -173,8 +173,9 @@ function _checkDataHandleFields(handle: TestingDataHandle) {
   // dataId: canonical uses branded DataId, testing uses plain string.
   // The brand is a compile-time fiction — extension authors never construct DataIds.
   const _dataId: string = handle.dataId;
+  const _attributes: CanonicalDataHandle["attributes"] = handle.attributes;
 
-  void [_name, _specName, _kind, _version, _size, _tags, _dataId];
+  void [_name, _specName, _kind, _version, _size, _tags, _dataId, _attributes];
 }
 
 // DataWriter: verify method parameter types match.


### PR DESCRIPTION
## Summary

- Add optional `attributes?: Record<string, unknown>` field to `DataHandle` so workflow reports can access top-level resource scalars without round-tripping through `dataRepository.getContent()` + JSON parse
- Populate the field in `createResourceWriter` with a shallow copy of the resource data after writing
- Mirror the field in `@swamp/testing` `DataHandle` and update the compat test
- Update DataHandle documentation in `design/models.md` and the extension model API skill reference

Closes swamp-club#1401

## Test Plan

- 2 new unit tests in `data_writer_test.ts`: resource handles include attributes, attributes is a shallow copy (mutation safety)
- Compat test updated to verify `@swamp/testing` DataHandle mirrors the new field
- Full test suite passes (9502 passed, 0 failed)
- `deno check`, `deno lint`, `deno fmt` all clean (pre-existing type error in `deno_runtime.ts` unrelated)