### PR TITLE
feat(models): add rollbackOnFailure for method-level write atomicity

### DIFF
--- a/design/models.md
+++ b/design/models.md
@@ -632,6 +632,50 @@ Lightweight reference to data already persisted:
 | `metadata` | Full metadata for the data artifact       |
 | `attributes` | Top-level resource attributes (resource kind only, optional) |
 
+### Write Atomicity (rollbackOnFailure)
+
+By default, `writeResource()` and `createFileWriter()` commit each write
+immediately — the `latest` marker advances and the data is visible to
+`data.latest()` consumers. If a method fails midway, earlier writes persist.
+
+Methods can opt into all-or-nothing write semantics by setting
+`rollbackOnFailure: true` on the method definition:
+
+```typescript
+methods: {
+  readAll: {
+    description: "Read all 96 wells",
+    rollbackOnFailure: true,
+    arguments: z.object({}),
+    execute: async (args, ctx) => {
+      for (const well of wells) {
+        await ctx.writeResource("reading", well, await instrument.read(well));
+      }
+      return {};
+    },
+  },
+}
+```
+
+When `rollbackOnFailure` is true, writes use deferred-latest mode:
+
+1. **During execution**: Data persists to disk but the `latest` marker is not
+   advanced. The catalog row is written with `is_latest=0`. Concurrent readers
+   calling `data.latest()` see the previous version (or nothing).
+2. **On success**: All `latest` markers advance and catalog rows flip to
+   `is_latest=1`. Data becomes visible atomically.
+3. **On failure**: Version directories are deleted and catalog rows are removed.
+   No trace of the failed writes remains.
+
+The deferred-latest approach has no TOCTOU window — markers are never advanced
+during execution, so there is nothing to roll back on failure.
+
+**When NOT to use**: Methods that interact with external systems and write data
+reflecting real-world state should not set this flag. Their writes may be the
+most accurate picture of reality even if the method fails partway. Methods that
+deliberately write-then-throw (e.g. a code-review model that writes results
+then throws on verdict=FAIL) must also leave this flag unset.
+
 ## Output
 
 Each method invocation produces an output record, which gets tracked in the

