### PR TITLE
feat(serve): track active runs in control-plane store for cross-instance visibility

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -79,6 +79,10 @@ import { parseWebhookFlag, WebhookService } from "../../serve/webhook.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { ActiveRunRegistry } from "../../serve/active_run_registry.ts";
+import {
+  deleteActiveRun,
+  writeActiveRun,
+} from "../../serve/active_run_tracker.ts";
 import { RunCancelRegistry } from "../../serve/run_cancel_registry.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
@@ -1718,6 +1722,7 @@ export const serveCommand = new Command()
         activeRunRegistry,
         runTracker,
         dispatchService,
+        controlPlaneStore,
         defaultVault: repoMarker?.defaultVault,
         instanceId,
       };
@@ -1777,6 +1782,23 @@ export const serveCommand = new Command()
                   );
                 });
               }
+            },
+          }
+          : undefined,
+        activeRunHook: controlPlaneStore && instanceId
+          ? {
+            write: (runId: string, resourceName: string, runKind: string) => {
+              writeActiveRun(controlPlaneStore, instanceId, runId, {
+                resourceName,
+                runKind: runKind as
+                  | "workflow-run"
+                  | "workflow-resume"
+                  | "method-run",
+                startedAt: new Date().toISOString(),
+              });
+            },
+            delete: (runId: string) => {
+              deleteActiveRun(controlPlaneStore, instanceId, runId);
             },
           }
           : undefined,

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -101,6 +101,7 @@ export { severityAtOrAbove } from "../domain/workflows/assert_severity.ts";
 
 // Scheduled execution
 export {
+  type ActiveRunHook,
   type CronFireDedupCallback,
   normalizeFireTime,
   type ScheduledExecutionDeps,

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -115,6 +115,11 @@ export interface PendingRunHook {
   delete(id: string): void;
 }
 
+export interface ActiveRunHook {
+  write(runId: string, resourceName: string, runKind: string): void;
+  delete(runId: string): void;
+}
+
 /**
  * Callback for cross-instance cron fire dedup. Returns true if this
  * instance should execute, false if another instance already claimed
@@ -131,6 +136,7 @@ export interface ScheduledExecutionDeps {
   repoDir: string;
   executeWorkflow: WorkflowExecutor;
   pendingRunHook?: PendingRunHook;
+  activeRunHook?: ActiveRunHook;
   cronFireDedup?: CronFireDedupCallback;
 }
 
@@ -426,9 +432,9 @@ export class ScheduledExecutionService {
     // During this narrow window cancelByRunId() cannot match this run;
     // the window closes as soon as executeWorkflow emits "started".
     this.running.set(workflowId, { controller, runId: "" });
+    let runId = "";
 
     try {
-      let runId = "";
       let completedRun: WorkflowRunView | undefined;
       let streamError: string | undefined;
 
@@ -443,6 +449,11 @@ export class ScheduledExecutionService {
               if (event.kind === "started") {
                 runId = event.runId;
                 this.running.set(workflowId, { controller, runId });
+                this.deps.activeRunHook?.write(
+                  runId,
+                  workflowName,
+                  "workflow-run",
+                );
               }
               if (event.kind === "completed") {
                 completedRun = event.run;
@@ -517,6 +528,9 @@ export class ScheduledExecutionService {
       );
     } finally {
       this.running.delete(workflowId);
+      if (runId) {
+        this.deps.activeRunHook?.delete(runId);
+      }
     }
   }
 

--- a/src/serve/active_run_tracker.ts
+++ b/src/serve/active_run_tracker.ts
@@ -1,0 +1,117 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import type { RunKind } from "./active_run_registry.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "active-run-tracker"]);
+
+export interface ActiveRunRecord {
+  instanceId: string;
+  resourceName: string;
+  runKind: RunKind;
+  startedAt: string;
+}
+
+function activeRunKey(instanceId: string, runId: string): string {
+  return `active-runs/${instanceId}/${runId}`;
+}
+
+const encoder = new TextEncoder();
+
+export function writeActiveRun(
+  store: ControlPlaneStore,
+  instanceId: string,
+  runId: string,
+  record: Omit<ActiveRunRecord, "instanceId">,
+): void {
+  const full: ActiveRunRecord = { instanceId, ...record };
+  store.put(
+    activeRunKey(instanceId, runId),
+    encoder.encode(JSON.stringify(full)),
+  )
+    .catch((err: unknown) => {
+      logger.warn("Failed to write active-run record for {runId}: {error}", {
+        runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
+export function deleteActiveRun(
+  store: ControlPlaneStore,
+  instanceId: string,
+  runId: string,
+): void {
+  store.delete(activeRunKey(instanceId, runId))
+    .catch((err: unknown) => {
+      logger.warn("Failed to delete active-run record for {runId}: {error}", {
+        runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
+export function rekeyActiveRun(
+  store: ControlPlaneStore,
+  instanceId: string,
+  oldRunId: string,
+  newRunId: string,
+  record: Omit<ActiveRunRecord, "instanceId">,
+): void {
+  const full: ActiveRunRecord = { instanceId, ...record };
+  Promise.all([
+    store.delete(activeRunKey(instanceId, oldRunId)),
+    store.put(
+      activeRunKey(instanceId, newRunId),
+      encoder.encode(JSON.stringify(full)),
+    ),
+  ]).catch((err: unknown) => {
+    logger.warn(
+      "Failed to rekey active-run record from {oldRunId} to {newRunId}: {error}",
+      {
+        oldRunId,
+        newRunId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  });
+}
+
+export async function cleanupActiveRunsForInstance(
+  store: ControlPlaneStore,
+  instanceId: string,
+): Promise<number> {
+  const keys = await store.list(`active-runs/${instanceId}/`);
+  let cleaned = 0;
+  for (const key of keys) {
+    await store.delete(key).catch((err: unknown) => {
+      logger.warn(
+        "Failed to delete stale active-run record {key}: {error}",
+        {
+          key,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    });
+    cleaned++;
+  }
+  return cleaned;
+}

--- a/src/serve/active_run_tracker_test.ts
+++ b/src/serve/active_run_tracker_test.ts
@@ -1,0 +1,173 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import {
+  cleanupActiveRunsForInstance,
+  deleteActiveRun,
+  rekeyActiveRun,
+  writeActiveRun,
+} from "./active_run_tracker.ts";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+
+await initializeLogging({});
+
+function createMockStore(): ControlPlaneStore & {
+  data: Map<string, Uint8Array>;
+} {
+  const data = new Map<string, Uint8Array>();
+  return {
+    data,
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+function parseRecord(
+  store: ControlPlaneStore & { data: Map<string, Uint8Array> },
+  key: string,
+): Record<string, unknown> | null {
+  const raw = store.data.get(key);
+  if (!raw) return null;
+  return JSON.parse(new TextDecoder().decode(raw));
+}
+
+Deno.test("writeActiveRun: writes record to control-plane store", async () => {
+  const store = createMockStore();
+  writeActiveRun(store, "instance-1", "run-abc", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  // writeActiveRun is fire-and-forget; flush microtasks
+  await new Promise((r) => setTimeout(r, 10));
+
+  const record = parseRecord(store, "active-runs/instance-1/run-abc");
+  assertEquals(record, {
+    instanceId: "instance-1",
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+});
+
+Deno.test("deleteActiveRun: removes record from control-plane store", async () => {
+  const store = createMockStore();
+  writeActiveRun(store, "instance-1", "run-abc", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  assertEquals(store.data.has("active-runs/instance-1/run-abc"), true);
+
+  deleteActiveRun(store, "instance-1", "run-abc");
+  await new Promise((r) => setTimeout(r, 10));
+  assertEquals(store.data.has("active-runs/instance-1/run-abc"), false);
+});
+
+Deno.test("rekeyActiveRun: deletes old key and writes new key", async () => {
+  const store = createMockStore();
+  writeActiveRun(store, "instance-1", "temp-uuid", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  rekeyActiveRun(store, "instance-1", "temp-uuid", "domain-run-id", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  assertEquals(store.data.has("active-runs/instance-1/temp-uuid"), false);
+  const record = parseRecord(store, "active-runs/instance-1/domain-run-id");
+  assertEquals(record, {
+    instanceId: "instance-1",
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+});
+
+Deno.test("cleanupActiveRunsForInstance: deletes all records for an instance", async () => {
+  const store = createMockStore();
+
+  writeActiveRun(store, "stale-instance", "run-1", {
+    resourceName: "workflow-a",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  writeActiveRun(store, "stale-instance", "run-2", {
+    resourceName: "workflow-b",
+    runKind: "method-run",
+    startedAt: "2026-08-01T12:01:00Z",
+  });
+  writeActiveRun(store, "healthy-instance", "run-3", {
+    resourceName: "workflow-c",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:02:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  const cleaned = await cleanupActiveRunsForInstance(store, "stale-instance");
+  assertEquals(cleaned, 2);
+  assertEquals(store.data.has("active-runs/stale-instance/run-1"), false);
+  assertEquals(store.data.has("active-runs/stale-instance/run-2"), false);
+  assertEquals(store.data.has("active-runs/healthy-instance/run-3"), true);
+});
+
+Deno.test("writeActiveRun: does not throw on store failure", async () => {
+  const store = createMockStore();
+  store.put = () => Promise.reject(new Error("S3 unreachable"));
+
+  writeActiveRun(store, "instance-1", "run-abc", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  // No throw — the error is caught and logged
+});
+
+Deno.test("deleteActiveRun: does not throw on store failure", async () => {
+  const store = createMockStore();
+  store.delete = () => Promise.reject(new Error("S3 unreachable"));
+
+  deleteActiveRun(store, "instance-1", "run-abc");
+  await new Promise((r) => setTimeout(r, 10));
+  // No throw — the error is caught and logged
+});

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -36,6 +36,7 @@ import type { FileSystemUnifiedDataRepository } from "../infrastructure/persiste
 import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
+import { cleanupActiveRunsForInstance } from "./active_run_tracker.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
 
 const logger = getSwampLogger(["serve", "boot-reconciliation"]);
@@ -484,6 +485,19 @@ export async function reconcileRemoteInterruptedRuns(
       "Reaped run {runId} from dead remote instance {instanceId}",
       { runId: run.id, instanceId: run.instanceId },
     );
+  }
+
+  for (const claimedId of claimedInstanceIds) {
+    const activeRunsCleaned = await cleanupActiveRunsForInstance(
+      deps.controlPlaneStore,
+      claimedId,
+    );
+    if (activeRunsCleaned > 0) {
+      logger.info(
+        "Cleaned up {count} stale active-run records for instance {instanceId}",
+        { count: activeRunsCleaned, instanceId: claimedId },
+      );
+    }
   }
 
   for (const key of claimedHeartbeatKeys) {

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -85,6 +85,7 @@ import {
 } from "../../domain/access/principal.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
+import { deleteActiveRun, writeActiveRun } from "../active_run_tracker.ts";
 import {
   authorizeOrReject,
   type ConnectionContext,
@@ -431,9 +432,13 @@ export async function handleModelMethodRun(
         }
       }
       registry.deregister(runId);
+      if (ctx.controlPlaneStore && ctx.instanceId) {
+        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      }
     }
   })();
 
+  const startedAt = new Date();
   try {
     registry.register({
       runId,
@@ -441,7 +446,7 @@ export async function handleModelMethodRun(
       resourceName: payload.modelIdOrName,
       buffer,
       controller: runController,
-      startedAt: new Date(),
+      startedAt,
       completion,
     });
   } catch {
@@ -453,6 +458,14 @@ export async function handleModelMethodRun(
       `Too many concurrent runs; wait for active runs to complete`,
     );
     return;
+  }
+
+  if (ctx.controlPlaneStore && ctx.instanceId) {
+    writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {
+      resourceName: payload.modelIdOrName,
+      runKind: "method-run",
+      startedAt: startedAt.toISOString(),
+    });
   }
 
   await subscribeUntilDetach(buffer, socket, requestId, controller);

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -25,6 +25,7 @@ import type { RepositoryContext } from "../../infrastructure/persistence/reposit
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync_service.ts";
+import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
 import type { RunCancelRegistry } from "../run_cancel_registry.ts";
 import type { RunTrackerRepository } from "../../domain/models/run_tracker_repository.ts";
 import type { ServerMessage } from "../protocol.ts";
@@ -96,6 +97,7 @@ export interface ConnectionContext {
   activeRunRegistry?: import("../active_run_registry.ts").ActiveRunRegistry;
   runTracker?: RunTrackerRepository;
   dispatchService?: import("../dispatch_service.ts").DispatchService;
+  controlPlaneStore?: ControlPlaneStore;
   defaultVault?: string;
   /** HA instance identifier — present when `--detach-runs` is active. */
   instanceId?: string;

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -89,6 +89,11 @@ import {
 } from "../../infrastructure/tracing/mod.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import {
+  deleteActiveRun,
+  rekeyActiveRun,
+  writeActiveRun,
+} from "../active_run_tracker.ts";
+import {
   authorizeOrReject,
   type ConnectionContext,
   sanitizeErrorForClient,
@@ -216,7 +221,21 @@ export async function handleWorkflowRun(
             const domainRunId = (event as { runId: string }).runId;
             if (domainRunId && domainRunId !== runId) {
               if (registry.rekey(runId, domainRunId)) {
+                const oldRunId = runId;
                 runId = domainRunId;
+                if (ctx.controlPlaneStore && ctx.instanceId) {
+                  rekeyActiveRun(
+                    ctx.controlPlaneStore,
+                    ctx.instanceId,
+                    oldRunId,
+                    domainRunId,
+                    {
+                      resourceName: payload.workflowIdOrName,
+                      runKind: "workflow-run",
+                      startedAt: startedAt.toISOString(),
+                    },
+                  );
+                }
               }
             }
           }
@@ -245,9 +264,13 @@ export async function handleWorkflowRun(
       }
     } finally {
       registry.deregister(runId);
+      if (ctx.controlPlaneStore && ctx.instanceId) {
+        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      }
     }
   })();
 
