### PR TITLE
feat(datastore): add putIfAbsent CAS primitive to ControlPlaneStore

### DIFF
--- a/src/domain/datastore/control_plane_store.ts
+++ b/src/domain/datastore/control_plane_store.ts
@@ -29,6 +29,7 @@
  */
 export interface ControlPlaneStore {
   put(key: string, data: Uint8Array): Promise<void>;
+  putIfAbsent(key: string, data: Uint8Array): Promise<boolean>;
   get(key: string): Promise<Uint8Array | null>;
   delete(key: string): Promise<void>;
   list(prefix: string): Promise<string[]>;

--- a/src/domain/datastore/control_plane_store.ts
+++ b/src/domain/datastore/control_plane_store.ts
@@ -29,7 +29,7 @@
  */
 export interface ControlPlaneStore {
   put(key: string, data: Uint8Array): Promise<void>;
-  putIfAbsent(key: string, data: Uint8Array): Promise<boolean>;
+  putIfAbsent?(key: string, data: Uint8Array): Promise<boolean>;
   get(key: string): Promise<Uint8Array | null>;
   delete(key: string): Promise<void>;
   list(prefix: string): Promise<string[]>;

--- a/src/infrastructure/persistence/fs_control_plane_store.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store.ts
@@ -52,9 +52,14 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
         while (written < data.length) {
           written += await file.write(data.subarray(written));
         }
-      } finally {
+      } catch (writeError) {
         file.close();
+        try {
+          await Deno.remove(path);
+        } catch { /* best-effort cleanup */ }
+        throw writeError;
       }
+      file.close();
       return true;
     } catch (error) {
       if (error instanceof Deno.errors.AlreadyExists) {

--- a/src/infrastructure/persistence/fs_control_plane_store.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store.ts
@@ -42,6 +42,28 @@ export class FileSystemControlPlaneStore implements ControlPlaneStore {
     await atomicWriteFile(path, data);
   }
 
+  async putIfAbsent(key: string, data: Uint8Array): Promise<boolean> {
+    const path = this.#keyToPath(key);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    try {
+      const file = await Deno.open(path, { createNew: true, write: true });
+      try {
+        let written = 0;
+        while (written < data.length) {
+          written += await file.write(data.subarray(written));
+        }
+      } finally {
+        file.close();
+      }
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.AlreadyExists) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   async get(key: string): Promise<Uint8Array | null> {
     try {
       return await Deno.readFile(this.#keyToPath(key));

--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -255,6 +255,14 @@ Deno.test("FileSystemControlPlaneStore: two rapid putIfAbsent calls — one wins
       1,
       "exactly one call should fail",
     );
+
+    const stored = decoder.decode((await store.get("locks/race"))!);
+    const validPayloads = ["instance-a", "instance-b"];
+    assertEquals(
+      validPayloads.includes(stored),
+      true,
+      `stored data should match the winner's payload, got: ${stored}`,
+    );
   });
 });
 

--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -190,6 +190,74 @@ Deno.test("FileSystemControlPlaneStore: list with empty prefix returns all keys"
   });
 });
 
+Deno.test("FileSystemControlPlaneStore: putIfAbsent on new key returns true", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+    const data = encoder.encode("claimed");
+
+    const result = await store.putIfAbsent("locks/job-1", data);
+
+    assertEquals(result, true);
+    assertEquals(decoder.decode((await store.get("locks/job-1"))!), "claimed");
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: putIfAbsent on existing key returns false and preserves data", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("locks/job-1", encoder.encode("first"));
+    const result = await store.putIfAbsent(
+      "locks/job-1",
+      encoder.encode("second"),
+    );
+
+    assertEquals(result, false);
+    assertEquals(decoder.decode((await store.get("locks/job-1"))!), "first");
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: putIfAbsent after delete returns true", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    await store.put("locks/job-1", encoder.encode("original"));
+    await store.delete("locks/job-1");
+    const result = await store.putIfAbsent(
+      "locks/job-1",
+      encoder.encode("reclaimed"),
+    );
+
+    assertEquals(result, true);
+    assertEquals(
+      decoder.decode((await store.get("locks/job-1"))!),
+      "reclaimed",
+    );
+  });
+});
+
+Deno.test("FileSystemControlPlaneStore: two rapid putIfAbsent calls — one wins", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FileSystemControlPlaneStore(dir);
+
+    const [a, b] = await Promise.all([
+      store.putIfAbsent("locks/race", encoder.encode("instance-a")),
+      store.putIfAbsent("locks/race", encoder.encode("instance-b")),
+    ]);
+
+    assertEquals(
+      [a, b].filter(Boolean).length,
+      1,
+      "exactly one call should succeed",
+    );
+    assertEquals(
+      [a, b].filter((x) => !x).length,
+      1,
+      "exactly one call should fail",
+    );
+  });
+});
+
 Deno.test("FileSystemControlPlaneStore: rejects path traversal via ..", async () => {
   await withTempDir(async (dir) => {
     const store = new FileSystemControlPlaneStore(dir);


### PR DESCRIPTION
## Summary

- Add `putIfAbsent(key, data) → boolean` to the `ControlPlaneStore` interface — an atomic compare-and-set primitive that writes only if the key doesn't already exist
- Implement on `FileSystemControlPlaneStore` using `Deno.open({ createNew: true })`, which is atomic on all operating systems
- Uses a writeAll loop to guarantee correctness for payloads larger than a single write syscall

**Why:** Active-active HA requires this for cron fire dedup and per-item work claims — two instances racing to claim the same work need a primitive that guarantees exactly one wins.

Part of #1448

## Test Plan

- `putIfAbsent` on a new key returns `true` and data is readable via `get`
- `putIfAbsent` on an existing key returns `false` and does NOT overwrite existing data
- `putIfAbsent` after `delete` returns `true` (key can be reclaimed)
- Two concurrent `putIfAbsent` calls on the same key — exactly one returns `true`
- All 19 tests pass (15 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)