### PR TITLE
feat(runs): track who initiated model and workflow runs

### DIFF
--- a/src/cli/auth_context.ts
+++ b/src/cli/auth_context.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { UserError } from "../domain/errors.ts";
+import { AuthRepository } from "../infrastructure/persistence/auth_repository.ts";
 
 const COLLECTIVE_TOKEN_PREFIX = "swamp_org_";
 
@@ -131,4 +132,11 @@ export function requireScope(scope: string): void {
       `includes the ${scope} scope and set SWAMP_API_KEY.\n`,
     "missing_scope",
   );
+}
+
+export async function resolveCliInitiatedBy(): Promise<string> {
+  if (!state().authenticated || state().collectiveToken) return "ghost";
+  const creds = await new AuthRepository().load();
+  if (creds?.username) return `user:${creds.username}`;
+  return "ghost";
 }

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -79,7 +79,7 @@ import {
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { suppressSyncExitOnSignal } from "../../infrastructure/persistence/datastore_sync_coordinator.ts";
 import { parseTimeout } from "../duration_parser.ts";
-import { isAuthenticated } from "../auth_context.ts";
+import { isAuthenticated, resolveCliInitiatedBy } from "../auth_context.ts";
 import {
   DEFAULT_STALE_TTL_MS,
   RunTrackerStore,
@@ -423,6 +423,8 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
           flushModelLocks = lockResult.flush;
         }
 
+        const initiatedBy = await resolveCliInitiatedBy();
+
         // Build the list of input sets to iterate over
         const inputSets: Record<string, unknown>[] = stdinItems
           ? stdinItems.map((item) =>
@@ -475,6 +477,7 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
                 tracestate: resolveTracestate(
                   options.tracestate as string | undefined,
                 ),
+                initiatedBy,
               }),
               renderer.handlers(),
             );

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -70,6 +70,7 @@ function responseToActiveRuns(response: RunHistoryResponse): ActiveRun[] {
       startedAt: r.startedAt,
       heartbeatAt: r.heartbeatAt,
       status: r.status as ActiveRunStatus,
+      initiatedBy: r.initiatedBy,
     })
   );
 }

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -82,7 +82,7 @@ import {
 } from "../../libswamp/mod.ts";
 import { createWorkflowRunRenderer } from "../../presentation/renderers/workflow_run.ts";
 import { JUnitWorkflowRunRenderer } from "../../presentation/renderers/workflow_run_junit.ts";
-import { isAuthenticated } from "../auth_context.ts";
+import { isAuthenticated, resolveCliInitiatedBy } from "../auth_context.ts";
 import { getActiveTelemetryService } from "../telemetry_integration.ts";
 import {
   resolveServerToken,
@@ -451,6 +451,8 @@ export const workflowRunCommand = new Command()
         )
         : [cliInputs];
 
+      const initiatedBy = await resolveCliInitiatedBy();
+
       if (options.junit && inputSets.length > 1) {
         throw new UserError(
           "--junit cannot be combined with multiple input sets (--stdin with NDJSON). " +
@@ -499,6 +501,7 @@ export const workflowRunCommand = new Command()
             options.tracestate as string | undefined,
           ),
           assertFailOnSeverity: failOnSeverity,
+          initiatedBy,
         });
 
         const baseHandlers = renderer.handlers();

