### PR TITLE
feat(issue-lifecycle): adversarial regression verification and session summary

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -118,8 +118,7 @@ where you decide whether to thank the issue author:
 
 - If the issue author is an **external contributor** (not a repo collaborator),
   call `notify` to post a thank-you ripple mentioning them by handle.
-- If the issue author is a **collaborator**, call `skip_notify` to proceed
-  directly to done.
+- If the issue author is a **collaborator**, call `skip_notify` to proceed.
 
 Check collaborator status with:
 
@@ -129,6 +128,16 @@ gh api /repos/swamp-club/swamp/collaborators --jq '.[].login' | grep -qx '<autho
 
 If the author is NOT in the collaborator list, they are external — call
 `notify`. Otherwise call `skip_notify`.
+
+### Phase 6: Session Summary
+
+After `notify` or `skip_notify`, the lifecycle enters the `summarizing` phase.
+Read [references/implementation.md](references/implementation.md) — section 7
+covers the summary step.
+
+Restate the original problem and the delivered outcome in plain language, then
+call `summarize` to close out the lifecycle. This final check ensures the work
+actually addressed the issue.
 
 ## Classification Types
 
@@ -188,6 +197,7 @@ Use this table to determine what to do next:
 | `pr_failed`      | Fix the issue, then `link_pr` (new PR) or `implement` (major rework)       |
 | `releasing`      | Check release build: `ship` when done, or `complete` as fallback           |
 | `notify`         | Check if author is external: `notify` to thank them, `skip_notify` to skip |
+| `summarizing`    | Call `summarize` with the problem restatement and delivered outcome        |
 | `done`           | Nothing to do — lifecycle is complete                                      |
 
 The canonical phase list lives in the `TRANSITIONS` constant in
