### PR TITLE
fix(serve): address review feedback on active-run tracking

### DIFF
--- a/src/serve/active_run_tracker.ts
+++ b/src/serve/active_run_tracker.ts
@@ -102,16 +102,19 @@ export async function cleanupActiveRunsForInstance(
   const keys = await store.list(`active-runs/${instanceId}/`);
   let cleaned = 0;
   for (const key of keys) {
-    await store.delete(key).catch((err: unknown) => {
-      logger.warn(
-        "Failed to delete stale active-run record {key}: {error}",
-        {
-          key,
-          error: err instanceof Error ? err.message : String(err),
-        },
-      );
-    });
-    cleaned++;
+    const deleted = await store.delete(key).then(() => true).catch(
+      (err: unknown) => {
+        logger.warn(
+          "Failed to delete stale active-run record {key}: {error}",
+          {
+            key,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        return false;
+      },
+    );
+    if (deleted) cleaned++;
   }
   return cleaned;
 }

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -189,6 +189,7 @@ export async function handleWorkflowRun(
   const buffer = new RunEventBuffer(DEFAULT_BUFFER_CAPACITY);
   const runController = new AbortController();
   let runId: string = crypto.randomUUID();
+  const startedAt = new Date();
 
   const completion = (async () => {
     try {
@@ -270,7 +271,6 @@ export async function handleWorkflowRun(
     }
   })();
 
-  const startedAt = new Date();
   try {
     registry.register({
       runId,


### PR DESCRIPTION
## Summary

- `cleanupActiveRunsForInstance`: only increment `cleaned` counter on successful delete, not when `.catch` swallows a failure
- `handleWorkflowRun`: move `startedAt` declaration before the async IIFE to eliminate temporal dead zone risk in the `onEvent` callback

Follow-up to #2049 addressing review feedback from the adversarial and code reviews.

## Test Plan

- [x] `active_run_tracker_test.ts` — 6 tests pass
- [x] Full test suite — 9743 tests pass, 0 failures
- [x] `deno fmt --check` / `deno lint` clean