--- a/src/domain/models/active_run.ts
+++ b/src/domain/models/active_run.ts
@@ -42,6 +42,7 @@ export interface ActiveRunData {
   readonly startedAt: string;
   readonly heartbeatAt: string;
   readonly status: ActiveRunStatus;
+  readonly initiatedBy?: string | null;
 }
 
 export class ActiveRun {
@@ -56,6 +57,7 @@ export class ActiveRun {
   readonly pid: number;
   readonly hostname: string;
   readonly startedAt: Date;
+  readonly initiatedBy: string | null;
 
   private constructor(data: ActiveRunData) {
     this.id = data.id;
@@ -68,6 +70,7 @@ export class ActiveRun {
     this.startedAt = new Date(data.startedAt);
     this._heartbeatAt = new Date(data.heartbeatAt);
     this._status = data.status;
+    this.initiatedBy = data.initiatedBy ?? null;
   }
 
   get status(): ActiveRunStatus {
@@ -84,6 +87,7 @@ export class ActiveRun {
     methodName: string;
     pid: number;
     hostname: string;
+    initiatedBy?: string;
   }): ActiveRun {
     const now = new Date().toISOString();
     return new ActiveRun({
@@ -97,6 +101,7 @@ export class ActiveRun {
       startedAt: now,
       heartbeatAt: now,
       status: "running",
+      initiatedBy: opts.initiatedBy ?? null,
     });
   }
 
@@ -105,6 +110,7 @@ export class ActiveRun {
     workflowName: string;
     pid: number;
     hostname: string;
+    initiatedBy?: string;
   }): ActiveRun {
     const now = new Date().toISOString();
     return new ActiveRun({
@@ -118,6 +124,7 @@ export class ActiveRun {
       startedAt: now,
       heartbeatAt: now,
       status: "running",
+      initiatedBy: opts.initiatedBy ?? null,
     });
   }
 
@@ -137,6 +144,7 @@ export class ActiveRun {
       startedAt: this.startedAt.toISOString(),
       heartbeatAt: this._heartbeatAt.toISOString(),
       status: this._status,
+      initiatedBy: this.initiatedBy,
     };
   }
 

--- a/src/domain/models/active_run_test.ts
+++ b/src/domain/models/active_run_test.ts
@@ -208,3 +208,58 @@ Deno.test("ActiveRun.toData: roundtrips through fromData", () => {
   assertEquals(restored.hostname, run.hostname);
   assertEquals(restored.status, run.status);
 });
+
+Deno.test("ActiveRun.createModelMethodRun: sets initiatedBy when provided", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+    initiatedBy: "user:paul",
+  });
+
+  assertEquals(run.initiatedBy, "user:paul");
+  assertEquals(run.toData().initiatedBy, "user:paul");
+});
+
+Deno.test("ActiveRun.createModelMethodRun: initiatedBy defaults to null", () => {
+  const run = ActiveRun.createModelMethodRun({
+    id: "test-id",
+    modelType: "@test/model",
+    methodName: "start",
+    pid: 1234,
+    hostname: "test-host",
+  });
+
+  assertEquals(run.initiatedBy, null);
+});
+
+Deno.test("ActiveRun.createWorkflowRun: sets initiatedBy when provided", () => {
+  const run = ActiveRun.createWorkflowRun({
+    id: "test-id",
+    workflowName: "test-workflow",
+    pid: 1234,
+    hostname: "test-host",
+    initiatedBy: "user:paul",
+  });
+
+  assertEquals(run.initiatedBy, "user:paul");
+});
+
+Deno.test("ActiveRun.fromData: initiatedBy absent defaults to null", () => {
+  const run = ActiveRun.fromData({
+    id: "test-id",
+    runKind: "model_method",
+    modelType: "@test/model",
+    methodName: "start",
+    workflowName: null,
+    pid: 1234,
+    hostname: "test-host",
+    startedAt: new Date().toISOString(),
+    heartbeatAt: new Date().toISOString(),
+    status: "running",
+  });
+
+  assertEquals(run.initiatedBy, null);
+});

--- a/src/domain/models/model_output.ts
+++ b/src/domain/models/model_output.ts
@@ -78,6 +78,7 @@ export const ExecutionProvenanceSchema = z.object({
   stepName: z.string().optional(),
   parentOutputId: z.string().uuid().optional(),
   callerExtension: z.string().optional(),
+  initiatedBy: z.string().optional(),
 });
 
 /**

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -278,6 +278,8 @@ export interface StepExecutionContext {
   skipCheckLabels?: string[];
   /** Skip all pre-flight checks */
   skipAllChecks?: boolean;
+  /** Identity of the user who initiated this run */
+  initiatedBy?: string;
   /** Resolved base directory for data storage (S3 cache path) */
   dataBaseDir?: string;
   /** Catalog store for write-through indexing */
@@ -835,6 +837,7 @@ export class DefaultStepExecutor implements StepExecutor {
         methodName: task.methodName,
         pid: Deno.pid,
         hostname: hostname(),
+        initiatedBy: ctx.initiatedBy,
       });
       runTracker.register(activeRun);
     }
@@ -1015,6 +1018,7 @@ export class DefaultStepExecutor implements StepExecutor {
       workflowRunId: ctx.workflowRunId,
       job: ctx.jobName,
       step: ctx.stepName,
+      ...(ctx.initiatedBy ? { initiatedBy: ctx.initiatedBy } : {}),
     };
 
     // Resolve vary suffixes per output spec from current step inputs.
