### PR TITLE
feat(serve): add --server support for extension pull/update, datastore setup, and vault migrate

### DIFF
--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -258,10 +258,13 @@ const datastoreSetupExtensionCommand = withRemoteOptions(
       server,
       options.token as string | undefined,
     );
+    const clientTimeoutMs = options.timeout
+      ? Math.min(options.timeout, 21600) * 1000
+      : 300_000;
     const response = await requestServerResponse<
       DatastoreSetupExtensionResponse
     >(
-      { server, token },
+      { server, token, timeoutMs: clientTimeoutMs },
       {
         type: "datastore.setup.extension",
         payload: {

--- a/src/cli/commands/datastore_setup.ts
+++ b/src/cli/commands/datastore_setup.ts
@@ -29,6 +29,7 @@ import {
   consumeStream,
   createDatastoreSetupDeps,
   createLibSwampContext,
+  type DatastoreSetupData,
   datastoreSetupExtension,
   datastoreSetupFilesystem,
 } from "../../libswamp/mod.ts";
@@ -49,6 +50,13 @@ import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { parseTimeoutFlag } from "./datastore_sync.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { DatastoreSetupExtensionResponse } from "../../serve/protocol.ts";
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { dim, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
@@ -187,84 +195,56 @@ const datastoreSetupFilesystemCommand = new Command()
     );
   });
 
-const datastoreSetupExtensionCommand = new Command()
-  .description(
-    "Set up an extension-provided datastore (e.g., @swamp/s3-datastore)",
-  )
-  .example(
-    "Set up S3 datastore",
-    `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"my-bucket","region":"us-east-1"}'`,
-  )
-  .example(
-    "Set up with namespace (shared prefix)",
-    `swamp datastore setup extension @swamp/s3-datastore --namespace my-project --config '{"bucket":"shared","prefix":"swamp","region":"us-east-1"}'`,
-  )
-  .arguments("<type:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option(
-    "--config <config:string>",
-    'JSON config object for the extension (e.g., \'{"bucket":"name","region":"us-east-1"}\')',
-    { required: true },
-  )
-  .option(
-    "--namespace <slug:string>",
-    "Namespace to scope this datastore to (avoids absorbing foreign data from shared prefixes)",
-  )
-  .option(
-    "--skip-migration",
-    "Skip pushing local .swamp/ data to the remote (does not skip remote→local cache hydration, which always runs)",
-  )
-  .option(
-    "--hydration-strategy <strategy:string>",
-    'Content download strategy: "full" (default, download everything) or "lazy" (metadata only, download content on demand)',
-  )
-  .option(
-    "--timeout <seconds:integer>",
-    "Override the sync timeout for the initial push and hydration pull (seconds, " +
-      "max 21600). Wins over SWAMP_DATASTORE_SYNC_TIMEOUT_MS. " +
-      "Preferred escape hatch for large first-time setups.",
-  )
-  .action(async function (options: AnyOptions, type: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "datastore",
-      "setup",
-      "extension",
-    ]);
+const datastoreSetupExtensionCommand = withRemoteOptions(
+  new Command()
+    .description(
+      "Set up an extension-provided datastore (e.g., @swamp/s3-datastore)",
+    )
+    .example(
+      "Set up S3 datastore",
+      `swamp datastore setup extension @swamp/s3-datastore --config '{"bucket":"my-bucket","region":"us-east-1"}'`,
+    )
+    .example(
+      "Set up with namespace (shared prefix)",
+      `swamp datastore setup extension @swamp/s3-datastore --namespace my-project --config '{"bucket":"shared","prefix":"swamp","region":"us-east-1"}'`,
+    )
+    .arguments("<type:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option(
+      "--config <config:string>",
+      'JSON config object for the extension (e.g., \'{"bucket":"name","region":"us-east-1"}\')',
+      { required: true },
+    )
+    .option(
+      "--namespace <slug:string>",
+      "Namespace to scope this datastore to (avoids absorbing foreign data from shared prefixes)",
+    )
+    .option(
+      "--skip-migration",
+      "Skip pushing local .swamp/ data to the remote (does not skip remote→local cache hydration, which always runs)",
+    )
+    .option(
+      "--hydration-strategy <strategy:string>",
+      'Content download strategy: "full" (default, download everything) or "lazy" (metadata only, download content on demand)',
+    )
+    .option(
+      "--timeout <seconds:integer>",
+      "Override the sync timeout for the initial push and hydration pull (seconds, " +
+        "max 21600). Wins over SWAMP_DATASTORE_SYNC_TIMEOUT_MS. " +
+        "Preferred escape hatch for large first-time setups.",
+    ),
+).action(async function (options: AnyOptions, type: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "datastore",
+    "setup",
+    "extension",
+  ]);
 
-    // Remap legacy type names (e.g., "s3" → "@swamp/s3-datastore")
-    const renamedTo = RENAMED_DATASTORE_TYPES[type];
-    const resolvedType = renamedTo ?? type;
-
-    await datastoreTypeRegistry.ensureLoaded();
-
-    // Auto-resolve the extension if needed — catch network errors so
-    // the registry check below produces a clean UserError instead of
-    // an opaque stack trace.
-    if (resolvedType.startsWith("@")) {
-      try {
-        await resolveDatastoreType(resolvedType, getAutoResolver());
-      } catch {
-        // Fall through to the registry check which has a user-friendly error
-      }
-    }
-
-    if (!datastoreTypeRegistry.has(resolvedType)) {
-      throw new UserError(
-        `Datastore type "${resolvedType}" is not registered. ` +
-          `Install it with: swamp extension pull ${resolvedType}`,
-      );
-    }
-
-    requireAuthenticated(
-      "External datastores are a team feature",
-      "datastore:*",
-    );
-    requireScope("datastore:*");
-
-    // Parse config JSON and extract namespace before provider validation
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
     let config: Record<string, unknown>;
     try {
       config = JSON.parse(options.config) as Record<string, unknown>;
@@ -274,58 +254,131 @@ const datastoreSetupExtensionCommand = new Command()
       );
     }
 
-    const configNamespace = config.namespace;
-
-    const { repoDir, marker } = await resolveDatastoreForRepo(
-      resolveRepoDir(options.repoDir),
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createDatastoreSetupDeps(repoDir);
+    const response = await requestServerResponse<
+      DatastoreSetupExtensionResponse
+    >(
+      { server, token },
+      {
+        type: "datastore.setup.extension",
+        payload: {
+          type,
+          config,
+          skipMigration: !!options.skipMigration,
+          hydrationStrategy: options.hydrationStrategy,
+          namespace: options.namespace,
+          timeout: options.timeout,
+        },
+      },
+    );
     const renderer = createDatastoreSetupRenderer(cliCtx.outputMode);
-
-    const hydrationStrategy = options.hydrationStrategy as
-      | "full"
-      | "lazy"
-      | undefined;
-    if (
-      hydrationStrategy !== undefined && hydrationStrategy !== "full" &&
-      hydrationStrategy !== "lazy"
-    ) {
-      throw new UserError(
-        `Invalid --hydration-strategy: "${hydrationStrategy}". Must be "full" or "lazy".`,
-      );
-    }
-
-    const syncTimeoutMsOverride = options.timeout != null
-      ? parseTimeoutFlag(options.timeout)
-      : undefined;
-
-    // Resolve namespace: --namespace flag wins, then --config JSON, then
-    // existing .swamp.yaml value. The namespace MUST survive setup so the
-    // initial pullChanged is scoped and the written config preserves it.
-    const namespace = typeof options.namespace === "string"
-      ? options.namespace
-      : typeof configNamespace === "string"
-      ? configNamespace
-      : marker?.datastore?.namespace;
-
     await consumeStream(
-      datastoreSetupExtension(ctx, deps, {
-        type: resolvedType,
-        config,
-        repoDir,
-        repoId: marker?.repoId,
-        skipMigration: !!options.skipMigration,
-        hydrationStrategy,
-        namespace,
-        syncTimeoutMsOverride,
-      }),
+      (async function* () {
+        yield {
+          kind: "completed" as const,
+          data: response.data as unknown as DatastoreSetupData,
+        };
+      })(),
       renderer.handlers(),
     );
+    return;
+  }
 
