### PR TITLE
fix(serve): classify WebSocket auth rejections instead of surfacing opaque Deno errors (swamp-club#1482)

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -190,7 +190,7 @@ export function requestServerResponse<T>(
   const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
   const timeoutMs = options.timeoutMs ?? REQUEST_RESPONSE_TIMEOUT_MS;
 
-  return new Promise<T>((resolve, reject) => {
+  const raw = new Promise<T>((resolve, reject) => {
     let settled = false;
     const timer = setTimeout(() => {
       if (!settled) {
@@ -303,6 +303,18 @@ export function requestServerResponse<T>(
       } catch { /* not a protocol frame */ }
     };
   });
+
+  return raw.catch(async (err: unknown) => {
+    if (
+      err instanceof UserError &&
+      err.message.startsWith("Could not connect to")
+    ) {
+      throw new UserError(
+        await classifyConnectionError(baseUrl, err.message),
+      );
+    }
+    throw err;
+  });
 }
 
 // deno-lint-ignore no-explicit-any
@@ -323,6 +335,40 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
       "--token <token:string>",
       "Server token in <name>.<secret> format; only applies with --server (overrides stored credentials and SWAMP_SERVER_TOKEN)",
     ) as T;
+}
+
+/** Timeout for the health probe on connection failure (ms). */
+const HEALTH_PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * Probes the server's unauthenticated /health endpoint to check if the
+ * server is reachable and healthy. Used to disambiguate auth rejections
+ * (server is up but returned 401/403) from genuine transport errors.
+ */
+export async function probeServerHealth(wsUrl: string): Promise<boolean> {
+  const httpUrl = toHttpUrl(wsUrl);
+  try {
+    const healthUrl = new URL("/health", httpUrl);
+    const response = await fetch(healthUrl, {
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+    if (!response.ok) return false;
+    const body = await response.json();
+    return typeof body === "object" && body !== null &&
+      (body as Record<string, unknown>).status === "ok";
+  } catch {
+    return false;
+  }
+}
+
+async function classifyConnectionError(
+  wsUrl: string,
+  originalMessage: string,
+): Promise<string> {
+  if (await probeServerHealth(wsUrl)) {
+    return `Authentication failed — run: swamp auth server-login --server ${wsUrl}`;
+  }
+  return originalMessage;
 }
 
 // Force HTTP/1.1 ALPN for wss:// connections so WebSocket upgrades succeed
@@ -451,7 +497,21 @@ async function* streamServerRun(
   };
 
   try {
-    await opened;
+    try {
+      await opened;
+    } catch (err) {
+      if (
+        err instanceof UserError && (
+          err.message.startsWith("Could not connect to") ||
+          err.message.includes("closed before it opened")
+        )
+      ) {
+        throw new UserError(
+          await classifyConnectionError(baseUrl, err.message),
+        );
+      }
+      throw err;
+    }
     options.signal?.addEventListener("abort", onAbort, { once: true });
     if (options.signal?.aborted) {
       throw new DOMException("Run was aborted", "AbortError");

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -27,6 +27,7 @@ import { UserError } from "../domain/errors.ts";
 import {
   appendTokenToUrl,
   normalizeServerUrl,
+  probeServerHealth,
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
@@ -645,4 +646,145 @@ Deno.test("resolveServerToken: returns undefined when no credential", async () =
     emptyRepo,
   );
   assertEquals(result, undefined);
+});
+
+// ── auth error classification tests ──────────────────────────────────
+
+/**
+ * Server that rejects WebSocket upgrades with 401 but serves a healthy
+ * /health endpoint — simulates a swamp serve instance rejecting stale
+ * credentials.
+ */
+function authRejectingServer(
+  opts?: { healthBody?: unknown; healthStatus?: number },
+): {
+  url: string;
+  shutdown: () => Promise<void>;
+} {
+  const server = Deno.serve(
+    { port: 0, hostname: "127.0.0.1", onListen: () => {} },
+    (req) => {
+      if (req.headers.get("upgrade") === "websocket") {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      const url = new URL(req.url);
+      if (url.pathname === "/health" || url.pathname === "/") {
+        return Response.json(
+          opts?.healthBody ?? { status: "ok" },
+          { status: opts?.healthStatus ?? 200 },
+        );
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  );
+  return {
+    url: `ws://127.0.0.1:${server.addr.port}`,
+    shutdown: () => server.shutdown(),
+  };
+}
+
+Deno.test({
+  name: "probeServerHealth: returns true for healthy server",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer();
+    try {
+      assertEquals(await probeServerHealth(server.url), true);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "probeServerHealth: returns false for unreachable server",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    assertEquals(await probeServerHealth("ws://127.0.0.1:1"), false);
+  },
+});
+
+Deno.test({
+  name:
+    "probeServerHealth: returns false when response body is not valid health JSON",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer({ healthBody: { status: "degraded" } });
+    try {
+      assertEquals(await probeServerHealth(server.url), false);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: auth rejection shows authentication error when server is healthy",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer();
+    try {
+      const error = await assertRejects(async () => {
+        for await (
+          const _ of runWorkflowOverServer({
+            server: server.url,
+            payload: { workflowIdOrName: "wf" },
+          })
+          // deno-lint-ignore no-empty
+        ) {}
+      }, UserError);
+      assertStringIncludes(error.message, "Authentication failed");
+      assertStringIncludes(error.message, "swamp auth server-login");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "requestServerResponse: auth rejection shows authentication error when server is healthy",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = authRejectingServer();
+    try {
+      const error = await assertRejects(
+        () =>
+          requestServerResponse(
+            { server: server.url },
+            { type: "access.grant.list" },
+          ),
+        UserError,
+      );
+      assertStringIncludes(error.message, "Authentication failed");
+      assertStringIncludes(error.message, "swamp auth server-login");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: connection refused preserves original error when server is unreachable",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const error = await assertRejects(async () => {
+      for await (
+        const _ of runWorkflowOverServer({
+          server: "ws://127.0.0.1:1",
+          payload: { workflowIdOrName: "wf" },
+        })
+        // deno-lint-ignore no-empty
+      ) {}
+    }, UserError);
+    assertStringIncludes(error.message, "Could not connect to");
+  },
 });


### PR DESCRIPTION
## Summary

Fixes swamp-club#1482 — when a `--server` WebSocket handshake fails with HTTP 401/403, the CLI surfaces Deno's opaque runtime error (e.g. "HTTP/2 not supported by this client") instead of an actionable auth message. This actively misdirects debugging toward the TLS/proxy stack.

**Fix:** On WebSocket connection failure, probe the server's unauthenticated `/health` endpoint to disambiguate. If the server is reachable and healthy (`{"status": "ok"}`), the failure was auth — surface `Authentication failed — run: swamp auth server-login --server <url>`. If the server is unreachable, preserve the original error.

Changes:
- `src/cli/remote_run.ts` — add `probeServerHealth()` and `classifyConnectionError()`, wrap both `requestServerResponse` and `streamServerRun` error paths
- `src/cli/remote_run_test.ts` — 6 new tests covering healthy/unreachable/invalid health responses, auth rejection via both stream and request-response paths, and connection-refused passthrough

**Not addressed (separate concern):** untrusted TLS certs also surface through the same generic error path — noted for future work.

## Test Plan

- [x] `deno run test src/cli/remote_run_test.ts` — 30 passed (6 new)
- [x] `deno run test` — 9636 passed, 0 failed
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] New `authRejectingServer` test helper rejects WebSocket upgrades with 401 while serving `/health` with 200, verifying the auth-specific error message surfaces
- [x] Unreachable server test verifies original error is preserved when the health probe fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)