### PR TITLE
fix(sources): reject source add for paths already scanned by default (swamp-club#1419)

### DIFF
--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -38,9 +38,11 @@ import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import {
   resolveDatastoresDir,
+  resolveDriversDir,
   resolveModelsDir,
   resolveReportsDir,
   resolveVaultsDir,
+  resolveWorkflowsDir,
 } from "../mod.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -95,8 +97,8 @@ export const extensionSourceAddCommand = new Command()
       resolveVaultsDir(marker),
       resolveDatastoresDir(marker),
       resolveReportsDir(marker),
-      "extensions/drivers",
-      "extensions/workflows",
+      resolveDriversDir(marker),
+      resolveWorkflowsDir(marker),
     ];
     const deps = await createSourceAddDeps(
       repoDir,

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -36,6 +36,12 @@ import { UserError } from "../../domain/errors.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
+import {
+  resolveDatastoresDir,
+  resolveModelsDir,
+  resolveReportsDir,
+  resolveVaultsDir,
+} from "../mod.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -84,7 +90,20 @@ export const extensionSourceAddCommand = new Command()
     const marker = await markerRepo.read(RepoPath.create(repoDir));
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
-    const deps = await createSourceAddDeps(repoDir, tools, skillsDirs);
+    const defaultKindDirs = [
+      resolveModelsDir(marker),
+      resolveVaultsDir(marker),
+      resolveDatastoresDir(marker),
+      resolveReportsDir(marker),
+      "extensions/drivers",
+      "extensions/workflows",
+    ];
+    const deps = await createSourceAddDeps(
+      repoDir,
+      tools,
+      skillsDirs,
+      defaultKindDirs,
+    );
 
     let only: ExtensionKind[] | undefined;
     if (options.only) {

--- a/src/cli/commands/extension_source_add.ts
+++ b/src/cli/commands/extension_source_add.ts
@@ -38,7 +38,6 @@ import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import {
   resolveDatastoresDir,
-  resolveDriversDir,
   resolveModelsDir,
   resolveReportsDir,
   resolveVaultsDir,
@@ -97,7 +96,6 @@ export const extensionSourceAddCommand = new Command()
       resolveVaultsDir(marker),
       resolveDatastoresDir(marker),
       resolveReportsDir(marker),
-      resolveDriversDir(marker),
       resolveWorkflowsDir(marker),
     ];
     const deps = await createSourceAddDeps(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -192,8 +192,6 @@ import "../domain/models/models.ts";
 // separate files to avoid circular imports through mod.ts.
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 export { resolveModelsDir };
-import { resolveDriversDir } from "./resolve_drivers_dir.ts";
-export { resolveDriversDir };
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 export { resolveWorkflowsDir };
 import { resolveVaultsDir } from "./resolve_vaults_dir.ts";

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -192,6 +192,8 @@ import "../domain/models/models.ts";
 // separate files to avoid circular imports through mod.ts.
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 export { resolveModelsDir };
+import { resolveDriversDir } from "./resolve_drivers_dir.ts";
+export { resolveDriversDir };
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 export { resolveWorkflowsDir };
 import { resolveVaultsDir } from "./resolve_vaults_dir.ts";

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { normalize } from "@std/path";
 import type { LibSwampContext } from "../context.ts";
 import { alreadyExists, validationFailed } from "../errors.ts";
 import type { SourceModifyEvent } from "./source_events.ts";
@@ -57,6 +58,11 @@ export interface SourceAddDeps {
   copySkills: (skills: ResolvedSkill[]) => Promise<string[]>;
   /** Removes named skill directories (used for cleanup on partial failure). */
   cleanupSkills: (skillNames: string[]) => Promise<void>;
+  /** Absolute paths of directories already scanned by default (e.g.
+   * `extensions/models`). Source paths that resolve to one of these are
+   * rejected — adding them would cause every file to be processed twice,
+   * producing nondeterministic BundleBuildFailed errors (swamp-club#1419). */
+  defaultKindDirs: readonly string[];
 }
 
 /** Wires real infrastructure into SourceAddDeps. */
@@ -64,6 +70,7 @@ export async function createSourceAddDeps(
   repoDir: string,
   tools?: string[],
   skillsDirs?: string[],
+  defaultKindDirs?: readonly string[],
 ): Promise<SourceAddDeps> {
   const resolvedTools = tools?.length ? tools : ["claude"];
   const dirs = skillsDirs?.length ? skillsDirs : [];
@@ -90,6 +97,7 @@ export async function createSourceAddDeps(
         await removeSourceSkills(skillNames, dir);
       }
     },
+    defaultKindDirs: defaultKindDirs ?? [],
   };
 }
 
@@ -120,6 +128,26 @@ export async function* sourceAdd(
       error: alreadyExists("Extension source", path),
     };
     return;
+  }
+
+  // Reject paths that overlap with a default extension scan directory.
+  // These are already scanned as the primary dir in buildIndex(); adding
+  // them as a source mount causes every file to be discovered twice.
+  if (!isGlobPattern(path) && deps.defaultKindDirs.length > 0) {
+    const normalizedPath = normalize(path);
+    for (const kindDir of deps.defaultKindDirs) {
+      if (normalize(kindDir) === normalizedPath) {
+        yield {
+          kind: "error",
+          error: validationFailed(
+            `'${path}' is already scanned as a default extension directory. ` +
+              `Source mounts are for external directories — local extensions ` +
+              `under this path are loaded automatically.`,
+          ),
+        };
+        return;
+      }
+    }
   }
 
   // Validate that the source actually contributes extensions. Concrete

