### PR TITLE
fix(issues): stop redactor false positives on timestamps and content digests (swamp-club#1463)

### DIFF
--- a/src/domain/issues/content_redactor.ts
+++ b/src/domain/issues/content_redactor.ts
@@ -220,6 +220,17 @@ function isSafeIpv6(ip: string): boolean {
   return false;
 }
 
+function isLikelyTimestamp(s: string): boolean {
+  const parts = s.split(":");
+  if (parts.length !== 3) return false;
+  if (!parts.every((p) => /^\d{1,2}$/.test(p))) return false;
+  const [h, m, sec] = parts.map(Number);
+  return h <= 23 && m <= 59 && sec <= 59;
+}
+
+const SAFE_HEX_KEY_RE =
+  /(?:"|\\")?(?:checksum|sha256|sha1|sha512|digest|hash|contentHash|etag|md5)(?:"|\\")?[\s]*:[\s]*(?:"|\\")?$/i;
+
 // Common TLDs — used to distinguish real hostnames from dotted code
 // identifiers in the FQDN matcher. Code identifiers like "includes",
 // "get", "env", "length" are not TLDs so they get skipped.
@@ -618,6 +629,7 @@ function applyRedactions(
   // 12. IPv6 (before IPv4 to avoid partial matches on mapped addresses)
   result = result.replace(IPV6_RE, (match) => {
     if (isSafeIpv6(match)) return match;
+    if (isLikelyTimestamp(match)) return match;
     count("IP address");
     return placeholders.get("IP", match);
   });
@@ -652,10 +664,15 @@ function applyRedactions(
   );
 
   // 16. Long hex strings (likely tokens/hashes — after all specific patterns)
-  result = result.replace(LONG_HEX_RE, (match) => {
-    count("secret");
-    return placeholders.get("REDACTED-SECRET", match);
-  });
+  result = result.replace(
+    LONG_HEX_RE,
+    (match: string, offset: number, source: string) => {
+      const preceding = source.slice(Math.max(0, offset - 40), offset);
+      if (SAFE_HEX_KEY_RE.test(preceding)) return match;
+      count("secret");
+      return placeholders.get("REDACTED-SECRET", match);
+    },
+  );
 
   // 17. Long base64 strings
   result = result.replace(LONG_BASE64_RE, (match) => {

--- a/src/domain/issues/content_redactor_test.ts
+++ b/src/domain/issues/content_redactor_test.ts
@@ -369,6 +369,39 @@ Deno.test("redactIssueContent: long hex strings are redacted", () => {
   assertEquals(result.text, "Token was [REDACTED-SECRET-1] in header");
 });
 
+Deno.test("redactIssueContent: hex digest in JSON checksum field is not redacted", () => {
+  const sha256 =
+    "868f2f74abc123def456789012345678901234567890abcdef1234567817030a";
+  const input = `{ "checksum": "${sha256}", "isLatest": true }`;
+  const result = redactIssueContent(input);
+  assertEquals(result.text, input);
+  assertEquals(result.summary.totalRedactions, 0);
+});
+
+Deno.test("redactIssueContent: hex digest with various safe key names is not redacted", () => {
+  const hex = "a1b2c3d4e5f6".repeat(6); // 72 chars
+  for (const key of ["sha256", "sha1", "digest", "hash", "etag", "md5"]) {
+    const input = `"${key}": "${hex}"`;
+    const result = redactIssueContent(input);
+    assertEquals(result.text, input, `expected ${key} to be safe`);
+  }
+});
+
+Deno.test("redactIssueContent: hex digest with escaped JSON quotes is not redacted", () => {
+  const sha256 =
+    "868f2f74abc123def456789012345678901234567890abcdef1234567817030a";
+  const input = `\\"checksum\\": \\"${sha256}\\"`;
+  const result = redactIssueContent(input);
+  assertEquals(result.text, input);
+  assertEquals(result.summary.totalRedactions, 0);
+});
+
+Deno.test("redactIssueContent: standalone hex string without safe key is still redacted", () => {
+  const hex = "a".repeat(64);
+  const result = redactIssueContent(`The value ${hex} was found`);
+  assertEquals(result.text, "The value [REDACTED-SECRET-1] was found");
+});
+
 Deno.test("redactIssueContent: scheme URL without credentials does not swallow following lines", () => {
   const input = [
     "Steps:",
@@ -473,6 +506,34 @@ Deno.test("redactIssueContent: IPv6 localhost and link-local are not redacted", 
     "found fe80:0000:0000:0000:0000:0000:0000:0001 on interface",
   );
   assertStringIncludes(r2.text, "fe80:");
+});
+
+Deno.test("redactIssueContent: HH:MM:SS timestamps are not redacted as IPs", () => {
+  const input = "system │ Starting workflow remote-demo · 20:18:09 UTC\n" +
+    " build │ done echo-on-worker in 729ms · 14:30:45 UTC";
+  const result = redactIssueContent(input);
+  assertStringIncludes(result.text, "20:18:09");
+  assertStringIncludes(result.text, "14:30:45");
+  assertEquals(result.summary.totalRedactions, 0);
+});
+
+Deno.test("redactIssueContent: boundary timestamps are not redacted", () => {
+  const r1 = redactIssueContent("started at 00:00:00 UTC");
+  assertStringIncludes(r1.text, "00:00:00");
+
+  const r2 = redactIssueContent("ended at 23:59:59 UTC");
+  assertStringIncludes(r2.text, "23:59:59");
+});
+
+Deno.test("redactIssueContent: real IPv6 with 3+ groups is still redacted", () => {
+  const result = redactIssueContent(
+    "Listening on 2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+  );
+  assertStringIncludes(result.text, "[IP-");
+  assertEquals(
+    result.text.includes("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+    false,
+  );
 });
 
 // --- Angle-bracket placeholder handling ---


### PR DESCRIPTION
## Summary

Fixes two content redactor false positives reported in swamp-club#1463:

- **HH:MM:SS timestamps masked as IPs**: The IPv6 regex matched `20:18:09`-style timestamps because each segment is valid hex and the regex accepts 3+ colon-separated groups. Added `isLikelyTimestamp` guard that detects exactly 3 groups of 1-2 digit decimal values in valid time ranges (0-23, 0-59, 0-59).
- **SHA-256 digests masked as secrets**: The long-hex matcher (`LONG_HEX_RE`) caught 64-char content digests in swamp's own `data` and `report` output. Added `SAFE_HEX_KEY_RE` context check that exempts hex strings preceded by known safe JSON keys (`checksum`, `sha256`, `sha1`, `sha512`, `digest`, `hash`, `contentHash`, `etag`, `md5`), supporting both regular and escaped JSON quotes.

Both fixes follow the existing guard-function pattern (`isSafeIpv4`, `isSafeIpv6`) — no regex changes needed.

**Deliberate non-goal**: The issue author's suggestion to skip redaction inside fenced code blocks remains out of scope per the decision in PR #1895 — fences are where accidental secrets most often appear. The two specific false positives are fixed without weakening that protection.

## Test Plan

- Added 7 new unit tests covering both fixes (71 total, all passing)
- Verified against reproduction of the exact scenarios from the issue
- Confirmed real IPv6 addresses and standalone hex secrets are still redacted
- `deno check`, `deno lint`, `deno fmt --check` all pass