### PR TITLE
test(datastore): add path-traversal test for putIfAbsent

### DIFF
--- a/src/infrastructure/persistence/fs_control_plane_store_test.ts
+++ b/src/infrastructure/persistence/fs_control_plane_store_test.ts
@@ -275,6 +275,10 @@ Deno.test("FileSystemControlPlaneStore: rejects path traversal via ..", async ()
       PathTraversalError,
     );
     await assertRejects(
+      () => store.putIfAbsent!("../../etc/passwd", encoder.encode("bad")),
+      PathTraversalError,
+    );
+    await assertRejects(
       () => store.get("../secret"),
       PathTraversalError,
     );


### PR DESCRIPTION
## Summary

- Add `putIfAbsent` to the existing path-traversal rejection test for parity with `put`, `get`, `delete`, and `list`

Flagged during adversarial review of #2033 — `putIfAbsent` routes through the same `#keyToPath` → `assertContainedPath` guard, but wasn't covered.

Part of #1448

## Test Plan

- `deno run test src/infrastructure/persistence/fs_control_plane_store_test.ts` — 19/19 pass
- Path-traversal test now asserts `putIfAbsent("../../etc/passwd", ...)` throws `PathTraversalError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)