### PR TITLE
fix(quality): ignore imports inside template literals in bare-specifier scan (swamp-club#1490)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -98,7 +98,8 @@ unreliable under atomic-rename saves, mtime-preserving sync tools, and
 sub-millisecond edits (issue #125). If the source contains
 bare specifiers (e.g., `from "zod"` instead of `from "npm:zod@4"`) and a cached
 bundle exists, the cached bundle is used since re-bundling would fail without
-the project's `deno.json` import map.
+the project's `deno.json` import map. Only the module's own static imports count
+— import statements inside template literals are generated code and are ignored.
 
 ### Custom Type Configuration
 

--- a/design/extension.md
+++ b/design/extension.md
@@ -509,6 +509,11 @@ actually contains bare specifiers (e.g., `from "zod"` instead of
 containing `@anthropic-ai/claude-code` for tooling) from being mistakenly
 treated as the extension's project config.
 
+Specifiers are read from the module's own static imports only. Import statements
+that appear inside template literals are generated code — the specifier belongs
+to the script the extension emits at runtime, not to the extension's own module
+graph — so they are ignored by every bare-specifier check.
+
 #### Bundling permutations
 
 | Scenario                                  | `deno bundle` flags                                      | Quality check flags    | Notes                                                                                                                                                              |
@@ -554,7 +559,9 @@ require a project config to resolve, and a cached bundle exists, the loader uses
 the cached bundle rather than attempting a re-bundle that would fail without the
 config. This supports pulled extensions that were built with a `deno.json` or
 `package.json` project — the archive includes pre-built bundles but not the
-project config.
+project config. Imports inside template literals do not count here either: an
+extension that only generates code re-bundles normally rather than being pinned
+to its cached bundle.
 
 When a non-filesystem datastore is configured (e.g. `@swamp/s3-datastore`),
 bundle paths are resolved through the `DatastorePathResolver` instead of the

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -206,6 +206,12 @@ const IMPORT_SPECIFIER_RE =
   /(?:import|export)\s+[^;()]*?from\s+["']([^"']+)["']/g;
 
 function isBareSpecifier(specifier: string): boolean {
+  // A specifier carrying a `${...}` placeholder is interpolated at runtime, not
+  // a package name. stripSourceComments already removes the common source of
+  // these (generated code inside template literals), but `import x from
+  // "${pkg}"` is valid TypeScript at the top level — double quotes do not
+  // interpolate — so the classifier guards itself rather than trusting callers.
+  if (specifier.includes("${")) return false;
   if (specifier.startsWith(".")) return false;
   if (specifier.startsWith("npm:")) return false;
   if (specifier.startsWith("jsr:")) return false;
@@ -217,8 +223,18 @@ function isBareSpecifier(specifier: string): boolean {
 
 // See also: stripComments in extension_dependency_extractor.ts (import-line
 // only) and stripCommentsAndStrings in extension_quality_checker.ts (strips
-// both). This variant strips all comments while preserving string literals
-// so the import-specifier regex can still match real import strings.
+// both). This variant blanks comments and template literals while preserving
+// ' and " string contents, so the import-specifier regex can still match real
+// import strings — a specifier always lives in one of those two quote styles.
+//
+// Template literals are blanked because a static import specifier can never be
+// one (`import x from `y`` is a SyntaxError), so an import statement between
+// backticks is always generated code, not part of this module's own graph
+// (swamp-club#1490 — the same false-positive lineage as #602 and #657). When a
+// backtick has no closing partner — a regex literal, say, which this scanner
+// cannot recognise — the span is re-emitted verbatim rather than blanked, so an
+// unbalanced backtick degrades to a no-op instead of erasing the rest of the
+// file from the caller's view.
 function stripSourceComments(source: string): string {
   const result: string[] = [];
   let i = 0;
@@ -295,24 +311,18 @@ function stripSourceComments(source: string): string {
       continue;
     }
 
-    // Template literal — preserve content
+    // Template literal — blank content
     if (source[i] === "`") {
-      result.push(source[i]);
-      i++;
-      while (i < source.length && source[i] !== "`") {
-        if (source[i] === "\\") {
-          result.push(source[i]);
-          i++;
-        }
-        if (i < source.length) {
-          result.push(source[i]);
-          i++;
-        }
+      const span: string[] = [];
+      const next = skipTemplateLiteral(source, i, span);
+      if (next === null) {
+        // Unterminated: the backtick was not a template after all. Keep the
+        // remainder verbatim — byte-identical to leaving it unscanned.
+        result.push(source.slice(i));
+        break;
       }
-      if (i < source.length && source[i] === "`") {
-        result.push(source[i]);
-        i++;
-      }
+      result.push(span.join(""));
+      i = next;
       continue;
     }
 
@@ -321,6 +331,122 @@ function stripSourceComments(source: string): string {
   }
 
   return result.join("");
+}
+
+/** Blanks a character, keeping newlines so line positions do not drift. */
+function blank(ch: string): string {
+  return ch === "\n" ? "\n" : " ";
+}
+
+/**
+ * Consumes the template literal opening at `start`, appending its blanked span
+ * to `out`. Returns the index just past the closing backtick, or null when the
+ * source ends first — the caller re-emits the span verbatim in that case.
+ */
+function skipTemplateLiteral(
+  source: string,
+  start: number,
+  out: string[],
+): number | null {
+  out.push(" ");
+  let i = start + 1;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\") {
+      out.push(" ");
+      i++;
+      if (i < source.length) {
+        out.push(blank(source[i]));
+        i++;
+      }
+      continue;
+    }
+    if (ch === "`") {
+      out.push(" ");
+      return i + 1;
+    }
+    if (ch === "$" && source[i + 1] === "{") {
+      out.push(" ", " ");
+      i = skipInterpolation(source, i + 2, out);
+      continue;
+    }
+    out.push(blank(ch));
+    i++;
+  }
+  return null;
+}
+
+/**
+ * Consumes a `${...}` interpolation body starting just past the `${`. Counts
+ * every brace so an object literal cannot close the interpolation early, and
+ * delegates quotes and nested templates so their contents cannot either.
+ */
+function skipInterpolation(
+  source: string,
+  start: number,
+  out: string[],
+): number {
+  let depth = 1;
+  let i = start;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "{") {
+      depth++;
+      out.push(" ");
+      i++;
+      continue;
+    }
+    if (ch === "}") {
+      depth--;
+      out.push(" ");
+      i++;
+      if (depth === 0) return i;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipQuoted(source, i, ch, out);
+      continue;
+    }
+    if (ch === "`") {
+      const next = skipTemplateLiteral(source, i, out);
+      // A nested template that never closes means the enclosing one does not
+      // either — hand the whole span back to the caller's verbatim fallback.
+      if (next === null) return source.length;
+      i = next;
+      continue;
+    }
+    out.push(blank(ch));
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Consumes a ' or " string inside an interpolation, blanking it so braces in
+ * its content are not counted against the interpolation depth.
+ */
+function skipQuoted(
+  source: string,
+  start: number,
+  quote: string,
+  out: string[],
+): number {
+  out.push(" ");
+  let i = start + 1;
+  while (i < source.length && source[i] !== quote && source[i] !== "\n") {
+    if (source[i] === "\\") {
+      out.push(" ");
+      i++;
+      if (i >= source.length) break;
+    }
+    out.push(blank(source[i]));
+    i++;
+  }
+  if (i < source.length && source[i] === quote) {
+    out.push(" ");
+    i++;
+  }
+  return i;
 }
 
 export function sourceHasBareSpecifiers(source: string): boolean {

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -779,6 +779,118 @@ export function check() {
   assertEquals(sourceHasBareSpecifiers(source), false);
 });
 
+// --- generated-code false-positive regression tests (swamp-club#1490) ---
+
+Deno.test("extractBareSpecifierNames: ignores an interpolated specifier in generated code", () => {
+  // The reported shape: an eval script built as a template literal, whose
+  // second import resolves to a valid npm: specifier only at runtime.
+  const source = `export function buildScript(pkg: string): string {
+  return \`
+import * as modeling from "npm:@jscad/modeling@2.12.0";
+import * as serializer from "\${pkg}";
+console.log(serializer, modeling);
+\`;
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: ignores a static bare specifier in generated code", () => {
+  // No interpolation at all — the specifier is bare in the generated script,
+  // which is the generated module's problem, not this module's.
+  const source = `export function buildScript(): string {
+  return \`import { z } from "zod";\`;
+}
+`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
+Deno.test("extractBareSpecifierNames: detects a real bare import alongside generated code", () => {
+  const source = `import { helper } from "my-helpers";
+
+export function buildScript(pkg: string): string {
+  return \`import * as s from "\${pkg}";\`;
+}
+
+export const h = helper;
+`;
+  assertEquals(extractBareSpecifierNames(source), ["my-helpers"]);
+});
+
+Deno.test("extractBareSpecifierNames: handles a nested template inside an interpolation", () => {
+  const source = `export function buildScript(names: string[]): string {
+  return \`\${names.map((n) => \`import "\${n}";\`).join("\\n")}\`;
+}
+
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: handles object-literal braces inside an interpolation", () => {
+  const source = `export function buildScript(): string {
+  return \`config = \${JSON.stringify({ mode: "full" })};
+import { x } from "generated";\`;
+}
+
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: handles an unbalanced brace quoted inside an interpolation", () => {
+  const source = `export function buildScript(): string {
+  return \`\${"}"} import { x } from "generated";\`;
+}
+
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: handles an escaped backtick inside a template", () => {
+  const source = `export function buildScript(): string {
+  return \`echo \\\` import { x } from "generated";\`;
+}
+
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: still detects imports after a backtick in a regex literal", () => {
+  // The scanner cannot recognise regex literals, so this backtick has no
+  // closing partner. The span must be preserved verbatim rather than blanked,
+  // or the real import below it would go unreported.
+  const source = `const BACKTICK = /\`/;
+import { z } from "zod";
+`;
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("extractBareSpecifierNames: preserves the tail after an unterminated template", () => {
+  const source = `const broken = \`unterminated
+import { z } from "zod";
+`;
+  // Degrades to the pre-fix reading rather than blanking the rest of the file.
+  assertEquals(extractBareSpecifierNames(source), ["zod"]);
+});
+
+Deno.test("sourceHasBareSpecifiers: ignores an interpolated specifier in generated code", () => {
+  const source = `export function buildScript(pkg: string): string {
+  return \`import * as s from "\${pkg}";\`;
+}
+`;
+  assertEquals(sourceHasBareSpecifiers(source), false);
+});
+
+Deno.test("extractBareSpecifierNames: ignores an interpolated specifier outside a template", () => {
+  // Valid TypeScript — double quotes do not interpolate — so isBareSpecifier
+  // must reject it on its own, without help from the template stripping.
+  const source = `import * as s from "\${pkg}";`;
+  assertEquals(extractBareSpecifierNames(source), []);
+});
+
 Deno.test("uint8ArrayToBase64 handles large input without stack overflow", () => {
   // 1MB of data — would blow the stack with String.fromCharCode(...bytes)
   const size = 1_000_000;
@@ -854,6 +966,24 @@ Deno.test("isExpectedBundleFailure: returns false for npm-only imports without d
     const filePath = extDir + "/model.ts";
     await Deno.writeTextFile(filePath, source);
     // No bare specifiers — failure is unexpected regardless of deno.json
+    assertEquals(isExpectedBundleFailure(filePath, repoDir), false);
+  } finally {
+    await Deno.remove(repoDir, { recursive: true });
+  }
+});
+
+Deno.test("isExpectedBundleFailure: returns false for generated imports without deno.json", async () => {
+  const repoDir = await Deno.makeTempDir({ prefix: "swamp_expected_test_" });
+  const extDir = repoDir + "/extensions/models/myext";
+  await Deno.mkdir(extDir, { recursive: true });
+  try {
+    // Codegen only — the module itself has no bare specifiers, so a rebundle
+    // failure here is a real failure and must not be silenced by the cache
+    // (swamp-club#1490).
+    const source =
+      `export const script = \`import * as s from "\${pkg}";\`;\nexport const x = 1;`;
+    const filePath = extDir + "/model.ts";
+    await Deno.writeTextFile(filePath, source);
     assertEquals(isExpectedBundleFailure(filePath, repoDir), false);
   } finally {
     await Deno.remove(repoDir, { recursive: true });


### PR DESCRIPTION
## Summary

Fixes swamp-club#1490. The extension quality scanner read import statements **inside template literals** as the module's own static imports, so an extension that generates code hit the hard bare-specifier gate and was refused a score entirely.

`@magistr/jscad-cad` builds an eval script as a template literal whose serializer import is interpolated at runtime. The scanner read the literal text `${pkg}` as an unresolvable bare package name and errored out with no score at all — forcing a fully compliant extension to carry an `UNSCORABLE` `baselinePercentage: 0` ratchet.

`stripSourceComments` now blanks template literal contents the way it already blanks comments. The justification is lexical, not heuristic: a static import specifier can never *be* a template literal (``import x from `y` `` is a SyntaxError), so an import statement between backticks is always generated code, never part of this module's graph. The scan is interpolation-aware — it counts every brace so an object literal inside `${...}` cannot close it early, and delegates nested quotes and templates so their contents cannot either.

**Why not an AST (the issue's option 1):** this repo carries no TypeScript/SWC/deno_ast parser and the CLI ships as a `deno compile` single binary, so pulling `npm:typescript` in to serve one heuristic scanner is a large permanent size cost. The context-aware lexer buys the specific correctness the AST would have here.

### The failure direction, bounded

Blanking trades a false positive for a false *negative* if it runs away. This scanner cannot distinguish a backtick in a regex literal from an opening backtick, so an unbalanced backtick re-emits its span **verbatim** rather than blanking it — byte-identical to the previous behaviour for malformed input. Without that, the tail of a file would silently vanish from the scanner's view and a genuine bare import would go unreported by every consumer.

`isBareSpecifier` also rejects any specifier containing `${` on its own. That is **not** unreachable code after the stripping change: `import x from "${pkg}"` is valid TypeScript at the top level, since double quotes do not interpolate.

### Blast radius

Four consumers share these two predicates; all are corrected by the same change:

| Consumer | Prior false-positive behaviour |
| --- | --- |
| `quality.ts` bare-specifier gate | hard error, no score (the reported bug) |
| `push.ts` | spurious medium `bare-specifiers` warning |
| `isExpectedBundleFailure` | cached bundle served in place of a rebundle |
| `extension_push.ts` | an unrelated `package.json` claimed as project config, enforcing `requireNodeModules()` |

The pulled-extension cache fast path is unaffected — both callers pass `trustPulledCache` ahead of the predicate. The only site relying on `isExpectedBundleFailure` is `rebundleAndUpdateCatalog`, where a codegen extension now rebundles normally instead of being pinned to a stale cache.

The dependency extractor still reads `npm:`/`jsr:` specifiers out of template literals, deliberately: the generated script really does fetch them at runtime, so trust-auditing them is correct.

## Test Plan

Verified against the **reported extension**, not a reconstruction — a clone of `umag/swamp-workspace` (the verified repository on the registry record for `@magistr/jscad-cad`), driven with the issue's own command.

| | `swamp extension quality jscad-cad/manifest.yaml --repo-dir <root> --json` |
| --- | --- |
| Pre-fix (worktree at `main`, 2e585ffc) | `{"error":"...bare import specifiers...\"${pkg}\"..."}` — exit 1, no score |
| Post-fix (compiled binary) | `"status":"passed"`, 14/14, **100%**, exit 0 |

- The real trigger is a harder case than a minimal repro: its template carries three interpolations containing function calls, parens and escaped strings (`${JSON.stringify(source)}`, `${paramsJson}`, `${JSON.stringify(ctorRef)}`), so the brace counting and quote delegation are load-bearing on real input.
- **True positives intact:** a genuine `import { z } from "zod";` added to that same extension — resolvable via its own `deno.json` import map, so bundling succeeds and the gate is actually reached — still errors with `... cannot be resolved by the server-side scorer: "zod"`, exit 1.
- `@jscad/modeling@2.12.0` is still audited post-fix, confirming the dependency extractor path was correctly left alone.
- 12 new cases in `bundle_test.ts` against the real exports, covering the interpolated and static-bare generated forms, a real import *alongside* generated code, nested templates, object-literal braces, a quoted unbalanced brace, an escaped backtick, a backtick in a regex literal, an unterminated template, and an interpolated specifier outside any template. The four pre-existing swamp-club#657 tests pass unchanged — they only ever passed incidentally, since `IMPORT_SPECIFIER_RE`'s `[^;()]*?` cannot cross the parens in `export function foo(...)`, which is why this class survived two prior fixes.
- `deno fmt`, `deno lint`, `deno check main.ts`, `deno run test` (9666 passed, 0 failed, 29 ignored), `deno run compile`.

### Known residual

An entire import statement embedded in a plain quoted string — `const s = "import x from 'zod'";` — is still read as a real import, because quoted contents must stay preserved for the regex to find genuine specifiers at all. Same class of defect; only an AST fully closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)