-    await nudgeVaultMigration(repoDir);
-  });
+  // Remap legacy type names (e.g., "s3" → "@swamp/s3-datastore")
+  const renamedTo = RENAMED_DATASTORE_TYPES[type];
+  const resolvedType = renamedTo ?? type;
+
+  await datastoreTypeRegistry.ensureLoaded();
+
+  // Auto-resolve the extension if needed — catch network errors so
+  // the registry check below produces a clean UserError instead of
+  // an opaque stack trace.
+  if (resolvedType.startsWith("@")) {
+    try {
+      await resolveDatastoreType(resolvedType, getAutoResolver());
+    } catch {
+      // Fall through to the registry check which has a user-friendly error
+    }
+  }
+
+  if (!datastoreTypeRegistry.has(resolvedType)) {
+    throw new UserError(
+      `Datastore type "${resolvedType}" is not registered. ` +
+        `Install it with: swamp extension pull ${resolvedType}`,
+    );
+  }
+
+  requireAuthenticated(
+    "External datastores are a team feature",
+    "datastore:*",
+  );
+  requireScope("datastore:*");
+
+  // Parse config JSON and extract namespace before provider validation
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(options.config) as Record<string, unknown>;
+  } catch {
+    throw new UserError(
+      `Invalid JSON in --config: ${options.config}`,
+    );
+  }
+
+  const configNamespace = config.namespace;
+
+  const { repoDir, marker } = await resolveDatastoreForRepo(
+    resolveRepoDir(options.repoDir),
+  );
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createDatastoreSetupDeps(repoDir);
+  const renderer = createDatastoreSetupRenderer(cliCtx.outputMode);
+
+  const hydrationStrategy = options.hydrationStrategy as
+    | "full"
+    | "lazy"
+    | undefined;
+  if (
+    hydrationStrategy !== undefined && hydrationStrategy !== "full" &&
+    hydrationStrategy !== "lazy"
+  ) {
+    throw new UserError(
+      `Invalid --hydration-strategy: "${hydrationStrategy}". Must be "full" or "lazy".`,
+    );
+  }
+
+  const syncTimeoutMsOverride = options.timeout != null
+    ? parseTimeoutFlag(options.timeout)
+    : undefined;
+
+  // Resolve namespace: --namespace flag wins, then --config JSON, then
+  // existing .swamp.yaml value. The namespace MUST survive setup so the
+  // initial pullChanged is scoped and the written config preserves it.
+  const namespace = typeof options.namespace === "string"
+    ? options.namespace
+    : typeof configNamespace === "string"
+    ? configNamespace
+    : marker?.datastore?.namespace;
+
+  await consumeStream(
+    datastoreSetupExtension(ctx, deps, {
+      type: resolvedType,
+      config,
+      repoDir,
+      repoId: marker?.repoId,
+      skipMigration: !!options.skipMigration,
+      hydrationStrategy,
+      namespace,
+      syncTimeoutMsOverride,
+    }),
+    renderer.handlers(),
+  );
+
+  await nudgeVaultMigration(repoDir);
+});
 
 const datastoreSetupS3DeprecatedCommand = new Command()
   .description(

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -237,7 +237,7 @@ export const extensionPullCommand = withRemoteOptions(
       options.token as string | undefined,
     );
     const response = await requestServerResponse<ExtensionPullResponse>(
-      { server, token },
+      { server, token, timeoutMs: 300_000 },
       {
         type: "extension.pull",
         payload: {

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -44,6 +44,7 @@ import {
   extensionPull,
   type ExtensionPullDeps,
   type ExtensionRegistryInfo,
+  type InstallResult,
   type LockfileRepository,
   parseExtensionRef,
   resolveServerUrl,
@@ -55,6 +56,13 @@ import {
   renderExtensionPullCancelled,
 } from "../../presentation/renderers/extension_pull.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { ExtensionPullResponse } from "../../serve/protocol.ts";
 
 // Re-export types that other CLI commands depend on
 export {
@@ -186,108 +194,139 @@ export async function pullExtension(
   }
 }
 
-export const extensionPullCommand = new Command()
-  .name("pull")
-  .description("Pull an extension from the swamp registry")
-  .example("Pull an extension", "swamp extension pull @stack72/aws-ec2")
-  .example("Force re-pull", "swamp extension pull @stack72/aws-ec2 --force")
-  .arguments("<extension:string>")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("-y, --yes", "Overwrite existing files without prompting")
-  .option(
-    "--force",
-    "Overwrite existing files without prompting (alias for --yes)",
-  )
-  .option(
-    "--channel <channel:string>",
-    "Release channel: 'beta', 'rc', or 'stable' (default: stable)",
-  )
-  .action(async function (options: AnyOptions, extension: string) {
-    let channel: string | undefined = options.channel;
-    if (
-      channel !== undefined && !ReleaseChannel.isValid(channel)
-    ) {
-      throw new UserError(
-        `Invalid channel: "${channel}". Must be one of: beta, rc, stable.`,
-      );
-    }
-    if (channel === "stable") {
-      channel = undefined;
-    }
-
-    const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);
-    ctx.logger.debug`Starting extension pull`;
-
-    // 1. Validate repo (lightweight — no datastore resolution, so pulling
-    // the repo's own datastore extension doesn't circular-fail; see #445)
-    const { repoDir, marker } = await requireRepoMarker(
-      resolveRepoDir(options.repoDir),
+export const extensionPullCommand = withRemoteOptions(
+  new Command()
+    .name("pull")
+    .description("Pull an extension from the swamp registry")
+    .example("Pull an extension", "swamp extension pull @stack72/aws-ec2")
+    .example("Force re-pull", "swamp extension pull @stack72/aws-ec2 --force")
+    .arguments("<extension:string>")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("-y, --yes", "Overwrite existing files without prompting")
+    .option(
+      "--force",
+      "Overwrite existing files without prompting (alias for --yes)",
+    )
+    .option(
+      "--channel <channel:string>",
+      "Release channel: 'beta', 'rc', or 'stable' (default: stable)",
+    ),
+).action(async function (options: AnyOptions, extension: string) {
+  let channel: string | undefined = options.channel;
+  if (
+    channel !== undefined && !ReleaseChannel.isValid(channel)
+  ) {
+    throw new UserError(
+      `Invalid channel: "${channel}". Must be one of: beta, rc, stable.`,
     );
+  }
+  if (channel === "stable") {
+    channel = undefined;
+  }
 
-    // 2. Parse extension reference
-    const ref = parseExtensionRef(extension);
+  const ctx = createContext(options as GlobalOptions, ["extension", "pull"]);
+  ctx.logger.debug`Starting extension pull`;
 
-    // 3. Validate name format
-    validateExtensionName(ref.name);
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<ExtensionPullResponse>(
+      { server, token },
+      {
+        type: "extension.pull",
+        payload: {
+          extensionName: extension,
+          force: options.yes ?? options.force ?? false,
+          channel,
+        },
+      },
+    );
+    const renderer = createExtensionPullRenderer(ctx.outputMode);
+    await consumeStream(
+      (async function* () {
+        yield {
+          kind: "completed" as const,
+          data: response.data as unknown as InstallResult,
+        };
+      })(),
+      renderer.handlers(),
+    );
+    return;
+  }
 
-    const tools = marker?.tools?.length ? marker.tools : ["claude"];
-    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
-    const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
-    await warnLegacyExtensionLayout(
+  // 1. Validate repo (lightweight — no datastore resolution, so pulling
+  // the repo's own datastore extension doesn't circular-fail; see #445)
+  const { repoDir, marker } = await requireRepoMarker(
+    resolveRepoDir(options.repoDir),
+  );
+
+  // 2. Parse extension reference
+  const ref = parseExtensionRef(extension);
+
+  // 3. Validate name format
+  validateExtensionName(ref.name);
+  const modelsDir = resolveModelsDir(marker);
+  const absoluteModelsDir = resolve(repoDir, modelsDir);
+  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+
+  const tools = marker?.tools?.length ? marker.tools : ["claude"];
+  const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+  const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
+  await warnLegacyExtensionLayout(
+    lockfilePath,
+    (msg) => ctx.logger.warn(msg),
+    primarySkillsDirRelative,
+  );
+
+  // 7. Construct W2 service deps (denoRuntime + ExtensionRepository)
+  // so phase 8 fires synchronously at install time. Both are required
+  // for `extensionPull` to route through {@link InstallExtensionService}
+  // — without them it falls back to the pre-W2 free-function path.
+  const denoRuntime = new EmbeddedDenoRuntime();
+  const catalog = new ExtensionCatalogStore(
+    swampPath(repoDir, "_extension_catalog.db"),
+  );
+  try {
+    const serverUrl = resolveServerUrl();
+    const identity = await loadIdentity();
+    const deps = await createExtensionPullDeps(
+      serverUrl,
       lockfilePath,
-      (msg) => ctx.logger.warn(msg),
-      primarySkillsDirRelative,
+      skillsDirs,
+      repoDir,
+      { identity },
     );
+    const repository = new ExtensionRepository({
+      catalog,
+      lockfileRepository: deps.lockfileRepository,
+      repoRoot: repoDir,
+      localManifestIdentity: readLocalManifestIdentity(repoDir),
+    });
 
-    // 7. Construct W2 service deps (denoRuntime + ExtensionRepository)
-    // so phase 8 fires synchronously at install time. Both are required
-    // for `extensionPull` to route through {@link InstallExtensionService}
-    // — without them it falls back to the pre-W2 free-function path.
-    const denoRuntime = new EmbeddedDenoRuntime();
-    const catalog = new ExtensionCatalogStore(
-      swampPath(repoDir, "_extension_catalog.db"),
-    );
-    try {
-      const serverUrl = resolveServerUrl();
-      const identity = await loadIdentity();
-      const deps = await createExtensionPullDeps(
-        serverUrl,
-        lockfilePath,
-        skillsDirs,
-        repoDir,
-        { identity },
-      );
-      const repository = new ExtensionRepository({
-        catalog,
-        lockfileRepository: deps.lockfileRepository,
-        repoRoot: repoDir,
-        localManifestIdentity: readLocalManifestIdentity(repoDir),
-      });
-
-      await pullExtension(ref, {
-        getExtension: deps.getExtension,
-        getLatestVersion: deps.getLatestVersion,
-        downloadArchive: deps.downloadArchive,
-        getChecksum: deps.getChecksum,
-        logger: ctx.logger,
-        lockfileRepository: deps.lockfileRepository,
-        skillsDirs,
-        repoDir,
-        force: options.yes ?? options.force ?? false,
-        outputMode: ctx.outputMode,
-        alreadyPulled: new Set(),
-        depth: 0,
-        channel,
-        denoRuntime,
-        repository,
-      });
-    } finally {
-      catalog.close();
-    }
-  });
+    await pullExtension(ref, {
+      getExtension: deps.getExtension,
+      getLatestVersion: deps.getLatestVersion,
+      downloadArchive: deps.downloadArchive,
+      getChecksum: deps.getChecksum,
+      logger: ctx.logger,
+      lockfileRepository: deps.lockfileRepository,
+      skillsDirs,
+      repoDir,
+      force: options.yes ?? options.force ?? false,
+      outputMode: ctx.outputMode,
+      alreadyPulled: new Set(),
+      depth: 0,
+      channel,
+      denoRuntime,
+      repository,
+    });
+  } finally {
+    catalog.close();
+  }
+});

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -86,7 +86,7 @@ export const extensionUpdateCommand = withRemoteOptions(
       options.token as string | undefined,
     );
     const response = await requestServerResponse<ExtensionUpdateResponse>(
-      { server, token },
+      { server, token, timeoutMs: 300_000 },
       {
         type: "extension.update",
         payload: {

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -32,6 +32,7 @@ import {
   createExtensionUpdateDeps,
   createLibSwampContext,
   extensionUpdate,
+  type ExtensionUpdateResult,
   UpgradeExtensionService,
   warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
@@ -43,6 +44,13 @@ import { createExtensionUpdateRenderer } from "../../presentation/renderers/exte
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
 import { loadIdentity } from "../load_identity.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { ExtensionUpdateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -51,122 +59,156 @@ function resolveServerUrl(): string {
   return Deno.env.get("SWAMP_CLUB_URL") ?? DEFAULT_SWAMP_CLUB_URL;
 }
 
-export const extensionUpdateCommand = new Command()
-  .name("update")
-  .description("Update installed extensions to latest versions")
-  .example("Update all extensions", "swamp extension update")
-  .example("Update one extension", "swamp extension update @stack72/aws-ec2")
-  .example("Check for updates", "swamp extension update --check")
-  .arguments("[extension:string]")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .option("--check", "Show what's outdated without pulling")
-  .action(async function (options: AnyOptions, extensionArg?: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "extension",
-      "update",
-    ]);
-    cliCtx.logger.debug`Starting extension update`;
+export const extensionUpdateCommand = withRemoteOptions(
+  new Command()
+    .name("update")
+    .description("Update installed extensions to latest versions")
+    .example("Update all extensions", "swamp extension update")
+    .example("Update one extension", "swamp extension update @stack72/aws-ec2")
+    .example("Check for updates", "swamp extension update --check")
+    .arguments("[extension:string]")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .option("--check", "Show what's outdated without pulling"),
+).action(async function (options: AnyOptions, extensionArg?: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "extension",
+    "update",
+  ]);
+  cliCtx.logger.debug`Starting extension update`;
 
-    // 1. Validate repo (lightweight — no datastore resolution, so updating
-    // the repo's own datastore extension doesn't circular-fail; see #445)
-    const { repoDir, marker } = await requireRepoMarker(
-      resolveRepoDir(options.repoDir),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
-    const modelsDir = resolveModelsDir(marker);
-    const absoluteModelsDir = resolve(repoDir, modelsDir);
-    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
-
-    // Per-extension models/workflows/vaults/drivers/datastores/reports
-    // destinations are derived inside installExtension from the
-    // extension's scoped name. Only skillsDir is tool-dependent.
-    const tools = marker?.tools?.length ? marker.tools : ["claude"];
-    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
-
-    const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
-    await warnLegacyExtensionLayout(
-      lockfilePath,
-      (msg) => cliCtx.logger.warn(msg),
-      primarySkillsDirRelative,
-    );
-
-    // 4. Parse extension name if given
-    let extensionName: string | undefined;
-    if (extensionArg) {
-      const ref = parseExtensionRef(extensionArg);
-      extensionName = ref.name;
-    }
-
-    // 4. Wire deps — inject installExtension from CLI layer
-    const serverUrl = resolveServerUrl();
-
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    // W2 (commit 3): construct shared denoRuntime + repository so each
-    // upgrade routes through InstallExtensionService and phase 8 fires
-    // (catalog populated synchronously, I-Repo-1 fires on collision,
-    // FS rollback). The catalog stays open for the duration of the
-    // bulk update — closed in the finally block.
-    const denoRuntime = new EmbeddedDenoRuntime();
-    const catalog = new ExtensionCatalogStore(
-      swampPath(repoDir, "_extension_catalog.db"),
-    );
-    try {
-      const identity = await loadIdentity();
-      const deps = await createExtensionUpdateDeps({
-        lockfilePath,
-        serverUrl,
-        identity,
-        installExtension: async (
-          name: string,
-          version: string,
-          channel?: string,
-        ) => {
-          // Construct a fresh InstallContext per upgrade — captures a
-          // current snapshot of the lockfile per the
-          // InstallContext.lockfileRepository single-use rule. Reusing one
-          // context across multiple installs would expose stale state.
-          const installCtx = await createInstallContext(serverUrl, {
-            logger: cliCtx.logger,
-            lockfilePath,
-            skillsDirs,
-            repoDir,
-            force: true,
-            identity,
-            channel,
-          });
-          // Build a fresh ExtensionRepository per upgrade so its lockfile
-          // snapshot lines up with the InstallContext's. Catalog is
-          // shared across the bulk run for atomicity-of-each-upgrade.
-          const repository = new ExtensionRepository({
-            catalog,
-            lockfileRepository: installCtx.lockfileRepository,
-            repoRoot: repoDir,
-          });
-          // W2 (commit 5): route through UpgradeExtensionService for
-          // explicit upgrade-intent at the call site. Internally this
-          // delegates to InstallExtensionService whose phase 8
-          // tombstones the prior version atomically (saveAll is one
-          // SQLite txn).
-          return await new UpgradeExtensionService({
-            denoRuntime,
-            repository,
-          })
-            .execute(name, version, installCtx);
-        },
-      });
-
-      // 5. Execute and render
-      const renderer = createExtensionUpdateRenderer(cliCtx.outputMode);
-      await consumeStream(
-        extensionUpdate(ctx, deps, {
-          extensionName,
+    const response = await requestServerResponse<ExtensionUpdateResponse>(
+      { server, token },
+      {
+        type: "extension.update",
+        payload: {
+          extensionName: extensionArg
+            ? parseExtensionRef(extensionArg).name
+            : undefined,
           checkOnly: !!options.check,
-        }),
-        renderer.handlers(),
-      );
-    } finally {
-      catalog.close();
-    }
-  });
+        },
+      },
+    );
+    const renderer = createExtensionUpdateRenderer(cliCtx.outputMode);
+    const mode = options.check ? "check" : "update";
+    await consumeStream(
+      (async function* () {
+        yield {
+          kind: "completed" as const,
+          data: response.data as unknown as ExtensionUpdateResult,
+          mode: mode as "check" | "update",
+        };
+      })(),
+      renderer.handlers(),
+    );
+    return;
+  }
+
+  // 1. Validate repo (lightweight — no datastore resolution, so updating
+  // the repo's own datastore extension doesn't circular-fail; see #445)
+  const { repoDir, marker } = await requireRepoMarker(
+    resolveRepoDir(options.repoDir),
+  );
+  const modelsDir = resolveModelsDir(marker);
+  const absoluteModelsDir = resolve(repoDir, modelsDir);
+  const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+
+  // Per-extension models/workflows/vaults/drivers/datastores/reports
+  // destinations are derived inside installExtension from the
+  // extension's scoped name. Only skillsDir is tool-dependent.
+  const tools = marker?.tools?.length ? marker.tools : ["claude"];
+  const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+
+  const primarySkillsDirRelative = relative(repoDir, skillsDirs[0]);
+  await warnLegacyExtensionLayout(
+    lockfilePath,
+    (msg) => cliCtx.logger.warn(msg),
+    primarySkillsDirRelative,
+  );
+
+  // 4. Parse extension name if given
+  let extensionName: string | undefined;
+  if (extensionArg) {
+    const ref = parseExtensionRef(extensionArg);
+    extensionName = ref.name;
+  }
+
+  // 4. Wire deps — inject installExtension from CLI layer
+  const serverUrl = resolveServerUrl();
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  // W2 (commit 3): construct shared denoRuntime + repository so each
+  // upgrade routes through InstallExtensionService and phase 8 fires
+  // (catalog populated synchronously, I-Repo-1 fires on collision,
+  // FS rollback). The catalog stays open for the duration of the
+  // bulk update — closed in the finally block.
+  const denoRuntime = new EmbeddedDenoRuntime();
+  const catalog = new ExtensionCatalogStore(
+    swampPath(repoDir, "_extension_catalog.db"),
+  );
+  try {
+    const identity = await loadIdentity();
+    const deps = await createExtensionUpdateDeps({
+      lockfilePath,
+      serverUrl,
+      identity,
+      installExtension: async (
+        name: string,
+        version: string,
+        channel?: string,
+      ) => {
+        // Construct a fresh InstallContext per upgrade — captures a
+        // current snapshot of the lockfile per the
+        // InstallContext.lockfileRepository single-use rule. Reusing one
+        // context across multiple installs would expose stale state.
+        const installCtx = await createInstallContext(serverUrl, {
+          logger: cliCtx.logger,
+          lockfilePath,
+          skillsDirs,
+          repoDir,
+          force: true,
+          identity,
+          channel,
+        });
+        // Build a fresh ExtensionRepository per upgrade so its lockfile
+        // snapshot lines up with the InstallContext's. Catalog is
+        // shared across the bulk run for atomicity-of-each-upgrade.
+        const repository = new ExtensionRepository({
+          catalog,
+          lockfileRepository: installCtx.lockfileRepository,
+          repoRoot: repoDir,
+        });
+        // W2 (commit 5): route through UpgradeExtensionService for
+        // explicit upgrade-intent at the call site. Internally this
+        // delegates to InstallExtensionService whose phase 8
+        // tombstones the prior version atomically (saveAll is one
+        // SQLite txn).
+        return await new UpgradeExtensionService({
+          denoRuntime,
+          repository,
+        })
+          .execute(name, version, installCtx);
+      },
+    });
+
+    // 5. Execute and render
+    const renderer = createExtensionUpdateRenderer(cliCtx.outputMode);
+    await consumeStream(
+      extensionUpdate(ctx, deps, {
+        extensionName,
+        checkOnly: !!options.check,
+      }),
+      renderer.handlers(),
+    );
+  } finally {
+    catalog.close();
+  }
+});

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -127,7 +127,7 @@ Both the source and target vaults must be different types.`,
       options.token as string | undefined,
     );
     const response = await requestServerResponse<VaultMigrateResponse>(
-      { server, token },
+      { server, token, timeoutMs: 300_000 },
       {
         type: "vault.migrate",
         payload: {

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -105,6 +105,11 @@ Both the source and target vaults must be different types.`,
         "--to-type is required when using --server (interactive mode is not available remotely)",
       );
     }
+    if (options.dryRun) {
+      throw new UserError(
+        "--dry-run is not supported with --server",
+      );
+    }
 
     let targetConfig: Record<string, unknown> | undefined;
     if (options.config) {

--- a/src/cli/commands/vault_migrate.ts
+++ b/src/cli/commands/vault_migrate.ts
@@ -23,6 +23,7 @@ import {
   createLibSwampContext,
   createVaultMigrateDeps,
   vaultMigrate,
+  type VaultMigrateData,
   vaultMigratePreview,
 } from "../../libswamp/mod.ts";
 import {
@@ -42,59 +43,69 @@ import {
   promptConfirmation,
   promptLine,
 } from "../prompt_helpers.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { VaultMigrateResponse } from "../../serve/protocol.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const vaultMigrateCommand = new Command()
-  .name("migrate")
-  .description(
-    `Migrate a vault to a different backend type.
+export const vaultMigrateCommand = withRemoteOptions(
+  new Command()
+    .name("migrate")
+    .description(
+      `Migrate a vault to a different backend type.
 
 Copies all secrets from the current backend to a new one, then updates
 the vault configuration. The vault name stays the same, so all existing
 vault references continue to work without modification.
 
 Both the source and target vaults must be different types.`,
-  )
-  .arguments("<vault_name:string>")
-  .option("--to-type <type:string>", "Target vault type")
-  .option(
-    "--config <config:string>",
-    'Provider-specific config as JSON (e.g. \'{"region":"us-east-1"}\')',
-  )
-  .option("-y, --yes", "Skip confirmation prompt")
-  .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
-  .option("--dry-run", "Preview migration without making changes")
-  .option(
-    "--repo-dir <dir:string>",
-    "Repository directory (env: SWAMP_REPO_DIR)",
-  )
-  .example(
-    "Migrate to AWS Secrets Manager",
-    'swamp vault migrate my-vault --to-type @swamp/aws-sm --config \'{"region":"us-east-1"}\'',
-  )
-  .example(
-    "Interactive migration",
-    "swamp vault migrate my-vault",
-  )
-  .example(
-    "Preview migration (dry run)",
-    "swamp vault migrate my-vault --to-type @swamp/aws-sm --dry-run",
-  )
-  .action(async function (options: AnyOptions, vaultName: string) {
-    const cliCtx = createContext(options as GlobalOptions, [
-      "vault",
-      "migrate",
-    ]);
-    cliCtx.logger.debug`Migrating vault: ${vaultName}`;
+    )
+    .arguments("<vault_name:string>")
+    .option("--to-type <type:string>", "Target vault type")
+    .option(
+      "--config <config:string>",
+      'Provider-specific config as JSON (e.g. \'{"region":"us-east-1"}\')',
+    )
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("-f, --force", "Skip confirmation prompt (alias for --yes)")
+    .option("--dry-run", "Preview migration without making changes")
+    .option(
+      "--repo-dir <dir:string>",
+      "Repository directory (env: SWAMP_REPO_DIR)",
+    )
+    .example(
+      "Migrate to AWS Secrets Manager",
+      'swamp vault migrate my-vault --to-type @swamp/aws-sm --config \'{"region":"us-east-1"}\'',
+    )
+    .example(
+      "Interactive migration",
+      "swamp vault migrate my-vault",
+    )
+    .example(
+      "Preview migration (dry run)",
+      "swamp vault migrate my-vault --to-type @swamp/aws-sm --dry-run",
+    ),
+).action(async function (options: AnyOptions, vaultName: string) {
+  const cliCtx = createContext(options as GlobalOptions, [
+    "vault",
+    "migrate",
+  ]);
+  cliCtx.logger.debug`Migrating vault: ${vaultName}`;
 
-    const { repoDir } = await requireInitializedRepoUnlocked({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    if (!options.toType) {
+      throw new UserError(
+        "--to-type is required when using --server (interactive mode is not available remotely)",
+      );
+    }
 
-    // Parse --config JSON if provided
     let targetConfig: Record<string, unknown> | undefined;
     if (options.config) {
       try {
@@ -106,209 +117,254 @@ Both the source and target vaults must be different types.`,
       }
     }
 
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = await createVaultMigrateDeps(repoDir);
-
-    // Resolve --to-type: use the provided value or prompt interactively
-    let toType: string = options.toType;
-    if (!toType) {
-      if (cliCtx.outputMode === "json") {
-        throw new UserError(
-          "Interactive vault migration is not available in JSON mode. Provide --to-type explicitly.",
-        );
-      }
-
-      // Look up the vault to show current type
-      const vaultConfig = await deps.findVaultConfig(vaultName);
-      if (!vaultConfig) {
-        throw new UserError(
-          `Vault '${vaultName}' not found. Use 'swamp vault search' to see available vaults.`,
-        );
-      }
-
-      const currentType = vaultConfig.type;
-      const logger = getSwampLogger(["vault", "migrate"]);
-      logger
-        .info`Vault ${vaultName} is currently using type ${currentType}.`;
-
-      const VAULT_CHOICES = [
-        "AWS Secrets Manager",
-        "Azure Key Vault",
-        "1Password",
-        "Other",
-      ];
-      const chosen = await promptChoice(
-        "Select the target vault provider:",
-        VAULT_CHOICES,
-      );
-
-      if (chosen === "AWS Secrets Manager") {
-        toType = "@swamp/aws-sm";
-        const region = await promptLine("AWS region (e.g. us-east-1): ");
-        if (region) {
-          targetConfig = { region };
-        }
-      } else if (chosen === "Azure Key Vault") {
-        toType = "@swamp/azure-kv";
-        const vaultUrl = await promptLine("Azure Key Vault URL: ");
-        if (vaultUrl) {
-          targetConfig = { vaultUrl };
-        }
-      } else if (chosen === "1Password") {
-        toType = "@swamp/1password";
-        const vault = await promptLine(
-          "1Password vault name (or Enter for default): ",
-        );
-        if (vault) {
-          targetConfig = { vault };
-        }
-      } else {
-        // Other: search for a vault extension by keyword
-        const query = await promptLine(
-          "Search for a vault extension (e.g. hashicorp, doppler): ",
-        );
-        if (!query) {
-          throw new UserError("No search query provided.");
-        }
-
-        const encoder = new TextEncoder();
-        await Deno.stdout.write(
-          encoder.encode(
-            `\nSearching for "${query}" vault extensions…\n`,
-          ),
-        );
-
-        const searchCmd = new Deno.Command(Deno.execPath(), {
-          args: [
-            "extension",
-            "search",
-            query,
-            "--content-type",
-            "vaults",
-            "--json",
-          ],
-          stdout: "piped",
-          stderr: "piped",
-          signal: AbortSignal.timeout(30_000),
-        });
-        const searchOutput = await searchCmd.output();
-        let searchResults: Array<{ type: string; description: string }> = [];
-        if (searchOutput.success) {
-          try {
-            const parsed = JSON.parse(
-              new TextDecoder().decode(searchOutput.stdout),
-            ) as {
-              extensions?: Array<{
-                name: string;
-                description: string;
-              }>;
-            };
-            searchResults = (parsed.extensions ?? []).map((r) => ({
-              type: r.name,
-              description: r.description,
-            }));
-          } catch {
-            // Treat parse failure as no results
-          }
-        }
-
-        if (searchResults.length === 0) {
-          throw new UserError(
-            `No vault extensions found for "${query}". ` +
-              `Browse available extensions at https://swamp-club.com/extensions`,
-          );
-        }
-
-        const typeChoices = searchResults.map((r) =>
-          `${r.type} — ${r.description}`
-        );
-        const chosenExt = await promptChoice(
-          "Which vault extension?",
-          typeChoices,
-        );
-        toType = chosenExt.split(" — ")[0];
-
-        const configJson = await promptLine(
-          `Config JSON for ${toType} (e.g. {}, or Enter to skip): `,
-        );
-        if (configJson) {
-          try {
-            targetConfig = JSON.parse(configJson);
-          } catch {
-            throw new UserError(`Invalid JSON: ${configJson}`);
-          }
-        }
-      }
-    }
-
-    // Phase 1: Preview
-    let preview;
-    try {
-      preview = await vaultMigratePreview(ctx, deps, {
-        vaultName,
-        targetType: toType,
-        targetConfig,
-        repoDir,
-      });
-    } catch (error) {
-      if ("code" in (error as Record<string, unknown>)) {
-        throw new UserError((error as { message: string }).message);
-      }
-      throw error;
-    }
-
-    const logger = getSwampLogger(["vault", "migrate"]);
-
-    if (cliCtx.outputMode === "log") {
-      logger
-        .info`Vault ${preview.vaultName} (${preview.currentType}) has ${preview.secretCount} secret(s).`;
-      logger
-        .info`Target: ${preview.targetTypeName} (${preview.targetType})`;
-    }
-
-    // Phase 2: Dry run or confirmation
-    if (options.dryRun) {
-      if (cliCtx.outputMode === "json") {
-        console.log(JSON.stringify(
-          {
-            dryRun: true,
-            vaultName: preview.vaultName,
-            currentType: preview.currentType,
-            currentTypeName: preview.currentTypeName,
-            targetType: preview.targetType,
-            targetTypeName: preview.targetTypeName,
-            secretCount: preview.secretCount,
-          },
-          null,
-          2,
-        ));
-      } else {
-        logger.info`Dry run — no changes made.`;
-      }
-      return;
-    }
-
-    if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
-      const confirmed = await promptConfirmation(
-        `Migrate vault backend from ${preview.currentType} to ${preview.targetType}?`,
-      );
-      if (!confirmed) {
-        renderVaultMigrateCancelled(cliCtx.outputMode);
-        return;
-      }
-    }
-
-    // Phase 3: Execute migration
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
+    );
+    const response = await requestServerResponse<VaultMigrateResponse>(
+      { server, token },
+      {
+        type: "vault.migrate",
+        payload: {
+          vaultName,
+          targetType: options.toType,
+          targetConfig,
+        },
+      },
+    );
     const renderer = createVaultMigrateRenderer(cliCtx.outputMode);
     await consumeStream(
-      vaultMigrate(ctx, deps, {
-        vaultName,
-        targetType: toType,
-        targetConfig,
-        repoDir,
-      }),
+      (async function* () {
+        yield {
+          kind: "completed" as const,
+          data: response.data as unknown as VaultMigrateData,
+        };
+      })(),
       renderer.handlers(),
     );
+    return;
+  }
 
