### PR TITLE
feat(workflow): show guard expression when steps are skipped (swamp-club#1489)

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -699,8 +699,24 @@ error message.
 ### Events and rendering
 
 Guard-skipped steps emit a `step_skipped` event with `reason: "guarded"` (vs
-`"dependency"` for dependency skips). The console renderer shows
-`skipped (guarded)` to distinguish from dependency skips.
+`"dependency"` for dependency skips). The event includes `guardExpression` (the
+raw CEL expression string) and `guardResult` (the evaluated value) so consumers
+can display why the step was skipped.
+
+Console output shows the guard expression inline:
+
+```
+   main │ skipped (guarded) · guard: data.latest("checker", "result").attributes.exitCode == 0
+```
+
+JSON output includes both fields:
+
+```json
+{"step":"do-work","job":"main","status":"skipped","reason":"guarded","guardExpression":"data.latest(\"checker\", \"result\").attributes.exitCode == 0","guardResult":true}
+```
+
+Debug-level logging (`--log-level debug`) emits guard evaluation results for both
+skipped and non-skipped steps, showing the expression and its result.
 
 ## Data Output Overrides with Vary Dimensions
 

--- a/src/domain/workflows/execution_events.ts
+++ b/src/domain/workflows/execution_events.ts
@@ -75,6 +75,8 @@ export type WorkflowExecutionEvent =
     jobId: string;
     stepId: string;
     reason?: "guarded" | "dependency";
+    guardExpression?: string;
+    guardResult?: unknown;
     forEachTemplate?: string;
     forEachIndex?: number;
   }

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -2683,6 +2683,7 @@ export class WorkflowExecutionService {
           `Step "${stepName}" guard must be a $\{{ }} expression, got: ${step.guard}`,
         );
       }
+      const guardLogger = getWorkflowRunLogger(workflow.name);
       try {
         const celEvaluator = new CelEvaluator();
         const guardContext: Record<string, unknown> = {
@@ -2751,6 +2752,8 @@ export class WorkflowExecutionService {
           guardContext,
         );
         if (guardResult) {
+          guardLogger
+            .debug`Step ${stepName} guard skipped: ${guardCel} → ${guardResult}`;
           stepRun.skip();
           stepSpan.setAttribute("step.status", "skipped");
           stepSpan.setAttribute("step.skip.reason", "guarded");
@@ -2760,11 +2763,15 @@ export class WorkflowExecutionService {
             jobId: job.name,
             stepId: stepName,
             reason: "guarded",
+            guardExpression: guardCel,
+            guardResult,
             forEachTemplate,
             forEachIndex,
           };
           return;
         }
+        guardLogger
+          .debug`Step ${stepName} guard passed: ${guardCel} → ${guardResult}`;
       } catch (error) {
         stepRun.fail(String(error));
         stepSpan.setAttribute("step.status", "failed");

--- a/src/libswamp/workflows/run.ts
+++ b/src/libswamp/workflows/run.ts
@@ -106,6 +106,8 @@ export type WorkflowRunEvent =
     jobId: string;
     stepId: string;
     reason?: "guarded" | "dependency";
+    guardExpression?: string;
+    guardResult?: unknown;
     forEachTemplate?: string;
     forEachIndex?: number;
   }

--- a/src/presentation/output/console_writer.ts
+++ b/src/presentation/output/console_writer.ts
@@ -152,9 +152,16 @@ export class PipeWriter {
     return this.line(name, `${red("failed")} ${dim(`· ${timestamp}`)}`);
   }
 
-  skippedLine(name: string, reason?: string): string {
+  skippedLine(
+    name: string,
+    reason?: string,
+    guardExpression?: string,
+  ): string {
     const extra = reason ? ` (${reason})` : "";
-    return this.line(name, `${dim(`skipped${extra}`)}`);
+    const guard = guardExpression
+      ? ` ${dim(`· guard: ${guardExpression}`)}`
+      : "";
+    return this.line(name, `${dim(`skipped${extra}`)}${guard}`);
   }
 
   stepLine(

--- a/src/presentation/output/console_writer_test.ts
+++ b/src/presentation/output/console_writer_test.ts
@@ -177,6 +177,29 @@ Deno.test("PipeWriter.skippedLine: formats skip with reason", () => {
   });
 });
 
+Deno.test("PipeWriter.skippedLine: includes guard expression when provided", () => {
+  noColor(() => {
+    const pipe = new PipeWriter(["load"]);
+    const line = pipe.skippedLine(
+      "load",
+      "guarded",
+      'data.latest("checker", "result").attributes.exitCode == 0',
+    );
+    assertEquals(
+      line,
+      ' load │ skipped (guarded) · guard: data.latest("checker", "result").attributes.exitCode == 0',
+    );
+  });
+});
+
+Deno.test("PipeWriter.skippedLine: omits guard when not provided", () => {
+  noColor(() => {
+    const pipe = new PipeWriter(["load"]);
+    const line = pipe.skippedLine("load", "guarded");
+    assertEquals(line, " load │ skipped (guarded)");
+  });
+});
+
 Deno.test("PipeWriter.stepLine: formats step with model and method", () => {
   noColor(() => {
     const pipe = new PipeWriter(["extract"]);

--- a/src/presentation/renderers/workflow_run.ts
+++ b/src/presentation/renderers/workflow_run.ts
@@ -301,7 +301,9 @@ class ConsoleWorkflowRunRenderer implements WorkflowRunRenderer {
         if (!this.pipe) return;
         this.clearHeartbeat(e.jobId, e.stepId);
         const displayName = this.getDisplayName(e.jobId, e.stepId, e);
-        writeOutput(this.pipe.skippedLine(displayName, e.reason));
+        writeOutput(
+          this.pipe.skippedLine(displayName, e.reason, e.guardExpression),
+        );
       },
       step_queued: (e) => {
         if (!this.pipe) return;
@@ -738,6 +740,12 @@ class JsonWorkflowRunRenderer implements WorkflowRunRenderer {
             job: e.jobId,
             status: "skipped",
             reason: "guarded",
+            ...(e.guardExpression !== undefined && {
+              guardExpression: e.guardExpression,
+            }),
+            ...(e.guardResult !== undefined && {
+              guardResult: e.guardResult,
+            }),
           }));
         }
       },

--- a/src/presentation/renderers/workflow_run_test.ts
+++ b/src/presentation/renderers/workflow_run_test.ts
@@ -532,6 +532,61 @@ Deno.test("JsonWorkflowRunRenderer: completed serializes WorkflowRunView", async
   }
 });
 
