### PR TITLE
feat(datastore): add control-plane store capability

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -322,6 +322,9 @@ export function collectServeExtraArgs(options: AnyOptions): string[] {
   if (options.trustedHosts) {
     args.push("--trusted-hosts", options.trustedHosts as string);
   }
+  if (options.detachRuns) {
+    args.push("--detach-runs");
+  }
   return args;
 }
 
@@ -485,6 +488,10 @@ const daemonEnableCommand = new Command()
   .option(
     "--trusted-hosts <hosts:string>",
     "Comma-separated hostnames to trust for Host header validation (env: SWAMP_TRUSTED_HOSTS)",
+  )
+  .option(
+    "--detach-runs",
+    "Enable durable run mode — runs survive client disconnect and process restart",
   )
   .example("Enable daemon", "swamp serve daemon enable")
   .example(
@@ -1871,6 +1878,7 @@ export const serveCommand = new Command()
               port: listenPort,
               url: `${wsScheme}://${hostname}:${listenPort}`,
               schedulingEnabled: enableSchedule,
+              detachRuns,
             }));
           } else {
             logger.info("WebSocket API server listening on {url}", {
@@ -2241,44 +2249,76 @@ export const serveCommand = new Command()
         }
         const remaining = activeRunRegistry.list();
         if (remaining.length > 0) {
+          if (isJson) {
+            console.log(JSON.stringify({
+              status: "aborting",
+              undrained: remaining.length,
+            }));
+          }
           logger.info`Aborting ${remaining.length} undrained run(s)...`;
           for (const run of remaining) {
             run.controller.abort(new Error("server shutdown"));
           }
           await activeRunRegistry.drainAll(5_000);
 
-          for (const run of remaining) {
-            if (
-              run.kind === "workflow-run" || run.kind === "workflow-resume"
-            ) {
-              try {
-                const reapCutoff = new Date(
-                  run.startedAt.getTime() - 60_000,
-                );
-                const runs = await repoContext.workflowRunRepo
-                  .findAllGlobalSince(reapCutoff);
-                const match = runs.find((r) => r.run.id === run.runId);
-                if (
-                  match &&
-                  (match.run.status === "running" ||
-                    match.run.status === "cancelled")
-                ) {
-                  match.run.interrupt("server_shutdown");
-                  await repoContext.workflowRunRepo.save(
-                    match.workflowId,
-                    match.run,
+          const workflowRuns = remaining.filter((r) =>
+            r.kind === "workflow-run" || r.kind === "workflow-resume"
+          );
+          if (workflowRuns.length > 0) {
+            const earliestCutoff = new Date(
+              Math.min(...workflowRuns.map((r) => r.startedAt.getTime())) -
+                60_000,
+            );
+            let allRuns:
+              | Awaited<
+                ReturnType<
+                  typeof repoContext.workflowRunRepo.findAllGlobalSince
+                >
+              >
+              | undefined;
+            try {
+              allRuns = await repoContext.workflowRunRepo
+                .findAllGlobalSince(earliestCutoff);
+            } catch (err) {
+              logger.warn(
+                "Failed to load workflow runs for interrupt: {error}",
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                },
+              );
+            }
+            if (allRuns) {
+              for (const run of workflowRuns) {
+                try {
+                  const match = allRuns.find((r) => r.run.id === run.runId);
+                  if (
+                    match &&
+                    (match.run.status === "running" ||
+                      match.run.status === "cancelled")
+                  ) {
+                    match.run.interrupt("server_shutdown");
+                    await repoContext.workflowRunRepo.save(
+                      match.workflowId,
+                      match.run,
+                    );
+                    if (isJson) {
+                      console.log(JSON.stringify({
+                        status: "interrupted",
+                        runId: run.runId,
+                      }));
+                    }
+                    logger
+                      .info`Interrupted workflow run ${run.runId} (server shutdown)`;
+                  }
+                } catch (err) {
+                  logger.warn(
+                    "Failed to interrupt run {runId}: {error}",
+                    {
+                      runId: run.runId,
+                      error: err instanceof Error ? err.message : String(err),
+                    },
                   );
-                  logger
-                    .info`Interrupted workflow run ${run.runId} (server shutdown)`;
                 }
-              } catch (err) {
-                logger.warn(
-                  "Failed to interrupt run {runId}: {error}",
-                  {
-                    runId: run.runId,
-                    error: err instanceof Error ? err.message : String(err),
-                  },
-                );
               }
             }
           }

--- a/src/domain/datastore/control_plane_store.ts
+++ b/src/domain/datastore/control_plane_store.ts
@@ -1,0 +1,35 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Direct read/write access to small control-plane records in the remote
+ * datastore. Bypasses the sync index and cache pipeline entirely — used
+ * for coordination state (instance heartbeats, pending run entries) that
+ * must survive instance death.
+ *
+ * Keys are slash-delimited paths (e.g. `heartbeats/{id}`,
+ * `pending-runs/{id}`). The extension maps them under `_control/` in the
+ * remote backend, scoped by namespace when configured.
+ */
+export interface ControlPlaneStore {
+  put(key: string, data: Uint8Array): Promise<void>;
+  get(key: string): Promise<Uint8Array | null>;
+  delete(key: string): Promise<void>;
+  list(prefix: string): Promise<string[]>;
+}

--- a/src/domain/datastore/datastore_sync_service.ts
+++ b/src/domain/datastore/datastore_sync_service.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { ControlPlaneStore } from "./control_plane_store.ts";
 import { UserError } from "../errors.ts";
 
 /** Describes what a sync operation is about. */
@@ -63,6 +64,14 @@ export interface SyncCapabilities {
    * Core uses this to gate `sync --push` behind a confirmation prompt.
    */
   previewPush?: boolean;
+  /**
+   * When `true`, the extension supports
+   * {@link DatastoreSyncService.controlPlaneStore} — direct read/write
+   * access to small control-plane records that bypass the sync index and
+   * cache pipeline. Used for coordination state (instance heartbeats,
+   * pending run entries) in HA deployments.
+   */
+  controlPlane?: boolean;
 }
 
 /**
@@ -325,6 +334,20 @@ export interface DatastoreSyncService {
     manifest: PushManifest,
     options?: DatastoreSyncOptions,
   ): Promise<number | void>;
+
+  /**
+   * Return a {@link ControlPlaneStore} for direct read/write access to
+   * small control-plane records in the remote backend.
+   *
+   * Records bypass the sync index and cache pipeline entirely — they
+   * live under `_control/` in the remote datastore, scoped by namespace
+   * when configured.
+   *
+   * Optional — only implemented by extensions that advertise
+   * `controlPlane: true` in their capabilities. Core checks
+   * `caps?.controlPlane && syncService.controlPlaneStore` before calling.
+   */
+  controlPlaneStore?(): ControlPlaneStore;
 
   /**
    * Detect and optionally remove foreign namespace data under the

--- a/src/domain/datastore/mod.ts
+++ b/src/domain/datastore/mod.ts
@@ -46,6 +46,8 @@ export {
 
 export { type DatastorePathResolver } from "./datastore_path_resolver.ts";
 
+export { type ControlPlaneStore } from "./control_plane_store.ts";
+
 export {
   type CatalogExportEntry,
   type CatalogExportRow,

--- a/src/infrastructure/persistence/fs_control_plane_store.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store.ts
@@ -20,6 +20,7 @@
 import { dirname, join } from "@std/path";
 import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
 import { atomicWriteFile } from "./atomic_write.ts";
+import { assertContainedPath } from "./safe_path.ts";
 
 /**
  * Filesystem-backed {@link ControlPlaneStore} used as a fallback when the
@@ -64,7 +65,7 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
   }
 
   async list(prefix: string): Promise<string[]> {
-    const searchDir = this.#keyToPath(prefix);
+    const searchDir = prefix === "" ? this.#rootDir : this.#keyToPath(prefix);
     const keys: string[] = [];
     try {
       await this.#collectKeys(searchDir, this.#rootDir, keys);
@@ -83,6 +84,7 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
     keys: string[],
   ): Promise<void> {
     for await (const entry of Deno.readDir(dir)) {
+      if (entry.isSymlink) continue;
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory) {
         await this.#collectKeys(fullPath, rootDir, keys);
@@ -94,7 +96,7 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
   }
 
   #keyToPath(key: string): string {
-    const segments = key.split("/");
-    return join(this.#rootDir, ...segments);
+    assertContainedPath(key, this.#rootDir);
+    return join(this.#rootDir, ...key.split("/"));
   }
 }

--- a/src/infrastructure/persistence/fs_control_plane_store.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store.ts
@@ -1,0 +1,100 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { dirname, join } from "@std/path";
+import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
+import { atomicWriteFile } from "./atomic_write.ts";
+
+/**
+ * Filesystem-backed {@link ControlPlaneStore} used as a fallback when the
+ * datastore extension doesn't advertise `controlPlane`.
+ *
+ * Stores records at `{datastorePath}/_control/{key}` using atomic writes
+ * to avoid partial reads.
+ */
+export class FileSystemControlPlaneStore implements ControlPlaneStore {
+  readonly #rootDir: string;
+
+  constructor(datastorePath: string) {
+    this.#rootDir = join(datastorePath, "_control");
+  }
+
+  async put(key: string, data: Uint8Array): Promise<void> {
+    const path = this.#keyToPath(key);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await atomicWriteFile(path, data);
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    try {
+      return await Deno.readFile(this.#keyToPath(key));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await Deno.remove(this.#keyToPath(key));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    const searchDir = this.#keyToPath(prefix);
+    const keys: string[] = [];
+    try {
+      await this.#collectKeys(searchDir, this.#rootDir, keys);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
+    return keys.sort();
+  }
+
+  async #collectKeys(
+    dir: string,
+    rootDir: string,
+    keys: string[],
+  ): Promise<void> {
+    for await (const entry of Deno.readDir(dir)) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory) {
+        await this.#collectKeys(fullPath, rootDir, keys);
+      } else if (entry.isFile && !entry.name.endsWith(".tmp")) {
+        const relative = fullPath.slice(rootDir.length + 1);
+        keys.push(relative.replaceAll("\\", "/"));
+      }
+    }
+  }
+
+  #keyToPath(key: string): string {
+    const segments = key.split("/");
+    return join(this.#rootDir, ...segments);
+  }
+}

--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -17,8 +17,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { FileSystemControlPlaneStore } from "./fs_control_plane_store.ts";
+import { PathTraversalError } from "./safe_path.ts";
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await Deno.makeTempDir({
@@ -174,5 +175,62 @@ Deno.test("FileSystemControlPlaneStore: delete then put same key", async () => {
 
     const result = await store.get("key");
     assertEquals(decoder.decode(result!), "v2");
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: list with empty prefix returns all keys", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("heartbeats/i-1", encoder.encode("h1"));
+    await store.put("pending-runs/r-1", encoder.encode("p1"));
+
+    const all = await store.list("");
+    assertEquals(all, ["heartbeats/i-1", "pending-runs/r-1"]);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: rejects path traversal via ..", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await assertRejects(
+      () => store.put("../../etc/passwd", encoder.encode("bad")),
+      PathTraversalError,
+    );
+    await assertRejects(
+      () => store.get("../secret"),
+      PathTraversalError,
+    );
+    await assertRejects(
+      () => store.delete("heartbeats/../../outside"),
+      PathTraversalError,
+    );
+    await assertRejects(
+      () => store.list(".."),
+      PathTraversalError,
+    );
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: rejects absolute path keys", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await assertRejects(
+      () => store.put("/etc/passwd", encoder.encode("bad")),
+      PathTraversalError,
+    );
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: rejects empty key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await assertRejects(
+      () => store.put("", encoder.encode("bad")),
+      PathTraversalError,
+    );
   });
 });

--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -1,0 +1,178 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { FileSystemControlPlaneStore } from "./fs_control_plane_store.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({
+    prefix: "swamp-control-plane-store-test-",
+  });
+  try {
+    await fn(dir);
+  } finally {
+    if (Deno.build.os === "windows") {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    } else {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+Deno.test("FileSystemControlPlaneStore: put and get round-trip", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+    const data = encoder.encode('{"instance":"i-1","ts":1234}');
+
+    await store.put("heartbeats/i-1", data);
+    const result = await store.get("heartbeats/i-1");
+
+    assertEquals(result !== null, true);
+    assertEquals(decoder.decode(result!), '{"instance":"i-1","ts":1234}');
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: get returns null for missing key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    const result = await store.get("heartbeats/nonexistent");
+    assertEquals(result, null);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: put overwrites existing key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("heartbeats/i-1", encoder.encode("v1"));
+    await store.put("heartbeats/i-1", encoder.encode("v2"));
+    const result = await store.get("heartbeats/i-1");
+
+    assertEquals(decoder.decode(result!), "v2");
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: delete removes key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("heartbeats/i-1", encoder.encode("data"));
+    await store.delete("heartbeats/i-1");
+    const result = await store.get("heartbeats/i-1");
+
+    assertEquals(result, null);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: delete is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.delete("heartbeats/nonexistent");
+    await store.delete("heartbeats/nonexistent");
+    const result = await store.get("heartbeats/nonexistent");
+
+    assertEquals(result, null);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: list with prefix filtering", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("heartbeats/i-1", encoder.encode("h1"));
+    await store.put("heartbeats/i-2", encoder.encode("h2"));
+    await store.put("pending-runs/r-1", encoder.encode("p1"));
+
+    const heartbeats = await store.list("heartbeats");
+    assertEquals(heartbeats, ["heartbeats/i-1", "heartbeats/i-2"]);
+
+    const pending = await store.list("pending-runs");
+    assertEquals(pending, ["pending-runs/r-1"]);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: list returns empty for missing prefix", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    const result = await store.list("nonexistent");
+    assertEquals(result, []);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: nested key paths", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("deep/nested/path/key", encoder.encode("deep-value"));
+    const result = await store.get("deep/nested/path/key");
+
+    assertEquals(decoder.decode(result!), "deep-value");
+
+    const keys = await store.list("deep/nested");
+    assertEquals(keys, ["deep/nested/path/key"]);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: list returns sorted keys", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("heartbeats/z-last", encoder.encode("z"));
+    await store.put("heartbeats/a-first", encoder.encode("a"));
+    await store.put("heartbeats/m-middle", encoder.encode("m"));
+
+    const keys = await store.list("heartbeats");
+    assertEquals(keys, [
+      "heartbeats/a-first",
+      "heartbeats/m-middle",
+      "heartbeats/z-last",
+    ]);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: put/get binary data", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+    const binary = new Uint8Array([0, 1, 2, 255, 128, 64]);
+
+    await store.put("binary/record", binary);
+    const result = await store.get("binary/record");
+
+    assertEquals(result, binary);
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: delete then put same key", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("key", encoder.encode("v1"));
+    await store.delete("key");
+    await store.put("key", encoder.encode("v2"));
+
+    const result = await store.get("key");
+    assertEquals(decoder.decode(result!), "v2");
+  });
+});

--- a/src/infrastructure/persistence/lockfile_repository.ts
+++ b/src/infrastructure/persistence/lockfile_repository.ts
@@ -36,6 +36,8 @@ export interface WriteEntryOptions {
   filesChecksum?: string;
   serverUrl?: string;
   channel?: string;
+  /** Preserve the original pulledAt timestamp (e.g. lockfile-restore flows). */
+  pulledAt?: string;
 }
 
 /**
@@ -138,7 +140,7 @@ export class LockfileRepository {
       const current = await readUpstreamExtensions(this.lockfilePath);
       current[name] = {
         version,
-        pulledAt: new Date().toISOString(),
+        pulledAt: options?.pulledAt ?? new Date().toISOString(),
         files,
         ...(options?.include && options.include.length > 0
           ? { include: options.include }

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
+import { hostname } from "node:os";
 import { ActiveRun } from "../../domain/models/active_run.ts";
 import { type PendingRunEntry, RunTrackerStore } from "./run_tracker_store.ts";
 
@@ -390,5 +391,112 @@ Deno.test("RunTrackerStore: schema v2 migration adds pending_runs to existing DB
     assertEquals(store2.findAllRunning().length, 1);
   } finally {
     store2.close();
+  }
+});
+
+// ── reapDeadProcessRuns tests ──────────────────────────────────────
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns marks dead-PID runs as failed", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "dead-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "dead-1");
+    assertEquals(store.findById("dead-1")?.status, "failed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips runs from current process", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "self-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: Deno.pid,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("self-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips runs from different host", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "remote-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: "other-host",
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("remote-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns skips completed runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "done-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+    store.complete("done-1", "completed");
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 0);
+  } finally {
+    store.close();
   }
 });

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -713,7 +713,8 @@ export async function installExtension(
   // lockfile snapshot was captured at InstallContext construction
   // (per createInstallContext / createExtensionPullDeps); callers MUST
   // construct a fresh context per install (see InstallContext JSDoc).
-  const oldFiles = ctx.lockfileRepository.getEntry(ref.name)?.files ?? [];
+  const oldEntry = ctx.lockfileRepository.getEntry(ref.name);
+  const oldFiles = oldEntry?.files ?? [];
 
   const extInfo = await ctx.getExtension(ref.name);
   if (!extInfo) {
@@ -1181,6 +1182,7 @@ export async function installExtension(
         filesChecksum: filesChecksum ?? undefined,
         serverUrl: resolveServerUrl(),
         channel: ctx.channel,
+        pulledAt: oldEntry?.version === version ? oldEntry.pulledAt : undefined,
       },
     );
 

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -308,8 +308,12 @@ export class ScheduledExecutionService {
   private handleFire(workflowId: WorkflowId): void {
     const workflowName = this.workflowNames.get(workflowId) ?? workflowId;
 
-    // Overlap prevention — skip if this specific workflow is already running
-    if (this.running.has(workflowId)) {
+    // Overlap prevention — skip if this specific workflow is already running.
+    // Replayed runs are keyed by name (not UUID), so check both.
+    if (
+      this.running.has(workflowId) ||
+      this.running.has(workflowName as WorkflowId)
+    ) {
       this.emit({
         kind: "schedule_skipped",
         workflowId,

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -190,7 +190,8 @@ export function replayPendingRuns(deps: ReplayPendingRunsDeps): number {
   const pending = deps.runTracker.findAllPendingRuns();
   if (pending.length === 0) return 0;
 
-  logger.info`Replaying ${pending.length} pending run(s) from previous process`;
+  logger
+    .debug`Replaying ${pending.length} pending run(s) from previous process`;
 
   let replayed = 0;
   for (const entry of pending) {

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -20,9 +20,12 @@
 import { assertEquals } from "@std/assert";
 import {
   type BootReconciliationDeps,
+  replayPendingRuns,
+  type ReplayPendingRunsDeps,
   sweepStaleRecords,
   type TransitionInput,
 } from "./boot_reconciliation.ts";
+import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { Data } from "../domain/data/data.ts";
 import { ModelType } from "../domain/models/model_type.ts";
@@ -351,6 +354,169 @@ Deno.test("sweepStaleRecords: skips records with missing worker name attribute",
 
   assertEquals(result.workers, 0);
   assertEquals(h.transitions.length, 0);
+});
+
+// ── replayPendingRuns tests ──────────────────────────────────────────
+
+interface ReplayedWebhook {
+  pendingRunId: string;
+  workflowIdOrName: string;
+  route: string;
+}
+
+interface ReplayedCron {
+  pendingRunId: string;
+  workflowIdOrName: string;
+}
+
+function createReplayHarness(
+  pending: PendingRunEntry[],
+  opts: { hasWebhook?: boolean; hasCron?: boolean } = {},
+) {
+  const deleted: string[] = [];
+  const webhookReplays: ReplayedWebhook[] = [];
+  const cronReplays: ReplayedCron[] = [];
+
+  const runTracker = {
+    findAllPendingRuns: () => pending,
+    deletePendingRun: (id: string) => deleted.push(id),
+  } as unknown as ReplayPendingRunsDeps["runTracker"];
+
+  const webhookService = opts.hasWebhook !== false
+    ? {
+      enqueueForReplay: (entry: ReplayedWebhook) => webhookReplays.push(entry),
+    } as unknown as ReplayPendingRunsDeps["webhookService"]
+    : undefined;
+
+  const scheduledExecution = opts.hasCron !== false
+    ? {
+      enqueueForReplay: (entry: ReplayedCron) => cronReplays.push(entry),
+    } as unknown as ReplayPendingRunsDeps["scheduledExecution"]
+    : undefined;
+
+  return {
+    deps: { runTracker, webhookService, scheduledExecution },
+    deleted,
+    webhookReplays,
+    cronReplays,
+  };
+}
+
+Deno.test("replayPendingRuns: returns 0 with no pending runs", () => {
+  const h = createReplayHarness([]);
+  assertEquals(replayPendingRuns(h.deps), 0);
+});
+
+Deno.test("replayPendingRuns: replays webhook run to webhook service", () => {
+  const h = createReplayHarness([{
+    id: "pr-1",
+    source: "webhook",
+    workflowIdOrName: "deploy-flow",
+    payload: JSON.stringify({
+      body: { ref: "main" },
+      headers: { "x-sig": "abc" },
+      route: "/hooks/deploy",
+    }),
+    route: "/hooks/deploy",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.webhookReplays[0].workflowIdOrName, "deploy-flow");
+  assertEquals(h.webhookReplays[0].pendingRunId, "pr-1");
+});
+
+Deno.test("replayPendingRuns: replays cron run to scheduled execution", () => {
+  const h = createReplayHarness([{
+    id: "pr-2",
+    source: "cron",
+    workflowIdOrName: "nightly-sync",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.cronReplays.length, 1);
+  assertEquals(h.cronReplays[0].workflowIdOrName, "nightly-sync");
+  assertEquals(h.cronReplays[0].pendingRunId, "pr-2");
+});
+
+Deno.test("replayPendingRuns: discards webhook run with corrupt payload", () => {
+  const h = createReplayHarness([{
+    id: "pr-bad",
+    source: "webhook",
+    workflowIdOrName: "deploy-flow",
+    payload: "not-json{{{",
+    route: "/hooks/deploy",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.webhookReplays.length, 0);
+  assertEquals(h.deleted, ["pr-bad"]);
+});
+
+Deno.test("replayPendingRuns: discards run when no matching service", () => {
+  const h = createReplayHarness(
+    [{
+      id: "pr-orphan",
+      source: "webhook",
+      workflowIdOrName: "some-flow",
+      createdAt: "2026-01-01T00:00:00Z",
+    }],
+    { hasWebhook: false },
+  );
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 0);
+  assertEquals(h.deleted, ["pr-orphan"]);
+});
+
+Deno.test("replayPendingRuns: replays mixed webhook and cron runs", () => {
+  const h = createReplayHarness([
+    {
+      id: "pr-1",
+      source: "webhook",
+      workflowIdOrName: "deploy",
+      payload: JSON.stringify({ body: null, headers: {} }),
+      route: "/hooks/ci",
+      createdAt: "2026-01-01T00:00:01Z",
+    },
+    {
+      id: "pr-2",
+      source: "cron",
+      workflowIdOrName: "nightly",
+      createdAt: "2026-01-01T00:00:02Z",
+    },
+  ]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 2);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.cronReplays.length, 1);
+});
+
+Deno.test("replayPendingRuns: webhook with no payload uses empty object", () => {
+  const h = createReplayHarness([{
+    id: "pr-empty",
+    source: "webhook",
+    workflowIdOrName: "deploy",
+    route: "/hooks/ci",
+    createdAt: "2026-01-01T00:00:00Z",
+  }]);
+
+  const count = replayPendingRuns(h.deps);
+
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
 });
 
 Deno.test("sweepStaleRecords: sweeps all three model types together", async () => {


### PR DESCRIPTION
## Summary

- Add `ControlPlaneStore` interface for direct read/write access to small control-plane records in the remote datastore, bypassing the sync index and cache pipeline entirely
- Add `controlPlane` capability flag to `SyncCapabilities` and optional `controlPlaneStore()` method on `DatastoreSyncService`, following the existing duck-typed capability pattern
- Add `FileSystemControlPlaneStore` fallback implementation using atomic writes at `{datastorePath}/_control/{key}` for datastores that don't advertise `controlPlane`

This lays the groundwork for swamp serve HA coordination state (instance heartbeats, pending run entries) that must survive instance death. No consumers yet — the serve-side work and `@swamp/s3-datastore` extension implementation come in follow-up PRs.

## Test Plan

- 11 unit tests for `FileSystemControlPlaneStore`: put/get round-trip, missing key returns null, overwrite, delete, idempotent delete, prefix-filtered list, empty prefix, nested key paths, sorted keys, binary data, delete-then-put
- Existing `DatastoreSyncService` tests pass unchanged
- `deno check`, `deno lint`, `deno fmt` all pass