--- a/src/libswamp/sources/add.ts
+++ b/src/libswamp/sources/add.ts
@@ -58,7 +58,7 @@ export interface SourceAddDeps {
   copySkills: (skills: ResolvedSkill[]) => Promise<string[]>;
   /** Removes named skill directories (used for cleanup on partial failure). */
   cleanupSkills: (skillNames: string[]) => Promise<void>;
-  /** Absolute paths of directories already scanned by default (e.g.
+  /** Paths of directories already scanned by default (e.g.
    * `extensions/models`). Source paths that resolve to one of these are
    * rejected — adding them would cause every file to be processed twice,
    * producing nondeterministic BundleBuildFailed errors (swamp-club#1419). */

--- a/src/libswamp/sources/add_test.ts
+++ b/src/libswamp/sources/add_test.ts
@@ -40,6 +40,7 @@ function createTestDeps(
     resolveKinds?: (source: SwampSource) => ExtensionKind[];
     /** Override the glob expansion for the next call. */
     expandSource?: (source: SwampSource) => SwampSource[];
+    defaultKindDirs?: string[];
   } = {},
 ): TestDeps {
   const state = { written: null as SwampSourcesConfig | null };
@@ -56,6 +57,7 @@ function createTestDeps(
     resolveSkills: () => Promise.resolve([]),
     copySkills: () => Promise.resolve([]),
     cleanupSkills: () => Promise.resolve(),
+    defaultKindDirs: options.defaultKindDirs ?? [],
     get written() {
       return state.written;
     },
@@ -150,6 +152,54 @@ Deno.test("sourceAdd: rejects empty path", async () => {
   const error = findError(events);
   assertEquals(error?.kind, "error");
   assertEquals(deps.written, null);
+});
+
+// ----------------------------------------------------------------
+// swamp-club#1419: reject sources that overlap default scan dirs.
+// ----------------------------------------------------------------
+
+Deno.test("sourceAdd: rejects path that matches a default kind dir", async () => {
+  const deps = createTestDeps({
+    defaultKindDirs: ["extensions/models", "extensions/vaults"],
+    resolveKinds: () => ["models"],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "extensions/models"),
+  );
+
+  const error = findError(events);
+  assertEquals(error?.kind, "error");
+  if (error?.kind === "error") {
+    assertStringIncludes(error.error.message, "already scanned");
+  }
+  assertEquals(deps.written, null);
+});
+
+Deno.test("sourceAdd: rejects path with leading ./ that normalizes to default dir", async () => {
+  const deps = createTestDeps({
+    defaultKindDirs: ["extensions/models"],
+    resolveKinds: () => ["models"],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "./extensions/models"),
+  );
+
+  const error = findError(events);
+  assertEquals(error?.kind, "error");
+  assertEquals(deps.written, null);
+});
+
+Deno.test("sourceAdd: allows path that does not overlap default dirs", async () => {
+  const deps = createTestDeps({
+    defaultKindDirs: ["extensions/models", "extensions/vaults"],
+    resolveKinds: () => ["models"],
+  });
+  const events = await collectEvents(
+    sourceAdd(ctx, deps, "/external/shared-extensions"),
+  );
+
+  const completed = findCompleted(events);
+  assertEquals(completed?.kind, "completed");
 });
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `swamp extension source add extensions/models` silently registered the default models directory as a source mount, causing `buildIndex()` to discover every file twice. Model types survived via `skipAlreadyRegistered`, but `processSecondaryExport` called `modelRegistry.extend()` twice per extension — first call succeeded, second threw "Method already exists on model type." This produced a strict fail/pass alternation on consecutive `swamp doctor extensions` runs.
- Reject at the `source add` entry point: compare the normalized source path against the resolved default kind directories (models, vaults, datastores, reports, drivers, workflows) and error before writing `.swamp-sources.yaml`.
- Added 3 unit tests covering exact match, `./` normalization, and non-overlapping path acceptance.

## Test Plan

- `deno run test` — 9371 passed, 0 failed
- Verified with reporter's repro script: `swamp extension source add extensions/models` now exits 1 with `'extensions/models' is already scanned as a default extension directory`
- Confirmed no `.swamp-sources.yaml` is created, and `swamp doctor extensions` passes 8/8 consecutive runs

Closes swamp-club#1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)