### PR TITLE
fix(datastore): recover from namespace-stripped pull duplicates at cache root (swamp-club#1458)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -252,6 +252,12 @@ at the un-namespaced path `{base}/{subdir}/`, it moves it to
 `{base}/{namespace}/{subdir}/` via `Deno.rename()`. The catalog is invalidated
 after migration so backfill rebuilds from the new paths.
 
+When a file exists at both the source (root) and destination (namespace) paths,
+forward migration compares their contents byte-by-byte. Byte-identical
+duplicates (e.g. from a buggy pull that wrote namespace-stripped copies to the
+cache root) are auto-resolved by deleting the root-level copy. Non-identical
+collisions still error — the user must resolve them manually.
+
 The reverse (`--reverse`) flattens namespaced paths back to solo layout, with
 conflict detection — it refuses if the un-namespaced path already contains data.
 `swamp datastore namespace unset --migrate` combines unset + reverse migration.

--- a/integration/giga_swamp_namespace_migrate_test.ts
+++ b/integration/giga_swamp_namespace_migrate_test.ts
@@ -137,6 +137,22 @@ function buildDeps(
       Deno.rename(source, destination),
     findFileCollisions: (source: string, destination: string) =>
       findFileCollisions(source, destination),
+    compareFiles: async (a: string, b: string) => {
+      try {
+        const [aBytes, bBytes] = await Promise.all([
+          Deno.readFile(a),
+          Deno.readFile(b),
+        ]);
+        if (aBytes.length !== bBytes.length) return false;
+        for (let i = 0; i < aBytes.length; i++) {
+          if (aBytes[i] !== bBytes[i]) return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    removeFile: (path: string) => Deno.remove(path),
     mergeDirInto: (source: string, destination: string) =>
       mergeDirInto(source, destination),
     ensureDir: (path: string) => ensureDir(path),

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -65,6 +65,7 @@ import type { DatastoreProvider } from "../../domain/datastore/datastore_provide
 import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_registry.ts";
 import { UserError } from "../../domain/errors.ts";
 import {
+  compareFiles,
   findFileCollisions,
   mergeDirInto,
 } from "../../infrastructure/persistence/directory_merge.ts";
@@ -372,21 +373,7 @@ function buildMigrateDeps(
       Deno.rename(source, destination),
     findFileCollisions: (source: string, destination: string) =>
       findFileCollisions(source, destination),
-    compareFiles: async (a: string, b: string) => {
-      try {
-        const [aBytes, bBytes] = await Promise.all([
-          Deno.readFile(a),
-          Deno.readFile(b),
-        ]);
-        if (aBytes.length !== bBytes.length) return false;
-        for (let i = 0; i < aBytes.length; i++) {
-          if (aBytes[i] !== bBytes[i]) return false;
-        }
-        return true;
-      } catch {
-        return false;
-      }
-    },
+    compareFiles: (a: string, b: string) => compareFiles(a, b),
     removeFile: (path: string) => Deno.remove(path),
     mergeDirInto: (source: string, destination: string) =>
       mergeDirInto(source, destination),

--- a/src/cli/commands/datastore_namespace.ts
+++ b/src/cli/commands/datastore_namespace.ts
@@ -372,6 +372,22 @@ function buildMigrateDeps(
       Deno.rename(source, destination),
     findFileCollisions: (source: string, destination: string) =>
       findFileCollisions(source, destination),
+    compareFiles: async (a: string, b: string) => {
+      try {
+        const [aBytes, bBytes] = await Promise.all([
+          Deno.readFile(a),
+          Deno.readFile(b),
+        ]);
+        if (aBytes.length !== bBytes.length) return false;
+        for (let i = 0; i < aBytes.length; i++) {
+          if (aBytes[i] !== bBytes[i]) return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    removeFile: (path: string) => Deno.remove(path),
     mergeDirInto: (source: string, destination: string) =>
       mergeDirInto(source, destination),
     ensureDir: (path: string) => ensureDir(path),

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -26,10 +26,13 @@ import {
   type DoctorDatastoresDeps,
   repairDatastoreContamination,
   type RepairDatastoresDeps,
+  repairUnmigratedData,
+  type RepairUnmigratedDataDeps,
 } from "../../libswamp/mod.ts";
 import {
   createDoctorDatastoresRenderer,
   createRepairDatastoresRenderer,
+  createUnmigratedDataRepairRenderer,
 } from "../../presentation/renderers/doctor_datastores.ts";
 import {
   createContext,
@@ -129,7 +132,9 @@ async function createDoctorDatastoresDeps(
       for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
         try {
           const stat = await Deno.stat(join(basePath, subdir));
-          if (stat.isDirectory) found.push(subdir);
+          if (stat.isDirectory && await dirHasFiles(join(basePath, subdir))) {
+            found.push(subdir);
+          }
         } catch {
           // Directory doesn't exist — expected when migrated
         }
@@ -259,6 +264,93 @@ async function createRepairDeps(
   };
 }
 
+async function dirHasFiles(dir: string): Promise<boolean> {
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile || entry.isSymlink) return true;
+    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function listFilesRecursive(
+  dir: string,
+  prefix = "",
+): Promise<string[]> {
+  const files: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory && !entry.isSymlink) {
+        files.push(...await listFilesRecursive(join(dir, entry.name), relPath));
+      } else {
+        files.push(relPath);
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+  return files;
+}
+
+async function createUnmigratedRepairDeps(
+  repoDir: string,
+): Promise<RepairUnmigratedDataDeps> {
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(RepoPath.create(repoDir));
+  const config = await resolveDatastoreConfig(marker, undefined, repoDir);
+
+  if (!config.namespace) {
+    throw new UserError(
+      "Unmigrated data repair is only available when a namespace is configured.",
+    );
+  }
+
+  const basePath = isCustomDatastoreConfig(config) && config.cachePath
+    ? config.cachePath
+    : isCustomDatastoreConfig(config)
+    ? config.datastorePath
+    : config.path;
+
+  return {
+    getBasePath: () => basePath,
+    getNamespace: () => config.namespace!,
+    listFiles: (dir: string) => listFilesRecursive(dir),
+    compareFiles: async (a: string, b: string) => {
+      try {
+        const [aBytes, bBytes] = await Promise.all([
+          Deno.readFile(a),
+          Deno.readFile(b),
+        ]);
+        if (aBytes.length !== bBytes.length) return false;
+        for (let i = 0; i < aBytes.length; i++) {
+          if (aBytes[i] !== bBytes[i]) return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    removeFile: (path: string) => Deno.remove(path),
+    removeEmptyDirs: async (dir: string) => {
+      try {
+        await Deno.remove(dir, { recursive: true });
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) throw error;
+      }
+    },
+    dirExists: async (path: string) => {
+      try {
+        const stat = await Deno.stat(path);
+        return stat.isDirectory;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
 export const doctorDatastoresCommand = withRemoteOptions(
   new Command()
     .description(
@@ -332,6 +424,28 @@ export const doctorDatastoresCommand = withRemoteOptions(
   const libCtx = createLibSwampContext();
 
   if (options.repair) {
+    let exitCode = 0;
+
+    try {
+      const unmigratedDeps = await createUnmigratedRepairDeps(repoDir);
+      const unmigratedRenderer = createUnmigratedDataRepairRenderer(
+        cliCtx.outputMode,
+      );
+
+      await consumeStream(
+        repairUnmigratedData(libCtx, unmigratedDeps, {
+          confirm: Boolean(options.yes),
+        }),
+        unmigratedRenderer.handlers(),
+      );
+
+      if (unmigratedRenderer.overallStatus === "fail") {
+        exitCode = 1;
+      }
+    } catch {
+      // No namespace configured or other precondition not met — skip
+    }
+
     const deps = await createRepairDeps(repoDir);
     const renderer = createRepairDatastoresRenderer(cliCtx.outputMode);
 
@@ -344,7 +458,7 @@ export const doctorDatastoresCommand = withRemoteOptions(
 
     cliCtx.logger.debug("doctor datastores repair completed");
 
-    if (renderer.overallStatus === "fail") {
+    if (renderer.overallStatus === "fail" || exitCode !== 0) {
       Deno.exit(1);
     }
     return;

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -337,11 +337,11 @@ export const doctorDatastoresCommand = withRemoteOptions(
     .example("Check this repo's datastore", "swamp doctor datastores")
     .example("Machine-readable output for CI", "swamp doctor datastores --json")
     .example(
-      "Preview namespace contamination cleanup",
+      "Preview datastore repair",
       "swamp doctor datastores --repair",
     )
     .example(
-      "Execute namespace contamination cleanup",
+      "Execute datastore repair",
       "swamp doctor datastores --repair -y",
     )
     .option(

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -64,6 +64,10 @@ import { RUNS_INDEX_FILENAME } from "../../infrastructure/persistence/workflow_r
 import { catalogDbPath } from "../../infrastructure/persistence/repository_factory.ts";
 import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { join } from "@std/path";
+import {
+  compareFiles,
+  dirHasFiles,
+} from "../../infrastructure/persistence/directory_merge.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -264,16 +268,6 @@ async function createRepairDeps(
   };
 }
 
-async function dirHasFiles(dir: string): Promise<boolean> {
-  for await (const entry of Deno.readDir(dir)) {
-    if (entry.isFile || entry.isSymlink) return true;
-    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
-      return true;
-    }
-  }
-  return false;
-}
-
 async function listFilesRecursive(
   dir: string,
   prefix = "",
@@ -281,9 +275,11 @@ async function listFilesRecursive(
   const files: string[] = [];
   try {
     for await (const entry of Deno.readDir(dir)) {
-      const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const relPath = prefix ? join(prefix, entry.name) : entry.name;
       if (entry.isDirectory && !entry.isSymlink) {
-        files.push(...await listFilesRecursive(join(dir, entry.name), relPath));
+        files.push(
+          ...await listFilesRecursive(join(dir, entry.name), relPath),
+        );
       } else {
         files.push(relPath);
       }
@@ -317,21 +313,7 @@ async function createUnmigratedRepairDeps(
     getBasePath: () => basePath,
     getNamespace: () => config.namespace!,
     listFiles: (dir: string) => listFilesRecursive(dir),
-    compareFiles: async (a: string, b: string) => {
-      try {
-        const [aBytes, bBytes] = await Promise.all([
-          Deno.readFile(a),
-          Deno.readFile(b),
-        ]);
-        if (aBytes.length !== bBytes.length) return false;
-        for (let i = 0; i < aBytes.length; i++) {
-          if (aBytes[i] !== bBytes[i]) return false;
-        }
-        return true;
-      } catch {
-        return false;
-      }
-    },
+    compareFiles: (a: string, b: string) => compareFiles(a, b),
     removeFile: (path: string) => Deno.remove(path),
     removeEmptyDirs: async (dir: string) => {
       try {
@@ -373,7 +355,7 @@ export const doctorDatastoresCommand = withRemoteOptions(
     )
     .option(
       "--repair",
-      "Preview foreign namespace contamination cleanup (add -y to execute).",
+      "Preview and repair datastore issues: root-level unmigrated data and foreign namespace contamination (add -y to execute).",
     )
     .option(
       "-y, --yes",
@@ -426,8 +408,18 @@ export const doctorDatastoresCommand = withRemoteOptions(
   if (options.repair) {
     let exitCode = 0;
 
+    let unmigratedDeps: RepairUnmigratedDataDeps | null = null;
     try {
-      const unmigratedDeps = await createUnmigratedRepairDeps(repoDir);
+      unmigratedDeps = await createUnmigratedRepairDeps(repoDir);
+    } catch (error) {
+      if (error instanceof UserError) {
+        cliCtx.logger.debug`Skipping unmigrated data repair: ${error.message}`;
+      } else {
+        throw error;
+      }
+    }
+
+    if (unmigratedDeps) {
       const unmigratedRenderer = createUnmigratedDataRepairRenderer(
         cliCtx.outputMode,
       );
@@ -441,12 +433,6 @@ export const doctorDatastoresCommand = withRemoteOptions(
 
       if (unmigratedRenderer.overallStatus === "fail") {
         exitCode = 1;
-      }
-    } catch (error) {
-      if (error instanceof UserError) {
-        cliCtx.logger.debug`Skipping unmigrated data repair: ${error.message}`;
-      } else {
-        throw error;
       }
     }
 

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -67,6 +67,7 @@ import { join } from "@std/path";
 import {
   compareFiles,
   dirHasFiles,
+  removeEmptyDirs,
 } from "../../infrastructure/persistence/directory_merge.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -315,13 +316,7 @@ async function createUnmigratedRepairDeps(
     listFiles: (dir: string) => listFilesRecursive(dir),
     compareFiles: (a: string, b: string) => compareFiles(a, b),
     removeFile: (path: string) => Deno.remove(path),
-    removeEmptyDirs: async (dir: string) => {
-      try {
-        await Deno.remove(dir, { recursive: true });
-      } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) throw error;
-      }
-    },
+    removeEmptyDirs: (dir: string) => removeEmptyDirs(dir).then(() => {}),
     dirExists: async (path: string) => {
       try {
         const stat = await Deno.stat(path);

--- a/src/cli/commands/doctor_datastores.ts
+++ b/src/cli/commands/doctor_datastores.ts
@@ -442,8 +442,12 @@ export const doctorDatastoresCommand = withRemoteOptions(
       if (unmigratedRenderer.overallStatus === "fail") {
         exitCode = 1;
       }
-    } catch {
-      // No namespace configured or other precondition not met — skip
+    } catch (error) {
+      if (error instanceof UserError) {
+        cliCtx.logger.debug`Skipping unmigrated data repair: ${error.message}`;
+      } else {
+        throw error;
+      }
     }
 
     const deps = await createRepairDeps(repoDir);

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -407,10 +407,22 @@ export async function checkUnmigratedNamespaceData(
   for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
     try {
       const stat = await Deno.stat(join(basePath, subdir));
-      if (stat.isDirectory) found.push(subdir);
+      if (stat.isDirectory && await dirHasFiles(join(basePath, subdir))) {
+        found.push(subdir);
+      }
     } catch {
       // Not found — expected when migrated
     }
   }
   return found;
+}
+
+async function dirHasFiles(dir: string): Promise<boolean> {
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile || entry.isSymlink) return true;
+    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -32,6 +32,7 @@
  */
 
 import { isAbsolute, join, resolve } from "@std/path";
+import { dirHasFiles } from "../infrastructure/persistence/directory_merge.ts";
 import { getLogger } from "@logtape/logtape";
 import type { RepoMarkerData } from "../infrastructure/persistence/repo_marker_repository.ts";
 import {
@@ -415,14 +416,4 @@ export async function checkUnmigratedNamespaceData(
     }
   }
   return found;
-}
-
-async function dirHasFiles(dir: string): Promise<boolean> {
-  for await (const entry of Deno.readDir(dir)) {
-    if (entry.isFile || entry.isSymlink) return true;
-    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/src/infrastructure/persistence/directory_merge.ts
+++ b/src/infrastructure/persistence/directory_merge.ts
@@ -101,6 +101,32 @@ export async function mergeDirInto(
   return { moved, skipped: skippedPaths.length, skippedPaths };
 }
 
+export async function dirHasFiles(dir: string): Promise<boolean> {
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile || entry.isSymlink) return true;
+    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function compareFiles(a: string, b: string): Promise<boolean> {
+  try {
+    const [aBytes, bBytes] = await Promise.all([
+      Deno.readFile(a),
+      Deno.readFile(b),
+    ]);
+    if (aBytes.length !== bBytes.length) return false;
+    for (let i = 0; i < aBytes.length; i++) {
+      if (aBytes[i] !== bBytes[i]) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function removeEmptyDirs(dir: string): Promise<boolean> {
   const entries: Deno.DirEntry[] = [];
   for await (const entry of Deno.readDir(dir)) {

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -463,7 +463,7 @@ export async function* repairUnmigratedData(
               code: "non_identical_unmigrated_data",
               message:
                 `Root-level "${subdir}/" contains files that differ from ` +
-                `"${namespace}/${subdir}/". Run 'swamp datastore namespace migrate' ` +
+                `"${namespace}/${subdir}/". Run 'swamp datastore namespace migrate --confirm' ` +
                 `to resolve manually.`,
             },
           };

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -19,6 +19,7 @@
 
 import {
   type DatastoreConfig,
+  DEFAULT_DATASTORE_SUBDIRS,
   isCustomDatastoreConfig,
 } from "../../domain/datastore/datastore_config.ts";
 import type { NamespaceContaminationSummary } from "../../domain/datastore/datastore_sync_service.ts";
@@ -356,6 +357,134 @@ export async function* repairDatastoreContamination(
           },
         };
       }
+    })(),
+  );
+}
+
+// ============================================================================
+// Repair: root-level unmigrated data cleanup
+// ============================================================================
+
+export interface UnmigratedDataRepairResult {
+  removedDirectories: string[];
+  removedFiles: number;
+}
+
+export type RepairUnmigratedDataEvent =
+  | { kind: "scanning" }
+  | {
+    kind: "preview";
+    directories: string[];
+    namespace: string;
+  }
+  | { kind: "step"; description: string }
+  | {
+    kind: "completed";
+    result: UnmigratedDataRepairResult;
+    namespace: string;
+  }
+  | { kind: "not_needed" }
+  | { kind: "error"; error: SwampError };
+
+export interface RepairUnmigratedDataDeps {
+  getBasePath: () => string;
+  getNamespace: () => string;
+  listFiles: (dir: string) => Promise<string[]>;
+  compareFiles: (a: string, b: string) => Promise<boolean>;
+  removeFile: (path: string) => Promise<void>;
+  removeEmptyDirs: (dir: string) => Promise<void>;
+  dirExists: (path: string) => Promise<boolean>;
+}
+
+export async function* repairUnmigratedData(
+  _ctx: LibSwampContext,
+  deps: RepairUnmigratedDataDeps,
+  options: { confirm: boolean },
+): AsyncGenerator<RepairUnmigratedDataEvent> {
+  yield* withGeneratorSpan(
+    "swamp.doctor.datastores.repair.unmigrated",
+    {},
+    (async function* () {
+      yield { kind: "scanning" };
+
+      const basePath = deps.getBasePath();
+      const namespace = deps.getNamespace();
+
+      const unmigratedDirs: string[] = [];
+      for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
+        const rootDir = `${basePath}/${subdir}`;
+        if (await deps.dirExists(rootDir)) {
+          const files = await deps.listFiles(rootDir);
+          if (files.length > 0) {
+            unmigratedDirs.push(subdir);
+          }
+        }
+      }
+
+      if (unmigratedDirs.length === 0) {
+        yield { kind: "not_needed" };
+        return;
+      }
+
+      if (!options.confirm) {
+        yield { kind: "preview", directories: unmigratedDirs, namespace };
+        return;
+      }
+
+      let totalRemoved = 0;
+      const cleaned: string[] = [];
+
+      for (const subdir of unmigratedDirs) {
+        yield {
+          kind: "step",
+          description:
+            `Checking ${subdir}/ for duplicates against ${namespace}/${subdir}/`,
+        };
+
+        const rootDir = `${basePath}/${subdir}`;
+        const nsDir = `${basePath}/${namespace}/${subdir}`;
+        const files = await deps.listFiles(rootDir);
+
+        let allIdentical = true;
+        for (const relPath of files) {
+          const rootFile = `${rootDir}/${relPath}`;
+          const nsFile = `${nsDir}/${relPath}`;
+          if (!await deps.compareFiles(rootFile, nsFile)) {
+            allIdentical = false;
+            break;
+          }
+        }
+
+        if (!allIdentical) {
+          yield {
+            kind: "error",
+            error: {
+              code: "non_identical_unmigrated_data",
+              message:
+                `Root-level "${subdir}/" contains files that differ from ` +
+                `"${namespace}/${subdir}/". Run 'swamp datastore namespace migrate' ` +
+                `to resolve manually.`,
+            },
+          };
+          return;
+        }
+
+        for (const relPath of files) {
+          await deps.removeFile(`${rootDir}/${relPath}`);
+          totalRemoved++;
+        }
+        await deps.removeEmptyDirs(rootDir);
+        cleaned.push(subdir);
+      }
+
+      yield {
+        kind: "completed",
+        result: {
+          removedDirectories: cleaned,
+          removedFiles: totalRemoved,
+        },
+        namespace,
+      };
     })(),
   );
 }

--- a/src/libswamp/datastores/doctor_datastores.ts
+++ b/src/libswamp/datastores/doctor_datastores.ts
@@ -27,6 +27,7 @@ import type { NamespaceContaminationSummary } from "../../domain/datastore/datas
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
+import { join } from "@std/path";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 /** Result of a single health check within the datastore doctor scan. */
@@ -412,7 +413,7 @@ export async function* repairUnmigratedData(
 
       const unmigratedDirs: string[] = [];
       for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
-        const rootDir = `${basePath}/${subdir}`;
+        const rootDir = join(basePath, subdir);
         if (await deps.dirExists(rootDir)) {
           const files = await deps.listFiles(rootDir);
           if (files.length > 0) {
@@ -441,14 +442,14 @@ export async function* repairUnmigratedData(
             `Checking ${subdir}/ for duplicates against ${namespace}/${subdir}/`,
         };
 
-        const rootDir = `${basePath}/${subdir}`;
-        const nsDir = `${basePath}/${namespace}/${subdir}`;
+        const rootDir = join(basePath, subdir);
+        const nsDir = join(basePath, namespace, subdir);
         const files = await deps.listFiles(rootDir);
 
         let allIdentical = true;
         for (const relPath of files) {
-          const rootFile = `${rootDir}/${relPath}`;
-          const nsFile = `${nsDir}/${relPath}`;
+          const rootFile = join(rootDir, relPath);
+          const nsFile = join(nsDir, relPath);
           if (!await deps.compareFiles(rootFile, nsFile)) {
             allIdentical = false;
             break;
@@ -470,7 +471,7 @@ export async function* repairUnmigratedData(
         }
 
         for (const relPath of files) {
-          await deps.removeFile(`${rootDir}/${relPath}`);
+          await deps.removeFile(join(rootDir, relPath));
           totalRemoved++;
         }
         await deps.removeEmptyDirs(rootDir);

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -27,6 +27,9 @@ import {
   repairDatastoreContamination,
   type RepairDatastoresDeps,
   type RepairDatastoresEvent,
+  repairUnmigratedData,
+  type RepairUnmigratedDataDeps,
+  type RepairUnmigratedDataEvent,
 } from "./doctor_datastores.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 
@@ -596,4 +599,189 @@ Deno.test("repairDatastoreContamination: yields error event on mid-repair failur
     );
   }
   assertEquals(events.find((e) => e.kind === "completed"), undefined);
+});
+
+// ============================================================================
+// Repair: root-level unmigrated data cleanup
+// ============================================================================
+
+function makeUnmigratedDeps(
+  overrides: Partial<RepairUnmigratedDataDeps> = {},
+): RepairUnmigratedDataDeps {
+  return {
+    getBasePath: () => "/tmp/cache",
+    getNamespace: () => "homelab",
+    listFiles: () => Promise.resolve([]),
+    compareFiles: () => Promise.resolve(true),
+    removeFile: () => Promise.resolve(),
+    removeEmptyDirs: () => Promise.resolve(),
+    dirExists: () => Promise.resolve(false),
+    ...overrides,
+  };
+}
+
+Deno.test("repairUnmigratedData: not needed when no root-level dirs have files", async () => {
+  const deps = makeUnmigratedDeps();
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: true }),
+  );
+
+  assertEquals(events[0].kind, "scanning");
+  assertEquals(events[1].kind, "not_needed");
+  assertEquals(events.length, 2);
+});
+
+Deno.test("repairUnmigratedData: preview mode shows dirs without modifying", async () => {
+  const removedFiles: string[] = [];
+  const deps = makeUnmigratedDeps({
+    dirExists: (path) =>
+      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+    listFiles: (dir) => {
+      if (dir.endsWith("/data")) {
+        return Promise.resolve(["model/raw", "model/metadata.yaml"]);
+      }
+      if (dir.endsWith("/outputs")) {
+        return Promise.resolve(["report.yaml"]);
+      }
+      return Promise.resolve([]);
+    },
+    removeFile: (path) => {
+      removedFiles.push(path);
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: false }),
+  );
+
+  const preview = events.find((e) => e.kind === "preview");
+  assertEquals(preview?.kind, "preview");
+  if (preview?.kind === "preview") {
+    assertEquals(preview.namespace, "homelab");
+    assertEquals(preview.directories.includes("data"), true);
+    assertEquals(preview.directories.includes("outputs"), true);
+  }
+  assertEquals(removedFiles.length, 0);
+});
+
+Deno.test("repairUnmigratedData: confirm removes identical duplicates", async () => {
+  const removedFiles: string[] = [];
+  const removedDirs: string[] = [];
+
+  const deps = makeUnmigratedDeps({
+    dirExists: (path) => Promise.resolve(path.endsWith("/data")),
+    listFiles: () => Promise.resolve(["model/raw", "model/metadata.yaml"]),
+    compareFiles: () => Promise.resolve(true),
+    removeFile: (path) => {
+      removedFiles.push(path);
+      return Promise.resolve();
+    },
+    removeEmptyDirs: (dir) => {
+      removedDirs.push(dir);
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: true }),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  if (completed?.kind === "completed") {
+    assertEquals(completed.result.removedFiles, 2);
+    assertEquals(completed.result.removedDirectories, ["data"]);
+    assertEquals(completed.namespace, "homelab");
+  }
+  assertEquals(removedFiles.length, 2);
+  assertEquals(removedFiles[0], "/tmp/cache/data/model/raw");
+  assertEquals(removedFiles[1], "/tmp/cache/data/model/metadata.yaml");
+  assertEquals(removedDirs.length, 1);
+  assertEquals(removedDirs[0], "/tmp/cache/data");
+});
+
+Deno.test("repairUnmigratedData: errors on non-identical files without deleting anything", async () => {
+  const removedFiles: string[] = [];
+
+  const deps = makeUnmigratedDeps({
+    dirExists: (path) => Promise.resolve(path.endsWith("/data")),
+    listFiles: () => Promise.resolve(["model/raw"]),
+    compareFiles: () => Promise.resolve(false),
+    removeFile: (path) => {
+      removedFiles.push(path);
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: true }),
+  );
+
+  const errorEvent = events.find((e) => e.kind === "error");
+  assertEquals(errorEvent?.kind, "error");
+  if (errorEvent?.kind === "error") {
+    assertEquals(errorEvent.error.code, "non_identical_unmigrated_data");
+    assertStringIncludes(errorEvent.error.message, "differ from");
+    assertStringIncludes(errorEvent.error.message, "namespace migrate");
+  }
+  assertEquals(removedFiles.length, 0);
+});
+
+Deno.test("repairUnmigratedData: handles multiple dirs, stops on first non-identical", async () => {
+  const removedFiles: string[] = [];
+
+  const deps = makeUnmigratedDeps({
+    dirExists: (path) =>
+      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+    listFiles: (dir) => {
+      if (dir.endsWith("/data")) {
+        return Promise.resolve(["file1.yaml"]);
+      }
+      if (dir.endsWith("/outputs")) {
+        return Promise.resolve(["report.yaml"]);
+      }
+      return Promise.resolve([]);
+    },
+    compareFiles: (_a, b) => {
+      if (b.includes("/outputs/")) return Promise.resolve(false);
+      return Promise.resolve(true);
+    },
+    removeFile: (path) => {
+      removedFiles.push(path);
+      return Promise.resolve();
+    },
+  });
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: true }),
+  );
+
+  const errorEvent = events.find((e) => e.kind === "error");
+  assertEquals(errorEvent?.kind, "error");
+  if (errorEvent?.kind === "error") {
+    assertStringIncludes(errorEvent.error.message, "outputs");
+  }
+});
+
+Deno.test("repairUnmigratedData: emits step events during confirm", async () => {
+  const deps = makeUnmigratedDeps({
+    dirExists: (path) =>
+      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+    listFiles: () => Promise.resolve(["file.yaml"]),
+    compareFiles: () => Promise.resolve(true),
+  });
+
+  const events = await collect<RepairUnmigratedDataEvent>(
+    repairUnmigratedData(createLibSwampContext(), deps, { confirm: true }),
+  );
+
+  const steps = events.filter(
+    (e): e is Extract<RepairUnmigratedDataEvent, { kind: "step" }> =>
+      e.kind === "step",
+  );
+  assertEquals(steps.length, 2);
+  assertStringIncludes(steps[0].description, "data/");
+  assertStringIncludes(steps[1].description, "outputs/");
 });

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -734,7 +734,7 @@ Deno.test("repairUnmigratedData: errors on non-identical files without deleting 
   if (errorEvent?.kind === "error") {
     assertEquals(errorEvent.error.code, "non_identical_unmigrated_data");
     assertStringIncludes(errorEvent.error.message, "differ from");
-    assertStringIncludes(errorEvent.error.message, "namespace migrate");
+    assertStringIncludes(errorEvent.error.message, "namespace migrate --confirm");
   }
   assertEquals(removedFiles.length, 0);
 });

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -734,7 +734,10 @@ Deno.test("repairUnmigratedData: errors on non-identical files without deleting 
   if (errorEvent?.kind === "error") {
     assertEquals(errorEvent.error.code, "non_identical_unmigrated_data");
     assertStringIncludes(errorEvent.error.message, "differ from");
-    assertStringIncludes(errorEvent.error.message, "namespace migrate --confirm");
+    assertStringIncludes(
+      errorEvent.error.message,
+      "namespace migrate --confirm",
+    );
   }
   assertEquals(removedFiles.length, 0);
 });

--- a/src/libswamp/datastores/doctor_datastores_test.ts
+++ b/src/libswamp/datastores/doctor_datastores_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join, SEPARATOR } from "@std/path";
 import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import {
@@ -634,14 +635,18 @@ Deno.test("repairUnmigratedData: not needed when no root-level dirs have files",
 
 Deno.test("repairUnmigratedData: preview mode shows dirs without modifying", async () => {
   const removedFiles: string[] = [];
+  const dataSuffix = `${SEPARATOR}data`;
+  const outputsSuffix = `${SEPARATOR}outputs`;
   const deps = makeUnmigratedDeps({
     dirExists: (path) =>
-      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+      Promise.resolve(
+        path.endsWith(dataSuffix) || path.endsWith(outputsSuffix),
+      ),
     listFiles: (dir) => {
-      if (dir.endsWith("/data")) {
+      if (dir.endsWith(dataSuffix)) {
         return Promise.resolve(["model/raw", "model/metadata.yaml"]);
       }
-      if (dir.endsWith("/outputs")) {
+      if (dir.endsWith(outputsSuffix)) {
         return Promise.resolve(["report.yaml"]);
       }
       return Promise.resolve([]);
@@ -669,9 +674,10 @@ Deno.test("repairUnmigratedData: preview mode shows dirs without modifying", asy
 Deno.test("repairUnmigratedData: confirm removes identical duplicates", async () => {
   const removedFiles: string[] = [];
   const removedDirs: string[] = [];
+  const dataSuffix = `${SEPARATOR}data`;
 
   const deps = makeUnmigratedDeps({
-    dirExists: (path) => Promise.resolve(path.endsWith("/data")),
+    dirExists: (path) => Promise.resolve(path.endsWith(dataSuffix)),
     listFiles: () => Promise.resolve(["model/raw", "model/metadata.yaml"]),
     compareFiles: () => Promise.resolve(true),
     removeFile: (path) => {
@@ -696,17 +702,21 @@ Deno.test("repairUnmigratedData: confirm removes identical duplicates", async ()
     assertEquals(completed.namespace, "homelab");
   }
   assertEquals(removedFiles.length, 2);
-  assertEquals(removedFiles[0], "/tmp/cache/data/model/raw");
-  assertEquals(removedFiles[1], "/tmp/cache/data/model/metadata.yaml");
+  assertEquals(removedFiles[0], join("/tmp/cache", "data", "model/raw"));
+  assertEquals(
+    removedFiles[1],
+    join("/tmp/cache", "data", "model/metadata.yaml"),
+  );
   assertEquals(removedDirs.length, 1);
-  assertEquals(removedDirs[0], "/tmp/cache/data");
+  assertEquals(removedDirs[0], join("/tmp/cache", "data"));
 });
 
 Deno.test("repairUnmigratedData: errors on non-identical files without deleting anything", async () => {
   const removedFiles: string[] = [];
+  const dataSuffix = `${SEPARATOR}data`;
 
   const deps = makeUnmigratedDeps({
-    dirExists: (path) => Promise.resolve(path.endsWith("/data")),
+    dirExists: (path) => Promise.resolve(path.endsWith(dataSuffix)),
     listFiles: () => Promise.resolve(["model/raw"]),
     compareFiles: () => Promise.resolve(false),
     removeFile: (path) => {
@@ -731,21 +741,27 @@ Deno.test("repairUnmigratedData: errors on non-identical files without deleting 
 
 Deno.test("repairUnmigratedData: handles multiple dirs, stops on first non-identical", async () => {
   const removedFiles: string[] = [];
+  const dataSuffix = `${SEPARATOR}data`;
+  const outputsSuffix = `${SEPARATOR}outputs`;
 
   const deps = makeUnmigratedDeps({
     dirExists: (path) =>
-      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+      Promise.resolve(
+        path.endsWith(dataSuffix) || path.endsWith(outputsSuffix),
+      ),
     listFiles: (dir) => {
-      if (dir.endsWith("/data")) {
+      if (dir.endsWith(dataSuffix)) {
         return Promise.resolve(["file1.yaml"]);
       }
-      if (dir.endsWith("/outputs")) {
+      if (dir.endsWith(outputsSuffix)) {
         return Promise.resolve(["report.yaml"]);
       }
       return Promise.resolve([]);
     },
     compareFiles: (_a, b) => {
-      if (b.includes("/outputs/")) return Promise.resolve(false);
+      if (b.includes(`${SEPARATOR}outputs${SEPARATOR}`)) {
+        return Promise.resolve(false);
+      }
       return Promise.resolve(true);
     },
     removeFile: (path) => {
@@ -766,9 +782,13 @@ Deno.test("repairUnmigratedData: handles multiple dirs, stops on first non-ident
 });
 
 Deno.test("repairUnmigratedData: emits step events during confirm", async () => {
+  const dataSuffix = `${SEPARATOR}data`;
+  const outputsSuffix = `${SEPARATOR}outputs`;
   const deps = makeUnmigratedDeps({
     dirExists: (path) =>
-      Promise.resolve(path.endsWith("/data") || path.endsWith("/outputs")),
+      Promise.resolve(
+        path.endsWith(dataSuffix) || path.endsWith(outputsSuffix),
+      ),
     listFiles: () => Promise.resolve(["file.yaml"]),
     compareFiles: () => Promise.resolve(true),
   });

--- a/src/libswamp/datastores/namespace_migrate.ts
+++ b/src/libswamp/datastores/namespace_migrate.ts
@@ -122,6 +122,8 @@ export interface NamespaceMigrateDeps {
     source: string,
     destination: string,
   ) => Promise<string[]>;
+  compareFiles: (a: string, b: string) => Promise<boolean>;
+  removeFile: (path: string) => Promise<void>;
   ensureDir: (path: string) => Promise<void>;
   invalidateCatalog: () => void;
   markDirtyBulk: () => Promise<void>;
@@ -176,6 +178,12 @@ export async function* datastoreNamespaceMigrate(
 
       const directories: SubdirPreview[] = [];
       const allCollisions: Array<{ subdir: string; paths: string[] }> = [];
+      const identicalCollisions: Array<{
+        subdir: string;
+        source: string;
+        destination: string;
+        paths: string[];
+      }> = [];
 
       for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
         const source = input.reverse
@@ -211,7 +219,24 @@ export async function* datastoreNamespaceMigrate(
             destination,
           );
           if (collidingPaths.length > 0) {
-            allCollisions.push({ subdir, paths: collidingPaths });
+            const nonIdentical: string[] = [];
+            for (const relPath of collidingPaths) {
+              const srcFile = join(source, ...relPath.split("/"));
+              const dstFile = join(destination, ...relPath.split("/"));
+              if (!await deps.compareFiles(srcFile, dstFile)) {
+                nonIdentical.push(relPath);
+              }
+            }
+            if (nonIdentical.length > 0) {
+              allCollisions.push({ subdir, paths: nonIdentical });
+            } else {
+              identicalCollisions.push({
+                subdir,
+                source,
+                destination,
+                paths: collidingPaths,
+              });
+            }
           }
         }
 
@@ -299,6 +324,15 @@ export async function* datastoreNamespaceMigrate(
       }
 
       const succeeded: string[] = [];
+
+      for (const ic of identicalCollisions) {
+        for (const relPath of ic.paths) {
+          const srcFile = join(ic.source, ...relPath.split("/"));
+          await deps.removeFile(srcFile);
+        }
+        ctx.logger
+          .info`Removed ${ic.paths.length} identical duplicate(s) from ${ic.subdir}/`;
+      }
 
       for (const dir of directories) {
         try {

--- a/src/libswamp/datastores/namespace_migrate_test.ts
+++ b/src/libswamp/datastores/namespace_migrate_test.ts
@@ -44,6 +44,8 @@ function makeDeps(
     mergeDirInto: (): Promise<MergeDirResult> =>
       Promise.resolve({ moved: 0, skipped: 0, skippedPaths: [] }),
     findFileCollisions: () => Promise.resolve([]),
+    compareFiles: () => Promise.resolve(true),
+    removeFile: () => Promise.resolve(),
     ensureDir: () => Promise.resolve(),
     invalidateCatalog: () => {},
     markDirtyBulk: () => Promise.resolve(),
@@ -300,7 +302,7 @@ Deno.test("datastoreNamespaceMigrate: skips nonexistent subdirs", async () => {
   }
 });
 
-Deno.test("datastoreNamespaceMigrate: pre-flight aborts on file collisions in forward migration", async () => {
+Deno.test("datastoreNamespaceMigrate: pre-flight aborts on non-identical file collisions in forward migration", async () => {
   const ctx = createLibSwampContext({});
   const allPaths = new Set([
     join(DS_PATH, "data"),
@@ -311,6 +313,7 @@ Deno.test("datastoreNamespaceMigrate: pre-flight aborts on file collisions in fo
     dirSize: () => Promise.resolve({ fileCount: 5, totalBytes: 2000 }),
     findFileCollisions: (_src, _dst) =>
       Promise.resolve(["model-a/latest.yaml", "model-b/v1.yaml"]),
+    compareFiles: () => Promise.resolve(false),
   });
 
   const events = await collect<NamespaceMigrateEvent>(
@@ -346,6 +349,7 @@ Deno.test("datastoreNamespaceMigrate: re-run after partial failure detects colli
       }
       return Promise.resolve([]);
     },
+    compareFiles: () => Promise.resolve(false),
     renameDir: () => {
       renameCalled = true;
       return Promise.resolve();
@@ -394,6 +398,7 @@ Deno.test("datastoreNamespaceMigrate: nested collisions across multiple subdirs 
       }
       return Promise.resolve([]);
     },
+    compareFiles: () => Promise.resolve(false),
   });
 
   const events = await collect<NamespaceMigrateEvent>(
@@ -530,4 +535,84 @@ Deno.test("datastoreNamespaceMigrate: reverse migration not blocked by foreign n
 
   const preview = events.find((e) => e.kind === "preview");
   assertEquals(preview?.kind, "preview");
+});
+
+Deno.test("datastoreNamespaceMigrate: forward migration deletes byte-identical collisions", async () => {
+  const ctx = createLibSwampContext({});
+  const removedFiles: string[] = [];
+
+  const deps = makeDeps({
+    dirExists: () => Promise.resolve(true),
+    dirSize: () => Promise.resolve({ fileCount: 2, totalBytes: 100 }),
+    findFileCollisions: () =>
+      Promise.resolve(["data/file1.yaml", "data/file2.yaml"]),
+    compareFiles: () => Promise.resolve(true),
+    removeFile: (path: string) => {
+      removedFiles.push(path);
+      return Promise.resolve();
+    },
+    mergeDirInto: (): Promise<MergeDirResult> =>
+      Promise.resolve({ moved: 0, skipped: 0, skippedPaths: [] }),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const completed = events.find((e) => e.kind === "completed");
+  assertEquals(completed?.kind, "completed");
+  assertEquals(removedFiles.length > 0, true);
+});
+
+Deno.test("datastoreNamespaceMigrate: forward migration errors on non-identical collisions", async () => {
+  const ctx = createLibSwampContext({});
+
+  const deps = makeDeps({
+    dirExists: () => Promise.resolve(true),
+    dirSize: () => Promise.resolve({ fileCount: 2, totalBytes: 100 }),
+    findFileCollisions: () =>
+      Promise.resolve(["data/file1.yaml", "data/file2.yaml"]),
+    compareFiles: () => Promise.resolve(false),
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const error = events.find((e) => e.kind === "error");
+  assertEquals(error?.kind, "error");
+  if (error?.kind === "error") {
+    assertStringIncludes(
+      error.error.message,
+      "already exist at the destination",
+    );
+  }
+});
+
+Deno.test("datastoreNamespaceMigrate: forward migration with mixed identical and non-identical collisions errors", async () => {
+  const ctx = createLibSwampContext({});
+  let callCount = 0;
+
+  const deps = makeDeps({
+    dirExists: (path: string) => {
+      if (path === join(DS_PATH, "data")) return Promise.resolve(true);
+      if (path === join(DS_PATH, NAMESPACE, "data")) {
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(false);
+    },
+    dirSize: () => Promise.resolve({ fileCount: 2, totalBytes: 100 }),
+    findFileCollisions: () => Promise.resolve(["file1.yaml", "file2.yaml"]),
+    compareFiles: () => {
+      callCount++;
+      return Promise.resolve(callCount <= 1);
+    },
+  });
+
+  const events = await collect<NamespaceMigrateEvent>(
+    datastoreNamespaceMigrate(ctx, deps, { confirm: true, reverse: false }),
+  );
+
+  const error = events.find((e) => e.kind === "error");
+  assertEquals(error?.kind, "error");
 });

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -26,21 +26,12 @@ import { datastoreTypeRegistry } from "../../domain/datastore/datastore_type_reg
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { PushPreviewSummary } from "../../domain/datastore/datastore_sync_service.ts";
 import { runBoundedSync } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
+import { dirHasFiles } from "../../infrastructure/persistence/directory_merge.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 
 import { join } from "@std/path";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
-
-async function dirHasFiles(dir: string): Promise<boolean> {
-  for await (const entry of Deno.readDir(dir)) {
-    if (entry.isFile || entry.isSymlink) return true;
-    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
-      return true;
-    }
-  }
-  return false;
-}
 
 /**
  * Data structure for the datastore sync output.

--- a/src/libswamp/datastores/sync.ts
+++ b/src/libswamp/datastores/sync.ts
@@ -31,6 +31,17 @@ import type { SwampError } from "../errors.ts";
 
 import { join } from "@std/path";
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
+
+async function dirHasFiles(dir: string): Promise<boolean> {
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile || entry.isSymlink) return true;
+    if (entry.isDirectory && await dirHasFiles(join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Data structure for the datastore sync output.
  */
@@ -206,7 +217,12 @@ export async function createDatastoreSyncDeps(
           for (const subdir of DEFAULT_DATASTORE_SUBDIRS) {
             try {
               const stat = await Deno.stat(join(config.cachePath!, subdir));
-              if (stat.isDirectory) found.push(subdir);
+              if (
+                stat.isDirectory &&
+                await dirHasFiles(join(config.cachePath!, subdir))
+              ) {
+                found.push(subdir);
+              }
             } catch {
               // Not found — expected when migrated
             }

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -239,6 +239,10 @@ export {
   type RepairDatastoresDeps,
   type RepairDatastoresEvent,
   type RepairDatastoresResult,
+  repairUnmigratedData,
+  type RepairUnmigratedDataDeps,
+  type RepairUnmigratedDataEvent,
+  type UnmigratedDataRepairResult,
   type VaultMismatchFinding,
 } from "./datastores/doctor_datastores.ts";
 export {

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -414,6 +414,9 @@ class JsonUnmigratedDataRepairRenderer implements UnmigratedDataRepairRenderer {
       },
       not_needed: () => {
         this.overallStatus = "pass";
+        console.log(
+          JSON.stringify({ status: "unmigrated_not_needed" }, null, 2),
+        );
       },
       error: (e) => {
         this.overallStatus = "fail";

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -22,6 +22,7 @@ import type {
   DoctorDatastoresEvent,
   EventHandlers,
   RepairDatastoresEvent,
+  RepairUnmigratedDataEvent,
 } from "../../libswamp/mod.ts";
 import { UserError } from "../../domain/errors.ts";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
@@ -315,5 +316,117 @@ export function createRepairDatastoresRenderer(
       return new JsonRepairDatastoresRenderer();
     case "log":
       return new LogRepairDatastoresRenderer();
+  }
+}
+
+// ============================================================================
+// Unmigrated data repair renderer
+// ============================================================================
+
+export type UnmigratedDataRepairStatus = "pass" | "fail" | "preview";
+
+export interface UnmigratedDataRepairRenderer {
+  handlers(): EventHandlers<RepairUnmigratedDataEvent>;
+  readonly overallStatus: UnmigratedDataRepairStatus;
+}
+
+class LogUnmigratedDataRepairRenderer implements UnmigratedDataRepairRenderer {
+  overallStatus: UnmigratedDataRepairStatus = "pass";
+
+  handlers(): EventHandlers<RepairUnmigratedDataEvent> {
+    return {
+      scanning: () => {
+        writeOutput(dim("Scanning for root-level unmigrated data…"));
+      },
+      preview: (e) => {
+        this.overallStatus = "preview";
+        writeOutput(`\n${bold("Root-level unmigrated data cleanup:")}`);
+        for (const dir of e.directories) {
+          writeOutput(
+            `  Remove ${dir}/ (duplicate of ${e.namespace}/${dir}/)`,
+          );
+        }
+        writeOutput(dim("\n  Run with -y to proceed."));
+      },
+      step: (e) => {
+        writeOutput(`  ${e.description}`);
+      },
+      completed: (e) => {
+        this.overallStatus = "pass";
+        const { result } = e;
+        writeOutput(
+          `\n${green("✓")} ${bold("Unmigrated data cleanup complete:")}`,
+        );
+        writeOutput(
+          `  Removed ${result.removedFiles} duplicate file(s) from ${
+            result.removedDirectories.join(", ")
+          }`,
+        );
+      },
+      not_needed: () => {
+        this.overallStatus = "pass";
+      },
+      error: (e) => {
+        this.overallStatus = "fail";
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+class JsonUnmigratedDataRepairRenderer implements UnmigratedDataRepairRenderer {
+  overallStatus: UnmigratedDataRepairStatus = "pass";
+
+  handlers(): EventHandlers<RepairUnmigratedDataEvent> {
+    return {
+      scanning: () => {},
+      preview: (e) => {
+        this.overallStatus = "preview";
+        console.log(
+          JSON.stringify(
+            {
+              status: "unmigrated_preview",
+              namespace: e.namespace,
+              directories: e.directories,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      step: () => {},
+      completed: (e) => {
+        this.overallStatus = "pass";
+        console.log(
+          JSON.stringify(
+            {
+              status: "unmigrated_repaired",
+              namespace: e.namespace,
+              result: e.result,
+            },
+            null,
+            2,
+          ),
+        );
+      },
+      not_needed: () => {
+        this.overallStatus = "pass";
+      },
+      error: (e) => {
+        this.overallStatus = "fail";
+        throw new UserError(e.error.message);
+      },
+    };
+  }
+}
+
+export function createUnmigratedDataRepairRenderer(
+  mode: OutputMode,
+): UnmigratedDataRepairRenderer {
+  switch (mode) {
+    case "json":
+      return new JsonUnmigratedDataRepairRenderer();
+    case "log":
+      return new LogUnmigratedDataRepairRenderer();
   }
 }

--- a/src/presentation/renderers/doctor_datastores.ts
+++ b/src/presentation/renderers/doctor_datastores.ts
@@ -365,6 +365,9 @@ class LogUnmigratedDataRepairRenderer implements UnmigratedDataRepairRenderer {
       },
       not_needed: () => {
         this.overallStatus = "pass";
+        writeOutput(
+          dim("No root-level unmigrated data found."),
+        );
       },
       error: (e) => {
         this.overallStatus = "fail";
@@ -400,7 +403,7 @@ class JsonUnmigratedDataRepairRenderer implements UnmigratedDataRepairRenderer {
         console.log(
           JSON.stringify(
             {
-              status: "unmigrated_repaired",
+              status: "unmigrated_completed",
               namespace: e.namespace,
               result: e.result,
             },


### PR DESCRIPTION
## Summary

- Fix `checkUnmigratedNamespaceData` to ignore empty directories created by setup, preventing false-positive push blocks
- Make `namespace migrate --confirm` handle byte-identical collisions by deleting root-level duplicates instead of erroring
- Extend `doctor datastores --repair` to clean up root-level unmigrated data (previously only handled foreign-namespace contamination)
- Root cause (S3 extension `pullChanged` stripping namespace from keys) tracked in #2021

## Test Plan

- 3 new unit tests for byte-identical collision handling (identical, non-identical, mixed)
- Updated 3 existing collision tests to specify non-identical content
- All 9619 tests pass, 0 failures
- Manually verified with MinIO: bidirectional sync creates duplicates → `namespace migrate --confirm` recovers → `doctor --repair` recovers → push succeeds

Closes swamp-club#1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)