-    cliCtx.logger.debug("Vault migrate command completed");
+  const { repoDir } = await requireInitializedRepoUnlocked({
+    repoDir: resolveRepoDir(options.repoDir),
+    outputMode: cliCtx.outputMode,
   });
+
+  // Parse --config JSON if provided
+  let targetConfig: Record<string, unknown> | undefined;
+  if (options.config) {
+    try {
+      targetConfig = JSON.parse(options.config);
+    } catch {
+      throw new UserError(
+        `Invalid JSON in --config: ${options.config}`,
+      );
+    }
+  }
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = await createVaultMigrateDeps(repoDir);
+
+  // Resolve --to-type: use the provided value or prompt interactively
+  let toType: string = options.toType;
+  if (!toType) {
+    if (cliCtx.outputMode === "json") {
+      throw new UserError(
+        "Interactive vault migration is not available in JSON mode. Provide --to-type explicitly.",
+      );
+    }
+
+    // Look up the vault to show current type
+    const vaultConfig = await deps.findVaultConfig(vaultName);
+    if (!vaultConfig) {
+      throw new UserError(
+        `Vault '${vaultName}' not found. Use 'swamp vault search' to see available vaults.`,
+      );
+    }
+
+    const currentType = vaultConfig.type;
+    const logger = getSwampLogger(["vault", "migrate"]);
+    logger
+      .info`Vault ${vaultName} is currently using type ${currentType}.`;
+
+    const VAULT_CHOICES = [
+      "AWS Secrets Manager",
+      "Azure Key Vault",
+      "1Password",
+      "Other",
+    ];
+    const chosen = await promptChoice(
+      "Select the target vault provider:",
+      VAULT_CHOICES,
+    );
+
+    if (chosen === "AWS Secrets Manager") {
+      toType = "@swamp/aws-sm";
+      const region = await promptLine("AWS region (e.g. us-east-1): ");
+      if (region) {
+        targetConfig = { region };
+      }
+    } else if (chosen === "Azure Key Vault") {
+      toType = "@swamp/azure-kv";
+      const vaultUrl = await promptLine("Azure Key Vault URL: ");
+      if (vaultUrl) {
+        targetConfig = { vaultUrl };
+      }
+    } else if (chosen === "1Password") {
+      toType = "@swamp/1password";
+      const vault = await promptLine(
+        "1Password vault name (or Enter for default): ",
+      );
+      if (vault) {
+        targetConfig = { vault };
+      }
+    } else {
+      // Other: search for a vault extension by keyword
+      const query = await promptLine(
+        "Search for a vault extension (e.g. hashicorp, doppler): ",
+      );
+      if (!query) {
+        throw new UserError("No search query provided.");
+      }
+
+      const encoder = new TextEncoder();
+      await Deno.stdout.write(
+        encoder.encode(
+          `\nSearching for "${query}" vault extensions…\n`,
+        ),
+      );
+
+      const searchCmd = new Deno.Command(Deno.execPath(), {
+        args: [
+          "extension",
+          "search",
+          query,
+          "--content-type",
+          "vaults",
+          "--json",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+        signal: AbortSignal.timeout(30_000),
+      });
+      const searchOutput = await searchCmd.output();
+      let searchResults: Array<{ type: string; description: string }> = [];
+      if (searchOutput.success) {
+        try {
+          const parsed = JSON.parse(
+            new TextDecoder().decode(searchOutput.stdout),
+          ) as {
+            extensions?: Array<{
+              name: string;
+              description: string;
+            }>;
+          };
+          searchResults = (parsed.extensions ?? []).map((r) => ({
+            type: r.name,
+            description: r.description,
+          }));
+        } catch {
+          // Treat parse failure as no results
+        }
+      }
+
+      if (searchResults.length === 0) {
+        throw new UserError(
+          `No vault extensions found for "${query}". ` +
+            `Browse available extensions at https://swamp-club.com/extensions`,
+        );
+      }
+
+      const typeChoices = searchResults.map((r) =>
+        `${r.type} — ${r.description}`
+      );
+      const chosenExt = await promptChoice(
+        "Which vault extension?",
+        typeChoices,
+      );
+      toType = chosenExt.split(" — ")[0];
+
+      const configJson = await promptLine(
+        `Config JSON for ${toType} (e.g. {}, or Enter to skip): `,
+      );
+      if (configJson) {
+        try {
+          targetConfig = JSON.parse(configJson);
+        } catch {
+          throw new UserError(`Invalid JSON: ${configJson}`);
+        }
+      }
+    }
+  }
+
+  // Phase 1: Preview
+  let preview;
+  try {
+    preview = await vaultMigratePreview(ctx, deps, {
+      vaultName,
+      targetType: toType,
+      targetConfig,
+      repoDir,
+    });
+  } catch (error) {
+    if ("code" in (error as Record<string, unknown>)) {
+      throw new UserError((error as { message: string }).message);
+    }
+    throw error;
+  }
+
+  const logger = getSwampLogger(["vault", "migrate"]);
+
+  if (cliCtx.outputMode === "log") {
+    logger
+      .info`Vault ${preview.vaultName} (${preview.currentType}) has ${preview.secretCount} secret(s).`;
+    logger
+      .info`Target: ${preview.targetTypeName} (${preview.targetType})`;
+  }
+
+  // Phase 2: Dry run or confirmation
+  if (options.dryRun) {
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify(
+        {
+          dryRun: true,
+          vaultName: preview.vaultName,
+          currentType: preview.currentType,
+          currentTypeName: preview.currentTypeName,
+          targetType: preview.targetType,
+          targetTypeName: preview.targetTypeName,
+          secretCount: preview.secretCount,
+        },
+        null,
+        2,
+      ));
+    } else {
+      logger.info`Dry run — no changes made.`;
+    }
+    return;
+  }
+
+  if (cliCtx.outputMode === "log" && !options.yes && !options.force) {
+    const confirmed = await promptConfirmation(
+      `Migrate vault backend from ${preview.currentType} to ${preview.targetType}?`,
+    );
+    if (!confirmed) {
+      renderVaultMigrateCancelled(cliCtx.outputMode);
+      return;
+    }
+  }
+
+  // Phase 3: Execute migration
+  const renderer = createVaultMigrateRenderer(cliCtx.outputMode);
+  await consumeStream(
+    vaultMigrate(ctx, deps, {
+      vaultName,
+      targetType: toType,
+      targetConfig,
+      repoDir,
+    }),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Vault migrate command completed");
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -721,9 +721,9 @@ const DatastoreSetupExtensionRequestSchema = z.object({
     type: z.string(),
     config: z.record(z.string(), z.unknown()),
     skipMigration: z.boolean().optional(),
-    hydrationStrategy: z.string().optional(),
+    hydrationStrategy: z.enum(["full", "lazy"]).optional(),
     namespace: z.string().optional(),
-    timeout: z.number().optional(),
+    timeout: z.number().int().positive().max(21600).optional(),
   }),
 });
 