@@ -1470,6 +1474,8 @@ interface StepOptions {
   skipAllChecks?: boolean;
   /** Minimum assert severity that fails the run (default: all failures fail) */
   assertFailOnSeverity?: AssertSeverity;
+  /** Identity of the user who initiated this run */
+  initiatedBy?: string;
 }
 
 /**
@@ -1578,6 +1584,8 @@ export class WorkflowExecutionService {
       skipAllChecks?: boolean;
       /** Minimum assert severity that fails the run */
       assertFailOnSeverity?: AssertSeverity;
+      /** Identity of the user who initiated this run */
+      initiatedBy?: string;
     },
   ): AsyncGenerator<WorkflowExecutionEvent> {
     const tracer = getTracer();
@@ -1654,7 +1662,7 @@ export class WorkflowExecutionService {
           ...(workflow.tags ?? {}),
           ...(options?.runtimeTags ?? {}),
         };
-        run = WorkflowRun.create(workflow, mergedTags);
+        run = WorkflowRun.create(workflow, mergedTags, options?.initiatedBy);
         if (options?.inputs) {
           run.captureInputs(options.inputs);
         }
@@ -1696,6 +1704,7 @@ export class WorkflowExecutionService {
             workflowName: workflow.name,
             pid: Deno.pid,
             hostname: hostname(),
+            initiatedBy: options?.initiatedBy,
           });
           this.runTracker.register(wfActiveRun);
         }
