### PR TITLE
fix(serve): address review feedback on continuous reconciliation

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -951,7 +951,7 @@ export const serveCommand = new Command()
   .option(
     "--stale-ttl <duration:string>",
     "How long a heartbeat can go without update before the instance is considered dead. " +
-      "Should be at least 2-3x --heartbeat-interval. " +
+      "Must be at least 2x --heartbeat-interval (values below this are rejected). " +
       "Accepts seconds (90), explicit units (90s, 2m). Default: 90s. " +
       "Only used with --detach-runs (env: SWAMP_STALE_TTL)",
   )
@@ -1590,22 +1590,23 @@ export const serveCommand = new Command()
     if (!detachRuns) {
       if (heartbeatIntervalMs !== undefined) {
         logger.warn(
-          "--heartbeat-interval is set but --detach-runs is not active — setting will have no effect",
+          "--heartbeat-interval is set but --detach-runs is not active — heartbeat-interval will have no effect",
         );
       }
       if (staleTtlMs !== undefined) {
         logger.warn(
-          "--stale-ttl is set but --detach-runs is not active — setting will have no effect",
+          "--stale-ttl is set but --detach-runs is not active — stale-ttl will have no effect",
         );
       }
       if (reconciliationIntervalMs !== undefined) {
         logger.warn(
-          "--reconciliation-interval is set but --detach-runs is not active — setting will have no effect",
+          "--reconciliation-interval is set but --detach-runs is not active — reconciliation-interval will have no effect",
         );
       }
     }
 
     if (
+      detachRuns &&
       staleTtlMs !== undefined && heartbeatIntervalMs !== undefined &&
       staleTtlMs < heartbeatIntervalMs * 2
     ) {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1048,20 +1048,20 @@ export const serveCommand = new Command()
 
     const heartbeatIntervalRaw =
       (options.heartbeatInterval as string | undefined) ??
-        Deno.env.get("SWAMP_HEARTBEAT_INTERVAL") ?? undefined;
+        Deno.env.get("SWAMP_HEARTBEAT_INTERVAL");
     const heartbeatIntervalMs = heartbeatIntervalRaw !== undefined
       ? parseTimeout(heartbeatIntervalRaw, "--heartbeat-interval")
       : undefined;
 
     const staleTtlRaw = (options.staleTtl as string | undefined) ??
-      Deno.env.get("SWAMP_STALE_TTL") ?? undefined;
+      Deno.env.get("SWAMP_STALE_TTL");
     const staleTtlMs = staleTtlRaw !== undefined
       ? parseTimeout(staleTtlRaw, "--stale-ttl")
       : undefined;
 
     const reconciliationIntervalRaw =
       (options.reconciliationInterval as string | undefined) ??
-        Deno.env.get("SWAMP_RECONCILIATION_INTERVAL") ?? undefined;
+        Deno.env.get("SWAMP_RECONCILIATION_INTERVAL");
     const reconciliationIntervalMs = reconciliationIntervalRaw !== undefined
       ? parseTimeout(reconciliationIntervalRaw, "--reconciliation-interval")
       : undefined;
@@ -1586,6 +1586,34 @@ export const serveCommand = new Command()
     const cancelRegistry = new RunCancelRegistry();
     const detachRuns = options.detachRuns === true;
     const activeRunRegistry = detachRuns ? new ActiveRunRegistry() : undefined;
+
+    if (!detachRuns) {
+      if (heartbeatIntervalMs !== undefined) {
+        logger.warn(
+          "--heartbeat-interval is set but --detach-runs is not active — setting will have no effect",
+        );
+      }
+      if (staleTtlMs !== undefined) {
+        logger.warn(
+          "--stale-ttl is set but --detach-runs is not active — setting will have no effect",
+        );
+      }
+      if (reconciliationIntervalMs !== undefined) {
+        logger.warn(
+          "--reconciliation-interval is set but --detach-runs is not active — setting will have no effect",
+        );
+      }
+    }
+
+    if (
+      staleTtlMs !== undefined && heartbeatIntervalMs !== undefined &&
+      staleTtlMs < heartbeatIntervalMs * 2
+    ) {
+      throw new UserError(
+        `--stale-ttl (${staleTtlRaw}) must be at least 2x --heartbeat-interval (${heartbeatIntervalRaw}), ` +
+          "otherwise live instances will appear stale",
+      );
+    }
 
     // HA instance identity — generated only when detach-runs is active so
     // each process gets a unique ID that survives across reconnects.
@@ -2619,40 +2647,46 @@ export const serveCommand = new Command()
 
         const RECONCILIATION_INTERVAL_MS = reconciliationIntervalMs ?? 60_000;
         const RECONCILIATION_JITTER_MS = 500;
+        const runReconciliationTick = async () => {
+          try {
+            const reaped = await reconcileRemoteInterruptedRuns({
+              controlPlaneStore: controlPlaneStore!,
+              instanceId: instanceId!,
+              runTracker,
+              staleTtlMs,
+            });
+            if (reaped > 0) {
+              logger
+                .info`Continuous reconciliation reaped ${reaped} run(s)`;
+            }
+          } catch (err: unknown) {
+            logger.warn(
+              "Continuous reconciliation failed: {error}",
+              { error: err instanceof Error ? err.message : String(err) },
+            );
+          }
+          try {
+            await cleanupExpiredClaims({
+              controlPlaneStore: controlPlaneStore!,
+            });
+          } catch (err: unknown) {
+            logger.warn(
+              "Reconciliation claim cleanup failed: {error}",
+              { error: err instanceof Error ? err.message : String(err) },
+            );
+          }
+        };
         const scheduleReconciliation = () => {
           const jitter = new Uint32Array(1);
           crypto.getRandomValues(jitter);
           const jitterMs = (jitter[0] / 0xFFFFFFFF) * RECONCILIATION_JITTER_MS;
-          const timer = setTimeout(async () => {
-            try {
-              const reaped = await reconcileRemoteInterruptedRuns({
-                controlPlaneStore: controlPlaneStore!,
-                instanceId: instanceId!,
-                runTracker,
-                staleTtlMs,
-              });
-              if (reaped > 0) {
-                logger
-                  .info`Continuous reconciliation reaped ${reaped} run(s)`;
-              }
-            } catch (err: unknown) {
-              logger.warn(
-                "Continuous reconciliation failed: {error}",
-                { error: err instanceof Error ? err.message : String(err) },
-              );
-            }
-            try {
-              await cleanupExpiredClaims({
-                controlPlaneStore: controlPlaneStore!,
-              });
-            } catch (err: unknown) {
-              logger.warn(
-                "Reconciliation claim cleanup failed: {error}",
-                { error: err instanceof Error ? err.message : String(err) },
-              );
-            }
-            scheduleReconciliation();
-          }, RECONCILIATION_INTERVAL_MS + jitterMs);
+          const timer = setTimeout(
+            () =>
+              runReconciliationTick().catch(() => {}).finally(
+                scheduleReconciliation,
+              ),
+            RECONCILIATION_INTERVAL_MS + jitterMs,
+          );
           Deno.unrefTimer(timer);
         };
         scheduleReconciliation();


### PR DESCRIPTION
## Summary

Follow-up to #2044 — addresses three suggestions from the CLI UX, Code, and Adversarial reviews.

- **Remove redundant `?? undefined`** from env var fallback chains — `Deno.env.get()` already returns `string | undefined`
- **Warn on silent no-op flags** — emit `logger.warn` when `--heartbeat-interval`, `--stale-ttl`, or `--reconciliation-interval` are set without `--detach-runs`, matching the existing pattern for `--admins` without `--auth-mode`
- **Validate stale-TTL vs heartbeat interval** — reject `--stale-ttl < 2x --heartbeat-interval` with a `UserError` to prevent misconfiguration that would mark live instances as stale
- **Match async timer pattern** — extract the async reconciliation callback and wrap with `.catch().finally()` to match the fire-record reaper's promise-handling pattern

## Test plan

- [x] 59 tests pass (42 reconciliation + 17 daemon flag forwarding)
- [x] Type check, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)