@@ -1699,9 +1699,9 @@ export function handleMessage(
         socket,
         ctx,
         request.id,
+        request.payload,
         controller,
         principal,
-        request.payload,
       );
       break;
     case "doctor.datastores":

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -92,6 +92,7 @@ import {
 } from "./handlers/report_handlers.ts";
 import {
   handleAuditTimeline,
+  handleDatastoreSetupExtension,
   handleDatastoreStatus,
   handleDoctorDatastores,
   handleDoctorExtensions,
@@ -102,10 +103,13 @@ import {
   handleExtensionInstall,
   handleExtensionList,
   handleExtensionOutdated,
+  handleExtensionPull,
   handleExtensionRm,
   handleExtensionSearch,
+  handleExtensionUpdate,
   handleRunDoctor,
   handleRunHistory,
+  handleVaultMigrate,
   handleWorkerList,
   handleWorkerQueueList,
   handleWorkerVerify,
@@ -710,6 +714,29 @@ const DatastoreStatusRequestSchema = z.object({
   id: z.string().min(1).max(256),
 });
 
+const DatastoreSetupExtensionRequestSchema = z.object({
+  type: z.literal("datastore.setup.extension"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    type: z.string(),
+    config: z.record(z.string(), z.unknown()),
+    skipMigration: z.boolean().optional(),
+    hydrationStrategy: z.string().optional(),
+    namespace: z.string().optional(),
+    timeout: z.number().optional(),
+  }),
+});
+
+const VaultMigrateRequestSchema = z.object({
+  type: z.literal("vault.migrate"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    vaultName: z.string(),
+    targetType: z.string(),
+    targetConfig: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
 // ── Extension operation schemas ─────────────────────────────────────
 
 const ExtensionListRequestSchema = z.object({
@@ -748,6 +775,16 @@ const ExtensionInstallRequestSchema = z.object({
   id: z.string().min(1).max(256),
 });
 
+const ExtensionPullRequestSchema = z.object({
+  type: z.literal("extension.pull"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    extensionName: z.string(),
+    force: z.boolean().optional(),
+    channel: z.string().optional(),
+  }),
+});
+
 const ExtensionRmRequestSchema = z.object({
   type: z.literal("extension.rm"),
   id: z.string().min(1).max(256),
@@ -759,6 +796,15 @@ const ExtensionRmRequestSchema = z.object({
 const ExtensionOutdatedRequestSchema = z.object({
   type: z.literal("extension.outdated"),
   id: z.string().min(1).max(256),
+});
+
+const ExtensionUpdateRequestSchema = z.object({
+  type: z.literal("extension.update"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    extensionName: z.string().optional(),
+    checkOnly: z.boolean().optional(),
+  }).optional(),
 });
 
 // ── Doctor operation schemas ────────────────────────────────────────
@@ -858,12 +904,16 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   WorkerQueueListRequestSchema,
   WorkerVerifyRequestSchema,
   DatastoreStatusRequestSchema,
+  DatastoreSetupExtensionRequestSchema,
+  VaultMigrateRequestSchema,
   ExtensionListRequestSchema,
   ExtensionSearchRequestSchema,
   ExtensionInfoRequestSchema,
   ExtensionInstallRequestSchema,
+  ExtensionPullRequestSchema,
   ExtensionRmRequestSchema,
   ExtensionOutdatedRequestSchema,
+  ExtensionUpdateRequestSchema,
   DoctorVaultsRequestSchema,
   DoctorSecretsRequestSchema,
   DoctorWorkflowsRequestSchema,
@@ -1557,6 +1607,26 @@ export function handleMessage(
         principal,
       );
       break;
+    case "datastore.setup.extension":
+      task = handleDatastoreSetupExtension(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
+    case "vault.migrate":
+      task = handleVaultMigrate(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
     case "extension.list":
       task = handleExtensionList(
         socket,
@@ -1595,6 +1665,16 @@ export function handleMessage(
         principal,
       );
       break;
+    case "extension.pull":
+      task = handleExtensionPull(
+        socket,
+        ctx,
+        request.id,
+        request.payload,
+        controller,
+        principal,
+      );
+      break;
     case "extension.rm":
       task = handleExtensionRm(
         socket,
@@ -1612,6 +1692,16 @@ export function handleMessage(
         request.id,
         controller,
         principal,
+      );
+      break;
+    case "extension.update":
+      task = handleExtensionUpdate(
+        socket,
+        ctx,
+        request.id,
+        controller,
+        principal,
+        request.payload,
       );
       break;
     case "doctor.datastores":

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -709,7 +709,12 @@ export async function handleExtensionPull(
       payload: { data: result ?? {} },
     });
   } catch (error) {
-    const message = sanitizeErrorForClient(error);
+    const raw = error instanceof Error
+      ? error
+      : typeof error === "object" && error !== null && "message" in error
+      ? (error as { message: string }).message
+      : error;
+    const message = sanitizeErrorForClient(raw);
     sendError(socket, requestId, "extension_pull_failed", message);
   } finally {
     catalog?.close();
@@ -850,9 +855,9 @@ export async function handleExtensionUpdate(
   socket: WebSocket,
   ctx: ConnectionContext,
   requestId: string,
+  payload: ExtensionUpdatePayload | undefined,
   controller: AbortController,
   principal: Principal | null,
-  payload?: ExtensionUpdatePayload,
 ): Promise<void> {
   if (
     !authorizeOrReject(socket, requestId, principal, "admin", {
@@ -945,7 +950,12 @@ export async function handleExtensionUpdate(
       payload: { data: result ?? {} },
     });
   } catch (error) {
-    const message = sanitizeErrorForClient(error);
+    const raw = error instanceof Error
+      ? error
+      : typeof error === "object" && error !== null && "message" in error
+      ? (error as { message: string }).message
+      : error;
+    const message = sanitizeErrorForClient(raw);
     sendError(socket, requestId, "extension_update_failed", message);
   } finally {
     catalog?.close();

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -31,16 +31,21 @@ import {
   buildAggregateState,
   consumeStream,
   createAuditTimelineDeps,
+  createDatastoreSetupDeps,
   createDatastoreStatusDeps,
   createDoctorSecretsDeps,
   createDoctorVaultsDeps,
   createExtensionInfoDeps,
   createExtensionListDeps,
+  createExtensionPullDeps,
   createExtensionRmDeps,
   createExtensionUpdateDeps,
+  createInstallContext,
   createLibSwampContext,
+  createVaultMigrateDeps,
   createWorkerListDeps,
   createWorkerQueueListDeps,
+  datastoreSetupExtension,
   datastoreStatus,
   doctorDatastores,
   type DoctorDatastoresDeps,
@@ -54,14 +59,20 @@ import {
   extensionInfo,
   extensionInstall,
   extensionList,
+  extensionPull,
   extensionRm,
   extensionSearch,
   type ExtensionSearchDeps,
   extensionUpdate,
   LockfileRepository,
+  parseExtensionRef,
   ReconcileFromDiskService,
   type ReconcileTransition,
   resolveServerUrl,
+  UpgradeExtensionService,
+  validateExtensionName,
+  vaultMigrate,
+  vaultMigratePreview,
   workerList,
   workerQueueList,
 } from "../../libswamp/mod.ts";
@@ -76,9 +87,13 @@ import { createExtensionInstallDeps } from "../../cli/create_extension_install_d
 import { resolveModelsDir } from "../../cli/resolve_models_dir.ts";
 import type {
   AuditTimelinePayload,
+  DatastoreSetupExtensionPayload,
   ExtensionInfoPayload,
+  ExtensionPullPayload,
   ExtensionRmPayload,
   ExtensionSearchPayload,
+  ExtensionUpdatePayload,
+  VaultMigratePayload,
   WorkerListPayload,
   WorkerProbeResult,
   WorkerVerifyPayload,
@@ -596,6 +611,111 @@ export async function handleExtensionInstall(
   }
 }
 
+export async function handleExtensionPull(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: ExtensionPullPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  let catalog: ExtensionCatalogStore | undefined;
+  try {
+    const repoDir = ctx.repoDir;
+    const ref = parseExtensionRef(payload.extensionName);
+    validateExtensionName(ref.name);
+
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = isAbsolute(modelsDir)
+      ? modelsDir
+      : resolve(repoDir, modelsDir);
+    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+
+    const denoRuntime = new EmbeddedDenoRuntime();
+    catalog = new ExtensionCatalogStore(
+      swampPath(repoDir, "_extension_catalog.db"),
+    );
+
+    const serverUrl = resolveServerUrl();
+    const deps = await createExtensionPullDeps(
+      serverUrl,
+      lockfilePath,
+      skillsDirs,
+      repoDir,
+    );
+    const repository = new ExtensionRepository({
+      catalog,
+      lockfileRepository: deps.lockfileRepository,
+      repoRoot: repoDir,
+      localManifestIdentity: readLocalManifestIdentity(repoDir),
+    });
+
+    const libCtx = createLibSwampContext();
+    const pullDeps = {
+      getExtension: deps.getExtension,
+      getLatestVersion: deps.getLatestVersion,
+      downloadArchive: deps.downloadArchive,
+      getChecksum: deps.getChecksum,
+      lockfileRepository: deps.lockfileRepository,
+      skillsDirs,
+      repoDir,
+      alreadyPulled: new Set<string>(),
+      depth: 0,
+      denoRuntime,
+      repository,
+    };
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      extensionPull(libCtx, pullDeps, {
+        ref,
+        force: payload.force ?? false,
+        channel: payload.channel,
+      }),
+      {
+        installing: () => {},
+        deprecated_warning: () => {},
+        "orphans-pruned": () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "extension.pull",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "extension_pull_failed", message);
+  } finally {
+    catalog?.close();
+  }
+}
+
 export async function handleExtensionRm(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -723,6 +843,264 @@ export async function handleExtensionOutdated(
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "extension_outdated_failed", message);
+  }
+}
+
+export async function handleExtensionUpdate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  controller: AbortController,
+  principal: Principal | null,
+  payload?: ExtensionUpdatePayload,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  let catalog: ExtensionCatalogStore | undefined;
+  try {
+    const libCtx = createLibSwampContext();
+    const logger = getSwampLogger(["serve", "extension", "update"]);
+    const repoDir = ctx.repoDir;
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const modelsDir = resolveModelsDir(marker);
+    const absoluteModelsDir = isAbsolute(modelsDir)
+      ? modelsDir
+      : resolve(repoDir, modelsDir);
+    const lockfilePath = join(absoluteModelsDir, "upstream_extensions.json");
+
+    const tools = marker?.tools?.length ? marker.tools : ["claude"];
+    const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
+
+    const denoRuntime = new EmbeddedDenoRuntime();
+    catalog = new ExtensionCatalogStore(
+      swampPath(repoDir, "_extension_catalog.db"),
+    );
+
+    const serverUrl = resolveServerUrl();
+    const deps = await createExtensionUpdateDeps({
+      lockfilePath,
+      serverUrl,
+      installExtension: async (
+        name: string,
+        version: string,
+        channel?: string,
+      ) => {
+        const installCtx = await createInstallContext(serverUrl, {
+          logger,
+          lockfilePath,
+          skillsDirs,
+          repoDir,
+          force: true,
+          channel,
+        });
+        const repository = new ExtensionRepository({
+          catalog: catalog!,
+          lockfileRepository: installCtx.lockfileRepository,
+          repoRoot: repoDir,
+        });
+        return await new UpgradeExtensionService({
+          denoRuntime,
+          repository,
+        }).execute(name, version, installCtx);
+      },
+    });
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      extensionUpdate(libCtx, deps, {
+        extensionName: payload?.extensionName,
+        checkOnly: payload?.checkOnly ?? false,
+      }),
+      {
+        no_extensions: () => {},
+        extension_not_installed: () => {},
+        checking: () => {},
+        updating: () => {},
+        "orphans-pruned": () => {},
+        "shadowed-by-local": () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "extension.update",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const message = sanitizeErrorForClient(error);
+    sendError(socket, requestId, "extension_update_failed", message);
+  } finally {
+    catalog?.close();
+  }
+}
+
+export async function handleDatastoreSetupExtension(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: DatastoreSetupExtensionPayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const repoDir = ctx.repoDir;
+    const markerRepo = new RepoMarkerRepository();
+    const marker = await markerRepo.read(RepoPath.create(repoDir));
+    const deps = createDatastoreSetupDeps(repoDir);
+
+    const MAX_TIMEOUT_SECONDS = 21600;
+    const syncTimeoutMsOverride = payload.timeout != null
+      ? Math.min(payload.timeout, MAX_TIMEOUT_SECONDS) * 1000
+      : undefined;
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      datastoreSetupExtension(libCtx, deps, {
+        type: payload.type,
+        config: payload.config,
+        repoDir,
+        repoId: marker?.repoId,
+        skipMigration: payload.skipMigration ?? false,
+        hydrationStrategy: payload.hydrationStrategy as
+          | "full"
+          | "lazy"
+          | undefined,
+        namespace: payload.namespace,
+        syncTimeoutMsOverride,
+      }),
+      {
+        validating: () => {},
+        migrating: () => {},
+        hydrating: () => {},
+        warning: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "datastore.setup.extension",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const raw = error instanceof Error
+      ? error
+      : typeof error === "object" && error !== null && "message" in error
+      ? (error as { message: string }).message
+      : error;
+    const message = sanitizeErrorForClient(raw);
+    sendError(
+      socket,
+      requestId,
+      "datastore_setup_extension_failed",
+      message,
+    );
+  }
+}
+
+export async function handleVaultMigrate(
+  socket: WebSocket,
+  ctx: ConnectionContext,
+  requestId: string,
+  payload: VaultMigratePayload,
+  controller: AbortController,
+  principal: Principal | null,
+): Promise<void> {
+  if (
+    !authorizeOrReject(socket, requestId, principal, "admin", {
+      kind: "model",
+      name: "*",
+      fields: {},
+    }, ctx)
+  ) return;
+
+  try {
+    const libCtx = createLibSwampContext();
+    const repoDir = ctx.repoDir;
+    const deps = await createVaultMigrateDeps(repoDir);
+
+    await vaultMigratePreview(libCtx, deps, {
+      vaultName: payload.vaultName,
+      targetType: payload.targetType,
+      targetConfig: payload.targetConfig,
+      repoDir,
+    });
+
+    let result: Record<string, unknown> | undefined;
+    await consumeStream(
+      vaultMigrate(libCtx, deps, {
+        vaultName: payload.vaultName,
+        targetType: payload.targetType,
+        targetConfig: payload.targetConfig,
+        repoDir,
+      }),
+      {
+        copying_secret: () => {},
+        updating_config: () => {},
+        completed: (e) => {
+          result = e.data as unknown as Record<string, unknown>;
+        },
+        error: (e) => {
+          throw new Error(e.error.message);
+        },
+      },
+    );
+
+    if (controller.signal.aborted) {
+      sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      return;
+    }
+
+    send(socket, {
+      type: "vault.migrate",
+      id: requestId,
+      payload: { data: result ?? {} },
+    });
+  } catch (error) {
+    const raw = error instanceof Error
+      ? error
+      : typeof error === "object" && error !== null && "message" in error
+      ? (error as { message: string }).message
+      : error;
+    const message = sanitizeErrorForClient(raw);
+    sendError(socket, requestId, "vault_migrate_failed", message);
   }
 }
 

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -401,11 +401,41 @@ export interface ExtensionInfoPayload {
 
 export type ExtensionInstallPayload = Record<string, never>;
 
+export interface ExtensionPullPayload {
+  extensionName: string;
+  force?: boolean;
+  channel?: string;
+}
+
 export interface ExtensionRmPayload {
   extensionName: string;
 }
 
 export type ExtensionOutdatedPayload = Record<string, never>;
+
+export interface ExtensionUpdatePayload {
+  extensionName?: string;
+  checkOnly?: boolean;
+}
+
+// ── Datastore setup ─────────────────────────────────────────────────
+
+export interface DatastoreSetupExtensionPayload {
+  type: string;
+  config: Record<string, unknown>;
+  skipMigration?: boolean;
+  hydrationStrategy?: string;
+  namespace?: string;
+  timeout?: number;
+}
+
+// ── Vault migrate ───────────────────────────────────────────────────
+
+export interface VaultMigratePayload {
+  vaultName: string;
+  targetType: string;
+  targetConfig?: Record<string, unknown>;
+}
 
 // ── Doctor operations ────────────────────────────────────────────────
 
@@ -545,15 +575,27 @@ export type ServerRequest =
   }
   | { type: "worker.verify"; id: string; payload?: WorkerVerifyPayload }
   | { type: "datastore.status"; id: string; payload?: DatastoreStatusPayload }
+  | {
+    type: "datastore.setup.extension";
+    id: string;
+    payload: DatastoreSetupExtensionPayload;
+  }
+  | { type: "vault.migrate"; id: string; payload: VaultMigratePayload }
   | { type: "extension.list"; id: string; payload?: ExtensionListPayload }
   | { type: "extension.search"; id: string; payload?: ExtensionSearchPayload }
   | { type: "extension.info"; id: string; payload: ExtensionInfoPayload }
   | { type: "extension.install"; id: string; payload?: ExtensionInstallPayload }
+  | { type: "extension.pull"; id: string; payload: ExtensionPullPayload }
   | { type: "extension.rm"; id: string; payload: ExtensionRmPayload }
   | {
     type: "extension.outdated";
     id: string;
     payload?: ExtensionOutdatedPayload;
+  }
+  | {
+    type: "extension.update";
+    id: string;
+    payload?: ExtensionUpdatePayload;
   }
   | { type: "doctor.vaults"; id: string; payload?: DoctorVaultsPayload }
   | {
@@ -863,6 +905,14 @@ export interface DatastoreStatusResponse {
   data: Record<string, unknown>;
 }
 
+export interface DatastoreSetupExtensionResponse {
+  data: Record<string, unknown>;
+}
+
+export interface VaultMigrateResponse {
+  data: Record<string, unknown>;
+}
+
 export interface ExtensionListResponse {
   data: Record<string, unknown>;
 }
@@ -879,11 +929,19 @@ export interface ExtensionInstallResponse {
   data: Record<string, unknown>;
 }
 
+export interface ExtensionPullResponse {
+  data: Record<string, unknown>;
+}
+
 export interface ExtensionRmResponse {
   data: Record<string, unknown>;
 }
 
 export interface ExtensionOutdatedResponse {
+  data: Record<string, unknown>;
+}
+
+export interface ExtensionUpdateResponse {
   data: Record<string, unknown>;
 }
 
@@ -1057,15 +1115,27 @@ export type ServerMessage =
   }
   | { type: "worker.verify"; id: string; payload: WorkerVerifyResponse }
   | { type: "datastore.status"; id: string; payload: DatastoreStatusResponse }
+  | {
+    type: "datastore.setup.extension";
+    id: string;
+    payload: DatastoreSetupExtensionResponse;
+  }
+  | { type: "vault.migrate"; id: string; payload: VaultMigrateResponse }
   | { type: "extension.list"; id: string; payload: ExtensionListResponse }
   | { type: "extension.search"; id: string; payload: ExtensionSearchResponse }
   | { type: "extension.info"; id: string; payload: ExtensionInfoResponse }
   | { type: "extension.install"; id: string; payload: ExtensionInstallResponse }
+  | { type: "extension.pull"; id: string; payload: ExtensionPullResponse }
   | { type: "extension.rm"; id: string; payload: ExtensionRmResponse }
   | {
     type: "extension.outdated";
     id: string;
     payload: ExtensionOutdatedResponse;
+  }
+  | {
+    type: "extension.update";
+    id: string;
+    payload: ExtensionUpdateResponse;
   }
   | { type: "doctor.vaults"; id: string; payload: DoctorVaultsResponse }
   | {


### PR DESCRIPTION
## Summary

- Adds `--server` flag to `extension pull`, `extension update`, `datastore setup extension`, and `vault migrate` — enabling remote server administration without SSH access
- Adds wire protocol types, Zod validation schemas, and server-side handlers for `extension.pull`, `extension.update`, `datastore.setup.extension`, and `vault.migrate`
- Fixes `[object Object]` error messages when server handlers catch `SwampError` (plain objects, not `Error` instances)
- `extension update --check --server` routes through the new `extension.update` frame (with `checkOnly: true`) instead of the existing `extension.outdated` frame, so the `extensionName` filter works correctly
- `vault migrate --server` requires `--to-type` (interactive mode unavailable remotely)

## Test Plan

- [x] `deno check` — all 7 modified files pass
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno run test` — 9516 passed, 0 failed
- [x] Compiled binary, started `swamp serve`, verified `--server` and `--token` appear in `--help` for all 4 commands
- [x] End-to-end: `extension pull @swamp/gcp/storage --server` — pulled 26 files
- [x] End-to-end: `extension update --check --server` — reported up to date
- [x] End-to-end: `extension update --server` — 1 up to date
- [x] End-to-end: `doctor vaults --server` — scanned 594 definitions
- [x] End-to-end: `datastore setup extension @swamp/s3-datastore --server` against ministack S3 — setup completed
- [x] End-to-end: `vault migrate my-secrets --to-type @swamp/aws-sm --server` against ministack Secrets Manager — 1 secret migrated, verified in ministack
- [x] Error paths: nonexistent vault, missing `--to-type`, unregistered datastore type — all produce clean error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)