### PR TITLE
fix(serve): guard heartbeat double-start and clarify --detach-runs help

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -904,7 +904,11 @@ export const serveCommand = new Command()
       "  1. Client disconnect: a WebSocket close detaches the client instead of cancelling the run; " +
       "clients can re-attach by run ID.\n" +
       "  2. Process restart: webhook and cron runs are queued to a local SQLite database before " +
-      "being acknowledged and replayed if the process dies before executing them; in-flight runs " +
+      "being acknowledged and replayed if the process dies before executing them. " +
+      "When the datastore supports control-plane operations (e.g. @swamp/s3-datastore), " +
+      "pending runs and instance identity are also written to the remote store, enabling " +
+      "recovery after machine failure — not just process restart. " +
+      "In-flight runs " +
       "interrupted by shutdown or crash are marked failed with an interrupt_reason tag and can be " +
       "resumed via 'swamp workflow resume --from <step>'.\n" +
       "Without this flag, runs are cancelled on disconnect and lost on restart (the default).",

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -317,6 +317,7 @@ export interface WorkflowRunInput {
   assertFailOnSeverity?: AssertSeverity;
   /** Identity of the user who initiated this run (e.g. "user:paul"). */
   initiatedBy?: string;
+  /** Serve instance identity for cross-machine run reconciliation. */
   instanceId?: string;
 }
 

--- a/src/serve/instance_heartbeat.ts
+++ b/src/serve/instance_heartbeat.ts
@@ -60,6 +60,7 @@ export class InstanceHeartbeatService {
   }
 
   async start(): Promise<void> {
+    if (this.#timer !== null) return;
     await this.#write();
     this.#timer = setInterval(() => {
       this.#write().catch((err) => {


### PR DESCRIPTION
## Summary

- Add double-call guard to `InstanceHeartbeatService.start()` — returns early if the timer is already running, preventing a leaked interval.
- Expand `--detach-runs` help text to describe cross-machine durability when a remote-capable datastore (e.g. `@swamp/s3-datastore`) is configured.
- Add JSDoc to `WorkflowRunInput.instanceId` for consistency with the sibling `initiatedBy` field.

Closes #1448

## Test Plan

- `deno check` passes on all changed files
- `deno fmt` and `deno lint` clean
- `deno run test src/serve/instance_heartbeat_test.ts` — all 10 tests pass
- Changes are documentation/guard-only; no behavioral change to existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)