+Deno.test("JsonWorkflowRunRenderer: step_skipped guarded includes guard fields", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createWorkflowRunRenderer("json", {
+      workflowName: "test-pipeline",
+    });
+    const handler = renderer.handlers().step_skipped;
+    handler({
+      kind: "step_skipped",
+      jobId: "main",
+      stepId: "do-work",
+      reason: "guarded",
+      guardExpression:
+        'data.latest("checker", "result").attributes.exitCode == 0',
+      guardResult: true,
+    });
+    assertEquals(logs.length, 1);
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.step, "do-work");
+    assertEquals(parsed.reason, "guarded");
+    assertEquals(
+      parsed.guardExpression,
+      'data.latest("checker", "result").attributes.exitCode == 0',
+    );
+    assertEquals(parsed.guardResult, true);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("JsonWorkflowRunRenderer: step_skipped dependency emits no output", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    const renderer = createWorkflowRunRenderer("json", {
+      workflowName: "test-pipeline",
+    });
+    const handler = renderer.handlers().step_skipped;
+    handler({
+      kind: "step_skipped",
+      jobId: "main",
+      stepId: "cleanup",
+      reason: "dependency",
+    });
+    assertEquals(logs.length, 0);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
 Deno.test("JsonWorkflowRunRenderer: error event throws UserError", () => {
   const renderer = createWorkflowRunRenderer("json", {
     workflowName: "test-pipeline",


### PR DESCRIPTION
## Summary

- When a workflow step is skipped due to a guard, the output now includes the guard expression that triggered the skip
- Console output: `skipped (guarded) · guard: <expression>`
- JSON output: adds `guardExpression` and `guardResult` fields to the skip event
- Debug-level LogTape logging for guard evaluation (both skip and pass-through cases)
- Updated `design/workflow.md` to document the new output

Closes swamp-club#1489

## Test Plan

- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno run test` — 9716 tests pass
- [x] `deno check` — no new type errors (pre-existing `DenoRuntime.getDenoEnv` error on main)
- [x] Manual verification with scratch repo: guard-skipped steps now show the expression in both log and JSON modes