--- a/integration/rollback_on_failure_test.ts
+++ b/integration/rollback_on_failure_test.ts
@@ -1,0 +1,563 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import { z } from "zod";
+import { InProcessExecutor } from "../src/domain/models/in_process_executor.ts";
+import type { MethodExecutor } from "../src/domain/models/in_process_executor.ts";
+import type { ExecutionRequest } from "../src/domain/models/execution_envelope.ts";
+import { Definition } from "../src/domain/definitions/definition.ts";
+import { ModelType } from "../src/domain/models/model_type.ts";
+import type {
+  MethodContext,
+  MethodDefinition,
+  ModelDefinition,
+} from "../src/domain/models/model.ts";
+import type { DefinitionRepository } from "../src/domain/definitions/repositories.ts";
+import { FileSystemUnifiedDataRepository } from "../src/infrastructure/persistence/unified_data_repository.ts";
+import { CatalogStore } from "../src/infrastructure/persistence/catalog_store.ts";
+import { createExtensionCelEnvironment } from "../src/infrastructure/cel/cel_evaluator.ts";
+
+const MODEL_TYPE = ModelType.create("test/rollback-on-failure");
+
+const MarkerSchema = z.object({
+  marker: z.string(),
+  writtenAt: z.string(),
+});
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "swamp-rollback-test-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+function createModelDef(): ModelDefinition {
+  return {
+    type: MODEL_TYPE,
+    version: "2026.01.01.1",
+    resources: {
+      first: {
+        description: "First resource",
+        schema: MarkerSchema,
+        lifetime: "infinite",
+        garbageCollection: 20,
+      },
+      second: {
+        description: "Second resource",
+        schema: MarkerSchema,
+        lifetime: "infinite",
+        garbageCollection: 20,
+      },
+    },
+    files: {
+      log: {
+        description: "Log file",
+        contentType: "text/plain",
+        lifetime: "infinite",
+        garbageCollection: 20,
+      },
+    },
+    methods: {},
+  };
+}
+
+function createExecutor(): MethodExecutor {
+  return {
+    execute: (_definition, method, context) => method.execute({}, context),
+  };
+}
+
+function createContext(
+  repoDir: string,
+  dataRepo: FileSystemUnifiedDataRepository,
+  definitionId: string,
+): MethodContext {
+  return {
+    repoDir,
+    modelType: MODEL_TYPE,
+    modelId: definitionId,
+    globalArgs: {},
+    definition: {
+      id: definitionId,
+      name: "test-rollback",
+      version: 1,
+      tags: {},
+    },
+    methodName: "test",
+    logger: getLogger(["test"]),
+    dataRepository: dataRepo,
+    definitionRepository: {} as DefinitionRepository,
+    signal: new AbortController().signal,
+    extensionFile: () => {
+      throw new Error("extensionFile not stubbed");
+    },
+    createCelEnvironment: createExtensionCelEnvironment,
+  } as MethodContext;
+}
+
+Deno.test("rollbackOnFailure: success commits all writes", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description: "Writes two resources and succeeds",
+      rollbackOnFailure: true,
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        await ctx.writeResource!("first", "a", {
+          marker: "from-success",
+          writtenAt: new Date().toISOString(),
+        });
+        await ctx.writeResource!("second", "b", {
+          marker: "from-success",
+          writtenAt: new Date().toISOString(),
+        });
+        return {};
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "success");
+    assertEquals(result.outputs.length, 2);
+
+    const contentA = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "a",
+    );
+    assertEquals(contentA !== null, true);
+
+    const contentB = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "b",
+    );
+    assertEquals(contentB !== null, true);
+  });
+});
+
+Deno.test("rollbackOnFailure: failure rolls back all writes", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description: "Writes one resource then fails",
+      rollbackOnFailure: true,
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        await ctx.writeResource!("first", "a", {
+          marker: "from-failure",
+          writtenAt: new Date().toISOString(),
+        });
+        throw new Error("deliberate failure after the first write");
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "error");
+    assertEquals(result.outputs.length, 0);
+
+    const contentA = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "a",
+    );
+    assertEquals(contentA, null);
+  });
+});
+
+Deno.test("rollbackOnFailure: default path preserves writes on failure", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description:
+        "Writes one resource then fails (default path — no rollback)",
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        await ctx.writeResource!("first", "a", {
+          marker: "from-default-failure",
+          writtenAt: new Date().toISOString(),
+        });
+        throw new Error("deliberate failure after the first write");
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "error");
+    assertEquals(result.outputs.length, 1);
+
+    const contentA = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "a",
+    );
+    assertEquals(contentA !== null, true);
+  });
+});
+
+Deno.test("rollbackOnFailure: file writer rollback on failure", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description: "Uses createFileWriter then fails",
+      rollbackOnFailure: true,
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        const writer = ctx.createFileWriter!("log", "execution-log");
+        await writer.writeLine("line 1");
+        await writer.writeLine("line 2");
+        const handle = await writer.finalize();
+        await ctx.writeResource!("first", "a", {
+          marker: "from-file-test",
+          writtenAt: new Date().toISOString(),
+        });
+        throw new Error(
+          `deliberate failure after finalize and writeResource (handle v${handle.version})`,
+        );
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "error");
+    assertEquals(result.outputs.length, 0);
+
+    const logContent = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "execution-log",
+    );
+    assertEquals(logContent, null);
+
+    const resourceContent = await dataRepo.getContent(
+      MODEL_TYPE,
+      definition.id,
+      "a",
+    );
+    assertEquals(resourceContent, null);
+  });
+});
+
+Deno.test("rollbackOnFailure: unfinalized file writer cleaned up on failure", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description: "Starts a file writer but fails before finalize",
+      rollbackOnFailure: true,
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        const writer = ctx.createFileWriter!("log", "partial-log");
+        await writer.writeLine("line 1");
+        throw new Error("deliberate failure before finalize");
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "error");
+    assertEquals(result.outputs.length, 0);
+
+    const versions = await dataRepo.listVersions(
+      MODEL_TYPE,
+      definition.id,
+      "partial-log",
+    );
+    assertEquals(versions.length, 0);
+  });
+});
+
+Deno.test("rollbackOnFailure: multi-resource rollback (96-well scenario)", async () => {
+  await withTempDir(async (repoDir) => {
+    const catalogDb = join(repoDir, ".swamp", "catalog.db");
+    await Deno.mkdir(join(repoDir, ".swamp"), { recursive: true });
+    const catalogStore = new CatalogStore(catalogDb);
+    const dataRepo = new FileSystemUnifiedDataRepository(
+      repoDir,
+      undefined,
+      catalogStore,
+    );
+
+    const definition = Definition.create({
+      name: "test-rollback",
+      methods: { test: { arguments: {} } },
+    });
+
+    const method: MethodDefinition = {
+      description: "Writes 10 resources then fails at resource 11",
+      rollbackOnFailure: true,
+      arguments: z.object({}),
+      execute: async (_args, ctx) => {
+        for (let i = 0; i < 10; i++) {
+          await ctx.writeResource!("first", `well-${i}`, {
+            marker: `reading-${i}`,
+            writtenAt: new Date().toISOString(),
+          });
+        }
+        throw new Error("instrument failure at well 11");
+      },
+    };
+
+    const modelDef = createModelDef();
+    const context = createContext(repoDir, dataRepo, definition.id);
+
+    const executor = new InProcessExecutor(
+      createExecutor(),
+      definition,
+      method,
+      modelDef,
+      context,
+      "test",
+    );
+
+    const request: ExecutionRequest = {
+      protocolVersion: 1,
+      modelType: MODEL_TYPE.normalized,
+      modelId: definition.id,
+      methodName: "test",
+      globalArgs: {},
+      methodArgs: {},
+      definitionMeta: {
+        id: definition.id,
+        name: "test-rollback",
+        version: 1,
+        tags: {},
+      },
+    };
+
+    const result = await executor.execute(request);
+
+    assertEquals(result.status, "error");
+    assertEquals(result.outputs.length, 0);
+
+    for (let i = 0; i < 10; i++) {
+      const content = await dataRepo.getContent(
+        MODEL_TYPE,
+        definition.id,
+        `well-${i}`,
+      );
+      assertEquals(content, null, `well-${i} should have been rolled back`);
+    }
+  });
+});

