### PR TITLE
feat(serve): cron fire dedup for multi-instance swamp serve

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1718,10 +1718,19 @@ export const serveCommand = new Command()
               );
               break;
             case "schedule_skipped":
-              logger.warn(
-                "Skipped scheduled workflow {name}: {reason}",
-                { name: event.workflowName, reason: event.reason },
-              );
+              if (
+                event.reason === "Claimed by another instance"
+              ) {
+                logger.info(
+                  "Skipped scheduled workflow {name}: {reason}",
+                  { name: event.workflowName, reason: event.reason },
+                );
+              } else {
+                logger.warn(
+                  "Skipped scheduled workflow {name}: {reason}",
+                  { name: event.workflowName, reason: event.reason },
+                );
+              }
               break;
             case "schedule_completed":
               logger.info(
@@ -2541,16 +2550,22 @@ export const serveCommand = new Command()
       if (controlPlaneStore) {
         const FIRE_RECORD_REAP_INTERVAL_MS = 10 * 60 * 1000;
         const FIRE_RECORD_TTL_MS = 4 * 60 * 60 * 1000;
-        const reaperTimer = setInterval(async () => {
+        const reapFireRecords = async () => {
           try {
             const keys = await controlPlaneStore!.list("fire-records/");
             const cutoff = Date.now() - FIRE_RECORD_TTL_MS;
-            // Key format: fire-records/{workflowId}/{isoFireTime}
+            // Key format: fire-records/{workflowId}/{normalizedFireTime}
+            // normalizedFireTime uses hyphens instead of colons for
+            // Windows compat; restore colons for Date parsing.
             for (const key of keys) {
               const segments = key.split("/");
               if (segments.length < 3) continue;
               const timePart = segments.slice(2).join("/");
-              const ts = new Date(timePart).getTime();
+              const isoTime = timePart.replace(
+                /T(\d{2})-(\d{2})-(\d{2})Z/,
+                "T$1:$2:$3Z",
+              );
+              const ts = new Date(isoTime).getTime();
               if (Number.isNaN(ts) || ts < cutoff) {
                 await controlPlaneStore!.delete(key);
               }
@@ -2561,7 +2576,11 @@ export const serveCommand = new Command()
               { error: err instanceof Error ? err.message : String(err) },
             );
           }
-        }, FIRE_RECORD_REAP_INTERVAL_MS);
+        };
+        const reaperTimer = setInterval(
+          () => reapFireRecords().catch(() => {}),
+          FIRE_RECORD_REAP_INTERVAL_MS,
+        );
         Deno.unrefTimer(reaperTimer);
       }
     }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -71,7 +71,10 @@ import {
   toServiceMode,
 } from "../../presentation/output/serve_daemon_output.ts";
 import { groupCommandAction } from "../group_action.ts";
-import { ScheduledExecutionService } from "../../libswamp/mod.ts";
+import {
+  normalizeFireTime,
+  ScheduledExecutionService,
+} from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -1675,6 +1678,20 @@ export const serveCommand = new Command()
             },
           }
           : undefined,
