### PR TITLE
fix(datastore): demote version-prune log from info to debug

### DIFF
--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -1919,7 +1919,7 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
         toRemove,
       );
       logger
-        .info`Pruned ${toRemove.length} excess version(s) of ${dataName} (cap: ${cap}, prior: ${priorVersions.length})`;
+        .debug`Pruned ${toRemove.length} excess version(s) of ${dataName} (cap: ${cap}, prior: ${priorVersions.length})`;
     }
   }
 


### PR DESCRIPTION
## Summary

- Demotes the "Pruned N excess version(s)" log message in `UnifiedDataRepository` from `info` to `debug` level, preventing it from leaking into user-visible output during `swamp model method run` and `swamp workflow run`.

## Test Plan

- Verified `deno check`, `deno lint`, `deno fmt` all pass
- Ran `deno run test` — all tests pass (one pre-existing flaky SIGINT test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)