--- a/integration/vault_selection_test.ts
+++ b/integration/vault_selection_test.ts
@@ -73,6 +73,26 @@ function createMockRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/packages/testing/model_definition_types.ts
+++ b/packages/testing/model_definition_types.ts
@@ -83,6 +83,7 @@ export interface MethodDefinition<
 > {
   description: string;
   kind?: "create" | "read" | "update" | "delete" | "list" | "action";
+  rollbackOnFailure?: boolean;
   arguments: TArgs;
   execute(
     args: z.infer<TArgs>,

--- a/src/domain/data/composite_data_repository.ts
+++ b/src/domain/data/composite_data_repository.ts
@@ -23,6 +23,7 @@ import type { ModelType, ModelTypeInput } from "../models/model_type.ts";
 import { coerceModelType } from "../models/model_type.ts";
 import type { Namespace } from "./namespace.ts";
 import type {
+  DeferredWriteReceipt,
   GarbageCollectionResult,
   UnifiedDataRepository,
 } from "./repositories.ts";
@@ -421,6 +422,45 @@ export class CompositeUnifiedDataRepository implements UnifiedDataRepository {
       if (!seen.has(key)) merged.push(item);
     }
     return merged;
+  }
+
+  saveDeferred(
+    _type: ModelType,
+    _modelId: string,
+    _data: Data,
+    _content: Uint8Array,
+  ): Promise<DeferredWriteReceipt> {
+    throw new Error("saveDeferred is not supported in composite repository");
+  }
+
+  finalizeVersionDeferred(
+    _type: ModelType,
+    _modelId: string,
+    _data: Data,
+    _version: number,
+    _priorVersions?: number[],
+  ): Promise<
+    { receipt: DeferredWriteReceipt; size: number; checksum: string }
+  > {
+    throw new Error(
+      "finalizeVersionDeferred is not supported in composite repository",
+    );
+  }
+
+  advanceLatestMarkers(
+    _receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    throw new Error(
+      "advanceLatestMarkers is not supported in composite repository",
+    );
+  }
+
+  rollbackVersions(
+    _receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    throw new Error(
+      "rollbackVersions is not supported in composite repository",
+    );
   }
 
   async findByTaggedName(

--- a/src/domain/data/repositories.ts
+++ b/src/domain/data/repositories.ts
@@ -69,6 +69,16 @@ export interface GarbageCollectionResult {
 }
 
 /**
+ * Receipt for a deferred write — enough information to commit or roll back.
+ */
+export interface DeferredWriteReceipt {
+  readonly type: ModelType;
+  readonly modelId: string;
+  readonly dataName: string;
+  readonly version: number;
+}
+
+/**
  * Repository interface for unified Data storage with versioning.
  */
 export interface UnifiedDataRepository {
@@ -283,6 +293,49 @@ export interface UnifiedDataRepository {
     version: number,
     priorVersions?: number[],
   ): Promise<{ size: number; checksum: string }>;
+
+  /**
+   * Saves data without advancing the latest marker. Writes the version
+   * directory, content, and metadata to disk, and inserts a catalog row
+   * with is_latest=0. The data is invisible to latest-based reads until
+   * advanceLatestMarkers() is called.
+   *
+   * @returns A receipt that can be passed to advanceLatestMarkers or rollbackVersions
+   */
+  saveDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<DeferredWriteReceipt>;
+
+  /**
+   * Finalizes a previously allocated version without advancing the latest
+   * marker. Mirrors finalizeVersion but writes the catalog row with
+   * is_latest=0.
+   *
+   * @returns A receipt plus size and checksum
+   */
+  finalizeVersionDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+    priorVersions?: number[],
+  ): Promise<{ receipt: DeferredWriteReceipt; size: number; checksum: string }>;
+
+  /**
+   * Commits deferred writes by advancing the latest marker and flipping
+   * catalog is_latest to 1 for each receipt. Handles partial failure
+   * gracefully — logs and continues if one marker fails.
+   */
+  advanceLatestMarkers(receipts: DeferredWriteReceipt[]): Promise<void>;
+
+  /**
+   * Rolls back deferred writes by deleting version directories and removing
+   * catalog rows for each receipt.
+   */
+  rollbackVersions(receipts: DeferredWriteReceipt[]): Promise<void>;
 
   /**
    * Generates a new unique ID.

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -276,6 +276,9 @@ function convertToModelDefinition(
     methods[name] = {
       description: method.description,
       ...(method.kind ? { kind: method.kind as MethodKind } : {}),
+      ...(method.rollbackOnFailure != null
+        ? { rollbackOnFailure: Boolean(method.rollbackOnFailure) }
+        : {}),
       arguments: method.arguments,
       execute: wrapUserExecute(method.execute),
     };
@@ -572,6 +575,9 @@ export const modelKindAdapter: KindAdapter = {
       methods[name] = {
         description: method.description,
         ...(method.kind ? { kind: method.kind as MethodKind } : {}),
+        ...(method.rollbackOnFailure != null
+          ? { rollbackOnFailure: Boolean(method.rollbackOnFailure) }
+          : {}),
         arguments: method.arguments,
         execute: wrapUserExecute(method.execute),
       };

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -29,6 +29,7 @@ import {
   shellModel,
 } from "./shell_model.ts";
 import type { DataHandle, DataWriter, MethodContext } from "../../model.ts";
+import { ModelType } from "../../model_type.ts";
 import type { UnifiedDataRepository } from "../../../data/repositories.ts";
 import { SOLO_NAMESPACE } from "../../../data/namespace.ts";
 import type { DefinitionRepository } from "../../../definitions/repositories.ts";
@@ -250,6 +251,26 @@ function createMockDataRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/domain/models/data_writer.ts
+++ b/src/domain/models/data_writer.ts
@@ -21,7 +21,10 @@ import { z } from "zod";
 import { getLogger } from "@logtape/logtape";
 import { Data, isReservedDataName } from "../data/mod.ts";
 import type { DataId, OwnerDefinition } from "../data/mod.ts";
-import type { UnifiedDataRepository } from "../data/repositories.ts";
+import type {
+  DeferredWriteReceipt,
+  UnifiedDataRepository,
+} from "../data/repositories.ts";
 import type { ModelType } from "./model_type.ts";
 import type { MethodExecutionEvent } from "./method_events.ts";
 import type {
@@ -68,6 +71,8 @@ export class DefaultDataWriter implements DataWriter {
   private data: Data | null = null;
   private lineBuffer: string[] | null = null;
   private finalized = false;
+  private readonly deferred: boolean;
+  private deferredReceipt: DeferredWriteReceipt | null = null;
 
   constructor(
     repo: UnifiedDataRepository,
@@ -75,19 +80,47 @@ export class DefaultDataWriter implements DataWriter {
     modelId: string,
     options: ResolvedDataWriterOptions,
     callbacks: DataWriterCallbacks = {},
+    deferred = false,
   ) {
     this.repo = repo;
     this.modelType = modelType;
     this.modelId = modelId;
     this.options = options;
     this.callbacks = callbacks;
+    this.deferred = deferred;
     this.dataId = repo.nextId();
     this.name = options.name;
+  }
+
+  getDeferredReceipt(): DeferredWriteReceipt | null {
+    return this.deferredReceipt;
+  }
+
+  getPendingDeferredReceipt(): DeferredWriteReceipt | null {
+    if (!this.deferred || this.finalized || !this.allocated) return null;
+    return {
+      type: this.modelType,
+      modelId: this.modelId,
+      dataName: this.name,
+      version: this.allocated.version,
+    };
   }
 
   async writeAll(content: Uint8Array): Promise<DataHandle> {
     this.ensureNotFinalized();
     const data = this.createDataEntity();
+
+    if (this.deferred) {
+      const receipt = await this.repo.saveDeferred(
+        this.modelType,
+        this.modelId,
+        data,
+        content,
+      );
+      this.deferredReceipt = receipt;
+      this.finalized = true;
+      return this.buildHandle(receipt.version, content.length);
+    }
 
     const saveResult = await this.repo.save(
       this.modelType,
@@ -221,6 +254,19 @@ export class DefaultDataWriter implements DataWriter {
       throw new Error(
         `DataWriter "${this.name}" has not been used — nothing to finalize`,
       );
+    }
+
+    if (this.deferred) {
+      const { receipt, size } = await this.repo.finalizeVersionDeferred(
+        this.modelType,
+        this.modelId,
+        this.data,
+        this.allocated.version,
+        this.allocated.priorVersions,
+      );
+      this.deferredReceipt = receipt;
+      this.finalized = true;
+      return this.buildHandle(this.allocated.version, size);
     }
 
     const { size, checksum: _checksum } = await this.repo.finalizeVersion(
@@ -456,6 +502,7 @@ export function createResourceWriter(
   methodName?: string,
   onEvent?: (event: MethodExecutionEvent) => void,
   redactor?: SecretRedactor,
+  deferred = false,
 ): {
   writeResource: (
     specName: string,
@@ -464,8 +511,10 @@ export function createResourceWriter(
     overrides?: ResourceWriteOverrides,
   ) => Promise<DataHandle>;
   getHandles: () => DataHandle[];
+  getDeferredReceipts: () => DeferredWriteReceipt[];
 } {
   const handles: DataHandle[] = [];
+  const deferredReceipts: DeferredWriteReceipt[] = [];
   const writerLogger = getLogger([
     "swamp",
     "data-writer",
@@ -639,6 +688,8 @@ export function createResourceWriter(
       modelType,
       modelId,
       resolvedOptions,
+      {},
+      deferred,
     );
 
     const serialized = redactor
@@ -647,10 +698,18 @@ export function createResourceWriter(
     const handle = await writer.writeText(serialized);
     handle.attributes = { ...data };
     handles.push(handle);
+    const receipt = writer.getDeferredReceipt();
+    if (receipt) {
+      deferredReceipts.push(receipt);
+    }
     return handle;
   };
 
-  return { writeResource, getHandles: () => [...handles] };
+  return {
+    writeResource,
+    getHandles: () => [...handles],
+    getDeferredReceipts: () => [...deferredReceipts],
+  };
 }
 
 /**
@@ -826,6 +885,7 @@ export function createFileWriterFactory(
   definitionTags?: Record<string, string>,
   runtimeTags?: Record<string, string>,
   definitionName?: string,
+  deferred = false,
 ): {
   createFileWriter: (
     specName: string,
@@ -833,9 +893,11 @@ export function createFileWriterFactory(
     overrides?: FileWriterOverrides,
   ) => DataWriter;
   getHandles: () => DataHandle[];
+  getDeferredReceipts: () => DeferredWriteReceipt[];
 } {
   const handles: DataHandle[] = [];
   const writers: DefaultDataWriter[] = [];
+  const deferredReceipts: DeferredWriteReceipt[] = [];
 
   const createFileWriter = (
     specName: string,
@@ -956,6 +1018,7 @@ export function createFileWriterFactory(
       modelId,
       resolvedOptions,
       callbacks,
+      deferred,
     );
     writers.push(writer);
 
@@ -969,17 +1032,36 @@ export function createFileWriterFactory(
     writer.writeAll = async (content: Uint8Array) => {
       const handle = await originalWriteAll(content);
       handles.push(handle);
+      const receipt = writer.getDeferredReceipt();
+      if (receipt) {
+        deferredReceipts.push(receipt);
+      }
       return handle;
     };
 
     writer.finalize = async () => {
       const handle = await originalFinalize();
       handles.push(handle);
+      const receipt = writer.getDeferredReceipt();
+      if (receipt) {
+        deferredReceipts.push(receipt);
+      }
       return handle;
     };
 
     return writer;
   };
 
-  return { createFileWriter, getHandles: () => [...handles] };
+  return {
+    createFileWriter,
+    getHandles: () => [...handles],
+    getDeferredReceipts: () => {
+      const receipts = [...deferredReceipts];
+      for (const writer of writers) {
+        const pending = writer.getPendingDeferredReceipt();
+        if (pending) receipts.push(pending);
+      }
+      return receipts;
+    },
+  };
 }

--- a/src/domain/models/data_writer_test.ts
+++ b/src/domain/models/data_writer_test.ts
@@ -77,6 +77,26 @@ function createMockRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -150,9 +150,12 @@ export class InProcessExecutor {
     const resources = this.modelDef.resources ?? {};
     const files = this.modelDef.files ?? {};
 
+    const deferred = this.method.rollbackOnFailure === true;
+
     const {
       writeResource,
       getHandles: getResourceHandles,
+      getDeferredReceipts: getResourceReceipts,
     } = createResourceWriter(
       this.context.dataRepository,
       this.context.modelType,
@@ -167,11 +170,13 @@ export class InProcessExecutor {
       this.methodName,
       this.context.onEvent,
       this.context.redactor,
+      deferred,
     );
 
     const {
       createFileWriter,
       getHandles: getFileHandles,
+      getDeferredReceipts: getFileReceipts,
     } = createFileWriterFactory(
       this.context.dataRepository,
       this.context.modelType,
@@ -183,6 +188,7 @@ export class InProcessExecutor {
       this.definition.tags,
       this.context.runtimeTags,
       this.definition.name,
+      deferred,
     );
 
     const readResource = createResourceReader(
@@ -273,6 +279,15 @@ export class InProcessExecutor {
       );
 
       const durationMs = performance.now() - start;
+
+      if (deferred) {
+        const receipts = [
+          ...getResourceReceipts(),
+          ...getFileReceipts(),
+        ];
+        await this.context.dataRepository.advanceLatestMarkers(receipts);
+      }
+
       const writerHandles = [
         ...getResourceHandles(),
         ...getFileHandles(),
@@ -293,10 +308,27 @@ export class InProcessExecutor {
         followUpActions: result.followUpActions,
       };
     } catch (error) {
+      const durationMs = performance.now() - start;
+
+      if (deferred) {
+        const receipts = [
+          ...getResourceReceipts(),
+          ...getFileReceipts(),
+        ];
+        await this.context.dataRepository.rollbackVersions(receipts);
+
+        return {
+          status: "error",
+          error: error instanceof Error ? error.message : String(error),
+          outputs: [],
+          logs,
+          durationMs,
+        };
+      }
+
       // Collect handles for data that was already written to disk before the
       // throw. Without this, data produced by a method that writes-then-throws
       // (e.g. code-review verdict=FAIL) would be invisible to workflow queries.
-      const durationMs = performance.now() - start;
       const writerHandles = [
         ...getResourceHandles(),
         ...getFileHandles(),

--- a/src/domain/models/in_process_executor_test.ts
+++ b/src/domain/models/in_process_executor_test.ts
@@ -69,6 +69,26 @@ function createMockDataRepo(): UnifiedDataRepository {
       }),
     finalizeVersion: () =>
       Promise.resolve({ size: 0, checksum: "mock-checksum" }),
+    saveDeferred: () =>
+      Promise.resolve({
+        type: TEST_MODEL_TYPE,
+        modelId: "mock",
+        dataName: "mock",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: TEST_MODEL_TYPE,
+          modelId: "mock",
+          dataName: "mock",
+          version: 1,
+        },
+        size: 0,
+        checksum: "mock-checksum",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
     getLatestVersionSync: () => null,
     findByNameSync: () => null,
     listVersionsSync: () => [],

--- a/src/domain/models/method_execution_service.ts
+++ b/src/domain/models/method_execution_service.ts
@@ -822,6 +822,18 @@ export class DefaultMethodExecutionService implements MethodExecutionService {
       let result: MethodResult;
       let executionContext: MethodContext = context;
 
+      if (
+        method.rollbackOnFailure &&
+        context.placement &&
+        hasPlacement(context.placement)
+      ) {
+        throw new Error(
+          `Method '${methodName}' declares rollbackOnFailure but has remote ` +
+            `placement — deferred-latest writes are not yet supported for ` +
+            `remote execution. Remove rollbackOnFailure or run locally.`,
+        );
+      }
+
       try {
         if (context.placement && hasPlacement(context.placement)) {
           // Remote placement: the method body runs on a matching worker; the

--- a/src/domain/models/method_execution_service_test.ts
+++ b/src/domain/models/method_execution_service_test.ts
@@ -235,6 +235,26 @@ function createMockDataRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -744,6 +744,13 @@ export interface MethodDefinition<
   kind?: MethodKind;
 
   /**
+   * When true, writes use deferred-latest mode: data persists to disk but
+   * the latest marker is not advanced until the method succeeds. On failure,
+   * all written version directories are deleted.
+   */
+  rollbackOnFailure?: boolean;
+
+  /**
    * Zod schema for validating per-method arguments.
    * Arguments are validated before execute() is called.
    */

--- a/src/domain/models/model_test.ts
+++ b/src/domain/models/model_test.ts
@@ -199,6 +199,26 @@ function createMockDataRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/domain/models/user_model_loader_test.ts
+++ b/src/domain/models/user_model_loader_test.ts
@@ -233,6 +233,26 @@ function createMockDataRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/domain/models/validation_service_test.ts
+++ b/src/domain/models/validation_service_test.ts
@@ -1144,6 +1144,26 @@ function createMockDataRepo(): UnifiedDataRepository {
     rename: () => {
       throw new Error("not implemented");
     },
+    saveDeferred: () =>
+      Promise.resolve({
+        type: ModelType.create("test"),
+        modelId: "",
+        dataName: "",
+        version: 1,
+      }),
+    finalizeVersionDeferred: () =>
+      Promise.resolve({
+        receipt: {
+          type: ModelType.create("test"),
+          modelId: "",
+          dataName: "",
+          version: 1,
+        },
+        size: 0,
+        checksum: "",
+      }),
+    advanceLatestMarkers: () => Promise.resolve(),
+    rollbackVersions: () => Promise.resolve(),
   };
 }
 

--- a/src/infrastructure/persistence/in_memory_data_repository.ts
+++ b/src/infrastructure/persistence/in_memory_data_repository.ts
@@ -28,6 +28,7 @@ import {
 import type { Namespace } from "../../domain/data/namespace.ts";
 import { SOLO_NAMESPACE } from "../../domain/data/namespace.ts";
 import {
+  type DeferredWriteReceipt,
   EphemeralBudgetExceededError,
   type GarbageCollectionResult,
   OwnershipValidationError,
@@ -166,8 +167,11 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     modelId: string,
     dataName: string,
   ): number {
-    const current = this.getLatestVersionNumber(type, modelId, dataName);
-    return (current ?? 0) + 1;
+    const fromLatest = this.getLatestVersionNumber(type, modelId, dataName) ??
+      0;
+    const versions = this.listVersionsSync(type, modelId, dataName);
+    const fromMap = versions.length > 0 ? Math.max(...versions) : 0;
+    return Math.max(fromLatest, fromMap) + 1;
   }
 
   private pruneExcessVersions(
@@ -397,6 +401,134 @@ export class InMemoryUnifiedDataRepository implements UnifiedDataRepository {
     }
 
     return { size, checksum };
+  }
+
+  async saveDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<DeferredWriteReceipt> {
+    this.ensureNotDisposed();
+
+    if (isReservedDataName(data.name)) {
+      throw new Error(
+        `Data name '${data.name}' is reserved for internal use. Use a different name.`,
+      );
+    }
+
+    const existing = this.findByNameSync(type, modelId, data.name);
+    if (existing) {
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition,
+          data.ownerDefinition,
+        );
+      }
+    }
+
+    const newVersion = this.nextVersion(type, modelId, data.name);
+    this.ensureBudget(content.length);
+
+    const dataToSave = data.withNewVersion({
+      version: newVersion,
+      size: content.length,
+      checksum: await this.computeChecksum(content),
+    });
+
+    const key = dataKey(type.normalized, modelId, data.name, newVersion);
+    this.dataMap.set(key, dataToSave);
+    this.contentMap.set(key, content);
+    this.totalBytes += content.length;
+    // Do NOT update latestVersionMap — deferred
+
+    return { type, modelId, dataName: data.name, version: newVersion };
+  }
+
+  async finalizeVersionDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+    _priorVersions?: number[],
+  ): Promise<
+    { receipt: DeferredWriteReceipt; size: number; checksum: string }
+  > {
+    this.ensureNotDisposed();
+
+    let tempPath: string | undefined;
+    for (const [path, alloc] of this.allocatedPaths) {
+      if (
+        alloc.typeNormalized === type.normalized &&
+        alloc.modelId === modelId &&
+        alloc.data.name === data.name &&
+        alloc.version === version
+      ) {
+        tempPath = path;
+        break;
+      }
+    }
+
+    let content: Uint8Array;
+    if (tempPath) {
+      content = await Deno.readFile(tempPath);
+      await Deno.remove(tempPath).catch(() => {});
+      this.allocatedPaths.delete(tempPath);
+    } else {
+      content = new Uint8Array(0);
+    }
+
+    this.ensureBudget(content.length);
+
+    const checksum = await this.computeChecksum(content);
+    const size = content.length;
+
+    const dataToSave = data.withNewVersion({ version, size, checksum });
+
+    const key = dataKey(type.normalized, modelId, data.name, version);
+    this.dataMap.set(key, dataToSave);
+    this.contentMap.set(key, content);
+    this.totalBytes += content.length;
+    // Do NOT update latestVersionMap — deferred
+
+    return {
+      receipt: { type, modelId, dataName: data.name, version },
+      size,
+      checksum,
+    };
+  }
+
+  advanceLatestMarkers(
+    receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    for (const receipt of receipts) {
+      this.latestVersionMap.set(
+        latestKey(receipt.type.normalized, receipt.modelId, receipt.dataName),
+        receipt.version,
+      );
+    }
+    return Promise.resolve();
+  }
+
+  rollbackVersions(
+    receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    for (const receipt of receipts) {
+      const key = dataKey(
+        receipt.type.normalized,
+        receipt.modelId,
+        receipt.dataName,
+        receipt.version,
+      );
+      const content = this.contentMap.get(key);
+      if (content) {
+        this.totalBytes -= content.length;
+      }
+      this.dataMap.delete(key);
+      this.contentMap.delete(key);
+    }
+    return Promise.resolve();
   }
 
   // --- Read Operations ---

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -45,6 +45,7 @@ import type {
 import type { CatalogStore } from "./catalog_store.ts";
 import { type Namespace, SOLO_NAMESPACE } from "../../domain/data/namespace.ts";
 import {
+  type DeferredWriteReceipt,
   type GarbageCollectionResult,
   OwnershipValidationError,
   type UnifiedDataRepository,
@@ -642,6 +643,95 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     return { version: newVersion };
   }
 
+  async saveDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    content: Uint8Array,
+  ): Promise<DeferredWriteReceipt> {
+    if (isReservedDataName(data.name)) {
+      throw new Error(
+        `Data name '${data.name}' is reserved for internal use. Use a different name.`,
+      );
+    }
+
+    await this.notifyDirty(this.getDataNameDir(type, modelId, data.name));
+
+    const existing = await this.findByName(type, modelId, data.name);
+    if (existing) {
+      if (!existing.isOwnedBy(data.ownerDefinition)) {
+        throw new OwnershipValidationError(
+          data.name,
+          existing.ownerDefinition,
+          data.ownerDefinition,
+        );
+      }
+    }
+
+    const { version: newVersion } = await this.atomicAllocateVersionDir(
+      type,
+      modelId,
+      data.name,
+    );
+
+    const dataToSave = data.withNewVersion({
+      version: newVersion,
+      size: content.length,
+      checksum: await this.computeChecksum(content),
+    });
+
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      data.name,
+      newVersion,
+    );
+    const boundary = this.baseDir;
+    await assertSafePath(metadataPath, boundary);
+    const metadata = dataToSave.toData();
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
+    await atomicWriteTextFile(metadataPath, metadataContent);
+
+    const contentPath = this.getContentPath(
+      type,
+      modelId,
+      data.name,
+      newVersion,
+    );
+    await assertSafePath(contentPath, boundary);
+    await atomicWriteFile(contentPath, content);
+
+    // Catalog row with is_latest=0 — invisible to latest-based queries
+    this.catalogStore.upsert({
+      namespace: this.namespace,
+      type_normalized: type.normalized,
+      model_id: modelId,
+      data_name: data.name,
+      id: data.id,
+      version: newVersion,
+      is_latest: 0,
+      model_name: dataToSave.tags["modelName"] ?? "",
+      spec_name: dataToSave.tags["specName"] ?? "",
+      data_type: dataToSave.tags["type"] ?? "",
+      content_type: dataToSave.contentType,
+      lifetime: dataToSave.lifetime,
+      owner_type: dataToSave.ownerDefinition.ownerType,
+      streaming: dataToSave.streaming ? 1 : 0,
+      size: dataToSave.size ?? 0,
+      created_at: dataToSave.createdAt.toISOString(),
+      tags: JSON.stringify(dataToSave.tags),
+      owner_ref: dataToSave.ownerDefinition.ownerRef,
+      workflow_run_id: dataToSave.ownerDefinition.workflowRunId ?? "",
+      workflow_name: dataToSave.ownerDefinition.workflowName ?? "",
+      job_name: dataToSave.ownerDefinition.jobName ?? "",
+      step_name: dataToSave.ownerDefinition.stepName ?? "",
+      source: dataToSave.ownerDefinition.source ?? "",
+    });
+
+    return { type, modelId, dataName: data.name, version: newVersion };
+  }
+
   async append(
     type: ModelType,
     modelId: string,
@@ -1143,6 +1233,121 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     }
 
     return { size, checksum };
