### PR TITLE
fix(remote): stream stdout from remote steps to workflow runner

### DIFF
--- a/src/domain/models/in_process_executor.ts
+++ b/src/domain/models/in_process_executor.ts
@@ -42,7 +42,7 @@ import {
 import { DataAccessService } from "../data/data_access_service.ts";
 import { withConsoleGuard } from "./console_guard.ts";
 
-function wrapLoggerWithOutput(
+export function wrapLoggerWithOutput(
   logger: Logger,
   onEvent: ((event: MethodExecutionEvent) => void) | undefined,
 ): Logger {

--- a/src/worker/remote_method_context.ts
+++ b/src/worker/remote_method_context.ts
@@ -46,6 +46,7 @@ import type { OutputRepository } from "../domain/models/repositories.ts";
 import type { DataQueryService } from "../domain/data/data_query_service.ts";
 import type { VaultService } from "../domain/vaults/vault_service.ts";
 import { resolveVaultRefsInData } from "../domain/models/data_writer.ts";
+import { wrapLoggerWithOutput } from "../domain/models/in_process_executor.ts";
 import { SecretRedactor } from "../domain/secrets/mod.ts";
 import { createExtensionCelEnvironment } from "../infrastructure/cel/cel_evaluator.ts";
 import type { RpcChannel } from "../domain/remote/rpc_channel.ts";
@@ -562,7 +563,7 @@ export function createRemoteMethodContext(
     globalArgs: execution.globalArgs,
     definition: execution.definitionMeta,
     methodName: execution.methodName,
-    logger,
+    logger: wrapLoggerWithOutput(logger, options.onEvent),
     dataRepository,
     definitionRepository,
     outputRepository,

--- a/src/worker/remote_method_context_test.ts
+++ b/src/worker/remote_method_context_test.ts
@@ -73,6 +73,7 @@ function harness(
   extensionFilesDir?: string,
   artifactContent?: Record<string, unknown>,
   overrideDispatch?: DispatchParams,
+  onEvent?: (event: Record<string, unknown>) => void,
 ) {
   const calls: StubCall[] = [];
   // The orchestrator side of the control socket, with stub verb handlers.
@@ -201,6 +202,7 @@ function harness(
     scratchDir,
     extensionFilesDir,
     signal: new AbortController().signal,
+    onEvent,
   });
   return { context, getHandles, calls, lines, contents };
 }
@@ -400,6 +402,44 @@ Deno.test("remote context: empty secretValues leaves redactor without secrets", 
   await withScratch((dir) => {
     const h = harness(dir);
     assertEquals(h.context.redactor!.hasSecrets, false);
+    return Promise.resolve();
+  });
+});
+
+Deno.test("remote context: logger.info fires onEvent with stdout output event", async () => {
+  await withScratch((dir) => {
+    const events: Record<string, unknown>[] = [];
+    const h = harness(
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      (e) => events.push(e),
+    );
+    h.context.logger.info("hello from remote");
+    assertEquals(events.length, 1);
+    assertEquals(events[0].type, "output");
+    assertEquals(events[0].stream, "stdout");
+    assertEquals(events[0].line, "hello from remote");
+    return Promise.resolve();
+  });
+});
+
+Deno.test("remote context: logger.warn fires onEvent with stderr output event", async () => {
+  await withScratch((dir) => {
+    const events: Record<string, unknown>[] = [];
+    const h = harness(
+      dir,
+      undefined,
+      undefined,
+      undefined,
+      (e) => events.push(e),
+    );
+    h.context.logger.warn("something went wrong");
+    assertEquals(events.length, 1);
+    assertEquals(events[0].type, "output");
+    assertEquals(events[0].stream, "stderr");
+    assertEquals(events[0].line, "something went wrong");
     return Promise.resolve();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes swamp-club#1462 — remote workflow steps now stream stdout/stderr to the runner, matching local step behavior
- The worker-side `createRemoteMethodContext` was passing the raw logger into the `MethodContext` without wrapping it with `wrapLoggerWithOutput()`, so `logger.info()`/`logger.warn()` calls never fired `onEvent({ type: "output" })` events back through the RPC channel
- Exports `wrapLoggerWithOutput` from `in_process_executor.ts` (already used for local execution) and applies it in `remote_method_context.ts`

## Test Plan

- Added unit tests in `remote_method_context_test.ts` verifying `logger.info` fires `onEvent` with `{ type: "output", stream: "stdout" }` and `logger.warn` fires with `stream: "stderr"`
- Existing `in_process_executor_test.ts` tests continue to pass (14/14)
- Full test suite passes (9553 tests, 0 failures)

Closes swamp-club#1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)