@@ -1745,6 +1754,7 @@ export class WorkflowExecutionService {
         ancestorWorkflowIds: options?.ancestorWorkflowIds,
         workflowTags: workflow.tags,
         runtimeTags: options?.runtimeTags,
+        initiatedBy: options?.initiatedBy,
         secretRedactor,
         signal: options?.signal,
         // Default so per-step reports run even when the caller doesn't
@@ -2136,6 +2146,7 @@ export class WorkflowExecutionService {
       const stepOpts: StepOptions = {
         workflowTags: resolvedWorkflow.tags,
         runtimeTags: options?.runtimeTags,
+        initiatedBy: existingRun.initiatedBy,
         secretRedactor,
         signal: options?.signal,
         // workflow resume never receives CLI report flags — default so
@@ -2979,6 +2990,7 @@ export class WorkflowExecutionService {
           skipCheckNames: options.skipCheckNames,
           skipCheckLabels: options.skipCheckLabels,
           skipAllChecks: options.skipAllChecks,
+          initiatedBy: options.initiatedBy,
           dataBaseDir: this.dataBaseDir,
           catalogStore: this.catalogStore,
           namespace: this.namespace,

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -869,7 +869,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     if (this._resumeInputs.length > 0) {
       data.resumeInputs = [...this._resumeInputs];
     }
-    if (this._initiatedBy) {
+    if (this._initiatedBy !== undefined) {
       data.initiatedBy = this._initiatedBy;
     }
     return data;

--- a/src/domain/workflows/workflow_run.ts
+++ b/src/domain/workflows/workflow_run.ts
@@ -131,6 +131,7 @@ export const WorkflowRunSchema = z.object({
   // deliberately NOT persisted to avoid writing secrets (e.g. a freshly minted
   // auth key) to the plaintext run record.
   resumeInputs: z.array(z.string()).optional(),
+  initiatedBy: z.string().optional(),
 });
 
 /**
@@ -535,6 +536,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
     private _inputs: Record<string, unknown> = {},
     private _resumeInputs: string[] = [],
     private _pid: number | undefined = undefined,
+    private _initiatedBy: string | undefined = undefined,
   ) {}
 
   /**
@@ -543,6 +545,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
   static create(
     workflow: Workflow,
     tags?: Record<string, string>,
+    initiatedBy?: string,
   ): WorkflowRun {
     const id = crypto.randomUUID();
     const jobs = workflow.jobs.map((job) =>
@@ -563,6 +566,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
       undefined,
       tags ?? {},
       [],
+      {},
+      [],
+      undefined,
+      initiatedBy,
     );
   }
 
@@ -587,6 +594,7 @@ export class WorkflowRun implements TriggerEvaluationContext {
       validated.inputs ?? {},
       validated.resumeInputs ?? [],
       validated.pid,
+      validated.initiatedBy,
     );
   }
 
@@ -598,6 +606,10 @@ export class WorkflowRun implements TriggerEvaluationContext {
     | "failed"
     | "cancelled" {
     return this._status;
+  }
+
+  get initiatedBy(): string | undefined {
+    return this._initiatedBy;
   }
 
   get startedAt(): Date | undefined {
@@ -856,6 +868,9 @@ export class WorkflowRun implements TriggerEvaluationContext {
     }
     if (this._resumeInputs.length > 0) {
       data.resumeInputs = [...this._resumeInputs];
+    }
+    if (this._initiatedBy) {
+      data.initiatedBy = this._initiatedBy;
     }
     return data;
   }

--- a/src/domain/workflows/workflow_run_test.ts
+++ b/src/domain/workflows/workflow_run_test.ts
@@ -1134,3 +1134,41 @@ Deno.test("WorkflowRun.interrupt: converts cancelled run to failed", () => {
   assertEquals(run.status, "failed");
   assertEquals(run.tags["interrupt_reason"], "server_shutdown");
 });
+
+Deno.test("WorkflowRun.create: sets initiatedBy when provided", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf, {}, "user:paul");
+
+  assertEquals(run.initiatedBy, "user:paul");
+});
+
+Deno.test("WorkflowRun.create: initiatedBy defaults to undefined", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+
+  assertEquals(run.initiatedBy, undefined);
+});
+
+Deno.test("WorkflowRun: initiatedBy round-trips through serialization", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf, {}, "user:paul");
+  run.start();
+
+  const data = run.toData();
+  assertEquals(data.initiatedBy, "user:paul");
+
+  const restored = WorkflowRun.fromData(data);
+  assertEquals(restored.initiatedBy, "user:paul");
+});
+
+Deno.test("WorkflowRun: absent initiatedBy deserializes as undefined", () => {
+  const wf = createTestWorkflow();
+  const run = WorkflowRun.create(wf);
+  run.start();
+
+  const data = run.toData();
+  assertEquals(data.initiatedBy, undefined);
+
+  const restored = WorkflowRun.fromData(data);
+  assertEquals(restored.initiatedBy, undefined);
+});

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -39,7 +39,7 @@ const RUN_TRACKER_DB_NAME = "run_tracker.db";
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 export { STALE_TTL_MS as DEFAULT_STALE_TTL_MS } from "../../domain/models/active_run.ts";
 const RETENTION_DAYS = 7;
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 export interface PendingRunEntry {
   id: string;
@@ -76,6 +76,7 @@ interface ActiveRunRow {
   status: string;
   completed_at: string | null;
   cancel_reason: string | null;
+  initiated_by: string | null;
 }
 
 export class RunTrackerStore implements RunTrackerRepository {
@@ -174,6 +175,22 @@ export class RunTrackerStore implements RunTrackerRepository {
       `);
     }
 
+    if (currentVersion < 3) {
+      const tableExists = this.db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='active_runs'",
+      ).get();
+      if (tableExists) {
+        const columns = this.db.prepare(
+          "PRAGMA table_info(active_runs)",
+        ).all() as unknown as { name: string }[];
+        if (!columns.some((c) => c.name === "initiated_by")) {
+          this.db.exec(
+            "ALTER TABLE active_runs ADD COLUMN initiated_by TEXT",
+          );
+        }
+      }
+    }
+
     this.db.prepare(
       "INSERT OR REPLACE INTO run_tracker_meta (key, value) VALUES ('schema_version', ?)",
     ).run(String(SCHEMA_VERSION));
@@ -193,7 +210,8 @@ export class RunTrackerStore implements RunTrackerRepository {
         heartbeat_at  TEXT NOT NULL,
         status        TEXT NOT NULL DEFAULT 'running',
         completed_at  TEXT,
-        cancel_reason TEXT
+        cancel_reason TEXT,
+        initiated_by  TEXT
       );
 
       CREATE INDEX IF NOT EXISTS idx_active_runs_status
@@ -232,8 +250,8 @@ export class RunTrackerStore implements RunTrackerRepository {
     this.db.prepare(`
       INSERT INTO active_runs
         (id, run_kind, model_type, method_name, workflow_name,
-         pid, hostname, started_at, heartbeat_at, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         pid, hostname, started_at, heartbeat_at, status, initiated_by)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       data.id,
       data.runKind,
@@ -245,6 +263,7 @@ export class RunTrackerStore implements RunTrackerRepository {
       data.startedAt,
       data.heartbeatAt,
       data.status,
+      data.initiatedBy ?? null,
     );
   }
 
@@ -411,6 +430,7 @@ export class RunTrackerStore implements RunTrackerRepository {
       startedAt: row.started_at,
       heartbeatAt: row.heartbeat_at,
       status: row.status as ActiveRunStatus,
+      initiatedBy: row.initiated_by,
     };
   }
 }

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -500,3 +500,58 @@ Deno.test("RunTrackerStore: reapDeadProcessRuns skips completed runs", () => {
     store.close();
   }
 });
+
+Deno.test("RunTrackerStore: schema v3 migration adds initiated_by column", () => {
+  const dbPath = makeTempDbPath();
+  const store1 = new RunTrackerStore(dbPath);
+  store1.register(makeRun({ id: "pre-migration-run" }));
+  store1.close();
+
+  const store2 = new RunTrackerStore(dbPath);
+  try {
+    const found = store2.findById("pre-migration-run");
+    assertEquals(found?.id, "pre-migration-run");
+    assertEquals(found?.initiatedBy, null);
+  } finally {
+    store2.close();
+  }
+});
+
+Deno.test("RunTrackerStore: register stores initiatedBy", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.createModelMethodRun({
+      id: "with-user",
+      modelType: "@test/model",
+      methodName: "start",
+      pid: Deno.pid,
+      hostname: "test-host",
+      initiatedBy: "user:paul",
+    });
+    store.register(run);
+
+    const found = store.findById("with-user");
+    assertEquals(found?.initiatedBy, "user:paul");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: register stores null initiatedBy for ghost runs", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.createModelMethodRun({
+      id: "ghost-run",
+      modelType: "@test/model",
+      methodName: "start",
+      pid: Deno.pid,
+      hostname: "test-host",
+    });
+    store.register(run);
+
+    const found = store.findById("ghost-run");
+    assertEquals(found?.initiatedBy, null);
+  } finally {
+    store.close();
+  }
+});

--- a/src/libswamp/models/model_method_run_view.ts
+++ b/src/libswamp/models/model_method_run_view.ts
@@ -75,4 +75,5 @@ export interface ModelMethodRunView {
   reports?: Record<string, ReportResultView>;
   globalArguments?: Record<string, unknown>;
   methodArguments?: Record<string, unknown>;
+  initiatedBy?: string;
 }

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -247,6 +247,8 @@ export interface ModelMethodRunInput {
   traceparent?: string;
   /** W3C tracestate header for per-invocation trace context. */
   tracestate?: string;
+  /** Identity of the user who initiated this run (e.g. "user:paul"). */
+  initiatedBy?: string;
 }
 
 /**
@@ -645,6 +647,7 @@ export async function* modelMethodRun(
               definitionHash,
               modelVersion: modelDef.version,
               triggeredBy: "manual",
+              initiatedBy: input.initiatedBy,
             },
           });
           output.markRunning(Deno.pid);
@@ -660,6 +663,7 @@ export async function* modelMethodRun(
               methodName: input.methodName,
               pid: Deno.pid,
               hostname: hostname(),
+              initiatedBy: input.initiatedBy,
             });
             deps.runTracker.register(activeRun);
           }
@@ -743,6 +747,9 @@ export async function* modelMethodRun(
                       methodName: input.methodName,
                       logger: getRunLogger(definition.name, input.methodName),
                       runtimeTags: input.runtimeTags,
+                      tagOverrides: input.initiatedBy
+                        ? { initiatedBy: input.initiatedBy }
+                        : undefined,
                       dataOutputOverrides: evaluatedDefinition.resources
                         ? Object.entries(
                           evaluatedDefinition.resources,
@@ -1145,6 +1152,7 @@ export async function* modelMethodRun(
             reports: reportResults,
             globalArguments: reportGlobalArgs,
             methodArguments: reportMethodArgs,
+            initiatedBy: input.initiatedBy,
           };
           yield { kind: "completed", run: view };
 

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -315,6 +315,8 @@ export interface WorkflowRunInput {
   tracestate?: string;
   /** Minimum assert severity that fails the run. */
   assertFailOnSeverity?: AssertSeverity;
+  /** Identity of the user who initiated this run (e.g. "user:paul"). */
+  initiatedBy?: string;
 }
 
 /**
@@ -445,6 +447,7 @@ export function toRunData(
         tags: a.tags,
       }))
       : undefined,
+    initiatedBy: run.initiatedBy,
   };
 }
 
@@ -657,6 +660,7 @@ export async function* workflowRun(
               skipCheckLabels: resolvedInput.skipCheckLabels,
               skipAllChecks: resolvedInput.skipAllChecks,
               assertFailOnSeverity: resolvedInput.assertFailOnSeverity,
+              initiatedBy: resolvedInput.initiatedBy,
             })
           ) {
             if (event.kind === "report_completed") {

--- a/src/libswamp/workflows/workflow_run_view.ts
+++ b/src/libswamp/workflows/workflow_run_view.ts
@@ -109,6 +109,7 @@ export interface WorkflowRunView {
   reports?: ReportResultView[];
   /** Data artifacts produced at workflow scope (e.g. workflow-scope reports). */
   workflowDataArtifacts?: DataArtifactRefData[];
+  initiatedBy?: string;
 }
 
 export function extractFirstStepError(run: WorkflowRunView): string {

--- a/src/presentation/output/model_runs_output.ts
+++ b/src/presentation/output/model_runs_output.ts
@@ -62,7 +62,16 @@ export function writeModelRunsLog(runs: ActiveRun[]): void {
     return;
   }
 
-  const headers = ["STATUS", "KIND", "NAME", "ID", "AGE", "PID", "HOST"];
+  const headers = [
+    "STATUS",
+    "KIND",
+    "NAME",
+    "ID",
+    "AGE",
+    "INITIATED BY",
+    "PID",
+    "HOST",
+  ];
   const rows = runs.map((run) => {
     const stale = run.isStale(STALE_TTL_MS);
     const age = formatDuration(Date.now() - run.startedAt.getTime());
@@ -76,6 +85,7 @@ export function writeModelRunsLog(runs: ActiveRun[]): void {
       name,
       run.id.slice(0, 8),
       age,
+      run.initiatedBy ?? "-",
       String(run.pid),
       run.hostname,
     ];
@@ -93,7 +103,7 @@ export function writeModelRunsLog(runs: ActiveRun[]): void {
         return value.replace(trimmed, yellow(trimmed));
       }
     }
-    if (col === 3) return dim(value);
+    if (col === 3 || col === 5) return dim(value);
     return value;
   });
 
@@ -114,6 +124,7 @@ export function writeModelRunsJson(runs: ActiveRun[]): void {
       startedAt: r.startedAt.toISOString(),
       heartbeatAt: r.heartbeatAt.toISOString(),
       stale: r.isStale(STALE_TTL_MS),
+      initiatedBy: r.initiatedBy,
     })),
   }));
 }

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -1557,6 +1557,7 @@ export function handleRunHistory(
         startedAt: r.startedAt.toISOString(),
         heartbeatAt: r.heartbeatAt.toISOString(),
         stale: r.isStale(STALE_TTL_MS),
+        initiatedBy: r.initiatedBy,
       })),
     },
   });