+  }
+
+  async finalizeVersionDeferred(
+    type: ModelType,
+    modelId: string,
+    data: Data,
+    version: number,
+    _priorVersions?: number[],
+  ): Promise<
+    { receipt: DeferredWriteReceipt; size: number; checksum: string }
+  > {
+    await this.notifyDirty(this.getPath(type, modelId, data.name, version));
+
+    const contentPath = this.getContentPath(type, modelId, data.name, version);
+    const content = await Deno.readFile(contentPath);
+    const size = content.length;
+    const checksum = await this.computeChecksum(content);
+
+    const dataToSave = data.withNewVersion({ version, size, checksum });
+
+    const metadataPath = this.getMetadataPath(
+      type,
+      modelId,
+      data.name,
+      version,
+    );
+    const metadata = dataToSave.toData();
+    const cleanData = JSON.parse(JSON.stringify(metadata));
+    const metadataContent = stringifyYaml(cleanData as Record<string, unknown>);
+    await atomicWriteTextFile(metadataPath, metadataContent);
+
+    this.catalogStore.upsert({
+      namespace: this.namespace,
+      type_normalized: type.normalized,
+      model_id: modelId,
+      data_name: data.name,
+      id: data.id,
+      version,
+      is_latest: 0,
+      model_name: dataToSave.tags["modelName"] ?? "",
+      spec_name: dataToSave.tags["specName"] ?? "",
+      data_type: dataToSave.tags["type"] ?? "",
+      content_type: dataToSave.contentType,
+      lifetime: dataToSave.lifetime,
+      owner_type: dataToSave.ownerDefinition.ownerType,
+      streaming: dataToSave.streaming ? 1 : 0,
+      size: dataToSave.size ?? 0,
+      created_at: dataToSave.createdAt.toISOString(),
+      tags: JSON.stringify(dataToSave.tags),
+      owner_ref: dataToSave.ownerDefinition.ownerRef,
+      workflow_run_id: dataToSave.ownerDefinition.workflowRunId ?? "",
+      workflow_name: dataToSave.ownerDefinition.workflowName ?? "",
+      job_name: dataToSave.ownerDefinition.jobName ?? "",
+      step_name: dataToSave.ownerDefinition.stepName ?? "",
+      source: dataToSave.ownerDefinition.source ?? "",
+    });
+
+    return {
+      receipt: { type, modelId, dataName: data.name, version },
+      size,
+      checksum,
+    };
+  }
+
+  async advanceLatestMarkers(
+    receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    for (const receipt of receipts) {
+      try {
+        await this.updateLatestMarker(
+          receipt.type,
+          receipt.modelId,
+          receipt.dataName,
+          receipt.version,
+        );
+        const data = await this.findByName(
+          receipt.type,
+          receipt.modelId,
+          receipt.dataName,
+          receipt.version,
+        );
+        if (data) {
+          this.catalogUpsert(receipt.type, receipt.modelId, data);
+        }
+      } catch (error) {
+        logger
+          .warn`Failed to advance latest marker for ${receipt.dataName} v${receipt.version}: ${error}`;
+      }
+    }
+  }
+
+  async rollbackVersions(
+    receipts: DeferredWriteReceipt[],
+  ): Promise<void> {
+    for (const receipt of receipts) {
+      try {
+        const versionDir = this.getPath(
+          receipt.type,
+          receipt.modelId,
+          receipt.dataName,
+          receipt.version,
+        );
+        await Deno.remove(versionDir, { recursive: true });
+        this.catalogStore.removeVersion(
+          this.namespace,
+          receipt.type.normalized,
+          receipt.modelId,
+          receipt.dataName,
+          receipt.version,
+        );
+      } catch (error) {
+        logger
+          .warn`Failed to rollback version ${receipt.dataName} v${receipt.version}: ${error}`;
+      }
+    }
   }
 
   nextId(): DataId {

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -219,6 +219,12 @@ function createRemoteDataRepository(
       unsupported("dataRepository.findAllForModelSync"),
     findAllGlobalSync: () => unsupported("dataRepository.findAllGlobalSync"),
     findByTaggedName: () => unsupported("dataRepository.findByTaggedName"),
+    saveDeferred: () => unsupported("dataRepository.saveDeferred"),
+    finalizeVersionDeferred: () =>
+      unsupported("dataRepository.finalizeVersionDeferred"),
+    advanceLatestMarkers: () =>
+      unsupported("dataRepository.advanceLatestMarkers"),
+    rollbackVersions: () => unsupported("dataRepository.rollbackVersions"),
   } as UnifiedDataRepository;
 }
 


