### PR TITLE
fix(serve): tighten cron dedup reaper guard and decouple skip event

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1718,9 +1718,7 @@ export const serveCommand = new Command()
               );
               break;
             case "schedule_skipped":
-              if (
-                event.reason === "Claimed by another instance"
-              ) {
+              if (event.dedupSkip) {
                 logger.info(
                   "Skipped scheduled workflow {name}: {reason}",
                   { name: event.workflowName, reason: event.reason },
@@ -2547,7 +2545,8 @@ export const serveCommand = new Command()
 
       // Periodically reap stale fire-records so they don't accumulate
       // unboundedly. Runs every 10 minutes; deletes records older than 4 hours.
-      if (controlPlaneStore) {
+      // Only needed when dedup is active (putIfAbsent available).
+      if (controlPlaneStore?.putIfAbsent) {
         const FIRE_RECORD_REAP_INTERVAL_MS = 10 * 60 * 1000;
         const FIRE_RECORD_TTL_MS = 4 * 60 * 60 * 1000;
         const reapFireRecords = async () => {

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -69,6 +69,7 @@ export type ScheduledExecutionEvent =
     workflowId: WorkflowId;
     workflowName: string;
     reason: string;
+    dedupSkip?: boolean;
   }
   | {
     kind: "schedule_completed";
@@ -355,6 +356,7 @@ export class ScheduledExecutionService {
             workflowId,
             workflowName,
             reason: "Claimed by another instance",
+            dedupSkip: true,
           });
           return;
         }

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -293,7 +293,7 @@ Deno.test("ScheduledExecutionService: cronFireDedup returning true allows execut
   assertEquals(fired.length >= 1, true);
   const skipped = events.filter((e) =>
     e.kind === "schedule_skipped" &&
-    (e as { reason: string }).reason === "Claimed by another instance"
+    (e as { dedupSkip?: boolean }).dedupSkip === true
   );
   assertEquals(skipped.length, 0);
 });
@@ -321,7 +321,7 @@ Deno.test("ScheduledExecutionService: cronFireDedup returning false skips execut
 
   const skipped = events.filter((e) =>
     e.kind === "schedule_skipped" &&
-    (e as { reason: string }).reason === "Claimed by another instance"
+    (e as { dedupSkip?: boolean }).dedupSkip === true
   );
   assertEquals(skipped.length >= 1, true);
 
@@ -351,7 +351,7 @@ Deno.test("ScheduledExecutionService: cronFireDedup error falls through to execu
   assertEquals(fired.length >= 1, true);
   const skipped = events.filter((e) =>
     e.kind === "schedule_skipped" &&
-    (e as { reason: string }).reason === "Claimed by another instance"
+    (e as { dedupSkip?: boolean }).dedupSkip === true
   );
   assertEquals(skipped.length, 0);
 });


### PR DESCRIPTION
## Summary

Follow-up to #2038:

- Tighten reaper guard from `if (controlPlaneStore)` to `if (controlPlaneStore?.putIfAbsent)` so the fire-record reaper only runs when dedup is actually active
- Add `dedupSkip?: boolean` to the `schedule_skipped` event type so the presentation layer branches on a structured field instead of matching the reason string `"Claimed by another instance"`

## Test Plan

- Full test suite: 9700 passed, 0 failed
- `dedupSkip` field verified in existing dedup skip tests (assertions updated from string match to boolean check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)