### PR TITLE
fix(access): stop printing plaintext token to stdout (swamp-club#1466)

### DIFF
--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -49,7 +49,7 @@ const DEFAULT_DURATION = "30d";
 export const accessTokenMintCommand = new Command()
   .name("mint")
   .description(
-    "Mint a server token for user authentication; the plaintext is shown once",
+    "Mint a server token for user authentication; the plaintext is stored in a vault",
   )
   .example(
     "Mint a token for a user",

--- a/src/libswamp/access/token_create.ts
+++ b/src/libswamp/access/token_create.ts
@@ -37,7 +37,6 @@ import { createServerTokenRunDeps } from "./run_deps.ts";
 
 export interface ServerTokenCreateData {
   name: string;
-  token: string;
   principalId: string;
   expiresAt: string;
   vaultRef: { vaultName: string; secretKey: string };
@@ -67,7 +66,6 @@ export interface ServerTokenCreateDeps {
       vaultName: string;
     },
   ) => AsyncIterable<ModelMethodRunEvent>;
-  readSecret: (vaultName: string, secretKey: string) => Promise<string>;
 }
 
 export async function createServerTokenCreateDeps(
@@ -93,8 +91,6 @@ export async function createServerTokenCreateDeps(
         typeArg: SERVER_TOKEN_MODEL_TYPE.normalized,
         definitionName: input.name,
       }),
-    readSecret: (vaultName, secretKey) =>
-      vaultService.get(vaultName, secretKey, "access:server-token-create"),
   };
 }
 
@@ -194,13 +190,11 @@ export async function* serverTokenCreate(
       }
 
       const secretKey = tokenRecord.secretKey;
-      const plaintext = await deps.readSecret(vaultName, secretKey);
 
       yield {
         kind: "completed" as const,
         data: {
           name: input.name,
-          token: `${input.name}.${plaintext}`,
           principalId: input.principalId,
           expiresAt: tokenRecord.expiresAt as string,
           vaultRef: { vaultName, secretKey },

--- a/src/libswamp/access/token_create_test.ts
+++ b/src/libswamp/access/token_create_test.ts
@@ -76,12 +76,11 @@ function makeDeps(
         yield await Promise.resolve(event);
       }
     },
-    readSecret: () => Promise.resolve("plaintext-secret"),
     ...overrides,
   };
 }
 
