### PR TITLE
feat(serve): disposable instance HA — heartbeat, identity, and cross-machine reconciliation

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1661,13 +1661,29 @@ export const serveCommand = new Command()
                 controlPlaneStore.put(
                   `pending-runs/${entry.id}`,
                   new TextEncoder().encode(JSON.stringify(entry)),
-                ).catch(() => {});
+                ).catch((err: unknown) => {
+                  logger.warn(
+                    "Control-plane pending run write failed: {error}",
+                    {
+                      error: err instanceof Error ? err.message : String(err),
+                    },
+                  );
+                });
               }
             },
             delete: (id) => {
               runTracker.deletePendingRun(id);
               if (controlPlaneStore) {
-                controlPlaneStore.delete(`pending-runs/${id}`).catch(() => {});
+                controlPlaneStore.delete(`pending-runs/${id}`).catch(
+                  (err: unknown) => {
+                    logger.warn(
+                      "Control-plane pending run delete failed: {error}",
+                      {
+                        error: err instanceof Error ? err.message : String(err),
+                      },
+                    );
+                  },
+                );
               }
             },
           }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1629,6 +1629,7 @@ export const serveCommand = new Command()
         runTracker,
         dispatchService,
         defaultVault: repoMarker?.defaultVault,
+        instanceId,
       };
 
     const ac = new AbortController();

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1647,7 +1647,7 @@ export const serveCommand = new Command()
             resolvedRepoDir,
             repoContext,
             datastoreConfig,
-            input,
+            instanceId ? { ...input, instanceId } : input,
             signal,
             onEvent,
             syncService,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1914,6 +1914,7 @@ export const serveCommand = new Command()
         syncService,
         runTracker: detachRuns ? runTracker : undefined,
         controlPlaneStore,
+        instanceId,
       });
 
       webhookService.setEventHandler((event) => {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1511,6 +1511,37 @@ export const serveCommand = new Command()
     const detachRuns = options.detachRuns === true;
     const activeRunRegistry = detachRuns ? new ActiveRunRegistry() : undefined;
 
+    const instanceId = detachRuns ? crypto.randomUUID() : undefined;
+
+    let controlPlaneStore:
+      | import("../../domain/datastore/control_plane_store.ts").ControlPlaneStore
+      | undefined;
+    if (detachRuns && syncService) {
+      try {
+        const caps = syncService.capabilities?.();
+        if (caps?.controlPlane && syncService.controlPlaneStore) {
+          controlPlaneStore = syncService.controlPlaneStore();
+          logger.info("Control-plane store available (remote datastore)");
+        }
+      } catch {
+        // Extension doesn't support control-plane — fall back
+      }
+    }
+    if (detachRuns && !controlPlaneStore) {
+      const { FileSystemControlPlaneStore } = await import(
+        "../../infrastructure/persistence/fs_control_plane_store.ts"
+      );
+      const datastorePath = new DefaultDatastorePathResolver(
+        resolvedRepoDir,
+        datastoreConfig,
+      ).datastorePath();
+      controlPlaneStore = new FileSystemControlPlaneStore(datastorePath);
+    }
+
+    let heartbeatService:
+      | import("../../serve/instance_heartbeat.ts").InstanceHeartbeatService
+      | undefined;
+
     // Reap stale runs via the SQLite tracker (heartbeat + PID liveness).
     // This handles both model-method and workflow runs registered with the tracker.
     const runTracker = RunTrackerStore.fromSwampDir(
@@ -1548,6 +1579,21 @@ export const serveCommand = new Command()
       isProcessDead,
       detachRuns,
     );
+
+    if (controlPlaneStore && instanceId) {
+      const { reconcileRemoteInterruptedRuns } = await import(
+        "../../serve/boot_reconciliation.ts"
+      );
+      const reconciled = await reconcileRemoteInterruptedRuns({
+        controlPlaneStore,
+        instanceId,
+        workflowRunRepo: repoContext.workflowRunRepo,
+      });
+      if (reconciled > 0) {
+        logger
+          .info`Reconciled ${reconciled} interrupted run(s) from dead instance(s)`;
+      }
+    }
 
     const swept = await sweepStaleRecords({
       repoDir: resolvedRepoDir,
@@ -1608,8 +1654,21 @@ export const serveCommand = new Command()
           ),
         pendingRunHook: detachRuns
           ? {
-            enqueue: (entry) => runTracker.enqueuePendingRun(entry),
-            delete: (id) => runTracker.deletePendingRun(id),
+            enqueue: (entry) => {
+              runTracker.enqueuePendingRun(entry);
+              if (controlPlaneStore) {
+                controlPlaneStore.put(
+                  `pending-runs/${entry.id}`,
+                  new TextEncoder().encode(JSON.stringify(entry)),
+                ).catch(() => {});
+              }
+            },
+            delete: (id) => {
+              runTracker.deletePendingRun(id);
+              if (controlPlaneStore) {
+                controlPlaneStore.delete(`pending-runs/${id}`).catch(() => {});
+              }
+            },
           }
           : undefined,
       });
@@ -1837,6 +1896,7 @@ export const serveCommand = new Command()
         endpoints,
         syncService,
         runTracker: detachRuns ? runTracker : undefined,
+        controlPlaneStore,
       });
 
       webhookService.setEventHandler((event) => {
@@ -2366,6 +2426,9 @@ export const serveCommand = new Command()
           }
         }
       }
+      if (heartbeatService) {
+        await heartbeatService.stop();
+      }
       if (collectiveRefreshService) {
         await collectiveRefreshService.dispose();
       }
