### PR TITLE
fix(workflow): resolve globalArgument input refs against step inputs, not workflow inputs (swamp-club#1500)

### DIFF
--- a/design/workflow.md
+++ b/design/workflow.md
@@ -346,6 +346,21 @@ model **instance** which does not exist locally (`model_not_found`) produces a
 it could also be a typo. The warning surfaces the reference without failing
 validation.
 
+### GlobalArgument Input References
+
+When a model definition's `globalArguments` or method-level argument defaults
+contain `${{ inputs.* }}` expressions, the validator checks that each referenced
+input is supplied by the calling step's `inputs:` block. This catches cases where
+a model definition expects an input (e.g. `host: ${{ inputs.ip }}`) that the
+workflow step never provides, which would fail at runtime with an unresolved
+expression. The check resolves against the step's inputs — not the workflow's
+top-level inputs — because `${{ inputs.* }}` in a model definition refers to the
+model's own input namespace, populated by the step at runtime.
+
+Steps with dynamic inputs (a single `${{ ... }}` expression as the entire
+`inputs` value) are skipped, as are steps with dynamic model references, since
+neither can be statically analysed.
+
 ### Unknown Keys Are Rejected
 
 The workflow, job, and step schemas reject unknown keys at parse time with an

--- a/src/domain/workflows/validation_service.ts
+++ b/src/domain/workflows/validation_service.ts
@@ -108,7 +108,7 @@ export interface ModelMethodResolver {
  * 6. No cyclic dependencies between jobs
  * 7. No cyclic dependencies between steps within jobs
  * 8. Step inputs match method/workflow required arguments
- * 9. GlobalArgument expressions reference declared workflow inputs
+ * 9. GlobalArgument expressions reference inputs supplied by the step
  */
 export interface WorkflowValidationService {
   /**
@@ -161,7 +161,7 @@ export class DefaultWorkflowValidationService
       results.push(...await this.validateStepInputs(workflow));
     }
 
-    // 9. GlobalArgument expressions reference declared workflow inputs
+    // 9. GlobalArgument expressions reference inputs supplied by the step
     if (this.methodResolver) {
       results.push(
         ...await this.validateGlobalArgInputRefs(workflow),
@@ -602,9 +602,6 @@ export class DefaultWorkflowValidationService
     workflow: Workflow,
   ): Promise<WorkflowValidationResult[]> {
     const results: WorkflowValidationResult[] = [];
-    const declaredInputs = new Set(
-      Object.keys(workflow.inputs?.properties ?? {}),
-    );
 
     for (const job of workflow.jobs) {
       for (const step of job.steps) {
@@ -618,6 +615,9 @@ export class DefaultWorkflowValidationService
         if (!modelRef) continue;
         if (modelRef.includes("${{")) continue;
         if (taskData.modelType?.includes("${{")) continue;
+
+        // Dynamic step inputs cannot be statically analysed
+        if (typeof taskData.inputs === "string") continue;
 
         const checkName =
           `GlobalArgument input references for '${step.name}' in job '${job.name}' (${modelRef}.${taskData.methodName})`;
@@ -644,15 +644,18 @@ export class DefaultWorkflowValidationService
           continue;
         }
 
+        const stepInputs = new Set(
+          Object.keys(taskData.inputs ?? {}),
+        );
         const missing = [...referencedInputs].filter(
-          (name) => !declaredInputs.has(name),
+          (name) => !stepInputs.has(name),
         );
 
         if (missing.length > 0) {
           results.push(
             WorkflowValidationResult.fail(
               checkName,
-              `Model definition references undeclared workflow input(s): ${
+              `Model definition references input(s) not supplied by step: ${
                 missing.join(", ")
               }`,
             ),

--- a/src/domain/workflows/validation_service_test.ts
+++ b/src/domain/workflows/validation_service_test.ts
@@ -1329,7 +1329,7 @@ Deno.test("validateStepInputs: direct-execution step with CEL in modelType skips
 
 // ---------- validateGlobalArgInputRefs ----------
 
-Deno.test("validateGlobalArgInputRefs: fails when globalArguments reference undeclared workflow inputs", async () => {
+Deno.test("validateGlobalArgInputRefs: fails when step does not supply referenced input", async () => {
   const resolver = mockResolver({
     "my-model.execute": {
       status: "resolved",
@@ -1344,18 +1344,15 @@ Deno.test("validateGlobalArgInputRefs: fails when globalArguments reference unde
 
   const workflow = Workflow.create({
     name: "test",
-    inputs: {
-      properties: {
-        recordHost: { type: "string" },
-      },
-    },
     jobs: [
       Job.create({
         name: "job1",
         steps: [
           Step.create({
             name: "step1",
-            task: StepTask.model("my-model", "execute"),
+            task: StepTask.model("my-model", "execute", {
+              recordHost: "example.com",
+            }),
           }),
         ],
       }),
@@ -1370,7 +1367,7 @@ Deno.test("validateGlobalArgInputRefs: fails when globalArguments reference unde
   assertEquals(result?.error?.includes("dnsZone"), true);
 });
 
-Deno.test("validateGlobalArgInputRefs: passes when all referenced inputs are declared", async () => {
+Deno.test("validateGlobalArgInputRefs: passes when step supplies all referenced inputs", async () => {
   const resolver = mockResolver({
     "my-model.execute": {
       status: "resolved",
@@ -1385,19 +1382,16 @@ Deno.test("validateGlobalArgInputRefs: passes when all referenced inputs are dec
 
   const workflow = Workflow.create({
     name: "test",
-    inputs: {
-      properties: {
-        recordHost: { type: "string" },
-        dnsZone: { type: "string" },
-      },
-    },
     jobs: [
       Job.create({
         name: "job1",
         steps: [
           Step.create({
             name: "step1",
-            task: StepTask.model("my-model", "execute"),
+            task: StepTask.model("my-model", "execute", {
+              recordHost: "example.com",
+              dnsZone: "example.zone",
+            }),
           }),
         ],
       }),
@@ -1446,7 +1440,7 @@ Deno.test("validateGlobalArgInputRefs: passes when no expressions in globalArgum
   assertEquals(result?.passed, true);
 });
 
-Deno.test("validateGlobalArgInputRefs: fails when workflow has no inputs but globalArguments reference them", async () => {
+Deno.test("validateGlobalArgInputRefs: fails when step has no inputs but globalArguments reference them", async () => {
   const resolver = mockResolver({
     "my-model.execute": {
       status: "resolved",
@@ -1554,18 +1548,15 @@ Deno.test("validateGlobalArgInputRefs: handles bracket notation input references
 
   const workflow = Workflow.create({
     name: "test",
-    inputs: {
-      properties: {
-        "record-host": { type: "string" },
-      },
-    },
     jobs: [
       Job.create({
         name: "job1",
         steps: [
           Step.create({
             name: "step1",
-            task: StepTask.model("my-model", "execute"),
+            task: StepTask.model("my-model", "execute", {
+              "record-host": "example.com",
+            }),
           }),
         ],
       }),
@@ -1577,6 +1568,90 @@ Deno.test("validateGlobalArgInputRefs: handles bracket notation input references
     r.name.includes("GlobalArgument input references")
   );
   assertEquals(result?.passed, true);
+});
+
+Deno.test("validateGlobalArgInputRefs: passes when step supplies model input via expression", async () => {
+  const resolver = mockResolver({
+    "ssh-host.exec": {
+      status: "resolved",
+      requiredArgs: ["command"],
+      definitionProvidedArgs: ["host", "user"],
+      definitionProvidedArgValues: {
+        host: "${{ inputs.ip }}",
+        user: "root",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    inputs: {
+      properties: {
+        nodeName: { type: "string" },
+      },
+    },
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.model("ssh-host", "exec", {
+              ip: '${{ data.latest("node", inputs.nodeName).attributes.ipv4 }}',
+              command: "docker image prune -f",
+            }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result?.passed, true);
+});
+
+Deno.test("validateGlobalArgInputRefs: skips when step inputs is a dynamic expression", async () => {
+  const resolver = mockResolver({
+    "my-model.execute": {
+      status: "resolved",
+      requiredArgs: [],
+      definitionProvidedArgs: ["run"],
+      definitionProvidedArgValues: {
+        run: "${{ inputs.host }}",
+      },
+    },
+  });
+  const svc = new DefaultWorkflowValidationService(resolver);
+
+  const workflow = Workflow.create({
+    name: "test",
+    jobs: [
+      Job.create({
+        name: "job1",
+        steps: [
+          Step.create({
+            name: "step1",
+            task: StepTask.fromData({
+              type: "model_method",
+              modelIdOrName: "my-model",
+              methodName: "execute",
+              inputs: "${{ steps.previous.output }}",
+            }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const results = await svc.validate(workflow);
+  const result = results.find((r) =>
+    r.name.includes("GlobalArgument input references")
+  );
+  assertEquals(result, undefined);
 });
 
 Deno.test("validate: warns when queueTimeout is set without placement", async () => {


### PR DESCRIPTION
## Summary

- Fixes `validateGlobalArgInputRefs` to resolve `${{ inputs.* }}` expressions from model definitions against the **step's `inputs:` keys** instead of the workflow's top-level inputs
- The check was incorrectly treating model-namespace input references as workflow-namespace references, causing false failures on valid workflows using the documented model-inputs pattern (37 workflows affected in the reporter's repo)
- Preserves the original #622 behavior: inputs genuinely missing from the step's `inputs:` block still fail validation
- Updates existing tests to use step-level inputs, adds new test cases for the #1500 pattern (step supplies model input via expression) and dynamic step inputs (skip)
- Documents the GlobalArgument input references check in `design/workflow.md`

Fixes swamp-club#1500

## Test Plan

- [x] Updated 4 existing `validateGlobalArgInputRefs` unit tests to use step-level inputs
- [x] Added test: step supplies model input via expression (passes) — the #1500 pattern
- [x] Added test: dynamic step inputs expression (skips) — cannot be statically analysed
- [x] Verified #1500 fix with compiled binary: step supplies `ip` → check passes
- [x] Verified #622 original behavior with compiled binary: step omits `ip` → check fails with `"Model definition references input(s) not supplied by step: ip"`
- [x] Full test suite passes (9723 tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)