### PR TITLE
fix(extensions): exit 0 from quality command when score is computable (swamp-club#1481)

### DIFF
--- a/integration/extension_quality_test.ts
+++ b/integration/extension_quality_test.ts
@@ -43,10 +43,7 @@ async function runCli(
 }
 
 /**
- * Parse the first top-level JSON object from a string. When the CLI
- * exits non-zero in JSON mode, it prints the score object followed by
- * an error object — tests care about the score and want to ignore the
- * trailing error.
+ * Parse the first top-level JSON object from a string.
  */
 // deno-lint-ignore no-explicit-any
 function parseFirstJson(stdout: string): any {
@@ -244,8 +241,7 @@ Deno.test(
         "--no-color",
       ]);
 
-      // Exit non-zero since factors missed.
-      assertEquals(code !== 0, true);
+      assertEquals(code, 0);
       const parsed = parseFirstJson(stdout);
       assertEquals(parsed.allPassed, false);
 
@@ -286,7 +282,7 @@ Deno.test(
         "--no-color",
       ]);
 
-      assertEquals(code !== 0, true);
+      assertEquals(code, 0);
       const parsed = parseFirstJson(stdout);
       const byId = new Map<string, { status: string }>(
         parsed.factors.map((f: { id: string; status: string }) => [f.id, f]),

--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -181,10 +181,6 @@ export const extensionQualityCommand = new Command()
         renderer.handlers(),
       );
 
-      if (!renderer.passed()) {
-        throw new UserError(renderer.failureMessage());
-      }
-
       cliCtx.logger.debug`Extension quality command completed`;
     },
   );

--- a/src/presentation/renderers/extension_quality.ts
+++ b/src/presentation/renderers/extension_quality.ts
@@ -122,15 +122,6 @@ class LogExtensionQualityRenderer implements ExtensionQualityRenderer {
         logger
           .info`Note: \`repository-verified\` earns here when the URL is well-formed on an allowlisted host; the registry does the final public-reachable check on publish.`;
         logger.info`Packaged archive: ${archiveSize} bytes`;
-        if (!score.allPassed) {
-          this._passed = false;
-          const missing = score.factors
-            .filter((f) => f.status !== "earned")
-            .map((f) => f.id)
-            .join(", ");
-          this._failureMessage =
-            `Quality rubric factors missing: ${missing}. See messages above for remediation.`;
-        }
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -186,14 +177,6 @@ class JsonExtensionQualityRenderer implements ExtensionQualityRenderer {
           null,
           2,
         ));
