### PR TITLE
fix(serve): handle unrecognized OAuth device-token errors without crashing (swamp-club#1478)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1161,113 +1161,130 @@ export const serveCommand = new Command()
         );
       }
       const vaultName = vaultService.getDefaultVaultName() ?? vaultNames[0];
-      const credentials = await resolveOAuthClientCredentials(
-        {
-          getVaultSecret: async (v, k) => {
-            try {
-              return await vaultService.get(v, k, "serve:oauth-resolve");
-            } catch {
-              return null;
-            }
-          },
-          putVaultSecret: (v, k, val) => vaultService.put(v, k, val),
-          registerClient: async (providerUrl, signal) => {
-            const { startDeviceGrant, pollForToken } = await import(
-              "../../serve/oauth_client.ts"
-            );
-            const { BOOTSTRAP_CLIENT_ID } = await import(
-              "../../serve/oauth_registration.ts"
-            );
-            const { DeviceGrantPollError } = await import(
-              "../../serve/oauth_client.ts"
-            );
-
-            const grant = await startDeviceGrant(
-              providerUrl,
-              BOOTSTRAP_CLIENT_ID,
-              signal,
-            );
-
-            const verifyUrl = grant.verificationUriComplete ||
-              grant.verificationUri;
-            logger.info(
-              "First-time OAuth setup — visit {uri} and verify code: {code}",
-              { uri: verifyUrl, code: grant.userCode },
-            );
-
-            let currentIntervalMs = (grant.interval || 5) * 1000;
-            const deadline = Date.now() + grant.expiresIn * 1000;
-            let tokenResponse;
-            while (Date.now() < deadline) {
+      let credentials;
+      try {
+        credentials = await resolveOAuthClientCredentials(
+          {
+            getVaultSecret: async (v, k) => {
               try {
-                tokenResponse = await pollForToken(
-                  providerUrl,
-                  BOOTSTRAP_CLIENT_ID,
-                  "",
-                  grant.deviceCode,
-                  signal,
-                );
-                break;
-              } catch (err) {
-                if (err instanceof DeviceGrantPollError) {
-                  if (err.code === "slow_down") {
-                    currentIntervalMs += 5000;
-                  }
-                  if (
-                    err.code === "authorization_pending" ||
-                    err.code === "slow_down"
-                  ) {
-                    await new Promise((resolve) =>
-                      setTimeout(resolve, currentIntervalMs)
-                    );
-                    continue;
-                  }
-                }
-                throw err;
+                return await vaultService.get(v, k, "serve:oauth-resolve");
+              } catch {
+                return null;
               }
-            }
-            if (!tokenResponse) {
-              throw new Error("Bootstrap device grant timed out");
-            }
-
-            const resp = await fetch(
-              `${providerUrl}/api/auth/oauth2/register`,
-              {
-                method: "POST",
-                headers: {
-                  "content-type": "application/json",
-                  "authorization": `Bearer ${tokenResponse.accessToken}`,
-                },
-                body: JSON.stringify({
-                  client_name: `swamp-serve-${crypto.randomUUID().slice(0, 8)}`,
-                  redirect_uris: ["http://localhost"],
-                  grant_types: ["authorization_code"],
-                  scope: "openid profile email collectives",
-                }),
-                signal,
-              },
-            );
-            if (!resp.ok) {
-              const body = await resp.text().catch(() => "");
-              throw new Error(
-                `OAuth client registration failed: ${resp.status} ${resp.statusText}${
-                  body ? ` — ${body}` : ""
-                }`,
+            },
+            putVaultSecret: (v, k, val) => vaultService.put(v, k, val),
+            registerClient: async (providerUrl, signal) => {
+              const { startDeviceGrant, pollForToken } = await import(
+                "../../serve/oauth_client.ts"
               );
-            }
-            const data = await resp.json();
-            return {
-              clientId: data.client_id as string,
-              clientSecret: data.client_secret as string,
-              accessToken: tokenResponse.accessToken,
-            };
+              const { BOOTSTRAP_CLIENT_ID } = await import(
+                "../../serve/oauth_registration.ts"
+              );
+              const { DeviceGrantPollError } = await import(
+                "../../serve/oauth_client.ts"
+              );
+
+              const grant = await startDeviceGrant(
+                providerUrl,
+                BOOTSTRAP_CLIENT_ID,
+                signal,
+              );
+
+              const verifyUrl = grant.verificationUriComplete ||
+                grant.verificationUri;
+              logger.info(
+                "First-time OAuth setup — visit {uri} and verify code: {code}",
+                { uri: verifyUrl, code: grant.userCode },
+              );
+
+              let currentIntervalMs = (grant.interval || 5) * 1000;
+              const deadline = Date.now() + grant.expiresIn * 1000;
+              let tokenResponse;
+              while (Date.now() < deadline) {
+                try {
+                  tokenResponse = await pollForToken(
+                    providerUrl,
+                    BOOTSTRAP_CLIENT_ID,
+                    "",
+                    grant.deviceCode,
+                    signal,
+                  );
+                  break;
+                } catch (err) {
+                  if (err instanceof DeviceGrantPollError) {
+                    if (err.code === "slow_down") {
+                      currentIntervalMs += 5000;
+                    }
+                    if (
+                      err.code === "authorization_pending" ||
+                      err.code === "slow_down"
+                    ) {
+                      await new Promise((resolve) =>
+                        setTimeout(resolve, currentIntervalMs)
+                      );
+                      continue;
+                    }
+                    throw new UserError(
+                      `OAuth bootstrap failed: ${err.message}`,
+                    );
+                  }
+                  throw err;
+                }
+              }
+              if (!tokenResponse) {
+                throw new UserError(
+                  "OAuth bootstrap failed: device grant timed out",
+                );
+              }
+
+              const resp = await fetch(
+                `${providerUrl}/api/auth/oauth2/register`,
+                {
+                  method: "POST",
+                  headers: {
+                    "content-type": "application/json",
+                    "authorization": `Bearer ${tokenResponse.accessToken}`,
+                  },
+                  body: JSON.stringify({
+                    client_name: `swamp-serve-${
+                      crypto.randomUUID().slice(0, 8)
+                    }`,
+                    redirect_uris: ["http://localhost"],
+                    grant_types: ["authorization_code"],
+                    scope: "openid profile email collectives",
+                  }),
+                  signal,
+                },
+              );
+              if (!resp.ok) {
+                const body = await resp.text().catch(() => "");
+                throw new Error(
+                  `OAuth client registration failed: ${resp.status} ${resp.statusText}${
+                    body ? ` — ${body}` : ""
+                  }`,
+                );
+              }
+              const data = await resp.json();
+              return {
+                clientId: data.client_id as string,
+                clientSecret: data.client_secret as string,
+                accessToken: tokenResponse.accessToken,
+              };
+            },
           },
-        },
-        authConfig.oauthProvider,
-        vaultName,
-        authConfig.oauthClientId,
-        AbortSignal.timeout(300_000),
-      );
+          authConfig.oauthProvider,
+          vaultName,
+          authConfig.oauthClientId,
+          AbortSignal.timeout(300_000),
+        );
+      } catch (err) {
+        if (err instanceof UserError) throw err;
+        throw new UserError(
+          `OAuth bootstrap failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
       authConfig.oauthClientId = credentials.clientId;
       oauthClientSecret = credentials.clientSecret;
       logger.info(

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -261,6 +261,10 @@ async function handleDeviceToken(
           return jsonResponse(403, {
             error: "Authorization denied by user",
           });
+        case "unknown":
+          return jsonResponse(502, {
+            error: "Upstream provider returned an unexpected error",
+          });
       }
     }
     logger.error`Token exchange error: ${

--- a/src/serve/device_auth_handler_test.ts
+++ b/src/serve/device_auth_handler_test.ts
@@ -262,6 +262,25 @@ Deno.test("handleDeviceAuth: POST /auth/device/token returns 403 for access_deni
   assertEquals(body.error, "Authorization denied by user");
 });
 
+Deno.test("handleDeviceAuth: POST /auth/device/token returns 502 for unknown poll error", async () => {
+  const deps = makeMockDeps({
+    pollForToken: () =>
+      Promise.reject(
+        new DeviceGrantPollError(
+          "unknown",
+          "Token request failed: 400 invalid_grant",
+        ),
+      ),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 502);
+  const body = await result!.json();
+  assertEquals(body.error, "Upstream provider returned an unexpected error");
+});
+
 // ── POST /auth/device/token — admission ───────────────────────────────
 
 Deno.test("handleDeviceAuth: POST /auth/device/token returns 403 when admission denied", async () => {

--- a/src/serve/oauth_client.ts
+++ b/src/serve/oauth_client.ts
@@ -50,7 +50,8 @@ export type DeviceGrantPollErrorCode =
   | "authorization_pending"
   | "slow_down"
   | "expired_token"
-  | "access_denied";
+  | "access_denied"
+  | "unknown";
 
 /**
  * Error thrown when polling the OAuth token endpoint during the device
@@ -135,7 +136,8 @@ export async function pollForToken(
         errorCode as DeviceGrantPollErrorCode,
       );
     }
-    throw new Error(
+    throw new DeviceGrantPollError(
+      "unknown",
       `Token request failed: ${resp.status} ${data.error ?? resp.statusText}`,
     );
   }

--- a/src/serve/oauth_client_test.ts
+++ b/src/serve/oauth_client_test.ts
@@ -312,12 +312,12 @@ Deno.test("pollForToken: throws DeviceGrantPollError for access_denied", async (
   }
 });
 
-Deno.test("pollForToken: throws generic Error for unknown error code", async () => {
+Deno.test("pollForToken: throws DeviceGrantPollError with code 'unknown' for unrecognized error code", async () => {
   const mock = startMockServer(() =>
     Response.json({ error: "server_error" }, { status: 500 })
   );
   try {
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         pollForToken(
           `http://localhost:${mock.port}`,
@@ -326,9 +326,33 @@ Deno.test("pollForToken: throws generic Error for unknown error code", async () 
           "d",
           AbortSignal.timeout(5000),
         ),
-      Error,
+      DeviceGrantPollError,
       "Token request failed: 500",
     );
+    assertEquals(error.code, "unknown");
+  } finally {
+    await mock.shutdown();
+  }
+});
+
+Deno.test("pollForToken: throws DeviceGrantPollError with code 'unknown' for invalid_grant", async () => {
+  const mock = startMockServer(() =>
+    Response.json({ error: "invalid_grant" }, { status: 400 })
+  );
+  try {
+    const error = await assertRejects(
+      () =>
+        pollForToken(
+          `http://localhost:${mock.port}`,
+          "c",
+          "s",
+          "d",
+          AbortSignal.timeout(5000),
+        ),
+      DeviceGrantPollError,
+      "Token request failed: 400",
+    );
+    assertEquals(error.code, "unknown");
   } finally {
     await mock.shutdown();
   }


### PR DESCRIPTION
## Summary

- Extended `DeviceGrantPollErrorCode` with `"unknown"` so `pollForToken` wraps every unrecognized OAuth error code in a typed `DeviceGrantPollError` instead of throwing a plain `Error`
- Terminal poll errors (`expired_token`, `access_denied`, `unknown`) in the bootstrap retry loop now throw `UserError` for a clean exit with a diagnosable message
- Wrapped `resolveOAuthClientCredentials` in a try/catch as defense-in-depth so no bootstrap error can crash `swamp serve`
- Added `"unknown"` handling in `device_auth_handler.ts` → 502 Bad Gateway

## Test Plan

- [x] Updated `oauth_client_test.ts`: unknown error codes now assert `DeviceGrantPollError` with code `"unknown"`; added `invalid_grant` test case
- [x] Added `device_auth_handler_test.ts` test for `"unknown"` poll error → 502
- [x] Verified with compiled binary against mock OAuth provider returning `invalid_grant` — process exits cleanly with `Error: OAuth bootstrap failed: Token request failed: 400 invalid_grant`
- [x] Verified unreachable provider — process exits cleanly with `Error: OAuth bootstrap failed: error sending request...`
- [x] Full test suite passes (9640 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)