@@ -1604,6 +1605,7 @@ export function handleRunDoctor(
     startedAt: r.startedAt.toISOString(),
     heartbeatAt: r.heartbeatAt.toISOString(),
     stale: r.isStale(STALE_TTL_MS),
+    initiatedBy: r.initiatedBy,
   });
 
   send(socket, {

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -79,7 +79,10 @@ import {
 } from "../../infrastructure/tracing/mod.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
-import type { Principal } from "../../domain/access/principal.ts";
+import {
+  type Principal,
+  principalToString,
+} from "../../domain/access/principal.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import {
@@ -190,6 +193,7 @@ export async function handleModelMethodRun(
         ctx.cancelRegistry.register("method-run", requestId, controller);
       }
 
+      const initiatedBy = principal ? principalToString(principal) : "ghost";
       const runMethod = async () => {
         for await (
           const event of modelMethodRun(libCtx, deps, {
@@ -210,6 +214,7 @@ export async function handleModelMethodRun(
             skipCheckLabels: payload.skipCheckLabels,
             traceparent: payload.traceparent,
             tracestate: payload.tracestate,
+            initiatedBy,
           })
         ) {
           if (socket.readyState !== WebSocket.OPEN) break;
@@ -318,6 +323,7 @@ export async function handleModelMethodRun(
     }
   }
 
+  const initiatedBy = principal ? principalToString(principal) : "ghost";
   const buffer = new RunEventBuffer(DEFAULT_BUFFER_CAPACITY);
   const runController = new AbortController();
   const runId: string = crypto.randomUUID();
@@ -376,6 +382,7 @@ export async function handleModelMethodRun(
             skipCheckLabels: payload.skipCheckLabels,
             traceparent: payload.traceparent,
             tracestate: payload.tracestate,
+            initiatedBy,
           })
         ) {
           const serialized = serializeEvent(

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -115,6 +115,7 @@ export async function handleWorkflowRun(
     }, ctx)
   ) return;
 
+  const initiatedBy = principal ? principalToString(principal) : "ghost";
   const registry = ctx.activeRunRegistry;
   if (!registry) {
     let registeredRunId: string | undefined;
@@ -139,6 +140,7 @@ export async function handleWorkflowRun(
           skipCheckLabels: payload.skipCheckLabels,
           traceparent: payload.traceparent,
           tracestate: payload.tracestate,
+          initiatedBy,
         },
         controller.signal,
         (event) => {
@@ -204,6 +206,7 @@ export async function handleWorkflowRun(
           skipCheckLabels: payload.skipCheckLabels,
           traceparent: payload.traceparent,
           tracestate: payload.tracestate,
+          initiatedBy,
         },
         runController.signal,
         (event) => {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -994,6 +994,7 @@ export interface RunHistoryResponse {
     startedAt: string;
     heartbeatAt: string;
     stale: boolean;
+    initiatedBy?: string | null;
   }>;
 }
 


### PR DESCRIPTION
## Summary

- Adds `initiatedBy` field to model method runs, workflow runs, active run tracker, and data artifact tags
- On swamp serve: identity comes from the authenticated `Principal` (e.g. `"user:paultest"`)
- On local CLI: identity comes from cached auth credentials (e.g. `"user:stack72"`)
- Unauthenticated/collective/webhook/system runs are attributed as `"ghost"`
- Old runs before this feature have no `initiatedBy` (field absent), distinguishable from `"ghost"`

### Where it's stored
- `ExecutionProvenance.initiatedBy` on `ModelOutput` (YAML)
- `WorkflowRun.initiatedBy` (YAML)
- `active_runs.initiated_by` column (SQLite, schema v2→v3 migration)
- Data artifact tags: `tags["initiatedBy"]` — queryable via `swamp data query 'tags["initiatedBy"] == "user:paul"'`

### Where it's displayed
- `swamp run history` table has new `INITIATED BY` column
- JSON output includes `initiatedBy` on run views and run history
- Model output provenance section

### Backward compatibility
- All new fields are optional (`z.string().optional()` / nullable `TEXT`)
- Old YAML files parse fine — `initiatedBy` is `undefined`
- Old SQLite rows get `NULL` from `ALTER TABLE ADD COLUMN`
- Wire protocol unchanged — `initiatedBy` is server-derived, not client-sent
- Old data queries unaffected — extra tag key is ignored by existing queries
- **Not sent in telemetry** — strictly local storage only

## Test plan

- [x] `deno check` — clean (2 pre-existing errors in unrelated bench file)
- [x] `deno lint` — clean
- [x] `deno fmt` — clean
- [x] `deno run test` — 9657 passed, 0 failed
- [x] `deno run compile` — binary compiles
- [x] E2E: local CLI run (logged in) → `initiatedBy: "user:stack72"` in JSON, YAML, run history
- [x] E2E: serve run (auth-mode none) → `initiatedBy: "ghost"`
- [x] E2E: serve run (token auth) → `initiatedBy: "user:paultest"` — authenticated principal flows through
- [x] E2E: data artifact metadata contains `initiatedBy` tag
- [x] E2E: `swamp data query 'tags["initiatedBy"] == "user:stack72"'` returns correct results
- [x] E2E: old data without tag loads and queries without error
- [x] Independent audit of 9 regression risk areas — all SAFE
- [x] Verified `initiatedBy` is NOT sent in telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)