### PR TITLE
fix(serve): surface OAuth error body in startDeviceGrant (swamp-club#1477)

### DIFF
--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -85,8 +85,11 @@ export async function startDeviceGrant(
     signal,
   });
   if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
     throw new Error(
-      `Device authorization request failed: ${resp.status} ${resp.statusText}`,
+      `Device authorization request failed: ${resp.status} ${
+        data.error ?? resp.statusText
+      }${data.error_description ? ` — ${data.error_description}` : ""}`,
     );
   }
   const data = await resp.json();

--- a/src/serve/oauth_client_test.ts
+++ b/src/serve/oauth_client_test.ts
@@ -126,7 +126,33 @@ Deno.test("startDeviceGrant: sends client_id in JSON body", async () => {
   }
 });
 
-Deno.test("startDeviceGrant: throws on HTTP error", async () => {
+Deno.test("startDeviceGrant: surfaces OAuth error from JSON body", async () => {
+  const mock = startMockServer(() =>
+    new Response(
+      JSON.stringify({
+        error: "invalid_client",
+        error_description: "client not registered",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    )
+  );
+  try {
+    await assertRejects(
+      () =>
+        startDeviceGrant(
+          `http://localhost:${mock.port}`,
+          "test-client",
+          AbortSignal.timeout(5000),
+        ),
+      Error,
+      "Device authorization request failed: 400 invalid_client — client not registered",
+    );
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("startDeviceGrant: falls back to statusText for non-JSON body", async () => {
   const mock = startMockServer(() =>
     new Response("Bad Request", { status: 400 })
   );


### PR DESCRIPTION
## Summary

- `startDeviceGrant` discarded the response body on failure, making device-code
  rejections undiagnosable — every 400 produced the same opaque
  `Device authorization request failed: 400 Bad Request` message
- Now reads the body and surfaces the OAuth `error` and `error_description`
  fields, mirroring `pollForToken`'s existing pattern in the same file
- Added test for JSON error body with `error` + `error_description`; kept
  existing non-JSON fallback test

Closes swamp-club#1477

## Test Plan

- [x] New test: `startDeviceGrant: surfaces OAuth error from JSON body` — asserts
  `400 invalid_client — client not registered` appears in the thrown message
- [x] Existing test renamed to `startDeviceGrant: falls back to statusText for
  non-JSON body` — confirms `.catch(() => ({}))` fallback preserves current
  behavior
- [x] All 24 `oauth_client_test.ts` tests pass
- [x] `deno fmt`, `deno lint`, `deno check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)