+  const startedAt = new Date();
   try {
     registry.register({
       runId,
@@ -255,7 +278,7 @@ export async function handleWorkflowRun(
       resourceName: payload.workflowIdOrName,
       buffer,
       controller: runController,
-      startedAt: new Date(),
+      startedAt,
       completion,
     });
   } catch {
@@ -267,6 +290,14 @@ export async function handleWorkflowRun(
       `Too many concurrent runs; wait for active runs to complete`,
     );
     return;
+  }
+
+  if (ctx.controlPlaneStore && ctx.instanceId) {
+    writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {
+      resourceName: payload.workflowIdOrName,
+      runKind: "workflow-run",
+      startedAt: startedAt.toISOString(),
+    });
   }
 
   await subscribeUntilDetach(buffer, socket, requestId, controller);
@@ -1144,9 +1175,13 @@ export async function handleWorkflowResume(
     } finally {
       ephemeral?.dispose();
       registry.deregister(runId);
+      if (ctx.controlPlaneStore && ctx.instanceId) {
+        deleteActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId);
+      }
     }
   })();
 
+  const startedAt = new Date();
   try {
     registry.register({
       runId,
@@ -1154,7 +1189,7 @@ export async function handleWorkflowResume(
       resourceName: payload.workflowIdOrName,
       buffer,
       controller: runController,
-      startedAt: new Date(),
+      startedAt,
       completion,
     });
   } catch {
@@ -1166,6 +1201,14 @@ export async function handleWorkflowResume(
       `Too many concurrent runs; wait for active runs to complete`,
     );
     return;
+  }
+
+  if (ctx.controlPlaneStore && ctx.instanceId) {
+    writeActiveRun(ctx.controlPlaneStore, ctx.instanceId, runId, {
+      resourceName: payload.workflowIdOrName,
+      runKind: "workflow-resume",
+      startedAt: startedAt.toISOString(),
+    });
   }
 
   await subscribeUntilDetach(buffer, socket, requestId, controller);

--- a/src/serve/webhook.ts
+++ b/src/serve/webhook.ts
@@ -29,6 +29,7 @@ import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_se
 import type { WebhookPayload } from "../domain/expressions/model_resolver.ts";
 import { UserError } from "../domain/errors.ts";
 import { executeWorkflowWithLocks } from "./deps.ts";
+import { deleteActiveRun, writeActiveRun } from "./active_run_tracker.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import {
   extractFirstStepError,
@@ -583,9 +584,9 @@ export class WebhookService {
     const controller = new AbortController();
     const execId = crypto.randomUUID();
     this.running.set(execId, controller);
+    let runId = "";
 
     try {
-      let runId = "";
       let completedRun: WorkflowRunView | undefined;
 
       await executeWorkflowWithLocks(
@@ -603,6 +604,18 @@ export class WebhookService {
         (event) => {
           if (event.kind === "started") {
             runId = event.runId;
+            if (this.deps.controlPlaneStore && this.deps.instanceId) {
+              writeActiveRun(
+                this.deps.controlPlaneStore,
+                this.deps.instanceId,
+                runId,
+                {
+                  resourceName: workflowIdOrName,
+                  runKind: "workflow-run",
+                  startedAt: new Date().toISOString(),
+                },
+              );
+            }
           }
           if (event.kind === "completed") {
             completedRun = event.run;
@@ -656,6 +669,13 @@ export class WebhookService {
       );
     } finally {
       this.running.delete(execId);
+      if (runId && this.deps.controlPlaneStore && this.deps.instanceId) {
+        deleteActiveRun(
+          this.deps.controlPlaneStore,
+          this.deps.instanceId,
+          runId,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Write `active-runs/{instanceId}/{runId}` records to the control-plane store when runs start, delete them when runs complete — covers all 5 execution paths (detached workflow run/resume, model method run, webhook, cron)
- Add `controlPlaneStore` to `ConnectionContext` so WebSocket handlers can access it
- Add `ActiveRunHook` callback interface for `ScheduledExecutionService` to preserve domain layer boundaries
- Clean up stale active-run records during reconciliation when a dead instance is claimed

All control-plane writes are best-effort (fire-and-forget with logged `.catch`) — they never block or fail the run itself. Reconciliation is the safety net for any missed deletes.

Closes swamp-club#1507

## Test Plan

- [x] 6 unit tests for core tracker functions (write, delete, rekey, cleanup, write-failure, delete-failure)
- [x] 42 boot reconciliation tests pass (including stale instance cleanup)
- [x] 10 scheduled execution tests pass
- [x] 9743 project-wide tests pass, 0 failures
- [x] Integration-tested with MinIO S3 datastore: record visible at `_control/active-runs/{instanceId}/{runId}` during run, deleted after completion
- [x] `deno check` — no new type errors
- [x] `deno lint` — clean
- [x] `deno fmt` — clean