### PR TITLE
feat(access): allow re-minting a token after revocation (swamp-club#1471)

### DIFF
--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -103,9 +103,12 @@ async function mint(
   }
   const existing = await context.readResource!(TOKEN_DATA_NAME);
   if (existing !== null) {
-    throw new Error(
-      `Server token '${context.definition.name}' already exists — revoke it first`,
-    );
+    const parsed = ServerTokenSchema.parse(existing);
+    if (parsed.state !== "revoked") {
+      throw new Error(
+        `Server token '${context.definition.name}' already exists — revoke it first`,
+      );
+    }
   }
 
   const name = context.definition.name;

--- a/src/domain/models/access/server_token_model_test.ts
+++ b/src/domain/models/access/server_token_model_test.ts
@@ -71,8 +71,31 @@ Deno.test("serverTokenModel: caller reads plaintext from vault after mint", asyn
   assertEquals(plaintext.length, 64);
 });
 
-Deno.test("serverTokenModel: mint twice with the same name fails", async () => {
+Deno.test("serverTokenModel: mint twice with the same name fails when active", async () => {
   const { context } = await mintToken();
+  await assertRejects(
+    () => serverTokenModel.methods.mint.execute(mintArgs, context),
+    Error,
+    "already exists",
+  );
+});
+
+Deno.test("serverTokenModel: mint after revoke succeeds with fresh credentials", async () => {
+  const { context, store, vault, plaintext: oldPlaintext } = await mintToken();
+  await serverTokenModel.methods.revoke.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "revoked");
+  await serverTokenModel.methods.mint.execute(mintArgs, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "active");
+  const newPlaintext = vault.get(
+    `local/${serverTokenSecretKey("user-token-1")}`,
+  )!;
+  assertNotEquals(newPlaintext, oldPlaintext);
+});
+
+Deno.test("serverTokenModel: mint after expire still fails", async () => {
+  const { context } = await mintToken();
+  await serverTokenModel.methods.expire.execute({}, context);
   await assertRejects(
     () => serverTokenModel.methods.mint.execute(mintArgs, context),
     Error,


### PR DESCRIPTION
## Summary

- Relaxes the `mint` guard in `server_token_model.ts` to allow re-minting a token with the same name when the existing token is in `revoked` state
- Previously, `mint` rejected any name with an existing record regardless of state, forcing users to pick a fresh name after every revocation (e.g. `alice-01`, `alice-02`)
- Grants attach to the principal, not the token name, so reusing a revoked name is safe

## Test Plan

- Updated existing "mint twice with the same name fails" test to clarify it tests active-state rejection
- Added "mint after revoke succeeds with fresh credentials" test — verifies re-mint produces a new active token with a different vault secret
- Added "mint after expire still fails" test — verifies the guard still rejects expired tokens
- Full test suite passes (9632 tests)

Closes swamp-club#1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)