### PR TITLE
fix(extensions): preserve pulledAt timestamp on extension install restore

### DIFF
--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -36,6 +36,8 @@ export interface WriteEntryOptions {
   filesChecksum?: string;
   serverUrl?: string;
   channel?: string;
+  /** Preserve the original pulledAt timestamp (e.g. lockfile-restore flows). */
+  pulledAt?: string;
 }
 
 /**
@@ -138,7 +140,7 @@ export class LockfileRepository {
       const current = await readUpstreamExtensions(this.lockfilePath);
       current[name] = {
         version,
-        pulledAt: new Date().toISOString(),
+        pulledAt: options?.pulledAt ?? new Date().toISOString(),
         files,
         ...(options?.include && options.include.length > 0
           ? { include: options.include }

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -713,7 +713,8 @@ export async function installExtension(
   // lockfile snapshot was captured at InstallContext construction
   // (per createInstallContext / createExtensionPullDeps); callers MUST
   // construct a fresh context per install (see InstallContext JSDoc).
-  const oldFiles = ctx.lockfileRepository.getEntry(ref.name)?.files ?? [];
+  const oldEntry = ctx.lockfileRepository.getEntry(ref.name);
+  const oldFiles = oldEntry?.files ?? [];
 
   const extInfo = await ctx.getExtension(ref.name);
   if (!extInfo) {
@@ -1181,6 +1182,7 @@ export async function installExtension(
         filesChecksum: filesChecksum ?? undefined,
         serverUrl: resolveServerUrl(),
         channel: ctx.channel,
+        pulledAt: oldEntry?.version === version ? oldEntry.pulledAt : undefined,
       },
     );
 


### PR DESCRIPTION
## Summary

- `extension install` (the lockfile-restore path after cloning a repo) was overwriting the `pulledAt` timestamp in `upstream_extensions.json` with the current time, even though the same version was being re-installed. This made the lockfile appear dirty after every clone+install cycle.
- Preserve the original `pulledAt` when re-installing the same version; fresh pulls and version upgrades still get a new timestamp.

## Test Plan

- Verified end-to-end: init repo → pull extension → snapshot lockfile → delete `.swamp/pulled-extensions` and `.swamp/bundles` (simulating clone) → run `extension install` → diff lockfile against snapshot → **no diff** (previously the `pulledAt` line changed)
- All existing unit tests pass (`lockfile_repository_test.ts`, `install_test.ts`, `pull_test.ts`, `install_extension_service_test.ts`)
- `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)