### PR TITLE
fix(serve): followups for safe-restart durable run mode

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2269,38 +2269,57 @@ export const serveCommand = new Command()
               Math.min(...workflowRuns.map((r) => r.startedAt.getTime())) -
                 60_000,
             );
+            let allRuns:
+              | Awaited<
+                ReturnType<
+                  typeof repoContext.workflowRunRepo.findAllGlobalSince
+                >
+              >
+              | undefined;
             try {
-              const allRuns = await repoContext.workflowRunRepo
+              allRuns = await repoContext.workflowRunRepo
                 .findAllGlobalSince(earliestCutoff);
-              for (const run of workflowRuns) {
-                const match = allRuns.find((r) => r.run.id === run.runId);
-                if (
-                  match &&
-                  (match.run.status === "running" ||
-                    match.run.status === "cancelled")
-                ) {
-                  match.run.interrupt("server_shutdown");
-                  await repoContext.workflowRunRepo.save(
-                    match.workflowId,
-                    match.run,
-                  );
-                  if (isJson) {
-                    console.log(JSON.stringify({
-                      status: "interrupted",
-                      runId: run.runId,
-                    }));
-                  }
-                  logger
-                    .info`Interrupted workflow run ${run.runId} (server shutdown)`;
-                }
-              }
             } catch (err) {
               logger.warn(
-                "Failed to interrupt undrained workflow runs: {error}",
+                "Failed to load workflow runs for interrupt: {error}",
                 {
                   error: err instanceof Error ? err.message : String(err),
                 },
               );
+            }
+            if (allRuns) {
+              for (const run of workflowRuns) {
+                try {
+                  const match = allRuns.find((r) => r.run.id === run.runId);
+                  if (
+                    match &&
+                    (match.run.status === "running" ||
+                      match.run.status === "cancelled")
+                  ) {
+                    match.run.interrupt("server_shutdown");
+                    await repoContext.workflowRunRepo.save(
+                      match.workflowId,
+                      match.run,
+                    );
+                    if (isJson) {
+                      console.log(JSON.stringify({
+                        status: "interrupted",
+                        runId: run.runId,
+                      }));
+                    }
+                    logger
+                      .info`Interrupted workflow run ${run.runId} (server shutdown)`;
+                  }
+                } catch (err) {
+                  logger.warn(
+                    "Failed to interrupt run {runId}: {error}",
+                    {
+                      runId: run.runId,
+                      error: err instanceof Error ? err.message : String(err),
+                    },
+                  );
+                }
+              }
             }
           }
         }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -322,6 +322,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.trustedHosts) {
     args.push("--trusted-hosts", options.trustedHosts as string);
   }
+  if (options.detachRuns) {
+    args.push("--detach-runs");
+  }
   return args;
 }
 
@@ -485,6 +488,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--trusted-hosts <hosts:string>",
     "Comma-separated hostnames to trust for Host header validation (env: SWAMP_TRUSTED_HOSTS)",
