### PR TITLE
feat(access): add --vault flag to token rotate (swamp-club#1470)

### DIFF
--- a/.claude/skills/swamp/references/serve/guide.md
+++ b/.claude/skills/swamp/references/serve/guide.md
@@ -180,10 +180,11 @@ swamp access can-i --action run --on workflow:@acme/deploy --server wss://...
 ## Token Management
 
 ```bash
-swamp access token mint <name> --principal user:<id>   # plaintext shown once
+swamp access token mint <name> --principal user:<id>   # plaintext stored in vault
 swamp access token list
 swamp access token revoke <name>
 swamp access token rotate <name>                       # revoke + mint replacement
+swamp access token rotate <name> --vault <vault>       # rotate into a different vault
 ```
 
 ## OAuth Login

--- a/src/cli/commands/access_token_rotate.ts
+++ b/src/cli/commands/access_token_rotate.ts
@@ -69,6 +69,10 @@ export const accessTokenRotateCommand = new Command()
     "Lifetime for the new token (e.g. 30m, 1h, 24h, 7d, 30d)",
     { default: DEFAULT_DURATION },
   )
+  .option(
+    "--vault <vault:string>",
+    "Vault that stores the token plaintext (defaults to the vault from the existing token)",
+  )
   .action(async function (options: AnyOptions, name: string) {
     const cliCtx = createContext(options as GlobalOptions, [
       "access",
@@ -130,6 +134,7 @@ export const accessTokenRotateCommand = new Command()
         serverTokenRotate(libCtx, deps, {
           name,
           durationMs,
+          vaultName: options.vault as string | undefined,
         }),
         withDefaults<ServerTokenRotateEvent>({
           completed: (event) => {

--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -189,6 +189,7 @@ async function redeem(
 
 const RotateArgsSchema = z.object({
   durationMs: z.number().int().positive().optional(),
+  vaultName: z.string().min(1).optional(),
 });
 
 async function rotate(
@@ -202,7 +203,8 @@ async function rotate(
   const name = context.definition.name;
   const secretKey = serverTokenSecretKey(name);
   const plaintext = generateOpaqueToken();
-  await context.vaultService.put(existing.vaultName, secretKey, plaintext);
+  const vaultName = args.vaultName ?? existing.vaultName;
+  await context.vaultService.put(vaultName, secretKey, plaintext);
 
   const now = Date.now();
   const durationMs = args.durationMs ?? DEFAULT_DURATION_MS;
@@ -215,7 +217,7 @@ async function rotate(
     groups: existing.groups,
     createdAt: new Date(now).toISOString(),
     expiresAt: new Date(now + durationMs).toISOString(),
-    vaultName: existing.vaultName,
+    vaultName,
     secretKey,
   };
   const handle = await context.writeResource!("token", TOKEN_DATA_NAME, token);

--- a/src/libswamp/access/token_rotate.ts
+++ b/src/libswamp/access/token_rotate.ts
@@ -18,10 +18,11 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { LibSwampContext } from "../context.ts";
-import type { SwampError } from "../errors.ts";
+import { type SwampError, validationFailed } from "../errors.ts";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { modelMethodRun, type ModelMethodRunEvent } from "../models/run.ts";
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
+import { VaultService } from "../../domain/vaults/vault_service.ts";
 import { createServerTokenRunDeps } from "./run_deps.ts";
 
 export interface ServerTokenRotateData {
@@ -39,11 +40,13 @@ export type ServerTokenRotateEvent =
 export interface ServerTokenRotateInput {
   name: string;
   durationMs?: number;
+  vaultName?: string;
 }
 
 export interface ServerTokenRotateDeps {
+  listVaultNames: () => Promise<string[]>;
   runRotate: (
-    input: { name: string; durationMs?: number },
+    input: { name: string; durationMs?: number; vaultName?: string },
   ) => AsyncIterable<ModelMethodRunEvent>;
 }
 
@@ -53,16 +56,20 @@ export async function createServerTokenRotateDeps(
   repoContext: RepositoryContext,
 ): Promise<ServerTokenRotateDeps> {
   const runDeps = await createServerTokenRunDeps(repoDir, repoContext);
+  const vaultService = await VaultService.fromRepository(repoDir);
   return {
-    runRotate: (input) =>
-      modelMethodRun(ctx, runDeps, {
+    listVaultNames: () => Promise.resolve(vaultService.getVaultNames()),
+    runRotate: (input) => {
+      const inputs: Record<string, unknown> = {};
+      if (input.durationMs !== undefined) inputs.durationMs = input.durationMs;
+      if (input.vaultName !== undefined) inputs.vaultName = input.vaultName;
+      return modelMethodRun(ctx, runDeps, {
         modelIdOrName: input.name,
         methodName: "rotate",
-        inputs: input.durationMs !== undefined
-          ? { durationMs: input.durationMs }
-          : {},
+        inputs,
         lastEvaluated: false,
-      }),
+      });
+    },
   };
 }
 
@@ -77,6 +84,22 @@ export async function* serverTokenRotate(
     "swamp.access.token.rotate",
     { "token.name": input.name },
     (async function* () {
+      if (input.vaultName !== undefined) {
+        const available = await deps.listVaultNames();
+        if (!available.includes(input.vaultName)) {
+          const hint = available.length > 0
+            ? `Available vaults: ${available.join(", ")}`
+            : "No vaults are configured. Create one with: swamp vault create <type> <name>";
+          yield {
+            kind: "error" as const,
+            error: validationFailed(
+              `Vault '${input.vaultName}' is not configured. ${hint}`,
+            ),
+          };
+          return;
+        }
+      }
+
       yield { kind: "rotating" as const, name: input.name };
 
       let tokenRecord: Record<string, unknown> | undefined;
@@ -84,6 +107,7 @@ export async function* serverTokenRotate(
         const event of deps.runRotate({
           name: input.name,
           durationMs: input.durationMs,
+          vaultName: input.vaultName,
         })
       ) {
         if (event.kind === "error") {

--- a/src/libswamp/access/token_rotate_test.ts
+++ b/src/libswamp/access/token_rotate_test.ts
@@ -70,6 +70,7 @@ function makeDeps(
   overrides?: Partial<ServerTokenRotateDeps>,
 ): ServerTokenRotateDeps {
   return {
+    listVaultNames: () => Promise.resolve(["main-vault", "backup-vault"]),
     runRotate: async function* (input) {
       for (const event of rotateEvents(input.name)) {
         yield await Promise.resolve(event);
@@ -199,4 +200,80 @@ Deno.test("serverTokenRotate: errors when token record is missing from result", 
   >;
   assertEquals(error.kind, "error");
   assertStringIncludes(error.error.message, "token-main");
+});
+
+Deno.test("serverTokenRotate: passes vaultName override to the model method", async () => {
+  let receivedVault: string | undefined;
+  const deps = makeDeps({
+    runRotate: async function* (input) {
+      receivedVault = input.vaultName;
+      for (
+        const event of rotateEvents(input.name, {
+          name: input.name,
+          state: "active",
+          principalId: "user:sarah",
+          principalEmail: "sarah@example.com",
+          createdAt: "2026-06-19T00:00:00.000Z",
+          expiresAt: EXPIRES_AT,
+          vaultName: "backup-vault",
+          secretKey: `server-token-${input.name}`,
+        })
+      ) {
+        yield await Promise.resolve(event);
+      }
+    },
+  });
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, {
+      name: "tok",
+      vaultName: "backup-vault",
+    }),
+  );
+  assertEquals(receivedVault, "backup-vault");
+  const completed = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.vaultRef.vaultName, "backup-vault");
+});
+
+Deno.test("serverTokenRotate: uses existing vault when no override provided", async () => {
+  let receivedVault: string | undefined;
+  const deps = makeDeps({
+    runRotate: async function* (input) {
+      receivedVault = input.vaultName;
+      for (const event of rotateEvents(input.name)) {
+        yield await Promise.resolve(event);
+      }
+    },
+  });
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), deps, {
+      name: "tok",
+    }),
+  );
+  assertEquals(receivedVault, undefined);
+  const completed = events[1] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.vaultRef.vaultName, "main-vault");
+});
+
+Deno.test("serverTokenRotate: errors when requested vault does not exist", async () => {
+  const events = await collect<ServerTokenRotateEvent>(
+    serverTokenRotate(createLibSwampContext(), makeDeps(), {
+      name: "tok",
+      vaultName: "nonexistent-vault",
+    }),
+  );
+  assertEquals(events.length, 1);
+  const error = events[0] as Extract<
+    ServerTokenRotateEvent,
+    { kind: "error" }
+  >;
+  assertEquals(error.kind, "error");
+  assertStringIncludes(error.error.message, "Vault 'nonexistent-vault'");
+  assertStringIncludes(error.error.message, "not configured");
+  assertStringIncludes(error.error.message, "main-vault");
 });


### PR DESCRIPTION
## Summary

- Add `--vault` flag to `swamp access token rotate` so users can override which vault stores the rotated token's secret, matching the existing `--vault` on `access token mint`
- Previously rotate always inherited the vault from the original token record — the only workaround was `revoke` then `mint --vault`, which leaves a revoked entry behind
- Validates the requested vault exists before rotating, with a clear error listing available vaults

Closes swamp-club#1470

## Test Plan

- [x] 3 new unit tests: vault override passed through, default behavior unchanged, invalid vault yields error
- [x] All 9590 existing tests pass
- [x] `deno check`, `deno lint`, `deno fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)