### PR DESCRIPTION
## Summary

- Add opt-in `rollbackOnFailure` flag on `MethodDefinition` for all-or-nothing write semantics
- Writes use deferred-latest mode: data persists to disk but the `latest` marker is not advanced until the method succeeds; on failure, version directories are deleted
- No behavioral change for existing methods — the flag defaults to `false` and the default write path is completely unchanged

This is the direct fix for #1430 — a method that fails midway no longer leaves partial writes visible to `data.latest()` consumers.

Closes #1451
Fixes #1430

## Implementation

| Layer | Change |
|-------|--------|
| `MethodDefinition` | New `rollbackOnFailure?: boolean` field (model.ts + testing mirror) |
| `UnifiedDataRepository` | `saveDeferred()`, `finalizeVersionDeferred()`, `advanceLatestMarkers()`, `rollbackVersions()` on interface + FS + InMemory implementations |
| `DefaultDataWriter` | Deferred write mode via constructor flag; `getPendingDeferredReceipt()` for unfinalized streaming writers |
| `createResourceWriter` / `createFileWriterFactory` | Thread `deferred` flag, expose `getDeferredReceipts()` |
| `InProcessExecutor` | Read flag from `MethodDefinition`, commit on success, rollback on failure |
| `DefaultMethodExecutionService` | Pre-flight check: `rollbackOnFailure` + remote placement fails early |
| `model_kind_adapter.ts` | Preserve `rollbackOnFailure` through extension loading (both `convertToModelDefinition` and `processSecondaryExport`) |

## Test plan

- [x] 6 integration tests: success commits, single-write rollback, default path unchanged, file writer rollback, unfinalized writer cleanup, multi-resource rollback (96-well scenario)
- [x] 9522 existing tests pass (0 failed)
- [x] End-to-end verification with compiled binary against real swamp repo — 6 scenarios with real extension model confirmed correct behavior
- [x] `deno check` clean (only pre-existing `getDenoEnv` error)
- [x] `deno fmt --check` clean
- [x] `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)