+  )
+  .option(
+    "--detach-runs",
+    "Enable durable run mode — runs survive client disconnect and process restart",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -1871,6 +1878,7 @@ export const serveCommand = new Command()
               port: listenPort,
               url: `${wsScheme}://${hostname}:${listenPort}`,
               schedulingEnabled: enableSchedule,
+              detachRuns,
             }));
           } else {
             logger.info("WebSocket API server listening on {url}", {
@@ -2241,23 +2249,31 @@ export const serveCommand = new Command()
         }
         const remaining = activeRunRegistry.list();
         if (remaining.length > 0) {
+          if (isJson) {
+            console.log(JSON.stringify({
+              status: "aborting",
+              undrained: remaining.length,
+            }));
+          }
           logger.info`Aborting ${remaining.length} undrained run(s)...`;
           for (const run of remaining) {
             run.controller.abort(new Error("server shutdown"));
           }
           await activeRunRegistry.drainAll(5_000);
 
-          for (const run of remaining) {
-            if (
-              run.kind === "workflow-run" || run.kind === "workflow-resume"
-            ) {
-              try {
-                const reapCutoff = new Date(
-                  run.startedAt.getTime() - 60_000,
-                );
-                const runs = await repoContext.workflowRunRepo
-                  .findAllGlobalSince(reapCutoff);
-                const match = runs.find((r) => r.run.id === run.runId);
+          const workflowRuns = remaining.filter((r) =>
+            r.kind === "workflow-run" || r.kind === "workflow-resume"
+          );
+          if (workflowRuns.length > 0) {
+            const earliestCutoff = new Date(
+              Math.min(...workflowRuns.map((r) => r.startedAt.getTime())) -
+                60_000,
+            );
+            try {
+              const allRuns = await repoContext.workflowRunRepo
+                .findAllGlobalSince(earliestCutoff);
+              for (const run of workflowRuns) {
+                const match = allRuns.find((r) => r.run.id === run.runId);
                 if (
                   match &&
                   (match.run.status === "running" ||
@@ -2268,18 +2284,23 @@ export const serveCommand = new Command()
                     match.workflowId,
                     match.run,
                   );
+                  if (isJson) {
+                    console.log(JSON.stringify({
+                      status: "interrupted",
+                      runId: run.runId,
+                    }));
+                  }
                   logger
                     .info`Interrupted workflow run ${run.runId} (server shutdown)`;
                 }
-              } catch (err) {
-                logger.warn(
-                  "Failed to interrupt run {runId}: {error}",
-                  {
-                    runId: run.runId,
-                    error: err instanceof Error ? err.message : String(err),
-                  },
-                );
               }
+            } catch (err) {
+              logger.warn(
+                "Failed to interrupt undrained workflow runs: {error}",
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                },
+              );
             }
           }
         }

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
+import { hostname } from "node:os";
 import { ActiveRun } from "../../domain/models/active_run.ts";
 import { type PendingRunEntry, RunTrackerStore } from "./run_tracker_store.ts";
 
@@ -390,5 +391,112 @@ Deno.test("RunTrackerStore: schema v2 migration adds pending_runs to existing DB
     assertEquals(store2.findAllRunning().length, 1);
   } finally {
     store2.close();
+  }
+});
+
+// ── reapDeadProcessRuns tests ──────────────────────────────────────
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns marks dead-PID runs as failed", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "dead-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "dead-1");
+    assertEquals(store.findById("dead-1")?.status, "failed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips runs from current process", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "self-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: Deno.pid,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("self-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips runs from different host", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "remote-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: "other-host",
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("remote-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips completed runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "done-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+    store.complete("done-1", "completed");
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+  } finally {
+    store.close();
   }
 });

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -308,8 +308,12 @@ export class ScheduledExecutionService {
   private handleFire(workflowId: WorkflowId): void {
     const workflowName = this.workflowNames.get(workflowId) ?? workflowId;
 
-    // Overlap prevention — skip if this specific workflow is already running
-    if (this.running.has(workflowId)) {
+    // Overlap prevention — skip if this specific workflow is already running.
+    // Replayed runs are keyed by name (not UUID), so check both.
+    if (
+      this.running.has(workflowId) ||
+      this.running.has(workflowName as WorkflowId)
+    ) {
       this.emit({
         kind: "schedule_skipped",
         workflowId,

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -190,7 +190,8 @@ export function replayPendingRuns(deps: ReplayPendingRunsDeps): number {
   const pending = deps.runTracker.findAllPendingRuns();
   if (pending.length === 0) return 0;
 
-  logger.info`Replaying ${pending.length} pending run(s) from previous process`;
+  logger
+    .debug`Replaying ${pending.length} pending run(s) from previous process`;
 
   let replayed = 0;
   for (const entry of pending) {

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -20,9 +20,12 @@
 import { assertEquals } from "@std/assert";
 import {
   type BootReconciliationDeps,
+  replayPendingRuns,
+  type ReplayPendingRunsDeps,
   sweepStaleRecords,
   type TransitionInput,
 } from "./boot_reconciliation.ts";
+import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { Data } from "../domain/data/data.ts";
 import { ModelType } from "../domain/models/model_type.ts";
@@ -351,6 +354,169 @@ Deno.test("sweepStaleRecords: skips records with missing worker name attribute",
 
   assertEquals(result.workers, 0);
   assertEquals(h.transitions.length, 0);
+});
+
+// ── replayPendingRuns tests ──────────────────────────────────────────
+
+interface ReplayedWebhook {
+  pendingRunId: string;
+  workflowIdOrName: string;
+  route: string;
+}
+
+interface ReplayedCron {
+  pendingRunId: string;
+  workflowIdOrName: string;
+}
+
+function createReplayHarness(
+  pending: PendingRunEntry[],
+  opts: { hasWebhook?: boolean; hasCron?: boolean } = {},
+) {
+  const deleted: string[] = [];
+  const webhookReplays: ReplayedWebhook[] = [];
+  const cronReplays: ReplayedCron[] = [];
+
+  const runTracker = {
+    findAllPendingRuns: () => pending,
+    deletePendingRun: (id: string) => deleted.push(id),
+  } as unknown as ReplayPendingRunsDeps["runTracker"];
+
+  const webhookService = opts.hasWebhook !== false
+    ? {
+      enqueueForReplay: (entry: ReplayedWebhook) => webhookReplays.push(entry),
+    } as unknown as ReplayPendingRunsDeps["webhookService"]
+    : undefined;
+
+  const scheduledExecution = opts.hasCron !== false
+    ? {
+      enqueueForReplay: (entry: ReplayedCron) => cronReplays.push(entry),
+    } as unknown as ReplayPendingRunsDeps["scheduledExecution"]
+    : undefined;
+
+  return {
+    deps: { runTracker, webhookService, scheduledExecution },
+    deleted,
+    webhookReplays,
+    cronReplays,
+  };
+}
+
+Deno.test("replayPendingRuns: returns 0 with no pending runs", () => {
+  const h = createReplayHarness([]);
+  assertEquals(replayPendingRuns(h.deps), 0);
+});
+
+Deno.test("replayPendingRuns: replays webhook run to webhook service", () => {
+  const h = createReplayHarness([{
+    id: "pr-1",
+    source: "webhook",
+    workflowIdOrName: "deploy-flow",
+    payload: JSON.stringify({
+      body: { ref: "main" },
+      headers: { "x-sig": "abc" },
+      route: "/hooks/deploy",
+    }),
+    route: "/hooks/deploy",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.webhookReplays[0].workflowIdOrName, "deploy-flow");
+  assertEquals(h.webhookReplays[0].pendingRunId, "pr-1");
+});
+
+Deno.test("replayPendingRuns: replays cron run to scheduled execution", () => {
+  const h = createReplayHarness([{
+    id: "pr-2",
+    source: "cron",
+    workflowIdOrName: "nightly-sync",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.cronReplays.length, 1);
+  assertEquals(h.cronReplays[0].workflowIdOrName, "nightly-sync");
+  assertEquals(h.cronReplays[0].pendingRunId, "pr-2");
+});
+
+Deno.test("replayPendingRuns: discards webhook run with corrupt payload", () => {
+  const h = createReplayHarness([{
+    id: "pr-bad",
+    source: "webhook",
+    workflowIdOrName: "deploy-flow",
+    payload: "not-json{{{",
+    route: "/hooks/deploy",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.webhookReplays.length, 0);
+  assertEquals(h.deleted, ["pr-bad"]);
+});
+
+Deno.test("replayPendingRuns: discards run when no matching service", () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-orphan",
+      source: "webhook",
+      workflowIdOrName: "some-flow",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    { hasWebhook: false },
+  );
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.deleted, ["pr-orphan"]);
+});
+
+Deno.test("replayPendingRuns: replays mixed webhook and cron runs", () => {
+  const h = createReplayHarness([
+    {
+      id: "pr-1",
+      source: "webhook",
+      workflowIdOrName: "deploy",
+      payload: JSON.stringify({ body: null, headers: {} }),
+      route: "/hooks/ci",
+      createdAt: "2026-01-01T00:00:01Z",
+    },
+    {
+      id: "pr-2",
+      source: "cron",
+      workflowIdOrName: "nightly",
+      createdAt: "2026-01-01T00:00:02Z",
+    },
+  ]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 2);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.cronReplays.length, 1);
+});
+
+Deno.test("replayPendingRuns: webhook with no payload uses empty object", () => {
+  const h = createReplayHarness([{
+    id: "pr-empty",
+    source: "webhook",
+    workflowIdOrName: "deploy",
+    route: "/hooks/ci",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
 });
 
 Deno.test("sweepStaleRecords: sweeps all three model types together", async () => {


### PR DESCRIPTION
## Summary

Followup fixes from the safe-restart PR (#2012):

- **Wire `--detach-runs` into `daemon enable`** — operators using the daemon (primary production path) can now enable durable run mode
- **Add `detachRuns` to listening JSON event** — scripts and monitoring can verify the mode is active
- **Emit structured JSON events during shutdown** — `{"status":"aborting"}` and `{"status":"interrupted"}` events visible to `--json` consumers
- **Fix cron overlap detection for replayed runs** — `handleFire` now checks by name in addition to UUID, preventing a redundant execution when a cron timer fires during boot replay
- **Hoist `findAllGlobalSince` out of shutdown loop** — single filesystem scan instead of N scans for N undrained workflow runs
- **Deduplicate replay count logging** — demoted `boot_reconciliation.ts` message to `debug`; the caller's post-replay message is canonical
- **Unit tests for `replayPendingRuns`** — 7 tests covering webhook/cron routing, corrupt payload, missing service, mixed sources
- **Unit tests for `reapDeadProcessRuns`** — 4 tests covering dead PID reaping, current-process skip, cross-host skip, completed-run skip

## Test Plan

- `deno check` passes on all modified files
- `deno fmt --check` and `deno lint` clean
- All 9594 tests pass (`deno run test`)
- `deno run compile` produces a valid binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)