+        cronFireDedup: controlPlaneStore?.putIfAbsent
+          ? async (workflowId, fireTime) => {
+            const key = `fire-records/${workflowId}/${
+              normalizeFireTime(fireTime)
+            }`;
+            const data = new TextEncoder().encode(
+              JSON.stringify({
+                instanceId,
+                claimedAt: new Date().toISOString(),
+              }),
+            );
+            return await controlPlaneStore!.putIfAbsent!(key, data);
+          }
+          : undefined,
       });
 
       await scheduledExecution.start((event) => {
@@ -2517,6 +2534,35 @@ export const serveCommand = new Command()
         );
         await heartbeatService.start();
         logger.info`Instance heartbeat started (id: ${instanceId})`;
+      }
+
+      // Periodically reap stale fire-records so they don't accumulate
+      // unboundedly. Runs every 10 minutes; deletes records older than 4 hours.
+      if (controlPlaneStore) {
+        const FIRE_RECORD_REAP_INTERVAL_MS = 10 * 60 * 1000;
+        const FIRE_RECORD_TTL_MS = 4 * 60 * 60 * 1000;
+        const reaperTimer = setInterval(async () => {
+          try {
+            const keys = await controlPlaneStore!.list("fire-records/");
+            const cutoff = Date.now() - FIRE_RECORD_TTL_MS;
+            // Key format: fire-records/{workflowId}/{isoFireTime}
+            for (const key of keys) {
+              const segments = key.split("/");
+              if (segments.length < 3) continue;
+              const timePart = segments.slice(2).join("/");
+              const ts = new Date(timePart).getTime();
+              if (Number.isNaN(ts) || ts < cutoff) {
+                await controlPlaneStore!.delete(key);
+              }
+            }
+          } catch (err: unknown) {
+            logger.warn(
+              "Fire record reaper failed: {error}",
+              { error: err instanceof Error ? err.message : String(err) },
+            );
+          }
+        }, FIRE_RECORD_REAP_INTERVAL_MS);
+        Deno.unrefTimer(reaperTimer);
       }
     }
 

--- a/src/domain/workflows/workflow_scheduler.ts
+++ b/src/domain/workflows/workflow_scheduler.ts
@@ -29,8 +29,14 @@ import type { WorkflowId } from "./workflow_id.ts";
 
 /**
  * Callback invoked when a scheduled workflow should fire.
+ * Receives the canonical fire time — the cron-pattern-matched
+ * time, not the wall-clock time — so callers can derive a
+ * deterministic key for cross-instance dedup.
  */
-export type ScheduleFireCallback = (workflowId: WorkflowId) => void;
+export type ScheduleFireCallback = (
+  workflowId: WorkflowId,
+  fireTime: Date,
+) => void | Promise<void>;
 
 /**
  * Information about a registered schedule.
@@ -55,7 +61,11 @@ export class WorkflowScheduler {
     const cron = new Cron(
       cronExpression,
       { paused: this.onFire === null },
-      () => this.onFire?.(workflowId),
+      () =>
+        this.onFire?.(
+          workflowId,
+          canonicalFireTime(this.entries.get(workflowId)!),
+        ),
     );
 
     this.entries.set(workflowId, cron);
@@ -115,4 +125,27 @@ export class WorkflowScheduler {
   get size(): number {
     return this.entries.size;
   }
+}
+
+/**
+ * Computes the canonical fire time for a cron callback by snapping
+ * the current wall-clock time back to the cron pattern grid.
+ *
+ * croner's `currentRun()` returns wall-clock `new Date()`, NOT the
+ * deterministic scheduled time. Two instances with slight clock skew
+ * could get different values and both claim a fire slot. This function
+ * enumerates recent pattern matches and picks the latest one at or
+ * before `now`, which is deterministic across instances regardless of
+ * sub-second clock differences.
+ */
+export function canonicalFireTime(cron: Cron, now?: Date): Date {
+  const ref = now ?? new Date();
+  const lookback = new Date(ref.getTime() - 120_000);
+  const runs = cron.nextRuns(200, lookback);
+  for (let i = runs.length - 1; i >= 0; i--) {
+    if (runs[i].getTime() <= ref.getTime()) {
+      return runs[i];
+    }
+  }
+  return ref;
 }

