### PR TITLE
feat(serve): cross-instance client re-attach for multi-instance swamp serve (swamp-club#1514)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1750,6 +1750,7 @@ export const serveCommand = new Command()
         controlPlaneStore,
         defaultVault: repoMarker?.defaultVault,
         instanceId,
+        staleTtlMs,
       };
 
     const ac = new AbortController();

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -722,7 +722,7 @@ async function* streamServerRun(
 }
 
 function getReconnectLogger(
-  options: ServerRunOptions,
+  _options: ServerRunOptions,
 ): (msg: string) => void {
   return (msg: string) => {
     try {

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -638,9 +638,11 @@ async function* streamServerRun(
     type: "run.attach";
     payload: { runId: string; afterSeq: number };
   } = request;
+  const logger = getReconnectLogger(options);
 
   while (true) {
     let outcome: StreamOutcome;
+    let receivedEvents = false;
     try {
       const stream = singleConnectionStream(options, currentRequest, state);
       while (true) {
@@ -649,12 +651,22 @@ async function* streamServerRun(
           outcome = result.value;
           break;
         }
+        receivedEvents = true;
         yield result.value;
       }
     } catch (err) {
-      if (!state.runId || err instanceof DOMException) throw err;
-      // Connection failure during reconnection — treat as disconnected
+      if (
+        !state.runId || err instanceof DOMException ||
+        err instanceof UserError
+      ) {
+        throw err;
+      }
       outcome = { kind: "disconnected" };
+    }
+
+    if (receivedEvents) {
+      reconnectRetries = 0;
+      elsewhereRetries = 0;
     }
 
     if (outcome.kind === "done") {
@@ -664,8 +676,8 @@ async function* streamServerRun(
     if (outcome.kind === "interrupted") {
       throw new UserError(
         `Run was interrupted — the instance running it (${outcome.instanceId}) ` +
-          `is no longer reachable (${outcome.reason}). ` +
-          `Check the run's final status with: swamp run history`,
+          "is no longer active. " +
+          "Check the run's final status with: swamp run history",
       );
     }
 
@@ -674,10 +686,14 @@ async function* streamServerRun(
       if (elsewhereRetries > MAX_ELSEWHERE_RETRIES) {
         throw new UserError(
           "Run is on another instance but could not reach it after " +
-            `${MAX_ELSEWHERE_RETRIES} retries`,
+            `${MAX_ELSEWHERE_RETRIES} retries. ` +
+            "Check the run's final status with: swamp run history",
         );
       }
-      await delay(ELSEWHERE_RETRY_DELAY_MS);
+      logger(
+        `Run is on another instance, retrying (${elsewhereRetries}/${MAX_ELSEWHERE_RETRIES})...`,
+      );
+      await delay(ELSEWHERE_RETRY_DELAY_MS, options.signal);
       currentRequest = {
         type: "run.attach",
         payload: { runId: state.runId!, afterSeq: state.lastSeq },
@@ -690,10 +706,14 @@ async function* streamServerRun(
     if (reconnectRetries > MAX_RECONNECT_RETRIES) {
       throw new UserError(
         "Connection lost and could not reconnect after " +
-          `${MAX_RECONNECT_RETRIES} retries`,
+          `${MAX_RECONNECT_RETRIES} retries. ` +
+          "Check the run's final status with: swamp run history",
       );
     }
-    await delay(1_000 * reconnectRetries);
+    logger(
+      `Connection dropped, reconnecting (${reconnectRetries}/${MAX_RECONNECT_RETRIES})...`,
+    );
+    await delay(1_000 * reconnectRetries, options.signal);
     currentRequest = {
       type: "run.attach",
       payload: { runId: state.runId!, afterSeq: state.lastSeq },
@@ -701,6 +721,25 @@ async function* streamServerRun(
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function getReconnectLogger(
+  options: ServerRunOptions,
+): (msg: string) => void {
+  return (msg: string) => {
+    try {
+      Deno.stderr.writeSync(new TextEncoder().encode(`\r\x1b[K${msg}\n`));
+    } catch {
+      // Ignore write errors (piped, closed, etc.)
+    }
+  };
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    }, { once: true });
+  });
 }

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -61,6 +61,15 @@ const CANCEL_DRAIN_MS = 10_000;
 /** How long to wait for the WebSocket to open. */
 const CONNECT_TIMEOUT_MS = 15_000;
 
+/** Max reconnection attempts after a WebSocket drop with a known runId. */
+const MAX_RECONNECT_RETRIES = 5;
+
+/** Max retries when the server responds with run.elsewhere. */
+const MAX_ELSEWHERE_RETRIES = 10;
+
+/** Base delay (ms) between run.elsewhere retries. */
+const ELSEWHERE_RETRY_DELAY_MS = 1_500;
+
 export interface ServerRunOptions {
   /** Server URL: ws://, wss://, http://, or https://. */
   server: string;
@@ -394,22 +403,34 @@ interface OutboundRequest {
   payload: WorkflowRunPayload | ModelMethodRunPayload | WorkflowResumePayload;
 }
 
+type StreamOutcome =
+  | { kind: "done" }
+  | { kind: "disconnected" }
+  | { kind: "elsewhere"; instanceId: string }
+  | { kind: "interrupted"; instanceId: string; reason: string };
+
 /**
- * One request, one event stream. The generator completes on `done`, throws
- * UserError on an `error` frame, and treats a premature socket close as a
- * failure — a run whose end we never saw is not a success.
+ * Single-connection event stream. Yields deserialized run events and returns
+ * an outcome indicating why the connection ended. The `state` object tracks
+ * the runId and last seen seq across reconnections.
  */
-async function* streamServerRun(
+async function* singleConnectionStream(
   options: ServerRunOptions,
-  request: OutboundRequest,
-): AsyncIterable<{ kind: string; [key: string]: unknown }> {
+  request: OutboundRequest | {
+    type: "run.attach";
+    payload: { runId: string; afterSeq: number };
+  },
+  state: { runId: string | undefined; lastSeq: number },
+): AsyncGenerator<
+  { kind: string; [key: string]: unknown },
+  StreamOutcome
+> {
   const baseUrl = normalizeServerUrl(options.server);
   const url = appendTokenToUrl(baseUrl, options.token);
   const headers = options.headers ?? resolveExtraHeaders();
   const requestId = crypto.randomUUID();
   const socket = (options.createSocket ?? defaultCreateSocket)(url, headers);
 
-  // Push-queue bridging socket callbacks to the generator.
   const queue: ServerMessage[] = [];
   let wake: (() => void) | null = null;
   let socketClosed = false;
@@ -522,7 +543,7 @@ async function* streamServerRun(
       const message = queue.shift();
       if (message !== undefined) {
         if (message.type === "done") {
-          return;
+          return { kind: "done" as const };
         }
         if (message.type === "error") {
           if (cancelSent || message.error.code === "cancelled") {
@@ -532,12 +553,48 @@ async function* streamServerRun(
             `Server reported ${message.error.code}: ${message.error.message}`,
           );
         }
+        if (message.type === "run.elsewhere") {
+          return {
+            kind: "elsewhere" as const,
+            instanceId: message.payload.instanceId,
+          };
+        }
+        if (message.type === "run.interrupted") {
+          return {
+            kind: "interrupted" as const,
+            instanceId: message.payload.instanceId,
+            reason: message.payload.reason,
+          };
+        }
         if (message.type === "event") {
-          yield deserializeEvent(message.event);
+          const event = deserializeEvent(message.event);
+          if (
+            typeof event === "object" && event !== null && "kind" in event &&
+            "runId" in event
+          ) {
+            state.runId = event.runId as string;
+          }
+          if (
+            typeof message.event === "object" && message.event !== null &&
+            "seq" in message.event &&
+            typeof message.event.seq === "number"
+          ) {
+            state.lastSeq = message.event.seq;
+          }
+          if (
+            typeof event === "object" && event !== null && "kind" in event &&
+            event.kind === "run.accepted"
+          ) {
+            continue;
+          }
+          yield event;
         }
         continue;
       }
       if (socketClosed) {
+        if (state.runId) {
+          return { kind: "disconnected" as const };
+        }
         throw new UserError(
           "Connection to the server closed before the run completed",
         );
@@ -548,7 +605,6 @@ async function* streamServerRun(
           "AbortError",
         );
       }
-      // Wait for the next frame, close, or cancel-drain tick.
       await new Promise<void>((resolve) => {
         wake = resolve;
         if (cancelSent) {
@@ -564,4 +620,87 @@ async function* streamServerRun(
       // Already closed.
     }
   }
+}
+
+/**
+ * One request, one event stream with automatic reconnection. The generator
+ * completes on `done`, throws UserError on an `error` frame, and reconnects
+ * transparently when the socket drops mid-run (if a runId is known).
+ */
+async function* streamServerRun(
+  options: ServerRunOptions,
+  request: OutboundRequest,
+): AsyncIterable<{ kind: string; [key: string]: unknown }> {
+  const state = { runId: undefined as string | undefined, lastSeq: 0 };
+  let reconnectRetries = 0;
+  let elsewhereRetries = 0;
+  let currentRequest: OutboundRequest | {
+    type: "run.attach";
+    payload: { runId: string; afterSeq: number };
+  } = request;
+
+  while (true) {
+    let outcome: StreamOutcome;
+    try {
+      const stream = singleConnectionStream(options, currentRequest, state);
+      while (true) {
+        const result = await stream.next();
+        if (result.done) {
+          outcome = result.value;
+          break;
+        }
+        yield result.value;
+      }
+    } catch (err) {
+      if (!state.runId || err instanceof DOMException) throw err;
+      // Connection failure during reconnection — treat as disconnected
+      outcome = { kind: "disconnected" };
+    }
+
+    if (outcome.kind === "done") {
+      return;
+    }
+
+    if (outcome.kind === "interrupted") {
+      throw new UserError(
+        `Run was interrupted — the instance running it (${outcome.instanceId}) ` +
+          `is no longer reachable (${outcome.reason}). ` +
+          `Check the run's final status with: swamp run history`,
+      );
+    }
+
+    if (outcome.kind === "elsewhere") {
+      elsewhereRetries++;
+      if (elsewhereRetries > MAX_ELSEWHERE_RETRIES) {
+        throw new UserError(
+          "Run is on another instance but could not reach it after " +
+            `${MAX_ELSEWHERE_RETRIES} retries`,
+        );
+      }
+      await delay(ELSEWHERE_RETRY_DELAY_MS);
+      currentRequest = {
+        type: "run.attach",
+        payload: { runId: state.runId!, afterSeq: state.lastSeq },
+      };
+      continue;
+    }
+
+    // disconnected — attempt reconnection
+    reconnectRetries++;
+    if (reconnectRetries > MAX_RECONNECT_RETRIES) {
+      throw new UserError(
+        "Connection lost and could not reconnect after " +
+          `${MAX_RECONNECT_RETRIES} retries`,
+      );
+    }
+    await delay(1_000 * reconnectRetries);
+    currentRequest = {
+      type: "run.attach",
+      payload: { runId: state.runId!, afterSeq: state.lastSeq },
+    };
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -788,3 +788,216 @@ Deno.test({
     assertStringIncludes(error.message, "Could not connect to");
   },
 });
+
+// ── cross-instance reconnection tests ─────────────────────────────────
+
+Deno.test({
+  name:
+    "remote run: reconnects and sends run.attach after socket drop with known runId",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    let connectionCount = 0;
+    const server = scriptedServer((request, reply, socket) => {
+      connectionCount++;
+      if (request.type === "workflow.run") {
+        reply({
+          type: "event",
+          id: request.id,
+          event: {
+            kind: "started",
+            runId: "run-123",
+            workflowName: "wf",
+            seq: 1,
+          },
+        });
+        reply({
+          type: "event",
+          id: request.id,
+          event: { kind: "job_started", jobName: "job1", seq: 2 },
+        });
+        setTimeout(() => socket.close(), 20);
+      } else if (request.type === "run.attach") {
+        reply({
+          type: "run.attached",
+          id: request.id,
+          payload: {
+            runId: "run-123",
+            kind: "workflow-run",
+            startedAt: "2026-08-01T00:00:00Z",
+          },
+        });
+        reply({
+          type: "event",
+          id: request.id,
+          event: { kind: "completed", status: "succeeded", seq: 3 },
+        });
+        reply({ type: "done", id: request.id });
+      }
+    });
+    try {
+      const events: string[] = [];
+      for await (
+        const event of runWorkflowOverServer({
+          server: server.url,
+          payload: { workflowIdOrName: "wf" },
+        })
+      ) {
+        events.push(event.kind);
+      }
+      assertEquals(events, ["started", "job_started", "completed"]);
+      assertEquals(connectionCount >= 2, true);
+      const attachReq = server.received.find(
+        (r) => (r as { type: string }).type === "run.attach",
+      ) as { type: string; payload: { runId: string; afterSeq: number } };
+      assertEquals(attachReq.payload.runId, "run-123");
+      assertEquals(attachReq.payload.afterSeq, 2);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "remote run: handles run.elsewhere by retrying through load balancer",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    let elsewhereCount = 0;
+    const server = scriptedServer((request, reply) => {
+      if (request.type === "workflow.run") {
+        reply({
+          type: "event",
+          id: request.id,
+          event: {
+            kind: "started",
+            runId: "run-456",
+            workflowName: "wf",
+            seq: 1,
+          },
+        });
+        reply({
+          type: "event",
+          id: request.id,
+          event: { kind: "completed", status: "succeeded", seq: 2 },
+        });
+        reply({ type: "done", id: request.id });
+        return;
+      }
+      if (request.type === "run.attach") {
+        elsewhereCount++;
+        if (elsewhereCount <= 2) {
+          reply({
+            type: "run.elsewhere",
+            id: request.id,
+            payload: { runId: "run-456", instanceId: "instance-other" },
+          });
+          return;
+        }
+        reply({
+          type: "run.attached",
+          id: request.id,
+          payload: {
+            runId: "run-456",
+            kind: "workflow-run",
+            startedAt: "2026-08-01T00:00:00Z",
+          },
+        });
+        reply({
+          type: "event",
+          id: request.id,
+          event: { kind: "completed", status: "succeeded", seq: 3 },
+        });
+        reply({ type: "done", id: request.id });
+      }
+    });
+    try {
+      const events: string[] = [];
+      for await (
+        const event of runWorkflowOverServer({
+          server: server.url,
+          payload: { workflowIdOrName: "wf" },
+        })
+      ) {
+        events.push(event.kind);
+      }
+      assertEquals(events, ["started", "completed"]);
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name: "remote run: run.interrupted throws UserError with instance details",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((request, reply, socket) => {
+      if (request.type === "workflow.run") {
+        reply({
+          type: "event",
+          id: request.id,
+          event: {
+            kind: "started",
+            runId: "run-dead",
+            workflowName: "wf",
+            seq: 1,
+          },
+        });
+        setTimeout(() => socket.close(), 20);
+      } else if (request.type === "run.attach") {
+        reply({
+          type: "run.interrupted",
+          id: request.id,
+          payload: {
+            runId: "run-dead",
+            instanceId: "dead-instance",
+            reason: "instance_dead",
+          },
+        });
+      }
+    });
+    try {
+      const error = await assertRejects(async () => {
+        for await (
+          const _ of runWorkflowOverServer({
+            server: server.url,
+            payload: { workflowIdOrName: "wf" },
+          })
+          // deno-lint-ignore no-empty
+        ) {}
+      }, UserError);
+      assertStringIncludes(error.message, "interrupted");
+      assertStringIncludes(error.message, "dead-instance");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "remote run: does not attempt reconnect when socket drops before runId is known",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const server = scriptedServer((_request, _reply, socket) => {
+      socket.close();
+    });
+    try {
+      const error = await assertRejects(async () => {
+        for await (
+          const _ of runWorkflowOverServer({
+            server: server.url,
+            payload: { workflowIdOrName: "wf" },
+          })
+          // deno-lint-ignore no-empty
+        ) {}
+      }, UserError);
+      assertStringIncludes(error.message, "closed before the run completed");
+    } finally {
+      await server.shutdown();
+    }
+  },
+});

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -864,7 +864,7 @@ Deno.test({
   sanitizeResources: false,
   fn: async () => {
     let elsewhereCount = 0;
-    const server = scriptedServer((request, reply) => {
+    const server = scriptedServer((request, reply, socket) => {
       if (request.type === "workflow.run") {
         reply({
           type: "event",
@@ -876,12 +876,7 @@ Deno.test({
             seq: 1,
           },
         });
-        reply({
-          type: "event",
-          id: request.id,
-          event: { kind: "completed", status: "succeeded", seq: 2 },
-        });
-        reply({ type: "done", id: request.id });
+        setTimeout(() => socket.close(), 20);
         return;
       }
       if (request.type === "run.attach") {
@@ -922,6 +917,11 @@ Deno.test({
         events.push(event.kind);
       }
       assertEquals(events, ["started", "completed"]);
+      assertEquals(elsewhereCount, 3);
+      const attachRequests = server.received.filter(
+        (r) => (r as { type: string }).type === "run.attach",
+      );
+      assertEquals(attachRequests.length, 3);
     } finally {
       await server.shutdown();
     }

--- a/src/serve/active_run_tracker.ts
+++ b/src/serve/active_run_tracker.ts
@@ -95,6 +95,29 @@ export function rekeyActiveRun(
   });
 }
 
+const decoder = new TextDecoder();
+
+export async function findActiveRunByRunId(
+  store: ControlPlaneStore,
+  runId: string,
+): Promise<{ record: ActiveRunRecord; instanceId: string } | null> {
+  const keys = await store.list("active-runs/");
+  const suffix = `/${runId}`;
+  for (const key of keys) {
+    if (key.endsWith(suffix)) {
+      const data = await store.get(key);
+      if (!data) continue;
+      try {
+        const record = JSON.parse(decoder.decode(data)) as ActiveRunRecord;
+        return { record, instanceId: record.instanceId };
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
 export async function cleanupActiveRunsForInstance(
   store: ControlPlaneStore,
   instanceId: string,

--- a/src/serve/active_run_tracker_test.ts
+++ b/src/serve/active_run_tracker_test.ts
@@ -22,6 +22,7 @@ import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.
 import {
   cleanupActiveRunsForInstance,
   deleteActiveRun,
+  findActiveRunByRunId,
   rekeyActiveRun,
   writeActiveRun,
 } from "./active_run_tracker.ts";
@@ -148,6 +149,56 @@ Deno.test("cleanupActiveRunsForInstance: deletes all records for an instance", a
   assertEquals(store.data.has("active-runs/stale-instance/run-1"), false);
   assertEquals(store.data.has("active-runs/stale-instance/run-2"), false);
   assertEquals(store.data.has("active-runs/healthy-instance/run-3"), true);
+});
+
+Deno.test("findActiveRunByRunId: finds run across instances", async () => {
+  const store = createMockStore();
+  writeActiveRun(store, "instance-a", "run-1", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  writeActiveRun(store, "instance-b", "run-2", {
+    resourceName: "build-model",
+    runKind: "method-run",
+    startedAt: "2026-08-01T12:01:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  const result = await findActiveRunByRunId(store, "run-2");
+  assertEquals(result?.instanceId, "instance-b");
+  assertEquals(result?.record.resourceName, "build-model");
+  assertEquals(result?.record.runKind, "method-run");
+});
+
+Deno.test("findActiveRunByRunId: returns null when run not found", async () => {
+  const store = createMockStore();
+  writeActiveRun(store, "instance-a", "run-1", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+    startedAt: "2026-08-01T12:00:00Z",
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  const result = await findActiveRunByRunId(store, "run-nonexistent");
+  assertEquals(result, null);
+});
+
+Deno.test("findActiveRunByRunId: returns null on empty store", async () => {
+  const store = createMockStore();
+  const result = await findActiveRunByRunId(store, "run-1");
+  assertEquals(result, null);
+});
+
+Deno.test("findActiveRunByRunId: handles corrupted record gracefully", async () => {
+  const store = createMockStore();
+  store.data.set(
+    "active-runs/instance-a/run-bad",
+    new TextEncoder().encode("not-json"),
+  );
+
+  const result = await findActiveRunByRunId(store, "run-bad");
+  assertEquals(result, null);
 });
 
 Deno.test("writeActiveRun: does not throw on store failure", async () => {

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -127,6 +127,8 @@ import {
   sendError,
   subscribeUntilDetach,
 } from "./handlers/shared.ts";
+import { findActiveRunByRunId } from "./active_run_tracker.ts";
+import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 
 export { sanitizeErrorForClient } from "./handlers/shared.ts";
 export type { ConnectionContext } from "./handlers/shared.ts";
@@ -1859,6 +1861,52 @@ async function handleRunAttach(
 ): Promise<void> {
   const run = ctx.activeRunRegistry?.get(payload.runId);
   if (!run) {
+    if (ctx.controlPlaneStore) {
+      const result = await findActiveRunByRunId(
+        ctx.controlPlaneStore,
+        payload.runId,
+      );
+      if (result) {
+        const resourceKind = result.record.runKind === "method-run"
+          ? "model"
+          : "workflow";
+        if (
+          !authorizeOrReject(socket, requestId, principal, "run", {
+            kind: resourceKind,
+            name: result.record.resourceName,
+            fields: {},
+          }, ctx)
+        ) return;
+
+        const heartbeatData = await ctx.controlPlaneStore.get(
+          `heartbeats/${result.instanceId}`,
+        );
+        if (heartbeatData) {
+          const hb = InstanceHeartbeatService.parseRecord(heartbeatData);
+          if (hb && !InstanceHeartbeatService.isStale(hb, ctx.staleTtlMs)) {
+            send(socket, {
+              type: "run.elsewhere",
+              id: requestId,
+              payload: {
+                runId: payload.runId,
+                instanceId: result.instanceId,
+              },
+            });
+            return;
+          }
+        }
+        send(socket, {
+          type: "run.interrupted",
+          id: requestId,
+          payload: {
+            runId: payload.runId,
+            instanceId: result.instanceId,
+            reason: "instance_dead",
+          },
+        });
+        return;
+      }
+    }
     sendError(
       socket,
       requestId,

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -2031,6 +2031,287 @@ Deno.test("typeArg authz: @ prefix on typeArg is stripped before authorization",
   );
 });
 
+// ── handleRunAttach cross-instance fallback tests ───────────────────────
+
+function createMockControlPlaneStore():
+  & import("../domain/datastore/control_plane_store.ts").ControlPlaneStore
+  & {
+    data: Map<string, Uint8Array>;
+  } {
+  const data = new Map<string, Uint8Array>();
+  return {
+    data,
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+const encoder = new TextEncoder();
+
+function seedActiveRun(
+  store: ReturnType<typeof createMockControlPlaneStore>,
+  instanceId: string,
+  runId: string,
+  opts: { resourceName: string; runKind: string },
+): void {
+  store.data.set(
+    `active-runs/${instanceId}/${runId}`,
+    encoder.encode(JSON.stringify({
+      instanceId,
+      resourceName: opts.resourceName,
+      runKind: opts.runKind,
+      startedAt: "2026-08-01T12:00:00Z",
+    })),
+  );
+}
+
+function seedHeartbeat(
+  store: ReturnType<typeof createMockControlPlaneStore>,
+  instanceId: string,
+  heartbeatAt: string,
+): void {
+  store.data.set(
+    `heartbeats/${instanceId}`,
+    encoder.encode(JSON.stringify({
+      instanceId,
+      hostname: "host-1",
+      pid: 1234,
+      startedAt: "2026-08-01T11:00:00Z",
+      heartbeatAt,
+    })),
+  );
+}
+
+const runAttachGrant = makeGrant({
+  subject: { kind: "user", name: "adam" },
+  actions: ["run"],
+  resource: { kind: "workflow", pattern: "*" },
+});
+
+Deno.test("handleRunAttach: miss + active-runs record + fresh heartbeat returns run.elsewhere", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const cpStore = createMockControlPlaneStore();
+  seedActiveRun(cpStore, "instance-remote", "run-xyz", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+  });
+  seedHeartbeat(cpStore, "instance-remote", new Date().toISOString());
+
+  const ctx = makeCtx(modeTokenConfig, [runAttachGrant]);
+  (ctx as unknown as Record<string, unknown>).controlPlaneStore = cpStore;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-1",
+      payload: { runId: "run-xyz" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "run.elsewhere");
+  assertEquals(response.id, "attach-1");
+  assertEquals(
+    (response.payload as Record<string, unknown>).runId,
+    "run-xyz",
+  );
+  assertEquals(
+    (response.payload as Record<string, unknown>).instanceId,
+    "instance-remote",
+  );
+});
+
+Deno.test("handleRunAttach: miss + active-runs record + stale heartbeat returns run.interrupted", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const cpStore = createMockControlPlaneStore();
+  seedActiveRun(cpStore, "instance-dead", "run-abc", {
+    resourceName: "build-model",
+    runKind: "workflow-run",
+  });
+  seedHeartbeat(cpStore, "instance-dead", "2026-07-01T00:00:00Z");
+
+  const ctx = makeCtx(modeTokenConfig, [runAttachGrant]);
+  (ctx as unknown as Record<string, unknown>).controlPlaneStore = cpStore;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-2",
+      payload: { runId: "run-abc" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "run.interrupted");
+  assertEquals(response.id, "attach-2");
+  assertEquals(
+    (response.payload as Record<string, unknown>).reason,
+    "instance_dead",
+  );
+});
+
+Deno.test("handleRunAttach: miss + no active-runs record returns not_found", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const cpStore = createMockControlPlaneStore();
+
+  const ctx = makeCtx(modeTokenConfig, [runAttachGrant]);
+  (ctx as unknown as Record<string, unknown>).controlPlaneStore = cpStore;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-3",
+      payload: { runId: "run-nonexistent" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "error");
+  assertEquals(
+    (response.error as Record<string, unknown>).code,
+    "not_found",
+  );
+});
+
+Deno.test("handleRunAttach: miss + active-runs record + no heartbeat returns run.interrupted", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const cpStore = createMockControlPlaneStore();
+  seedActiveRun(cpStore, "instance-orphaned", "run-orphan", {
+    resourceName: "deploy-pipeline",
+    runKind: "workflow-run",
+  });
+
+  const ctx = makeCtx(modeTokenConfig, [runAttachGrant]);
+  (ctx as unknown as Record<string, unknown>).controlPlaneStore = cpStore;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-4",
+      payload: { runId: "run-orphan" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "run.interrupted");
+  assertEquals(
+    (response.payload as Record<string, unknown>).reason,
+    "instance_dead",
+  );
+});
+
+Deno.test("handleRunAttach: miss + no control-plane store returns not_found", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const ctx = makeCtx(modeTokenConfig, [runAttachGrant]);
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-5",
+      payload: { runId: "run-anywhere" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "error");
+  assertEquals(
+    (response.error as Record<string, unknown>).code,
+    "not_found",
+  );
+});
+
+Deno.test("handleRunAttach: miss + active-runs record + unauthorized principal returns error without leaking existence", async () => {
+  const mock = createMockSocket();
+  const active = new Map<string, AbortController>();
+  const cpStore = createMockControlPlaneStore();
+  seedActiveRun(cpStore, "instance-remote", "run-secret", {
+    resourceName: "secret-workflow",
+    runKind: "workflow-run",
+  });
+  seedHeartbeat(cpStore, "instance-remote", new Date().toISOString());
+
+  const noRunGrant = makeGrant({
+    subject: { kind: "user", name: "adam" },
+    actions: ["read"],
+    resource: { kind: "workflow", pattern: "*" },
+  });
+  const ctx = makeCtx(modeTokenConfig, [noRunGrant]);
+  (ctx as unknown as Record<string, unknown>).controlPlaneStore = cpStore;
+
+  handleMessage(
+    mock as unknown as WebSocket,
+    ctx,
+    active,
+    makeEvent(JSON.stringify({
+      type: "run.attach",
+      id: "attach-6",
+      payload: { runId: "run-secret" },
+    })),
+    testPrincipal,
+  );
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  const response = parseSent(mock);
+  assertEquals(response.type, "error");
+  assertEquals(
+    (response.error as Record<string, unknown>).code,
+    "unauthorized",
+  );
+  const allTypes = mock.sent.map((s) => JSON.parse(s).type);
+  assertEquals(allTypes.includes("run.elsewhere"), false);
+  assertEquals(allTypes.includes("run.interrupted"), false);
+});
+
 // ── sanitizeErrorForClient tests ────────────────────────────────────────
 
 Deno.test("sanitizeErrorForClient: redacts absolute Unix paths", () => {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -101,6 +101,8 @@ export interface ConnectionContext {
   defaultVault?: string;
   /** HA instance identifier — present when `--detach-runs` is active. */
   instanceId?: string;
+  /** Heartbeat stale TTL in ms — used by cross-instance run.attach fallback. */
+  staleTtlMs?: number;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -1169,4 +1169,14 @@ export type ServerMessage =
     type: "run.attached";
     id: string;
     payload: { runId: string; kind: string; startedAt: string };
+  }
+  | {
+    type: "run.elsewhere";
+    id: string;
+    payload: { runId: string; instanceId: string };
+  }
+  | {
+    type: "run.interrupted";
+    id: string;
+    payload: { runId: string; instanceId: string; reason: "instance_dead" };
   };


### PR DESCRIPTION
## Summary

- When a client's WebSocket drops in a multi-instance deployment behind a load balancer, the CLI automatically reconnects and re-attaches to the run
- Server falls back to the control-plane store to locate runs across instances, returning `run.elsewhere` (live instance) or `run.interrupted` (dead instance)
- Authorization is enforced on the cross-instance path before revealing run existence
- Fixes pre-existing bug where `model method run --server` with `--detach-runs` crashed because the client had no handler for the `run.accepted` event

## Test plan

- [ ] 182 unit tests pass across `active_run_tracker_test.ts` (10), `connection_test.ts` (138), `remote_run_test.ts` (34)
- [ ] E2E verified with Caddy LB + MinIO S3 + two serve instances:
  - `run.elsewhere` → retry → `run.attached` + event streaming resumes
  - Instance SIGKILL → client reconnects → `run.interrupted` after heartbeat stale
- [ ] `model method run --server` works with and without `--detach-runs`
- [ ] Authorization denied on cross-instance path returns `unauthorized` without leaking run existence

Closes swamp-club#1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)