### PR TITLE
fix(serve): prevent silent hang for unhandled request types, add version --server

### DIFF
--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -27,6 +27,12 @@ import {
 } from "../../libswamp/mod.ts";
 import { createVersionRenderer } from "../../presentation/renderers/version.ts";
 import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
 
 // This gets replaced by the compile script during release builds
 export const VERSION = "20260206.200442.0-sha.";
@@ -41,21 +47,47 @@ export function getVersionData(): VersionData {
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
-export const versionCommand = new Command()
-  .description("Display the version of swamp")
-  .action(async function (options: AnyOptions) {
-    const cliCtx = createContext(options as GlobalOptions, ["version"]);
-    cliCtx.logger.debug("Executing version command");
-    cliCtx.logger
-      .debug`Output mode: ${cliCtx.outputMode}, verbosity: ${cliCtx.verbosity}`;
+export const versionCommand = withRemoteOptions(
+  new Command()
+    .description("Display the version of swamp"),
+).action(async function (options: AnyOptions) {
+  const cliCtx = createContext(options as GlobalOptions, ["version"]);
+  cliCtx.logger.debug("Executing version command");
 
-    const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createVersionDeps();
-    const renderer = createVersionRenderer(cliCtx.outputMode);
-    await consumeStream(
-      version(ctx, deps, { version: VERSION }),
-      renderer.handlers(),
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (server) {
+    const token = await resolveServerToken(
+      server,
+      options.token as string | undefined,
     );
+    const response = await requestServerResponse<
+      { version: string; gitSha: string }
+    >(
+      { server, token },
+      { type: "server.version" },
+    );
+    if (cliCtx.outputMode === "json") {
+      console.log(JSON.stringify({
+        server: { version: response.version, gitSha: response.gitSha },
+        client: { version: VERSION, gitSha: GIT_SHA },
+      }));
+    } else {
+      console.log(`server: ${response.version} (${response.gitSha})`);
+      console.log(`client: ${VERSION} (${GIT_SHA})`);
+    }
+    return;
+  }
 
-    cliCtx.logger.debug("Version command completed");
-  });
+  cliCtx.logger
+    .debug`Output mode: ${cliCtx.outputMode}, verbosity: ${cliCtx.verbosity}`;
+
+  const ctx = createLibSwampContext({ logger: cliCtx.logger });
+  const deps = createVersionDeps();
+  const renderer = createVersionRenderer(cliCtx.outputMode);
+  await consumeStream(
+    version(ctx, deps, { version: VERSION }),
+    renderer.handlers(),
+  );
+
+  cliCtx.logger.debug("Version command completed");
+});

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -24,6 +24,8 @@ import * as zodModule from "zod";
 
 const logger = getLogger(["swamp", "models", "bundle"]);
 
+const BUNDLE_TIMEOUT_MS = 120_000;
+
 declare global {
   var __swamp_zod: typeof zodModule | undefined;
 }
@@ -173,6 +175,12 @@ export interface BundleOptions {
    * (which triggers macOS TCC prompts).
    */
   env?: Record<string, string>;
+
+  /**
+   * Abort signal forwarded to the subprocess. When aborted the child
+   * process is killed and the returned promise rejects.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -511,10 +519,14 @@ export async function bundleExtension(
 
     args.push("--platform", "deno", "-o", tempFile, absolutePath);
 
+    const signal = options?.signal ??
+      AbortSignal.timeout(BUNDLE_TIMEOUT_MS);
+
     const command = new Deno.Command(denoPath, {
       args,
       stdout: "piped",
       stderr: "piped",
+      signal,
       // For package.json projects, set cwd so Deno auto-detects package.json
       // and resolves bare specifiers from node_modules/.
       ...(options?.packageJsonDir ? { cwd: options.packageJsonDir } : {}),

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -27,6 +27,10 @@ import type { ServerRequest } from "./protocol.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { Principal } from "../domain/access/principal.ts";
 import {
+  GIT_SHA as SERVER_GIT_SHA,
+  VERSION as SERVER_VERSION,
+} from "../cli/commands/version.ts";
+import {
   handleDataDelete,
   handleDataGet,
   handleDataList,
@@ -858,7 +862,13 @@ const RunAttachRequestSchema = z.object({
   }),
 });
 
+const ServerVersionRequestSchema = z.object({
+  type: z.literal("server.version"),
+  id: z.string().min(1).max(256),
+});
+
 const ServerRequestSchema = z.discriminatedUnion("type", [
+  ServerVersionRequestSchema,
   WorkflowRunRequestSchema,
   ModelMethodRunRequestSchema,
   AccessGrantListRequestSchema,
@@ -1078,6 +1088,15 @@ export function handleMessage(
 
   let task: Promise<void>;
   switch (request.type) {
+    case "server.version":
+      task = Promise.resolve(
+        send(socket, {
+          type: "server.version",
+          id: request.id,
+          payload: { version: SERVER_VERSION, gitSha: SERVER_GIT_SHA },
+        }),
+      );
+      break;
     case "workflow.run":
       task = handleWorkflowRun(
         socket,
@@ -1804,6 +1823,18 @@ export function handleMessage(
         principal,
       );
       break;
+    default: {
+      const unhandled = request as { id: string; type: string };
+      task = Promise.resolve(
+        sendError(
+          socket,
+          unhandled.id,
+          "unsupported_operation",
+          `Operation '${unhandled.type}' is not supported by this server version`,
+        ),
+      );
+      break;
+    }
   }
 
   task

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -663,7 +663,9 @@ export async function handleExtensionPull(
       localManifestIdentity: readLocalManifestIdentity(repoDir),
     });
 
-    const libCtx = createLibSwampContext();
+    const libCtx = createLibSwampContext({
+      signal: controller.signal,
+    });
     const pullDeps = {
       getExtension: deps.getExtension,
       getLatestVersion: deps.getLatestVersion,
@@ -686,7 +688,9 @@ export async function handleExtensionPull(
         channel: payload.channel,
       }),
       {
-        installing: () => {},
+        installing: () => {
+          if (controller.signal.aborted) throw new Error("cancelled");
+        },
         deprecated_warning: () => {},
         "orphans-pruned": () => {},
         completed: (e) => {
@@ -869,7 +873,7 @@ export async function handleExtensionUpdate(
 
   let catalog: ExtensionCatalogStore | undefined;
   try {
-    const libCtx = createLibSwampContext();
+    const libCtx = createLibSwampContext({ signal: controller.signal });
     const logger = getSwampLogger(["serve", "extension", "update"]);
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -455,6 +455,7 @@ export interface RunAttachPayload {
 }
 
 export type ServerRequest =
+  | { type: "server.version"; id: string }
   | { type: "workflow.run"; id: string; payload: WorkflowRunPayload }
   | { type: "model.method.run"; id: string; payload: ModelMethodRunPayload }
   | { type: "access.grant.list"; id: string; payload?: AccessGrantListPayload }
@@ -1015,6 +1016,11 @@ export type ServerMessage =
    * that predate it ignore unknown frame types.
    */
   | { type: "done"; id: string }
+  | {
+    type: "server.version";
+    id: string;
+    payload: { version: string; gitSha: string };
+  }
   | { type: "access.grant.list"; id: string; payload: AccessGrantListResponse }
   | {
     type: "access.group.list";


### PR DESCRIPTION
## Summary

- Fixes `extension pull --server` hanging indefinitely when the deployed
  serve binary predates the `extension.pull` handler — the dispatch switch
  had no default case, so unrecognized request types caused a silent crash
  with no response sent
- Adds `swamp version --server` so operators can verify what version a
  deployed serve instance is running before debugging further
- Adds a 120s timeout to the `deno bundle` subprocess as a safety net
  against indefinite hangs
- Wires the abort signal into extension pull/update handlers so the server
  stops processing when the client disconnects

## Test Plan

- Ran `swamp serve` locally, verified `extension pull --server` completes
  successfully (~10s for `@swamp/s3-datastore`)
- Verified `swamp version --server` returns both server and client versions
  in log and JSON modes
- `deno check main.ts` passes
- `deno fmt --check`, `deno lint` pass
- All 9616 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)