--- a/src/domain/workflows/workflow_scheduler.ts
+++ b/src/domain/workflows/workflow_scheduler.ts
@@ -61,11 +61,14 @@ export class WorkflowScheduler {
     const cron = new Cron(
       cronExpression,
       { paused: this.onFire === null },
-      () =>
-        this.onFire?.(
-          workflowId,
-          canonicalFireTime(this.entries.get(workflowId)!),
-        ),
+      () => {
+        const entry = this.entries.get(workflowId);
+        if (!entry) return;
+        const result = this.onFire?.(workflowId, canonicalFireTime(entry));
+        if (result instanceof Promise) {
+          result.catch(() => {});
+        }
+      },
     );
 
     this.entries.set(workflowId, cron);
@@ -129,14 +132,14 @@ export class WorkflowScheduler {
 
 /**
  * Computes the canonical fire time for a cron callback by snapping
- * the current wall-clock time back to the cron pattern grid.
+ * the current wall-clock time to the nearest cron pattern grid point.
  *
  * croner's `currentRun()` returns wall-clock `new Date()`, NOT the
  * deterministic scheduled time. Two instances with slight clock skew
  * could get different values and both claim a fire slot. This function
  * enumerates recent pattern matches and picks the latest one at or
- * before `now`, which is deterministic across instances regardless of
- * sub-second clock differences.
+ * before `now`. If the timer fires slightly early (before the
+ * scheduled second boundary), it snaps forward to the imminent match.
  */
 export function canonicalFireTime(cron: Cron, now?: Date): Date {
   const ref = now ?? new Date();
@@ -145,6 +148,14 @@ export function canonicalFireTime(cron: Cron, now?: Date): Date {
   for (let i = runs.length - 1; i >= 0; i--) {
     if (runs[i].getTime() <= ref.getTime()) {
       return runs[i];
+    }
+  }
+  // Timer fired slightly before the scheduled second — snap forward
+  // to the imminent match if it's within 2 seconds.
+  const EARLY_TOLERANCE_MS = 2_000;
+  for (const run of runs) {
+    if (run.getTime() - ref.getTime() <= EARLY_TOLERANCE_MS) {
+      return run;
     }
   }
   return ref;

--- a/src/domain/workflows/workflow_scheduler_test.ts
+++ b/src/domain/workflows/workflow_scheduler_test.ts
@@ -18,7 +18,8 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import { WorkflowScheduler } from "./workflow_scheduler.ts";
+import { canonicalFireTime, WorkflowScheduler } from "./workflow_scheduler.ts";
+import { Cron } from "croner";
 import type { WorkflowId } from "./workflow_id.ts";
 
 const TEST_ID_1 = "aaaaaaaa-1111-1111-1111-111111111111" as WorkflowId;
@@ -91,7 +92,9 @@ Deno.test("WorkflowScheduler: start fires callback on cron match", async () => {
 
   // Use per-second cron: fires every second
   scheduler.register(TEST_ID_1, "* * * * * *");
-  scheduler.start((id) => fired.push(id));
+  scheduler.start((id) => {
+    fired.push(id);
+  });
 
   // Wait for at least one fire
   await new Promise((resolve) => setTimeout(resolve, 1500));
@@ -99,4 +102,47 @@ Deno.test("WorkflowScheduler: start fires callback on cron match", async () => {
 
   assertEquals(fired.length > 0, true);
   assertEquals(fired[0], TEST_ID_1);
+});
+
+Deno.test("canonicalFireTime: snaps to cron grid regardless of sub-second offset", () => {
+  // Pattern fires at :00, :10, :20, :30, :40, :50 of each minute
+  const cron = new Cron("*/10 * * * * *", { paused: true });
+
+  // Simulate wall-clock at :30.123 — should snap to :30.000
+  const base = new Date("2026-08-01T12:00:30.000Z");
+  const skewed = new Date(base.getTime() + 123);
+  const result = canonicalFireTime(cron, skewed);
+  assertEquals(result.getTime(), base.getTime());
+
+  // Simulate wall-clock at :30.999 — still snaps to :30.000
+  const lateSkew = new Date(base.getTime() + 999);
+  assertEquals(canonicalFireTime(cron, lateSkew).getTime(), base.getTime());
+
+  cron.stop();
+});
+
+Deno.test("canonicalFireTime: two instances with 500ms clock skew produce the same time", () => {
+  const cron = new Cron("0 * * * *", { paused: true });
+
+  // Instance A fires at exactly the top of the hour
+  const instanceA = new Date("2026-08-01T15:00:00.050Z");
+  // Instance B's clock is 500ms behind
+  const instanceB = new Date("2026-08-01T15:00:00.550Z");
+
+  const timeA = canonicalFireTime(cron, instanceA);
+  const timeB = canonicalFireTime(cron, instanceB);
+  assertEquals(timeA.getTime(), timeB.getTime());
+  assertEquals(timeA.toISOString(), "2026-08-01T15:00:00.000Z");
+
+  cron.stop();
+});
+
+Deno.test("canonicalFireTime: handles per-second cron", () => {
+  const cron = new Cron("* * * * * *", { paused: true });
+
+  const now = new Date("2026-08-01T12:00:45.789Z");
+  const result = canonicalFireTime(cron, now);
+  assertEquals(result.toISOString(), "2026-08-01T12:00:45.000Z");
+
+  cron.stop();
 });

--- a/src/domain/workflows/workflow_scheduler_test.ts
+++ b/src/domain/workflows/workflow_scheduler_test.ts
@@ -146,3 +146,14 @@ Deno.test("canonicalFireTime: handles per-second cron", () => {
 
   cron.stop();
 });
+
+Deno.test("canonicalFireTime: snaps forward when timer fires early", () => {
+  const cron = new Cron("0 * * * *", { paused: true });
+
+  // Timer fires 2ms before the scheduled hour boundary
+  const earlyFire = new Date("2026-08-01T14:59:59.998Z");
+  const result = canonicalFireTime(cron, earlyFire);
+  assertEquals(result.toISOString(), "2026-08-01T15:00:00.000Z");
+
+  cron.stop();
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -101,6 +101,8 @@ export { severityAtOrAbove } from "../domain/workflows/assert_severity.ts";
 
 // Scheduled execution
 export {
+  type CronFireDedupCallback,
+  normalizeFireTime,
   type ScheduledExecutionDeps,
   type ScheduledExecutionEvent,
   type ScheduledExecutionEventHandler,

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -356,10 +356,6 @@ export class ScheduledExecutionService {
             workflowName,
             reason: "Claimed by another instance",
           });
-          logger.info(
-            "Skipping scheduled run for {name}: claimed by another instance",
-            { name: workflowName },
-          );
           return;
         }
       } catch (err: unknown) {
@@ -530,8 +526,10 @@ export class ScheduledExecutionService {
 /**
  * Normalizes a fire time to a deterministic key component shared
  * across all instances. Truncates to the second and formats as
- * ISO 8601 UTC without milliseconds (e.g. "2026-08-01T00:00:00Z").
+ * ISO 8601 UTC without milliseconds, with colons replaced by
+ * hyphens for Windows filesystem compatibility
+ * (e.g. "2026-08-01T00-00-00Z").
  */
 export function normalizeFireTime(date: Date): string {
-  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z").replaceAll(":", "-");
 }

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -114,11 +114,23 @@ export interface PendingRunHook {
   delete(id: string): void;
 }
 
+/**
+ * Callback for cross-instance cron fire dedup. Returns true if this
+ * instance should execute, false if another instance already claimed
+ * the fire slot. When not provided (single-instance mode), all fires
+ * proceed unconditionally.
+ */
+export type CronFireDedupCallback = (
+  workflowId: string,
+  fireTime: Date,
+) => Promise<boolean>;
+
 export interface ScheduledExecutionDeps {
   workflowRepo: WorkflowRepository;
   repoDir: string;
   executeWorkflow: WorkflowExecutor;
   pendingRunHook?: PendingRunHook;
+  cronFireDedup?: CronFireDedupCallback;
 }
 
 export class ScheduledExecutionService {
@@ -163,7 +175,9 @@ export class ScheduledExecutionService {
     await this.watcher.scanExisting();
 
     // Start the scheduler — cron jobs begin firing
-    this.scheduler.start((workflowId) => this.handleFire(workflowId));
+    this.scheduler.start((workflowId, fireTime) =>
+      this.handleFire(workflowId, fireTime)
+    );
 
     // Start watching for changes
     await this.watcher.start();
@@ -305,7 +319,10 @@ export class ScheduledExecutionService {
     }
   }
 
-  private handleFire(workflowId: WorkflowId): void {
+  private async handleFire(
+    workflowId: WorkflowId,
+    fireTime: Date,
+  ): Promise<void> {
     const workflowName = this.workflowNames.get(workflowId) ?? workflowId;
 
     // Overlap prevention — skip if this specific workflow is already running.
@@ -325,6 +342,35 @@ export class ScheduledExecutionService {
         { name: workflowName },
       );
       return;
+    }
+
+    // Cross-instance dedup — race to claim this fire slot via the
+    // control-plane store. If another instance won, skip silently.
+    if (this.deps.cronFireDedup) {
+      try {
+        const claimed = await this.deps.cronFireDedup(workflowId, fireTime);
+        if (!claimed) {
+          this.emit({
+            kind: "schedule_skipped",
+            workflowId,
+            workflowName,
+            reason: "Claimed by another instance",
+          });
+          logger.info(
+            "Skipping scheduled run for {name}: claimed by another instance",
+            { name: workflowName },
+          );
+          return;
+        }
+      } catch (err: unknown) {
+        logger.warn(
+          "Cron fire dedup failed for {name}, proceeding with execution: {error}",
+          {
+            name: workflowName,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+      }
     }
 
     this.emit({
@@ -479,4 +525,13 @@ export class ScheduledExecutionService {
   private emit(event: ScheduledExecutionEvent): void {
     this.eventHandler?.(event);
   }
+}
+
+/**
+ * Normalizes a fire time to a deterministic key component shared
+ * across all instances. Truncates to the second and formats as
+ * ISO 8601 UTC without milliseconds (e.g. "2026-08-01T00:00:00Z").
+ */
+export function normalizeFireTime(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
 }

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals } from "@std/assert";
 import {
+  normalizeFireTime,
   type ScheduledExecutionEvent,
   ScheduledExecutionService,
 } from "./scheduled_execution.ts";
@@ -269,4 +270,103 @@ Deno.test("ScheduledExecutionService: stop clears schedules", async () => {
 
   await service.stop();
   assertEquals(service.listSchedules().length, 0);
+});
+
+Deno.test("ScheduledExecutionService: cronFireDedup returning true allows execution", async () => {
+  const wf = createTestWorkflow("dedup-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    cronFireDedup: () => Promise.resolve(true),
+  });
+
+  await service.start((e) => events.push(e));
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const fired = events.filter((e) => e.kind === "schedule_fired");
+  assertEquals(fired.length >= 1, true);
+  const skipped = events.filter((e) =>
+    e.kind === "schedule_skipped" &&
+    (e as { reason: string }).reason === "Claimed by another instance"
+  );
+  assertEquals(skipped.length, 0);
+});
+
+Deno.test("ScheduledExecutionService: cronFireDedup returning false skips execution", async () => {
+  const wf = createTestWorkflow("dedup-skip-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  let executionCount = 0;
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => {
+      executionCount++;
+      return Promise.resolve();
+    },
+    cronFireDedup: () => Promise.resolve(false),
+  });
+
+  await service.start((e) => events.push(e));
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const skipped = events.filter((e) =>
+    e.kind === "schedule_skipped" &&
+    (e as { reason: string }).reason === "Claimed by another instance"
+  );
+  assertEquals(skipped.length >= 1, true);
+
+  const fired = events.filter((e) => e.kind === "schedule_fired");
+  assertEquals(fired.length, 0);
+  assertEquals(executionCount, 0);
+});
+
+Deno.test("ScheduledExecutionService: cronFireDedup error falls through to execution", async () => {
+  const wf = createTestWorkflow("dedup-error-wf", "* * * * * *");
+  const events: ScheduledExecutionEvent[] = [];
+
+  const mockRepo = createMockWorkflowRepo([wf]);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+    cronFireDedup: () => Promise.reject(new Error("S3 unreachable")),
+  });
+
+  await service.start((e) => events.push(e));
+
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  await service.stop();
+
+  const fired = events.filter((e) => e.kind === "schedule_fired");
+  assertEquals(fired.length >= 1, true);
+  const skipped = events.filter((e) =>
+    e.kind === "schedule_skipped" &&
+    (e as { reason: string }).reason === "Claimed by another instance"
+  );
+  assertEquals(skipped.length, 0);
+});
+
+Deno.test("normalizeFireTime: truncates milliseconds and formats as UTC", () => {
+  assertEquals(
+    normalizeFireTime(new Date("2026-08-01T12:30:45.123Z")),
+    "2026-08-01T12:30:45Z",
+  );
+  assertEquals(
+    normalizeFireTime(new Date("2026-08-01T00:00:00.000Z")),
+    "2026-08-01T00:00:00Z",
+  );
+  assertEquals(
+    normalizeFireTime(new Date("2026-12-31T23:59:59.999Z")),
+    "2026-12-31T23:59:59Z",
+  );
 });

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -356,17 +356,17 @@ Deno.test("ScheduledExecutionService: cronFireDedup error falls through to execu
   assertEquals(skipped.length, 0);
 });
 
-Deno.test("normalizeFireTime: truncates milliseconds and formats as UTC", () => {
+Deno.test("normalizeFireTime: truncates milliseconds and replaces colons for Windows compat", () => {
   assertEquals(
     normalizeFireTime(new Date("2026-08-01T12:30:45.123Z")),
-    "2026-08-01T12:30:45Z",
+    "2026-08-01T12-30-45Z",
   );
   assertEquals(
     normalizeFireTime(new Date("2026-08-01T00:00:00.000Z")),
-    "2026-08-01T00:00:00Z",
+    "2026-08-01T00-00-00Z",
   );
   assertEquals(
     normalizeFireTime(new Date("2026-12-31T23:59:59.999Z")),
-    "2026-12-31T23:59:59Z",
+    "2026-12-31T23-59-59Z",
   );
 });


### PR DESCRIPTION
## Summary

- Adds exactly-once cron fire semantics for multi-instance `swamp serve` using `putIfAbsent` on the control-plane store
- Before queueing a cron fire, each instance races to create a fire record at `fire-records/{workflowId}/{canonicalFireTime}` — one wins, the rest emit `schedule_skipped` and back off
- `canonicalFireTime()` snaps wall-clock time to the cron pattern grid by enumerating recent matches via croner's `nextRuns()`, producing a deterministic key across instances regardless of sub-second clock skew
- The dedup callback is optional — when absent (single-instance or no `putIfAbsent` on the store), all fires proceed unchanged
- Best-effort: if `putIfAbsent` fails (store unreachable), the fire proceeds with a warning rather than silently skipping
- A periodic reaper (every 10 min) deletes fire records older than 4 hours

Closes #1448

## Test Plan

- Unit tests for `canonicalFireTime()` verifying deterministic grid-snapping across sub-second offsets and 500ms clock skew
- Unit tests for `cronFireDedup` callback: returns true (proceeds), returns false (skips with correct reason), throws (falls through to execution)
- Unit test for `normalizeFireTime` ISO formatting
- Live two-instance test: compiled binary, two `swamp serve --detach-runs` processes on different ports sharing the same repo, verified exactly-once execution across multiple cron ticks with fire records on disk confirming alternating winners
- Full test suite: 9699 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)