-        if (!score.allPassed) {
-          this._passed = false;
-          const missing = score.factors
-            .filter((f) => f.status !== "earned")
-            .map((f) => f.id)
-            .join(", ");
-          this._failureMessage = `Quality rubric factors missing: ${missing}.`;
-        }
       },
       error: (e) => {
         throw new UserError(e.error.message);

--- a/src/presentation/renderers/extension_quality_test.ts
+++ b/src/presentation/renderers/extension_quality_test.ts
@@ -1,18 +1,21 @@
-// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
 //
 // This file is part of Swamp.
 //
-// Swamp is free software: you can redistribute it and/or modify it under the terms
-// of the GNU Affero General Public License version 3 as published by the Free
-// Software Foundation, with the Swamp Extension and Definition Exception (found in
-// the "COPYING-EXCEPTION" file).
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
 //
-// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
 //
-// You should have received a copy of the GNU Affero General Public License along
-// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";

--- a/src/presentation/renderers/extension_quality_test.ts
+++ b/src/presentation/renderers/extension_quality_test.ts
@@ -1,0 +1,165 @@
+// Swamp, an Automation Framework Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Affero General Public License version 3 as published by the Free
+// Software Foundation, with the Swamp Extension and Definition Exception (found in
+// the "COPYING-EXCEPTION" file).
+//
+// Swamp is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License along
+// with Swamp. If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { ExtensionQualityEvent } from "../../libswamp/mod.ts";
+import type { RubricScore } from "../../domain/extensions/extension_rubric_scorer.ts";
+import type { DependencyTrustResult } from "../../domain/extensions/extension_dependency_trust_checker.ts";
+import { UserError } from "../../domain/errors.ts";
+import { createExtensionQualityRenderer } from "./extension_quality.ts";
+
+await initializeLogging({});
+
+function makeScore(overrides: Partial<RubricScore> = {}): RubricScore {
+  return {
+    rubricVersion: 3,
+    factors: [
+      {
+        id: "has-readme",
+        label: "Has README or module doc",
+        earnedPoints: 2,
+        maxPoints: 2,
+        status: "earned",
+      },
+      {
+        id: "symbols-docs",
+        label: "Most symbols documented",
+        earnedPoints: 0,
+        maxPoints: 1,
+        status: "missing",
+        remediation: "Add JSDoc to >=80% of exported symbols.",
+      },
+    ],
+    earnedPoints: 12,
+    maxEarnablePoints: 14,
+    percentage: 85,
+    allPassed: false,
+    ...overrides,
+  };
+}
+
+const emptyTrustResult: DependencyTrustResult = {
+  passed: true,
+  audited: [],
+  errors: [],
+  warnings: [],
+};
+
+function completedEvent(
+  score: RubricScore,
+): Extract<ExtensionQualityEvent, { kind: "completed" }> {
+  return {
+    kind: "completed",
+    data: {
+      score,
+      cacheHash: "abc123",
+      archiveSize: 1024,
+      cacheHit: false,
+      dependencyTrustResult: emptyTrustResult,
+    },
+  };
+}
+
+Deno.test(
+  "createExtensionQualityRenderer: json completed with allPassed=false reports passed",
+  () => {
+    const renderer = createExtensionQualityRenderer("json");
+    const handlers = renderer.handlers();
+
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      handlers.completed(completedEvent(makeScore({ allPassed: false })));
+    } finally {
+      console.log = originalLog;
+    }
+
+    assertEquals(renderer.passed(), true);
+  },
+);
+
+Deno.test(
+  "createExtensionQualityRenderer: json completed with allPassed=true reports passed",
+  () => {
+    const renderer = createExtensionQualityRenderer("json");
+    const handlers = renderer.handlers();
+
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      handlers.completed(completedEvent(makeScore({ allPassed: true })));
+    } finally {
+      console.log = originalLog;
+    }
+
+    assertEquals(renderer.passed(), true);
+  },
+);
+
+Deno.test(
+  "createExtensionQualityRenderer: json error throws UserError",
+  () => {
+    const renderer = createExtensionQualityRenderer("json");
+    const handlers = renderer.handlers();
+
+    assertThrows(
+      () =>
+        handlers.error({
+          kind: "error",
+          error: {
+            code: "quality_failed",
+            message: "Extension has model upgrade chain errors",
+          },
+        }),
+      UserError,
+      "Extension has model upgrade chain errors",
+    );
+  },
+);
+
+Deno.test(
+  "createExtensionQualityRenderer: log completed with allPassed=false reports passed",
+  () => {
+    const renderer = createExtensionQualityRenderer("log");
+    const handlers = renderer.handlers();
+
+    handlers.completed(completedEvent(makeScore({ allPassed: false })));
+
+    assertEquals(renderer.passed(), true);
+  },
+);
+
+Deno.test(
+  "createExtensionQualityRenderer: log error throws UserError",
+  () => {
+    const renderer = createExtensionQualityRenderer("log");
+    const handlers = renderer.handlers();
+
+    assertThrows(
+      () =>
+        handlers.error({
+          kind: "error",
+          error: {
+            code: "quality_failed",
+            message: "Bundle compilation failed",
+          },
+        }),
+      UserError,
+      "Bundle compilation failed",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- `swamp extension quality --json` now exits 0 whenever a complete score is produced, even if `allPassed` is false (imperfect grade). The JSON output already communicates the result via `status: "failed"` and `allPassed: false`.
- Exit 1 is reserved for genuinely uncomputable cases (error events where no score object is emitted, e.g. broken upgrade chains or invalid manifests).
- Removes the "Quality rubric factors missing" error message from both log and JSON renderers — the per-factor remediation lines and the JSON score object already provide this information.

Fixes swamp-club#1481

## Test Plan

- Added unit tests for both log and JSON renderers verifying `passed()=true` on completed events with `allPassed=false`, and `UserError` thrown on error events
- Updated integration tests that previously asserted non-zero exit for imperfect-but-computable scores to expect exit 0
- Reproduced the bug in a scratch repo (85% score, exit 1 → now exit 0) and verified genuinely uncomputable cases still exit 1
- Full test suite passes: 9621 passed, 0 failed