### PR TITLE
feat(serve): refresh trust list on hot-reload SIGHUP (swamp-club#1499)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -73,6 +73,7 @@ import {
 import { groupCommandAction } from "../group_action.ts";
 import {
   normalizeFireTime,
+  resolveTrustedCollectives,
   ScheduledExecutionService,
 } from "../../libswamp/mod.ts";
 import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
@@ -148,6 +149,8 @@ import {
 import type { WorkflowRun } from "../../domain/workflows/workflow_run.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
 import { requireAuthenticated, requireScope } from "../auth_context.ts";
+import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
+import { AuthRepository } from "../../infrastructure/persistence/auth_repository.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -767,10 +770,32 @@ async function reloadPulledExtensions(
   }
 }
 
+async function reloadTrustedCollectives(
+  repoDir: string,
+): Promise<void> {
+  const markerRepo = new RepoMarkerRepository();
+  const marker = await markerRepo.read(RepoPath.create(repoDir));
+
+  let authCollectives: string[] | undefined;
+  try {
+    const authRepo = new AuthRepository();
+    const creds = await authRepo.load();
+    authCollectives = creds?.collectives;
+  } catch {
+    // Auth file unreadable — continue without membership collectives
+  }
+
+  const collectives = resolveTrustedCollectives(marker, authCollectives);
+  const resolver = getAutoResolver();
+  if (resolver) {
+    resolver.updateAllowedCollectives(collectives);
+  }
+}
+
 const reloadCommand = new Command()
   .name("reload")
   .description(
-    "Reload pulled extension bundles on a running serve process.\n\n" +
+    "Reload pulled extension bundles and refresh the trust list on a running serve process.\n\n" +
       "Reads .swamp/serve.pid and sends SIGHUP to trigger hot-reload. " +
       "Requires the serve process to be running with --hot-reload.",
   )
@@ -2413,8 +2438,19 @@ export const serveCommand = new Command()
         reloading = true;
         logger.info("SIGHUP received, reloading pulled extensions...");
         reloadPulledExtensions(resolvedRepoDir, extensionLockfilePath)
-          .then((count) => {
+          .then(async (count) => {
             logger.info`Hot-reloaded ${count} type(s)`;
+            try {
+              await reloadTrustedCollectives(resolvedRepoDir);
+              logger.info("Trust list refreshed from .swamp.yaml");
+            } catch (err) {
+              logger.warn(
+                "Failed to refresh trust list, keeping current config: {error}",
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                },
+              );
+            }
           })
           .catch((err) => {
             logger.error(

--- a/src/domain/extensions/extension_auto_resolver.ts
+++ b/src/domain/extensions/extension_auto_resolver.ts
@@ -182,6 +182,11 @@ export class ExtensionAutoResolver {
     this.config = config;
   }
 
+  updateAllowedCollectives(collectives: string[]): void {
+    this.config.allowedCollectives = collectives;
+    this.warnedUntrusted.clear();
+  }
+
   /**
    * Attempts to resolve an unknown type by finding and installing
    * the extension that provides it.

--- a/src/domain/extensions/extension_auto_resolver_test.ts
+++ b/src/domain/extensions/extension_auto_resolver_test.ts
@@ -732,3 +732,59 @@ Deno.test("installAndLoad: emits noStableVersion when latestVersion is null", as
   );
   assertEquals(installer.installCalls.length, 0);
 });
+
+Deno.test("updateAllowedCollectives: allows previously untrusted collective", async () => {
+  const output = createMockOutput();
+  const installer = createMockInstaller();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: installer,
+    output,
+  });
+
+  const result1 = await resolver.resolve("@acme/widgets/foo");
+  assertEquals(result1, false);
+  assertEquals(
+    output.calls.filter((c) => c.startsWith("collectiveNotTrusted")).length,
+    1,
+  );
+
+  resolver.updateAllowedCollectives(["swamp", "acme"]);
+
+  const result2 = await resolver.resolve("@acme/widgets/foo");
+  assertEquals(result2, false);
+  assertEquals(output.calls.filter((c) => c.startsWith("notFound")).length, 1);
+});
+
+Deno.test("updateAllowedCollectives: clears warned-untrusted set", async () => {
+  const output = createMockOutput();
+  const resolver = new ExtensionAutoResolver({
+    allowedCollectives: ["swamp"],
+    extensionLookup: createMockLookup(),
+    extensionInstaller: createMockInstaller(),
+    output,
+  });
+
+  await resolver.resolve("@acme/widgets/foo");
+  assertEquals(
+    output.calls.filter((c) => c.startsWith("collectiveNotTrusted")).length,
+    1,
+  );
+
+  await resolver.resolve("@acme/widgets/bar");
+  assertEquals(
+    output.calls.filter((c) => c.startsWith("collectiveNotTrusted")).length,
+    1,
+    "second resolve should not re-warn for same collective",
+  );
+
+  resolver.updateAllowedCollectives(["swamp"]);
+
+  await resolver.resolve("@acme/widgets/baz");
+  assertEquals(
+    output.calls.filter((c) => c.startsWith("collectiveNotTrusted")).length,
+    2,
+    "after updateAllowedCollectives, warn hint should fire again",
+  );
+});


### PR DESCRIPTION
## Summary

- Adds `updateAllowedCollectives` method to `ExtensionAutoResolver` so the trusted collectives list can be refreshed without recreating the entire resolver
- Adds `reloadTrustedCollectives` function in `serve.ts` that re-reads `.swamp.yaml` and auth collectives after SIGHUP, updating the auto-resolver in-place
- Updates `swamp serve reload` description to mention trust list refresh

Previously, the SIGHUP hot-reload handler only re-bundled pulled extensions from the lockfile — it never re-read `.swamp.yaml`, so trust list changes (e.g. `swamp extension trust add`) required a full daemon restart. Now the trust list is refreshed alongside extension bundles on every SIGHUP.

Closes swamp-club#1499

## Test Plan

- Added unit tests for `updateAllowedCollectives` — verifies previously untrusted collectives are allowed after update, and that the warned-untrusted set is cleared so fresh trust hints fire
- Manually verified end-to-end: started `swamp serve --hot-reload`, added a trusted collective, sent SIGHUP, confirmed `Trust list refreshed from .swamp.yaml` log message
- All 9737 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)