### PR TITLE
feat(serve): startup cache hydration for disposable instance replacement (swamp-club#1491)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -131,6 +131,7 @@ import { swampPath } from "../../infrastructure/persistence/paths.ts";
 import { canonicalizePath } from "../../infrastructure/persistence/canonicalize_path.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
 import {
+  hydrateLocalCache,
   reconcileRemoteInterruptedRuns,
   replayPendingRuns,
   sweepStaleRecords,
@@ -1544,6 +1545,14 @@ export const serveCommand = new Command()
     }
 
     let heartbeatService: InstanceHeartbeatService | undefined;
+
+    if (detachRuns && syncService) {
+      await hydrateLocalCache({
+        syncService,
+        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+        signal: AbortSignal.timeout(60_000),
+      });
+    }
 
     // Reap stale runs via the SQLite tracker (heartbeat + PID liveness).
     // This handles both model-method and workflow runs registered with the tracker.

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -34,6 +34,7 @@ import type { ModelType } from "../domain/models/model_type.ts";
 import type { Data } from "../domain/data/data.ts";
 import type { FileSystemUnifiedDataRepository } from "../infrastructure/persistence/unified_data_repository.ts";
 import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 
@@ -56,6 +57,39 @@ export interface SweepResult {
   leases: number;
   pendingDispatches: number;
   workers: number;
+}
+
+// ── Startup Cache Hydration ─────────────────────────────────────────
+
+export interface HydrateLocalCacheDeps {
+  syncService: DatastoreSyncService;
+  catalogInvalidate: () => void;
+  signal?: AbortSignal;
+}
+
+export interface HydrateResult {
+  pulled: number;
+}
+
+export async function hydrateLocalCache(
+  deps: HydrateLocalCacheDeps,
+): Promise<HydrateResult> {
+  logger.info("Hydrating local cache from remote datastore");
+  try {
+    const pulled = await deps.syncService.pullChanged({ signal: deps.signal });
+    const count = typeof pulled === "number" ? pulled : 0;
+    if (count > 0) {
+      logger.info`Pulled ${count} file(s) from remote datastore`;
+    }
+    deps.catalogInvalidate();
+    return { pulled: count };
+  } catch (err: unknown) {
+    logger.warn(
+      "Startup cache hydration failed: {error}",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    return { pulled: 0 };
+  }
 }
 
 async function defaultRunTransition(

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -20,6 +20,8 @@
 import { assertEquals } from "@std/assert";
 import {
   type BootReconciliationDeps,
+  hydrateLocalCache,
+  type HydrateLocalCacheDeps,
   reconcileRemoteInterruptedRuns,
   type ReconcileRemoteInterruptedRunsDeps,
   replayPendingRuns,
@@ -27,6 +29,7 @@ import {
   sweepStaleRecords,
   type TransitionInput,
 } from "./boot_reconciliation.ts";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
@@ -832,4 +835,60 @@ Deno.test("reconcileRemoteInterruptedRuns: reaps multiple stale instances", asyn
   assertEquals(h.completed.length, 2);
   const reapedIds = h.completed.map((c) => c.runId).sort();
   assertEquals(reapedIds, ["run-1", "run-2"]);
+});
+
+// ── hydrateLocalCache tests ─────────────────────────────────────────
+
+function createHydrateDeps(
+  opts: {
+    pullResult?: number | void;
+    pullError?: Error;
+  } = {},
+): { deps: HydrateLocalCacheDeps; invalidated: boolean[] } {
+  const invalidated: boolean[] = [];
+  const syncService = {
+    pullChanged: () => {
+      if (opts.pullError) return Promise.reject(opts.pullError);
+      return Promise.resolve(opts.pullResult);
+    },
+  } as unknown as DatastoreSyncService;
+
+  return {
+    deps: {
+      syncService,
+      catalogInvalidate: () => invalidated.push(true),
+    },
+    invalidated,
+  };
+}
+
+Deno.test("hydrateLocalCache: calls pullChanged and returns file count", async () => {
+  const h = createHydrateDeps({ pullResult: 42 });
+  const result = await hydrateLocalCache(h.deps);
+  assertEquals(result.pulled, 42);
+});
+
+Deno.test("hydrateLocalCache: invalidates catalog after successful pull", async () => {
+  const h = createHydrateDeps({ pullResult: 5 });
+  await hydrateLocalCache(h.deps);
+  assertEquals(h.invalidated.length, 1);
+});
+
+Deno.test("hydrateLocalCache: handles void return from pullChanged", async () => {
+  const h = createHydrateDeps({ pullResult: undefined });
+  const result = await hydrateLocalCache(h.deps);
+  assertEquals(result.pulled, 0);
+  assertEquals(h.invalidated.length, 1);
+});
+
+Deno.test("hydrateLocalCache: catches pull failure and returns zero", async () => {
+  const h = createHydrateDeps({ pullError: new Error("S3 timeout") });
+  const result = await hydrateLocalCache(h.deps);
+  assertEquals(result.pulled, 0);
+});
+
+Deno.test("hydrateLocalCache: does not invalidate catalog on failure", async () => {
+  const h = createHydrateDeps({ pullError: new Error("network error") });
+  await hydrateLocalCache(h.deps);
+  assertEquals(h.invalidated.length, 0);
 });


### PR DESCRIPTION
## Summary

- When `swamp serve` starts with `--detach-runs` and a remote datastore (S3/GCS), the local cache is now automatically hydrated via `pullChanged()` before boot reconciliation runs
- This ensures `reapOrphanedWorkflowRuns` and `sweepStaleRecords` can find WorkflowRun YAML and model data from dead predecessor instances
- Operators no longer need to add `swamp datastore sync --pull` to cloud-init / init containers before starting serve

## Test Plan

- [x] Unit tests for `hydrateLocalCache`: successful pull with count, catalog invalidation, void return handling, failure catch + warn, no catalog invalidation on failure
- [x] E2E verified with MinIO: wiped local cache, started serve with `--detach-runs`, confirmed hydration pulled 23 files and `reapOrphanedWorkflowRuns` found the orphaned workflow run
- [x] Negative case: serve without `--detach-runs` does not hydrate (correct)
- [x] Full test suite passes (9717 tests, 0 failures)
- [x] `deno check`, `deno lint`, `deno fmt`, `deno run compile` all pass

Closes swamp-club#1491