@@ -2409,14 +2472,27 @@ export const serveCommand = new Command()
     }
 
     if (detachRuns) {
-      const replayed = replayPendingRuns({
+      const replayed = await replayPendingRuns({
         runTracker,
         webhookService: webhookService ?? undefined,
         scheduledExecution: scheduledExecution ?? undefined,
+        controlPlaneStore,
       });
       if (replayed > 0) {
         logger.info`Replayed ${replayed} pending run(s) from previous process`;
       }
+    }
+
+    if (controlPlaneStore && instanceId) {
+      const { InstanceHeartbeatService } = await import(
+        "../../serve/instance_heartbeat.ts"
+      );
+      heartbeatService = new InstanceHeartbeatService(
+        controlPlaneStore,
+        instanceId,
+      );
+      await heartbeatService.start();
+      logger.info`Instance heartbeat started (id: ${instanceId})`;
     }
 
     await server.finished;

--- a/src/domain/models/active_run.ts
+++ b/src/domain/models/active_run.ts
@@ -42,6 +42,7 @@ export interface ActiveRunData {
   readonly startedAt: string;
   readonly heartbeatAt: string;
   readonly status: ActiveRunStatus;
+  readonly instanceId?: string;
 }
 
 export class ActiveRun {
@@ -56,6 +57,7 @@ export class ActiveRun {
   readonly pid: number;
   readonly hostname: string;
   readonly startedAt: Date;
+  readonly instanceId: string | undefined;
 
   private constructor(data: ActiveRunData) {
     this.id = data.id;
@@ -68,6 +70,7 @@ export class ActiveRun {
     this.startedAt = new Date(data.startedAt);
     this._heartbeatAt = new Date(data.heartbeatAt);
     this._status = data.status;
+    this.instanceId = data.instanceId;
   }
 
   get status(): ActiveRunStatus {
@@ -84,6 +87,7 @@ export class ActiveRun {
     methodName: string;
     pid: number;
     hostname: string;
+    instanceId?: string;
   }): ActiveRun {
     const now = new Date().toISOString();
     return new ActiveRun({
@@ -97,6 +101,7 @@ export class ActiveRun {
       startedAt: now,
       heartbeatAt: now,
       status: "running",
+      instanceId: opts.instanceId,
     });
   }
 
@@ -105,6 +110,7 @@ export class ActiveRun {
     workflowName: string;
     pid: number;
     hostname: string;
+    instanceId?: string;
   }): ActiveRun {
     const now = new Date().toISOString();
     return new ActiveRun({
@@ -118,6 +124,7 @@ export class ActiveRun {
       startedAt: now,
       heartbeatAt: now,
       status: "running",
+      instanceId: opts.instanceId,
     });
   }
 
@@ -137,6 +144,7 @@ export class ActiveRun {
       startedAt: this.startedAt.toISOString(),
       heartbeatAt: this._heartbeatAt.toISOString(),
       status: this._status,
+      instanceId: this.instanceId,
     };
   }
 

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -1578,6 +1578,8 @@ export class WorkflowExecutionService {
       skipAllChecks?: boolean;
       /** Minimum assert severity that fails the run */
       assertFailOnSeverity?: AssertSeverity;
+      /** Serve instance identity for cross-machine reconciliation */
+      instanceId?: string;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
     const tracer = getTracer();
@@ -1687,7 +1689,7 @@ export class WorkflowExecutionService {
         runSpan.setAttribute("workflow.run_id", run.id);
 
         // Start execution
-        run.start(Deno.pid);
+        run.start(Deno.pid, options?.instanceId);
 
         // Register workflow run with the tracker
         if (this.runTracker) {
@@ -1696,6 +1698,7 @@ export class WorkflowExecutionService {
             workflowName: workflow.name,
             pid: Deno.pid,
             hostname: hostname(),
+            instanceId: options?.instanceId,
           });
           this.runTracker.register(wfActiveRun);
         }

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -122,6 +122,7 @@ export const WorkflowRunSchema = z.object({
   workflowDataArtifacts: z.array(DataArtifactRefSchema).optional(),
   logFile: z.string().optional(),
   pid: z.number().int().positive().optional(),
+  instanceId: z.string().optional(),
   tags: z.record(z.string(), z.string()).default({}),
   // Effective workflow inputs captured when a run suspends, so post-resume
   // steps can resolve `inputs.*`. Optional for backward compatibility with
@@ -535,6 +536,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _inputs: Record<string, unknown> = {},
     private _resumeInputs: string[] = [],
     private _pid: number | undefined = undefined,
+    private _instanceId: string | undefined = undefined,
   ) {}
 
   /**
@@ -587,6 +589,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       validated.inputs ?? {},
       validated.resumeInputs ?? [],
       validated.pid,
+      validated.instanceId,
     );
   }
 
@@ -610,6 +613,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
 
   get pid(): number | undefined {
     return this._pid;
+  }
+
+  get instanceId(): string | undefined {
+    return this._instanceId;
   }
 
   get jobs(): ReadonlyArray<JobRun> {
@@ -669,10 +676,11 @@ export class WorkflowRun implements TriggerEvaluationContext {
   /**
    * Marks the workflow run as started and records the owning process ID.
    */
-  start(pid?: number): void {
+  start(pid?: number, instanceId?: string): void {
     this._status = "running";
     this._startedAt = new Date();
     this._pid = pid;
+    if (instanceId) this._instanceId = instanceId;
   }
 
   /**
@@ -842,6 +850,9 @@ export class WorkflowRun implements TriggerEvaluationContext {
     };
     if (this._pid !== undefined) {
       data.pid = this._pid;
+    }
+    if (this._instanceId !== undefined) {
+      data.instanceId = this._instanceId;
     }
     if (this._logFile) {
       data.logFile = this._logFile;

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -39,7 +39,7 @@ const RUN_TRACKER_DB_NAME = "run_tracker.db";
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 export { STALE_TTL_MS as DEFAULT_STALE_TTL_MS } from "../../domain/models/active_run.ts";
 const RETENTION_DAYS = 7;
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 export interface PendingRunEntry {
   id: string;
@@ -76,6 +76,7 @@ interface ActiveRunRow {
   status: string;
   completed_at: string | null;
   cancel_reason: string | null;
+  instance_id: string | null;
 }
 
 export class RunTrackerStore implements RunTrackerRepository {
@@ -174,6 +175,22 @@ export class RunTrackerStore implements RunTrackerRepository {
       `);
     }
 
+    if (currentVersion < 3) {
+      const tableExists = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='active_runs'",
+      ).get();
+      if (tableExists) {
+        const columns = this.db.prepare(
+          "PRAGMA table_info(active_runs)",
+        ).all() as unknown as { name: string }[];
+        if (!columns.some((c) => c.name === "instance_id")) {
+          this.db.exec(
+            "ALTER TABLE active_runs ADD COLUMN instance_id TEXT",
+          );
+        }
+      }
+    }
+
     this.db.prepare(
       "INSERT OR REPLACE INTO run_tracker_meta (key, value) VALUES ('schema_version', ?)",
     ).run(String(SCHEMA_VERSION));
@@ -193,7 +210,8 @@ export class RunTrackerStore implements RunTrackerRepository {
         heartbeat_at  TEXT NOT NULL,
         status        TEXT NOT NULL DEFAULT 'running',
         completed_at  TEXT,
-        cancel_reason TEXT
+        cancel_reason TEXT,
+        instance_id   TEXT
       );
 
       CREATE INDEX IF NOT EXISTS idx_active_runs_status
@@ -232,8 +250,8 @@ export class RunTrackerStore implements RunTrackerRepository {
     this.db.prepare(`
       INSERT INTO active_runs
         (id, run_kind, model_type, method_name, workflow_name,
-         pid, hostname, started_at, heartbeat_at, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         pid, hostname, started_at, heartbeat_at, status, instance_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       data.id,
       data.runKind,
@@ -245,6 +263,7 @@ export class RunTrackerStore implements RunTrackerRepository {
       data.startedAt,
       data.heartbeatAt,
       data.status,
+      data.instanceId ?? null,
     );
   }
 
@@ -411,6 +430,7 @@ export class RunTrackerStore implements RunTrackerRepository {
       startedAt: row.started_at,
       heartbeatAt: row.heartbeat_at,
       status: row.status as ActiveRunStatus,
+      instanceId: row.instance_id ?? undefined,
     };
   }
 }

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -659,6 +659,7 @@ export async function* workflowRun(
               skipCheckLabels: resolvedInput.skipCheckLabels,
               skipAllChecks: resolvedInput.skipAllChecks,
               assertFailOnSeverity: resolvedInput.assertFailOnSeverity,
+              instanceId: resolvedInput.instanceId,
             })
           ) {
             if (event.kind === "report_completed") {

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -315,6 +315,8 @@ export interface WorkflowRunInput {
   tracestate?: string;
   /** Minimum assert severity that fails the run. */
   assertFailOnSeverity?: AssertSeverity;
+  /** Serve instance identity for cross-machine reconciliation. */
+  instanceId?: string;
 }
 
 /**

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -209,6 +209,10 @@ export async function replayPendingRuns(
           !localIds.has(parsed.id)
         ) {
           remotePending.push(parsed);
+        } else if (parsed.id && !localIds.has(parsed.id)) {
+          logger
+            .warn`Discarding invalid remote pending run ${key}: missing required fields`;
+          await deps.controlPlaneStore.delete(key).catch(() => {});
         }
       } catch {
         const id = key.replace("pending-runs/", "");
@@ -245,6 +249,11 @@ export async function replayPendingRuns(
             logger
               .warn`Discarding pending run ${entry.id}: corrupt payload`;
             deps.runTracker.deletePendingRun(entry.id);
+            if (deps.controlPlaneStore) {
+              await deps.controlPlaneStore.delete(
+                `pending-runs/${entry.id}`,
+              ).catch(() => {});
+            }
             continue;
           }
         }
@@ -275,6 +284,11 @@ export async function replayPendingRuns(
           .info`Replayed pending cron run for ${entry.workflowIdOrName}`;
       } else {
         deps.runTracker.deletePendingRun(entry.id);
+        if (deps.controlPlaneStore) {
+          await deps.controlPlaneStore.delete(
+            `pending-runs/${entry.id}`,
+          ).catch(() => {});
+        }
         logger
           .warn`Discarding pending run ${entry.id} (source: ${entry.source}, no matching service)`;
       }

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -204,7 +204,10 @@ export async function replayPendingRuns(
       if (!data) continue;
       try {
         const parsed = JSON.parse(new TextDecoder().decode(data));
-        if (parsed.id && !localIds.has(parsed.id)) {
+        if (
+          parsed.id && parsed.source && parsed.workflowIdOrName &&
+          !localIds.has(parsed.id)
+        ) {
           remotePending.push(parsed);
         }
       } catch {
@@ -281,13 +284,9 @@ export async function replayPendingRuns(
         error: err instanceof Error ? err.message : String(err),
       });
       deps.runTracker.deletePendingRun(entry.id);
-    }
-
-    if (deps.controlPlaneStore) {
-      try {
-        await deps.controlPlaneStore.delete(`pending-runs/${entry.id}`);
-      } catch {
-        // Best-effort remote cleanup
+      if (deps.controlPlaneStore) {
+        await deps.controlPlaneStore.delete(`pending-runs/${entry.id}`)
+          .catch(() => {});
       }
     }
   }

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -286,7 +286,15 @@ export async function replayPendingRuns(
       deps.runTracker.deletePendingRun(entry.id);
       if (deps.controlPlaneStore) {
         await deps.controlPlaneStore.delete(`pending-runs/${entry.id}`)
-          .catch(() => {});
+          .catch((err: unknown) => {
+            logger.warn(
+              "Failed to delete remote pending run {id}: {error}",
+              {
+                id: entry.id,
+                error: err instanceof Error ? err.message : String(err),
+              },
+            );
+          });
       }
     }
   }

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -184,12 +184,46 @@ export interface ReplayPendingRunsDeps {
   webhookService?: import("./webhook.ts").WebhookService;
   scheduledExecution?:
     import("../libswamp/workflows/scheduled_execution.ts").ScheduledExecutionService;
+  controlPlaneStore?:
+    import("../domain/datastore/control_plane_store.ts").ControlPlaneStore;
 }
 
-export function replayPendingRuns(deps: ReplayPendingRunsDeps): number {
-  const pending = deps.runTracker.findAllPendingRuns();
+export async function replayPendingRuns(
+  deps: ReplayPendingRunsDeps,
+): Promise<number> {
+  const localPending = deps.runTracker.findAllPendingRuns();
+  const localIds = new Set(localPending.map((e) => e.id));
+
+  const remotePending:
+    import("../infrastructure/persistence/run_tracker_store.ts").PendingRunEntry[] =
+      [];
+  if (deps.controlPlaneStore) {
+    const keys = await deps.controlPlaneStore.list("pending-runs/");
+    for (const key of keys) {
+      const data = await deps.controlPlaneStore.get(key);
+      if (!data) continue;
+      try {
+        const parsed = JSON.parse(new TextDecoder().decode(data));
+        if (parsed.id && !localIds.has(parsed.id)) {
+          remotePending.push(parsed);
+        }
+      } catch {
+        const id = key.replace("pending-runs/", "");
+        logger
+          .warn`Discarding remote pending run ${id}: corrupt payload`;
+        await deps.controlPlaneStore.delete(key);
+      }
+    }
+  }
+
+  const pending = [...localPending, ...remotePending];
   if (pending.length === 0) return 0;
 
+  const remoteCount = remotePending.length;
+  if (remoteCount > 0) {
+    logger
+      .info`Found ${remoteCount} pending run(s) from remote control-plane store`;
+  }
   logger
     .debug`Replaying ${pending.length} pending run(s) from previous process`;
 
@@ -248,9 +282,97 @@ export function replayPendingRuns(deps: ReplayPendingRunsDeps): number {
       });
       deps.runTracker.deletePendingRun(entry.id);
     }
+
+    if (deps.controlPlaneStore) {
+      try {
+        await deps.controlPlaneStore.delete(`pending-runs/${entry.id}`);
+      } catch {
+        // Best-effort remote cleanup
+      }
+    }
   }
 
   return replayed;
+}
+
+export interface RemoteReconciliationDeps {
+  controlPlaneStore:
+    import("../domain/datastore/control_plane_store.ts").ControlPlaneStore;
+  instanceId: string;
+  workflowRunRepo: {
+    findAllGlobalSince(
+      since: Date,
+    ): Promise<
+      Array<{
+        run: import("../domain/workflows/workflow_run.ts").WorkflowRun;
+        workflowId: import("../domain/workflows/workflow_id.ts").WorkflowId;
+      }>
+    >;
+    save(
+      workflowId: import("../domain/workflows/workflow_id.ts").WorkflowId,
+      run: import("../domain/workflows/workflow_run.ts").WorkflowRun,
+    ): Promise<void>;
+  };
+}
+
+export async function reconcileRemoteInterruptedRuns(
+  deps: RemoteReconciliationDeps,
+): Promise<number> {
+  const { InstanceHeartbeatService } = await import("./instance_heartbeat.ts");
+
+  const heartbeatKeys = await deps.controlPlaneStore.list("heartbeats/");
+  if (heartbeatKeys.length === 0) return 0;
+
+  const staleInstanceIds: string[] = [];
+  for (const key of heartbeatKeys) {
+    const data = await deps.controlPlaneStore.get(key);
+    if (!data) continue;
+
+    const record = InstanceHeartbeatService.parseRecord(data);
+    if (!record) continue;
+    if (record.instanceId === deps.instanceId) continue;
+
+    if (InstanceHeartbeatService.isStale(record)) {
+      staleInstanceIds.push(record.instanceId);
+      logger.warn(
+        "Stale instance detected: {instanceId} (last heartbeat: {heartbeatAt})",
+        {
+          instanceId: record.instanceId,
+          heartbeatAt: record.heartbeatAt,
+        },
+      );
+    }
+  }
+
+  if (staleInstanceIds.length === 0) return 0;
+
+  const staleSet = new Set(staleInstanceIds);
+  const reapCutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const runs = await deps.workflowRunRepo.findAllGlobalSince(reapCutoff);
+
+  let reconciled = 0;
+  for (const { run, workflowId } of runs) {
+    if (run.status !== "running") continue;
+    if (!run.instanceId || !staleSet.has(run.instanceId)) continue;
+
+    run.interrupt("server_crash");
+    await deps.workflowRunRepo.save(workflowId, run);
+    reconciled++;
+    logger.warn(
+      "Reconciled interrupted run {runId} (workflow: {workflowName}, stale instance: {instanceId})",
+      {
+        runId: run.id,
+        workflowName: run.workflowName,
+        instanceId: run.instanceId,
+      },
+    );
+  }
+
+  for (const instanceId of staleInstanceIds) {
+    await deps.controlPlaneStore.delete(`heartbeats/${instanceId}`);
+  }
+
+  return reconciled;
 }
 
 async function loadAttrsForType(

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -20,11 +20,13 @@
 import { assertEquals } from "@std/assert";
 import {
   type BootReconciliationDeps,
+  reconcileRemoteInterruptedRuns,
   replayPendingRuns,
   type ReplayPendingRunsDeps,
   sweepStaleRecords,
   type TransitionInput,
 } from "./boot_reconciliation.ts";
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { Data } from "../domain/data/data.ts";
@@ -553,4 +555,317 @@ Deno.test("sweepStaleRecords: sweeps all three model types together", async () =
 
   assertEquals(result, { leases: 1, pendingDispatches: 1, workers: 1 });
   assertEquals(h.transitions.length, 3);
+});
+
+// ── reconcileRemoteInterruptedRuns tests ────────────────────────────
+
+function createMockControlPlaneStore(): ControlPlaneStore & {
+  data: Map<string, Uint8Array>;
+} {
+  const data = new Map<string, Uint8Array>();
+  return {
+    data,
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)).sort(),
+      );
+    },
+  };
+}
+
+function makeHeartbeat(
+  instanceId: string,
+  stale: boolean,
+): Uint8Array {
+  const heartbeatAt = stale
+    ? new Date(Date.now() - 120_000).toISOString()
+    : new Date().toISOString();
+  return new TextEncoder().encode(JSON.stringify({
+    instanceId,
+    hostname: "test-host",
+    pid: 12345,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt,
+  }));
+}
+
+interface MockRun {
+  id: string;
+  workflowName: string;
+  status: string;
+  instanceId?: string;
+  interrupted: boolean;
+  saved: boolean;
+}
+
+function createMockWorkflowRunRepo(
+  runs: MockRun[],
+): import("./boot_reconciliation.ts").RemoteReconciliationDeps[
+  "workflowRunRepo"
+] {
+  return {
+    findAllGlobalSince(_since: Date) {
+      return Promise.resolve(
+        runs.map((r) => ({
+          run: {
+            id: r.id,
+            workflowName: r.workflowName,
+            status: r.status,
+            instanceId: r.instanceId,
+            interrupt(_reason: string) {
+              r.interrupted = true;
+              r.status = "failed";
+            },
+          } as unknown as import("../domain/workflows/workflow_run.ts").WorkflowRun,
+          workflowId:
+            `wf-${r.id}` as unknown as import("../domain/workflows/workflow_id.ts").WorkflowId,
+        })),
+      );
+    },
+    save(_wid, _run) {
+      const run = _run as unknown as { id: string };
+      const match = runs.find((r) => r.id === run.id);
+      if (match) match.saved = true;
+      return Promise.resolve();
+    },
+  };
+}
+
+Deno.test("reconcileRemoteInterruptedRuns: no heartbeats returns 0", async () => {
+  const store = createMockControlPlaneStore();
+  const repo = createMockWorkflowRunRepo([]);
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: repo,
+  });
+
+  assertEquals(count, 0);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: fresh heartbeat is skipped", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/other", makeHeartbeat("other", false));
+
+  const runs: MockRun[] = [{
+    id: "r1",
+    workflowName: "wf1",
+    status: "running",
+    instanceId: "other",
+    interrupted: false,
+    saved: false,
+  }];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 0);
+  assertEquals(runs[0].interrupted, false);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: stale heartbeat interrupts matching runs", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/dead", makeHeartbeat("dead", true));
+
+  const runs: MockRun[] = [{
+    id: "r1",
+    workflowName: "wf1",
+    status: "running",
+    instanceId: "dead",
+    interrupted: false,
+    saved: false,
+  }];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 1);
+  assertEquals(runs[0].interrupted, true);
+  assertEquals(runs[0].saved, true);
+  assertEquals(store.data.has("heartbeats/dead"), false);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: skips own heartbeat", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/my-instance", makeHeartbeat("my-instance", true));
+
+  const runs: MockRun[] = [{
+    id: "r1",
+    workflowName: "wf1",
+    status: "running",
+    instanceId: "my-instance",
+    interrupted: false,
+    saved: false,
+  }];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 0);
+  assertEquals(runs[0].interrupted, false);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: skips runs without instanceId", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/dead", makeHeartbeat("dead", true));
+
+  const runs: MockRun[] = [{
+    id: "r1",
+    workflowName: "wf1",
+    status: "running",
+    instanceId: undefined,
+    interrupted: false,
+    saved: false,
+  }];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 0);
+  assertEquals(runs[0].interrupted, false);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: skips non-running runs", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/dead", makeHeartbeat("dead", true));
+
+  const runs: MockRun[] = [{
+    id: "r1",
+    workflowName: "wf1",
+    status: "succeeded",
+    instanceId: "dead",
+    interrupted: false,
+    saved: false,
+  }];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 0);
+});
+
+Deno.test("reconcileRemoteInterruptedRuns: multiple stale instances", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set("heartbeats/dead-a", makeHeartbeat("dead-a", true));
+  store.data.set("heartbeats/dead-b", makeHeartbeat("dead-b", true));
+
+  const runs: MockRun[] = [
+    {
+      id: "r1",
+      workflowName: "wf1",
+      status: "running",
+      instanceId: "dead-a",
+      interrupted: false,
+      saved: false,
+    },
+    {
+      id: "r2",
+      workflowName: "wf2",
+      status: "running",
+      instanceId: "dead-b",
+      interrupted: false,
+      saved: false,
+    },
+  ];
+
+  const count = await reconcileRemoteInterruptedRuns({
+    controlPlaneStore: store,
+    instanceId: "my-instance",
+    workflowRunRepo: createMockWorkflowRunRepo(runs),
+  });
+
+  assertEquals(count, 2);
+  assertEquals(runs[0].interrupted, true);
+  assertEquals(runs[1].interrupted, true);
+  assertEquals(store.data.has("heartbeats/dead-a"), false);
+  assertEquals(store.data.has("heartbeats/dead-b"), false);
+});
+
+// ── replayPendingRuns remote merge tests ────────────────────────────
+
+Deno.test("replayPendingRuns: merges remote entries when local is empty", async () => {
+  const store = createMockControlPlaneStore();
+  const entry: PendingRunEntry = {
+    id: "remote-1",
+    source: "webhook",
+    workflowIdOrName: "deploy",
+    payload: '{"body":{},"headers":{},"route":"/hooks/test"}',
+    route: "/hooks/test",
+    createdAt: new Date().toISOString(),
+  };
+  store.data.set(
+    "pending-runs/remote-1",
+    new TextEncoder().encode(JSON.stringify(entry)),
+  );
+
+  const h = createReplayHarness([]);
+  (h.deps as ReplayPendingRunsDeps).controlPlaneStore = store;
+
+  const count = await replayPendingRuns(h.deps);
+  assertEquals(count, 1);
+  assertEquals(h.webhookReplays.length, 1);
+  assertEquals(h.webhookReplays[0].workflowIdOrName, "deploy");
+});
+
+Deno.test("replayPendingRuns: deduplicates remote entries against local", async () => {
+  const store = createMockControlPlaneStore();
+  const entry: PendingRunEntry = {
+    id: "dup-1",
+    source: "webhook",
+    workflowIdOrName: "deploy",
+    payload: '{"body":{},"headers":{},"route":"/hooks/test"}',
+    route: "/hooks/test",
+    createdAt: new Date().toISOString(),
+  };
+  store.data.set(
+    "pending-runs/dup-1",
+    new TextEncoder().encode(JSON.stringify(entry)),
+  );
+
+  const h = createReplayHarness([entry]);
+  (h.deps as ReplayPendingRunsDeps).controlPlaneStore = store;
+
+  const count = await replayPendingRuns(h.deps);
+  assertEquals(count, 1);
+});
+
+Deno.test("replayPendingRuns: discards invalid remote entries", async () => {
+  const store = createMockControlPlaneStore();
+  store.data.set(
+    "pending-runs/bad-1",
+    new TextEncoder().encode('{"id":"bad-1"}'),
+  );
+
+  const h = createReplayHarness([]);
+  (h.deps as ReplayPendingRunsDeps).controlPlaneStore = store;
+
+  const count = await replayPendingRuns(h.deps);
+  assertEquals(count, 0);
 });

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -402,12 +402,12 @@ function createReplayHarness(
   };
 }
 
-Deno.test("replayPendingRuns: returns 0 with no pending runs", () => {
+Deno.test("replayPendingRuns: returns 0 with no pending runs", async () => {
   const h = createReplayHarness([]);
-  assertEquals(replayPendingRuns(h.deps), 0);
+  assertEquals(await replayPendingRuns(h.deps), 0);
 });
 
-Deno.test("replayPendingRuns: replays webhook run to webhook service", () => {
+Deno.test("replayPendingRuns: replays webhook run to webhook service", async () => {
   const h = createReplayHarness([{
     id: "pr-1",
     source: "webhook",
@@ -421,7 +421,7 @@ Deno.test("replayPendingRuns: replays webhook run to webhook service", () => {
     createdAt: "2026-01-01T00:00:00Z",
   }]);
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 1);
   assertEquals(h.webhookReplays.length, 1);
@@ -429,7 +429,7 @@ Deno.test("replayPendingRuns: replays webhook run to webhook service", () => {
   assertEquals(h.webhookReplays[0].pendingRunId, "pr-1");
 });
 
-Deno.test("replayPendingRuns: replays cron run to scheduled execution", () => {
+Deno.test("replayPendingRuns: replays cron run to scheduled execution", async () => {
   const h = createReplayHarness([{
     id: "pr-2",
     source: "cron",
@@ -437,7 +437,7 @@ Deno.test("replayPendingRuns: replays cron run to scheduled execution", () => {
     createdAt: "2026-01-01T00:00:00Z",
   }]);
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 1);
   assertEquals(h.cronReplays.length, 1);
@@ -445,7 +445,7 @@ Deno.test("replayPendingRuns: replays cron run to scheduled execution", () => {
   assertEquals(h.cronReplays[0].pendingRunId, "pr-2");
 });
 
-Deno.test("replayPendingRuns: discards webhook run with corrupt payload", () => {
+Deno.test("replayPendingRuns: discards webhook run with corrupt payload", async () => {
   const h = createReplayHarness([{
     id: "pr-bad",
     source: "webhook",
@@ -455,14 +455,14 @@ Deno.test("replayPendingRuns: discards webhook run with corrupt payload", () => 
     createdAt: "2026-01-01T00:00:00Z",
   }]);
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 0);
   assertEquals(h.webhookReplays.length, 0);
   assertEquals(h.deleted, ["pr-bad"]);
 });
 
-Deno.test("replayPendingRuns: discards run when no matching service", () => {
+Deno.test("replayPendingRuns: discards run when no matching service", async () => {
   const h = createReplayHarness(
     [{
       id: "pr-orphan",
@@ -473,13 +473,13 @@ Deno.test("replayPendingRuns: discards run when no matching service", () => {
     { hasWebhook: false },
   );
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 0);
   assertEquals(h.deleted, ["pr-orphan"]);
 });
 
-Deno.test("replayPendingRuns: replays mixed webhook and cron runs", () => {
+Deno.test("replayPendingRuns: replays mixed webhook and cron runs", async () => {
   const h = createReplayHarness([
     {
       id: "pr-1",
@@ -497,14 +497,14 @@ Deno.test("replayPendingRuns: replays mixed webhook and cron runs", () => {
     },
   ]);
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 2);
   assertEquals(h.webhookReplays.length, 1);
   assertEquals(h.cronReplays.length, 1);
 });
 
-Deno.test("replayPendingRuns: webhook with no payload uses empty object", () => {
+Deno.test("replayPendingRuns: webhook with no payload uses empty object", async () => {
   const h = createReplayHarness([{
     id: "pr-empty",
     source: "webhook",
@@ -513,7 +513,7 @@ Deno.test("replayPendingRuns: webhook with no payload uses empty object", () => 
     createdAt: "2026-01-01T00:00:00Z",
   }]);
 
-  const count = replayPendingRuns(h.deps);
+  const count = await replayPendingRuns(h.deps);
 
   assertEquals(count, 1);
   assertEquals(h.webhookReplays.length, 1);

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -97,6 +97,7 @@ export interface ConnectionContext {
   runTracker?: RunTrackerRepository;
   dispatchService?: import("../dispatch_service.ts").DispatchService;
   defaultVault?: string;
+  instanceId?: string;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -139,6 +139,7 @@ export async function handleWorkflowRun(
           skipCheckLabels: payload.skipCheckLabels,
           traceparent: payload.traceparent,
           tracestate: payload.tracestate,
+          instanceId: ctx.instanceId,
         },
         controller.signal,
         (event) => {
@@ -204,6 +205,7 @@ export async function handleWorkflowRun(
           skipCheckLabels: payload.skipCheckLabels,
           traceparent: payload.traceparent,
           tracestate: payload.tracestate,
+          instanceId: ctx.instanceId,
         },
         runController.signal,
         (event) => {

--- a/src/serve/instance_heartbeat.ts
+++ b/src/serve/instance_heartbeat.ts
@@ -104,6 +104,7 @@ export class InstanceHeartbeatService {
     ttlMs = DEFAULT_STALE_TTL_MS,
   ): boolean {
     const heartbeatTime = new Date(record.heartbeatAt).getTime();
+    if (isNaN(heartbeatTime)) return true;
     return Date.now() - heartbeatTime > ttlMs;
   }
 

--- a/src/serve/instance_heartbeat.ts
+++ b/src/serve/instance_heartbeat.ts
@@ -1,0 +1,127 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "heartbeat"]);
+
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const DEFAULT_STALE_TTL_MS = 90_000;
+
+export interface HeartbeatRecord {
+  instanceId: string;
+  hostname: string;
+  pid: number;
+  startedAt: string;
+  heartbeatAt: string;
+}
+
+export class InstanceHeartbeatService {
+  readonly #store: ControlPlaneStore;
+  readonly #instanceId: string;
+  readonly #hostname: string;
+  readonly #pid: number;
+  readonly #startedAt: string;
+  readonly #intervalMs: number;
+  #timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    store: ControlPlaneStore,
+    instanceId: string,
+    options?: { intervalMs?: number },
+  ) {
+    this.#store = store;
+    this.#instanceId = instanceId;
+    this.#hostname = Deno.hostname();
+    this.#pid = Deno.pid;
+    this.#startedAt = new Date().toISOString();
+    this.#intervalMs = options?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  }
+
+  get instanceId(): string {
+    return this.#instanceId;
+  }
+
+  async start(): Promise<void> {
+    await this.#write();
+    this.#timer = setInterval(() => {
+      this.#write().catch((err) => {
+        logger.warn("Heartbeat write failed: {error}", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, this.#intervalMs);
+    Deno.unrefTimer(this.#timer);
+  }
+
+  async stop(): Promise<void> {
+    if (this.#timer !== null) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    try {
+      await this.#store.delete(`heartbeats/${this.#instanceId}`);
+    } catch (err) {
+      logger.warn("Heartbeat delete on shutdown failed: {error}", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async #write(): Promise<void> {
+    const record: HeartbeatRecord = {
+      instanceId: this.#instanceId,
+      hostname: this.#hostname,
+      pid: this.#pid,
+      startedAt: this.#startedAt,
+      heartbeatAt: new Date().toISOString(),
+    };
+    await this.#store.put(
+      `heartbeats/${this.#instanceId}`,
+      new TextEncoder().encode(JSON.stringify(record)),
+    );
+  }
+
+  static isStale(
+    record: HeartbeatRecord,
+    ttlMs = DEFAULT_STALE_TTL_MS,
+  ): boolean {
+    const heartbeatTime = new Date(record.heartbeatAt).getTime();
+    return Date.now() - heartbeatTime > ttlMs;
+  }
+
+  static parseRecord(data: Uint8Array): HeartbeatRecord | null {
+    try {
+      const parsed = JSON.parse(new TextDecoder().decode(data));
+      if (
+        typeof parsed.instanceId === "string" &&
+        typeof parsed.hostname === "string" &&
+        typeof parsed.pid === "number" &&
+        typeof parsed.startedAt === "string" &&
+        typeof parsed.heartbeatAt === "string"
+      ) {
+        return parsed as HeartbeatRecord;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/serve/instance_heartbeat_test.ts
+++ b/src/serve/instance_heartbeat_test.ts
@@ -1,0 +1,152 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import {
+  type HeartbeatRecord,
+  InstanceHeartbeatService,
+} from "./instance_heartbeat.ts";
+
+function createMockStore(): ControlPlaneStore & {
+  data: Map<string, Uint8Array>;
+} {
+  const data = new Map<string, Uint8Array>();
+  return {
+    data,
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)).sort(),
+      );
+    },
+  };
+}
+
+Deno.test("InstanceHeartbeatService: start writes heartbeat record", async () => {
+  const store = createMockStore();
+  const service = new InstanceHeartbeatService(store, "inst-1", {
+    intervalMs: 60_000,
+  });
+
+  await service.start();
+  try {
+    const raw = store.data.get("heartbeats/inst-1");
+    assertEquals(raw !== undefined, true);
+
+    const record = JSON.parse(new TextDecoder().decode(raw!));
+    assertEquals(record.instanceId, "inst-1");
+    assertEquals(typeof record.hostname, "string");
+    assertEquals(typeof record.pid, "number");
+    assertEquals(typeof record.startedAt, "string");
+    assertEquals(typeof record.heartbeatAt, "string");
+  } finally {
+    await service.stop();
+  }
+});
+
+Deno.test("InstanceHeartbeatService: stop deletes heartbeat record", async () => {
+  const store = createMockStore();
+  const service = new InstanceHeartbeatService(store, "inst-1", {
+    intervalMs: 60_000,
+  });
+
+  await service.start();
+  assertEquals(store.data.has("heartbeats/inst-1"), true);
+
+  await service.stop();
+  assertEquals(store.data.has("heartbeats/inst-1"), false);
+});
+
+Deno.test("InstanceHeartbeatService: instanceId getter", async () => {
+  const store = createMockStore();
+  const service = new InstanceHeartbeatService(store, "inst-42", {
+    intervalMs: 60_000,
+  });
+  assertEquals(service.instanceId, "inst-42");
+  await service.stop();
+});
+
+Deno.test("InstanceHeartbeatService.isStale: fresh record is not stale", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host",
+    pid: 1234,
+    startedAt: new Date().toISOString(),
+    heartbeatAt: new Date().toISOString(),
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record), false);
+});
+
+Deno.test("InstanceHeartbeatService.isStale: old record is stale", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host",
+    pid: 1234,
+    startedAt: new Date(Date.now() - 120_000).toISOString(),
+    heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record), true);
+});
+
+Deno.test("InstanceHeartbeatService.isStale: custom TTL", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host",
+    pid: 1234,
+    startedAt: new Date(Date.now() - 5_000).toISOString(),
+    heartbeatAt: new Date(Date.now() - 5_000).toISOString(),
+  };
+  assertEquals(InstanceHeartbeatService.isStale(record, 3_000), true);
+  assertEquals(InstanceHeartbeatService.isStale(record, 10_000), false);
+});
+
+Deno.test("InstanceHeartbeatService.parseRecord: valid record", () => {
+  const record: HeartbeatRecord = {
+    instanceId: "inst-1",
+    hostname: "host",
+    pid: 1234,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    heartbeatAt: "2026-01-01T00:00:30.000Z",
+  };
+  const data = new TextEncoder().encode(JSON.stringify(record));
+  const parsed = InstanceHeartbeatService.parseRecord(data);
+  assertEquals(parsed?.instanceId, "inst-1");
+  assertEquals(parsed?.pid, 1234);
+});
+
+Deno.test("InstanceHeartbeatService.parseRecord: invalid JSON returns null", () => {
+  const data = new TextEncoder().encode("not json");
+  assertEquals(InstanceHeartbeatService.parseRecord(data), null);
+});
+
+Deno.test("InstanceHeartbeatService.parseRecord: missing fields returns null", () => {
+  const data = new TextEncoder().encode('{"instanceId":"x"}');
+  assertEquals(InstanceHeartbeatService.parseRecord(data), null);
+});

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -291,6 +291,7 @@ export interface WebhookServiceDeps {
     import("../infrastructure/persistence/run_tracker_store.ts").RunTrackerStore;
   controlPlaneStore?:
     import("../domain/datastore/control_plane_store.ts").ControlPlaneStore;
+  instanceId?: string;
 }
 
 /**
@@ -581,7 +582,13 @@ export class WebhookService {
         this.deps.repoDir,
         this.deps.repoContext,
         this.deps.datastoreConfig,
-        { workflowIdOrName, webhook: payload, traceparent, tracestate },
+        {
+          workflowIdOrName,
+          webhook: payload,
+          traceparent,
+          tracestate,
+          instanceId: this.deps.instanceId,
+        },
         controller.signal,
         (event) => {
           if (event.kind === "started") {

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -447,7 +447,11 @@ export class WebhookService {
         this.deps.controlPlaneStore.put(
           `pending-runs/${pendingRunId}`,
           new TextEncoder().encode(JSON.stringify(pendingEntry)),
-        ).catch(() => {});
+        ).catch((err: unknown) => {
+          logger.warn("Control-plane store write failed: {error}", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
       }
     }
 
@@ -538,7 +542,11 @@ export class WebhookService {
           if (this.deps.controlPlaneStore) {
             this.deps.controlPlaneStore.delete(
               `pending-runs/${pendingRunId}`,
-            ).catch(() => {});
+            ).catch((err: unknown) => {
+              logger.warn("Control-plane store write failed: {error}", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
           }
         }
         await this.executeWorkflow(

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -289,6 +289,8 @@ export interface WebhookServiceDeps {
   syncService?: DatastoreSyncService;
   runTracker?:
     import("../infrastructure/persistence/run_tracker_store.ts").RunTrackerStore;
+  controlPlaneStore?:
+    import("../domain/datastore/control_plane_store.ts").ControlPlaneStore;
 }
 
 /**
@@ -430,16 +432,23 @@ export class WebhookService {
     let pendingRunId: string | undefined;
     if (this.deps.runTracker) {
       pendingRunId = crypto.randomUUID();
-      this.deps.runTracker.enqueuePendingRun({
+      const pendingEntry = {
         id: pendingRunId,
-        source: "webhook",
+        source: "webhook" as const,
         workflowIdOrName: endpoint.workflowIdOrName,
         payload: JSON.stringify(webhookPayload),
         route: endpoint.route,
         traceparent,
         tracestate,
         createdAt: new Date().toISOString(),
-      });
+      };
+      this.deps.runTracker.enqueuePendingRun(pendingEntry);
+      if (this.deps.controlPlaneStore) {
+        this.deps.controlPlaneStore.put(
+          `pending-runs/${pendingRunId}`,
+          new TextEncoder().encode(JSON.stringify(pendingEntry)),
+        ).catch(() => {});
+      }
     }
 
     this.runQueue.push({
@@ -526,6 +535,11 @@ export class WebhookService {
         } = this.runQueue.shift()!;
         if (pendingRunId && this.deps.runTracker) {
           this.deps.runTracker.deletePendingRun(pendingRunId);
+          if (this.deps.controlPlaneStore) {
+            this.deps.controlPlaneStore.delete(
+              `pending-runs/${pendingRunId}`,
+            ).catch(() => {});
+          }
         }
         await this.executeWorkflow(
           workflowIdOrName,


### PR DESCRIPTION
## Summary

Phase 3 of the HA serve work (#1448). With `--detach-runs` and a remote datastore that supports the control-plane store capability (`@swamp/s3-datastore` ≥ latest), swamp serve can now run as a disposable instance — AWS ASG of 1, Kubernetes pod — where the instance can die and be replaced without losing work.

Builds on run decoupling (#2005), safe restarts (#2012), and the control-plane store interface (#2017).

## What this enables

**Before:** Same-machine restarts are durable (Phase 2), but if the machine itself dies (spot termination, OOM kill, node failure), pending webhooks and run state tracking are lost with the local SQLite.

**After:** The replacement instance boots fresh, reads heartbeats and pending runs from S3 via the control-plane store, detects that its predecessor is dead, marks interrupted runs as failed with `interrupt_reason: server_crash`, replays any pending webhook/cron work from S3, and starts serving. No operator involvement.

**Scope:** Same-machine restart durability (Phase 2) + cross-machine durability (Phase 3). Single instance only — multi-instance active-active is a later phase.

## How it works

### Instance identity

Every serve process generates a UUID on startup. This `instanceId` is:
- Written to the heartbeat record in the control-plane store (S3)
- Stored on every `WorkflowRun` it creates (new optional `instanceId` field)
- Stored on every `ActiveRun` in the run tracker (new `instance_id` column, schema v3)

The UUID is in-memory only — the instance is disposable, its identity lives in the remote heartbeat and on the runs it created.

### Instance heartbeat

`InstanceHeartbeatService` writes a periodic record to the control-plane store:

- Key: `heartbeats/{instanceId}`
- Value: `{ instanceId, hostname, pid, startedAt, heartbeatAt }`
- Interval: 30 seconds
- Stale TTL: 90 seconds

On graceful shutdown (SIGTERM), the heartbeat is deleted. On crash (SIGKILL, OOM), the record stays and goes stale — the replacement instance detects it.

### Cross-machine boot reconciliation

On startup with `--detach-runs` and a control-plane store:

1. List all heartbeat keys from the control-plane store
2. Identify stale instances (heartbeatAt older than 90s, excluding self)
3. Find WorkflowRun YAML files with matching `instanceId` and `status: running`
4. Call `interrupt("server_crash")` on each — marks run as `failed` with `interrupt_reason` tag, resets running steps
5. Delete stale heartbeat keys
6. Fall back to PID-based liveness for runs without `instanceId` (backward compat)

### Durable pending runs in remote

Webhook and cron intake now dual-write pending runs:
- SQLite (synchronous, fast) — same-machine restarts
- Control-plane store (async, remote) — machine death

On boot, `replayPendingRuns` merges entries from both sources. On a fresh machine (empty local SQLite), only remote entries are replayed. Remote entries are cleaned up after successful replay.

### Filesystem fallback

When the datastore doesn't support the control-plane capability, a built-in `FileSystemControlPlaneStore` provides the same interface writing to `{datastorePath}/_control/`. This preserves Phase 2 behavior (same-machine durability) without requiring the S3 extension.

## Configuration states

| Datastore | Control-plane | What survives |
|-----------|--------------|---------------|
| Filesystem | n/a | Disconnection + same-machine restart |
| Remote (S3) | no (old extension) | Same as filesystem |
| Remote (S3) | yes | Disconnection + restart + instance replacement |

## What does NOT change

- **Without `--detach-runs`**: zero behavior change
- **Filesystem datastores**: unchanged — filesystem fallback provides same Phase 2 behavior
- **Extension contract**: uses the `controlPlane` capability and `controlPlaneStore()` method added in #2017 — no new contract changes
- **Existing runs without `instanceId`**: fall back to PID-based reconciliation
- **The sync pipeline**: completely untouched

## Files changed

| File | Change |
|------|--------|
| `src/serve/instance_heartbeat.ts` | NEW — heartbeat write/delete lifecycle, stale detection |
| `src/serve/instance_heartbeat_test.ts` | NEW — 9 tests |
| `src/domain/workflows/workflow_run.ts` | `instanceId` field on schema + start() |
| `src/domain/models/active_run.ts` | `instanceId` field on ActiveRunData + factory methods |
| `src/infrastructure/persistence/run_tracker_store.ts` | Schema v3 migration, `instance_id` column |
| `src/serve/boot_reconciliation.ts` | `reconcileRemoteInterruptedRuns()`, remote pending run merge in `replayPendingRuns()` |
| `src/serve/webhook.ts` | Dual-write pending runs to control-plane store |
| `src/cli/commands/serve.ts` | Instance UUID, control-plane store probe, heartbeat start/stop, remote reconciliation, dual-write hook |

## Test plan

### Unit tests (319 passing)

- `InstanceHeartbeatService` — 9 tests: write, delete, stale detection, parse, invalid data
- All existing tests — zero regressions

### Binary verification (23 scenarios across 3 suites)

All against the compiled `swamp` binary with real swamp commands:

- **Suite 1** (6 tests): Normal serve without `--detach-runs` — zero regressions
- **Suite 2** (11 tests): Phase 1 detached runs — zero regressions
- **Suite 3** (6 tests): Phase 2 safe restarts — zero regressions

### MinIO end-to-end verification

Against a real MinIO S3-compatible backend:

1. **Heartbeat lifecycle** — written to `_control/heartbeats/{id}` in S3 on startup, deleted on SIGTERM
2. **Crash + stale heartbeat + reconciliation** — SIGKILL serve, wait 95s, restart, verify run marked `status: failed` with `interrupt_reason: server_crash`
3. **instanceId persisted** — verified in WorkflowRun YAML on disk
4. **Filesystem fallback** — heartbeat written to `{repoDir}/.swamp/_control/`, deleted on shutdown
5. **Pending run replay from S3** — pending run written directly to S3, serve started on fresh machine (local SQLite deleted), workflow replayed and completed successfully, S3 entry cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)