### PR TITLE
fix(auth): resolve SWAMP_SERVE_URL in server-login command

### DIFF
--- a/src/cli/commands/auth_server_login.ts
+++ b/src/cli/commands/auth_server_login.ts
@@ -20,6 +20,7 @@
 import { Command } from "@cliffy/command";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { resolveServeUrl } from "../remote_run.ts";
 import { FileServerCredentialRepository } from "../../infrastructure/persistence/server_credential_repository.ts";
 import { normalizeServerUrl } from "../../domain/auth/server_url.ts";
 import { splitServerToken } from "../../serve/token_auth.ts";
@@ -46,8 +47,7 @@ export const authServerLoginCommand = new Command()
   )
   .option(
     "--server <url:string>",
-    "Server URL to associate the token with",
-    { required: true },
+    "Server URL to authenticate with (env: SWAMP_SERVE_URL)",
   )
   .option(
     "--token <token:string>",
@@ -59,21 +59,26 @@ export const authServerLoginCommand = new Command()
       "server-login",
     ]);
 
+    const server = resolveServeUrl(options.server as string | undefined);
+    if (!server) {
+      throw new UserError(
+        "--server is required (or set SWAMP_SERVE_URL)",
+      );
+    }
+
     const token = options.token as string | undefined;
 
     if (token) {
-      // Static token flow (unchanged)
-      await handleStaticToken(options, cliCtx, token);
+      await handleStaticToken(server, cliCtx, token);
     } else {
-      // OAuth device flow
-      await handleOAuthFlow(options, cliCtx);
+      await handleOAuthFlow(server, cliCtx);
     }
 
     cliCtx.logger.debug("Server login command completed");
   });
 
 async function handleStaticToken(
-  options: AnyOptions,
+  rawUrl: string,
   cliCtx: { outputMode: string },
   token: string,
 ): Promise<void> {
@@ -84,7 +89,6 @@ async function handleStaticToken(
     );
   }
 
-  let rawUrl = options.server as string;
   try {
     const parsed = new URL(rawUrl);
     if (parsed.protocol === "ws:") parsed.protocol = "http:";
@@ -92,7 +96,7 @@ async function handleStaticToken(
     rawUrl = parsed.href;
   } catch {
     throw new UserError(
-      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+      `Invalid --server URL "${rawUrl}": expected ws://, wss://, http://, or https:// URL`,
     );
   }
   let serverUrl: string;
@@ -100,7 +104,7 @@ async function handleStaticToken(
     serverUrl = normalizeServerUrl(rawUrl);
   } catch {
     throw new UserError(
-      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+      `Invalid --server URL "${rawUrl}": expected ws://, wss://, http://, or https:// URL`,
     );
   }
 
@@ -127,10 +131,9 @@ async function handleStaticToken(
 }
 
 async function handleOAuthFlow(
-  options: AnyOptions,
+  rawUrl: string,
   cliCtx: { outputMode: string },
 ): Promise<void> {
-  let rawUrl = options.server as string;
   try {
     const parsed = new URL(rawUrl);
     if (parsed.protocol === "ws:") parsed.protocol = "http:";
@@ -138,7 +141,7 @@ async function handleOAuthFlow(
     rawUrl = parsed.href;
   } catch {
     throw new UserError(
-      `Invalid --server URL "${options.server}": expected ws://, wss://, http://, or https:// URL`,
+      `Invalid --server URL "${rawUrl}": expected ws://, wss://, http://, or https:// URL`,
     );
   }
   const normalizedUrl = normalizeServerUrl(rawUrl);

--- a/src/cli/commands/auth_server_login_test.ts
+++ b/src/cli/commands/auth_server_login_test.ts
@@ -1,0 +1,43 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+// Import models barrel to trigger self-registration
+import "../../domain/models/models.ts";
+
+// Initialize logging for tests
+await initializeLogging({});
+
+Deno.test("authServerLoginCommand: --server option is not required", async () => {
+  const { authServerLoginCommand } = await import("./auth_server_login.ts");
+  const options = authServerLoginCommand.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+  assertEquals(!!serverOpt!.required, false);
+});
+
+Deno.test("authServerLoginCommand: --server description mentions SWAMP_SERVE_URL", async () => {
+  const { authServerLoginCommand } = await import("./auth_server_login.ts");
+  const options = authServerLoginCommand.getOptions();
+  const serverOpt = options.find((o) => o.name === "server");
+  assertEquals(serverOpt !== undefined, true);
+  assertStringIncludes(serverOpt!.description, "SWAMP_SERVE_URL");
+});


### PR DESCRIPTION
## Summary

Fixes swamp-club#1486.

- Drop `required: true` from the `--server` option on `swamp auth server-login`
- Resolve the server URL through `resolveServeUrl()` (which falls back to `SWAMP_SERVE_URL`), matching every other remote-capable command
- Raise a `UserError` with `--server is required (or set SWAMP_SERVE_URL)` when neither source provides a URL
- Update the `--server` option description to mention the env var

## Test Plan

- Added unit tests verifying `--server` is not required and the description mentions `SWAMP_SERVE_URL`
- Manually verified with compiled binary:
  - No `--server` + no env var → `--server is required (or set SWAMP_SERVE_URL)`
  - `SWAMP_SERVE_URL=wss://host` without `--server` → command picks up env var and proceeds to OAuth flow