-Deno.test("serverTokenCreate: mints and yields the plaintext once", async () => {
+Deno.test("serverTokenCreate: mints and yields vault ref without plaintext", async () => {
   const events = await collect<ServerTokenCreateEvent>(
     serverTokenCreate(createLibSwampContext(), makeDeps(), {
       name: "adam-token",
@@ -103,7 +102,6 @@ Deno.test("serverTokenCreate: mints and yields the plaintext once", async () => 
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data, {
     name: "adam-token",
-    token: "adam-token.plaintext-secret",
     principalId: "user:adam",
     expiresAt: EXPIRES_AT,
     vaultRef: {

--- a/src/libswamp/access/token_rotate.ts
+++ b/src/libswamp/access/token_rotate.ts
@@ -22,12 +22,10 @@ import type { SwampError } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
-import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { createServerTokenRunDeps } from "./run_deps.ts";
 
 export interface ServerTokenRotateData {
   name: string;
-  token: string;
   principalId: string;
   expiresAt: string;
   vaultRef: { vaultName: string; secretKey: string };
@@ -47,7 +45,6 @@ export interface ServerTokenRotateDeps {
   runRotate: (
     input: { name: string; durationMs?: number },
   ) => AsyncIterable<ModelMethodRunEvent>;
-  readSecret: (vaultName: string, secretKey: string) => Promise<string>;
 }
 
 export async function createServerTokenRotateDeps(
@@ -56,7 +53,6 @@ export async function createServerTokenRotateDeps(
   repoContext: RepositoryContext,
 ): Promise<ServerTokenRotateDeps> {
   const runDeps = await createServerTokenRunDeps(repoDir, repoContext);
-  const vaultService = await VaultService.fromRepository(repoDir);
   return {
     runRotate: (input) =>
       modelMethodRun(ctx, runDeps, {
@@ -67,8 +63,6 @@ export async function createServerTokenRotateDeps(
           : {},
         lastEvaluated: false,
       }),
-    readSecret: (vaultName, secretKey) =>
-      vaultService.get(vaultName, secretKey, "access:server-token-rotate"),
   };
 }
 
@@ -127,16 +121,10 @@ export async function* serverTokenRotate(
         return;
       }
 
-      const plaintext = await deps.readSecret(
-        tokenRecord.vaultName,
-        tokenRecord.secretKey,
-      );
-
       yield {
         kind: "completed" as const,
         data: {
           name: input.name,
-          token: `${input.name}.${plaintext}`,
           principalId: typeof tokenRecord.principalId === "string"
             ? tokenRecord.principalId
             : "",

--- a/src/libswamp/access/token_rotate_test.ts
+++ b/src/libswamp/access/token_rotate_test.ts
@@ -75,12 +75,11 @@ function makeDeps(
         yield await Promise.resolve(event);
       }
     },
-    readSecret: () => Promise.resolve("new-plaintext-secret"),
     ...overrides,
   };
 }
 
-Deno.test("serverTokenRotate: rotates and yields the new plaintext", async () => {
+Deno.test("serverTokenRotate: rotates and yields vault ref without plaintext", async () => {
   const events = await collect<ServerTokenRotateEvent>(
     serverTokenRotate(createLibSwampContext(), makeDeps(), {
       name: "sarah-token",
@@ -95,7 +94,6 @@ Deno.test("serverTokenRotate: rotates and yields the new plaintext", async () =>
   assertEquals(completed.kind, "completed");
   assertEquals(completed.data, {
     name: "sarah-token",
-    token: "sarah-token.new-plaintext-secret",
     principalId: "user:sarah",
     expiresAt: EXPIRES_AT,
     vaultRef: {

--- a/src/presentation/output/access_token_output.ts
+++ b/src/presentation/output/access_token_output.ts
@@ -23,7 +23,7 @@
  * terminal-output design system.
  */
 
-import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
+import { bold, cyan, dim, green, red } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type {
   ServerTokenCreateData,
@@ -89,11 +89,11 @@ export function renderServerTokenCreate(
       dim(`(key ${data.vaultRef.secretKey})`)
     }`,
     "",
-    `  ${bold(data.token)}`,
-    "",
-    yellow(
-      "This token is shown once and will not be displayed again — store it now.",
-    ),
+    `Retrieve the token with: ${
+      bold(
+        `swamp vault get ${data.vaultRef.vaultName} ${data.vaultRef.secretKey}`,
+      )
+    }`,
   ];
   writeOutput(lines.join("\n"));
 }
@@ -167,11 +167,11 @@ export function renderServerTokenRotate(
       dim(`(key ${data.vaultRef.secretKey})`)
     }`,
     "",
-    `  ${bold(data.token)}`,
-    "",
-    yellow(
-      "Previous token has been revoked. Store the new token now — it will not be shown again.",
-    ),
+    `Retrieve the new token with: ${
+      bold(
+        `swamp vault get ${data.vaultRef.vaultName} ${data.vaultRef.secretKey}`,
+      )
+    }`,
   ];
   writeOutput(lines.join("\n"));
 }


### PR DESCRIPTION
## Summary

- `swamp access token mint` and `rotate` no longer print the plaintext token to stdout — since a vault is always required, the secret should never leave the vault at display time
- Both commands now show a `swamp vault get <vault> <key>` retrieval command instead, so the user can fetch the token when they need it
- Removes the `readSecret` dependency from both `serverTokenCreate` and `serverTokenRotate` — it was only used for display

Fixes swamp-club#1466

## Follow-up issues filed

- swamp-club#1470 — add `--vault` flag to `access token rotate`
- swamp-club#1471 — allow `mint` to reuse revoked token names
- swamp-club#1472 — update manual docs that reference "shown once" behavior

## Test plan

- [x] All 12 unit tests updated and passing (7 in `token_create_test.ts`, 5 in `token_rotate_test.ts`)
- [x] Full test suite passes (9566 tests)
- [x] `deno check` clean (pre-existing TS2741 unrelated)
- [x] `deno lint` and `deno fmt` clean