@@ -219,8 +229,14 @@ When a PR has already merged and the lifecycle just needs to be marked done:
    swamp model @swamp/issue-lifecycle method run notify issue-<N>
    swamp model @swamp/issue-lifecycle method run skip_notify issue-<N>
    ```
-6. For quick close-out, `complete` still works from `implementing`, `pr_open`,
-   or `releasing` (transitions to `notify`, then use `notify` or `skip_notify`).
+6. If the phase is `summarizing`, record the summary:
+   ```
+   swamp model @swamp/issue-lifecycle method run summarize issue-<N> \
+     --input originalProblem="<problem>" --input deliveredOutcome="<outcome>" --input outcomeMet=true
+   ```
+7. For quick close-out, `complete` still works from `implementing`, `pr_open`,
+   or `releasing` (transitions to `notify`, then `notify`/`skip_notify`, then
+   `summarize`).
 
 ## Key Rules
 

--- a/.claude/skills/issue-lifecycle/references/implementation.md
+++ b/.claude/skills/issue-lifecycle/references/implementation.md
@@ -148,7 +148,24 @@ gh api /repos/swamp-club/swamp/collaborators --jq '.[].login' | grep -qx '<autho
   ```
   swamp model @swamp/issue-lifecycle method run notify issue-<N>
   ```
-- **Collaborator**: call `skip_notify` to proceed to done:
+- **Collaborator**: call `skip_notify` to proceed:
   ```
   swamp model @swamp/issue-lifecycle method run skip_notify issue-<N>
   ```
+
+## 7. Session Summary
+
+After `notify` or `skip_notify`, the phase is `summarizing`. Restate the
+original problem and the delivered outcome in simple, plain-language terms. The
+human should be able to read these two statements and immediately judge whether
+the work was on target.
+
+```
+swamp model @swamp/issue-lifecycle method run summarize issue-<N> \
+  --input originalProblem="<plain-language restatement of the bug or feature request>" \
+  --input deliveredOutcome="<plain-language description of what was built or fixed>" \
+  --input outcomeMet=<true|false>
+```
+
+This transitions the phase to `done` and posts a `session_summarized` lifecycle
+entry.

--- a/.claude/skills/issue-lifecycle/references/triage.md
+++ b/.claude/skills/issue-lifecycle/references/triage.md
@@ -81,18 +81,48 @@ swamp model @swamp/issue-lifecycle method run triage issue-<N> \
 - `platform` — admin-only platform infrastructure work
 - `security` — security vulnerability, hardening, or compliance work
 
-Add `--input isRegression=true` when the bug previously worked. Look for signals
-like: "this used to work", "stopped working after", "worked in version X",
-references to recent changes that broke existing behavior, or git history
-showing the affected code was recently modified. A regression is still
-classified as `type: bug` — `isRegression` is a detail on the classification
-record.
+**Regression classification requires adversarial verification.** If you believe
+the issue is a regression, you MUST complete the following before calling
+`triage`:
 
-When `isRegression=true`, also provide
+1. **Gather evidence FOR regression**: Find concrete proof it previously worked
+   — a commit where the behavior was correct, a version where it passed, test
+   output, or a git bisect result. Vague signals like "this used to work" from
+   the issue author are not sufficient on their own — corroborate with code
+   history.
+
+2. **Argue AGAINST regression**: Construct the strongest case that this is NOT a
+   regression. Ask yourself: "Did this ever actually work correctly, or was it
+   always broken and just unnoticed?" Consider: the feature was never shipped,
+   docs were stale, the behavior was never tested, the reporter may be
+   misremembering, or the expected behavior changed intentionally.
+
+3. **Reach a verdict**: Weigh both sides. If the evidence survives the
+   challenge, the verdict is `confirmed`. If the counter-argument is stronger,
+   the verdict is `downgraded` — it's a plain bug, not a regression. Present
+   both sides and your verdict to the human before calling `triage`.
+
+4. **Pass all four regression fields** to the `triage` command:
+   ```
+   --input isRegression=true \
+   --input regressionEvidence="<concrete proof it previously worked>" \
+   --input regressionCounterEvidence="<strongest case it is NOT a regression>" \
+   --input regressionVerdict=<confirmed|downgraded> \
+   --input regressionVerdictReasoning="<why the verdict holds>"
+   ```
+   The `triage` method will reject the call if any of these four fields are
+   missing when `isRegression=true`. If the verdict is `downgraded`, the method
+   automatically sets `isRegression=false` in the classification record and the
+   swamp-club lifecycle entry — no regression data is sent upstream.
+
+When `regressionVerdict=confirmed`, also provide
 `--input regressionIntroducedIn=<version>`. Check `git log` on the affected
 files and cross-reference with recent releases to identify which version
 introduced the breakage. If the introducing version cannot be determined, omit
 the field.
+
+Marking a regression means our pipeline failed to catch a breakage — we must be
+very sure before sending that signal.
 
 **If you cannot classify confidently**, do NOT guess. Ask the human first, or
 call `triage` with `confidence=low` and `clarifyingQuestions` populated, then

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -47,6 +47,7 @@ export const Phase = z.enum([
   "pr_failed",
   "releasing",
   "notify",
+  "summarizing",
   "done",
 ]);
 
@@ -85,6 +86,7 @@ export const TRANSITIONS: Record<string, Phase[]> = {
   complete: ["implementing", "pr_open", "releasing"],
   notify: ["notify"],
   skip_notify: ["notify"],
+  summarize: ["summarizing"],
 };
 
 // ---------------------------------------------------------------------------
@@ -134,6 +136,22 @@ export const ClassificationSchema = z.object({
   ),
   regressionIntroducedIn: z.string().optional().describe(
     "Version that introduced the regression (e.g. '2026.06.12.1'). Only set when isRegression is true.",
+  ),
+  regressionEvidence: z.string().optional().describe(
+    "Concrete evidence that this previously worked (commit hash, version, test output). " +
+      "Required when isRegression is true.",
+  ),
+  regressionCounterEvidence: z.string().optional().describe(
+    "The strongest argument that this is NOT a regression (e.g. never worked correctly, " +
+      "docs were stale, different behavior was expected). Required when isRegression is true.",
+  ),
+  regressionVerdict: z.enum(["confirmed", "downgraded"]).optional().describe(
+    "Final verdict after weighing evidence and counter-evidence. 'confirmed' means " +
+      "it is a true regression; 'downgraded' means it is a plain bug. " +
+      "Required when isRegression is true.",
+  ),
+  regressionVerdictReasoning: z.string().optional().describe(
+    "Why the verdict stands despite the counter-evidence. Required when isRegression is true.",
   ),
   clarifyingQuestions: z.array(z.string()).optional(),
   classifiedAt: z.string(),
@@ -253,3 +271,16 @@ export const PullRequestSchema = z.object({
 });
 
 export type PullRequestData = z.infer<typeof PullRequestSchema>;
+
+export const SummarySchema = z.object({
+  originalProblem: z.string().describe(
+    "Plain-language restatement of the bug or feature request from the issue.",
+  ),
+  deliveredOutcome: z.string().describe(
+    "Plain-language description of what was actually built or fixed.",
+  ),
+  outcomeMet: z.boolean().describe(
+    "Whether the delivered outcome addresses the original problem.",
+  ),
+  summarizedAt: z.string(),
+});

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -17,20 +17,22 @@
 import { assertEquals } from "@std/assert";
 import { Phase, PullRequestSchema, TRANSITIONS } from "./schemas.ts";
 
-Deno.test("Phase: includes pr_open, pr_failed, releasing, notify between implementing and done", () => {
+Deno.test("Phase: includes pr_open, pr_failed, releasing, notify, summarizing between implementing and done", () => {
   const phases = Phase.options;
   const implementingIdx = phases.indexOf("implementing");
   const prOpenIdx = phases.indexOf("pr_open");
   const prFailedIdx = phases.indexOf("pr_failed");
   const releasingIdx = phases.indexOf("releasing");
   const notifyIdx = phases.indexOf("notify");
+  const summarizingIdx = phases.indexOf("summarizing");
   const doneIdx = phases.indexOf("done");
 
   assertEquals(prOpenIdx, implementingIdx + 1);
   assertEquals(prFailedIdx, prOpenIdx + 1);
   assertEquals(releasingIdx, prFailedIdx + 1);
   assertEquals(notifyIdx, releasingIdx + 1);
-  assertEquals(doneIdx, notifyIdx + 1);
+  assertEquals(summarizingIdx, notifyIdx + 1);
+  assertEquals(doneIdx, summarizingIdx + 1);
 });
 
 Deno.test("TRANSITIONS: link_pr accepts implementing, pr_open, and pr_failed", () => {

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -35,6 +35,7 @@ import {
   type StateData,
   StateSchema,
   StepVerificationSchema,
+  SummarySchema,
   TRANSITIONS,
 } from "./_lib/schemas.ts";
 import { createSwampClubClient, loadAuthFile } from "./_lib/swamp_club.ts";
@@ -73,7 +74,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.07.05.1",
+  version: "2026.07.30.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -163,6 +164,16 @@ export const model = {
         "No globalArguments changes.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.07.30.1",
+      description:
+        "Adversarial regression verification — triage now requires evidence, " +
+        "counter-evidence, and a verdict when isRegression is true. " +
+        "Session summary — new summarizing phase between notify and done; " +
+        "notify/skip_notify transition to summarizing, new summarize method " +
+        "records problem/outcome before closing. No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
 
   resources: {
@@ -217,6 +228,14 @@ export const model = {
         "overwritten by subsequent link_pr calls so the record always " +
         "reflects the latest link.",
       schema: PullRequestSchema,
+      lifetime: "infinite" as const,
+      garbageCollection: 5,
+    },
+    "summary": {
+      description:
+        "Session summary restating the original problem and delivered outcome. " +
+        "Written at the end of the lifecycle to verify the work addressed the issue.",
+      schema: SummarySchema,
       lifetime: "infinite" as const,
       garbageCollection: 5,
     },
@@ -664,6 +683,23 @@ export const model = {
         regressionIntroducedIn: z.string().optional().describe(
           "Version that introduced the regression (e.g. '2026.06.12.1'). Only set when isRegression is true.",
         ),
+        regressionEvidence: z.string().optional().describe(
+          "Concrete evidence that this previously worked (commit hash, version, test output). " +
+            "Required when isRegression is true.",
+        ),
+        regressionCounterEvidence: z.string().optional().describe(
+          "The strongest argument that this is NOT a regression. " +
+            "Required when isRegression is true.",
+        ),
+        regressionVerdict: z.enum(["confirmed", "downgraded"]).optional()
+          .describe(
+            "Final verdict after weighing evidence and counter-evidence. " +
+              "Required when isRegression is true.",
+          ),
+        regressionVerdictReasoning: z.string().optional().describe(
+          "Why the verdict stands despite the counter-evidence. " +
+            "Required when isRegression is true.",
+        ),
         clarifyingQuestions: z.array(z.string()).optional(),
       }),
       execute: async (
@@ -673,6 +709,10 @@ export const model = {
           reasoning: string;
           isRegression?: boolean;
           regressionIntroducedIn?: string;
+          regressionEvidence?: string;
+          regressionCounterEvidence?: string;
+          regressionVerdict?: "confirmed" | "downgraded";
+          regressionVerdictReasoning?: string;
           clarifyingQuestions?: string[];
         },
         context: {
@@ -691,6 +731,33 @@ export const model = {
         const { issueNumber } = context.globalArgs;
         const handles = [];
 
+        let effectiveIsRegression = args.isRegression;
+        let effectiveRegressionIntroducedIn = args.regressionIntroducedIn;
+
+        if (args.isRegression) {
+          if (
+            !args.regressionEvidence ||
+            !args.regressionCounterEvidence ||
+            !args.regressionVerdict ||
+            !args.regressionVerdictReasoning
+          ) {
+            throw new Error(
+              "Regression classification requires adversarial verification: " +
+                "regressionEvidence, regressionCounterEvidence, regressionVerdict, " +
+                "and regressionVerdictReasoning are all required when isRegression is true.",
+            );
+          }
+
+          if (args.regressionVerdict === "downgraded") {
+            effectiveIsRegression = false;
+            effectiveRegressionIntroducedIn = undefined;
+            context.logger.info(
+              "Regression downgraded to plain bug after adversarial review: {reasoning}",
+              { reasoning: args.regressionVerdictReasoning },
+            );
+          }
+        }
+
         handles.push(
           await context.writeResource(
             "classification",
@@ -699,8 +766,12 @@ export const model = {
               type: args.type,
               confidence: args.confidence,
               reasoning: args.reasoning,
-              isRegression: args.isRegression,
-              regressionIntroducedIn: args.regressionIntroducedIn,
+              isRegression: effectiveIsRegression,
+              regressionIntroducedIn: effectiveRegressionIntroducedIn,
+              regressionEvidence: args.regressionEvidence,
+              regressionCounterEvidence: args.regressionCounterEvidence,
+              regressionVerdict: args.regressionVerdict,
+              regressionVerdictReasoning: args.regressionVerdictReasoning,
               clarifyingQuestions: args.clarifyingQuestions,
               classifiedAt: new Date().toISOString(),
             },
@@ -715,7 +786,7 @@ export const model = {
           }),
         );
 
-        const regressionLabel = args.isRegression ? " (regression)" : "";
+        const regressionLabel = effectiveIsRegression ? " (regression)" : "";
         context.logger.info(
           "Classified as {type}{regression} ({confidence}): {reasoning}",
           {
@@ -742,8 +813,12 @@ export const model = {
               type: args.type,
               confidence: args.confidence,
               reasoning: args.reasoning,
-              isRegression: args.isRegression ?? false,
-              regressionIntroducedIn: args.regressionIntroducedIn,
+              isRegression: effectiveIsRegression ?? false,
+              regressionIntroducedIn: effectiveRegressionIntroducedIn,
+              regressionEvidence: args.regressionEvidence,
+              regressionCounterEvidence: args.regressionCounterEvidence,
+              regressionVerdict: args.regressionVerdict,
+              regressionVerdictReasoning: args.regressionVerdictReasoning,
               clarifyingQuestions: args.clarifyingQuestions,
             },
             isVerbose: false,
@@ -1903,7 +1978,7 @@ export const model = {
     notify: {
       description:
         "Thank an external contributor by posting a ripple on the issue " +
-        "mentioning them by handle. Transitions to done.",
+        "mentioning them by handle. Transitions to summarizing.",
       arguments: z.object({
         message: z.string().optional().describe(
           "Custom thank-you message. If omitted, a default message is generated.",
@@ -1930,7 +2005,6 @@ export const model = {
       ) => {
         const { issueNumber } = context.globalArgs;
 
-        // Read the author from context, falling back to a re-fetch if missing.
         let author: string | undefined;
         const contextData = await context.readResource("context-main");
         if (contextData && typeof contextData.author === "string") {
@@ -1963,7 +2037,7 @@ export const model = {
         }
 
         const stateHandle = await context.writeResource("state", "state-main", {
-          phase: "done",
+          phase: "summarizing",
           issueNumber,
           updatedAt: new Date().toISOString(),
         });
@@ -1987,7 +2061,7 @@ export const model = {
 
     skip_notify: {
       description:
-        "Skip contributor notification and transition directly to done. " +
+        "Skip contributor notification and transition to summarizing. " +
         "Use when the issue author is a collaborator or notification is not needed.",
       arguments: z.object({}),
       execute: async (
@@ -2008,7 +2082,7 @@ export const model = {
         const { issueNumber } = context.globalArgs;
 
         const stateHandle = await context.writeResource("state", "state-main", {
-          phase: "done",
+          phase: "summarizing",
           issueNumber,
           updatedAt: new Date().toISOString(),
         });
@@ -2031,6 +2105,91 @@ export const model = {
         }
 
         return { dataHandles: [stateHandle] };
+      },
+    },
+
+    summarize: {
+      description:
+        "Record a session summary restating the original problem and delivered outcome. " +
+        "Transitions to done. Must be called after notify/skip_notify.",
+      arguments: z.object({
+        originalProblem: z.string().describe(
+          "Plain-language restatement of the bug or feature request from the issue.",
+        ),
+        deliveredOutcome: z.string().describe(
+          "Plain-language description of what was actually built or fixed.",
+        ),
+        outcomeMet: z.boolean().describe(
+          "Whether the delivered outcome addresses the original problem.",
+        ),
+      }),
+      execute: async (
+        args: {
+          originalProblem: string;
+          deliveredOutcome: string;
+          outcomeMet: boolean;
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+        const handles = [];
+
+        handles.push(
+          await context.writeResource("summary", "summary-main", {
+            originalProblem: args.originalProblem,
+            deliveredOutcome: args.deliveredOutcome,
+            outcomeMet: args.outcomeMet,
+            summarizedAt: new Date().toISOString(),
+          }),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "done",
+            issueNumber,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+
+        context.logger.info(
+          "Session summary recorded — outcome {met}: {outcome}",
+          {
+            met: args.outcomeMet ? "met" : "not met",
+            outcome: args.deliveredOutcome,
+          },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        await sc?.postLifecycleEntry({
+          step: "session_summarized",
+          targetStatus: "shipped",
+          summary: args.outcomeMet
+            ? `Outcome met: ${args.deliveredOutcome}`
+            : `Outcome NOT met: ${args.deliveredOutcome}`,
+          emoji: "\u{1F4DD}",
+          payload: {
+            originalProblem: args.originalProblem,
+            deliveredOutcome: args.deliveredOutcome,
+            outcomeMet: args.outcomeMet,
+          },
+          isVerbose: false,
+        });
+
+        return { dataHandles: handles };
       },
     },
   },

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -319,8 +319,8 @@ Deno.test("model: exposes the new link_pr method definition", () => {
   );
 });
 
-Deno.test("model: version bumped to 2026.07.05.1", () => {
-  assertEquals(model.version, "2026.07.05.1");
+Deno.test("model: version is 2026.07.30.1", () => {
+  assertEquals(model.version, "2026.07.30.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -946,7 +946,7 @@ Deno.test("start: succeeds even when PATCH fails", async () => {
 // notify
 // ---------------------------------------------------------------------------
 
-Deno.test("notify: transitions state to done and reads author from context", async () => {
+Deno.test("notify: transitions state to summarizing and reads author from context", async () => {
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "context-main": {
@@ -965,14 +965,14 @@ Deno.test("notify: transitions state to done and reads author from context", asy
 
     const stateWrite = writes.find((w) => w.specName === "state");
     assertEquals(stateWrite !== undefined, true);
-    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.phase, "summarizing");
     assertEquals(stateWrite!.data.issueNumber, 42);
   } finally {
     await restore();
   }
 });
 
-Deno.test("notify: transitions to done even when author is missing from context", async () => {
+Deno.test("notify: transitions to summarizing even when author is missing from context", async () => {
   const { context, writes, restore } = await buildTestContext(42, {
     resources: {
       "context-main": {
@@ -990,7 +990,7 @@ Deno.test("notify: transitions to done even when author is missing from context"
 
     const stateWrite = writes.find((w) => w.specName === "state");
     assertEquals(stateWrite !== undefined, true);
-    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.phase, "summarizing");
   } finally {
     await restore();
   }
@@ -1018,7 +1018,7 @@ Deno.test("notify: accepts custom message", async () => {
 
     const stateWrite = writes.find((w) => w.specName === "state");
     assertEquals(stateWrite !== undefined, true);
-    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.phase, "summarizing");
   } finally {
     await restore();
   }
@@ -1028,14 +1028,14 @@ Deno.test("notify: accepts custom message", async () => {
 // skip_notify
 // ---------------------------------------------------------------------------
 
-Deno.test("skip_notify: transitions state to done", async () => {
+Deno.test("skip_notify: transitions state to summarizing", async () => {
   const { context, writes, restore } = await buildTestContext(42);
   try {
     await model.methods.skip_notify.execute({}, context);
 
     const stateWrite = writes.find((w) => w.specName === "state");
     assertEquals(stateWrite !== undefined, true);
-    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.phase, "summarizing");
     assertEquals(stateWrite!.data.issueNumber, 42);
   } finally {
     await restore();
@@ -1381,4 +1381,187 @@ Deno.test("model: exposes justify_deviations method definition", () => {
 
 Deno.test("model: exposes code-conformance-clear check definition", () => {
   assertEquals("code-conformance-clear" in model.checks, true);
+});
+
+// ---------------------------------------------------------------------------
+// triage: regression verification
+// ---------------------------------------------------------------------------
+
+Deno.test("triage: rejects isRegression=true without adversarial evidence fields", async () => {
+  const { context, restore } = await buildTestContext(42);
+  try {
+    await assertRejects(
+      () =>
+        model.methods.triage.execute(
+          {
+            type: "bug",
+            confidence: "high",
+            reasoning: "It broke",
+            isRegression: true,
+          },
+          context,
+        ),
+      Error,
+      "Regression classification requires adversarial verification",
+    );
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("triage: accepts isRegression=true with all adversarial evidence fields (confirmed)", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.triage.execute(
+      {
+        type: "bug",
+        confidence: "high",
+        reasoning: "It broke",
+        isRegression: true,
+        regressionIntroducedIn: "2026.07.01.1",
+        regressionEvidence: "Commit abc123 shows it worked before",
+        regressionCounterEvidence: "Could be a test gap, not a regression",
+        regressionVerdict: "confirmed",
+        regressionVerdictReasoning:
+          "The feature demonstrably worked in the prior release",
+      },
+      context,
+    );
+
+    const classWrite = writes.find((w) => w.specName === "classification");
+    assertEquals(classWrite !== undefined, true);
+    assertEquals(classWrite!.data.isRegression, true);
+    assertEquals(classWrite!.data.regressionVerdict, "confirmed");
+    assertEquals(classWrite!.data.regressionIntroducedIn, "2026.07.01.1");
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("triage: downgrades regression to plain bug when verdict is downgraded", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.triage.execute(
+      {
+        type: "bug",
+        confidence: "high",
+        reasoning: "Reported as regression but never actually worked",
+        isRegression: true,
+        regressionIntroducedIn: "2026.07.01.1",
+        regressionEvidence: "User says it used to work",
+        regressionCounterEvidence:
+          "Git history shows this code path was never tested and the behavior was always incorrect",
+        regressionVerdict: "downgraded",
+        regressionVerdictReasoning:
+          "No evidence it ever worked — user was likely misremembering a different feature",
+      },
+      context,
+    );
+
+    const classWrite = writes.find((w) => w.specName === "classification");
+    assertEquals(classWrite !== undefined, true);
+    assertEquals(classWrite!.data.isRegression, false);
+    assertEquals(classWrite!.data.regressionVerdict, "downgraded");
+    assertEquals(
+      classWrite!.data.regressionIntroducedIn,
+      undefined,
+      "regressionIntroducedIn must be cleared on downgrade",
+    );
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("triage: non-regression classification does not require evidence fields", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.triage.execute(
+      {
+        type: "feature",
+        confidence: "high",
+        reasoning: "New feature request",
+      },
+      context,
+    );
+
+    const classWrite = writes.find((w) => w.specName === "classification");
+    assertEquals(classWrite !== undefined, true);
+    assertEquals(classWrite!.data.isRegression, undefined);
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+Deno.test("summarize: writes summary-main and transitions to done", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.summarize.execute(
+      {
+        originalProblem:
+          "The CLI crashed when running `swamp model list` with no models defined",
+        deliveredOutcome:
+          "Added an empty-state check that returns a helpful message instead of crashing",
+        outcomeMet: true,
+      },
+      context,
+    );
+
+    const summaryWrite = writes.find((w) => w.specName === "summary");
+    assertEquals(summaryWrite !== undefined, true);
+    assertEquals(summaryWrite!.instanceName, "summary-main");
+    assertEquals(
+      summaryWrite!.data.originalProblem,
+      "The CLI crashed when running `swamp model list` with no models defined",
+    );
+    assertEquals(
+      summaryWrite!.data.deliveredOutcome,
+      "Added an empty-state check that returns a helpful message instead of crashing",
+    );
+    assertEquals(summaryWrite!.data.outcomeMet, true);
+    assertEquals(typeof summaryWrite!.data.summarizedAt, "string");
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "done");
+    assertEquals(stateWrite!.data.issueNumber, 42);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("summarize: records outcomeMet=false when outcome does not match", async () => {
+  const { context, writes, restore } = await buildTestContext(42);
+  try {
+    await model.methods.summarize.execute(
+      {
+        originalProblem: "Need OAuth support for SSO login",
+        deliveredOutcome:
+          "Added basic API key auth but OAuth was deferred to a follow-up",
+        outcomeMet: false,
+      },
+      context,
+    );
+
+    const summaryWrite = writes.find((w) => w.specName === "summary");
+    assertEquals(summaryWrite !== undefined, true);
+    assertEquals(summaryWrite!.data.outcomeMet, false);
+  } finally {
+    await restore();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Model registration smoke tests (new features)
+// ---------------------------------------------------------------------------
+
+Deno.test("model: exposes summary resource definition", () => {
+  assertEquals("summary" in model.resources, true);
+});
+
+Deno.test("model: exposes summarize method definition", () => {
+  assertEquals("summarize" in model.methods, true);
 });


### PR DESCRIPTION
## Summary

- **Adversarial regression verification**: The `triage` method now rejects `isRegression=true` unless four evidence fields are provided (`regressionEvidence`, `regressionCounterEvidence`, `regressionVerdict`, `regressionVerdictReasoning`). A `downgraded` verdict automatically overrides `isRegression` to `false` before the classification and lifecycle entry are written to swamp-club — no false-positive regression data ever reaches the API.
- **Session summary**: New `summarizing` phase between `notify` and `done`. Both `notify` and `skip_notify` now transition to `summarizing`, and a new `summarize` method records the original problem statement and delivered outcome as a `summary-main` resource before closing the lifecycle.
- Model version bumped to `2026.07.30.1` with upgrade entry.

## Test Plan

- [x] `triage` rejects `isRegression=true` without adversarial evidence fields
- [x] `triage` accepts `isRegression=true` with all evidence fields (confirmed verdict)
- [x] `triage` downgrades regression to plain bug when verdict is `downgraded`
- [x] Non-regression classification does not require evidence fields
- [x] `notify` and `skip_notify` transition to `summarizing` instead of `done`
- [x] `summarize` writes `summary-main` resource and transitions to `done`
- [x] `summarize` records `outcomeMet=false` correctly
- [x] Phase enum and schema tests updated for `summarizing`
- [x] 64 tests pass, `deno check`, `deno lint`, `deno fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)