### PR TITLE
feat(workflows): add --graph flag to workflow get for DAG visualization

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -53,7 +53,8 @@
     "@opentelemetry/core": "npm:@opentelemetry/core@^1.30.1",
     "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@^1.30.1",
     "@opentelemetry/resources": "npm:@opentelemetry/resources@^1.30.1",
-    "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.40.0"
+    "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.40.0",
+    "@vercel/beautiful-mermaid": "npm:@vercel/beautiful-mermaid@^0.1.5"
   },
   "compilerOptions": {
     "jsx": "react",

--- a/deno.lock
+++ b/deno.lock
@@ -40,6 +40,7 @@
     "npm:@opentelemetry/semantic-conventions@^1.40.0": "1.40.0",
     "npm:@types/node@24.0.7": "24.0.7",
     "npm:@types/react@^19.2.14": "19.2.14",
+    "npm:@vercel/beautiful-mermaid@~0.1.5": "0.1.5",
     "npm:croner@^9.1.0": "9.1.0",
     "npm:fast-check@^3.23.2": "3.23.2",
     "npm:fast-json-patch@^3.1.1": "3.1.1",
@@ -564,6 +565,15 @@
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@dagrejs/dagre@1.1.8": {
+      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
+      "dependencies": [
+        "@dagrejs/graphlib"
+      ]
+    },
+    "@dagrejs/graphlib@2.2.4": {
+      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw=="
+    },
     "@marcbachmann/cel-js@7.6.1": {
       "integrity": "sha512-YyY8yiDU07ByKb2rJUoNgMAkYeeDvkdrONBREV2MP9siAW7yNft0KfbIoonWTIMY0fGtv8og0EhzKx3Xsi1Nmg==",
       "bin": true
@@ -1054,6 +1064,12 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dependencies": [
         "csstype"
+      ]
+    },
+    "@vercel/beautiful-mermaid@0.1.5": {
+      "integrity": "sha512-GAM0bsZUxq8mVzml3B2YbW3E+TkTzQ8VC+LopMk7dk3IA+K5UcPUnAoN6zCgXQMtZH4sn/keQQqbpeTBjkLnaQ==",
+      "dependencies": [
+        "@dagrejs/dagre"
       ]
     },
     "ansi-escapes@7.3.0": {
@@ -1745,6 +1761,7 @@
       "npm:@opentelemetry/sdk-trace-base@^1.30.1",
       "npm:@opentelemetry/semantic-conventions@^1.40.0",
       "npm:@types/react@^19.2.14",
+      "npm:@vercel/beautiful-mermaid@~0.1.5",
       "npm:croner@^9.1.0",
       "npm:fast-check@^3.23.2",
       "npm:fast-json-patch@^3.1.1",

--- a/src/cli/commands/workflow_get.ts
+++ b/src/cli/commands/workflow_get.ts
@@ -48,10 +48,15 @@ export const workflowGetCommand = withRemoteOptions(
     .name("get")
     .description("Show details of a workflow")
     .example("Show workflow details", "swamp workflow get deploy-pipeline")
+    .example("Show workflow DAG", "swamp workflow get deploy-pipeline --graph")
     .arguments("<workflow_id_or_name:workflow_name>")
     .option(
       "--repo-dir <dir:string>",
       "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--graph",
+      "Render the workflow as a dependency graph",
     ),
   // @ts-expect-error - Cliffy custom type returns unknown instead of string
 ).action(async function (options: AnyOptions, workflowIdOrName: string) {
@@ -70,7 +75,8 @@ export const workflowGetCommand = withRemoteOptions(
         payload: { workflowIdOrName },
       },
     );
-    const renderer = createWorkflowGetRenderer(cliCtx.outputMode);
+    const graph = Boolean(options.graph);
+    const renderer = createWorkflowGetRenderer(cliCtx.outputMode, { graph });
     await consumeStream(
       (async function* () {
         yield {
@@ -93,7 +99,8 @@ export const workflowGetCommand = withRemoteOptions(
   const ctx = createLibSwampContext({ logger: cliCtx.logger });
   const deps = createWorkflowGetDeps(repoContext.workflowRepo);
 
-  const renderer = createWorkflowGetRenderer(cliCtx.outputMode);
+  const graph = Boolean(options.graph);
+  const renderer = createWorkflowGetRenderer(cliCtx.outputMode, { graph });
   await consumeStream(
     workflowGet(ctx, deps, workflowIdOrName),
     renderer.handlers(),

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -277,6 +277,8 @@ export {
   type WorkflowGetData,
   type WorkflowGetDeps,
   type WorkflowGetEvent,
+  type WorkflowGetJobDependency,
+  type WorkflowGetStepDependency,
 } from "./workflows/get.ts";
 export {
   createWorkflowHistoryGetDeps,

--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -19,6 +19,7 @@
 
 import type { InputsSchema } from "../../domain/definitions/definition.ts";
 import type { ReportSelection } from "../../domain/reports/report_selection.ts";
+import type { TriggerConditionData } from "../../domain/workflows/trigger_condition.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import {
   createWorkflowId,
@@ -30,6 +31,17 @@ import type { SwampError } from "../errors.ts";
 import { notFound } from "../errors.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+export interface WorkflowGetJobDependency {
+  job: string;
+  condition: TriggerConditionData;
+}
+
+export interface WorkflowGetStepDependency {
+  step: string;
+  condition: TriggerConditionData;
+}
+
 /**
  * Data structure for the workflow get output.
  */
@@ -44,9 +56,11 @@ export interface WorkflowGetData {
   jobs: {
     name: string;
     description?: string;
+    dependsOn: WorkflowGetJobDependency[];
     steps: {
       name: string;
       description?: string;
+      dependsOn: WorkflowGetStepDependency[];
       task: {
         type: string;
         [key: string]: unknown;
@@ -118,9 +132,17 @@ export async function* workflowGet(
         jobs: workflow.jobs.map((job) => ({
           name: job.name,
           description: job.description,
+          dependsOn: job.dependsOn.map((d) => ({
+            job: d.job,
+            condition: d.condition.toData(),
+          })),
           steps: job.steps.map((step) => ({
             name: step.name,
             description: step.description,
+            dependsOn: step.dependsOn.map((d) => ({
+              step: d.step,
+              condition: d.condition.toData(),
+            })),
             task: step.task.toData(),
           })),
         })),

--- a/src/libswamp/workflows/get_test.ts
+++ b/src/libswamp/workflows/get_test.ts
@@ -42,7 +42,12 @@ const testWorkflow = {
   reports: { require: ["junit"] },
   jobs: [{
     name: "job1",
-    steps: [{ name: "step1", task: { toData: () => ({ type: "model/run" }) } }],
+    dependsOn: [],
+    steps: [{
+      name: "step1",
+      dependsOn: [],
+      task: { toData: () => ({ type: "model/run" }) },
+    }],
   }],
 };
 
@@ -96,9 +101,11 @@ Deno.test("workflowGet yields resolving -> completed with workflow data on succe
         jobs: [{
           name: "job1",
           description: undefined,
+          dependsOn: [],
           steps: [{
             name: "step1",
             description: undefined,
+            dependsOn: [],
             task: { type: "model/run" },
           }],
         }],

--- a/src/presentation/renderers/workflow_get.ts
+++ b/src/presentation/renderers/workflow_get.ts
@@ -25,13 +25,24 @@ import type {
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
 import { UserError } from "../../domain/errors.ts";
+import { renderWorkflowGraph } from "./workflow_graph.ts";
+
+export interface WorkflowGetRendererOptions {
+  graph?: boolean;
+}
 
 class LogWorkflowGetRenderer implements Renderer<WorkflowGetEvent> {
+  constructor(private readonly options: WorkflowGetRendererOptions) {}
+
   handlers(): EventHandlers<WorkflowGetEvent> {
     return {
       resolving: () => {},
       completed: (e) => {
-        console.log(JSON.stringify(e.data, null, 2));
+        if (this.options.graph) {
+          console.log(renderWorkflowGraph(e.data));
+        } else {
+          console.log(JSON.stringify(e.data, null, 2));
+        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -56,12 +67,13 @@ class JsonWorkflowGetRenderer implements Renderer<WorkflowGetEvent> {
 
 export function createWorkflowGetRenderer(
   mode: OutputMode,
+  options: WorkflowGetRendererOptions = {},
 ): Renderer<WorkflowGetEvent> {
   switch (mode) {
     case "json":
       return new JsonWorkflowGetRenderer();
     case "log":
-      return new LogWorkflowGetRenderer();
+      return new LogWorkflowGetRenderer(options);
   }
 }
 

--- a/src/presentation/renderers/workflow_get_test.ts
+++ b/src/presentation/renderers/workflow_get_test.ts
@@ -35,7 +35,19 @@ const testData: WorkflowGetData = {
   },
   tags: { team: "platform" },
   reports: undefined,
-  jobs: [],
+  jobs: [
+    {
+      name: "build",
+      dependsOn: [],
+      steps: [
+        {
+          name: "compile",
+          dependsOn: [],
+          task: { type: "model_method" },
+        },
+      ],
+    },
+  ],
   path: "/repo/workflows/my-workflow.yaml",
 };
 

--- a/src/presentation/renderers/workflow_graph.ts
+++ b/src/presentation/renderers/workflow_graph.ts
@@ -1,0 +1,111 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { renderMermaidAscii } from "@vercel/beautiful-mermaid";
+import type { WorkflowGetData } from "../../libswamp/mod.ts";
+
+const ASCII_OPTIONS = { paddingX: 2, paddingY: 1, boxBorderPadding: 0 };
+
+function taskLabel(task: { type: string; [key: string]: unknown }): string {
+  switch (task.type) {
+    case "model_method":
+      return "model";
+    case "workflow":
+      return "workflow";
+    case "manual_approval":
+      return "approval";
+    case "assert":
+      return "assert";
+    default:
+      return task.type;
+  }
+}
+
+function buildJobDiagram(data: WorkflowGetData): string {
+  const lines = ["graph TD"];
+  const ids = new Map<string, string>();
+  for (const [i, job] of data.jobs.entries()) {
+    const id = `j${i}`;
+    ids.set(job.name, id);
+    lines.push(`  ${id}[${job.name}]`);
+  }
+  for (const job of data.jobs) {
+    for (const dep of job.dependsOn) {
+      const fromId = ids.get(dep.job);
+      const toId = ids.get(job.name);
+      if (fromId && toId) {
+        lines.push(`  ${fromId} --> ${toId}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+function buildStepDiagram(job: WorkflowGetData["jobs"][number]): string {
+  const lines = ["graph TD"];
+  const ids = new Map<string, string>();
+  for (const [i, step] of job.steps.entries()) {
+    const id = `s${i}`;
+    const label = `${step.name} - ${taskLabel(step.task)}`;
+    ids.set(step.name, id);
+    lines.push(`  ${id}[${label}]`);
+  }
+  for (const step of job.steps) {
+    for (const dep of step.dependsOn) {
+      const fromId = ids.get(dep.step);
+      const toId = ids.get(step.name);
+      if (fromId && toId) {
+        lines.push(`  ${fromId} --> ${toId}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export function renderWorkflowGraph(
+  data: WorkflowGetData,
+): string {
+  const lines: string[] = [];
+
+  const jobCount = data.jobs.length;
+  const stepCount = data.jobs.reduce((n, j) => n + j.steps.length, 0);
+  lines.push(
+    `Workflow: ${data.name} (${jobCount} ${
+      jobCount === 1 ? "job" : "jobs"
+    }, ${stepCount} ${stepCount === 1 ? "step" : "steps"})`,
+  );
+
+  const hasJobDeps = data.jobs.some((j) => j.dependsOn.length > 0);
+  if (hasJobDeps) {
+    lines.push("");
+    lines.push("Jobs:");
+    lines.push(renderMermaidAscii(buildJobDiagram(data), ASCII_OPTIONS));
+  }
+
+  for (const job of data.jobs) {
+    if (job.steps.length <= 1) continue;
+    const hasStepDeps = job.steps.some((s) => s.dependsOn.length > 0);
+    if (!hasStepDeps) continue;
+    lines.push("");
+    lines.push(`Job: ${job.name}`);
+    lines.push(renderMermaidAscii(buildStepDiagram(job), ASCII_OPTIONS));
+  }
+
+  return lines.join("\n");
+}

--- a/src/presentation/renderers/workflow_graph_test.ts
+++ b/src/presentation/renderers/workflow_graph_test.ts
@@ -1,0 +1,146 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertStringIncludes } from "@std/assert";
+import type { WorkflowGetData } from "../../libswamp/mod.ts";
+import { renderWorkflowGraph } from "./workflow_graph.ts";
+
+const singleJobWorkflow: WorkflowGetData = {
+  id: "wf-1",
+  name: "simple",
+  version: 1,
+  tags: {},
+  jobs: [
+    {
+      name: "build",
+      dependsOn: [],
+      steps: [
+        {
+          name: "compile",
+          dependsOn: [],
+          task: { type: "model_method", modelIdOrName: "m", methodName: "run" },
+        },
+      ],
+    },
+  ],
+  path: "/workflows/simple.yaml",
+};
+
+const multiJobWorkflow: WorkflowGetData = {
+  id: "wf-2",
+  name: "deploy-pipeline",
+  version: 1,
+  tags: {},
+  jobs: [
+    {
+      name: "build",
+      dependsOn: [],
+      steps: [
+        {
+          name: "compile",
+          dependsOn: [],
+          task: { type: "model_method", modelIdOrName: "m", methodName: "run" },
+        },
+      ],
+    },
+    {
+      name: "test",
+      dependsOn: [{ job: "build", condition: { type: "succeeded" } }],
+      steps: [
+        {
+          name: "unit",
+          dependsOn: [],
+          task: { type: "model_method", modelIdOrName: "m", methodName: "run" },
+        },
+        {
+          name: "integration",
+          dependsOn: [{ step: "unit", condition: { type: "succeeded" } }],
+          task: { type: "model_method", modelIdOrName: "m", methodName: "run" },
+        },
+      ],
+    },
+    {
+      name: "deploy",
+      dependsOn: [{ job: "test", condition: { type: "succeeded" } }],
+      steps: [
+        {
+          name: "approve",
+          dependsOn: [],
+          task: {
+            type: "manual_approval",
+            prompt: "Deploy?",
+            timeout: 3600,
+          },
+        },
+        {
+          name: "run-deploy",
+          dependsOn: [{ step: "approve", condition: { type: "succeeded" } }],
+          task: {
+            type: "workflow",
+            workflowIdOrName: "child-deploy",
+          },
+        },
+      ],
+    },
+  ],
+  path: "/workflows/deploy-pipeline.yaml",
+};
+
+Deno.test("renderWorkflowGraph: includes workflow name and counts", () => {
+  const output = renderWorkflowGraph(multiJobWorkflow);
+  assertStringIncludes(output, "Workflow: deploy-pipeline");
+  assertStringIncludes(output, "3 jobs");
+  assertStringIncludes(output, "5 steps");
+});
+
+Deno.test("renderWorkflowGraph: renders job-level DAG when jobs have dependencies", () => {
+  const output = renderWorkflowGraph(multiJobWorkflow);
+  assertStringIncludes(output, "Jobs:");
+  assertStringIncludes(output, "build");
+  assertStringIncludes(output, "test");
+  assertStringIncludes(output, "deploy");
+});
+
+Deno.test("renderWorkflowGraph: renders step-level DAG for jobs with step dependencies", () => {
+  const output = renderWorkflowGraph(multiJobWorkflow);
+  assertStringIncludes(output, "Job: test");
+  assertStringIncludes(output, "unit");
+  assertStringIncludes(output, "integration");
+  assertStringIncludes(output, "Job: deploy");
+  assertStringIncludes(output, "approve");
+  assertStringIncludes(output, "run-deploy");
+});
+
+Deno.test("renderWorkflowGraph: shows task type labels in step DAG", () => {
+  const output = renderWorkflowGraph(multiJobWorkflow);
+  assertStringIncludes(output, "- model");
+  assertStringIncludes(output, "- approval");
+  assertStringIncludes(output, "- workflow");
+});
+
+Deno.test("renderWorkflowGraph: skips job DAG when no job dependencies", () => {
+  const output = renderWorkflowGraph(singleJobWorkflow);
+  assertStringIncludes(output, "Workflow: simple");
+  assertStringIncludes(output, "1 job");
+  assertStringIncludes(output, "1 step");
+  const hasJobsSection = output.includes("Jobs:");
+  if (hasJobsSection) {
+    throw new Error("Expected no Jobs section for single job without deps");
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `--graph` flag to `swamp workflow get` that renders the workflow's
  dependency graph as ASCII art in the terminal
- Uses `@vercel/beautiful-mermaid` (~3 MB, dagre-based layout) to render
  padded box-drawing graphs with proper edge routing for fan-out/fan-in
  patterns
- Shows job-level DAG when jobs have inter-job dependencies, and step-level
  DAGs per job when steps have inter-step dependencies
- Task types are labeled in step graphs (model, workflow, approval, assert)
- Extends `WorkflowGetData` to include `dependsOn` for both jobs and steps,
  which was previously omitted from the view projection

### Example output

```
Workflow: diamond-pipeline (5 jobs, 5 steps)

Jobs:
┌────────┐
│ fetch  ├───────┐
└────┬───┘       │
     ▼           ▼
┌────────┐  ┌─────────┐
│validate│  │transform│
└────┬───┘  └────┬────┘
     ▼           │
┌────────┐       │
│ merge  │◄──────┘
└────┬───┘
     ▼
┌────────┐
│ report │
└────────┘
```

## Test Plan

- Added unit tests for the graph renderer (5 tests: header/counts, job DAG,
  step DAG, task labels, single-job-no-deps skip)
- Updated existing `workflow_get` and `get_test` tests for new `dependsOn`
  fields
- Manually tested with 4 workflow types in a temp repo: simple linear chain,
  diamond fan-out/fan-in, nested parent with child workflow + approval gate,
  and child workflow
- Full test suite passes (9514 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)