### PR TITLE
fix(workflows): let workflow edit open broken workflows instead of not-found (swamp-club#1468)

### DIFF
--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -32,6 +32,11 @@ import { EditorService } from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
+import {
+  type BrokenWorkflow,
+  findBrokenWorkflow,
+  workflowsDirFor,
+} from "./broken_workflow.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
@@ -70,6 +75,7 @@ export interface WorkflowEditInput {
 export interface WorkflowEditDeps {
   findById: (id: WorkflowId) => Promise<Workflow | null>;
   findByName: (name: string) => Promise<Workflow | null>;
+  findBrokenWorkflow: (idOrName: string) => Promise<BrokenWorkflow | null>;
   getPath: (id: WorkflowId) => string;
   resolveSymlink: (name: string) => Promise<string | null>;
   fileExists: (path: string) => Promise<boolean>;
@@ -86,9 +92,12 @@ export function createWorkflowEditDeps(
   workflowRepo: WorkflowRepository,
 ): WorkflowEditDeps {
   const editorService = new EditorService();
+  const workflowsDir = workflowsDirFor(repoDir);
   return {
     findById: (id) => workflowRepo.findById(id),
     findByName: (name) => workflowRepo.findByName(name),
+    findBrokenWorkflow: (idOrName) =>
+      findBrokenWorkflow(workflowsDir, idOrName),
     getPath: (id) => workflowRepo.getPath(id),
     resolveSymlink: async (name) => {
       const symlinkPath = join(repoDir, "workflows", name, "workflow.yaml");
@@ -151,11 +160,18 @@ export async function* workflowEdit(
         if (workflow) {
           filePath = deps.getPath(workflow.id);
         } else {
-          yield {
-            kind: "error",
-            error: notFound("Workflow", workflowIdOrName),
-          };
-          return;
+          const broken = await deps.findBrokenWorkflow(workflowIdOrName);
+          if (broken) {
+            ctx.logger
+              .debug`Found broken workflow by ID, opening file: ${broken.file}`;
+            filePath = broken.file;
+          } else {
+            yield {
+              kind: "error",
+              error: notFound("Workflow", workflowIdOrName),
+            };
+            return;
+          }
         }
       } else {
         ctx.logger.debug`Looking up by name: ${workflowIdOrName}`;
@@ -175,11 +191,18 @@ export async function* workflowEdit(
               .debug`Using symlink fallback for broken workflow: ${resolvedPath}`;
             filePath = resolvedPath;
           } else {
-            yield {
-              kind: "error",
-              error: notFound("Workflow", workflowIdOrName),
-            };
-            return;
+            const broken = await deps.findBrokenWorkflow(workflowIdOrName);
+            if (broken) {
+              ctx.logger
+                .debug`Found broken workflow by name, opening file: ${broken.file}`;
+              filePath = broken.file;
+            } else {
+              yield {
+                kind: "error",
+                error: notFound("Workflow", workflowIdOrName),
+              };
+              return;
+            }
           }
         }
       }

--- a/src/libswamp/workflows/edit_test.ts
+++ b/src/libswamp/workflows/edit_test.ts
@@ -33,6 +33,7 @@ function makeDeps(
   return {
     findById: () => Promise.resolve(null),
     findByName: () => Promise.resolve(null),
+    findBrokenWorkflow: () => Promise.resolve(null),
     getPath: () => "/fake/path/workflow.yaml",
     resolveSymlink: () => Promise.resolve(null),
     fileExists: () => Promise.resolve(true),
@@ -194,4 +195,113 @@ Deno.test("workflowEdit: yields error for broken workflow with stdin", async () 
   const last = events[1] as Extract<WorkflowEditEvent, { kind: "error" }>;
   assertEquals(last.kind, "error");
   assertEquals(last.error.code, "validation_failed");
+});
+
+Deno.test("workflowEdit: opens broken workflow by name via findBrokenWorkflow fallback", async () => {
+  const deps = makeDeps({
+    findByName: () => Promise.resolve(null),
+    resolveSymlink: () => Promise.resolve(null),
+    findBrokenWorkflow: () =>
+      Promise.resolve({
+        file: "/repo/workflows/workflow-abc.yaml",
+        name: "broken-wf",
+        id: "abc",
+        error: "Unknown key 'ependssss'",
+      }),
+    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+  });
+
+  const events = await collect<WorkflowEditEvent>(
+    workflowEdit(createLibSwampContext(), deps, {
+      workflowIdOrName: "broken-wf",
+    }),
+  );
+
+  assertEquals(events, [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: {
+        path: "/repo/workflows/workflow-abc.yaml",
+        editor: "Neovim",
+        status: "opened",
+        name: "broken-wf",
+        id: "unknown",
+      },
+    },
+  ]);
+});
+
+Deno.test("workflowEdit: opens broken workflow by UUID via findBrokenWorkflow fallback", async () => {
+  const brokenId = "550e8400-e29b-41d4-a716-446655440000";
+  const deps = makeDeps({
+    findById: () => {
+      throw new Error("Unknown key 'ependssss'");
+    },
+    findBrokenWorkflow: () =>
+      Promise.resolve({
+        file: `/repo/workflows/workflow-${brokenId}.yaml`,
+        name: "broken-wf",
+        id: brokenId,
+        error: "Unknown key 'ependssss'",
+      }),
+    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+  });
+
+  const events = await collect<WorkflowEditEvent>(
+    workflowEdit(createLibSwampContext(), deps, {
+      workflowIdOrName: brokenId,
+    }),
+  );
+
+  assertEquals(events, [
+    { kind: "resolving" },
+    {
+      kind: "completed",
+      data: {
+        path: `/repo/workflows/workflow-${brokenId}.yaml`,
+        editor: "Neovim",
+        status: "opened",
+        name: brokenId,
+        id: "unknown",
+      },
+    },
+  ]);
+});
+
+Deno.test("workflowEdit: yields not_found when workflow genuinely missing (name)", async () => {
+  const deps = makeDeps({
+    findByName: () => Promise.resolve(null),
+    resolveSymlink: () => Promise.resolve(null),
+    findBrokenWorkflow: () => Promise.resolve(null),
+  });
+
+  const events = await collect<WorkflowEditEvent>(
+    workflowEdit(createLibSwampContext(), deps, {
+      workflowIdOrName: "totally-missing",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  const last = events[1] as Extract<WorkflowEditEvent, { kind: "error" }>;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
+});
+
+Deno.test("workflowEdit: yields not_found when workflow genuinely missing (UUID)", async () => {
+  const deps = makeDeps({
+    findById: () => Promise.resolve(null),
+    findBrokenWorkflow: () => Promise.resolve(null),
+  });
+
+  const events = await collect<WorkflowEditEvent>(
+    workflowEdit(createLibSwampContext(), deps, {
+      workflowIdOrName: "550e8400-e29b-41d4-a716-446655440000",
+    }),
+  );
+
+  assertEquals(events.length, 2);
+  const last = events[1] as Extract<WorkflowEditEvent, { kind: "error" }>;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "not_found");
 });


### PR DESCRIPTION
## Summary

- When a workflow file has a schema error (e.g. a misspelled key like `ependssss` instead of `dependsOn`), `workflow edit` reported "Workflow not found" because the repository loader skips broken files. This added a `findBrokenWorkflow` fallback — the same pattern already used by `workflow run` and `workflow validate` — so the edit command opens the file in `$EDITOR` and lets the user fix their typo in place.
- Handles both name and UUID lookup paths.

Fixes swamp-club#1468

## Test Plan

- [x] Unit tests for broken workflow fallback by name and UUID
- [x] Unit tests for genuinely missing workflows still erroring correctly
- [x] Reproduced the bug in a scratch repo and verified the fix opens the editor instead of erroring
- [x] All existing edit tests still pass (10/10)
- [x] Full test suite passes (9572 passed, 1 pre-existing flaky failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)